### PR TITLE
MINOR: Downgrade log messages of swallowed exception to warnings

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -280,7 +280,8 @@ public class TaskManager {
                     // closing the topology
                     task.prepareCommit();
                 } catch (final RuntimeException swallow) {
-                    log.error("Error flushing cache for corrupted task {} ", task.id(), swallow);
+                    log.warn("Error flushing cache for corrupted task {}. " +
+                        "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
                 }
 
                 try {
@@ -291,7 +292,8 @@ public class TaskManager {
                         task.postCommit(true);
                     }
                 } catch (final RuntimeException swallow) {
-                    log.error("Error suspending corrupted task {} ", task.id(), swallow);
+                    log.warn("Error suspending corrupted task {}. " +
+                        "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
                 }
                 task.closeDirty();
             }
@@ -1473,13 +1475,15 @@ public class TaskManager {
             // before suspending and closing the topology
             task.prepareCommit();
         } catch (final RuntimeException swallow) {
-            log.error("Error flushing caches of dirty task {}", task.id(), swallow);
+            log.warn("Error flushing cache of dirty task {}. " +
+                "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
         }
 
         try {
             task.suspend();
         } catch (final RuntimeException swallow) {
-            log.error("Error suspending dirty task {}: {}", task.id(), swallow.getMessage());
+            log.warn("Error suspending dirty task {}. " +
+                "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
         }
 
         task.closeDirty();
@@ -1489,7 +1493,8 @@ public class TaskManager {
                 tasks.removeTask(task);
             }
         } catch (final RuntimeException swallow) {
-            log.error("Error removing dirty task {}: {}", task.id(), swallow.getMessage());
+            log.warn("Error removing dirty task {}. " +
+                "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -281,7 +281,8 @@ public class TaskManager {
                     task.prepareCommit();
                 } catch (final RuntimeException swallow) {
                     log.warn("Error flushing cache for corrupted task {}. " +
-                        "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
+                        "Since the task is closing dirty, the following exception is swallowed: {}",
+                        task.id(), swallow.getMessage());
                 }
 
                 try {
@@ -293,7 +294,8 @@ public class TaskManager {
                     }
                 } catch (final RuntimeException swallow) {
                     log.warn("Error suspending corrupted task {}. " +
-                        "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
+                        "Since the task is closing dirty, the following exception is swallowed: {}",
+                        task.id(), swallow.getMessage());
                 }
                 task.closeDirty();
             }
@@ -1476,14 +1478,16 @@ public class TaskManager {
             task.prepareCommit();
         } catch (final RuntimeException swallow) {
             log.warn("Error flushing cache of dirty task {}. " +
-                "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
+                "Since the task is closing dirty, the following exception is swallowed: {}",
+                task.id(), swallow.getMessage());
         }
 
         try {
             task.suspend();
         } catch (final RuntimeException swallow) {
             log.warn("Error suspending dirty task {}. " +
-                "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
+                "Since the task is closing dirty, the following exception is swallowed: {}",
+                task.id(), swallow.getMessage());
         }
 
         task.closeDirty();
@@ -1494,7 +1498,8 @@ public class TaskManager {
             }
         } catch (final RuntimeException swallow) {
             log.warn("Error removing dirty task {}. " +
-                "Since the task is closing dirty, the following exception is swallowed: ", task.id(), swallow);
+                "Since the task is closing dirty, the following exception is swallowed: {}",
+                task.id(), swallow);
         }
     }
 


### PR DESCRIPTION
Exceptions that are caught during closing a task dirty are swallowed. The corresponding log messages are on error level which is misleading since the exceptions do not cause any special handling or crash.

This commit downgrades the log messages of swallowed exceptions to warnings and explains in the log messages that the exceptions are swallowed.

Reviewers: Bill Bejeck <bill@confluent.io>