### PR TITLE
MINOR Mark Tls13SelectorTest#testCloseOldestConnection as flaky

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -83,7 +83,7 @@ import static org.mockito.Mockito.when;
 public class SelectorTest {
     protected static final int BUFFER_SIZE = 4 * 1024;
     private static final String METRIC_GROUP = "MetricGroup";
-    private static final long CONNECTION_MAX_IDLE_MS = 5_000;
+    static final long CONNECTION_MAX_IDLE_MS = 5_000;
 
     protected EchoServer server;
     protected Time time;

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -83,7 +83,7 @@ import static org.mockito.Mockito.when;
 public class SelectorTest {
     protected static final int BUFFER_SIZE = 4 * 1024;
     private static final String METRIC_GROUP = "MetricGroup";
-    static final long CONNECTION_MAX_IDLE_MS = 5_000;
+    private static final long CONNECTION_MAX_IDLE_MS = 5_000;
 
     protected EchoServer server;
     protected Time time;

--- a/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
@@ -35,6 +36,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Tls13SelectorTest extends SslSelectorTest {
 
@@ -44,6 +46,20 @@ public class Tls13SelectorTest extends SslSelectorTest {
             trustStoreFile, "client");
         configs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList("TLSv1.3"));
         return configs;
+    }
+
+    @Flaky(value = "KAFKA-14249", comment = "Copied from base class. Remove this override once the flakiness has been resolved.")
+    @Test
+    @Override
+    public void testCloseOldestConnection() throws Exception {
+        String id = "0";
+        selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
+        NetworkTestUtils.waitForChannelConnected(selector, id);
+        time.sleep(CONNECTION_MAX_IDLE_MS + 1_000);
+        selector.poll(0);
+
+        assertTrue(selector.disconnected().containsKey(id), "The idle connection should have been closed");
+        assertEquals(ChannelState.EXPIRED, selector.disconnected().get(id));
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Tls13SelectorTest extends SslSelectorTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
@@ -52,14 +52,7 @@ public class Tls13SelectorTest extends SslSelectorTest {
     @Test
     @Override
     public void testCloseOldestConnection() throws Exception {
-        String id = "0";
-        selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
-        NetworkTestUtils.waitForChannelConnected(selector, id);
-        time.sleep(CONNECTION_MAX_IDLE_MS + 1_000);
-        selector.poll(0);
-
-        assertTrue(selector.disconnected().containsKey(id), "The idle connection should have been closed");
-        assertEquals(ChannelState.EXPIRED, selector.disconnected().get(id));
+        super.testCloseOldestConnection();
     }
 
     /**


### PR DESCRIPTION
This test has a flakiness around 7%. It caused two back-to-back failures on trunk recently.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
