### PR TITLE
KAFKA-18989 Optimize FileRecord#searchForOffsetWithSize

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -301,7 +301,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
         FileChannelRecordBatch prevBatch = null;
 
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            // Special case: if baseOffset exactly equals targetOffset, return immediately
+            // if baseOffset exactly equals targetOffset, return immediately
             if (batch.baseOffset() == targetOffset) {
                 return new LogOffsetPosition(batch);
             }

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -301,14 +301,14 @@ public class FileRecords extends AbstractRecords implements Closeable {
         FileChannelRecordBatch prevBatch = null;
 
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            // if baseOffset exactly equals targetOffset, return immediately
+            // If baseOffset exactly equals targetOffset, return immediately
             if (batch.baseOffset() == targetOffset) {
                 return LogOffsetPosition.fromBatch(batch);
             }
             
             // If we find the first batch with baseOffset greater than targetOffset
             if (batch.baseOffset() > targetOffset) {
-                // Check if the previous batch contains the target
+                // If the previous batch contains the target
                 if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
                     return LogOffsetPosition.fromBatch(prevBatch);
                 else {

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -327,7 +327,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
         // Only one case would reach here: all batches have baseOffset less than or equal to targetOffset
         // Check if the last batch contains the target
         if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) {
-            return new LogOffsetPosition(prevBatch.baseOffset(), prevBatch.position(), prevBatch.sizeInBytes());
+            return new LogOffsetPosition(prevBatch);
         }
 
         return null;

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -319,7 +319,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
             }
             prevBatch = batch;
         }
-        // Only one case would reach here: all batches have baseOffset less than or equal to targetOffset
+        // Only one case would reach here: all batches have baseOffset less than targetOffset
         // Check if the last batch contains the target
         if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) 
             return LogOffsetPosition.fromBatch(prevBatch);

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -305,8 +305,8 @@ public class FileRecords extends AbstractRecords implements Closeable {
             if (batch.baseOffset() == targetOffset) {
                 return LogOffsetPosition.fromBatch(batch);
             }
-            // This indicates that either the current batch or the previous batch 
-            // contains the target we are looking for.
+            
+            // If we find the first batch with baseOffset greater than targetOffset
             if (batch.baseOffset() > targetOffset) {
                 // Check if the previous batch contains the target
                 if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -292,6 +292,11 @@ public class FileRecords extends AbstractRecords implements Closeable {
     /**
      * Search forward for the file position of the message batch whose last offset that is greater
      * than or equal to the target offset. If no such batch is found, return null.
+     * <p>
+     * The following logic is intentionally designed to minimize memory usage
+     * by avoiding unnecessary calls to {@link FileChannelRecordBatch#lastOffset()} for every batch.
+     * Instead, we use {@link FileChannelRecordBatch#baseOffset()} comparisons when possible, and only 
+     * check {@link FileChannelRecordBatch#lastOffset()} when absolutely necessary.
      *
      * @param targetOffset The offset to search for.
      * @param startingPosition The starting position in the file to begin searching from.

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -299,28 +298,38 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @return the batch's base offset, its physical position, and its size (including log overhead)
      */
     public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
-        FileChannelRecordBatch matchedBatch = null;
-        FileChannelRecordBatch nextBatch = null;
+        FileChannelRecordBatch prevBatch = null;
 
-        Iterator<FileChannelRecordBatch> batchIter = batchesFrom(startingPosition).iterator();
-        while (batchIter.hasNext()) {
-            FileChannelRecordBatch batch = batchIter.next();
-            if (targetOffset > batch.baseOffset()) {
-                matchedBatch = batch;
-                continue;
+        for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
+            // Special case: if baseOffset exactly equals targetOffset, return immediately
+            if (batch.baseOffset() == targetOffset) {
+                return new LogOffsetPosition(batch);
             }
-            nextBatch = batch;
-            break;
+
+            // If we find the first batch with baseOffset greater than targetOffset
+            if (batch.baseOffset() > targetOffset) {
+                // If there's no previous batch, return the current batch
+                if (prevBatch == null) {
+                    return new LogOffsetPosition(batch);
+                }
+
+                // Check if the previous batch contains the target
+                if (prevBatch.lastOffset() >= targetOffset) {
+                    return new LogOffsetPosition(prevBatch);
+                } else {
+                    // If the previous batch doesn't contain the target, return the current batch
+                    return new LogOffsetPosition(batch);
+                }
+            }
+            prevBatch = batch;
         }
 
-        if (matchedBatch != null) {
-            long lastOffset = matchedBatch.lastOffset();
-            if (nextBatch != null && lastOffset < targetOffset && nextBatch.baseOffset() >= targetOffset) {
-                return new LogOffsetPosition(nextBatch.baseOffset(), nextBatch.position(), nextBatch.sizeInBytes());
-            } else if (lastOffset >= targetOffset) {
-                return new LogOffsetPosition(matchedBatch.baseOffset(), matchedBatch.position(), matchedBatch.sizeInBytes());
-            }
+        // Only one case would reach here: all batches have baseOffset less than or equal to targetOffset
+        // Check if the last batch contains the target
+        if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) {
+            return new LogOffsetPosition(prevBatch.baseOffset(), prevBatch.position(), prevBatch.sizeInBytes());
         }
+
         return null;
     }
 
@@ -481,6 +490,12 @@ public class FileRecords extends AbstractRecords implements Closeable {
         public final long offset;
         public final int position;
         public final int size;
+
+        public LogOffsetPosition(FileChannelRecordBatch batch) {
+            this.offset = batch.baseOffset();
+            this.position = batch.position();
+            this.size = batch.sizeInBytes();
+        }
 
         public LogOffsetPosition(long offset, int position, int size) {
             this.offset = offset;

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -297,13 +297,17 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @param startingPosition The starting position in the file to begin searching from.
      * @return the batch's base offset, its physical position, and its size (including log overhead)
      */
-    public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
+    public LogOffsetPosition searchForOffsetFromPosition(long targetOffset, int startingPosition) {
         FileChannelRecordBatch prevBatch = null;
 
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
+            // if baseOffset exactly equals targetOffset, return immediately
+            if (batch.baseOffset() == targetOffset) {
+                return LogOffsetPosition.fromBatch(batch);
+            }
             // This indicates that either the current batch or the previous batch 
             // contains the target we are looking for.
-            if (batch.baseOffset() >= targetOffset) {
+            if (batch.baseOffset() > targetOffset) {
                 // Check if the previous batch contains the target
                 if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
                     return LogOffsetPosition.fromBatch(prevBatch);

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -298,11 +298,15 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @return the batch's base offset, its physical position, and its size (including log overhead)
      */
     public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
+        FileChannelRecordBatch matchedBatch = null;
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            long offset = batch.lastOffset();
-            if (offset >= targetOffset)
-                return new LogOffsetPosition(batch.baseOffset(), batch.position(), batch.sizeInBytes());
+            if (matchedBatch != null && targetOffset < batch.baseOffset()) {
+                break;
+            }
+            matchedBatch = batch;
         }
+        if (matchedBatch != null && matchedBatch.lastOffset() >= targetOffset)
+            return new LogOffsetPosition(matchedBatch.baseOffset(), matchedBatch.position(), matchedBatch.sizeInBytes());
         return null;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -301,13 +301,15 @@ public class FileRecords extends AbstractRecords implements Closeable {
         FileChannelRecordBatch prevBatch = null;
 
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
+            // This indicates that either the current batch or the previous batch 
+            // contains the target we are looking for.
             if (batch.baseOffset() >= targetOffset) {
                 // Check if the previous batch contains the target
                 if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
                     return new LogOffsetPosition(prevBatch);
                 else
-                    // If there's no previous batch, return the current batch or the
-                    // previous batch doesn't contain the target, return the current batch
+                    // If there's no previous batch or the previous batch doesn't contain the 
+                    // target, return the current batch
                     return new LogOffsetPosition(batch);
             }
             prevBatch = batch;

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -298,22 +299,27 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @return the batch's base offset, its physical position, and its size (including log overhead)
      */
     public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
-        System.out.println("targetOffset = " + targetOffset);
         FileChannelRecordBatch matchedBatch = null;
         FileChannelRecordBatch nextBatch = null;
-        for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            System.out.println("batch.baseOffset() = " + batch.baseOffset());
-            System.out.println("batch.lastOffset() = " + batch.lastOffset());
-            if (matchedBatch != null && targetOffset < batch.baseOffset()) {
-                nextBatch = batch;
-                break;
+
+        Iterator<FileChannelRecordBatch> batchIter = batchesFrom(startingPosition).iterator();
+        while (batchIter.hasNext()) {
+            FileChannelRecordBatch batch = batchIter.next();
+            if (targetOffset > batch.baseOffset()) {
+                matchedBatch = batch;
+                continue;
             }
-            matchedBatch = batch;
+            nextBatch = batch;
+            break;
         }
-        if (matchedBatch != null && nextBatch != null && matchedBatch.lastOffset() < targetOffset && nextBatch.baseOffset() >= targetOffset) {
-            return new LogOffsetPosition(nextBatch.baseOffset(), nextBatch.position(), nextBatch.sizeInBytes());
-        } else if (matchedBatch != null && matchedBatch.lastOffset() >= targetOffset) {
-            return new LogOffsetPosition(matchedBatch.baseOffset(), matchedBatch.position(), matchedBatch.sizeInBytes());
+
+        if (matchedBatch != null) {
+            long lastOffset = matchedBatch.lastOffset();
+            if (nextBatch != null && lastOffset < targetOffset && nextBatch.baseOffset() >= targetOffset) {
+                return new LogOffsetPosition(nextBatch.baseOffset(), nextBatch.position(), nextBatch.sizeInBytes());
+            } else if (lastOffset >= targetOffset) {
+                return new LogOffsetPosition(matchedBatch.baseOffset(), matchedBatch.position(), matchedBatch.sizeInBytes());
+            }
         }
         return null;
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -306,19 +306,19 @@ public class FileRecords extends AbstractRecords implements Closeable {
             if (batch.baseOffset() >= targetOffset) {
                 // Check if the previous batch contains the target
                 if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
-                    return new LogOffsetPosition(prevBatch);
-                else
+                    return LogOffsetPosition.fromBatch(prevBatch);
+                else {
                     // If there's no previous batch or the previous batch doesn't contain the 
                     // target, return the current batch
-                    return new LogOffsetPosition(batch);
+                    return LogOffsetPosition.fromBatch(batch);
+                }
             }
             prevBatch = batch;
         }
         // Only one case would reach here: all batches have baseOffset less than or equal to targetOffset
         // Check if the last batch contains the target
-        if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) {
-            return new LogOffsetPosition(prevBatch);
-        }
+        if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) 
+            return LogOffsetPosition.fromBatch(prevBatch);
 
         return null;
     }
@@ -480,11 +480,9 @@ public class FileRecords extends AbstractRecords implements Closeable {
         public final long offset;
         public final int position;
         public final int size;
-
-        public LogOffsetPosition(FileChannelRecordBatch batch) {
-            this.offset = batch.baseOffset();
-            this.position = batch.position();
-            this.size = batch.sizeInBytes();
+        
+        public static LogOffsetPosition fromBatch(FileChannelRecordBatch batch) {
+            return new LogOffsetPosition(batch.baseOffset(), batch.position(), batch.sizeInBytes());
         }
 
         public LogOffsetPosition(long offset, int position, int size) {

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -298,15 +298,23 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @return the batch's base offset, its physical position, and its size (including log overhead)
      */
     public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
+        System.out.println("targetOffset = " + targetOffset);
         FileChannelRecordBatch matchedBatch = null;
+        FileChannelRecordBatch nextBatch = null;
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
+            System.out.println("batch.baseOffset() = " + batch.baseOffset());
+            System.out.println("batch.lastOffset() = " + batch.lastOffset());
             if (matchedBatch != null && targetOffset < batch.baseOffset()) {
+                nextBatch = batch;
                 break;
             }
             matchedBatch = batch;
         }
-        if (matchedBatch != null && matchedBatch.lastOffset() >= targetOffset)
+        if (matchedBatch != null && nextBatch != null && matchedBatch.lastOffset() < targetOffset && nextBatch.baseOffset() >= targetOffset) {
+            return new LogOffsetPosition(nextBatch.baseOffset(), nextBatch.position(), nextBatch.sizeInBytes());
+        } else if (matchedBatch != null && matchedBatch.lastOffset() >= targetOffset) {
             return new LogOffsetPosition(matchedBatch.baseOffset(), matchedBatch.position(), matchedBatch.sizeInBytes());
+        }
         return null;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -301,29 +301,17 @@ public class FileRecords extends AbstractRecords implements Closeable {
         FileChannelRecordBatch prevBatch = null;
 
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            // if baseOffset exactly equals targetOffset, return immediately
-            if (batch.baseOffset() == targetOffset) {
-                return new LogOffsetPosition(batch);
-            }
-
-            // If we find the first batch with baseOffset greater than targetOffset
-            if (batch.baseOffset() > targetOffset) {
-                // If there's no previous batch, return the current batch
-                if (prevBatch == null) {
-                    return new LogOffsetPosition(batch);
-                }
-
+            if (batch.baseOffset() >= targetOffset) {
                 // Check if the previous batch contains the target
-                if (prevBatch.lastOffset() >= targetOffset) {
+                if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
                     return new LogOffsetPosition(prevBatch);
-                } else {
-                    // If the previous batch doesn't contain the target, return the current batch
+                else
+                    // If there's no previous batch, return the current batch or the
+                    // previous batch doesn't contain the target, return the current batch
                     return new LogOffsetPosition(batch);
-                }
             }
             prevBatch = batch;
         }
-
         // Only one case would reach here: all batches have baseOffset less than or equal to targetOffset
         // Check if the last batch contains the target
         if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) {

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -521,25 +523,66 @@ public class FileRecordsTest {
         verify(channel).transferFrom(any(), anyLong(), eq((long) size - firstWritten));
     }
 
-    @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountFirstBatchMatch() throws IOException {
+    /**
+     * Test two condition
+     * 1. If the target offset equals to the base offset of the first batch
+     * 2. If the target offset < the base offset of the first batch
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {5, 10})
+    public void testSearchForOffsetWithSizeLastOffsetCallCountFirstBatchMatch(long baseOffset) throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
-        when(batch.baseOffset()).thenReturn(10L);
+        when(batch.baseOffset()).thenReturn(baseOffset);
 
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        mockFileRecordBatches(fileRecords, batch);
 
-        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
-        batches.add(batch);
-        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
-                .when(fileRecords)
-                .batchesFrom(anyInt());
-        
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(5L, 0);
 
-        assertEquals(new FileRecords.LogOffsetPosition(batch), result);
+        assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch), result);
         verify(batch, never()).lastOffset();
+    }
+
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountFirstBatchLastOffsetMatch() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch.baseOffset()).thenReturn(3L);
+        when(batch.lastOffset()).thenReturn(5L);
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        mockFileRecordBatches(fileRecords, batch);
+
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(5L, 0);
+
+        assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch), result);
+        // target is equals to the last offset of the batch, we should call lastOffset
+        verify(batch, times(1)).lastOffset();
+    }
+
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountLastBatchLastOffsetMatch() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch prevBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(prevBatch.baseOffset()).thenReturn(5L);
+        when(prevBatch.lastOffset()).thenReturn(12L);
+        FileLogInputStream.FileChannelRecordBatch currentBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(currentBatch.baseOffset()).thenReturn(15L);
+        when(currentBatch.lastOffset()).thenReturn(20L);
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
+
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(20L, 0);
+
+        assertEquals(FileRecords.LogOffsetPosition.fromBatch(currentBatch), result);
+        // Because the target offset is in the current batch, we should not call lastOffset in the previous batch
+        verify(prevBatch, never()).lastOffset();
+        verify(currentBatch, times(1)).lastOffset();
     }
 
     @Test
@@ -553,17 +596,11 @@ public class FileRecordsTest {
         when(currentBatch.baseOffset()).thenReturn(15L); // >= targetOffset
 
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
-        
-        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
-        batches.add(prevBatch);
-        batches.add(currentBatch);
-        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
-                .when(fileRecords)
-                .batchesFrom(anyInt());
+        mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
 
-        assertEquals(new FileRecords.LogOffsetPosition(prevBatch), result);
+        assertEquals(FileRecords.LogOffsetPosition.fromBatch(prevBatch), result);
         // Because the target offset is in the current batch, we should call lastOffset 
         // on the previous batch
         verify(prevBatch, times(1)).lastOffset();
@@ -580,13 +617,7 @@ public class FileRecordsTest {
         when(batch2.lastOffset()).thenReturn(9L);  // < targetOffset
 
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
-
-        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
-        batches.add(batch1);
-        batches.add(batch2);
-        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
-                .when(fileRecords)
-                .batchesFrom(anyInt());
+        mockFileRecordBatches(fileRecords, batch1, batch2);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
 
@@ -597,33 +628,47 @@ public class FileRecordsTest {
         verify(batch2, times(1)).lastOffset();
     }
 
-    @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountAllBatchesSmallerLastBatchMatches() throws IOException {
+    /**
+     * Test two condition
+     * 1. If the target offset < the base offset of the last batch
+     * 2. If the target offset equals to the base offset of the last batch
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {8, 10})
+    public void testSearchForOffsetWithSizeLastOffsetCallCountAllBatchesSmallerLastBatchMatches(long baseOffset) throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
         when(batch1.baseOffset()).thenReturn(5L);  // < targetOffset
         FileLogInputStream.FileChannelRecordBatch batch2 = mock(FileLogInputStream.FileChannelRecordBatch.class);
-        when(batch2.baseOffset()).thenReturn(8L);  // < targetOffset
+        when(batch2.baseOffset()).thenReturn(baseOffset);  // < targetOffset or == targetOffset
         when(batch2.lastOffset()).thenReturn(12L); // >= targetOffset
 
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        mockFileRecordBatches(fileRecords, batch1, batch2);
 
-        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
-        batches.add(batch1);
-        batches.add(batch2);
+        long targetOffset = 10L;
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(targetOffset, 0);
+
+        assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch2), result);
+        if (targetOffset == baseOffset) {
+            // Because the target offset is equal to the base offset of the batch2, we should not call
+            // lastOffset on batch2
+            verify(batch1, times(1)).lastOffset();
+            verify(batch2, never()).lastOffset();
+        } else {
+            // Because the target offset is in the batch2, we should not call 
+            // lastOffset on batch1
+            verify(batch1, never()).lastOffset();
+            verify(batch2, times(1)).lastOffset();
+        }
+    }
+
+    private void mockFileRecordBatches(FileRecords fileRecords, FileLogInputStream.FileChannelRecordBatch... batch) {
+        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>(asList(batch));
         doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
                 .when(fileRecords)
                 .batchesFrom(anyInt());
-
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
-
-        assertEquals(new FileRecords.LogOffsetPosition(batch2), result);
-
-        // Because the target offset is in the batch2, we should not call 
-        // lastOffset on batch1
-        verify(batch1, never()).lastOffset();
-        verify(batch2, times(1)).lastOffset();
     }
 
     private void doTestConversion(Compression compression, byte toMagic) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -564,8 +564,66 @@ public class FileRecordsTest {
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
 
         assertEquals(new FileRecords.LogOffsetPosition(prevBatch), result);
-        // Because the target offset is not in the current batch, we should call lastOffset on the previous batch
+        // Because the target offset is in the current batch, we should call lastOffset 
+        // on the previous batch
         verify(prevBatch, times(1)).lastOffset();
+    }
+
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountAllBatchesSmallerLastBatchDoesntMatch() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch1.baseOffset()).thenReturn(5L);  // < targetOffset
+        FileLogInputStream.FileChannelRecordBatch batch2 = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch2.baseOffset()).thenReturn(8L);  // < targetOffset
+        when(batch2.lastOffset()).thenReturn(9L);  // < targetOffset
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+
+        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
+        batches.add(batch1);
+        batches.add(batch2);
+        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
+                .when(fileRecords)
+                .batchesFrom(anyInt());
+
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
+
+        assertNull(result);
+        // Because the target offset is exceeded by the last offset of the batch2, 
+        // we should call lastOffset on the batch2
+        verify(batch1, never()).lastOffset();
+        verify(batch2, times(1)).lastOffset();
+    }
+
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountAllBatchesSmallerLastBatchMatches() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch1.baseOffset()).thenReturn(5L);  // < targetOffset
+        FileLogInputStream.FileChannelRecordBatch batch2 = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch2.baseOffset()).thenReturn(8L);  // < targetOffset
+        when(batch2.lastOffset()).thenReturn(12L); // >= targetOffset
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+
+        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
+        batches.add(batch1);
+        batches.add(batch2);
+        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
+                .when(fileRecords)
+                .batchesFrom(anyInt());
+
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
+
+        assertEquals(new FileRecords.LogOffsetPosition(batch2), result);
+
+        // Because the target offset is in the batch2, we should not call 
+        // lastOffset on batch1
+        verify(batch1, never()).lastOffset();
+        verify(batch2, times(1)).lastOffset();
     }
 
     private void doTestConversion(Compression compression, byte toMagic) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -524,13 +524,16 @@ public class FileRecordsTest {
     }
 
     /**
-     * Test two conditions
-     * 1. If the target offset equals to the base offset of the first batch
-     * 2. If the target offset < the base offset of the first batch
+     * Test two conditions:
+     * 1. If the target offset equals the base offset of the first batch
+     * 2. If the target offset is less than the base offset of the first batch
+     * <p>
+     * If the base offset of the first batch is equal to or greater than the target offset, it should return the 
+     * position of the first batch and the lastOffset method should not be called.
      */
     @ParameterizedTest
     @ValueSource(longs = {5, 10})
-    public void testSearchForOffsetFromPositionAndFirstBatchMatch(long baseOffset) throws IOException {
+    public void testSearchForOffsetFromPosition1(long baseOffset) throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -545,8 +548,11 @@ public class FileRecordsTest {
         verify(batch, never()).lastOffset();
     }
 
+    /**
+     * Test the case when the target offset equals the last offset of the first batch.
+     */
     @Test
-    public void testSearchForOffsetFromPositionAndFirstBatchLastOffsetMatch() throws IOException {
+    public void testSearchForOffsetFromPosition2() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -563,8 +569,11 @@ public class FileRecordsTest {
         verify(batch, times(1)).lastOffset();
     }
 
+    /**
+     * Test the case when the target offset equals the last offset of the last batch.
+     */
     @Test
-    public void testSearchForOffsetFromPositionAndLastBatchLastOffsetMatch() throws IOException {
+    public void testSearchForOffsetFromPosition3() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch prevBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -585,8 +594,11 @@ public class FileRecordsTest {
         verify(currentBatch, times(1)).lastOffset();
     }
 
+    /**
+     * Test the case when the target offset is within the range of the previous batch.
+     */
     @Test
-    public void testSearchForOffsetFromPositionAndPrevBatchMatches() throws IOException {
+    public void testSearchForOffsetFromPosition4() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch prevBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -606,8 +618,11 @@ public class FileRecordsTest {
         verify(prevBatch, times(1)).lastOffset();
     }
 
+    /**
+     * Test the case when no batch matches the target offset.
+     */
     @Test
-    public void testSearchForOffsetFromPositionAndAllBatchesNonMatch() throws IOException {
+    public void testSearchForOffsetFromPosition5() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -629,13 +644,13 @@ public class FileRecordsTest {
     }
 
     /**
-     * Test two conditions
-     * 1. If the target offset < the base offset of the last batch
-     * 2. If the target offset equals to the base offset of the last batch
+     * Test two conditions:
+     * 1. If the target offset is less than the base offset of the last batch
+     * 2. If the target offset equals the base offset of the last batch
      */
     @ParameterizedTest
     @ValueSource(longs = {8, 10})
-    public void testSearchForOffsetFromPositionLastBatchMatches(long baseOffset) throws IOException {
+    public void testSearchForOffsetFromPosition6(long baseOffset) throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -664,8 +679,11 @@ public class FileRecordsTest {
         }
     }
 
+    /**
+     * Test the case when the target offset is between two batches.
+     */
     @Test
-    public void testSearchForOffsetFromPositionTargetBetweenTwoBatches() throws IOException {
+    public void testSearchForOffsetFromPosition7() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -51,10 +51,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -516,6 +519,52 @@ public class FileRecordsTest {
         fileRecords.writeTo(channel, firstWritten, secondWrittenLength);
         // But we still only write (size - firstWritten), which is not fulfilled in the old version
         verify(channel).transferFrom(any(), anyLong(), eq((long) size - firstWritten));
+    }
+
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountFirstBatchMatch() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch.baseOffset()).thenReturn(10L);
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+
+        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
+        batches.add(batch);
+        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
+                .when(fileRecords)
+                .batchesFrom(anyInt());
+        
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(5L, 0);
+
+        assertEquals(new FileRecords.LogOffsetPosition(batch), result);
+        verify(batch, never()).lastOffset();
+    }
+
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountPrevBatchMatches() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch prevBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(prevBatch.baseOffset()).thenReturn(5L);
+        when(prevBatch.lastOffset()).thenReturn(12L); // > targetOffset
+        FileLogInputStream.FileChannelRecordBatch currentBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(currentBatch.baseOffset()).thenReturn(15L); // >= targetOffset
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        
+        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>();
+        batches.add(prevBatch);
+        batches.add(currentBatch);
+        doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
+                .when(fileRecords)
+                .batchesFrom(anyInt());
+
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
+
+        assertEquals(new FileRecords.LogOffsetPosition(prevBatch), result);
+        verify(prevBatch, times(1)).lastOffset();
     }
 
     private void doTestConversion(Compression compression, byte toMagic) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -681,6 +681,7 @@ public class FileRecordsTest {
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(13L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch2), result);
+        // Because the target offset is between the two batches, we should call lastOffset on the batch1
         verify(batch1, times(1)).lastOffset();
         verify(batch2, never()).lastOffset();
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -664,6 +664,27 @@ public class FileRecordsTest {
         }
     }
 
+    @Test
+    public void testSearchForOffsetWithSizeLastOffsetCallCountTargetBetweenTwoBatches() throws IOException {
+        File mockFile = mock(File.class);
+        FileChannel mockChannel = mock(FileChannel.class);
+        FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch1.baseOffset()).thenReturn(5L);  
+        when(batch1.lastOffset()).thenReturn(10L); 
+        FileLogInputStream.FileChannelRecordBatch batch2 = mock(FileLogInputStream.FileChannelRecordBatch.class);
+        when(batch2.baseOffset()).thenReturn(15L);  
+        when(batch2.lastOffset()).thenReturn(20L);  
+
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        mockFileRecordBatches(fileRecords, batch1, batch2);
+
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(13L, 0);
+
+        assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch2), result);
+        verify(batch1, times(1)).lastOffset();
+        verify(batch2, never()).lastOffset();
+    }
+
     private void mockFileRecordBatches(FileRecords fileRecords, FileLogInputStream.FileChannelRecordBatch... batch) {
         List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>(asList(batch));
         doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -253,25 +253,25 @@ public class FileRecordsTest {
 
         int message1Size = batches.get(0).sizeInBytes();
         assertEquals(new FileRecords.LogOffsetPosition(0L, position, message1Size),
-            fileRecords.searchForOffsetWithSize(0, 0),
+            fileRecords.searchForOffsetFromPosition(0, 0),
             "Should be able to find the first message by its offset");
         position += message1Size;
 
         int message2Size = batches.get(1).sizeInBytes();
         assertEquals(new FileRecords.LogOffsetPosition(1L, position, message2Size),
-            fileRecords.searchForOffsetWithSize(1, 0),
+            fileRecords.searchForOffsetFromPosition(1, 0),
             "Should be able to find second message when starting from 0");
         assertEquals(new FileRecords.LogOffsetPosition(1L, position, message2Size),
-            fileRecords.searchForOffsetWithSize(1, position),
+            fileRecords.searchForOffsetFromPosition(1, position),
             "Should be able to find second message starting from its offset");
         position += message2Size + batches.get(2).sizeInBytes();
 
         int message4Size = batches.get(3).sizeInBytes();
         assertEquals(new FileRecords.LogOffsetPosition(50L, position, message4Size),
-            fileRecords.searchForOffsetWithSize(3, position),
+            fileRecords.searchForOffsetFromPosition(3, position),
             "Should be able to find fourth message from a non-existent offset");
         assertEquals(new FileRecords.LogOffsetPosition(50L, position, message4Size),
-            fileRecords.searchForOffsetWithSize(50,  position),
+            fileRecords.searchForOffsetFromPosition(50,  position),
             "Should be able to find fourth message by correct offset");
     }
 
@@ -281,7 +281,7 @@ public class FileRecordsTest {
     @Test
     public void testIteratorWithLimits() throws IOException {
         RecordBatch batch = batches(fileRecords).get(1);
-        int start = fileRecords.searchForOffsetWithSize(1, 0).position;
+        int start = fileRecords.searchForOffsetFromPosition(1, 0).position;
         int size = batch.sizeInBytes();
         FileRecords slice = fileRecords.slice(start, size);
         assertEquals(Collections.singletonList(batch), batches(slice));
@@ -295,7 +295,7 @@ public class FileRecordsTest {
     @Test
     public void testTruncate() throws IOException {
         RecordBatch batch = batches(fileRecords).get(0);
-        int end = fileRecords.searchForOffsetWithSize(1, 0).position;
+        int end = fileRecords.searchForOffsetFromPosition(1, 0).position;
         fileRecords.truncateTo(end);
         assertEquals(Collections.singletonList(batch), batches(fileRecords));
         assertEquals(batch.sizeInBytes(), fileRecords.sizeInBytes());
@@ -524,13 +524,13 @@ public class FileRecordsTest {
     }
 
     /**
-     * Test two condition
+     * Test two conditions
      * 1. If the target offset equals to the base offset of the first batch
      * 2. If the target offset < the base offset of the first batch
      */
     @ParameterizedTest
     @ValueSource(longs = {5, 10})
-    public void testSearchForOffsetWithSizeLastOffsetCallCountFirstBatchMatch(long baseOffset) throws IOException {
+    public void testSearchForOffsetFromPositionAndFirstBatchMatch(long baseOffset) throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -539,14 +539,14 @@ public class FileRecordsTest {
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
         mockFileRecordBatches(fileRecords, batch);
 
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(5L, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(5L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch), result);
         verify(batch, never()).lastOffset();
     }
 
     @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountFirstBatchLastOffsetMatch() throws IOException {
+    public void testSearchForOffsetFromPositionAndFirstBatchLastOffsetMatch() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -556,15 +556,15 @@ public class FileRecordsTest {
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
         mockFileRecordBatches(fileRecords, batch);
 
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(5L, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(5L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch), result);
-        // target is equals to the last offset of the batch, we should call lastOffset
+        // target is equal to the last offset of the batch, we should call lastOffset
         verify(batch, times(1)).lastOffset();
     }
 
     @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountLastBatchLastOffsetMatch() throws IOException {
+    public void testSearchForOffsetFromPositionAndLastBatchLastOffsetMatch() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch prevBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -577,7 +577,7 @@ public class FileRecordsTest {
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
         mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(20L, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(20L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(currentBatch), result);
         // Because the target offset is in the current batch, we should not call lastOffset in the previous batch
@@ -586,7 +586,7 @@ public class FileRecordsTest {
     }
 
     @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountPrevBatchMatches() throws IOException {
+    public void testSearchForOffsetFromPositionAndPrevBatchMatches() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch prevBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -598,7 +598,7 @@ public class FileRecordsTest {
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
         mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(10L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(prevBatch), result);
         // Because the target offset is in the current batch, we should call lastOffset 
@@ -607,7 +607,7 @@ public class FileRecordsTest {
     }
 
     @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountAllBatchesSmallerLastBatchDoesntMatch() throws IOException {
+    public void testSearchForOffsetFromPositionAndAllBatchesNonMatch() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -619,7 +619,7 @@ public class FileRecordsTest {
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(10L, 0);
 
         assertNull(result);
         // Because the target offset is exceeded by the last offset of the batch2, 
@@ -629,13 +629,13 @@ public class FileRecordsTest {
     }
 
     /**
-     * Test two condition
+     * Test two conditions
      * 1. If the target offset < the base offset of the last batch
      * 2. If the target offset equals to the base offset of the last batch
      */
     @ParameterizedTest
     @ValueSource(longs = {8, 10})
-    public void testSearchForOffsetWithSizeLastOffsetCallCountAllBatchesSmallerLastBatchMatches(long baseOffset) throws IOException {
+    public void testSearchForOffsetFromPositionLastBatchMatches(long baseOffset) throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -648,13 +648,13 @@ public class FileRecordsTest {
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         long targetOffset = 10L;
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(targetOffset, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(targetOffset, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch2), result);
         if (targetOffset == baseOffset) {
             // Because the target offset is equal to the base offset of the batch2, we should not call
-            // lastOffset on batch2
-            verify(batch1, times(1)).lastOffset();
+            // lastOffset on batch2 and batch1
+            verify(batch1, never()).lastOffset();
             verify(batch2, never()).lastOffset();
         } else {
             // Because the target offset is in the batch2, we should not call 
@@ -665,7 +665,7 @@ public class FileRecordsTest {
     }
 
     @Test
-    public void testSearchForOffsetWithSizeLastOffsetCallCountTargetBetweenTwoBatches() throws IOException {
+    public void testSearchForOffsetFromPositionTargetBetweenTwoBatches() throws IOException {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
@@ -678,7 +678,7 @@ public class FileRecordsTest {
         FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
-        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(13L, 0);
+        FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(13L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(batch2), result);
         // Because the target offset is between the two batches, we should call lastOffset on the batch1
@@ -687,7 +687,7 @@ public class FileRecordsTest {
     }
 
     private void mockFileRecordBatches(FileRecords fileRecords, FileLogInputStream.FileChannelRecordBatch... batch) {
-        List<FileLogInputStream.FileChannelRecordBatch> batches = new ArrayList<>(asList(batch));
+        List<FileLogInputStream.FileChannelRecordBatch> batches = asList(batch);
         doReturn((Iterable<FileLogInputStream.FileChannelRecordBatch>) batches::iterator)
                 .when(fileRecords)
                 .batchesFrom(anyInt());

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -564,6 +564,7 @@ public class FileRecordsTest {
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetWithSize(10L, 0);
 
         assertEquals(new FileRecords.LogOffsetPosition(prevBatch), result);
+        // Because the target offset is not in the current batch, we should call lastOffset on the previous batch
         verify(prevBatch, times(1)).lastOffset();
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -381,7 +381,7 @@ public class LogSegment implements Closeable {
      */
     LogOffsetPosition translateOffset(long offset, int startingFilePosition) throws IOException {
         OffsetPosition mapping = offsetIndex().lookup(offset);
-        return log.searchForOffsetWithSize(offset, Math.max(mapping.position, startingFilePosition));
+        return log.searchForOffsetFromPosition(offset, Math.max(mapping.position, startingFilePosition));
     }
 
     /**

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
@@ -600,7 +600,7 @@ public class LogSegmentTest {
                 int offsetToBeginCorruption = TestUtils.RANDOM.nextInt(messagesAppended);
                 // start corrupting somewhere in the middle of the chosen record all the way to the end
 
-                FileRecords.LogOffsetPosition recordPosition = seg.log().searchForOffsetWithSize(offsetToBeginCorruption, 0);
+                FileRecords.LogOffsetPosition recordPosition = seg.log().searchForOffsetFromPosition(offsetToBeginCorruption, 0);
                 int position = recordPosition.position + TestUtils.RANDOM.nextInt(15);
                 writeNonsenseToFile(seg.log().file(), position, (int) (seg.log().file().length() - position));
                 seg.recover(newProducerStateManager(), mock(LeaderEpochFileCache.class));


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-18989
The `lastOffset` includes the entire batch header, so we should check `baseOffset` instead.  

To optimize this, we need to update the search logic. The previous approach simply checked whether each batch's `lastOffset()` was greater than or equal to the target offset. Once it found the first batch that met this condition, it returned that batch immediately.  

Now that we are using `baseOffset()`, we need to handle a special case: if the `targetOffset` falls between the `lastOffset` of the previous batch and the `baseOffset` of the matching batch, we should select the matching batch. The updated logic is structured as follows:  

1. First, if baseOffset exactly equals targetOffset, return immediately.
2. If we find the first batch with baseOffset greater than targetOffset
    - Check if the previous batch contains the target
    - If there's no previous batch, return the current batch or the previous batch doesn't contain the target, return the current batch
5. After iterating through all batches, check if the last batch contains the target offset.

This code path is not thread-safe, so we need to prevent `EOFException`. To avoid this exception, I am still using an early return. In this scenario, `lastOffset` is still used within the loop, but it should be executed at most once within the loop.

Therefore, in the new implementation, `lastOffset` will be executed at most once. In most cases, this results in an optimization.

Test: Verifying Memory Usage Improvement  
To evaluate whether this optimization helps, I followed the steps below to monitor memory usage:  

1. Start a Standalone Kafka Server  
```sh
KAFKA_CLUSTER_ID="$(bin/kafka-storage.sh random-uuid)"
bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/server.properties
bin/kafka-server-start.sh config/server.properties
```  

2. Use Performance Console Tools to Produce and Consume Records  

**Produce Records:**  
```sh
./kafka-producer-perf-test.sh \
  --topic test-topic \
  --num-records 1000000000 \
  --record-size 100 \
  --throughput -1 \
  --producer-props bootstrap.servers=localhost:9092
```  
**Consume Records:**  
```sh
./bin/kafka-consumer-perf-test.sh \
  --topic test-topic \
  --messages 1000000000 \
  --bootstrap-server localhost:9092
```  
It can be observed that memory usage has significantly decreased.
trunk:
![CleanShot 2025-03-16 at 11 53 31@2x](https://github.com/user-attachments/assets/eec26b1d-38ed-41c8-8c49-e5c68643761b)
this PR:
![CleanShot 2025-03-16 at 17 41 56@2x](https://github.com/user-attachments/assets/c8d4c234-18c2-4642-88ae-9f96cf54fccc)

Reviewers: Kirk True <kirk@kirktrue.pro>, TengYao Chi <kitingiao@gmail.com>, David Arthur <mumrah@gmail.com>, Jun Rao <junrao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
