### PR TITLE
MINOR: Remove unused ConfigCommandOptions#forceOpt

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -536,7 +536,6 @@ object ConfigCommand extends Logging {
       .withRequiredArg
       .ofType(classOf[String])
       .withValuesSeparatedBy(',')
-    val forceOpt: OptionSpecBuilder = parser.accepts("force", "Suppress console prompts")
     val topic: OptionSpec[String] = parser.accepts("topic", "The topic's name.")
       .withRequiredArg
       .ofType(classOf[String])

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -28,6 +28,12 @@
                     </li>
                 </ul>
             </li>
+            <li><b>Command</b>
+                <ul>
+                    <li>The <code>force</code> option of <code>ConfigCommand</code> has been removed, as it has been non-operational since version 0.10.1.0.
+                    </li>
+                </ul>
+            </li>
         </ul>
 <h4><a id="upgrade_4_0_0" href="#upgrade_4_0_0">Upgrading to 4.0.0 from any version 3.3.x through 3.9.x</a></h4>
 


### PR DESCRIPTION
This field is unused, and we should remove it.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
