### PR TITLE
KAFKA-18954: Add ELR election rate metric

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1522,6 +1522,11 @@ NodeId	DirectoryId           	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTi
         <td>0</td>
       </tr>
       <tr>
+        <td>Eligible leader replicas election rate</td>
+        <td>kafka.controller:type=ControllerStats,name=EligibleLeaderReplicasElectionsPerSec</td>
+        <td>0</td>
+      </tr>
+      <tr>
         <td>Is controller active on broker</td>
         <td>kafka.controller:type=KafkaController,name=ActiveControllerCount</td>
         <td>only one broker in the cluster should have 1</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1522,8 +1522,8 @@ NodeId	DirectoryId           	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTi
         <td>0</td>
       </tr>
       <tr>
-        <td>Eligible leader replicas election rate</td>
-        <td>kafka.controller:type=ControllerStats,name=EligibleLeaderReplicasElectionsPerSec</td>
+        <td>Election from Eligible leader replicas rate</td>
+        <td>kafka.controller:type=ControllerStats,name=ElectionFromEligibleLeaderReplicasPerSec</td>
         <td>0</td>
       </tr>
       <tr>

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
@@ -55,8 +55,8 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         "KafkaController", "MetadataErrorCount");
     private static final MetricName UNCLEAN_LEADER_ELECTIONS_PER_SEC = getMetricName(
         "ControllerStats", "UncleanLeaderElectionsPerSec");
-    private static final MetricName ELIGIBLE_LEADER_REPLICAS_ELECTIONS_PER_SEC = getMetricName(
-        "ControllerStats", "EligibleLeaderReplicasElectionsPerSec");
+    private static final MetricName ELECTION_FROM_ELIGIBLE_LEADER_REPLICAS_PER_SEC = getMetricName(
+        "ControllerStats", "ElectionFromEligibleLeaderReplicasPerSec");
     private static final MetricName IGNORED_STATIC_VOTERS = getMetricName(
         "KafkaController", "IgnoredStaticVoters");
 
@@ -69,7 +69,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
     private final AtomicInteger preferredReplicaImbalanceCount = new AtomicInteger(0);
     private final AtomicInteger metadataErrorCount = new AtomicInteger(0);
     private Optional<Meter> uncleanLeaderElectionMeter = Optional.empty();
-    private Optional<Meter> eligibleLeaderReplicasElectionMeter = Optional.empty();
+    private Optional<Meter> electionFromEligibleLeaderReplicasMeter = Optional.empty();
     private final AtomicBoolean ignoredStaticVoters = new AtomicBoolean(false);
 
     /**
@@ -123,8 +123,8 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         }));
         registry.ifPresent(r -> uncleanLeaderElectionMeter =
                 Optional.of(registry.get().newMeter(UNCLEAN_LEADER_ELECTIONS_PER_SEC, "elections", TimeUnit.SECONDS)));
-        registry.ifPresent(r -> eligibleLeaderReplicasElectionMeter =
-                Optional.of(registry.get().newMeter(ELIGIBLE_LEADER_REPLICAS_ELECTIONS_PER_SEC, "elections", TimeUnit.SECONDS)));
+        registry.ifPresent(r -> electionFromEligibleLeaderReplicasMeter =
+                Optional.of(registry.get().newMeter(ELECTION_FROM_ELIGIBLE_LEADER_REPLICAS_PER_SEC, "elections", TimeUnit.SECONDS)));
 
         registry.ifPresent(r -> r.newGauge(IGNORED_STATIC_VOTERS, new Gauge<Integer>() {
             @Override
@@ -219,7 +219,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
     }
 
     public void updateEligibleLeaderReplicasElection(int count) {
-        this.eligibleLeaderReplicasElectionMeter.ifPresent(m -> m.mark(count));
+        this.electionFromEligibleLeaderReplicasMeter.ifPresent(m -> m.mark(count));
     }
 
     public void setIgnoredStaticVoters(boolean ignored) {
@@ -241,7 +241,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
             PREFERRED_REPLICA_IMBALANCE_COUNT,
             METADATA_ERROR_COUNT,
             UNCLEAN_LEADER_ELECTIONS_PER_SEC,
-            ELIGIBLE_LEADER_REPLICAS_ELECTIONS_PER_SEC,
+            ELECTION_FROM_ELIGIBLE_LEADER_REPLICAS_PER_SEC,
             IGNORED_STATIC_VOTERS
         ).forEach(r::removeMetric));
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
@@ -55,6 +55,8 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         "KafkaController", "MetadataErrorCount");
     private static final MetricName UNCLEAN_LEADER_ELECTIONS_PER_SEC = getMetricName(
         "ControllerStats", "UncleanLeaderElectionsPerSec");
+    private static final MetricName ELIGIBLE_LEADER_REPLICAS_ELECTIONS_PER_SEC = getMetricName(
+        "ControllerStats", "EligibleLeaderReplicasElectionsPerSec");
     private static final MetricName IGNORED_STATIC_VOTERS = getMetricName(
         "KafkaController", "IgnoredStaticVoters");
 
@@ -67,6 +69,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
     private final AtomicInteger preferredReplicaImbalanceCount = new AtomicInteger(0);
     private final AtomicInteger metadataErrorCount = new AtomicInteger(0);
     private Optional<Meter> uncleanLeaderElectionMeter = Optional.empty();
+    private Optional<Meter> eligibleLeaderReplicasElectionMeter = Optional.empty();
     private final AtomicBoolean ignoredStaticVoters = new AtomicBoolean(false);
 
     /**
@@ -120,6 +123,8 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         }));
         registry.ifPresent(r -> uncleanLeaderElectionMeter =
                 Optional.of(registry.get().newMeter(UNCLEAN_LEADER_ELECTIONS_PER_SEC, "elections", TimeUnit.SECONDS)));
+        registry.ifPresent(r -> eligibleLeaderReplicasElectionMeter =
+                Optional.of(registry.get().newMeter(ELIGIBLE_LEADER_REPLICAS_ELECTIONS_PER_SEC, "elections", TimeUnit.SECONDS)));
 
         registry.ifPresent(r -> r.newGauge(IGNORED_STATIC_VOTERS, new Gauge<Integer>() {
             @Override
@@ -213,6 +218,10 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         this.uncleanLeaderElectionMeter.ifPresent(m -> m.mark(count));
     }
 
+    public void updateEligibleLeaderReplicasElection(int count) {
+        this.eligibleLeaderReplicasElectionMeter.ifPresent(m -> m.mark(count));
+    }
+
     public void setIgnoredStaticVoters(boolean ignored) {
         ignoredStaticVoters.set(ignored);
     }
@@ -232,6 +241,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
             PREFERRED_REPLICA_IMBALANCE_COUNT,
             METADATA_ERROR_COUNT,
             UNCLEAN_LEADER_ELECTIONS_PER_SEC,
+            ELIGIBLE_LEADER_REPLICAS_ELECTIONS_PER_SEC,
             IGNORED_STATIC_VOTERS
         ).forEach(r::removeMetric));
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
@@ -218,7 +218,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         this.uncleanLeaderElectionMeter.ifPresent(m -> m.mark(count));
     }
 
-    public void updateEligibleLeaderReplicasElection(int count) {
+    public void updateElectionFromEligibleLeaderReplicasCount(int count) {
         this.electionFromEligibleLeaderReplicasMeter.ifPresent(m -> m.mark(count));
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -48,6 +48,7 @@ class ControllerMetricsChanges {
     private int offlinePartitionsChange = 0;
     private int partitionsWithoutPreferredLeaderChange = 0;
     private int uncleanLeaderElection = 0;
+    private int elrElection = 0;
 
     public int fencedBrokersChange() {
         return fencedBrokersChange;
@@ -132,6 +133,9 @@ class ControllerMetricsChanges {
             if (!PartitionRegistration.electionWasClean(next.leader, prevIsr, prevElr)) {
                 uncleanLeaderElection++;
             }
+            if (PartitionRegistration.electionWithElr(next.leader, prevElr)) {
+                elrElection++;
+            }
         }
         globalPartitionsChange += delta(wasPresent, isPresent);
         offlinePartitionsChange += delta(wasOffline, isOffline);
@@ -163,6 +167,10 @@ class ControllerMetricsChanges {
         if (uncleanLeaderElection > 0) {
             metrics.updateUncleanLeaderElection(uncleanLeaderElection);
             uncleanLeaderElection = 0;
+        }
+        if (elrElection > 0) {
+            metrics.updateEligibleLeaderReplicasElection(elrElection);
+            elrElection = 0;
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -169,7 +169,7 @@ class ControllerMetricsChanges {
             uncleanLeaderElection = 0;
         }
         if (electionFromElrCounter > 0) {
-            metrics.updateEligibleLeaderReplicasElection(electionFromElrCounter);
+            metrics.updateElectionFromEligibleLeaderReplicasCount(electionFromElrCounter);
             electionFromElrCounter = 0;
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -133,7 +133,7 @@ class ControllerMetricsChanges {
             if (!PartitionRegistration.electionWasClean(next.leader, prevIsr, prevElr)) {
                 uncleanLeaderElection++;
             }
-            if (PartitionRegistration.electionWithElr(next.leader, prevElr)) {
+            if (PartitionRegistration.electionFromElr(next.leader, prevElr)) {
                 elrElection++;
             }
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -48,7 +48,7 @@ class ControllerMetricsChanges {
     private int offlinePartitionsChange = 0;
     private int partitionsWithoutPreferredLeaderChange = 0;
     private int uncleanLeaderElection = 0;
-    private int elrElection = 0;
+    private int electionFromElrCounter = 0;
 
     public int fencedBrokersChange() {
         return fencedBrokersChange;
@@ -134,7 +134,7 @@ class ControllerMetricsChanges {
                 uncleanLeaderElection++;
             }
             if (PartitionRegistration.electionFromElr(next.leader, prevElr)) {
-                elrElection++;
+                electionFromElrCounter++;
             }
         }
         globalPartitionsChange += delta(wasPresent, isPresent);
@@ -168,9 +168,9 @@ class ControllerMetricsChanges {
             metrics.updateUncleanLeaderElection(uncleanLeaderElection);
             uncleanLeaderElection = 0;
         }
-        if (elrElection > 0) {
-            metrics.updateEligibleLeaderReplicasElection(elrElection);
-            elrElection = 0;
+        if (electionFromElrCounter > 0) {
+            metrics.updateEligibleLeaderReplicasElection(electionFromElrCounter);
+            electionFromElrCounter = 0;
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -169,6 +169,10 @@ public class PartitionRegistration {
         return newLeader == NO_LEADER || Replicas.contains(isr, newLeader) || Replicas.contains(elr, newLeader);
     }
 
+    public static boolean electionWithElr(int newLeader, int[] elr) {
+        return Replicas.contains(elr, newLeader);
+    }
+
     private static List<Uuid> checkDirectories(PartitionRecord record) {
         if (record.directories() != null && !record.directories().isEmpty() && record.replicas().size() != record.directories().size()) {
             throw new InvalidReplicaDirectoriesException(record);

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -169,7 +169,7 @@ public class PartitionRegistration {
         return newLeader == NO_LEADER || Replicas.contains(isr, newLeader) || Replicas.contains(elr, newLeader);
     }
 
-    public static boolean electionWithElr(int newLeader, int[] elr) {
+    public static boolean electionFromElr(int newLeader, int[] elr) {
         return Replicas.contains(elr, newLeader);
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
@@ -50,7 +50,7 @@ public class ControllerMetadataMetricsTest {
                         "kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount",
                         "kafka.controller:type=KafkaController,name=IgnoredStaticVoters",
                         "kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec",
-                        "kafka.controller:type=ControllerStats,name=EligibleLeaderReplicasElectionsPerSec"
+                        "kafka.controller:type=ControllerStats,name=ElectionFromEligibleLeaderReplicasPerSec"
                     )));
             }
             ControllerMetricsTestUtils.assertMetricsForTypeEqual(registry, "KafkaController",
@@ -198,12 +198,12 @@ public class ControllerMetadataMetricsTest {
     public void testUpdateEligibleLeaderReplicasElection() {
         MetricsRegistry registry = new MetricsRegistry();
         try (ControllerMetadataMetrics metrics = new ControllerMetadataMetrics(Optional.of(registry))) {
-            Meter EligibleLeaderReplicasElectionsPerSec = (Meter) registry
+            Meter ElectionFromEligibleLeaderReplicasPerSec = (Meter) registry
                 .allMetrics()
-                .get(metricName("ControllerStats", "EligibleLeaderReplicasElectionsPerSec"));
-            assertEquals(0, EligibleLeaderReplicasElectionsPerSec.count());
+                .get(metricName("ControllerStats", "ElectionFromEligibleLeaderReplicasPerSec"));
+            assertEquals(0, ElectionFromEligibleLeaderReplicasPerSec.count());
             metrics.updateEligibleLeaderReplicasElection(2);
-            assertEquals(2, EligibleLeaderReplicasElectionsPerSec.count());
+            assertEquals(2, ElectionFromEligibleLeaderReplicasPerSec.count());
         } finally {
             registry.shutdown();
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
@@ -195,14 +195,14 @@ public class ControllerMetadataMetricsTest {
 
     @SuppressWarnings("LocalVariableName")
     @Test
-    public void testUpdateEligibleLeaderReplicasElection() {
+    public void testUpdateElectionFromEligibleLeaderReplicasCount() {
         MetricsRegistry registry = new MetricsRegistry();
         try (ControllerMetadataMetrics metrics = new ControllerMetadataMetrics(Optional.of(registry))) {
             Meter ElectionFromEligibleLeaderReplicasPerSec = (Meter) registry
                 .allMetrics()
                 .get(metricName("ControllerStats", "ElectionFromEligibleLeaderReplicasPerSec"));
             assertEquals(0, ElectionFromEligibleLeaderReplicasPerSec.count());
-            metrics.updateEligibleLeaderReplicasElection(2);
+            metrics.updateElectionFromEligibleLeaderReplicasCount(2);
             assertEquals(2, ElectionFromEligibleLeaderReplicasPerSec.count());
         } finally {
             registry.shutdown();

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
@@ -49,7 +49,8 @@ public class ControllerMetadataMetricsTest {
                         "kafka.controller:type=KafkaController,name=OfflinePartitionsCount",
                         "kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount",
                         "kafka.controller:type=KafkaController,name=IgnoredStaticVoters",
-                        "kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec"
+                        "kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec",
+                        "kafka.controller:type=ControllerStats,name=EligibleLeaderReplicasElectionsPerSec"
                     )));
             }
             ControllerMetricsTestUtils.assertMetricsForTypeEqual(registry, "KafkaController",
@@ -187,6 +188,22 @@ public class ControllerMetadataMetricsTest {
             assertEquals(0, UncleanLeaderElectionsPerSec.count());
             metrics.updateUncleanLeaderElection(2);
             assertEquals(2, UncleanLeaderElectionsPerSec.count());
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    @SuppressWarnings("LocalVariableName")
+    @Test
+    public void testUpdateEligibleLeaderReplicasElection() {
+        MetricsRegistry registry = new MetricsRegistry();
+        try (ControllerMetadataMetrics metrics = new ControllerMetadataMetrics(Optional.of(registry))) {
+            Meter EligibleLeaderReplicasElectionsPerSec = (Meter) registry
+                .allMetrics()
+                .get(metricName("ControllerStats", "EligibleLeaderReplicasElectionsPerSec"));
+            assertEquals(0, EligibleLeaderReplicasElectionsPerSec.count());
+            metrics.updateEligibleLeaderReplicasElection(2);
+            assertEquals(2, EligibleLeaderReplicasElectionsPerSec.count());
         } finally {
             registry.shutdown();
         }

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -66,6 +66,12 @@ public class PartitionRegistrationTest {
     }
 
     @Test
+    public void testEligibleLeaderReplicasElection() {
+        assertTrue(PartitionRegistration.electionWithElr(1, new int[]{1, 2}));
+        assertFalse(PartitionRegistration.electionWithElr(1, new int[]{0, 2}));
+    }
+
+    @Test
     public void testPartitionControlInfoMergeAndDiff() {
         PartitionRegistration a = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -67,8 +67,8 @@ public class PartitionRegistrationTest {
 
     @Test
     public void testEligibleLeaderReplicasElection() {
-        assertTrue(PartitionRegistration.electionWithElr(1, new int[]{1, 2}));
-        assertFalse(PartitionRegistration.electionWithElr(1, new int[]{0, 2}));
+        assertTrue(PartitionRegistration.electionFromElr(1, new int[]{1, 2}));
+        assertFalse(PartitionRegistration.electionFromElr(1, new int[]{0, 2}));
     }
 
     @Test


### PR DESCRIPTION
Add a metric to track the number of election is done using ELR.
https://issues.apache.org/jira/browse/KAFKA-18954

Reviewers: Colin P. McCabe <cmccabe@apache.org>, Justine Olshan <jolshan@confluent.io>