### PR TITLE
KAFKA-18966: Change controller_num_nodes_override to override_num_isolated_controllers

### DIFF
--- a/tests/kafkatest/sanity_checks/test_bounce.py
+++ b/tests/kafkatest/sanity_checks/test_bounce.py
@@ -36,7 +36,7 @@ class TestBounce(Test):
         num_kafka_nodes = quorum_size if quorum.for_test(test_context) == quorum.combined_kraft else 1
         self.kafka = KafkaService(test_context, num_nodes=num_kafka_nodes, zk=None,
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}},
-                                  controller_num_nodes_override=quorum_size)
+                                  override_num_isolated_controllers=quorum_size)
         self.num_messages = 1000
 
     def create_producer(self):

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -239,7 +239,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 The value passed in is determined by the broker service when that is instantiated, and it uses the
                 same algorithm as described above: 1, 3, or 5 unless override_num_isolated_controllers is provided.
             5) In Combined KRaft quorum mode, the controller node count tries to be at least 3 unless the broker count is
-                less than 3.
+                less than 3(then only 1 controller node).
         :param ZookeeperService zk:
         :param dict topics: which topics to create automatically
         :param str security_protocol: security protocol for clients to use

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -200,7 +200,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  listener_security_config=ListenerSecurityConfig(), per_node_server_prop_overrides=None,
                  extra_kafka_opts="", tls_version=None,
                  isolated_kafka=None,
-                 controller_num_nodes_override=0,
+                 override_num_isolated_controllers=0,
                  allow_zk_with_kraft=False,
                  quorum_info_provider=None,
                  use_new_coordinator=None,
@@ -219,8 +219,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 The number of nodes having a broker role is defined by this parameter.
                 The node.id values will be 1..num_nodes
                 The number of nodes having a controller role will by default be 1, 3, or 5 depending on num_nodes
-                (1 if num_nodes < 3, otherwise 3 if num_nodes < 5, otherwise 5).  This calculation
-                can be overridden via controller_num_nodes_override, which must be between 1 and num_nodes,
+                (1 if num_nodes < 3, otherwise 3 if num_nodes < 5, otherwise 5).
                 inclusive, when non-zero.  Here are some possibilities:
                 num_nodes = 1:
                     broker having node.id=1: broker.roles=broker+controller
@@ -238,7 +237,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 The number of nodes, all of which will have broker.roles=controller, is defined by this parameter.
                 The node.id values will be 3001..(3000 + num_nodes)
                 The value passed in is determined by the broker service when that is instantiated, and it uses the
-                same algorithm as described above: 1, 3, or 5 unless controller_num_nodes_override is provided.
+                same algorithm as described above: 1, 3, or 5 unless override_num_isolated_controllers is provided.
             5) In Combined KRaft quorum mode, the controller node count tries to be at least 3 unless the broker count is
                 less than 3.
         :param ZookeeperService zk:
@@ -263,8 +262,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             e.g: {1: [["config1", "true"], ["config2", "1000"]], 2: [["config1", "false"], ["config2", "0"]]}
         :param str extra_kafka_opts: jvm args to add to KAFKA_OPTS variable
         :param KafkaService isolated_kafka: process.roles=controller for this cluster when not None; ignored when using ZooKeeper
-        :param int controller_num_nodes_override: the number of controller nodes to use in the cluster, instead of 5, 3, or 1 based on num_nodes, if positive, not using ZooKeeper, and isolated_kafka is not None; ignored otherwise
-                Also, in the Combined KRaft mode, the controller node count tries to be at least 3 unless the broker count is less than 3.
+        :param int override_num_isolated_controllers: the number of controller nodes to use in the cluster, instead of 5, 3, or 1 based on num_nodes, if positive, not using ZooKeeper, and isolated_kafka is not None; ignored otherwise
         :param bool allow_zk_with_kraft: if True, then allow a KRaft broker or controller to also use ZooKeeper
         :param quorum_info_provider: A function that takes this KafkaService as an argument and returns a ServiceQuorumInfo. If this is None, then the ServiceQuorumInfo is generated from the test context
         :param use_new_coordinator: When true, use the new implementation of the group coordinator as per KIP-848. If this is None, the default existing group coordinator is used.
@@ -328,9 +326,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.standalone_controller_bootstrapped = False
             if self.quorum_info.has_brokers:
                 num_nodes_broker_role = num_nodes
-                controller_num_nodes_override = min(num_nodes_broker_role, max(3, controller_num_nodes_override))
                 if self.quorum_info.has_controllers:
-                    self.num_nodes_controller_role = self.num_kraft_controllers(num_nodes_broker_role, controller_num_nodes_override)
+                    self.num_nodes_controller_role = self.num_kraft_controllers(num_nodes_broker_role, 0)
                     if self.isolated_kafka:
                         raise Exception("Must not specify isolated Kafka service with combined Controller quorum")
             else:
@@ -356,7 +353,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             if self.quorum_info.has_controllers:
                 self.controller_quorum = self
             else:
-                num_isolated_controller_nodes = self.num_kraft_controllers(num_nodes, controller_num_nodes_override)
+                num_isolated_controller_nodes = self.num_kraft_controllers(num_nodes, override_num_isolated_controllers)
                 self.isolated_controller_quorum = KafkaService(
                     context, num_isolated_controller_nodes, self.zk, security_protocol=self.controller_security_protocol,
                     interbroker_security_protocol=self.intercontroller_security_protocol,

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -231,10 +231,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     broker having node.id=1: broker.roles=broker+controller
                     broker having node.id=2: broker.roles=broker+controller
                     broker having node.id=3: broker.roles=broker+controller
-                num_nodes = 3, controller_num_nodes_override = 1
-                    broker having node.id=1: broker.roles=broker+controller
-                    broker having node.id=2: broker.roles=broker
-                    broker having node.id=3: broker.roles=broker
             3) Isolated KRaft quorum when instantiating the broker service:
                 The number of nodes, all of which will have broker.roles=broker, is defined by this parameter.
                 The node.id values will be 1..num_nodes
@@ -243,6 +239,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 The node.id values will be 3001..(3000 + num_nodes)
                 The value passed in is determined by the broker service when that is instantiated, and it uses the
                 same algorithm as described above: 1, 3, or 5 unless controller_num_nodes_override is provided.
+            5) In Combined KRaft quorum mode, the controller node count tries to be at least 3 unless the broker count is
+                less than 3.
         :param ZookeeperService zk:
         :param dict topics: which topics to create automatically
         :param str security_protocol: security protocol for clients to use
@@ -266,6 +264,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         :param str extra_kafka_opts: jvm args to add to KAFKA_OPTS variable
         :param KafkaService isolated_kafka: process.roles=controller for this cluster when not None; ignored when using ZooKeeper
         :param int controller_num_nodes_override: the number of controller nodes to use in the cluster, instead of 5, 3, or 1 based on num_nodes, if positive, not using ZooKeeper, and isolated_kafka is not None; ignored otherwise
+                Also, in the Combined KRaft mode, the controller node count tries to be at least 3 unless the broker count is less than 3.
         :param bool allow_zk_with_kraft: if True, then allow a KRaft broker or controller to also use ZooKeeper
         :param quorum_info_provider: A function that takes this KafkaService as an argument and returns a ServiceQuorumInfo. If this is None, then the ServiceQuorumInfo is generated from the test context
         :param use_new_coordinator: When true, use the new implementation of the group coordinator as per KIP-848. If this is None, the default existing group coordinator is used.
@@ -329,6 +328,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             self.standalone_controller_bootstrapped = False
             if self.quorum_info.has_brokers:
                 num_nodes_broker_role = num_nodes
+                controller_num_nodes_override = min(num_nodes_broker_role, max(3, controller_num_nodes_override))
                 if self.quorum_info.has_controllers:
                     self.num_nodes_controller_role = self.num_kraft_controllers(num_nodes_broker_role, controller_num_nodes_override)
                     if self.isolated_kafka:

--- a/tests/kafkatest/tests/core/authorizer_test.py
+++ b/tests/kafkatest/tests/core/authorizer_test.py
@@ -47,7 +47,7 @@ class AuthorizerTest(Test):
         topics = {"test_topic": {"partitions": 1, "replication-factor": 1}}
 
         self.kafka = KafkaService(self.test_context, num_nodes=1, zk=None,
-                                  topics=topics, controller_num_nodes_override=1)
+                                  topics=topics, override_num_isolated_controllers=1)
 
         broker_security_protocol = "SSL"
         broker_principal = "User:CN=systemtest"

--- a/tests/kafkatest/tests/core/compatibility_test_new_broker_test.py
+++ b/tests/kafkatest/tests/core/compatibility_test_new_broker_test.py
@@ -66,7 +66,7 @@ class ClientCompatibilityTestNewBroker(ProduceConsumeValidateTest):
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,
                                                                     'configs': {"min.insync.replicas": 2}}},
-                                  controller_num_nodes_override=1)
+                                  override_num_isolated_controllers=1)
         for node in self.kafka.nodes:
             if timestamp_type is not None:
                 node.config[config_property.MESSAGE_TIMESTAMP_TYPE] = timestamp_type

--- a/tests/kafkatest/tests/core/consumer_group_command_test.py
+++ b/tests/kafkatest/tests/core/consumer_group_command_test.py
@@ -49,7 +49,7 @@ class ConsumerGroupCommandTest(Test):
             self.test_context, self.num_brokers,
             None, security_protocol=security_protocol,
             interbroker_security_protocol=interbroker_security_protocol, topics=self.topics,
-            controller_num_nodes_override=self.num_brokers)
+            override_num_isolated_controllers=self.num_brokers)
         self.kafka.start()
 
     def start_consumer(self, group_protocol=None):

--- a/tests/kafkatest/tests/core/controller_mutation_quota_test.py
+++ b/tests/kafkatest/tests/core/controller_mutation_quota_test.py
@@ -54,7 +54,7 @@ class ControllerMutationQuotaTest(Test):
                 ["quota.window.num", "%s" % self.window_num],
                 ["controller.quota.window.size.seconds", "%s" % self.window_size_seconds]
             ],
-            controller_num_nodes_override=1)
+            override_num_isolated_controllers=1)
 
     def setUp(self):
         self.kafka.start()

--- a/tests/kafkatest/tests/core/fetch_from_follower_test.py
+++ b/tests/kafkatest/tests/core/fetch_from_follower_test.py
@@ -53,7 +53,7 @@ class FetchFromFollowerTest(ProduceConsumeValidateTest):
                                       2: [("broker.rack", "rack-b")],
                                       3: [("broker.rack", "rack-c")]
                                   },
-                                  controller_num_nodes_override=1)
+                                  override_num_isolated_controllers=1)
 
         self.producer_throughput = 1000
         self.num_producers = 1

--- a/tests/kafkatest/tests/core/group_mode_transactions_test.py
+++ b/tests/kafkatest/tests/core/group_mode_transactions_test.py
@@ -62,7 +62,7 @@ class GroupModeTransactionsTest(Test):
 
         self.kafka = KafkaService(test_context,
                                   num_nodes=self.num_brokers,
-                                  zk=None, controller_num_nodes_override=1)
+                                  zk=None, override_num_isolated_controllers=1)
 
     def seed_messages(self, topic, num_seed_messages):
         seed_timeout_sec = 10000

--- a/tests/kafkatest/tests/core/network_degrade_test.py
+++ b/tests/kafkatest/tests/core/network_degrade_test.py
@@ -34,7 +34,7 @@ class NetworkDegradeTest(Test):
 
     def __init__(self, test_context):
         super(NetworkDegradeTest, self).__init__(test_context)
-        self.kafka = KafkaService(test_context, num_nodes=2, zk=None, controller_num_nodes_override=2)
+        self.kafka = KafkaService(test_context, num_nodes=2, zk=None, override_num_isolated_controllers=2)
         self.trogdor = TrogdorService(context=self.test_context, client_services=[self.kafka.controller_quorum])
 
     def setUp(self):

--- a/tests/kafkatest/tests/core/quorum_reconfiguration_test.py
+++ b/tests/kafkatest/tests/core/quorum_reconfiguration_test.py
@@ -107,7 +107,7 @@ class TestQuorumReconfiguration(ProduceConsumeValidateTest):
                                                        "replication-factor": self.replication_factor,
                                                        'configs': {"min.insync.replicas": 1}}},
                                   version=DEV_BRANCH,
-                                  controller_num_nodes_override=2,
+                                  override_num_isolated_controllers=2,
                                   dynamicRaftQuorum=True)
         # Start a controller and the broker-only nodes
         # We leave starting the second controller for later in perform_reconfig
@@ -146,7 +146,7 @@ class TestQuorumReconfiguration(ProduceConsumeValidateTest):
                                                        "replication-factor": self.replication_factor,
                                                        'configs': {"min.insync.replicas": 1}}},
                                   version=DEV_BRANCH,
-                                  controller_num_nodes_override=2,
+                                  override_num_isolated_controllers=2,
                                   quorum_info_provider=remote_quorum,
                                   dynamicRaftQuorum=True)
         # Start a controller and the broker-only nodes

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -57,7 +57,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
                                           "min.insync.replicas": 3,
                                       }}
                                   },
-                                  controller_num_nodes_override=1)
+                                  override_num_isolated_controllers=1)
         self.timeout_sec = 60
         self.producer_throughput = 1000
         self.num_producers = 1

--- a/tests/kafkatest/tests/core/replica_scale_test.py
+++ b/tests/kafkatest/tests/core/replica_scale_test.py
@@ -30,7 +30,7 @@ class ReplicaScaleTest(Test):
     def __init__(self, test_context):
         super(ReplicaScaleTest, self).__init__(test_context=test_context)
         self.test_context = test_context
-        self.kafka = KafkaService(self.test_context, num_nodes=8, zk=None, controller_num_nodes_override=1)
+        self.kafka = KafkaService(self.test_context, num_nodes=8, zk=None, override_num_isolated_controllers=1)
 
     def setUp(self):
         self.kafka.start()

--- a/tests/kafkatest/tests/core/replication_replica_failure_test.py
+++ b/tests/kafkatest/tests/core/replication_replica_failure_test.py
@@ -62,7 +62,7 @@ class ReplicationReplicaFailureTest(EndToEndTest):
         """
         self.create_kafka(num_nodes=3,
                           server_prop_overrides=[["replica.lag.time.max.ms", "10000"]],
-                          controller_num_nodes_override=1)
+                          override_num_isolated_controllers=1)
         self.kafka.start()
 
         self.trogdor = TrogdorService(context=self.test_context,

--- a/tests/kafkatest/tests/core/replication_test.py
+++ b/tests/kafkatest/tests/core/replication_test.py
@@ -166,7 +166,7 @@ class ReplicationTest(EndToEndTest):
                           client_sasl_mechanism=client_sasl_mechanism,
                           interbroker_sasl_mechanism=interbroker_sasl_mechanism,
                           tls_version=tls_version,
-                          controller_num_nodes_override = num_controllers)
+                          override_num_isolated_controllers = num_controllers)
         self.kafka.start()
 
         compression_types = None if not compression_type else [compression_type]

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -43,7 +43,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
             "partitions": 3,
             "replication-factor": 3,
             'configs': {"min.insync.replicas": 2}}},
-            controller_num_nodes_override=1)
+            override_num_isolated_controllers=1)
 
     def create_producer_and_consumer(self):
         self.producer = VerifiableProducer(

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -66,7 +66,7 @@ class ThrottlingTest(ProduceConsumeValidateTest):
                                           }
                                       }
                                   },
-                                  controller_num_nodes_override=1)
+                                  override_num_isolated_controllers=1)
         self.producer_throughput = 1000
         self.timeout_sec = 400
         self.num_records = 2000

--- a/tests/kafkatest/tests/core/transactions_mixed_versions_test.py
+++ b/tests/kafkatest/tests/core/transactions_mixed_versions_test.py
@@ -189,7 +189,7 @@ class TransactionsMixedVersionsTest(Test):
                                   num_nodes=self.num_brokers,
                                   zk=None,
                                   version=oldKafkaVersion,
-                                  controller_num_nodes_override=1)
+                                  override_num_isolated_controllers=1)
 
         self.kafka.nodes[0].version = DEV_BRANCH
 

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -224,7 +224,7 @@ class TransactionsTest(Test):
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=self.num_brokers,
                                   zk=None,
-                                  controller_num_nodes_override=1,
+                                  override_num_isolated_controllers=1,
                                   use_transactions_v2=use_transactions_v2)
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol

--- a/tests/kafkatest/tests/core/transactions_upgrade_test.py
+++ b/tests/kafkatest/tests/core/transactions_upgrade_test.py
@@ -219,7 +219,7 @@ class TransactionsUpgradeTest(Test):
                                   num_nodes=self.num_brokers,
                                   zk=None,
                                   version=fromKafkaVersion,
-                                  controller_num_nodes_override=1)
+                                  override_num_isolated_controllers=1)
 
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol

--- a/tests/kafkatest/tests/kafka_test.py
+++ b/tests/kafkatest/tests/kafka_test.py
@@ -39,7 +39,7 @@ class KafkaTest(Test):
         self.kafka = KafkaService(
             test_context, self.num_brokers,
             self.zk, topics=self.topics,
-            controller_num_nodes_override=self.num_zk)
+            override_num_isolated_controllers=self.num_zk)
 
     def setUp(self):
         if self.zk:

--- a/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
@@ -81,7 +81,7 @@ class StreamsUpgradeTest(Test):
             'avg' : { 'partitions': 5, 'replication-factor': 1 },
             'wcnt' : { 'partitions': 5, 'replication-factor': 1 },
             'tagg' : { 'partitions': 5, 'replication-factor': 1 }
-        }, controller_num_nodes_override=1)
+        }, override_num_isolated_controllers=1)
         self.kafka.start()
 
         self.driver = StreamsSmokeTestDriverService(self.test_context, self.kafka)

--- a/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
+++ b/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
@@ -41,7 +41,7 @@ class StreamsNamedRepartitionTopicTest(Test):
         }
 
         self.kafka = KafkaService(self.test_context, num_nodes=3,
-                                  zk=None, topics=self.topics, controller_num_nodes_override=1)
+                                  zk=None, topics=self.topics, override_num_isolated_controllers=1)
 
         self.producer = VerifiableProducer(self.test_context,
                                            1,

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -45,7 +45,7 @@ class StreamsOptimizedTest(Test):
             self.join_topic: {'partitions': 6}
         }
 
-        self.kafka = KafkaService(self.test_context, num_nodes=3, controller_num_nodes_override=1,
+        self.kafka = KafkaService(self.test_context, num_nodes=3, override_num_isolated_controllers=1,
                                   zk=None, topics=self.topics)
 
         self.producer = VerifiableProducer(self.test_context,

--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -39,7 +39,7 @@ class StreamsStaticMembershipTest(Test):
         }
 
         self.kafka = KafkaService(self.test_context, num_nodes=3,
-                                  zk=None, topics=self.topics, controller_num_nodes_override=1)
+                                  zk=None, topics=self.topics, override_num_isolated_controllers=1)
 
         self.producer = VerifiableProducer(self.test_context,
                                            1,

--- a/tests/kafkatest/tests/tools/log_compaction_test.py
+++ b/tests/kafkatest/tests/tools/log_compaction_test.py
@@ -46,7 +46,7 @@ class LogCompactionTest(Test):
             server_prop_overrides=[
                 [config_property.LOG_SEGMENT_BYTES, LogCompactionTest.LOG_SEGMENT_BYTES],
             ],
-            controller_num_nodes_override=self.num_zk)
+            override_num_isolated_controllers=self.num_zk)
         self.kafka.start()
 
     def start_test_log_compaction_tool(self, security_protocol):

--- a/tests/kafkatest/tests/tools/replica_verification_test.py
+++ b/tests/kafkatest/tests/tools/replica_verification_test.py
@@ -54,7 +54,7 @@ class ReplicaVerificationToolTest(Test):
             self.test_context, self.num_brokers,
             self.zk, security_protocol=security_protocol,
             interbroker_security_protocol=interbroker_security_protocol, topics=self.topics,
-            controller_num_nodes_override=self.num_zk)
+            override_num_isolated_controllers=self.num_zk)
         self.kafka.start()
 
     def start_replica_verification_tool(self, security_protocol):


### PR DESCRIPTION
Bounce the broker that hosting the controller can cause unnecessary downtime for the partition. Avoid creating only 1 controller node in the combined kraft mode. For more details please check https://issues.apache.org/jira/browse/KAFKA-18966
