### PR TITLE
KAFKA-18979; Report correct kraft.version in ApiVersions

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -372,7 +372,7 @@ public class FeatureControlManager {
             metadataVersion.set(Optional.of(mv));
             log.info("Replayed a FeatureLevelRecord setting metadata.version to {}", mv);
         } else if (record.name().equals(KRaftVersion.FEATURE_NAME)) {
-            // Skip any feature level record for kraft.version. This has two benefits:
+            // KAFKA-18979 - Skip any feature level record for kraft.version. This has two benefits:
             // 1. It removes from snapshots any FeatureLevelRecord for kraft.version that was incorrectly written to the log
             // 2. Allows ApiVersions to report the correct finalized kraft.version
         } else {

--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -27,6 +27,7 @@ import org.apache.kafka.metadata.VersionRange;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.EligibleLeaderReplicasVersion;
 import org.apache.kafka.server.common.Feature;
+import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.mutable.BoundedList;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -370,6 +371,10 @@ public class FeatureControlManager {
             MetadataVersion mv = MetadataVersion.fromFeatureLevel(record.featureLevel());
             metadataVersion.set(Optional.of(mv));
             log.info("Replayed a FeatureLevelRecord setting metadata.version to {}", mv);
+        } else if (record.name().equals(KRaftVersion.FEATURE_NAME)) {
+            // Skip any feature level record for kraft.version. This has two benefits:
+            // 1. It removes from snapshots any FeatureLevelRecord for kraft.version that was incorrectly written to the log
+            // 2. Allows ApiVersions to report the correct finalized kraft.version
         } else {
             if (record.featureLevel() == 0) {
                 finalizedVersions.remove(record.name());

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesDelta.java
@@ -67,7 +67,7 @@ public final class FeaturesDelta {
                         + "updating the software version. The metadata version can be updated via the `kafka-features` command-line tool.", e);
             }
         } else if (record.name().equals(KRaftVersion.FEATURE_NAME)) {
-            // Skip any feature level record for kraft.version. This has two benefits:
+            // KAFKA-18979 - Skip any feature level record for kraft.version. This has two benefits:
             // 1. It removes from snapshots any FeatureLevelRecord for kraft.version that was incorrectly written to the log
             // 2. Allows ApiVersions to report the correct finalized kraft.version
         } else {

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesDelta.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import java.util.Optional;
  * Represents changes to the cluster in the metadata image.
  */
 public final class FeaturesDelta {
-    private static final short MINIMUM_PERSISTED_FEATURE_LEVEL = 4;
     private final FeaturesImage image;
 
     private final Map<String, Optional<Short>> changes = new HashMap<>();
@@ -66,6 +66,10 @@ public final class FeaturesDelta {
                         + "please ensure the metadata version is set to " + MetadataVersion.MINIMUM_VERSION + " (or higher) before "
                         + "updating the software version. The metadata version can be updated via the `kafka-features` command-line tool.", e);
             }
+        } else if (record.name().equals(KRaftVersion.FEATURE_NAME)) {
+            // Skip any feature level record for kraft.version. This has two benefits:
+            // 1. It removes from snapshots any FeatureLevelRecord for kraft.version that was incorrectly written to the log
+            // 2. Allows ApiVersions to report the correct finalized kraft.version
         } else {
             if (record.featureLevel() == 0) {
                 changes.put(record.name(), Optional.empty());

--- a/metadata/src/test/java/org/apache/kafka/image/FeaturesDeltaTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/FeaturesDeltaTest.java
@@ -18,12 +18,14 @@
 package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.common.MetadataVersionTestUtils;
 
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,4 +42,10 @@ class FeaturesDeltaTest {
             "Expected substring missing from exception message: " + exception.getMessage());
     }
 
+    @Test
+    public void testReplayKraftVersionFeatureLevel() {
+        var featuresDelta = new FeaturesDelta(new FeaturesImage(emptyMap(), MetadataVersion.MINIMUM_VERSION));
+        featuresDelta.replay(new FeatureLevelRecord().setName(KRaftVersion.FEATURE_NAME).setFeatureLevel(KRaftVersion.LATEST_PRODUCTION.featureLevel()));
+        assertEquals(emptyMap(), featuresDelta.changes());
+    }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/common/FinalizedFeatures.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/FinalizedFeatures.java
@@ -43,7 +43,16 @@ public record FinalizedFeatures(
 
     public FinalizedFeatures setFinalizedLevel(String key, short level) {
         if (level == (short) 0) {
-            return this;
+            if (finalizedFeatures.containsKey(key)) {
+                Map<String, Short> newFinalizedFeatures = new HashMap<>(finalizedFeatures);
+                newFinalizedFeatures.remove(key);
+                return new FinalizedFeatures(
+                    metadataVersion,
+                    newFinalizedFeatures,
+                    finalizedFeaturesEpoch);
+            } else {
+                return this;
+            }
         } else {
             Map<String, Short> newFinalizedFeatures = new HashMap<>(finalizedFeatures);
             newFinalizedFeatures.put(key, level);

--- a/server-common/src/test/java/org/apache/kafka/server/common/FinalizedFeaturesTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/FinalizedFeaturesTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import static org.apache.kafka.server.common.MetadataVersion.FEATURE_NAME;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class FinalizedFeaturesTest {
     @Test
@@ -35,5 +36,22 @@ class FinalizedFeaturesTest {
         assertEquals((short) 2,
                 finalizedFeatures.finalizedFeatures().get("foo"));
         assertEquals(2, finalizedFeatures.finalizedFeatures().size());
+    }
+
+    @Test
+    public void testSetFinalizedLevel() {
+        FinalizedFeatures finalizedFeatures = new FinalizedFeatures(
+            MINIMUM_VERSION,
+            Collections.singletonMap("foo", (short) 2),
+            123
+        );
+
+        // Override an existing finalized feature version to 0
+        FinalizedFeatures removedFeatures = finalizedFeatures.setFinalizedLevel("foo", (short) 0);
+        assertNull(removedFeatures.finalizedFeatures().get("foo"));
+
+        // Override a missing finalized feature version to 0
+        FinalizedFeatures sameFeatures = removedFeatures.setFinalizedLevel("foo", (short) 0);
+        assertEquals(sameFeatures.finalizedFeatures(), removedFeatures.finalizedFeatures());
     }
 }


### PR DESCRIPTION
Skip kraft.version when applying FeatureLevelRecord records. The kraft.version is stored as control records and not as metadata records. This solution has the benefits of removing from snapshots any FeatureLevelRecord for kraft.version that was incorrectly written to the log and allows ApiVersions to report the correct finalized kraft.version.