### PR TITLE
KAFKA-18819 StreamsGroupHeartbeat API and StreamsGroupDescribe API  check topic describe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeStreamsGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeStreamsGroupsHandler.java
@@ -238,7 +238,9 @@ public class DescribeStreamsGroupsHandler extends AdminApiHandler.Batched<Coordi
             Set<CoordinatorKey> groupsToUnmap) {
         switch (error) {
             case GROUP_AUTHORIZATION_FAILED:
+            case TOPIC_AUTHORIZATION_FAILED:
                 log.debug("`DescribeStreamsGroups` request for group id {} failed due to error {}", groupId.idValue, error);
+                // The topic auth response received on DescribeStreamsGroup is a generic one not including topic names, so we just pass it on unchanged here.
                 failed.put(groupId, error.exception(errorMsg));
                 break;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeStreamsGroupsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeStreamsGroupsHandler.java
@@ -240,7 +240,6 @@ public class DescribeStreamsGroupsHandler extends AdminApiHandler.Batched<Coordi
             case GROUP_AUTHORIZATION_FAILED:
             case TOPIC_AUTHORIZATION_FAILED:
                 log.debug("`DescribeStreamsGroups` request for group id {} failed due to error {}", groupId.idValue, error);
-                // The topic auth response received on DescribeStreamsGroup is a generic one not including topic names, so we just pass it on unchanged here.
                 failed.put(groupId, error.exception(errorMsg));
                 break;
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeResponse.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * - {@link Errors#INVALID_REQUEST}
  * - {@link Errors#INVALID_GROUP_ID}
  * - {@link Errors#GROUP_ID_NOT_FOUND}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class StreamsGroupDescribeResponse extends AbstractResponse {
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
@@ -43,7 +43,6 @@ import java.util.Map;
  * - {@link Errors#STREAMS_INVALID_TOPOLOGY}
  * - {@link Errors#STREAMS_INVALID_TOPOLOGY_EPOCH}
  * - {@link Errors#STREAMS_TOPOLOGY_FENCED}
- * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class StreamsGroupHeartbeatResponse extends AbstractResponse {
     private final StreamsGroupHeartbeatResponseData data;

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
@@ -43,6 +43,7 @@ import java.util.Map;
  * - {@link Errors#STREAMS_INVALID_TOPOLOGY}
  * - {@link Errors#STREAMS_INVALID_TOPOLOGY_EPOCH}
  * - {@link Errors#STREAMS_TOPOLOGY_FENCED}
+ * - {@link Errors#TOPIC_AUTHORIZATION_FAILED}
  */
 public class StreamsGroupHeartbeatResponse extends AbstractResponse {
     private final StreamsGroupHeartbeatResponseData data;

--- a/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
@@ -27,6 +27,7 @@
   // - INVALID_REQUEST (version 0+)
   // - INVALID_GROUP_ID (version 0+)
   // - GROUP_ID_NOT_FOUND (version 0+)
+  // - TOPIC_AUTHORIZATION_FAILED (version 0+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -30,11 +30,12 @@
   // - FENCED_MEMBER_EPOCH (version 0+)
   // - UNRELEASED_INSTANCE_ID (version 0+)
   // - GROUP_MAX_SIZE_REACHED (version 0+)
-  // - TOPIC_AUTHORIZATION_FAILED (version 0+) 
+  // - TOPIC_AUTHORIZATION_FAILED (version 0+)
   // - CLUSTER_AUTHORIZATION_FAILED (version 0+)
   // - STREAMS_INVALID_TOPOLOGY (version 0+)
   // - STREAMS_INVALID_TOPOLOGY_EPOCH (version 0+)
   // - STREAMS_TOPOLOGY_FENCED (version 0+)
+  // - TOPIC_AUTHORIZATION_FAILED (version 0+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -35,7 +35,6 @@
   // - STREAMS_INVALID_TOPOLOGY (version 0+)
   // - STREAMS_INVALID_TOPOLOGY_EPOCH (version 0+)
   // - STREAMS_TOPOLOGY_FENCED (version 0+)
-  // - TOPIC_AUTHORIZATION_FAILED (version 0+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2697,11 +2697,20 @@ class KafkaApis(val requestChannel: RequestChannel,
           requestHelper.sendMaybeThrottle(request, new StreamsGroupHeartbeatResponse(errorResponse))
           return CompletableFuture.completedFuture[Unit](())
         }
+
+        if (requiredTopics.nonEmpty) {
+          val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC, requiredTopics)(identity)
+          if (authorizedTopics.size < requiredTopics.size) {
+            val responseData = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
+            requestHelper.sendMaybeThrottle(request, new StreamsGroupHeartbeatResponse(responseData))
+            return CompletableFuture.completedFuture[Unit](())
+          }
+        }
       }
 
       groupCoordinator.streamsGroupHeartbeat(
         request.context,
-        streamsGroupHeartbeatRequest.data,
+        streamsGroupHeartbeatRequest.data
       ).handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.sendMaybeThrottle(request, streamsGroupHeartbeatRequest.getErrorResponse(exception))
@@ -2783,6 +2792,46 @@ class KafkaApis(val requestChannel: RequestChannel,
           } else {
             // Otherwise, we have to copy the results into the existing ones.
             response.groups.addAll(results)
+          }
+
+          // Clients are not allowed to see topics that are not authorized for Describe.
+          if (authorizer.isDefined) {
+            val topicsToCheck = response.groups.stream()
+              .flatMap(group => group.topology.subtopologies.stream)
+              .flatMap(subtopology => util.stream.Stream.of(
+                subtopology.sourceTopics,
+                subtopology.repartitionSinkTopics,
+                subtopology.repartitionSourceTopics.iterator.asScala.map(_.name).toList.asJava,
+                subtopology.stateChangelogTopics.iterator.asScala.map(_.name).toList.asJava))
+              .flatMap(_.stream)
+              .collect(Collectors.toSet[String])
+              .asScala
+
+            val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
+              topicsToCheck)(identity)
+
+            val updatedGroups = response.groups.stream.map { group =>
+              val hasUnauthorizedTopic = group.topology.subtopologies.stream()
+                .flatMap(subtopology => util.stream.Stream.of(
+                  subtopology.sourceTopics,
+                  subtopology.repartitionSinkTopics,
+                  subtopology.repartitionSourceTopics.iterator.asScala.map(_.name).toList.asJava,
+                  subtopology.stateChangelogTopics.iterator.asScala.map(_.name).toList.asJava))
+                .flatMap(_.stream)
+                .anyMatch(topic => !authorizedTopics.contains(topic))
+
+              if (hasUnauthorizedTopic) {
+                new StreamsGroupDescribeResponseData.DescribedGroup()
+                  .setGroupId(group.groupId)
+                  .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
+                  .setErrorMessage("The group has described topic(s) that the client is not authorized to describe.")
+                  .setMembers(List.empty.asJava)
+                  .setTopology(null)
+              } else {
+                group
+              }
+            }.collect(Collectors.toList[StreamsGroupDescribeResponseData.DescribedGroup])
+            response.setGroups(updatedGroups)
           }
 
           requestHelper.sendMaybeThrottle(request, new StreamsGroupDescribeResponse(response))

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2797,6 +2797,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           // Clients are not allowed to see topics that are not authorized for Describe.
           if (authorizer.isDefined) {
             val topicsToCheck = response.groups.stream()
+              .filter(group => group.topology != null)
               .flatMap(group => group.topology.subtopologies.stream)
               .flatMap(subtopology => java.util.stream.Stream.concat(
                 java.util.stream.Stream.concat(
@@ -2812,15 +2813,16 @@ class KafkaApis(val requestChannel: RequestChannel,
               topicsToCheck)(identity)
 
               val updatedGroups = response.groups.stream.map { group =>
-                val hasUnauthorizedTopic = group.topology.subtopologies.stream()
-                  .flatMap(subtopology => java.util.stream.Stream.concat(
-                    java.util.stream.Stream.concat(
+                val hasUnauthorizedTopic = if (group.topology == null) false else
+                  group.topology.subtopologies.stream()
+                    .flatMap(subtopology => java.util.stream.Stream.concat(
                       java.util.stream.Stream.concat(
-                        subtopology.sourceTopics.stream,
-                        subtopology.repartitionSinkTopics.stream),
-                      subtopology.repartitionSourceTopics.stream.map(_.name)),
-                    subtopology.stateChangelogTopics.stream.map(_.name)))
-                  .anyMatch(topic => !authorizedTopics.contains(topic))
+                        java.util.stream.Stream.concat(
+                          subtopology.sourceTopics.stream,
+                          subtopology.repartitionSinkTopics.stream),
+                        subtopology.repartitionSourceTopics.stream.map(_.name)),
+                      subtopology.stateChangelogTopics.stream.map(_.name)))
+                    .anyMatch(topic => !authorizedTopics.contains(topic))
 
               if (hasUnauthorizedTopic) {
                 new StreamsGroupDescribeResponseData.DescribedGroup()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2798,33 +2798,35 @@ class KafkaApis(val requestChannel: RequestChannel,
           if (authorizer.isDefined) {
             val topicsToCheck = response.groups.stream()
               .flatMap(group => group.topology.subtopologies.stream)
-              .flatMap(subtopology => util.stream.Stream.of(
-                subtopology.sourceTopics,
-                subtopology.repartitionSinkTopics,
-                subtopology.repartitionSourceTopics.iterator.asScala.map(_.name).toList.asJava,
-                subtopology.stateChangelogTopics.iterator.asScala.map(_.name).toList.asJava))
-              .flatMap(_.stream)
+              .flatMap(subtopology => java.util.stream.Stream.concat(
+                java.util.stream.Stream.concat(
+                  java.util.stream.Stream.concat(
+                    subtopology.sourceTopics.stream,
+                    subtopology.repartitionSinkTopics.stream),
+                  subtopology.repartitionSourceTopics.stream.map(_.name)),
+                subtopology.stateChangelogTopics.stream.map(_.name)))
               .collect(Collectors.toSet[String])
               .asScala
 
             val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
               topicsToCheck)(identity)
 
-            val updatedGroups = response.groups.stream.map { group =>
-              val hasUnauthorizedTopic = group.topology.subtopologies.stream()
-                .flatMap(subtopology => util.stream.Stream.of(
-                  subtopology.sourceTopics,
-                  subtopology.repartitionSinkTopics,
-                  subtopology.repartitionSourceTopics.iterator.asScala.map(_.name).toList.asJava,
-                  subtopology.stateChangelogTopics.iterator.asScala.map(_.name).toList.asJava))
-                .flatMap(_.stream)
-                .anyMatch(topic => !authorizedTopics.contains(topic))
+              val updatedGroups = response.groups.stream.map { group =>
+                val hasUnauthorizedTopic = group.topology.subtopologies.stream()
+                  .flatMap(subtopology => java.util.stream.Stream.concat(
+                    java.util.stream.Stream.concat(
+                      java.util.stream.Stream.concat(
+                        subtopology.sourceTopics.stream,
+                        subtopology.repartitionSinkTopics.stream),
+                      subtopology.repartitionSourceTopics.stream.map(_.name)),
+                    subtopology.stateChangelogTopics.stream.map(_.name)))
+                  .anyMatch(topic => !authorizedTopics.contains(topic))
 
               if (hasUnauthorizedTopic) {
                 new StreamsGroupDescribeResponseData.DescribedGroup()
                   .setGroupId(group.groupId)
                   .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
-                  .setErrorMessage("The group has described topic(s) that the client is not authorized to describe.")
+                  .setErrorMessage("The described group uses topics that the client is not authorized to describe.")
                   .setMembers(List.empty.asJava)
                   .setTopology(null)
               } else {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -10013,15 +10013,17 @@ class KafkaApisTest extends Logging {
     val fooTopicName = "foo"
     val barTopicName = "bar"
     val zarTopicName = "zar"
+    val tarTopicName = "tar"
 
     val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequestData().setGroupId(groupId).setTopology(
       new StreamsGroupHeartbeatRequestData.Topology()
         .setEpoch(3)
         .setSubtopologies(
-          Collections.singletonList(new StreamsGroupHeartbeatRequestData.Subtopology().setSubtopologyId("subtopology")
+          util.List.of(new StreamsGroupHeartbeatRequestData.Subtopology().setSubtopologyId("subtopology")
             .setSourceTopics(Collections.singletonList(fooTopicName))
             .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
             .setRepartitionSourceTopics(Collections.singletonList(new StreamsGroupHeartbeatRequestData.TopicInfo().setName(zarTopicName)))
+            .setStateChangelogTopics(Collections.singletonList(new StreamsGroupHeartbeatRequestData.TopicInfo().setName(tarTopicName)))
           )
         )
     )
@@ -10033,6 +10035,8 @@ class KafkaApisTest extends Logging {
       groupId -> AuthorizationResult.ALLOWED,
       fooTopicName -> AuthorizationResult.ALLOWED,
       barTopicName -> AuthorizationResult.DENIED,
+      zarTopicName -> AuthorizationResult.ALLOWED,
+      tarTopicName -> AuthorizationResult.ALLOWED
     )
     when(authorizer.authorize(
       any[RequestContext],
@@ -10400,16 +10404,16 @@ class KafkaApisTest extends Logging {
     )
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
 
-    val subtotplogy0 = new StreamsGroupDescribeResponseData.Subtopology()
-      .setSubtopologyId("subtotplogy0")
+    val subtopology0 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtopology0")
       .setSourceTopics(Collections.singletonList(fooTopicName))
 
-    val subtotplogy1 = new StreamsGroupDescribeResponseData.Subtopology()
-      .setSubtopologyId("subtotplogy1")
+    val subtopology1 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtopology1")
       .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
 
-    val subtotplogy2 = new StreamsGroupDescribeResponseData.Subtopology()
-      .setSubtopologyId("subtotplogy2")
+    val subtopology2 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtopology2")
       .setSourceTopics(Collections.singletonList(fooTopicName))
       .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
 
@@ -10417,15 +10421,15 @@ class KafkaApisTest extends Logging {
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(0))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy0))),
+          .setSubtopologies(Collections.singletonList(subtopology0))),
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(1))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy1))),
+          .setSubtopologies(Collections.singletonList(subtopology1))),
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(2))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy2)))
+          .setSubtopologies(Collections.singletonList(subtopology2)))
     ).asJava)
 
     var authorizedOperationsInt = Int.MinValue;
@@ -10440,15 +10444,15 @@ class KafkaApisTest extends Logging {
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(0))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy0))),
+          .setSubtopologies(Collections.singletonList(subtopology0))),
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(1))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy1))),
+          .setSubtopologies(Collections.singletonList(subtopology1))),
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(2))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy2)))
+          .setSubtopologies(Collections.singletonList(subtopology2)))
     ).map(group => group.setAuthorizedOperations(authorizedOperationsInt))
     val expectedStreamsGroupDescribeResponseData = new StreamsGroupDescribeResponseData()
       .setGroups(describedGroups.asJava)
@@ -10542,7 +10546,7 @@ class KafkaApisTest extends Logging {
   def testStreamsGroupDescribeFilterUnauthorizedTopics(includeAuthorizedOperations: Boolean): Unit = {
     val fooTopicName = "foo"
     val barTopicName = "bar"
-    val errorMessage = "The group has described topic(s) that the client is not authorized to describe."
+    val errorMessage = "The described group uses topics that the client is not authorized to describe."
 
     metadataCache = mock(classOf[KRaftMetadataCache])
 
@@ -10581,16 +10585,16 @@ class KafkaApisTest extends Logging {
     )
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
 
-    val subtotplogy0 = new StreamsGroupDescribeResponseData.Subtopology()
-      .setSubtopologyId("subtotplogy0")
+    val subtopology0 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtopology0")
       .setSourceTopics(Collections.singletonList(fooTopicName))
 
-    val subtotplogy1 = new StreamsGroupDescribeResponseData.Subtopology()
-      .setSubtopologyId("subtotplogy1")
+    val subtopology1 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtopology1")
       .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
 
-    val subtotplogy2 = new StreamsGroupDescribeResponseData.Subtopology()
-      .setSubtopologyId("subtotplogy2")
+    val subtopology2 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtopology2")
       .setSourceTopics(Collections.singletonList(fooTopicName))
       .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
 
@@ -10598,15 +10602,15 @@ class KafkaApisTest extends Logging {
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(0))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy0))),
+          .setSubtopologies(Collections.singletonList(subtopology0))),
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(1))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy1))),
+          .setSubtopologies(Collections.singletonList(subtopology1))),
       new StreamsGroupDescribeResponseData.DescribedGroup()
         .setGroupId(groupIds.get(2))
         .setTopology(new StreamsGroupDescribeResponseData.Topology()
-          .setSubtopologies(Collections.singletonList(subtotplogy2)))
+          .setSubtopologies(Collections.singletonList(subtopology2)))
     ).asJava)
 
     val response = verifyNoThrottling[StreamsGroupDescribeResponse](requestChannelRequest)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -9986,7 +9986,7 @@ class KafkaApisTest extends Logging {
   }
 
   @Test
-  def testStreamsGroupHeartbeatRequestAuthorizationFailed(): Unit = {
+  def testStreamsGroupHeartbeatRequestGroupAuthorizationFailed(): Unit = {
     metadataCache = mock(classOf[KRaftMetadataCache])
 
     val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequestData().setGroupId("group")
@@ -10004,6 +10004,54 @@ class KafkaApisTest extends Logging {
 
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code, response.data.errorCode)
+  }
+
+  @Test
+  def testStreamsGroupHeartbeatRequestTopicAuthorizationFailed(): Unit = {
+    metadataCache = mock(classOf[KRaftMetadataCache])
+    val groupId = "group"
+    val fooTopicName = "foo"
+    val barTopicName = "bar"
+    val zarTopicName = "zar"
+
+    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequestData().setGroupId(groupId).setTopology(
+      new StreamsGroupHeartbeatRequestData.Topology()
+        .setEpoch(3)
+        .setSubtopologies(
+          Collections.singletonList(new StreamsGroupHeartbeatRequestData.Subtopology().setSubtopologyId("subtopology")
+            .setSourceTopics(Collections.singletonList(fooTopicName))
+            .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
+            .setRepartitionSourceTopics(Collections.singletonList(new StreamsGroupHeartbeatRequestData.TopicInfo().setName(zarTopicName)))
+          )
+        )
+    )
+
+    val requestChannelRequest = buildRequest(new StreamsGroupHeartbeatRequest.Builder(streamsGroupHeartbeatRequest, true).build())
+
+    val authorizer: Authorizer = mock(classOf[Authorizer])
+    val acls = Map(
+      groupId -> AuthorizationResult.ALLOWED,
+      fooTopicName -> AuthorizationResult.ALLOWED,
+      barTopicName -> AuthorizationResult.DENIED,
+    )
+    when(authorizer.authorize(
+      any[RequestContext],
+      any[util.List[Action]]
+    )).thenAnswer { invocation =>
+      val actions = invocation.getArgument(1, classOf[util.List[Action]])
+      actions.asScala.map { action =>
+        acls.getOrElse(action.resourcePattern.name, AuthorizationResult.DENIED)
+      }.asJava
+    }
+
+    kafkaApis = createKafkaApis(
+      authorizer = Some(authorizer),
+      overrideProperties = Map(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG -> "classic,streams")
+    )
+    kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
+
+    val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
+    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED.code, response.data.errorCode)
   }
 
   @Test
@@ -10333,6 +10381,8 @@ class KafkaApisTest extends Logging {
   @ValueSource(booleans = Array(true, false))
   def testStreamsGroupDescribe(includeAuthorizedOperations: Boolean): Unit = {
     metadataCache = mock(classOf[KRaftMetadataCache])
+    val fooTopicName = "foo"
+    val barTopicName = "bar"
 
     val groupIds = List("group-id-0", "group-id-1", "group-id-2").asJava
     val streamsGroupDescribeRequestData = new StreamsGroupDescribeRequestData()
@@ -10350,10 +10400,32 @@ class KafkaApisTest extends Logging {
     )
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
 
+    val subtotplogy0 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtotplogy0")
+      .setSourceTopics(Collections.singletonList(fooTopicName))
+
+    val subtotplogy1 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtotplogy1")
+      .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
+
+    val subtotplogy2 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtotplogy2")
+      .setSourceTopics(Collections.singletonList(fooTopicName))
+      .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
+
     future.complete(List(
-      new StreamsGroupDescribeResponseData.DescribedGroup().setGroupId(groupIds.get(0)),
-      new StreamsGroupDescribeResponseData.DescribedGroup().setGroupId(groupIds.get(1)),
-      new StreamsGroupDescribeResponseData.DescribedGroup().setGroupId(groupIds.get(2))
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(0))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy0))),
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(1))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy1))),
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(2))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy2)))
     ).asJava)
 
     var authorizedOperationsInt = Int.MinValue;
@@ -10365,9 +10437,18 @@ class KafkaApisTest extends Logging {
 
     // Can't reuse the above list here because we would not test the implementation in KafkaApis then
     val describedGroups = List(
-      new StreamsGroupDescribeResponseData.DescribedGroup().setGroupId(groupIds.get(0)),
-      new StreamsGroupDescribeResponseData.DescribedGroup().setGroupId(groupIds.get(1)),
-      new StreamsGroupDescribeResponseData.DescribedGroup().setGroupId(groupIds.get(2))
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(0))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy0))),
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(1))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy1))),
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(2))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy2)))
     ).map(group => group.setAuthorizedOperations(authorizedOperationsInt))
     val expectedStreamsGroupDescribeResponseData = new StreamsGroupDescribeResponseData()
       .setGroups(describedGroups.asJava)
@@ -10454,6 +10535,88 @@ class KafkaApisTest extends Logging {
     future.completeExceptionally(Errors.FENCED_MEMBER_EPOCH.exception)
     val response = verifyNoThrottling[StreamsGroupDescribeResponse](requestChannelRequest)
     assertEquals(Errors.FENCED_MEMBER_EPOCH.code, response.data.groups.get(0).errorCode)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(true, false))
+  def testStreamsGroupDescribeFilterUnauthorizedTopics(includeAuthorizedOperations: Boolean): Unit = {
+    val fooTopicName = "foo"
+    val barTopicName = "bar"
+    val errorMessage = "The group has described topic(s) that the client is not authorized to describe."
+
+    metadataCache = mock(classOf[KRaftMetadataCache])
+
+    val groupIds = List("group-id-0", "group-id-1", "group-id-2").asJava
+    val streamsGroupDescribeRequestData = new StreamsGroupDescribeRequestData()
+      .setIncludeAuthorizedOperations(includeAuthorizedOperations)
+    streamsGroupDescribeRequestData.groupIds.addAll(groupIds)
+    val requestChannelRequest = buildRequest(new StreamsGroupDescribeRequest.Builder(streamsGroupDescribeRequestData, true).build())
+
+    val authorizer: Authorizer = mock(classOf[Authorizer])
+    val acls = Map(
+      groupIds.get(0) -> AuthorizationResult.ALLOWED,
+      groupIds.get(1) -> AuthorizationResult.ALLOWED,
+      groupIds.get(2) -> AuthorizationResult.ALLOWED,
+      fooTopicName    -> AuthorizationResult.ALLOWED,
+      barTopicName    -> AuthorizationResult.DENIED,
+    )
+    when(authorizer.authorize(
+      any[RequestContext],
+      any[util.List[Action]]
+    )).thenAnswer { invocation =>
+      val actions = invocation.getArgument(1, classOf[util.List[Action]])
+      actions.asScala.map { action =>
+        acls.getOrElse(action.resourcePattern.name, AuthorizationResult.DENIED)
+      }.asJava
+    }
+
+    val future = new CompletableFuture[util.List[StreamsGroupDescribeResponseData.DescribedGroup]]()
+    when(groupCoordinator.streamsGroupDescribe(
+      any[RequestContext],
+      any[util.List[String]]
+    )).thenReturn(future)
+    kafkaApis = createKafkaApis(
+      authorizer = Some(authorizer),
+      overrideProperties = Map(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG -> "classic,streams")
+    )
+    kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
+
+    val subtotplogy0 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtotplogy0")
+      .setSourceTopics(Collections.singletonList(fooTopicName))
+
+    val subtotplogy1 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtotplogy1")
+      .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
+
+    val subtotplogy2 = new StreamsGroupDescribeResponseData.Subtopology()
+      .setSubtopologyId("subtotplogy2")
+      .setSourceTopics(Collections.singletonList(fooTopicName))
+      .setRepartitionSinkTopics(Collections.singletonList(barTopicName))
+
+    future.complete(List(
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(0))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy0))),
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(1))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy1))),
+      new StreamsGroupDescribeResponseData.DescribedGroup()
+        .setGroupId(groupIds.get(2))
+        .setTopology(new StreamsGroupDescribeResponseData.Topology()
+          .setSubtopologies(Collections.singletonList(subtotplogy2)))
+    ).asJava)
+
+    val response = verifyNoThrottling[StreamsGroupDescribeResponse](requestChannelRequest)
+    assertNotNull(response.data)
+    assertEquals(3, response.data.groups.size)
+    assertEquals(Errors.NONE.code(), response.data.groups.get(0).errorCode())
+    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED.code(), response.data.groups.get(1).errorCode())
+    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED.code(), response.data.groups.get(2).errorCode())
+    assertEquals(errorMessage, response.data.groups.get(1).errorMessage())
+    assertEquals(errorMessage, response.data.groups.get(2).errorMessage())
   }
 
   @Test


### PR DESCRIPTION
This patch filters out the topic describe unauthorized topics from the StreamsGroupHeartbeat and StreamsGroupDescribe response.