### PR TITLE
MINOR:Add documentation to describe default quotas for user and client-id.

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -489,6 +489,13 @@ Configs for user-principal 'user1' are producer_byte_rate=1024,consumer_byte_rat
   Describe quota for a given client-id:
   <pre><code class="language-bash">$ bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type clients --entity-name clientA
 Configs for client-id 'clientA' are producer_byte_rate=1024,consumer_byte_rate=2048,request_percentage=200</code></pre>
+  Describe default quota for user:
+  <pre><code class="language-bash">$ bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type users --entity-default
+Quota configs for the default user-principal are consumer_byte_rate=2048.0, request_percentage=200.0, producer_byte_rate=1024.0</code></pre>
+  Describe default quota for client-id:
+  <pre><code class="language-bash">$ bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type clients --entity-default
+Quota configs for the default client-id are consumer_byte_rate=2048.0, request_percentage=200.0, producer_byte_rate=1024.0</code></pre>
+
   If entity name is not specified, all entities of the specified type are described. For example, describe all users:
   <pre><code class="language-bash">$ bin/kafka-configs.sh --bootstrap-server localhost:9092 --describe --entity-type users
 Configs for user-principal 'user1' are producer_byte_rate=1024,consumer_byte_rate=2048,request_percentage=200


### PR DESCRIPTION

Add documentation to describe default quotas for user and client-id, which were previously missing.

<img width="769" alt="kkk-01" src="https://github.com/user-attachments/assets/05fb9759-ea46-4211-9185-875e004c4527" />
