### PR TITLE
KAFKA-16616: refactor mergeWith and updatePartitionLeadership

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -388,6 +388,7 @@ public class Metadata implements Closeable {
         // 2. for which corresponding leader's node is missing in the new-nodes.
         // 3. for which the existing metadata doesn't know about the partition.
         List<PartitionMetadata> updatePartitionMetadata = new ArrayList<>();
+        Map<String, Uuid> topicIdsForUpdatedTopics = new HashMap<>();
         for (Entry<TopicPartition, Metadata.LeaderIdAndEpoch> partitionLeader: partitionLeaders.entrySet()) {
             TopicPartition partition = partitionLeader.getKey();
             Metadata.LeaderAndEpoch currentLeader = currentLeader(partition);
@@ -422,20 +423,16 @@ public class Metadata implements Closeable {
             updatePartitionMetadata.add(updatedMetadata);
 
             lastSeenLeaderEpochs.put(partition, newLeader.epoch.get());
+
+            final String updatedTopic = updatedMetadata.topic();
+            if (this.metadataSnapshot.topicIds().containsKey(updatedTopic))
+                topicIdsForUpdatedTopics.put(updatedTopic, this.metadataSnapshot.topicIds().get(updatedTopic));
         }
 
         if (updatePartitionMetadata.isEmpty()) {
             log.debug("No relevant metadata updates.");
             return new HashSet<>();
         }
-
-        Set<String> updatedTopics = updatePartitionMetadata.stream().map(MetadataResponse.PartitionMetadata::topic).collect(Collectors.toSet());
-
-        // Get topic-ids for updated topics from existing topic-ids.
-        Map<String, Uuid> existingTopicIds = this.metadataSnapshot.topicIds();
-        Map<String, Uuid> topicIdsForUpdatedTopics = updatedTopics.stream()
-            .filter(existingTopicIds::containsKey)
-            .collect(Collectors.toMap(e -> e, existingTopicIds::get));
 
         if (log.isDebugEnabled()) {
             updatePartitionMetadata.forEach(

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -425,8 +425,9 @@ public class Metadata implements Closeable {
             lastSeenLeaderEpochs.put(partition, newLeader.epoch.get());
 
             final String updatedTopic = updatedMetadata.topic();
-            if (this.metadataSnapshot.topicIds().containsKey(updatedTopic))
-                topicIdsForUpdatedTopics.put(updatedTopic, this.metadataSnapshot.topicIds().get(updatedTopic));
+            Uuid topicUuid = this.metadataSnapshot.topicIds().getOrDefault(updatedTopic, Uuid.ZERO_UUID);
+            if (!topicUuid.equals(Uuid.ZERO_UUID))
+                topicIdsForUpdatedTopics.put(updatedTopic, topicUuid);
         }
 
         if (updatePartitionMetadata.isEmpty()) {

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataSnapshot.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataSnapshot.java
@@ -173,12 +173,15 @@ public class MetadataSnapshot {
 
         Map<TopicPartition, PartitionMetadata> newMetadataByPartition = new HashMap<>(addPartitions.size());
 
-        // We want the most recent topic ID. We start with the previous ID stored for retained topics and then
-        // update with newest information from the MetadataResponse. We always take the latest state, removing existing
-        // topic IDs if the latest state contains the topic name but not a topic ID.
-        Map<String, Uuid> newTopicIds = this.topicIds.entrySet().stream()
-                .filter(entry -> shouldRetainTopic.test(entry.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Uuid> newTopicIds = new HashMap<>(this.topicIds.size());
+
+        for (Map.Entry<TopicPartition, PartitionMetadata> entry : metadataByPartition.entrySet()) {
+            if (shouldRetainTopic.test(entry.getKey().topic())) {
+                newMetadataByPartition.put(entry.getKey(), entry.getValue());
+                if (this.topicIds.containsKey(entry.getKey().topic()))
+                    newTopicIds.putIfAbsent(entry.getKey().topic(), this.topicIds.get(entry.getKey().topic()));
+            }
+        }
 
         for (PartitionMetadata partition : addPartitions) {
             newMetadataByPartition.put(partition.topicPartition, partition);
@@ -188,11 +191,6 @@ public class MetadataSnapshot {
             else
                 // Remove if the latest metadata does not have a topic ID
                 newTopicIds.remove(partition.topic());
-        }
-        for (Map.Entry<TopicPartition, PartitionMetadata> entry : metadataByPartition.entrySet()) {
-            if (shouldRetainTopic.test(entry.getKey().topic())) {
-                newMetadataByPartition.putIfAbsent(entry.getKey(), entry.getValue());
-            }
         }
 
         Set<String> newUnauthorizedTopics = fillSet(addUnauthorizedTopics, unauthorizedTopics, shouldRetainTopic);

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataSnapshot.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataSnapshot.java
@@ -178,11 +178,15 @@ public class MetadataSnapshot {
         for (Map.Entry<TopicPartition, PartitionMetadata> entry : metadataByPartition.entrySet()) {
             if (shouldRetainTopic.test(entry.getKey().topic())) {
                 newMetadataByPartition.put(entry.getKey(), entry.getValue());
-                if (this.topicIds.containsKey(entry.getKey().topic()))
-                    newTopicIds.putIfAbsent(entry.getKey().topic(), this.topicIds.get(entry.getKey().topic()));
+                Uuid topicUuid = this.topicIds.getOrDefault(entry.getKey().topic(), Uuid.ZERO_UUID);
+                if (!topicUuid.equals(Uuid.ZERO_UUID))
+                    newTopicIds.putIfAbsent(entry.getKey().topic(), topicUuid);
             }
         }
 
+        // We want the most recent topic ID. We start with the previous ID stored for retained topics and then
+        // update with the newest information from the MetadataResponse. We always take the latest state, removing existing
+        // topic IDs if the latest state contains the topic name but not a topic ID.
         for (PartitionMetadata partition : addPartitions) {
             newMetadataByPartition.put(partition.topicPartition, partition);
             Uuid id = addTopicIds.get(partition.topic());

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataSnapshot.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataSnapshot.java
@@ -177,7 +177,7 @@ public class MetadataSnapshot {
 
         for (Map.Entry<TopicPartition, PartitionMetadata> entry : metadataByPartition.entrySet()) {
             if (shouldRetainTopic.test(entry.getKey().topic())) {
-                newMetadataByPartition.put(entry.getKey(), entry.getValue());
+                newMetadataByPartition.putIfAbsent(entry.getKey(), entry.getValue());
                 Uuid topicUuid = this.topicIds.getOrDefault(entry.getKey().topic(), Uuid.ZERO_UUID);
                 if (!topicUuid.equals(Uuid.ZERO_UUID))
                     newTopicIds.putIfAbsent(entry.getKey().topic(), topicUuid);


### PR DESCRIPTION
This change addresses https://issues.apache.org/jira/browse/KAFKA-16616

No additional unit tests have been added but the unit tests under the clients directory have been run locally and passed.
