### PR TITLE
KAFKA-17808: Fix id typo for connector-dlq-adminclient

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1019,7 +1019,7 @@ public final class Worker {
         if (topic != null && !topic.isEmpty()) {
             Map<String, Object> producerProps = baseProducerConfigs(id.connector(), "connector-dlq-producer-" + id, config, connConfig, connectorClass,
                                                                 connectorClientConfigOverridePolicy, kafkaClusterId);
-            Map<String, Object> adminProps = adminConfigs(id.connector(), "connector-dlq-adminclient-", config, connConfig, connectorClass, connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
+            Map<String, Object> adminProps = adminConfigs(id.connector(), "connector-dlq-adminclient-" + id, config, connConfig, connectorClass, connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
             DeadLetterQueueReporter reporter = DeadLetterQueueReporter.createAndSetup(adminProps, id, connConfig, producerProps, errorHandlingMetrics);
 
             reporters.add(reporter);


### PR DESCRIPTION
## Description
Fix id typo for connector-dlq-adminclient. Please see Jira: https://issues.apache.org/jira/browse/KAFKA-17808

## Verification
### Setup Steps
Moefiy default `config/connect-file-sink.properties` (enabling dlq):
```
name=local-file-sink
connector.class=FileStreamSink
-tasks.max=1
+tasks.max=2
file=test.sink.txt
topics=connect-test

+errors.deadletterqueue.topic.name=dlq-topic
+errors.deadletterqueue.context.headers.enable=true
+errors.deadletterqueue.topic.replication.factor=1
+errors.tolerance=all 
```


Then, running:
```
bin/connect-standalone.sh config/connect-standalone.properties config/connect-file-sink.properties
```
### Before
```
$cat logs/connect.log | grep -ri connector-dlq-adminclient-   
logs/connect.log:       client.id = connector-dlq-adminclient-
logs/connect.log:       client.id = connector-dlq-adminclient-
logs/connect.log:[2025-03-05 03:51:55,766] INFO [local-file-sink|task-1] The mbean of App info: [kafka.admin.client], id: [connector-dlq-adminclient-] already exists, so skipping a new mbean creation. (org.apache.kafka.common.utils.AppInfoParser:66)
logs/connect.log:[2025-03-05 03:51:55,768] INFO App info kafka.admin.client for connector-dlq-adminclient- unregistered (org.apache.kafka.common.utils.AppInfoParser:89)
logs/connect.log:[2025-03-05 03:51:55,770] INFO App info kafka.admin.client for connector-dlq-adminclient- unregistered (org.apache.kafka.common.utils.AppInfoParser:89) 
```
### After
```
$cat logs/connect.log | grep -ri connector-dlq-adminclient-
logs/connect.log:       client.id = connector-dlq-adminclient-local-file-sink-0
logs/connect.log:       client.id = connector-dlq-adminclient-local-file-sink-1
logs/connect.log:[2025-03-07 12:53:44,220] INFO App info kafka.admin.client for connector-dlq-adminclient-local-file-sink-1 unregistered (org.apache.kafka.common.utils.AppInfoParser:89)
logs/connect.log:[2025-03-07 12:53:44,221] INFO App info kafka.admin.client for connector-dlq-adminclient-local-file-sink-0 unregistered (org.apache.kafka.common.utils.AppInfoParser:89)
```

## Test
Since the admin is not exposed, it is hard to write a unit test to check the ID.
https://github.com/apache/kafka/blob/trunk/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java#L84-L89