### PR TITLE
KAFKA-18931: added a share group session timeout task when group coordinator is loaded

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -4885,7 +4885,12 @@ public class GroupMetadataManager {
                     break;
 
                 case SHARE:
-                    // Nothing for now for the ShareGroup, as no members are persisted.
+                    ShareGroup shareGroup = (ShareGroup) group;
+                    log.info("Loaded share group {} with {} members.", groupId, shareGroup.members().size());
+                    shareGroup.members().forEach((memberId, member) -> {
+                        log.debug("Loaded member {} in share group {}.", memberId, groupId);
+                        scheduleShareGroupSessionTimeout(groupId, memberId);
+                    });
                     break;
 
                 default:


### PR DESCRIPTION
This PR adds `scheduleShareGroupSessionTimeout` for all the persisted members of a share group when the group coordinator is loaded.

Refer: [KAFKA-18931](https://issues.apache.org/jira/browse/KAFKA-18931)