### PR TITLE
MINOR: improve upgrade to v4.0.0 doc

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -31,6 +31,12 @@
         </ul>
 <h4><a id="upgrade_4_0_0" href="#upgrade_4_0_0">Upgrading to 4.0.0 from any version 3.3.x through 3.9.x</a></h4>
 
+<p>Note: Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, broker upgrades to 4.0.x (and higher) require KRaft mode and
+    the software and metadata versions must be at least 3.3.x (the first version when KRaft mode was deemed production ready). For clusters in KRaft mode
+    with versions older than 3.3.x, we recommend upgrading to 3.9.x before upgrading to 4.0.x. Clusters in ZooKeeper mode
+    have to be <a href="/{{version}}/documentation.html#kraft_zk_migration">migrated to KRaft mode</a> before they can be upgraded to 4.0.x.
+</p>
+
 <p><b>For a rolling upgrade:</b></p>
 
 <ol>
@@ -64,7 +70,7 @@
             Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, broker upgrades to 4.0.x (and higher) require KRaft mode and
             the software and metadata versions must be at least 3.3.x (the first version when KRaft mode was deemed production ready). For clusters in KRaft mode
             with versions older than 3.3.x, we recommend upgrading to 3.9.x before upgrading to 4.0.x. Clusters in ZooKeeper mode
-            have to be <a href="/39/documentation.html#kraft_zk_migration">migrated to KRaft mode</a> before they can be upgraded to 4.0.x.
+            have to be <a href="/{{version}}/documentation.html#kraft_zk_migration">migrated to KRaft mode</a> before they can be upgraded to 4.0.x.
         </li>
         <li>
             Apache Kafka 4.0 ships with a brand-new group coordinator implementation (See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=217387038#KIP848:TheNextGenerationoftheConsumerRebalanceProtocol-GroupCoordinator">here</a>).

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -31,7 +31,7 @@
         </ul>
 <h4><a id="upgrade_4_0_0" href="#upgrade_4_0_0">Upgrading to 4.0.0 from any version 3.3.x through 3.9.x</a></h4>
 
-<p>Note: Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, <b>broker upgrades to 4.0.x (and higher) require KRaft mode and
+<p>Note: Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, <b>broker upgrades to 4.0.0 (and higher) require KRaft mode and
     the software and metadata versions must be at least 3.3.x</b> (the first version when KRaft mode was deemed production ready). For clusters in KRaft mode
     with versions older than 3.3.x, we recommend upgrading to 3.9.x before upgrading to 4.0.x. Clusters in ZooKeeper mode
     have to be <a href="/{{version}}/documentation.html#kraft_zk_migration">migrated to KRaft mode</a> before they can be upgraded to 4.0.x.

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -31,8 +31,8 @@
         </ul>
 <h4><a id="upgrade_4_0_0" href="#upgrade_4_0_0">Upgrading to 4.0.0 from any version 3.3.x through 3.9.x</a></h4>
 
-<p>Note: Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, broker upgrades to 4.0.x (and higher) require KRaft mode and
-    the software and metadata versions must be at least 3.3.x (the first version when KRaft mode was deemed production ready). For clusters in KRaft mode
+<p>Note: Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, <b>broker upgrades to 4.0.x (and higher) require KRaft mode and
+    the software and metadata versions must be at least 3.3.x</b> (the first version when KRaft mode was deemed production ready). For clusters in KRaft mode
     with versions older than 3.3.x, we recommend upgrading to 3.9.x before upgrading to 4.0.x. Clusters in ZooKeeper mode
     have to be <a href="/{{version}}/documentation.html#kraft_zk_migration">migrated to KRaft mode</a> before they can be upgraded to 4.0.x.
 </p>
@@ -67,10 +67,8 @@
             <a href="https://cwiki.apache.org/confluence/x/K5sODg">KIP-896</a> for the details.
         </li>
         <li>
-            Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, broker upgrades to 4.0.x (and higher) require KRaft mode and
-            the software and metadata versions must be at least 3.3.x (the first version when KRaft mode was deemed production ready). For clusters in KRaft mode
-            with versions older than 3.3.x, we recommend upgrading to 3.9.x before upgrading to 4.0.x. Clusters in ZooKeeper mode
-            have to be <a href="/{{version}}/documentation.html#kraft_zk_migration">migrated to KRaft mode</a> before they can be upgraded to 4.0.x.
+            Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. About version upgrade,
+            check <a href="/{{version}}/documentation.html#upgrade_4_0_0">Upgrading to 4.0.0 from any version 3.3.x through 3.9.x</a> for more info.
         </li>
         <li>
             Apache Kafka 4.0 ships with a brand-new group coordinator implementation (See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=217387038#KIP848:TheNextGenerationoftheConsumerRebalanceProtocol-GroupCoordinator">here</a>).


### PR DESCRIPTION
In "Upgrading to 4.0.0 from any version 0.8.x through 3.9.x" section, we directly give instructions about  [Upgrading to KRaft-based clusters](https://kafka.apache.org/documentation/#upgrade_390_kraft), but there might still be some users under ZK cluster before upgrading to v4.0.0. We need to make it clear that they need to upgrade to KRaft mode first before upgrading to v4.0.0 in "Upgrading to 4.0.0 from any version 0.8.x through 3.9.x" section.

Before:
<img width="825" alt="image" src="https://github.com/user-attachments/assets/4309e963-a589-4003-b2fb-1acf5309b1f1" />

After:
![image](https://github.com/user-attachments/assets/49af2a5f-266c-40f9-9d67-32ea066c9315)
