### PR TITLE
KAFKA-18899: Improve handling of timeouts for commitAsync() in ShareConsumer.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -527,8 +527,12 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
      * Enqueue an AcknowledgeRequestState to be picked up on the next poll.
      *
      * @param acknowledgementsMap The acknowledgements to commit
+     * @param deadlineMs          Time until which the request will be retried if it fails with
+     *                            an expected retriable error.
      */
-    public void commitAsync(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap) {
+    public void commitAsync(
+            final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap,
+            final long deadlineMs) {
         final Cluster cluster = metadata.fetch();
         final ResultHandler resultHandler = new ResultHandler(Optional.empty());
 
@@ -552,7 +556,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                             if (asyncRequestState == null) {
                                 acknowledgeRequestStates.get(nodeId).setAsyncRequest(new AcknowledgeRequestState(logContext,
                                         ShareConsumeRequestManager.class.getSimpleName() + ":2",
-                                        Long.MAX_VALUE,
+                                        deadlineMs,
                                         retryBackoffMs,
                                         retryBackoffMaxMs,
                                         sessionHandler,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 
 import org.slf4j.Logger;
@@ -66,6 +67,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+
+import static org.apache.kafka.clients.consumer.internals.TimedRequestState.deadlineTimer;
 
 /**
  * {@code ShareConsumeRequestManager} is responsible for generating {@link ShareFetchRequest} and
@@ -511,7 +514,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 if (!acknowledgementsMapForNode.isEmpty()) {
                     acknowledgeRequestStates.get(nodeId).addSyncRequest(new AcknowledgeRequestState(logContext,
                         ShareConsumeRequestManager.class.getSimpleName() + ":1",
-                        deadlineMs,
+                        deadlineTimer(time, deadlineMs),
                         retryBackoffMs,
                         retryBackoffMaxMs,
                         sessionHandler,
@@ -562,7 +565,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                             if (asyncRequestState == null) {
                                 acknowledgeRequestStates.get(nodeId).setAsyncRequest(new AcknowledgeRequestState(logContext,
                                         ShareConsumeRequestManager.class.getSimpleName() + ":2",
-                                        defaultTimeoutMs,
+                                        time.timer(defaultTimeoutMs),
                                         retryBackoffMs,
                                         retryBackoffMaxMs,
                                         sessionHandler,
@@ -664,7 +667,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                     // There can only be one close() happening at a time. So per node, there will be one acknowledge request state.
                     acknowledgeRequestStates.get(nodeId).setCloseRequest(new AcknowledgeRequestState(logContext,
                             ShareConsumeRequestManager.class.getSimpleName() + ":3",
-                            deadlineMs,
+                            deadlineTimer(time, deadlineMs),
                             retryBackoffMs,
                             retryBackoffMaxMs,
                             sessionHandler,
@@ -1106,7 +1109,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
         AcknowledgeRequestState(LogContext logContext,
                                 String owner,
-                                long timeoutMs,
+                                Timer timer,
                                 long retryBackoffMs,
                                 long retryBackoffMaxMs,
                                 ShareSessionHandler sessionHandler,
@@ -1114,7 +1117,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                 Map<TopicIdPartition, Acknowledgements> acknowledgementsMap,
                                 ResultHandler resultHandler,
                                 AcknowledgeRequestType acknowledgeRequestType) {
-            super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, time.timer(timeoutMs));
+            super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, timer);
             this.sessionHandler = sessionHandler;
             this.nodeId = nodeId;
             this.acknowledgementsToSend = acknowledgementsMap;
@@ -1123,7 +1126,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             this.incompleteAcknowledgements = new HashMap<>();
             this.requestType = acknowledgeRequestType;
             this.isProcessed = false;
-            this.timeoutMs = timeoutMs;
+            this.timeoutMs = timer.timeoutMs();
         }
 
         UnsentRequest buildRequest() {
@@ -1207,7 +1210,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         }
 
         /**
-         * Resets the timer with the new deadline and resets the RequestState.
+         * Resets the timer with the configured timeout and resets the RequestState.
          */
         void resetTimerAndRequestState() {
             resetTimeout(timeoutMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 
 import org.slf4j.Logger;
@@ -67,8 +66,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
-import static org.apache.kafka.clients.consumer.internals.TimedRequestState.deadlineTimer;
 
 /**
  * {@code ShareConsumeRequestManager} is responsible for generating {@link ShareFetchRequest} and
@@ -514,7 +511,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 if (!acknowledgementsMapForNode.isEmpty()) {
                     acknowledgeRequestStates.get(nodeId).addSyncRequest(new AcknowledgeRequestState(logContext,
                         ShareConsumeRequestManager.class.getSimpleName() + ":1",
-                        deadlineTimer(time, deadlineMs),
+                        deadlineMs,
                         retryBackoffMs,
                         retryBackoffMaxMs,
                         sessionHandler,
@@ -536,12 +533,12 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
      * Enqueue an AcknowledgeRequestState to be picked up on the next poll.
      *
      * @param acknowledgementsMap The acknowledgements to commit
-     * @param defaultTimeoutMs    Timeout which would be used when the request is retried, i.e. if it fails with
+     * @param deadlineMs          Time until which the request will be retried if it fails with
      *                            an expected retriable error.
      */
     public void commitAsync(
             final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap,
-            final long defaultTimeoutMs) {
+            final long deadlineMs) {
         final Cluster cluster = metadata.fetch();
         final ResultHandler resultHandler = new ResultHandler(Optional.empty());
 
@@ -565,7 +562,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                             if (asyncRequestState == null) {
                                 acknowledgeRequestStates.get(nodeId).setAsyncRequest(new AcknowledgeRequestState(logContext,
                                         ShareConsumeRequestManager.class.getSimpleName() + ":2",
-                                        time.timer(defaultTimeoutMs),
+                                        deadlineMs,
                                         retryBackoffMs,
                                         retryBackoffMaxMs,
                                         sessionHandler,
@@ -667,7 +664,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                     // There can only be one close() happening at a time. So per node, there will be one acknowledge request state.
                     acknowledgeRequestStates.get(nodeId).setCloseRequest(new AcknowledgeRequestState(logContext,
                             ShareConsumeRequestManager.class.getSimpleName() + ":3",
-                            deadlineTimer(time, deadlineMs),
+                            deadlineMs,
                             retryBackoffMs,
                             retryBackoffMaxMs,
                             sessionHandler,
@@ -1109,7 +1106,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
         AcknowledgeRequestState(LogContext logContext,
                                 String owner,
-                                Timer timer,
+                                long deadlineMs,
                                 long retryBackoffMs,
                                 long retryBackoffMaxMs,
                                 ShareSessionHandler sessionHandler,
@@ -1117,7 +1114,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                 Map<TopicIdPartition, Acknowledgements> acknowledgementsMap,
                                 ResultHandler resultHandler,
                                 AcknowledgeRequestType acknowledgeRequestType) {
-            super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, timer);
+            super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, deadlineTimer(time, deadlineMs));
             this.sessionHandler = sessionHandler;
             this.nodeId = nodeId;
             this.acknowledgementsToSend = acknowledgementsMap;
@@ -1126,7 +1123,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             this.incompleteAcknowledgements = new HashMap<>();
             this.requestType = acknowledgeRequestType;
             this.isProcessed = false;
-            this.timeoutMs = timer.timeoutMs();
+            this.timeoutMs = remainingMs();
         }
 
         UnsentRequest buildRequest() {
@@ -1271,6 +1268,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             processPendingInFlightAcknowledgements(new InvalidRecordStateException(INVALID_RESPONSE));
             resultHandler.completeIfEmpty();
             isProcessed = true;
+            resetTimerAndRequestState();
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -533,12 +533,12 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
      * Enqueue an AcknowledgeRequestState to be picked up on the next poll.
      *
      * @param acknowledgementsMap The acknowledgements to commit
-     * @param deadlineMs          Time until which the request will be retried if it fails with
+     * @param defaultTimeoutMs    Timeout which would be used when the request is retried, i.e. if it fails with
      *                            an expected retriable error.
      */
     public void commitAsync(
             final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap,
-            final long deadlineMs) {
+            final long defaultTimeoutMs) {
         final Cluster cluster = metadata.fetch();
         final ResultHandler resultHandler = new ResultHandler(Optional.empty());
 
@@ -562,7 +562,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                             if (asyncRequestState == null) {
                                 acknowledgeRequestStates.get(nodeId).setAsyncRequest(new AcknowledgeRequestState(logContext,
                                         ShareConsumeRequestManager.class.getSimpleName() + ":2",
-                                        deadlineMs,
+                                        defaultTimeoutMs,
                                         retryBackoffMs,
                                         retryBackoffMaxMs,
                                         sessionHandler,
@@ -1099,11 +1099,14 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          */
         private boolean isProcessed;
 
-        private final long deadlineMs;
+        /**
+         * Timeout in milliseconds indicating how long the request would be retried if it fails with a retriable exception.
+         */
+        private final long timeoutMs;
 
         AcknowledgeRequestState(LogContext logContext,
                                 String owner,
-                                long deadlineMs,
+                                long timeoutMs,
                                 long retryBackoffMs,
                                 long retryBackoffMaxMs,
                                 ShareSessionHandler sessionHandler,
@@ -1111,7 +1114,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                 Map<TopicIdPartition, Acknowledgements> acknowledgementsMap,
                                 ResultHandler resultHandler,
                                 AcknowledgeRequestType acknowledgeRequestType) {
-            super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, deadlineTimer(time, deadlineMs));
+            super(logContext, owner, retryBackoffMs, retryBackoffMaxMs, time.timer(timeoutMs));
             this.sessionHandler = sessionHandler;
             this.nodeId = nodeId;
             this.acknowledgementsToSend = acknowledgementsMap;
@@ -1120,7 +1123,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             this.incompleteAcknowledgements = new HashMap<>();
             this.requestType = acknowledgeRequestType;
             this.isProcessed = false;
-            this.deadlineMs = deadlineMs;
+            this.timeoutMs = timeoutMs;
         }
 
         UnsentRequest buildRequest() {
@@ -1207,7 +1210,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          * Resets the timer with the new deadline and resets the RequestState.
          */
         void resetTimerAndRequestState() {
-            resetDeadline(deadlineMs);
+            resetTimeout(timeoutMs);
             reset();
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -373,7 +373,9 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                                                       AtomicBoolean isAsyncSent) {
         boolean asyncSent = true;
         try {
-            if (acknowledgeRequestState == null || (!acknowledgeRequestState.isCloseRequest() && acknowledgeRequestState.isEmpty())) {
+            if (acknowledgeRequestState == null ||
+                    (!acknowledgeRequestState.isCloseRequest() && acknowledgeRequestState.isEmpty()) ||
+                    (acknowledgeRequestState.isCloseRequest() && acknowledgeRequestState.isProcessed)) {
                 return Optional.empty();
             }
 
@@ -1272,9 +1274,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             resultHandler.completeIfEmpty();
             isProcessed = true;
             maybeResetTimerAndRequestState();
-            if (requestType == AcknowledgeRequestType.CLOSE) {
-                acknowledgeRequestStates.get(nodeId).setCloseRequest(null);
-            }
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -317,6 +317,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                     } else {
                         // Processing the acknowledgements from commitSync
                         for (AcknowledgeRequestState acknowledgeRequestState : requestStates.getValue().getSyncRequestQueue()) {
+                            if (!isNodeFree(nodeId)) {
+                                log.trace("Skipping acknowledge request because previous request to {} has not been processed, so acks are not sent", nodeId);
+                                break;
+                            }
                             maybeBuildRequest(acknowledgeRequestState, currentTimeMs, false, isAsyncSent).ifPresent(unsentRequests::add);
                         }
                     }
@@ -380,6 +384,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                     acknowledgeRequestState.handleAcknowledgeTimedOut(tip);
                 }
                 acknowledgeRequestState.incompleteAcknowledgements.clear();
+                // Reset timer for any future processing on the same request state.
+                acknowledgeRequestState.resetTimerAndRequestState();
                 return Optional.empty();
             }
 
@@ -1008,8 +1014,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
     }
 
     private TopicIdPartition lookupTopicId(Uuid topicId, int partitionIndex) {
-        String topicName = metadata.topicNames().getOrDefault(topicId,
-                topicNamesMap.remove(new IdAndPartition(topicId, partitionIndex)));
+        String topicName = metadata.topicNames().get(topicId);
+        if (topicName == null) {
+            topicName = topicNamesMap.remove(new IdAndPartition(topicId, partitionIndex));
+        }
         if (topicName == null) {
             log.error("Topic name not found in metadata for topicId {} and partitionIndex {}", topicId, partitionIndex);
             return null;
@@ -1091,6 +1099,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
          */
         private boolean isProcessed;
 
+        private final long deadlineMs;
+
         AcknowledgeRequestState(LogContext logContext,
                                 String owner,
                                 long deadlineMs,
@@ -1110,6 +1120,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             this.incompleteAcknowledgements = new HashMap<>();
             this.requestType = acknowledgeRequestType;
             this.isProcessed = false;
+            this.deadlineMs = deadlineMs;
         }
 
         UnsentRequest buildRequest() {
@@ -1190,6 +1201,14 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             return acknowledgementsToSend.isEmpty() &&
                     incompleteAcknowledgements.isEmpty() &&
                     inFlightAcknowledgements.isEmpty();
+        }
+
+        /**
+         * Resets the timer with the new deadline and resets the RequestState.
+         */
+        void resetTimerAndRequestState() {
+            resetDeadline(deadlineMs);
+            reset();
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -385,7 +385,7 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                 }
                 acknowledgeRequestState.incompleteAcknowledgements.clear();
                 // Reset timer for any future processing on the same request state.
-                acknowledgeRequestState.resetTimerAndRequestState();
+                acknowledgeRequestState.maybeResetTimerAndRequestState();
                 return Optional.empty();
             }
 
@@ -1208,10 +1208,13 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
 
         /**
          * Resets the timer with the configured timeout and resets the RequestState.
+         * This is only applicable for commitAsync() requests as these states could be re-used.
          */
-        void resetTimerAndRequestState() {
-            resetTimeout(timeoutMs);
-            reset();
+        void maybeResetTimerAndRequestState() {
+            if (requestType == AcknowledgeRequestType.COMMIT_ASYNC) {
+                resetTimeout(timeoutMs);
+                reset();
+            }
         }
 
         /**
@@ -1268,7 +1271,10 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             processPendingInFlightAcknowledgements(new InvalidRecordStateException(INVALID_RESPONSE));
             resultHandler.completeIfEmpty();
             isProcessed = true;
-            resetTimerAndRequestState();
+            maybeResetTimerAndRequestState();
+            if (requestType == AcknowledgeRequestType.CLOSE) {
+                acknowledgeRequestStates.get(nodeId).setCloseRequest(null);
+            }
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -651,7 +651,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                 applicationEventHandler.wakeupNetworkThread();
             } else if (!acknowledgementsMap.isEmpty()) {
                 // Asynchronously commit any waiting acknowledgements
-                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, defaultApiTimeoutMs));
+                Timer timer = time.timer(defaultApiTimeoutMs);
+                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer)));
 
                 // Notify the network thread to wake up and start the next round of fetching
                 applicationEventHandler.wakeupNetworkThread();
@@ -660,7 +661,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         } else {
             if (!acknowledgementsMap.isEmpty()) {
                 // Asynchronously commit any waiting acknowledgements
-                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, defaultApiTimeoutMs));
+                Timer timer = time.timer(defaultApiTimeoutMs);
+                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer)));
 
                 // Notify the network thread to wake up and start the next round of fetching
                 applicationEventHandler.wakeupNetworkThread();
@@ -758,7 +760,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
 
             Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap = acknowledgementsToSend();
             if (!acknowledgementsMap.isEmpty()) {
-                ShareAcknowledgeAsyncEvent event = new ShareAcknowledgeAsyncEvent(acknowledgementsMap, defaultApiTimeoutMs);
+                Timer timer = time.timer(defaultApiTimeoutMs);
+                ShareAcknowledgeAsyncEvent event = new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer));
                 applicationEventHandler.add(event);
             }
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -201,7 +201,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     private final SubscriptionState subscriptions;
     private final ConsumerMetadata metadata;
     private final Metrics metrics;
-    private final int defaultApiTimeoutMs;
+    private final Duration defaultApiTimeoutMs;
     private volatile boolean closed = false;
     // Init value is needed to avoid NPE in case of exception raised in the constructor
     private Optional<ClientTelemetryReporter> clientTelemetryReporter = Optional.empty();
@@ -250,7 +250,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             this.log = logContext.logger(getClass());
 
             log.debug("Initializing the Kafka share consumer");
-            this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+            this.defaultApiTimeoutMs = Duration.ofMillis(config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
             this.time = time;
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
             this.clientTelemetryReporter = CommonClientConfigs.telemetryReporter(clientId, config);
@@ -369,7 +369,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         this.currentFetch = ShareFetch.empty();
         this.subscriptions = subscriptions;
         this.metadata = metadata;
-        this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+        this.defaultApiTimeoutMs = Duration.ofMillis(config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
         this.acknowledgementMode = initializeAcknowledgementMode(config, log);
         this.fetchBuffer = new ShareFetchBuffer(logContext);
         this.completedAcknowledgements = new LinkedList<>();
@@ -450,7 +450,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                       final Metrics metrics,
                       final SubscriptionState subscriptions,
                       final ConsumerMetadata metadata,
-                      final int defaultApiTimeoutMs,
+                      final Duration defaultApiTimeoutMs,
                       final String groupId) {
         this.log = logContext.logger(getClass());
         this.subscriptions = subscriptions;
@@ -651,7 +651,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                 applicationEventHandler.wakeupNetworkThread();
             } else if (!acknowledgementsMap.isEmpty()) {
                 // Asynchronously commit any waiting acknowledgements
-                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap));
+                Timer timer = time.timer(defaultApiTimeoutMs);
+                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer)));
 
                 // Notify the network thread to wake up and start the next round of fetching
                 applicationEventHandler.wakeupNetworkThread();
@@ -660,7 +661,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         } else {
             if (!acknowledgementsMap.isEmpty()) {
                 // Asynchronously commit any waiting acknowledgements
-                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap));
+                Timer timer = time.timer(defaultApiTimeoutMs);
+                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer)));
 
                 // Notify the network thread to wake up and start the next round of fetching
                 applicationEventHandler.wakeupNetworkThread();
@@ -696,7 +698,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      */
     @Override
     public Map<TopicIdPartition, Optional<KafkaException>> commitSync() {
-        return this.commitSync(Duration.ofMillis(defaultApiTimeoutMs));
+        return this.commitSync(defaultApiTimeoutMs);
     }
 
     /**
@@ -758,7 +760,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
 
             Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap = acknowledgementsToSend();
             if (!acknowledgementsMap.isEmpty()) {
-                ShareAcknowledgeAsyncEvent event = new ShareAcknowledgeAsyncEvent(acknowledgementsMap);
+                Timer timer = time.timer(defaultApiTimeoutMs);
+                ShareAcknowledgeAsyncEvent event = new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer));
                 applicationEventHandler.add(event);
             }
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -201,7 +201,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     private final SubscriptionState subscriptions;
     private final ConsumerMetadata metadata;
     private final Metrics metrics;
-    private final Duration defaultApiTimeoutMs;
+    private final long defaultApiTimeoutMs;
     private volatile boolean closed = false;
     // Init value is needed to avoid NPE in case of exception raised in the constructor
     private Optional<ClientTelemetryReporter> clientTelemetryReporter = Optional.empty();
@@ -250,7 +250,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             this.log = logContext.logger(getClass());
 
             log.debug("Initializing the Kafka share consumer");
-            this.defaultApiTimeoutMs = Duration.ofMillis(config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
+            this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
             this.time = time;
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
             this.clientTelemetryReporter = CommonClientConfigs.telemetryReporter(clientId, config);
@@ -369,7 +369,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         this.currentFetch = ShareFetch.empty();
         this.subscriptions = subscriptions;
         this.metadata = metadata;
-        this.defaultApiTimeoutMs = Duration.ofMillis(config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
+        this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
         this.acknowledgementMode = initializeAcknowledgementMode(config, log);
         this.fetchBuffer = new ShareFetchBuffer(logContext);
         this.completedAcknowledgements = new LinkedList<>();
@@ -450,7 +450,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                       final Metrics metrics,
                       final SubscriptionState subscriptions,
                       final ConsumerMetadata metadata,
-                      final Duration defaultApiTimeoutMs,
+                      final long defaultApiTimeoutMs,
                       final String groupId) {
         this.log = logContext.logger(getClass());
         this.subscriptions = subscriptions;
@@ -651,8 +651,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                 applicationEventHandler.wakeupNetworkThread();
             } else if (!acknowledgementsMap.isEmpty()) {
                 // Asynchronously commit any waiting acknowledgements
-                Timer timer = time.timer(defaultApiTimeoutMs);
-                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer)));
+                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, defaultApiTimeoutMs));
 
                 // Notify the network thread to wake up and start the next round of fetching
                 applicationEventHandler.wakeupNetworkThread();
@@ -661,8 +660,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         } else {
             if (!acknowledgementsMap.isEmpty()) {
                 // Asynchronously commit any waiting acknowledgements
-                Timer timer = time.timer(defaultApiTimeoutMs);
-                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer)));
+                applicationEventHandler.add(new ShareAcknowledgeAsyncEvent(acknowledgementsMap, defaultApiTimeoutMs));
 
                 // Notify the network thread to wake up and start the next round of fetching
                 applicationEventHandler.wakeupNetworkThread();
@@ -698,7 +696,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      */
     @Override
     public Map<TopicIdPartition, Optional<KafkaException>> commitSync() {
-        return this.commitSync(defaultApiTimeoutMs);
+        return this.commitSync(Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     /**
@@ -760,8 +758,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
 
             Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap = acknowledgementsToSend();
             if (!acknowledgementsMap.isEmpty()) {
-                Timer timer = time.timer(defaultApiTimeoutMs);
-                ShareAcknowledgeAsyncEvent event = new ShareAcknowledgeAsyncEvent(acknowledgementsMap, calculateDeadlineMs(timer));
+                ShareAcknowledgeAsyncEvent event = new ShareAcknowledgeAsyncEvent(acknowledgementsMap, defaultApiTimeoutMs);
                 applicationEventHandler.add(event);
             }
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TimedRequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TimedRequestState.java
@@ -53,6 +53,10 @@ public class TimedRequestState extends RequestState {
         return timer.isExpired();
     }
 
+    public void resetDeadline(long deadlineMs) {
+        timer.resetDeadline(deadlineMs);
+    }
+
     public long remainingMs() {
         timer.update();
         return timer.remainingMs();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TimedRequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TimedRequestState.java
@@ -53,8 +53,8 @@ public class TimedRequestState extends RequestState {
         return timer.isExpired();
     }
 
-    public void resetDeadline(long deadlineMs) {
-        timer.resetDeadline(deadlineMs);
+    public void resetTimeout(long timeoutMs) {
+        timer.updateAndReset(timeoutMs);
     }
 
     public long remainingMs() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -508,7 +508,7 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
         }
 
         ShareConsumeRequestManager manager = requestManagers.shareConsumeRequestManager.get();
-        manager.commitAsync(event.acknowledgementsMap());
+        manager.commitAsync(event.acknowledgementsMap(), event.deadlineMs());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -508,7 +508,7 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
         }
 
         ShareConsumeRequestManager manager = requestManagers.shareConsumeRequestManager.get();
-        manager.commitAsync(event.acknowledgementsMap(), event.defaultTimeoutMs());
+        manager.commitAsync(event.acknowledgementsMap(), event.deadlineMs());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -508,7 +508,7 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
         }
 
         ShareConsumeRequestManager manager = requestManagers.shareConsumeRequestManager.get();
-        manager.commitAsync(event.acknowledgementsMap(), event.deadlineMs());
+        manager.commitAsync(event.acknowledgementsMap(), event.defaultTimeoutMs());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
@@ -24,24 +24,24 @@ import java.util.Map;
 public class ShareAcknowledgeAsyncEvent extends ApplicationEvent {
 
     private final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap;
-    private final long deadlineMs;
+    private final long defaultTimeoutMs;
 
-    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap, final long deadlineMs) {
+    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap, final long defaultTimeoutMs) {
         super(Type.SHARE_ACKNOWLEDGE_ASYNC);
         this.acknowledgementsMap = acknowledgementsMap;
-        this.deadlineMs = deadlineMs;
+        this.defaultTimeoutMs = defaultTimeoutMs;
     }
 
     public Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap() {
         return acknowledgementsMap;
     }
 
-    public long deadlineMs() {
-        return deadlineMs;
+    public long defaultTimeoutMs() {
+        return defaultTimeoutMs;
     }
 
     @Override
     protected String toStringBase() {
-        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap + ", deadlineMs=" + deadlineMs;
+        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap + ", defaultTimeoutMs=" + defaultTimeoutMs;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
@@ -24,13 +24,24 @@ import java.util.Map;
 public class ShareAcknowledgeAsyncEvent extends ApplicationEvent {
 
     private final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap;
+    private final long deadlineMs;
 
-    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap) {
+    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap, final long deadlineMs) {
         super(Type.SHARE_ACKNOWLEDGE_ASYNC);
         this.acknowledgementsMap = acknowledgementsMap;
+        this.deadlineMs = deadlineMs;
     }
 
     public Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap() {
         return acknowledgementsMap;
+    }
+
+    public long deadlineMs() {
+        return deadlineMs;
+    }
+
+    @Override
+    protected String toStringBase() {
+        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap + ", deadlineMs=" + deadlineMs;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
@@ -18,30 +18,32 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.NodeAcknowledgements;
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.utils.Timer;
 
 import java.util.Map;
 
 public class ShareAcknowledgeAsyncEvent extends ApplicationEvent {
 
     private final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap;
-    private final long defaultTimeoutMs;
+    private final long deadlineMs;
 
-    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap, final long defaultTimeoutMs) {
+    public ShareAcknowledgeAsyncEvent(final Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap,
+                                      final long deadlineMs) {
         super(Type.SHARE_ACKNOWLEDGE_ASYNC);
         this.acknowledgementsMap = acknowledgementsMap;
-        this.defaultTimeoutMs = defaultTimeoutMs;
+        this.deadlineMs = deadlineMs;
     }
 
     public Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap() {
         return acknowledgementsMap;
     }
 
-    public long defaultTimeoutMs() {
-        return defaultTimeoutMs;
+    public long deadlineMs() {
+        return deadlineMs;
     }
 
     @Override
     protected String toStringBase() {
-        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap + ", defaultTimeoutMs=" + defaultTimeoutMs;
+        return super.toStringBase() + ", acknowledgementsMap=" + acknowledgementsMap + ", deadlineMs=" + deadlineMs;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgeAsyncEvent.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.NodeAcknowledgements;
 import org.apache.kafka.common.TopicIdPartition;
-import org.apache.kafka.common.utils.Timer;
 
 import java.util.Map;
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -156,6 +156,7 @@ public class ShareConsumeRequestManagerTest {
 
     private final long retryBackoffMs = 100;
     private final long requestTimeoutMs = 30000;
+    private final long defaultApiTimeoutMs = 60000;
     private MockTime time = new MockTime(1);
     private SubscriptionState subscriptions;
     private ConsumerMetadata metadata;
@@ -364,7 +365,8 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
         acknowledgements.add(3L, AcknowledgeType.REJECT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -398,14 +400,16 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(1L, AcknowledgeType.ACCEPT);
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
         Acknowledgements acknowledgements2 = Acknowledgements.empty();
         acknowledgements2.add(3L, AcknowledgeType.REJECT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         client.prepareResponse(null, true);
         networkClientDelegate.poll(time.timer(0));
@@ -498,7 +502,8 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
         acknowledgements.add(3L, AcknowledgeType.REJECT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
         shareConsumeRequestManager.acknowledgeOnClose(Collections.emptyMap(),
                 calculateDeadlineMs(time.timer(100)));
 
@@ -657,14 +662,16 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
         acknowledgements.add(3L, AcknowledgeType.REJECT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         Acknowledgements acknowledgements2 = Acknowledgements.empty();
         acknowledgements.add(4L, AcknowledgeType.ACCEPT);
         acknowledgements.add(5L, AcknowledgeType.ACCEPT);
         acknowledgements.add(6L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
 
@@ -700,14 +707,16 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
         acknowledgements.add(3L, AcknowledgeType.REJECT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         Acknowledgements acknowledgements2 = Acknowledgements.empty();
         acknowledgements2.add(4L, AcknowledgeType.ACCEPT);
         acknowledgements2.add(5L, AcknowledgeType.ACCEPT);
         acknowledgements2.add(6L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)), 60000L);
+        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
+                calculateDeadlineMs(time.timer(60000L)));
 
         assertEquals(3, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
         assertEquals(1, shareConsumeRequestManager.requestStates(0).getSyncRequestQueue().size());
@@ -855,7 +864,8 @@ public class ShareConsumeRequestManagerTest {
                 RequestTestUtils.metadataUpdateWithIds(1, Map.of(topicName2, 1),
                         tp -> validLeaderEpoch, topicIds, false));
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -1171,7 +1181,8 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(1L, AcknowledgeType.ACCEPT);
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -1189,7 +1200,8 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgements2 = Acknowledgements.empty();
         acknowledgements2.add(3L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         TestUtils.retryOnExceptionWithTimeout(() -> assertEquals(1, shareConsumeRequestManager.sendAcknowledgements()));
 
@@ -1237,7 +1249,7 @@ public class ShareConsumeRequestManagerTest {
         acks.put(tip0, new NodeAcknowledgements(0, acknowledgements));
         acks.put(t2ip0, new NodeAcknowledgements(0, acknowledgements2));
 
-        shareConsumeRequestManager.commitAsync(acks);
+        shareConsumeRequestManager.commitAsync(acks, calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -1360,7 +1372,8 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgements = Acknowledgements.empty();
         acknowledgements.add(1L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -2101,7 +2114,7 @@ public class ShareConsumeRequestManagerTest {
         assertNotEquals(startingClusterMetadata, metadata.fetch());
 
         // We fail the acknowledgements for records which were received from node0 with NOT_LEADER_OR_FOLLOWER exception.
-        shareConsumeRequestManager.commitAsync(commitAcks);
+        shareConsumeRequestManager.commitAsync(commitAcks, calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
         assertEquals(1, completedAcknowledgements.get(0).size());
         assertEquals(acknowledgementsTp0, completedAcknowledgements.get(0).get(tip0));
         assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.exception(), completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
@@ -2280,7 +2293,8 @@ public class ShareConsumeRequestManagerTest {
         assertNotEquals(startingClusterMetadata, metadata.fetch());
 
         // We fail the acknowledgements for records which were received from node0 with NOT_LEADER_OR_FOLLOWER exception.
-        shareConsumeRequestManager.acknowledgeOnClose(Map.of(tip0, new NodeAcknowledgements(0, acknowledgementsTp0)), calculateDeadlineMs(time.timer(100)));
+        shareConsumeRequestManager.acknowledgeOnClose(Map.of(tip0, new NodeAcknowledgements(0, acknowledgementsTp0)),
+                calculateDeadlineMs(time.timer(100)));
 
         // Verify if the callback was invoked with the failed acknowledgements.
         assertEquals(1, completedAcknowledgements.get(0).size());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -332,7 +332,8 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(2L, AcknowledgeType.ACCEPT);
         acknowledgements.add(3L, AcknowledgeType.REJECT);
 
-        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), time.milliseconds() + 2000);
+        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+                calculateDeadlineMs(time.timer(2000)));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -576,7 +577,7 @@ public class ShareConsumeRequestManagerTest {
         resultHandler.complete(tip0, null, ShareConsumeRequestManager.AcknowledgeRequestType.COMMIT_ASYNC);
         assertEquals(0, completedAcknowledgements.size());
 
-        // Setting isCommitAsync to false should still not send any background event
+        // Setting the request type to COMMIT_SYNC should still not send any background event
         // as we have initialized remainingResults to null.
         resultHandler.complete(tip0, acknowledgements, ShareConsumeRequestManager.AcknowledgeRequestType.COMMIT_SYNC);
         assertEquals(0, completedAcknowledgements.size());
@@ -1142,7 +1143,8 @@ public class ShareConsumeRequestManagerTest {
         acknowledgements.add(5L, AcknowledgeType.RELEASE);
         acknowledgements.add(6L, AcknowledgeType.ACCEPT);
 
-        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), 60000L);
+        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
+            calculateDeadlineMs(time.timer(60000L)));
         assertNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
 
         assertEquals(1, shareConsumeRequestManager.requestStates(0).getSyncRequestQueue().size());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -145,6 +145,7 @@ public class ShareConsumeRequestManagerTest {
             put(topicName2, 1);
         }
     };
+    private final List<AcknowledgeType> acknowledgeTypes = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
     private final TopicPartition tp0 = new TopicPartition(topicName, 0);
     private final TopicIdPartition tip0 = new TopicIdPartition(topicId, tp0);
     private final TopicPartition tp1 = new TopicPartition(topicName, 1);
@@ -328,7 +329,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(2000)));
@@ -359,7 +360,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -392,7 +393,8 @@ public class ShareConsumeRequestManagerTest {
 
         fetchRecords();
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgements = getAcknowledgements(1,
+                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -455,7 +457,7 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
         // Remaining acknowledgements sent with close().
-        Acknowledgements acknowledgements2 = getAcknowledgements(2, 3);
+        Acknowledgements acknowledgements2 = getAcknowledgements(2, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.acknowledgeOnClose(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(100)));
@@ -489,7 +491,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -525,7 +527,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(100)));
@@ -551,7 +553,7 @@ public class ShareConsumeRequestManagerTest {
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         ShareConsumeRequestManager.ResultHandler resultHandler = shareConsumeRequestManager.buildResultHandler(null, Optional.empty());
 
@@ -575,7 +577,7 @@ public class ShareConsumeRequestManagerTest {
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         final CompletableFuture<Map<TopicIdPartition, Acknowledgements>> future = new CompletableFuture<>();
 
@@ -637,12 +639,12 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(4, 6);
+        Acknowledgements acknowledgements2 = getAcknowledgements(4, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -676,12 +678,12 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(4, 6);
+        Acknowledgements acknowledgements2 = getAcknowledgements(4, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(60000L)));
@@ -727,7 +729,9 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 6);
+        List<AcknowledgeType> acknowledgeTypeList = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT,
+                AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypeList.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), 60000L);
         assertNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
@@ -771,7 +775,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgements = getAcknowledgements(1, List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         // commitAsync() acknowledges the first 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
@@ -783,24 +787,24 @@ public class ShareConsumeRequestManagerTest {
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
         assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
 
-        // Response contains a retriable exception, so the we retry.
+        // Response contains a retriable exception, so we retry.
         client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
         networkClientDelegate.poll(time.timer(0));
 
-        Acknowledgements acknowledgements1 = getAcknowledgements(3, 4);
+        Acknowledgements acknowledgements1 = getAcknowledgements(3, List.of(AcknowledgeType.ACCEPT, AcknowledgeType.REJECT).toArray(new AcknowledgeType[0]));
 
         // 2nd commitAsync() acknowledges the next 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
         assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getIncompleteAcknowledgementsCount(tip0));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(5, 6);
+        Acknowledgements acknowledgements2 = getAcknowledgements(5, List.of(AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         // 3rd commitAsync() acknowledges the next 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)), calculateDeadlineMs(time, 1000L));
 
         time.sleep(2000L);
 
-        // As the timer for the initial commitAsync() was 1000ms, the request timed out and we fill the callback with a timeout exception.
+        // As the timer for the initial commitAsync() was 1000ms, the request timed out, and we fill the callback with a timeout exception.
         assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
         assertEquals(1, completedAcknowledgements.size());
         assertEquals(2, completedAcknowledgements.get(0).get(tip0).size());
@@ -837,7 +841,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgements = getAcknowledgements(1, List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         // commitSync() for the first 2 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
@@ -853,7 +857,8 @@ public class ShareConsumeRequestManagerTest {
         // We expire the commitSync request as it had a timer of 1000ms.
         time.sleep(2000L);
 
-        Acknowledgements acknowledgements1 = getAcknowledgements(3, 6);
+        List<AcknowledgeType> acknowledgeTypeList = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.REJECT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements1 = getAcknowledgements(3, acknowledgeTypeList.toArray(new AcknowledgeType[0]));
 
         // commitSync() for the next 4 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
@@ -892,7 +897,8 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgements = getAcknowledgements(1,
+                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         // Reading records from the share fetch buffer.
         fetchRecords();
@@ -936,7 +942,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -978,7 +984,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1020,7 +1026,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1057,7 +1063,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1104,7 +1110,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(0, 2);
+        Acknowledgements acknowledgements = getAcknowledgements(0, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1221,7 +1227,9 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 6);
+        List<AcknowledgeType> acknowledgeTypeList = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT,
+            AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypeList.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
             calculateDeadlineMs(time.timer(60000L)));
@@ -1259,7 +1267,8 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgements = getAcknowledgements(1,
+                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -1315,9 +1324,9 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements2 = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         Map<TopicIdPartition, NodeAcknowledgements> acks = new HashMap<>();
         acks.put(tip0, new NodeAcknowledgements(0, acknowledgements));
@@ -1467,7 +1476,8 @@ public class ShareConsumeRequestManagerTest {
         completedAcknowledgements.clear();
 
         // Send remaining acknowledgements through piggybacking on the next fetch.
-        Acknowledgements acknowledgements1 = getAcknowledgements(2, 3);
+        Acknowledgements acknowledgements1 = getAcknowledgements(2,
+                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.REJECT).toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)));
 
@@ -1517,7 +1527,7 @@ public class ShareConsumeRequestManagerTest {
 
         assignFromSubscribed(singleton(tp0));
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
@@ -2167,7 +2177,8 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgementsTp0 = Acknowledgements.empty();
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
-        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1,
+                        List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         Map<TopicIdPartition, NodeAcknowledgements> commitAcks = new HashMap<>();
         commitAcks.put(tip0, new NodeAcknowledgements(0, acknowledgementsTp0));
@@ -2255,7 +2266,8 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgementsTp0 = Acknowledgements.empty();
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
-        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1,
+                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         Map<TopicIdPartition, NodeAcknowledgements> commitAcks = new HashMap<>();
         commitAcks.put(tip0, new NodeAcknowledgements(0, acknowledgementsTp0));
@@ -2344,7 +2356,8 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgementsTp0 = Acknowledgements.empty();
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
-        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1, 2);
+        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1,
+                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.fetch(Map.of(tip1, new NodeAcknowledgements(1, acknowledgementsTp1)));
 
@@ -2604,10 +2617,11 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(fetch.isEmpty(), reason);
     }
 
-    private Acknowledgements getAcknowledgements(int startIndex, int endIndex) {
+    private Acknowledgements getAcknowledgements(int startIndex, AcknowledgeType... acknowledgeTypes) {
         Acknowledgements acknowledgements = Acknowledgements.empty();
-        for (int i = startIndex; i <= endIndex; i++) {
-            acknowledgements.add(i, AcknowledgeType.ACCEPT);
+        int index = startIndex;
+        for (AcknowledgeType type : acknowledgeTypes) {
+            acknowledgements.add(index++, type);
         }
         return acknowledgements;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -1202,6 +1202,54 @@ public class ShareConsumeRequestManagerTest {
     }
 
     @Test
+    public void testShareFetchAndCloseMultipleNodes() {
+        buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
+
+        subscriptions.subscribeToShareGroup(Collections.singleton(topicName));
+        subscriptions.assignFromSubscribed(List.of(tp0, tp1));
+
+        client.updateMetadata(
+                RequestTestUtils.metadataUpdateWithIds(2, Map.of(topicName, 2),
+                        tp -> validLeaderEpoch, topicIds, false));
+        Node nodeId0 = metadata.fetch().nodeById(0);
+        Node nodeId1 = metadata.fetch().nodeById(1);
+        Node tp0Leader = metadata.fetch().leaderFor(tp0);
+        Node tp1Leader = metadata.fetch().leaderFor(tp1);
+
+        assertEquals(nodeId0, tp0Leader);
+        assertEquals(nodeId1, tp1Leader);
+
+        assertEquals(2, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tip0, records, acquiredRecords, Errors.NONE));
+        client.prepareResponse(fullFetchResponse(tip1, records, acquiredRecords, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements1 = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+
+        Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap = new HashMap<>();
+        acknowledgementsMap.put(tip0, new NodeAcknowledgements(0, acknowledgements));
+        acknowledgementsMap.put(tip1, new NodeAcknowledgements(1, acknowledgements1));
+        shareConsumeRequestManager.acknowledgeOnClose(acknowledgementsMap, calculateDeadlineMs(time, 1000L));
+
+        assertEquals(2, shareConsumeRequestManager.sendAcknowledgements());
+
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));
+        client.prepareResponse(fullAcknowledgeResponse(tip1, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(2, completedAcknowledgements.get(0).size());
+        assertEquals(3, completedAcknowledgements.get(0).get(tip0).size());
+        assertEquals(3, completedAcknowledgements.get(0).get(tip1).size());
+        assertNull(shareConsumeRequestManager.requestStates(0).getCloseRequest());
+        assertNull(shareConsumeRequestManager.requestStates(1).getCloseRequest());
+    }
+
+    @Test
     public void testRetryAcknowledgementsWithLeaderChange() {
         buildRequestManager();
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -144,7 +144,6 @@ public class ShareConsumeRequestManagerTest {
             put(topicName2, 1);
         }
     };
-    private final List<AcknowledgeType> acknowledgeTypes = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
     private final TopicPartition tp0 = new TopicPartition(topicName, 0);
     private final TopicIdPartition tip0 = new TopicIdPartition(topicId, tp0);
     private final TopicPartition tp1 = new TopicPartition(topicName, 1);
@@ -328,7 +327,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(2000)));
@@ -358,7 +357,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -391,7 +390,7 @@ public class ShareConsumeRequestManagerTest {
         fetchRecords();
 
         Acknowledgements acknowledgements = getAcknowledgements(1,
-                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -454,7 +453,7 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
         // Remaining acknowledgements sent with close().
-        Acknowledgements acknowledgements2 = getAcknowledgements(2, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements2 = getAcknowledgements(2, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.acknowledgeOnClose(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(100)));
@@ -488,7 +487,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -523,7 +522,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(100)));
@@ -548,7 +547,7 @@ public class ShareConsumeRequestManagerTest {
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         ShareConsumeRequestManager.ResultHandler resultHandler = shareConsumeRequestManager.buildResultHandler(null, Optional.empty());
 
@@ -572,7 +571,7 @@ public class ShareConsumeRequestManagerTest {
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         final CompletableFuture<Map<TopicIdPartition, Acknowledgements>> future = new CompletableFuture<>();
 
@@ -634,12 +633,12 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(4, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements2 = getAcknowledgements(4, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -673,12 +672,12 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(4, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements2 = getAcknowledgements(4, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(60000L)));
@@ -724,9 +723,8 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        List<AcknowledgeType> acknowledgeTypeList = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT,
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT,
                 AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypeList.toArray(new AcknowledgeType[0]));
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), 60000L);
         assertNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
@@ -770,7 +768,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         // commitAsync() acknowledges the first 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
@@ -784,13 +782,13 @@ public class ShareConsumeRequestManagerTest {
         client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
         networkClientDelegate.poll(time.timer(0));
 
-        Acknowledgements acknowledgements1 = getAcknowledgements(3, List.of(AcknowledgeType.ACCEPT, AcknowledgeType.REJECT).toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements1 = getAcknowledgements(3, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         // 2nd commitAsync() acknowledges the next 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
         assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getIncompleteAcknowledgementsCount(tip0));
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(5, List.of(AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements2 = getAcknowledgements(5, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
 
         // 3rd commitAsync() acknowledges the next 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)), calculateDeadlineMs(time, 1000L));
@@ -833,7 +831,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         // commitSync() for the first 2 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
@@ -884,7 +882,7 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         Acknowledgements acknowledgements = getAcknowledgements(1,
-                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         // Reading records from the share fetch buffer.
         fetchRecords();
@@ -928,7 +926,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -970,7 +968,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1012,7 +1010,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1049,7 +1047,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1093,7 +1091,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(0, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(0, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1205,8 +1203,8 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
-        Acknowledgements acknowledgements1 = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements1 = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         Map<TopicIdPartition, NodeAcknowledgements> acknowledgementsMap = new HashMap<>();
         acknowledgementsMap.put(tip0, new NodeAcknowledgements(0, acknowledgements));
@@ -1347,9 +1345,9 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
-        Acknowledgements acknowledgements2 = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements2 = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         Map<TopicIdPartition, NodeAcknowledgements> acks = new HashMap<>();
         acks.put(tip0, new NodeAcknowledgements(0, acknowledgements));
@@ -1500,7 +1498,7 @@ public class ShareConsumeRequestManagerTest {
 
         // Send remaining acknowledgements through piggybacking on the next fetch.
         Acknowledgements acknowledgements1 = getAcknowledgements(2,
-                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.REJECT).toArray(new AcknowledgeType[0]));
+                AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)));
 
@@ -1550,7 +1548,7 @@ public class ShareConsumeRequestManagerTest {
 
         assignFromSubscribed(singleton(tp0));
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypes.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
@@ -2201,7 +2199,7 @@ public class ShareConsumeRequestManagerTest {
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
         Acknowledgements acknowledgementsTp1 = getAcknowledgements(1,
-                        List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+                        AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         Map<TopicIdPartition, NodeAcknowledgements> commitAcks = new HashMap<>();
         commitAcks.put(tip0, new NodeAcknowledgements(0, acknowledgementsTp0));
@@ -2287,7 +2285,7 @@ public class ShareConsumeRequestManagerTest {
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
         Acknowledgements acknowledgementsTp1 = getAcknowledgements(1,
-                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         Map<TopicIdPartition, NodeAcknowledgements> commitAcks = new HashMap<>();
         commitAcks.put(tip0, new NodeAcknowledgements(0, acknowledgementsTp0));
@@ -2377,7 +2375,7 @@ public class ShareConsumeRequestManagerTest {
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
         Acknowledgements acknowledgementsTp1 = getAcknowledgements(1,
-                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         shareConsumeRequestManager.fetch(Map.of(tip1, new NodeAcknowledgements(1, acknowledgementsTp1)));
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -813,7 +813,6 @@ public class ShareConsumeRequestManagerTest {
 
         // Further requests which came before the timeout are processed as expected.
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
-
         assertEquals(4, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
 
         client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -116,6 +116,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -795,6 +796,194 @@ public class ShareConsumeRequestManagerTest {
     }
 
     @Test
+    public void testRetryAcknowledgementsCommitAsync() throws InterruptedException {
+        buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
+
+        assignFromSubscribed(Collections.singleton(tp0));
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tip0, buildRecords(1L, 6, 1),
+                ShareCompletedFetchTest.acquiredRecords(1L, 6), Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        Acknowledgements acknowledgements = Acknowledgements.empty();
+        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
+        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        acknowledgements.add(4L, AcknowledgeType.ACCEPT);
+        acknowledgements.add(5L, AcknowledgeType.RELEASE);
+        acknowledgements.add(6L, AcknowledgeType.ACCEPT);
+
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
+        assertNull(shareConsumeRequestManager.requestStates(0).getSyncRequestQueue());
+
+        assertNotNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
+        assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
+
+        assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
+        assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
+        // Response contains a retriable exception.
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
+        networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getIncompleteAcknowledgementsCount(tip0));
+        assertEquals(0, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
+
+        // Wait till the request times out.
+        time.sleep(2000L);
+
+        assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
+
+        assertEquals(1, completedAcknowledgements.size());
+        assertEquals(6, completedAcknowledgements.get(0).get(tip0).size());
+        assertEquals(Errors.REQUEST_TIMED_OUT.exception(), completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
+    }
+
+    @Test
+    public void testRetryAcknowledgementsMultipleCommitAsync() {
+        buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
+
+        assignFromSubscribed(Collections.singleton(tp0));
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tip0, buildRecords(1L, 6, 1),
+                ShareCompletedFetchTest.acquiredRecords(1L, 6), Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        Acknowledgements acknowledgements = Acknowledgements.empty();
+        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
+        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+
+        // commitAsync() acknowledges the first 2 records.
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
+        assertNull(shareConsumeRequestManager.requestStates(0).getSyncRequestQueue());
+
+        assertNotNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
+        assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
+
+        assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
+        assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
+
+        // Response contains a retriable exception, so the we retry.
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
+        networkClientDelegate.poll(time.timer(0));
+
+        Acknowledgements acknowledgements1 = Acknowledgements.empty();
+        acknowledgements1.add(3L, AcknowledgeType.REJECT);
+        acknowledgements1.add(4L, AcknowledgeType.ACCEPT);
+
+        // 2nd commitAsync() acknowledges the next 2 records.
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
+
+        assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getIncompleteAcknowledgementsCount(tip0));
+        assertEquals(0, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
+
+
+        Acknowledgements acknowledgements2 = Acknowledgements.empty();
+        acknowledgements2.add(5L, AcknowledgeType.RELEASE);
+        acknowledgements2.add(6L, AcknowledgeType.ACCEPT);
+
+        // 3rd commitAsync() acknowledges the next 2 records.
+        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)), calculateDeadlineMs(time, 1000L));
+
+        time.sleep(2000L);
+
+        // As the timer for the initial commitAsync() was 1000ms, the request timed out and we fill the callback with a timeout exception.
+        assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
+        assertEquals(1, completedAcknowledgements.size());
+        assertEquals(2, completedAcknowledgements.get(0).get(tip0).size());
+        assertEquals(Errors.REQUEST_TIMED_OUT.exception(), completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
+        completedAcknowledgements.clear();
+
+        // Further requests which came before the timeout are processed as expected.
+        assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
+
+        assertEquals(4, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
+
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(0, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
+        assertEquals(1, completedAcknowledgements.size());
+        assertEquals(4, completedAcknowledgements.get(0).get(tip0).size());
+        assertNull(completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
+    }
+
+    @Test
+    public void testRetryAcknowledgementsMultipleCommitSync() throws InterruptedException {
+        buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
+
+        assignFromSubscribed(Collections.singleton(tp0));
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tip0, buildRecords(1L, 6, 1),
+                ShareCompletedFetchTest.acquiredRecords(1L, 6), Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        Acknowledgements acknowledgements = Acknowledgements.empty();
+        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
+        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+
+        // commitSync() for the first 2 acknowledgements.
+        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
+        assertNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
+
+        assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
+
+        // Response contains a retriable exception.
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
+        networkClientDelegate.poll(time.timer(0));
+        assertEquals(2, shareConsumeRequestManager.requestStates(0).getSyncRequestQueue().peek().getIncompleteAcknowledgementsCount(tip0));
+
+        // We expire the commitSync request as it had a timer of 1000ms.
+        time.sleep(2000L);
+
+        Acknowledgements acknowledgements1 = Acknowledgements.empty();
+        acknowledgements1.add(3L, AcknowledgeType.REJECT);
+        acknowledgements1.add(4L, AcknowledgeType.ACCEPT);
+        acknowledgements1.add(5L, AcknowledgeType.ACCEPT);
+        acknowledgements1.add(6L, AcknowledgeType.ACCEPT);
+
+        // commitSync() for the next 4 acknowledgements.
+        shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
+
+        // We send the 2nd commitSync request, and fail the first one as timer has expired.
+        assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
+        assertEquals(1, completedAcknowledgements.size());
+        assertEquals(2, completedAcknowledgements.get(0).get(tip0).size());
+        assertEquals(Errors.REQUEST_TIMED_OUT.exception(), completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
+        completedAcknowledgements.clear();
+
+        // We get a successful response for the 2nd commitSync request.
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(1, completedAcknowledgements.size());
+        assertEquals(4, completedAcknowledgements.get(0).get(tip0).size());
+        assertNull(completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
+
+        // Another call to poll removes the request state from the map.
+        assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
+
+        assertNull(shareConsumeRequestManager.requestStates(0));
+    }
+
+    @Test
     public void testPiggybackAcknowledgementsInFlight() {
         buildRequestManager();
 
@@ -843,6 +1032,7 @@ public class ShareConsumeRequestManagerTest {
     @Test
     public void testCommitAsyncWithSubscriptionChange() {
         buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
         assignFromSubscribed(singleton(tp0));
 
@@ -870,17 +1060,26 @@ public class ShareConsumeRequestManagerTest {
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
-        client.prepareResponse(fullAcknowledgeResponse(t2ip0, Errors.NONE));
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));
         networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(3, completedAcknowledgements.get(0).get(tip0).size());
+        assertNull(completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
 
         // We should send a fetch to the newly subscribed partition.
         assertEquals(1, sendFetches());
 
+        client.prepareResponse(fullFetchResponse(t2ip0, records, acquiredRecords, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        assertEquals(3, fetchRecords().get(t2p0).size());
     }
 
     @Test
     public void testCommitSyncWithSubscriptionChange() {
         buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
         assignFromSubscribed(singleton(tp0));
 
@@ -908,16 +1107,26 @@ public class ShareConsumeRequestManagerTest {
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
-        client.prepareResponse(fullAcknowledgeResponse(t2ip0, Errors.NONE));
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));
         networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(3, completedAcknowledgements.get(0).get(tip0).size());
+        assertNull(completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
 
         // We should send a fetch to the newly subscribed partition.
         assertEquals(1, sendFetches());
+
+        client.prepareResponse(fullFetchResponse(t2ip0, records, acquiredRecords, Errors.NONE));
+        networkClientDelegate.poll(time.timer(0));
+        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
+
+        assertEquals(3, fetchRecords().get(t2p0).size());
     }
 
     @Test
     public void testCloseWithSubscriptionChange() {
         buildRequestManager();
+        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
         assignFromSubscribed(singleton(tp0));
 
@@ -945,8 +1154,11 @@ public class ShareConsumeRequestManagerTest {
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
-        client.prepareResponse(fullAcknowledgeResponse(t2ip0, Errors.NONE));
+        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.NONE));
         networkClientDelegate.poll(time.timer(0));
+
+        assertEquals(3, completedAcknowledgements.get(0).get(tip0).size());
+        assertNull(completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
 
         // As we are closing, we would not send any more fetches.
         assertEquals(0, sendFetches());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -116,7 +116,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -341,7 +340,6 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         assertEquals(Map.of(tip0, acknowledgements), completedAcknowledgements.get(0));
-        completedAcknowledgements.clear();
     }
 
     @Test
@@ -372,7 +370,6 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         assertEquals(Map.of(tip0, acknowledgements), completedAcknowledgements.get(0));
-        completedAcknowledgements.clear();
     }
 
     @Test
@@ -508,7 +505,6 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         assertEquals(Map.of(tip0, acknowledgements), completedAcknowledgements.get(0));
-        completedAcknowledgements.clear();
     }
 
     @Test
@@ -544,7 +540,6 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         assertEquals(Map.of(tip0, acknowledgements), completedAcknowledgements.get(0));
-        completedAcknowledgements.clear();
     }
 
     @Test
@@ -779,9 +774,7 @@ public class ShareConsumeRequestManagerTest {
 
         // commitAsync() acknowledges the first 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
-        assertNull(shareConsumeRequestManager.requestStates(0).getSyncRequestQueue());
 
-        assertNotNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
         assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
@@ -804,7 +797,7 @@ public class ShareConsumeRequestManagerTest {
 
         time.sleep(2000L);
 
-        // As the timer for the initial commitAsync() was 1000ms, the request timed out, and we fill the callback with a timeout exception.
+        // As the timer for the initial commitAsync() was 1000ms, the request times out, and we fill the callback with a timeout exception.
         assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
         assertEquals(1, completedAcknowledgements.size());
         assertEquals(2, completedAcknowledgements.get(0).get(tip0).size());
@@ -844,7 +837,6 @@ public class ShareConsumeRequestManagerTest {
 
         // commitSync() for the first 2 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
-        assertNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
 
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
 
@@ -875,11 +867,6 @@ public class ShareConsumeRequestManagerTest {
         assertEquals(1, completedAcknowledgements.size());
         assertEquals(4, completedAcknowledgements.get(0).get(tip0).size());
         assertNull(completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
-
-        // Another call to poll removes the request state from the map.
-        assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
-
-        assertNull(shareConsumeRequestManager.requestStates(0));
     }
 
     @Test
@@ -1086,9 +1073,6 @@ public class ShareConsumeRequestManagerTest {
         buildRequestManager();
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName));
-        Set<TopicPartition> partitions = new HashSet<>();
-        partitions.add(tp0);
-        partitions.add(tp1);
         subscriptions.assignFromSubscribed(Collections.singletonList(tp0));
 
         client.updateMetadata(
@@ -1212,13 +1196,6 @@ public class ShareConsumeRequestManagerTest {
         client.updateMetadata(
                 RequestTestUtils.metadataUpdateWithIds(2, Map.of(topicName, 2),
                         tp -> validLeaderEpoch, topicIds, false));
-        Node nodeId0 = metadata.fetch().nodeById(0);
-        Node nodeId1 = metadata.fetch().nodeById(1);
-        Node tp0Leader = metadata.fetch().leaderFor(tp0);
-        Node tp1Leader = metadata.fetch().leaderFor(tp1);
-
-        assertEquals(nodeId0, tp0Leader);
-        assertEquals(nodeId1, tp1Leader);
 
         assertEquals(2, sendFetches());
         assertFalse(shareConsumeRequestManager.hasCompletedFetches());
@@ -1242,7 +1219,6 @@ public class ShareConsumeRequestManagerTest {
         client.prepareResponse(fullAcknowledgeResponse(tip1, Errors.NONE));
         networkClientDelegate.poll(time.timer(0));
 
-        assertEquals(2, completedAcknowledgements.get(0).size());
         assertEquals(3, completedAcknowledgements.get(0).get(tip0).size());
         assertEquals(3, completedAcknowledgements.get(0).get(tip1).size());
         assertNull(shareConsumeRequestManager.requestStates(0).getCloseRequest());
@@ -2262,10 +2238,7 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName));
-        Set<TopicPartition> partitions = new HashSet<>();
-        partitions.add(tp0);
-        partitions.add(tp1);
-        subscriptions.assignFromSubscribed(partitions);
+        subscriptions.assignFromSubscribed(List.of(tp0, tp1));
 
         client.updateMetadata(
                 RequestTestUtils.metadataUpdateWithIds(2, Map.of(topicName, 2),
@@ -2557,7 +2530,6 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         assertNull(completedAcknowledgements.get(0).get(tip1).getAcknowledgeException());
-        completedAcknowledgements.clear();
 
         partitionRecords = fetchRecords();
         assertTrue(partitionRecords.containsKey(tp0));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -846,8 +846,7 @@ public class ShareConsumeRequestManagerTest {
         // We expire the commitSync request as it had a timer of 1000ms.
         time.sleep(2000L);
 
-        List<AcknowledgeType> acknowledgeTypeList = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.REJECT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
-        Acknowledgements acknowledgements1 = getAcknowledgements(3, acknowledgeTypeList.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements1 = getAcknowledgements(3, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
 
         // commitSync() for the next 4 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
@@ -1248,9 +1247,8 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        List<AcknowledgeType> acknowledgeTypeList = List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT,
-            AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
-        Acknowledgements acknowledgements = getAcknowledgements(1, acknowledgeTypeList.toArray(new AcknowledgeType[0]));
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT,
+                AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
             calculateDeadlineMs(time.timer(60000L)));
@@ -1289,7 +1287,7 @@ public class ShareConsumeRequestManagerTest {
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
         Acknowledgements acknowledgements = getAcknowledgements(1,
-                List.of(AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT).toArray(new AcknowledgeType[0]));
+                AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -328,10 +328,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(2000)));
@@ -362,10 +359,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -398,9 +392,7 @@ public class ShareConsumeRequestManagerTest {
 
         fetchRecords();
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -463,9 +455,7 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
         // Remaining acknowledgements sent with close().
-        Acknowledgements acknowledgements2 = Acknowledgements.empty();
-        acknowledgements2.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements2.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements2 = getAcknowledgements(2, 3);
 
         shareConsumeRequestManager.acknowledgeOnClose(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(100)));
@@ -499,10 +489,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -538,10 +525,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(100)));
@@ -567,10 +551,7 @@ public class ShareConsumeRequestManagerTest {
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         ShareConsumeRequestManager.ResultHandler resultHandler = shareConsumeRequestManager.buildResultHandler(null, Optional.empty());
 
@@ -594,10 +575,7 @@ public class ShareConsumeRequestManagerTest {
         // Enabling the config so that background event is sent when the acknowledgement response is received.
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         final CompletableFuture<Map<TopicIdPartition, Acknowledgements>> future = new CompletableFuture<>();
 
@@ -659,18 +637,12 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
-        Acknowledgements acknowledgements2 = Acknowledgements.empty();
-        acknowledgements.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(5L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(6L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements2 = getAcknowledgements(4, 6);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -704,18 +676,12 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
 
-        Acknowledgements acknowledgements2 = Acknowledgements.empty();
-        acknowledgements2.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements2.add(5L, AcknowledgeType.ACCEPT);
-        acknowledgements2.add(6L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements2 = getAcknowledgements(4, 6);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(60000L)));
@@ -761,13 +727,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
-        acknowledgements.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(5L, AcknowledgeType.RELEASE);
-        acknowledgements.add(6L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 6);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), 60000L);
         assertNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
@@ -796,55 +756,6 @@ public class ShareConsumeRequestManagerTest {
     }
 
     @Test
-    public void testRetryAcknowledgementsCommitAsync() throws InterruptedException {
-        buildRequestManager();
-        shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
-
-        assignFromSubscribed(Collections.singleton(tp0));
-
-        // normal fetch
-        assertEquals(1, sendFetches());
-        assertFalse(shareConsumeRequestManager.hasCompletedFetches());
-
-        client.prepareResponse(fullFetchResponse(tip0, buildRecords(1L, 6, 1),
-                ShareCompletedFetchTest.acquiredRecords(1L, 6), Errors.NONE));
-        networkClientDelegate.poll(time.timer(0));
-        assertTrue(shareConsumeRequestManager.hasCompletedFetches());
-
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
-        acknowledgements.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(5L, AcknowledgeType.RELEASE);
-        acknowledgements.add(6L, AcknowledgeType.ACCEPT);
-
-        shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
-        assertNull(shareConsumeRequestManager.requestStates(0).getSyncRequestQueue());
-
-        assertNotNull(shareConsumeRequestManager.requestStates(0).getAsyncRequest());
-        assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getAcknowledgementsToSendCount(tip0));
-
-        assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
-        assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
-        // Response contains a retriable exception.
-        client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
-        networkClientDelegate.poll(time.timer(0));
-
-        assertEquals(6, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getIncompleteAcknowledgementsCount(tip0));
-        assertEquals(0, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
-
-        // Wait till the request times out.
-        time.sleep(2000L);
-
-        assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
-
-        assertEquals(1, completedAcknowledgements.size());
-        assertEquals(6, completedAcknowledgements.get(0).get(tip0).size());
-        assertEquals(Errors.REQUEST_TIMED_OUT.exception(), completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
-    }
-
-    @Test
     public void testRetryAcknowledgementsMultipleCommitAsync() {
         buildRequestManager();
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
@@ -860,9 +771,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
 
         // commitAsync() acknowledges the first 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
@@ -878,20 +787,13 @@ public class ShareConsumeRequestManagerTest {
         client.prepareResponse(fullAcknowledgeResponse(tip0, Errors.REQUEST_TIMED_OUT));
         networkClientDelegate.poll(time.timer(0));
 
-        Acknowledgements acknowledgements1 = Acknowledgements.empty();
-        acknowledgements1.add(3L, AcknowledgeType.REJECT);
-        acknowledgements1.add(4L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements1 = getAcknowledgements(3, 4);
 
         // 2nd commitAsync() acknowledges the next 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
-
         assertEquals(2, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getIncompleteAcknowledgementsCount(tip0));
-        assertEquals(0, shareConsumeRequestManager.requestStates(0).getAsyncRequest().getInFlightAcknowledgementsCount(tip0));
 
-
-        Acknowledgements acknowledgements2 = Acknowledgements.empty();
-        acknowledgements2.add(5L, AcknowledgeType.RELEASE);
-        acknowledgements2.add(6L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements2 = getAcknowledgements(5, 6);
 
         // 3rd commitAsync() acknowledges the next 2 records.
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)), calculateDeadlineMs(time, 1000L));
@@ -920,7 +822,7 @@ public class ShareConsumeRequestManagerTest {
     }
 
     @Test
-    public void testRetryAcknowledgementsMultipleCommitSync() throws InterruptedException {
+    public void testRetryAcknowledgementsMultipleCommitSync() {
         buildRequestManager();
         shareConsumeRequestManager.setAcknowledgementCommitCallbackRegistered(true);
 
@@ -935,9 +837,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
 
         // commitSync() for the first 2 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)), calculateDeadlineMs(time, 1000L));
@@ -953,18 +853,13 @@ public class ShareConsumeRequestManagerTest {
         // We expire the commitSync request as it had a timer of 1000ms.
         time.sleep(2000L);
 
-        Acknowledgements acknowledgements1 = Acknowledgements.empty();
-        acknowledgements1.add(3L, AcknowledgeType.REJECT);
-        acknowledgements1.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements1.add(5L, AcknowledgeType.ACCEPT);
-        acknowledgements1.add(6L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements1 = getAcknowledgements(3, 6);
 
         // commitSync() for the next 4 acknowledgements.
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)), calculateDeadlineMs(time, 1000L));
 
         // We send the 2nd commitSync request, and fail the first one as timer has expired.
         assertEquals(1, shareConsumeRequestManager.sendAcknowledgements());
-        assertEquals(1, completedAcknowledgements.size());
         assertEquals(2, completedAcknowledgements.get(0).get(tip0).size());
         assertEquals(Errors.REQUEST_TIMED_OUT.exception(), completedAcknowledgements.get(0).get(tip0).getAcknowledgeException());
         completedAcknowledgements.clear();
@@ -997,9 +892,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
 
         // Reading records from the share fetch buffer.
         fetchRecords();
@@ -1043,10 +936,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1072,8 +962,6 @@ public class ShareConsumeRequestManagerTest {
         client.prepareResponse(fullFetchResponse(t2ip0, records, acquiredRecords, Errors.NONE));
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
-
-        assertEquals(3, fetchRecords().get(t2p0).size());
     }
 
     @Test
@@ -1090,10 +978,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1119,8 +1004,6 @@ public class ShareConsumeRequestManagerTest {
         client.prepareResponse(fullFetchResponse(t2ip0, records, acquiredRecords, Errors.NONE));
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
-
-        assertEquals(3, fetchRecords().get(t2p0).size());
     }
 
     @Test
@@ -1137,10 +1020,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         subscriptions.subscribeToShareGroup(Collections.singleton(topicName2));
         subscriptions.assignFromSubscribed(Collections.singleton(t2p0));
@@ -1177,10 +1057,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(0L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(1L, AcknowledgeType.RELEASE);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1227,10 +1104,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(0L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(1L, AcknowledgeType.RELEASE);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(0, 2);
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1347,13 +1221,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
-        acknowledgements.add(4L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(5L, AcknowledgeType.RELEASE);
-        acknowledgements.add(6L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 6);
 
         shareConsumeRequestManager.commitSync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
             calculateDeadlineMs(time.timer(60000L)));
@@ -1391,9 +1259,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 2);
 
         shareConsumeRequestManager.commitAsync(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)),
                 calculateDeadlineMs(time.timer(defaultApiTimeoutMs)));
@@ -1449,15 +1315,9 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(0L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
-        Acknowledgements acknowledgements2 = Acknowledgements.empty();
-        acknowledgements2.add(0L, AcknowledgeType.ACCEPT);
-        acknowledgements2.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements2.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgements2 = getAcknowledgements(1, 3);
 
         Map<TopicIdPartition, NodeAcknowledgements> acks = new HashMap<>();
         acks.put(tip0, new NodeAcknowledgements(0, acknowledgements));
@@ -1607,9 +1467,7 @@ public class ShareConsumeRequestManagerTest {
         completedAcknowledgements.clear();
 
         // Send remaining acknowledgements through piggybacking on the next fetch.
-        Acknowledgements acknowledgements1 = Acknowledgements.empty();
-        acknowledgements1.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements1.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements1 = getAcknowledgements(2, 3);
 
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements1)));
 
@@ -1659,10 +1517,7 @@ public class ShareConsumeRequestManagerTest {
 
         assignFromSubscribed(singleton(tp0));
 
-        Acknowledgements acknowledgements = Acknowledgements.empty();
-        acknowledgements.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(2L, AcknowledgeType.ACCEPT);
-        acknowledgements.add(3L, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, 3);
 
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
@@ -2312,9 +2167,7 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgementsTp0 = Acknowledgements.empty();
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
-        Acknowledgements acknowledgementsTp1 = Acknowledgements.empty();
-        acknowledgementsTp1.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgementsTp1.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1, 2);
 
         Map<TopicIdPartition, NodeAcknowledgements> commitAcks = new HashMap<>();
         commitAcks.put(tip0, new NodeAcknowledgements(0, acknowledgementsTp0));
@@ -2402,9 +2255,7 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgementsTp0 = Acknowledgements.empty();
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
-        Acknowledgements acknowledgementsTp1 = Acknowledgements.empty();
-        acknowledgementsTp1.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgementsTp1.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1, 2);
 
         Map<TopicIdPartition, NodeAcknowledgements> commitAcks = new HashMap<>();
         commitAcks.put(tip0, new NodeAcknowledgements(0, acknowledgementsTp0));
@@ -2493,9 +2344,7 @@ public class ShareConsumeRequestManagerTest {
         Acknowledgements acknowledgementsTp0 = Acknowledgements.empty();
         acknowledgementsTp0.add(1L, AcknowledgeType.ACCEPT);
 
-        Acknowledgements acknowledgementsTp1 = Acknowledgements.empty();
-        acknowledgementsTp1.add(1L, AcknowledgeType.ACCEPT);
-        acknowledgementsTp1.add(2L, AcknowledgeType.ACCEPT);
+        Acknowledgements acknowledgementsTp1 = getAcknowledgements(1, 2);
 
         shareConsumeRequestManager.fetch(Map.of(tip1, new NodeAcknowledgements(1, acknowledgementsTp1)));
 
@@ -2753,6 +2602,14 @@ public class ShareConsumeRequestManagerTest {
         ShareFetch<?, ?> fetch = collectFetch();
         assertEquals(Collections.emptyMap(), fetch.records(), reason);
         assertTrue(fetch.isEmpty(), reason);
+    }
+
+    private Acknowledgements getAcknowledgements(int startIndex, int endIndex) {
+        Acknowledgements acknowledgements = Acknowledgements.empty();
+        for (int i = startIndex; i <= endIndex; i++) {
+            acknowledgements.add(i, AcknowledgeType.ACCEPT);
+        }
+        return acknowledgements;
     }
 
     private <K, V> Map<TopicPartition, List<ConsumerRecord<K, V>>> fetchRecords() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -453,7 +453,7 @@ public class ShareConsumeRequestManagerTest {
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
 
         // Remaining acknowledgements sent with close().
-        Acknowledgements acknowledgements2 = getAcknowledgements(2, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements2 = getAcknowledgements(2, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
 
         shareConsumeRequestManager.acknowledgeOnClose(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements2)),
                 calculateDeadlineMs(time.timer(100)));
@@ -1046,7 +1046,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(1, AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1090,7 +1090,7 @@ public class ShareConsumeRequestManagerTest {
         networkClientDelegate.poll(time.timer(0));
         assertTrue(shareConsumeRequestManager.hasCompletedFetches());
 
-        Acknowledgements acknowledgements = getAcknowledgements(0, AcknowledgeType.ACCEPT, AcknowledgeType.ACCEPT, AcknowledgeType.REJECT);
+        Acknowledgements acknowledgements = getAcknowledgements(0, AcknowledgeType.ACCEPT, AcknowledgeType.RELEASE, AcknowledgeType.ACCEPT);
 
         // Send acknowledgements via ShareFetch
         shareConsumeRequestManager.fetch(Map.of(tip0, new NodeAcknowledgements(0, acknowledgements)));
@@ -1218,8 +1218,10 @@ public class ShareConsumeRequestManagerTest {
 
         assertEquals(3, completedAcknowledgements.get(0).get(tip0).size());
         assertEquals(3, completedAcknowledgements.get(0).get(tip1).size());
-        assertNull(shareConsumeRequestManager.requestStates(0).getCloseRequest());
-        assertNull(shareConsumeRequestManager.requestStates(1).getCloseRequest());
+
+        assertEquals(0, shareConsumeRequestManager.sendAcknowledgements());
+        assertNull(shareConsumeRequestManager.requestStates(0));
+        assertNull(shareConsumeRequestManager.requestStates(1));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -164,7 +164,7 @@ public class ShareConsumerImplTest {
                 new Metrics(),
                 subscriptions,
                 metadata,
-                Duration.ofMillis(defaultApiTimeoutMs),
+                defaultApiTimeoutMs,
                 groupId
         );
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -164,7 +164,7 @@ public class ShareConsumerImplTest {
                 new Metrics(),
                 subscriptions,
                 metadata,
-                defaultApiTimeoutMs,
+                Duration.ofMillis(defaultApiTimeoutMs),
                 groupId
         );
     }


### PR DESCRIPTION
*What*

- Previously, the `ShareConsumer.commitAsync()` method retried sending `ShareAcknowledge` requests

indefinitely. Now it will instead use the defaultApiTimeout config to expire the request so that it does not retry forever.

- PR also fixes a bug in processing `commitSync() `requests, where we need an additional check if the node is free.

- Added unit tests to verify the above changes.