### PR TITLE
KAFKA-18942: Add reviewers to PR body with committer-tools

### DIFF
--- a/committer-tools/README.md
+++ b/committer-tools/README.md
@@ -46,11 +46,13 @@ See: https://cli.github.com/
 brew install gh
 ```
 
-## Find Reviewers
+## Find Reviewers and Update Trailer to PR body
 
 The reviewers.py script is used to simplify the process of producing our "Reviewers:"
-Git trailer. It parses the Git log to gather a set of "Authors" and "Reviewers". 
-Some simple string prefix matching is done to find candidates.
+Git trailer to PR body. It parses the Git log to gather a set of "Authors" and "Reviewers". 
+Some simple string prefix matching is done to find candidates. 
+After entering the pull request number, the script updates the "Reviewers:" trailer accordingly. 
+If the PR body already contains a "Reviewers:" trailer, the script replaces it with the updated list of reviewers.
 
 Usage:
 

--- a/committer-tools/README.md
+++ b/committer-tools/README.md
@@ -46,7 +46,7 @@ See: https://cli.github.com/
 brew install gh
 ```
 
-## Find Reviewers and Update Trailer to PR body
+## Find Reviewers and Update to PR body
 
 The reviewers.py script is used to simplify the process of producing our "Reviewers:"
 Git trailer to PR body. It parses the Git log to gather a set of "Authors" and "Reviewers". 

--- a/committer-tools/requirements.txt
+++ b/committer-tools/requirements.txt
@@ -18,4 +18,3 @@
 beautifulsoup4==4.12.3
 PyGithub==2.4.0
 ruamel.yaml==0.18.6
-shlex

--- a/committer-tools/requirements.txt
+++ b/committer-tools/requirements.txt
@@ -18,3 +18,4 @@
 beautifulsoup4==4.12.3
 PyGithub==2.4.0
 ruamel.yaml==0.18.6
+shlex

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -36,6 +36,7 @@ def prompt_for_user():
         if clean_input != "":
             return clean_input
 
+
 def append_message_to_pr_body(pr_url, message):
     try:
         cmd_get_pr = ["gh", "pr", "view", pr_url, "--json", "title,body"]
@@ -43,12 +44,11 @@ def append_message_to_pr_body(pr_url, message):
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
         print(f"The new PR body will be:\n{current_pr_body}{message}")
-        escaped_message = message.replace("<", "\<").replace(">", "\>")
+        escaped_message = message.replace("<", "\\<").replace(">", "\\>")
         updated_pr_body = f"{current_pr_body}{escaped_message}"
     except subprocess.CalledProcessError as e:
         print("Failed to retrieve PR description:", e.stderr)
         return
-
 
     choice = input(f"Update the body of {pr_title}? (y/n): ").strip().lower()
     if choice in ['n', 'no']:
@@ -123,7 +123,3 @@ if __name__ == "__main__":
             append_message_to_pr_body(url, reviewer_message)
         except (EOFError, KeyboardInterrupt):
             exit(0)
-
-        
-
-

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import json
+import subprocess
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -33,6 +35,29 @@ def prompt_for_user():
         clean_input = user_input.strip().lower()
         if clean_input != "":
             return clean_input
+
+def append_message_to_pr_body(pr_url, message):
+    try:
+        cmd_get_pr = ["gh", "pr", "view", pr_url, "--json", "title,body"]
+        result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
+        current_pr_body = json.loads(result.stdout).get("body", {})
+        pr_title = json.loads(result.stdout).get("title", {})
+        updated_pr_body = f"{current_pr_body}{message}"
+    except subprocess.CalledProcessError as e:
+        print("Failed to retrieve PR description:", e.stderr)
+        return
+
+    print(f"The new PR body will be:\n{updated_pr_body}")
+    choice = input(f"Update the body of {pr_title}? (y/n): ").strip().lower()
+    if choice in ['n', 'no']:
+        return
+
+    try:
+        cmd_edit_body = ["gh", "pr", "edit", pr_url, "--body", updated_pr_body]
+        subprocess.run(cmd_edit_body, check=True)
+        print("PR description updated successfully!")
+    except subprocess.CalledProcessError as e:
+        print("Failed to update PR description:", e.stderr)
 
 
 if __name__ == "__main__":
@@ -87,9 +112,16 @@ if __name__ == "__main__":
             continue
 
     if selected_reviewers:
-        out = "\n\nReviewers: "
-        out += ", ".join([f"{name} <{email}>" for name, email, _ in selected_reviewers])
-        out += "\n"
-        print(out)
+        reviewer_message = f'\n\nReviewers: {", ".join([f"{name} <{email}>" for name, email, _ in selected_reviewers])}\n'
+        print(reviewer_message)
+
+        try:
+            pr_number = input("\nEnter Pull Request number to append reviewer message to body (Ctrl+D or Ctrl+C to skip): ")
+            url = f"https://github.com/apache/kafka/pull/{pr_number}"
+            append_message_to_pr_body(url, reviewer_message)
+        except (EOFError, KeyboardInterrupt):
+            exit(0)
+
+        
 
 

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
         print(reviewer_message)
 
         try:
-            pr_number = input("\nEnter Pull Request number to append reviewer message to body (Ctrl+D or Ctrl+C to skip): ")
+            pr_number = input("\nEnter the Pull Request number to append reviewer message to body (Ctrl+D or Ctrl+C to skip): ")
             url = f"https://github.com/apache/kafka/pull/{pr_number}"
             append_message_to_pr_body(url, reviewer_message)
         except (EOFError, KeyboardInterrupt):

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -53,8 +53,8 @@ def update_trailers(body, trailer):
 def append_message_to_pr_body(pr: int , message: str):
     try:
         pr_url = f"https://github.com/apache/kafka/pull/{pr}"
-        cmd_get_pr = f"gh pr view {pr_url} --json title,body"
-        result = subprocess.run(shlex.split(cmd_get_pr), capture_output=True, text=True, check=True)
+        cmd_get_pr = shlex.split(f"gh pr view {pr_url} --json title,body")
+        result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
         updated_pr_body = update_trailers(current_pr_body, message)
@@ -67,8 +67,8 @@ def append_message_to_pr_body(pr: int , message: str):
         return
 
     try:
-        cmd_edit_body = f"gh pr edit {pr_url} --body '{updated_pr_body}'"
-        subprocess.run(shlex.split(cmd_edit_body), check=True)
+        cmd_edit_body = shlex.split(f"gh pr edit {pr_url} --body '{updated_pr_body}'")
+        subprocess.run(cmd_edit_body, check=True)
         print("PR body updated successfully!")
     except subprocess.CalledProcessError as e:
         print("Failed to update PR body:", e.stderr)

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -53,22 +53,23 @@ def update_trailers(body, trailer):
 def append_message_to_pr_body(pr: int , message: str):
     try:
         pr_url = f"https://github.com/apache/kafka/pull/{pr}"
-        cmd_get_pr = shlex.split(f"gh pr view {pr_url} --json title,body")
-        result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
-        current_pr_body = json.loads(result.stdout).get("body", {})
+        cmd_get_pr = f"gh pr view {pr_url} --json title,body"
+        result = subprocess.run(shlex.split(cmd_get_pr), capture_output=True, text=True, check=True)
+        current_pr_body = json.loads(result.stdout).get("body", {}).strip() + "\n"
         pr_title = json.loads(result.stdout).get("title", {})
         updated_pr_body = update_trailers(current_pr_body, message)
     except subprocess.CalledProcessError as e:
         print("Failed to retrieve PR body:", e.stderr)
         return
 
+    print(f"""New PR body will be:\n\n---\n{updated_pr_body}---\n""")
     choice = input(f'Update the body of "{pr_title}"? (y/n): ').strip().lower()
     if choice in ['n', 'no']:
         return
 
     try:
-        cmd_edit_body = shlex.split(f"gh pr edit {pr_url} --body {shlex.quote(updated_pr_body)}")
-        subprocess.run(cmd_edit_body, check=True)
+        cmd_edit_body = f"gh pr edit {pr_url} --body {shlex.quote(updated_pr_body)}"
+        subprocess.run(shlex.split(cmd_edit_body), check=True)
         print("PR body updated successfully!")
     except subprocess.CalledProcessError as e:
         print("Failed to update PR body:", e.stderr)
@@ -126,7 +127,8 @@ if __name__ == "__main__":
             continue
 
     if selected_reviewers:
-        reviewer_message = f'Reviewers: {", ".join([f"{name} <{email}>" for name, email, _ in selected_reviewers])}'
+        reviewer_message = "Reviewers: "
+        reviewer_message += ", ".join([f"{name} <{email}>" for name, email, _ in selected_reviewers])
         print(f"\n\n{reviewer_message}\n")
 
         try:

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -42,12 +42,14 @@ def append_message_to_pr_body(pr_url, message):
         result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
-        updated_pr_body = f"{current_pr_body}{message}"
+        print(f"The new PR body will be:\n{current_pr_body}{message}")
+        escaped_message = message.replace("<", "\<").replace(">", "\>")
+        updated_pr_body = f"{current_pr_body}{escaped_message}"
     except subprocess.CalledProcessError as e:
         print("Failed to retrieve PR description:", e.stderr)
         return
 
-    print(f"The new PR body will be:\n{updated_pr_body}")
+
     choice = input(f"Update the body of {pr_title}? (y/n): ").strip().lower()
     if choice in ['n', 'no']:
         return

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -67,7 +67,7 @@ def append_message_to_pr_body(pr: int , message: str):
         return
 
     try:
-        cmd_edit_body = shlex.split(f"gh pr edit {pr_url} --body '{updated_pr_body}'")
+        cmd_edit_body = shlex.split(f"gh pr edit {pr_url} --body {shlex.quote(updated_pr_body)}")
         subprocess.run(cmd_edit_body, check=True)
         print("PR body updated successfully!")
     except subprocess.CalledProcessError as e:

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -4,6 +4,7 @@
 import json
 import shlex
 import subprocess
+import tempfile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -38,6 +39,17 @@ def prompt_for_user():
             return clean_input
 
 
+def update_trailers(body, trailer):
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(body.encode())
+        fp.flush()
+        cmd = f"git interpret-trailers --if-exists replace --trailer '{trailer}' {fp.name} "
+        p = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
+        fp.close()
+
+    return p.stdout
+
+
 def append_message_to_pr_body(pr: int , message: str):
     try:
         pr_url = f"https://github.com/apache/kafka/pull/{pr}"
@@ -45,8 +57,7 @@ def append_message_to_pr_body(pr: int , message: str):
         result = subprocess.run(shlex.split(cmd_get_pr), capture_output=True, text=True, check=True)
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
-        escaped_message = message.replace("<", "\\<").replace(">", "\\>")
-        updated_pr_body = f"{current_pr_body}{escaped_message}"
+        updated_pr_body = update_trailers(current_pr_body, message)
     except subprocess.CalledProcessError as e:
         print("Failed to retrieve PR body:", e.stderr)
         return
@@ -115,8 +126,8 @@ if __name__ == "__main__":
             continue
 
     if selected_reviewers:
-        reviewer_message = f'\n\nReviewers: {", ".join([f"{name} <{email}>" for name, email, _ in selected_reviewers])}\n'
-        print(reviewer_message)
+        reviewer_message = f'Reviewers: {", ".join([f"{name} <{email}>" for name, email, _ in selected_reviewers])}'
+        print(f"\n\n{reviewer_message}\n")
 
         try:
             pr_number = int(input("\nPull Request (Ctrl+D or Ctrl+C to skip): "))

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -41,8 +41,8 @@ def prompt_for_user():
 def append_message_to_pr_body(pr: int , message: str):
     try:
         pr_url = f"https://github.com/apache/kafka/pull/{pr}"
-        cmd_get_pr = shlex.split(f"gh pr view {pr_url} --json title,body")
-        result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
+        cmd_get_pr = f"gh pr view {pr_url} --json title,body"
+        result = subprocess.run(shlex.split(cmd_get_pr), capture_output=True, text=True, check=True)
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
         escaped_message = message.replace("<", "\\<").replace(">", "\\>")
@@ -56,8 +56,8 @@ def append_message_to_pr_body(pr: int , message: str):
         return
 
     try:
-        cmd_edit_body = shlex.split(f"gh pr edit {pr_url} --body '{updated_pr_body}'")
-        subprocess.run(cmd_edit_body, check=True)
+        cmd_edit_body = f"gh pr edit {pr_url} --body '{updated_pr_body}'"
+        subprocess.run(shlex.split(cmd_edit_body), check=True)
         print("PR body updated successfully!")
     except subprocess.CalledProcessError as e:
         print("Failed to update PR body:", e.stderr)

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -46,7 +46,7 @@ def append_message_to_pr_body(pr_url, message):
         escaped_message = message.replace("<", "\\<").replace(">", "\\>")
         updated_pr_body = f"{current_pr_body}{escaped_message}"
     except subprocess.CalledProcessError as e:
-        print("Failed to retrieve PR description:", e.stderr)
+        print("Failed to retrieve PR body:", e.stderr)
         return
 
     choice = input(f'Update the body of "{pr_title}"? (y/n): ').strip().lower()
@@ -56,9 +56,9 @@ def append_message_to_pr_body(pr_url, message):
     try:
         cmd_edit_body = ["gh", "pr", "edit", pr_url, "--body", updated_pr_body]
         subprocess.run(cmd_edit_body, check=True)
-        print("PR description updated successfully!")
+        print("PR body updated successfully!")
     except subprocess.CalledProcessError as e:
-        print("Failed to update PR description:", e.stderr)
+        print("Failed to update PR body:", e.stderr)
 
 
 if __name__ == "__main__":

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -43,14 +43,13 @@ def append_message_to_pr_body(pr_url, message):
         result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
-        print(f"The new PR body will be:\n{current_pr_body}{message}")
         escaped_message = message.replace("<", "\\<").replace(">", "\\>")
         updated_pr_body = f"{current_pr_body}{escaped_message}"
     except subprocess.CalledProcessError as e:
         print("Failed to retrieve PR description:", e.stderr)
         return
 
-    choice = input(f"Update the body of {pr_title}? (y/n): ").strip().lower()
+    choice = input(f'Update the body of "{pr_title}"? (y/n): ').strip().lower()
     if choice in ['n', 'no']:
         return
 

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import shlex
 import subprocess
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -37,9 +38,10 @@ def prompt_for_user():
             return clean_input
 
 
-def append_message_to_pr_body(pr_url, message):
+def append_message_to_pr_body(pr: int , message: str):
     try:
-        cmd_get_pr = ["gh", "pr", "view", pr_url, "--json", "title,body"]
+        pr_url = f"https://github.com/apache/kafka/pull/{pr}"
+        cmd_get_pr = shlex.split(f"gh pr view {pr_url} --json title,body")
         result = subprocess.run(cmd_get_pr, capture_output=True, text=True, check=True)
         current_pr_body = json.loads(result.stdout).get("body", {})
         pr_title = json.loads(result.stdout).get("title", {})
@@ -54,7 +56,7 @@ def append_message_to_pr_body(pr_url, message):
         return
 
     try:
-        cmd_edit_body = ["gh", "pr", "edit", pr_url, "--body", updated_pr_body]
+        cmd_edit_body = shlex.split(f"gh pr edit {pr_url} --body '{updated_pr_body}'")
         subprocess.run(cmd_edit_body, check=True)
         print("PR body updated successfully!")
     except subprocess.CalledProcessError as e:
@@ -117,8 +119,7 @@ if __name__ == "__main__":
         print(reviewer_message)
 
         try:
-            pr_number = input("\nEnter the Pull Request number to append reviewer message to body (Ctrl+D or Ctrl+C to skip): ")
-            url = f"https://github.com/apache/kafka/pull/{pr_number}"
-            append_message_to_pr_body(url, reviewer_message)
+            pr_number = int(input("\nPull Request (Ctrl+D or Ctrl+C to skip): "))
+            append_message_to_pr_body(pr_number, reviewer_message)
         except (EOFError, KeyboardInterrupt):
             exit(0)


### PR DESCRIPTION
Make `reviewers.py` able to append the reviewer message to the PR body.
The tool has a comfirmation propmt to prevent human errors.

### Updates
2025-03-11: print result pr body
2025-03-11: Now the tool can detect If the PR body already contains a "Reviewers:" trailer, the script will replaces it with the updated list of reviewers.

Example session (don't use this pr to test, or you may get confused by words in code blocks):
```
$ ./reviewers.py
Utility to help generate 'Reviewers' string for Pull Requests. Use Ctrl+D or Ctrl+C to exit

Name or email (case insensitive): david ar

Possible matches (in order of most recent):
[1] David Arthur mumrah@gmail.com (579)
[2] David Arthur david.arthur@confluent.io (5)

Make a selection: 1
Reviewers so far: [('David Arthur', 'mumrah@gmail.com', 579)]

Name or email (case insensitive): ism

Possible matches (in order of most recent):
[1] Ismael Juma ismael@juma.me.uk (2811)
[2] Ismael Juma ijuma@apache.org (7)
[3] Ismael Juma ismael@confluent.io (24)
[4] Ismael Juma mlists@juma.me.uk (18)
[5] Ismael Juma github@juma.me.uk (12)

Make a selection: 1
Reviewers so far: [('David Arthur', 'mumrah@gmail.com', 579), ('Ismael Juma', 'ismael@juma.me.uk', 2811)]

Name or email (case insensitive): chia

Possible matches (in order of most recent):
[1] Chia-Ping Tsai chia7712@gmail.com (1916)
[2] Chia-Ping Tsai chia7712@apache.org (13)
[3] Chia-Chuan Yu yujuan476@gmail.com (11)
[4] Chia Chuan Yu yujuan476@gmail.com (10)

Make a selection: 1
Reviewers so far: [('David Arthur', 'mumrah@gmail.com', 579), ('Ismael Juma', 'ismael@juma.me.uk', 2811), ('Chia-Ping Tsai', 'chia7712@gmail.com', 1916)]

Name or email (case insensitive): ^C

Reviewers: David Arthur <mumrah@gmail.com>, Ismael Juma <ismael@juma.me.uk>, Chia-Ping Tsai <chia7712@gmail.com>


Pull Request (Ctrl+D or Ctrl+C to skip): 19177
New PR body will be:

---
Revert some java record migration in #19062  #18783 

As discussed in https://github.com/apache/kafka/pull/19062#issuecomment-2709637352, If a class has fields that may be mutable, we shouldn't migrate it to Java record because the hashcode/equals behavior are changed.

* LogFetchInfo (Records)
* Assignment (successCallback)
* RequestAndCompletionHandler (handler)

Reviewers: David Arthur <mumrah@gmail.com>, Ismael Juma <ismael@juma.me.uk>, Chia-Ping Tsai <chia7712@gmail.com>
---

Update the body of "MINOR: Revert migrate LogFetchInfo, Assignment and RequestAndCompletionHandler to java record"? (y/n): y
https://github.com/apache/kafka/pull/19177
PR body updated successfully!
```
