### PR TITLE
MINOR; Improve error message for the storage format command

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -352,7 +352,7 @@ public class Formatter {
                         "Cannot set kraft.version to " +
                         configuredKRaftVersionLevel.get() +
                         " if one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. " +
-                        "Try removing the --feature flag for kraft.version."
+                        "For dynamic controllers support, try removing the --feature flag for kraft.version."
                     );
                 }
             } else {
@@ -361,8 +361,8 @@ public class Formatter {
                         "Cannot set kraft.version to " +
                         configuredKRaftVersionLevel.get() +
                         " unless one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. " +
-                        "Try using one of --standalone, --initial-controllers, or --no-initial-controllers for dynamic " +
-                        "controllers support."
+                        "For dynamic controllers support, try using one of --standalone, --initial-controllers, or " +
+                        "--no-initial-controllers ."
                     );
                 }
             }

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -362,7 +362,7 @@ public class Formatter {
                         configuredKRaftVersionLevel.get() +
                         " unless one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. " +
                         "For dynamic controllers support, try using one of --standalone, --initial-controllers, or " +
-                        "--no-initial-controllers ."
+                        "--no-initial-controllers."
                     );
                 }
             }

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -348,15 +348,22 @@ public class Formatter {
         if (configuredKRaftVersionLevel.isPresent()) {
             if (configuredKRaftVersionLevel.get() == 0) {
                 if (hasDynamicQuorum()) {
-                    throw new FormatterException("Cannot set kraft.version to " +
-                        configuredKRaftVersionLevel.get() + " if KIP-853 configuration is present. " +
-                            "Try removing the --feature flag for kraft.version.");
+                    throw new FormatterException(
+                        "Cannot set kraft.version to " +
+                        configuredKRaftVersionLevel.get() +
+                        " if one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. " +
+                        "Try removing the --feature flag for kraft.version."
+                    );
                 }
             } else {
                 if (!hasDynamicQuorum()) {
-                    throw new FormatterException("Cannot set kraft.version to " +
-                        configuredKRaftVersionLevel.get() + " unless KIP-853 configuration is present. " +
-                            "Try removing the --feature flag for kraft.version.");
+                    throw new FormatterException(
+                        "Cannot set kraft.version to " +
+                        configuredKRaftVersionLevel.get() +
+                        " unless one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. " +
+                        "Try using one of --standalone, --initial-controllers, or --no-initial-controllers for dynamic " +
+                        "controllers support."
+                    );
                 }
             }
             return configuredKRaftVersionLevel.get();

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -423,7 +423,8 @@ public class FormatterTest {
             assertTrue(formatter1.formatter.hasDynamicQuorum());
             assertEquals(
                 "Cannot set kraft.version to 0 if one of the flags --standalone, --initial-controllers, or " +
-                "--no-initial-controllers is used. Try removing the --feature flag for kraft.version.",
+                "--no-initial-controllers is used. For dynamic controllers support, try removing the " +
+                "--feature flag for kraft.version.",
                 assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage()
             );
         }
@@ -438,8 +439,8 @@ public class FormatterTest {
             assertFalse(formatter1.formatter.hasDynamicQuorum());
             assertEquals(
                 "Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or " +
-                "--no-initial-controllers is used. Try using one of --standalone, --initial-controllers, or " +
-                "--no-initial-controllers for dynamic controllers support.",
+                "--no-initial-controllers is used. For dynamic controllers support, try using one of " +
+                "--standalone, --initial-controllers, or --no-initial-controllers.",
                 assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage()
             );
         }
@@ -533,8 +534,8 @@ public class FormatterTest {
             assertFalse(formatter1.formatter.hasDynamicQuorum());
             assertEquals(
                 "Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or " +
-                "--no-initial-controllers is used. Try using one of --standalone, --initial-controllers, or " +
-                "--no-initial-controllers for dynamic controllers support.",
+                "--no-initial-controllers is used. For dynamic controllers support, try using one of " +
+                "--standalone, --initial-controllers, or --no-initial-controllers.",
                 assertThrows(FormatterException.class, formatter1.formatter::run).getMessage()
             );
         }
@@ -550,7 +551,8 @@ public class FormatterTest {
             assertTrue(formatter1.formatter.hasDynamicQuorum());
             assertEquals(
                 "Cannot set kraft.version to 0 if one of the flags --standalone, --initial-controllers, or " +
-                "--no-initial-controllers is used. Try removing the --feature flag for kraft.version.",
+                "--no-initial-controllers is used. For dynamic controllers support, try removing the " +
+                "--feature flag for kraft.version.",
                 assertThrows(FormatterException.class, formatter1.formatter::run).getMessage()
             );
         }

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -421,10 +421,11 @@ public class FormatterTest {
             formatter1.formatter.setInitialControllers(DynamicVoters.
                     parse("1@localhost:8020:4znU-ou9Taa06bmEJxsjnw"));
             assertTrue(formatter1.formatter.hasDynamicQuorum());
-            assertEquals("Cannot set kraft.version to 0 if KIP-853 configuration is present. " +
-                "Try removing the --feature flag for kraft.version.",
-                    assertThrows(FormatterException.class,
-                        () -> formatter1.formatter.run()).getMessage());
+            assertEquals(
+                "Cannot set kraft.version to 0 if one of the flags --standalone, --initial-controllers, or " +
+                "--no-initial-controllers is used. Try removing the --feature flag for kraft.version.",
+                assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage()
+            );
         }
     }
 
@@ -435,10 +436,12 @@ public class FormatterTest {
             formatter1.formatter.setFeatureLevel("kraft.version", (short) 1);
             formatter1.formatter.setUnstableFeatureVersionsEnabled(true);
             assertFalse(formatter1.formatter.hasDynamicQuorum());
-            assertEquals("Cannot set kraft.version to 1 unless KIP-853 configuration is present. " +
-                "Try removing the --feature flag for kraft.version.",
-                    assertThrows(FormatterException.class,
-                        () -> formatter1.formatter.run()).getMessage());
+            assertEquals(
+                "Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or " +
+                "--no-initial-controllers is used. Try using one of --standalone, --initial-controllers, or " +
+                "--no-initial-controllers for dynamic controllers support.",
+                assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage()
+            );
         }
     }
 
@@ -528,10 +531,12 @@ public class FormatterTest {
             formatter1.formatter.setUnstableFeatureVersionsEnabled(true);
             formatter1.formatter.setNoInitialControllersFlag(false);
             assertFalse(formatter1.formatter.hasDynamicQuorum());
-            assertEquals("Cannot set kraft.version to 1 unless KIP-853 configuration is present. " +
-                    "Try removing the --feature flag for kraft.version.",
-                assertThrows(FormatterException.class,
-                    formatter1.formatter::run).getMessage());
+            assertEquals(
+                "Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or " +
+                "--no-initial-controllers is used. Try using one of --standalone, --initial-controllers, or " +
+                "--no-initial-controllers for dynamic controllers support.",
+                assertThrows(FormatterException.class, formatter1.formatter::run).getMessage()
+            );
         }
     }
 
@@ -543,10 +548,11 @@ public class FormatterTest {
             formatter1.formatter.setUnstableFeatureVersionsEnabled(true);
             formatter1.formatter.setNoInitialControllersFlag(true);
             assertTrue(formatter1.formatter.hasDynamicQuorum());
-            assertEquals("Cannot set kraft.version to 0 if KIP-853 configuration is present. " +
-                    "Try removing the --feature flag for kraft.version.",
-                assertThrows(FormatterException.class,
-                    formatter1.formatter::run).getMessage());
+            assertEquals(
+                "Cannot set kraft.version to 0 if one of the flags --standalone, --initial-controllers, or " +
+                "--no-initial-controllers is used. Try removing the --feature flag for kraft.version.",
+                assertThrows(FormatterException.class, formatter1.formatter::run).getMessage()
+            );
         }
     }
 }


### PR DESCRIPTION
Minor improvement on the error output for the storage format command. Suggests changes for a valid storage format command.

Reviewers: Justine Olshan <jolshan@confluent.io>
