### PR TITLE
KAFKA-18982: Allow ClusterTests to ignore specific thread leaks

### DIFF
--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTestThreadLeakIgnore.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTestThreadLeakIgnore.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.test.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD})
+@Retention(RUNTIME)
+public @interface ClusterTestThreadLeakIgnore {
+    // ignore threads left running that have names matching these prefixes
+    // useful when threads are created by client libraries or plugins (e.g. metrics reporters)
+    String[] prefixes() default {};
+}

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTestThreadLeakIgnore.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTestThreadLeakIgnore.java
@@ -22,10 +22,16 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * Used to indicate that a cluster test may ignore some new threads remaining after the execution,
+ * rather than fail due to {@link DetectThreadLeak}.
+ * Useful when such threads are created by client libraries or plugins (e.g. metrics reporters).
+ */
 @Target({METHOD})
 @Retention(RUNTIME)
 public @interface ClusterTestThreadLeakIgnore {
-    // ignore threads left running that have names matching these prefixes
-    // useful when threads are created by client libraries or plugins (e.g. metrics reporters)
+    /**
+     * ignore threads whose names match any of these prefixes
+     */
     String[] prefixes() default {};
 }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.test.api.ClusterFeature;
 import org.apache.kafka.common.test.api.ClusterTemplate;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.ClusterTestThreadLeakIgnore;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.DetectThreadLeak;
 import org.apache.kafka.common.test.api.Type;
@@ -48,6 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -156,8 +158,18 @@ public class ClusterTestExtensions implements TestTemplateInvocationContextProvi
     @Override
     public void beforeEach(ExtensionContext context) {
         if (isClusterTest(context)) {
-            DetectThreadLeak detectThreadLeak = DetectThreadLeak.of(thread ->
-                SKIPPED_THREAD_PREFIX.stream().noneMatch(prefix -> thread.getName().startsWith(prefix)));
+            Predicate<Thread> knownIgnorableThreads = thread ->
+                    SKIPPED_THREAD_PREFIX.stream().noneMatch(prefix -> thread.getName().startsWith(prefix));
+
+            ClusterTestThreadLeakIgnore threadLeakIgnore = context.getRequiredTestMethod().getDeclaredAnnotation(ClusterTestThreadLeakIgnore.class);
+            Predicate<Thread> extraIgnorableThreads = thread -> {
+                if (threadLeakIgnore != null) {
+                    return Arrays.stream(threadLeakIgnore.prefixes()).noneMatch(prefix -> thread.getName().startsWith(prefix));
+                }
+                return true;
+            };
+
+            DetectThreadLeak detectThreadLeak = DetectThreadLeak.of(knownIgnorableThreads.and(extraIgnorableThreads));
             getStore(context).put(DETECT_THREAD_LEAK_KEY, detectThreadLeak);
         }
     }

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestExtensionsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestExtensionsTest.java
@@ -51,6 +51,7 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTemplate;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.ClusterTestThreadLeakIgnore;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.Utils;
@@ -545,5 +546,20 @@ public class ClusterTestExtensionsTest {
             );
             assertInstanceOf(SaslAuthenticationException.class, exception.getCause());
         }
+    }
+
+    @ClusterTest(autoStart = AutoStart.NO)
+    @ClusterTestThreadLeakIgnore(prefixes = {"unmatchedPrefix", "testThreadLeakShould"})
+    public void testThreadLeakIgnore() {
+        new Thread("testThreadLeakShouldBeIgnored") {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(2000L);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }.start();
     }
 }


### PR DESCRIPTION
Optional annotation @ClusterTestThreadLeakIgnore can be used to ignore
specific thread leaks.

Can be used when writing ClusterTests for optional Kafka plugins such as metric reporters.