### PR TITLE
[WIP] KAFKA-18989: Optimize FileRecord#searchForOffsetWithSize

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -299,7 +299,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
      */
     public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            long offset = batch.lastOffset();
+            long offset = batch.baseOffset();
             if (offset >= targetOffset)
                 return new LogOffsetPosition(batch.baseOffset(), batch.position(), batch.sizeInBytes());
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-18989

Reason: `lastOffset` loads the entire batch header so perhaps we should avoid checking `lastOffset` for every batch.
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java#L686

```
        @Override
        public long baseOffset() {
            return offset;
        }

        @Override
        public long lastOffset() {
            return loadBatchHeader().lastOffset();
```

### IntelliJ Profiler:
Total Time
`lastOffset`
![image](https://github.com/user-attachments/assets/38132a9c-ba22-48f5-ba40-554d26d40a76)

`baseOffset`
![image](https://github.com/user-attachments/assets/b3efd939-af8f-44c5-9170-200bc14b5558)


Memory
`baseOffset`
![image](https://github.com/user-attachments/assets/1d6379e3-9e4f-4d2c-9a34-e052e41938c1)

`Gradle Test Run :clients:test > Gradle Test Executor 9 > FileRecordsTest > testSearch() PASSED
`
![image](https://github.com/user-attachments/assets/c9bb666d-a51c-4d6d-bd0e-dcbb3316544a)
