### PR TITLE
Fix IllegalStateException for Transaction Producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -722,6 +722,11 @@ public class TransactionManager {
     }
 
     public synchronized void maybeTransitionToErrorState(RuntimeException exception) {
+        // Prevent any state transitions if we're already in FATAL state since it's a terminal state
+        if (currentState == State.FATAL_ERROR) {
+            return;
+        }
+
         if (exception instanceof ClusterAuthorizationException
                 || exception instanceof TransactionalIdAuthorizationException
                 || exception instanceof ProducerFencedException
@@ -737,6 +742,7 @@ public class TransactionManager {
     }
 
     synchronized void handleFailedBatch(ProducerBatch batch, RuntimeException exception, boolean adjustSequenceNumbers) {
+        maybeTransitionToErrorState(exception);
         removeInFlightBatch(batch);
 
         if (hasFatalError()) {
@@ -746,7 +752,6 @@ public class TransactionManager {
             return;
         }
 
-        maybeTransitionToErrorState(exception);
         if (exception instanceof OutOfOrderSequenceException && !isTransactional()) {
             log.error("The broker returned {} for topic-partition {} with producerId {}, epoch {}, and sequence number {}",
                     exception, batch.topicPartition, batch.producerId(), batch.producerEpoch(), batch.baseSequence());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -737,7 +737,6 @@ public class TransactionManager {
     }
 
     synchronized void handleFailedBatch(ProducerBatch batch, RuntimeException exception, boolean adjustSequenceNumbers) {
-        maybeTransitionToErrorState(exception);
         removeInFlightBatch(batch);
 
         if (hasFatalError()) {
@@ -747,6 +746,7 @@ public class TransactionManager {
             return;
         }
 
+        maybeTransitionToErrorState(exception);
         if (exception instanceof OutOfOrderSequenceException && !isTransactional()) {
             log.error("The broker returned {} for topic-partition {} with producerId {}, epoch {}, and sequence number {}",
                     exception, batch.topicPartition, batch.producerId(), batch.producerEpoch(), batch.baseSequence());


### PR DESCRIPTION
Current Behavior:
- When a batch fails with a fatal error (e.g., ProducerFencedException), the TM transitions to FATAL state
- However, subsequent batches that fail can still trigger state transitions through code path `Sender.failBatch -> TM.handleFailedBatch > TM.maybeTransitionToErrorState` 
- This means that even after entering FATAL state, other batches could potentially transition the TM to ABORTABLE state

Example Scenario: 
```
Batch 1 fails with ProducerFencedException
  ↓
TM transitions to FATAL state
  ↓
Batch 2 fails with UnknownProducerIdException
  ↓
TM incorrectly transitions to ABORTABLE state (this is the bug)
```