### PR TITLE
MINOR: describeTopics should pass the timeout to the describeCluster call

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2370,7 +2370,7 @@ public class KafkaAdminClient extends AdminClient {
         }
 
         // First, we need to retrieve the node info.
-        DescribeClusterResult clusterResult = describeCluster();
+        DescribeClusterResult clusterResult = describeCluster(new DescribeClusterOptions().timeoutMs(options.timeoutMs));
         clusterResult.nodes().whenComplete(
             (nodes, exception) -> {
                 if (exception != null) {


### PR DESCRIPTION
Within the DescribeTopic call, it first uses describeCluster request to fetch the cluster info. Pass the timeout to the describeCluster call.
