### PR TITLE
MINOR Disable DeleteSegmentsByRetentionTimeTest

### DIFF
--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsByRetentionTimeTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsByRetentionTimeTest.java
@@ -17,12 +17,12 @@
 package org.apache.kafka.tiered.storage.integration;
 
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.test.api.Flaky;
+import org.junit.jupiter.api.Disabled;
 
 import java.util.Collections;
 import java.util.Map;
 
-@Flaky("KAFKA-18606")
+@Disabled("KAFKA-18606")
 public final class DeleteSegmentsByRetentionTimeTest extends BaseDeleteSegmentsTest {
 
     @Override


### PR DESCRIPTION
This test is now failing consistently on trunk, disrupting the build.