### PR TITLE
(WIP) KAFKA-18390: Use LinkedHashMap instead of Map in creating MetricName and SensorBuilder

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/server/quota/CustomQuotaCallbackTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/server/quota/CustomQuotaCallbackTest.java
@@ -31,10 +31,13 @@ import org.apache.kafka.server.config.QuotaConfig;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 @ClusterTestDefaults(controllers = 3, 
     types = {Type.KRAFT},
@@ -84,12 +87,12 @@ public class CustomQuotaCallbackTest {
         private String nodeId;
 
         @Override
-        public Map<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId) {
-            return Map.of();
+        public LinkedHashMap<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId) {
+            return mkMap();
         }
 
         @Override
-        public Double quotaLimit(ClientQuotaType quotaType, Map<String, String> metricTags) {
+        public Double quotaLimit(ClientQuotaType quotaType, LinkedHashMap<String, String> metricTags) {
             return Double.MAX_VALUE;
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -305,6 +305,8 @@ import static org.apache.kafka.common.message.ListPartitionReassignmentsResponse
 import static org.apache.kafka.common.requests.MetadataRequest.convertToMetadataRequestTopic;
 import static org.apache.kafka.common.requests.MetadataRequest.convertTopicIdsToMetadataRequestTopic;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * The default implementation of {@link Admin}. An instance of this class is created by invoking one of the
@@ -543,7 +545,7 @@ public class KafkaAdminClient extends AdminClient {
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
             clientTelemetryReporter = CommonClientConfigs.telemetryReporter(clientId, config);
             clientTelemetryReporter.ifPresent(reporters::add);
-            Map<String, String> metricTags = Collections.singletonMap("client-id", clientId);
+            LinkedHashMap<String, String> metricTags = mkMap(mkEntry("client-id", clientId));
             MetricConfig metricConfig = new MetricConfig().samples(config.getInt(AdminClientConfig.METRICS_NUM_SAMPLES_CONFIG))
                 .timeWindow(config.getLong(AdminClientConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
                 .recordLevel(Sensor.RecordingLevel.forName(config.getString(AdminClientConfig.METRICS_RECORDING_LEVEL_CONFIG)))

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,6 +54,9 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public final class ConsumerUtils {
 
@@ -142,7 +146,7 @@ public final class ConsumerUtils {
 
     public static Metrics createMetrics(ConsumerConfig config, Time time, List<MetricsReporter> reporters) {
         String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
-        Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
+        LinkedHashMap<String, String> metricsTags = mkMap(mkEntry(CONSUMER_CLIENT_ID_METRIC_TAG, clientId));
         MetricConfig metricConfig = new MetricConfig()
                 .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
                 .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
@@ -25,11 +25,10 @@ import org.apache.kafka.common.metrics.stats.WindowedCount;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkSeqMap;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * The {@link FetchMetricsManager} class provides wrapper methods to record lag, lead, latency, and fetch metrics.
@@ -106,7 +105,7 @@ public class FetchMetricsManager {
         String name = topicBytesFetchedMetricName(topic);
         maybeRecordDeprecatedBytesFetched(name, topic, bytes);
 
-        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
+        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicFetchSizeAvg)
             .withMax(metricsRegistry.topicFetchSizeMax)
             .withMeter(metricsRegistry.topicBytesConsumedRate, metricsRegistry.topicBytesConsumedTotal)
@@ -118,7 +117,7 @@ public class FetchMetricsManager {
         String name = topicRecordsFetchedMetricName(topic);
         maybeRecordDeprecatedRecordsFetched(name, topic, records);
 
-        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
+        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicRecordsPerRequestAvg)
             .withMeter(metricsRegistry.topicRecordsConsumedRate, metricsRegistry.topicRecordsConsumedTotal)
             .build();
@@ -131,7 +130,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLagMetricName(tp);
         maybeRecordDeprecatedPartitionLag(name, tp, lag);
 
-        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLag)
             .withMax(metricsRegistry.partitionRecordsLagMax)
             .withAvg(metricsRegistry.partitionRecordsLagAvg)
@@ -146,7 +145,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLeadMetricName(tp);
         maybeRecordDeprecatedPartitionLead(name, tp, lead);
 
-        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLead)
             .withMin(metricsRegistry.partitionRecordsLeadMin)
             .withAvg(metricsRegistry.partitionRecordsLeadAvg)
@@ -284,24 +283,24 @@ public class FetchMetricsManager {
     }
 
     private MetricName partitionPreferredReadReplicaMetricName(TopicPartition tp) {
-        Map<String, String> metricTags = mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
+        LinkedHashMap<String, String> metricTags = mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
         return this.metrics.metricInstance(metricsRegistry.partitionPreferredReadReplica, metricTags);
     }
 
     @Deprecated
     private MetricName deprecatedPartitionPreferredReadReplicaMetricName(TopicPartition tp) {
-        Map<String, String> metricTags = topicPartitionTags(tp);
+        LinkedHashMap<String, String> metricTags = topicPartitionTags(tp);
         return this.metrics.metricInstance(metricsRegistry.partitionPreferredReadReplica, metricTags);
     }
 
     @Deprecated
     static LinkedHashMap<String, String> topicTags(String topic) {
-        return mkSeqMap(mkEntry("topic", topic.replace('.', '_')));
+        return mkMap(mkEntry("topic", topic.replace('.', '_')));
     }
 
     @Deprecated
     static LinkedHashMap<String, String> topicPartitionTags(TopicPartition tp) {
-        return mkSeqMap(mkEntry("topic", tp.topic().replace('.', '_')),
+        return mkMap(mkEntry("topic", tp.topic().replace('.', '_')),
             mkEntry("partition", String.valueOf(tp.partition())));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
@@ -24,11 +24,12 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSeqMap;
 
 /**
  * The {@link FetchMetricsManager} class provides wrapper methods to record lag, lead, latency, and fetch metrics.
@@ -105,7 +106,7 @@ public class FetchMetricsManager {
         String name = topicBytesFetchedMetricName(topic);
         maybeRecordDeprecatedBytesFetched(name, topic, bytes);
 
-        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> Map.of("topic", topic))
+        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicFetchSizeAvg)
             .withMax(metricsRegistry.topicFetchSizeMax)
             .withMeter(metricsRegistry.topicBytesConsumedRate, metricsRegistry.topicBytesConsumedTotal)
@@ -117,7 +118,7 @@ public class FetchMetricsManager {
         String name = topicRecordsFetchedMetricName(topic);
         maybeRecordDeprecatedRecordsFetched(name, topic, records);
 
-        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> Map.of("topic", topic))
+        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicRecordsPerRequestAvg)
             .withMeter(metricsRegistry.topicRecordsConsumedRate, metricsRegistry.topicRecordsConsumedTotal)
             .build();
@@ -130,7 +131,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLagMetricName(tp);
         maybeRecordDeprecatedPartitionLag(name, tp, lag);
 
-        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLag)
             .withMax(metricsRegistry.partitionRecordsLagMax)
             .withAvg(metricsRegistry.partitionRecordsLagAvg)
@@ -145,7 +146,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLeadMetricName(tp);
         maybeRecordDeprecatedPartitionLead(name, tp, lead);
 
-        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLead)
             .withMin(metricsRegistry.partitionRecordsLeadMin)
             .withAvg(metricsRegistry.partitionRecordsLeadAvg)
@@ -283,7 +284,7 @@ public class FetchMetricsManager {
     }
 
     private MetricName partitionPreferredReadReplicaMetricName(TopicPartition tp) {
-        Map<String, String> metricTags = mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
+        Map<String, String> metricTags = mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
         return this.metrics.metricInstance(metricsRegistry.partitionPreferredReadReplica, metricTags);
     }
 
@@ -294,13 +295,13 @@ public class FetchMetricsManager {
     }
 
     @Deprecated
-    static Map<String, String> topicTags(String topic) {
-        return Map.of("topic", topic.replace('.', '_'));
+    static LinkedHashMap<String, String> topicTags(String topic) {
+        return mkSeqMap(mkEntry("topic", topic.replace('.', '_')));
     }
 
     @Deprecated
-    static Map<String, String> topicPartitionTags(TopicPartition tp) {
-        return mkMap(mkEntry("topic", tp.topic().replace('.', '_')),
+    static LinkedHashMap<String, String> topicPartitionTags(TopicPartition tp) {
+        return mkSeqMap(mkEntry("topic", tp.topic().replace('.', '_')),
             mkEntry("partition", String.valueOf(tp.partition())));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SensorBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SensorBuilder.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.metrics.stats.SampledStat;
 import org.apache.kafka.common.metrics.stats.Value;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -46,10 +47,10 @@ public class SensorBuilder {
     private final Map<String, String> tags;
 
     public SensorBuilder(Metrics metrics, String name) {
-        this(metrics, name, Collections::emptyMap);
+        this(metrics, name, LinkedHashMap::new);
     }
 
-    public SensorBuilder(Metrics metrics, String name, Supplier<Map<String, String>> tagsSupplier) {
+    public SensorBuilder(Metrics metrics, String name, Supplier<LinkedHashMap<String, String>> tagsSupplier) {
         this.metrics = metrics;
         Sensor s = metrics.getSensor(name);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SensorBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SensorBuilder.java
@@ -27,10 +27,10 @@ import org.apache.kafka.common.metrics.stats.Min;
 import org.apache.kafka.common.metrics.stats.SampledStat;
 import org.apache.kafka.common.metrics.stats.Value;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.function.Supplier;
+
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * {@code SensorBuilder} takes a bit of the boilerplate out of creating {@link Sensor sensors} for recording
@@ -44,7 +44,7 @@ public class SensorBuilder {
 
     private final boolean preexisting;
 
-    private final Map<String, String> tags;
+    private final LinkedHashMap<String, String> tags;
 
     public SensorBuilder(Metrics metrics, String name) {
         this(metrics, name, LinkedHashMap::new);
@@ -56,7 +56,7 @@ public class SensorBuilder {
 
         if (s != null) {
             sensor = s;
-            tags = Collections.emptyMap();
+            tags = mkMap();
             preexisting = true;
         } else {
             sensor = metrics.sensor(name);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -87,6 +87,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,6 +98,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * A Kafka client that publishes records to the Kafka cluster.
@@ -355,7 +358,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             log = logContext.logger(KafkaProducer.class);
             log.trace("Starting the Kafka producer");
 
-            Map<String, String> metricTags = Collections.singletonMap("client-id", clientId);
+            LinkedHashMap<String, String> metricTags = mkMap(mkEntry("client-id", clientId));
             MetricConfig metricConfig = new MetricConfig().samples(config.getInt(ProducerConfig.METRICS_NUM_SAMPLES_CONFIG))
                     .timeWindow(config.getLong(ProducerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
                     .recordLevel(Sensor.RecordingLevel.forName(config.getString(ProducerConfig.METRICS_RECORDING_LEVEL_CONFIG)))

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/KafkaProducerMetrics.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 public class KafkaProducerMetrics implements AutoCloseable {
 
@@ -36,7 +36,7 @@ public class KafkaProducerMetrics implements AutoCloseable {
     private static final String TOTAL_TIME_SUFFIX = "-time-ns-total";
     private static final String METADATA_WAIT = "metadata-wait";
 
-    private final Map<String, String> tags;
+    private final LinkedHashMap<String, String> tags;
     private final Metrics metrics;
     private final Sensor initTimeSensor;
     private final Sensor beginTxnTimeSensor;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetrics.java
@@ -21,9 +21,11 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class ProducerMetrics {
 
@@ -38,7 +40,7 @@ public class ProducerMetrics {
     }
 
     public static void main(String[] args) {
-        Map<String, String> metricTags = Collections.singletonMap("client-id", "client-id");
+        LinkedHashMap<String, String> metricTags = mkMap(mkEntry("client-id", "client-id"));
         MetricConfig metricConfig = new MetricConfig().tags(metricTags);
         Metrics metrics = new Metrics(metricConfig);
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -63,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +73,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.requests.ProduceResponse.INVALID_OFFSET;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * The background thread that handles the sending of produce requests to the Kafka cluster. This thread makes metadata
@@ -980,7 +983,7 @@ public class Sender implements Runnable {
             String topicRecordsCountName = "topic." + topic + ".records-per-batch";
             Sensor topicRecordCount = this.metrics.getSensor(topicRecordsCountName);
             if (topicRecordCount == null) {
-                Map<String, String> metricTags = Collections.singletonMap("topic", topic);
+                LinkedHashMap<String, String> metricTags = mkMap(mkEntry("topic", topic));
 
                 topicRecordCount = this.metrics.sensor(topicRecordsCountName);
                 MetricName rateMetricName = this.metrics.topicRecordSendRate(metricTags);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -23,9 +23,9 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class SenderMetricsRegistry {
@@ -161,39 +161,39 @@ public class SenderMetricsRegistry {
     }
 
     /* topic level metrics */
-    public MetricName topicRecordSendRate(Map<String, String> tags) {
+    public MetricName topicRecordSendRate(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicRecordSendRate, tags);
     }
 
-    public MetricName topicRecordSendTotal(Map<String, String> tags) {
+    public MetricName topicRecordSendTotal(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicRecordSendTotal, tags);
     }
 
-    public MetricName topicByteRate(Map<String, String> tags) {
+    public MetricName topicByteRate(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicByteRate, tags);
     }
 
-    public MetricName topicByteTotal(Map<String, String> tags) {
+    public MetricName topicByteTotal(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicByteTotal, tags);
     }
 
-    public MetricName topicCompressionRate(Map<String, String> tags) {
+    public MetricName topicCompressionRate(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicCompressionRate, tags);
     }
 
-    public MetricName topicRecordRetryRate(Map<String, String> tags) {
+    public MetricName topicRecordRetryRate(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicRecordRetryRate, tags);
     }
 
-    public MetricName topicRecordRetryTotal(Map<String, String> tags) {
+    public MetricName topicRecordRetryTotal(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicRecordRetryTotal, tags);
     }
 
-    public MetricName topicRecordErrorRate(Map<String, String> tags) {
+    public MetricName topicRecordErrorRate(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicRecordErrorRate, tags);
     }
 
-    public MetricName topicRecordErrorTotal(Map<String, String> tags) {
+    public MetricName topicRecordErrorTotal(LinkedHashMap<String, String> tags) {
         return this.metrics.metricInstance(this.topicRecordErrorTotal, tags);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/MetricName.java
+++ b/clients/src/main/java/org/apache/kafka/common/MetricName.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -92,7 +91,7 @@ public final class MetricName {
         return this.group;
     }
 
-    public Map<String, String> tags() {
+    public LinkedHashMap<String, String> tags() {
         return this.tags;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/MetricName.java
+++ b/clients/src/main/java/org/apache/kafka/common/MetricName.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -65,18 +66,18 @@ public final class MetricName {
     private final String name;
     private final String group;
     private final String description;
-    private final Map<String, String> tags;
+    private final LinkedHashMap<String, String> tags;
     private int hash = 0;
 
     /**
-     * Please create MetricName by method {@link org.apache.kafka.common.metrics.Metrics#metricName(String, String, String, Map)}
+     * Please create MetricName by method {@link org.apache.kafka.common.metrics.Metrics#metricName(String, String, String, LinkedHashMap)}
      *
      * @param name        The name of the metric
      * @param group       logical group name of the metrics to which this metric belongs
      * @param description A human-readable description to include in the metric
      * @param tags        additional key/value attributes of the metric
      */
-    public MetricName(String name, String group, String description, Map<String, String> tags) {
+    public MetricName(String name, String group, String description, LinkedHashMap<String, String> tags) {
         this.name = Objects.requireNonNull(name);
         this.group = Objects.requireNonNull(group);
         this.description = Objects.requireNonNull(description);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/MetricConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/MetricConfig.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.metrics;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -31,7 +30,7 @@ public class MetricConfig {
     private int samples;
     private long eventWindow;
     private long timeWindowMs;
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
     private Sensor.RecordingLevel recordingLevel;
 
     public MetricConfig() {
@@ -70,11 +69,11 @@ public class MetricConfig {
         return this;
     }
 
-    public Map<String, String> tags() {
+    public LinkedHashMap<String, String> tags() {
         return this.tags;
     }
 
-    public MetricConfig tags(Map<String, String> tags) {
+    public MetricConfig tags(LinkedHashMap<String, String> tags) {
         this.tags = tags;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -191,7 +191,7 @@ public final class Metrics implements Closeable {
      * @param description A human-readable description to include in the metric
      * @param tags        additional key/value attributes of the metric
      */
-    public MetricName metricName(String name, String group, String description, Map<String, String> tags) {
+    public MetricName metricName(String name, String group, String description, LinkedHashMap<String, String> tags) {
         Map<String, String> combinedTag = new LinkedHashMap<>(config.tags());
         combinedTag.putAll(tags);
         return new MetricName(name, group, description, combinedTag);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -192,7 +191,7 @@ public final class Metrics implements Closeable {
      * @param tags        additional key/value attributes of the metric
      */
     public MetricName metricName(String name, String group, String description, LinkedHashMap<String, String> tags) {
-        Map<String, String> combinedTag = new LinkedHashMap<>(config.tags());
+        LinkedHashMap<String, String> combinedTag = new LinkedHashMap<>(config.tags());
         combinedTag.putAll(tags);
         return new MetricName(name, group, description, combinedTag);
     }
@@ -206,7 +205,7 @@ public final class Metrics implements Closeable {
      * @param description A human-readable description to include in the metric
      */
     public MetricName metricName(String name, String group, String description) {
-        return metricName(name, group, description, new HashMap<>());
+        return metricName(name, group, description, new LinkedHashMap<>());
     }
 
     /**
@@ -216,7 +215,7 @@ public final class Metrics implements Closeable {
      * @param group       logical group name of the metrics to which this metric belongs
      */
     public MetricName metricName(String name, String group) {
-        return metricName(name, group, "", new HashMap<>());
+        return metricName(name, group, "", new LinkedHashMap<>());
     }
 
     /**
@@ -240,7 +239,7 @@ public final class Metrics implements Closeable {
      * @param group logical group name of the metrics to which this metric belongs
      * @param tags  key/value attributes of the metric
      */
-    public MetricName metricName(String name, String group, Map<String, String> tags) {
+    public MetricName metricName(String name, String group, LinkedHashMap<String, String> tags) {
         return metricName(name, group, "", tags);
     }
 
@@ -259,7 +258,7 @@ public final class Metrics implements Closeable {
     
         try (Metrics metrics = new Metrics()) {
             for (MetricNameTemplate template : allMetrics) {
-                Map<String, String> tags = new LinkedHashMap<>();
+                LinkedHashMap<String, String> tags = new LinkedHashMap<>();
                 for (String s : template.tags()) {
                     tags.put(s, "{" + s + "}");
                 }
@@ -652,7 +651,7 @@ public final class Metrics implements Closeable {
         return metricInstance(template, MetricsUtils.getTags(keyValue));
     }
 
-    public MetricName metricInstance(MetricNameTemplate template, Map<String, String> tags) {
+    public MetricName metricInstance(MetricNameTemplate template, LinkedHashMap<String, String> tags) {
         // check to make sure that the runtime defined tags contain all the template tags.
         Set<String> runtimeTagKeys = new HashSet<>(tags.keySet());
         runtimeTagKeys.addAll(config().tags().keySet());

--- a/clients/src/main/java/org/apache/kafka/common/metrics/internals/MetricsUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/internals/MetricsUtils.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.metrics.internals;
 import org.apache.kafka.common.metrics.Metrics;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class MetricsUtils {
@@ -54,10 +53,10 @@ public class MetricsUtils {
      * @param keyValue the key and value pairs for the tags; must be an even number
      * @return the map of tags that can be supplied to the {@link Metrics} methods; never null
      */
-    public static Map<String, String> getTags(String... keyValue) {
+    public static LinkedHashMap<String, String> getTags(String... keyValue) {
         if ((keyValue.length % 2) != 0)
             throw new IllegalArgumentException("keyValue needs to be specified in pairs");
-        Map<String, String> tags = new LinkedHashMap<>(keyValue.length / 2);
+        LinkedHashMap<String, String> tags = new LinkedHashMap<>(keyValue.length / 2);
 
         for (int i = 0; i < keyValue.length; i += 2)
             tags.put(keyValue[i], keyValue[i + 1]);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/internals/PluginMetricsImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/internals/PluginMetricsImpl.java
@@ -52,7 +52,7 @@ public class PluginMetricsImpl implements PluginMetrics, Closeable {
                 throw new IllegalArgumentException("Cannot use " + tagName + " as a tag name");
             }
         }
-        Map<String, String> metricsTags = new LinkedHashMap<>(this.tags);
+        LinkedHashMap<String, String> metricsTags = new LinkedHashMap<>(this.tags);
         metricsTags.putAll(tags);
         return metrics.metricName(name, GROUP, description, metricsTags);
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -56,6 +56,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
 /**
  * A nioSelector interface for doing non-blocking multi-connection network I/O.
  * <p>
@@ -150,7 +152,7 @@ public class Selector implements Selectable, AutoCloseable {
             Metrics metrics,
             Time time,
             String metricGrpPrefix,
-            Map<String, String> metricTags,
+            LinkedHashMap<String, String> metricTags,
             boolean metricsPerConnection,
             boolean recordTimePerConnection,
             ChannelBuilder channelBuilder,
@@ -190,7 +192,7 @@ public class Selector implements Selectable, AutoCloseable {
                     Metrics metrics,
                     Time time,
                     String metricGrpPrefix,
-                    Map<String, String> metricTags,
+                    LinkedHashMap<String, String> metricTags,
                     boolean metricsPerConnection,
                     boolean recordTimePerConnection,
                     ChannelBuilder channelBuilder,
@@ -206,7 +208,7 @@ public class Selector implements Selectable, AutoCloseable {
                     Metrics metrics,
                     Time time,
                     String metricGrpPrefix,
-                    Map<String, String> metricTags,
+                    LinkedHashMap<String, String> metricTags,
                     boolean metricsPerConnection,
                     ChannelBuilder channelBuilder,
                     LogContext logContext) {
@@ -218,7 +220,7 @@ public class Selector implements Selectable, AutoCloseable {
                     Metrics metrics,
                     Time time,
                     String metricGrpPrefix,
-                    Map<String, String> metricTags,
+                    LinkedHashMap<String, String> metricTags,
                     boolean metricsPerConnection,
                     ChannelBuilder channelBuilder,
                     LogContext logContext) {
@@ -226,11 +228,11 @@ public class Selector implements Selectable, AutoCloseable {
     }
 
     public Selector(long connectionMaxIdleMS, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
-        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, metrics, time, metricGrpPrefix, Collections.emptyMap(), true, channelBuilder, logContext);
+        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, metrics, time, metricGrpPrefix, mkMap(), true, channelBuilder, logContext);
     }
 
     public Selector(long connectionMaxIdleMS, int failedAuthenticationDelayMs, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
-        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, Collections.emptyMap(), true, channelBuilder, logContext);
+        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, mkMap(), true, channelBuilder, logContext);
     }
 
     /**
@@ -1147,7 +1149,7 @@ public class Selector implements Selectable, AutoCloseable {
         private final List<MetricName> topLevelMetricNames = new ArrayList<>();
         private final List<Sensor> sensors = new ArrayList<>();
 
-        public SelectorMetrics(Metrics metrics, String metricGrpPrefix, Map<String, String> metricTags, boolean metricsPerConnection) {
+        public SelectorMetrics(Metrics metrics, String metricGrpPrefix, LinkedHashMap<String, String> metricTags, boolean metricsPerConnection) {
             this.metrics = metrics;
             this.metricTags = metricTags;
             this.metricsPerConnection = metricsPerConnection;
@@ -1240,7 +1242,7 @@ public class Selector implements Selectable, AutoCloseable {
 
             this.connectionsByCipher = new IntGaugeSuite<>(log, "sslCiphers", metrics,
                 cipherInformation -> {
-                    Map<String, String> tags = new LinkedHashMap<>();
+                    LinkedHashMap<String, String> tags = new LinkedHashMap<>();
                     tags.put("cipher", cipherInformation.cipher());
                     tags.put("protocol", cipherInformation.protocol());
                     tags.putAll(metricTags);
@@ -1249,7 +1251,7 @@ public class Selector implements Selectable, AutoCloseable {
 
             this.connectionsByClient = new IntGaugeSuite<>(log, "clients", metrics,
                 clientInformation -> {
-                    Map<String, String> tags = new LinkedHashMap<>();
+                    LinkedHashMap<String, String> tags = new LinkedHashMap<>();
                     tags.put("clientSoftwareName", clientInformation.softwareName());
                     tags.put("clientSoftwareVersion", clientInformation.softwareVersion());
                     tags.putAll(metricTags);
@@ -1261,7 +1263,7 @@ public class Selector implements Selectable, AutoCloseable {
             this.metrics.addMetric(metricName, (config, now) -> channels.size());
         }
 
-        private Meter createMeter(Metrics metrics, String groupName, Map<String, String> metricTags,
+        private Meter createMeter(Metrics metrics, String groupName, LinkedHashMap<String, String> metricTags,
                 SampledStat stat, String baseName, String descriptiveName) {
             MetricName rateMetricName = metrics.metricName(baseName + "-rate", groupName,
                             String.format("The number of %s per second", descriptiveName), metricTags);
@@ -1273,12 +1275,12 @@ public class Selector implements Selectable, AutoCloseable {
                 return new Meter(stat, rateMetricName, totalMetricName);
         }
 
-        private Meter createMeter(Metrics metrics, String groupName,  Map<String, String> metricTags,
+        private Meter createMeter(Metrics metrics, String groupName,  LinkedHashMap<String, String> metricTags,
                 String baseName, String descriptiveName) {
             return createMeter(metrics, groupName, metricTags, null, baseName, descriptiveName);
         }
 
-        private Meter createIOThreadRatioMeter(Metrics metrics, String groupName,  Map<String, String> metricTags,
+        private Meter createIOThreadRatioMeter(Metrics metrics, String groupName,  LinkedHashMap<String, String> metricTags,
                                                String baseName, String action) {
             MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
                 String.format("The fraction of time the I/O thread spent %s", action), metricTags);
@@ -1300,7 +1302,7 @@ public class Selector implements Selectable, AutoCloseable {
                 String nodeRequestName = "node-" + connectionId + ".requests-sent";
                 Sensor nodeRequest = this.metrics.getSensor(nodeRequestName);
                 if (nodeRequest == null) {
-                    Map<String, String> tags = new LinkedHashMap<>(metricTags);
+                    LinkedHashMap<String, String> tags = new LinkedHashMap<>(metricTags);
                     tags.put("node-id", "node-" + connectionId);
 
                     nodeRequest = sensor(nodeRequestName);

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -821,6 +821,23 @@ public final class Utils {
     }
 
     /**
+     * Creates a map from a sequence of entries
+     *
+     * @param entries The entries to map
+     * @param <K>     The key type
+     * @param <V>     The value type
+     * @return A linked map
+     */
+    @SafeVarargs
+    public static <K, V> LinkedHashMap<K, V> mkSeqMap(final Map.Entry<K, V>... entries) {
+        final LinkedHashMap<K, V> result = new LinkedHashMap<>();
+        for (final Map.Entry<K, V> entry : entries) {
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
+    /**
      * Creates a {@link Properties} from a map
      *
      * @param properties A map of properties to add

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -812,24 +812,7 @@ public final class Utils {
      * @return A map
      */
     @SafeVarargs
-    public static <K, V> Map<K, V> mkMap(final Map.Entry<K, V>... entries) {
-        final LinkedHashMap<K, V> result = new LinkedHashMap<>();
-        for (final Map.Entry<K, V> entry : entries) {
-            result.put(entry.getKey(), entry.getValue());
-        }
-        return result;
-    }
-
-    /**
-     * Creates a map from a sequence of entries
-     *
-     * @param entries The entries to map
-     * @param <K>     The key type
-     * @param <V>     The value type
-     * @return A linked map
-     */
-    @SafeVarargs
-    public static <K, V> LinkedHashMap<K, V> mkSeqMap(final Map.Entry<K, V>... entries) {
+    public static <K, V> LinkedHashMap<K, V> mkMap(final Map.Entry<K, V>... entries) {
         final LinkedHashMap<K, V> result = new LinkedHashMap<>();
         for (final Map.Entry<K, V> entry : entries) {
             result.put(entry.getKey(), entry.getValue());

--- a/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaCallback.java
+++ b/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaCallback.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 /**
  * Quota callback interface for brokers and controllers that enables customization of client quota computation.
@@ -37,7 +37,7 @@ public interface ClientQuotaCallback extends Configurable {
      * @param clientId  The client id associated with the request
      * @return quota metric tags that indicate which other clients share this quota
      */
-    Map<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId);
+    LinkedHashMap<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId);
 
     /**
      * Returns the quota limit associated with the provided metric tags. These tags were returned from
@@ -51,7 +51,7 @@ public interface ClientQuotaCallback extends Configurable {
      * @param metricTags Metric tags for a quota metric of type `quotaType`
      * @return the quota limit for the provided metric tags or null if the metric tags are no longer in use
      */
-    Double quotaLimit(ClientQuotaType quotaType, Map<String, String> metricTags);
+    Double quotaLimit(ClientQuotaType quotaType, LinkedHashMap<String, String> metricTags);
 
     /**
      * Quota configuration update callback that is invoked when quota configuration for an entity is

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminFetchMetricsManagerTest.java
@@ -30,11 +30,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class AdminFetchMetricsManagerTest {
     private static final double EPSILON = 0.0001;
@@ -148,8 +150,8 @@ public class AdminFetchMetricsManagerTest {
         assertTrue(Double.isNaN(metricValue(nodeLatencyMax1)));
     }
 
-    private Map<String, String> genericTag(String connectionId) {
-        return Collections.singletonMap("node-id", "node-" + connectionId);
+    private LinkedHashMap<String, String> genericTag(String connectionId) {
+        return mkMap(mkEntry("node-id", "node-" + connectionId));
     }
 
     private void mockSleepTimeWindow() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -3251,7 +3251,7 @@ public void testPollIdleRatio(GroupProtocol groupProtocol) {
     }
 
     private static boolean consumerMetricPresent(KafkaConsumer<String, String> consumer, String name) {
-        MetricName metricName = new MetricName(name, "consumer-metrics", "", Collections.emptyMap());
+        MetricName metricName = new MetricName(name, "consumer-metrics", "", new LinkedHashMap<>());
         return consumer.metricsRegistry().metrics().containsKey(metricName);
     }
 
@@ -3645,8 +3645,8 @@ public void testClosingConsumerUnregistersConsumerMetrics(GroupProtocol groupPro
     private Map<MetricName, KafkaMetric> customMetrics() {
         MetricConfig metricConfig = new MetricConfig();
         Object lock = new Object();
-        MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new HashMap<>());
-        MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new HashMap<>());
+        MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new LinkedHashMap<>());
+        MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new LinkedHashMap<>());
 
         KafkaMetric streamClientMetricOne = new KafkaMetric(lock, metricNameOne, (Measurable) (m, now) -> 1.0, metricConfig, Time.SYSTEM);
         KafkaMetric streamClientMetricTwo = new KafkaMetric(lock, metricNameTwo, (Measurable) (m, now) -> 2.0, metricConfig, Time.SYSTEM);
@@ -3736,7 +3736,7 @@ public void testClosingConsumerUnregistersConsumerMetrics(GroupProtocol groupPro
     }
 
     private MetricName expectedMetricName(String clientId, String config, Class<?> clazz) {
-        Map<String, String> expectedTags = new LinkedHashMap<>();
+        LinkedHashMap<String, String> expectedTags = new LinkedHashMap<>();
         expectedTags.put("client-id", clientId);
         expectedTags.put("config", config);
         expectedTags.put("class", clazz.getSimpleName());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerMetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerMetricsTest.java
@@ -51,6 +51,7 @@ import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -165,7 +166,7 @@ public class KafkaShareConsumerMetricsTest {
     }
 
     private static boolean consumerMetricPresent(KafkaShareConsumer<String, String> consumer, String name) {
-        MetricName metricName = new MetricName(name, CONSUMER_SHARE_METRIC_GROUP_PREFIX + "-metrics", "", Collections.emptyMap());
+        MetricName metricName = new MetricName(name, CONSUMER_SHARE_METRIC_GROUP_PREFIX + "-metrics", "", new LinkedHashMap<>());
         return consumer.metricsRegistry().metrics().containsKey(metricName);
     }
 
@@ -383,8 +384,8 @@ public class KafkaShareConsumerMetricsTest {
     private Map<MetricName, KafkaMetric> customMetrics() {
         MetricConfig metricConfig = new MetricConfig();
         Object lock = new Object();
-        MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new HashMap<>());
-        MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new HashMap<>());
+        MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new LinkedHashMap<>());
+        MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new LinkedHashMap<>());
 
         KafkaMetric streamClientMetricOne = new KafkaMetric(lock, metricNameOne, (Measurable) (m, now) -> 1.0, metricConfig, Time.SYSTEM);
         KafkaMetric streamClientMetricTwo = new KafkaMetric(lock, metricNameTwo, (Measurable) (m, now) -> 2.0, metricConfig, Time.SYSTEM);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -99,6 +99,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -3274,7 +3275,7 @@ public abstract class ConsumerCoordinatorTest {
     public void testThreadSafeAssignedPartitionsMetric() throws Exception {
         // Get the assigned-partitions metric
         final Metric metric = metrics.metric(new MetricName("assigned-partitions", consumerId + groupId + "-coordinator-metrics",
-                "", Collections.emptyMap()));
+                "", new LinkedHashMap<>()));
 
         // Start polling the metric in the background
         final AtomicBoolean doStop = new AtomicBoolean();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManagerTest.java
@@ -32,11 +32,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 import static org.apache.kafka.clients.consumer.internals.FetchMetricsManager.topicPartitionTags;
 import static org.apache.kafka.clients.consumer.internals.FetchMetricsManager.topicTags;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -121,9 +123,9 @@ public class FetchMetricsManagerTest {
     public void testBytesFetchedTopic() {
         String topicName1 = TOPIC_NAME;
         String topicName2 = "another.topic";
-        Map<String, String> tags1 = Map.of("topic", topicName1);
-        Map<String, String> tags2 = Map.of("topic", topicName2);
-        Map<String, String> deprecatedTags = topicTags(topicName2);
+        LinkedHashMap<String, String> tags1 = mkMap(mkEntry("topic", topicName1));
+        LinkedHashMap<String, String> tags2 = mkMap(mkEntry("topic", topicName2));
+        LinkedHashMap<String, String> deprecatedTags = topicTags(topicName2);
         int initialMetricsSize = metrics.metrics().size();
 
         metricsManager.recordBytesFetched(topicName1, 2);
@@ -170,9 +172,9 @@ public class FetchMetricsManagerTest {
     public void testRecordsFetchedTopic() {
         String topicName1 = TOPIC_NAME;
         String topicName2 = "another.topic";
-        Map<String, String> tags1 = Map.of("topic", topicName1);
-        Map<String, String> tags2 = Map.of("topic", topicName2);
-        Map<String, String> deprecatedTags = topicTags(topicName2);
+        LinkedHashMap<String, String> tags1 = mkMap(mkEntry("topic", topicName1));
+        LinkedHashMap<String, String> tags2 = mkMap(mkEntry("topic", topicName2));
+        LinkedHashMap<String, String> deprecatedTags = topicTags(topicName2);
         int initialMetricsSize = metrics.metrics().size();
 
         metricsManager.recordRecordsFetched(topicName1, 2);
@@ -208,9 +210,9 @@ public class FetchMetricsManagerTest {
         TopicPartition tp1 = new TopicPartition(TOPIC_NAME, 0);
         TopicPartition tp2 = new TopicPartition("another.topic", 0);
 
-        Map<String, String> tags1 = Map.of("topic", tp1.topic(), "partition", String.valueOf(tp1.partition()));
-        Map<String, String> tags2 = Map.of("topic", tp2.topic(), "partition", String.valueOf(tp2.partition()));
-        Map<String, String> deprecatedTags = topicPartitionTags(tp2);
+        LinkedHashMap<String, String> tags1 = mkMap(mkEntry("topic", tp1.topic()), mkEntry("partition", String.valueOf(tp1.partition())));
+        LinkedHashMap<String, String> tags2 = mkMap(mkEntry("topic", tp2.topic()), mkEntry("partition", String.valueOf(tp2.partition())));
+        LinkedHashMap<String, String> deprecatedTags = topicPartitionTags(tp2);
         int initialMetricsSize = metrics.metrics().size();
 
         metricsManager.recordPartitionLag(tp1, 14);
@@ -255,9 +257,9 @@ public class FetchMetricsManagerTest {
         TopicPartition tp1 = new TopicPartition(TOPIC_NAME, 0);
         TopicPartition tp2 = new TopicPartition("another.topic", 0);
 
-        Map<String, String> tags1 = Map.of("topic", tp1.topic(), "partition", String.valueOf(tp1.partition()));
-        Map<String, String> tags2 = Map.of("topic", tp2.topic(), "partition", String.valueOf(tp2.partition()));
-        Map<String, String> deprecatedTags = topicPartitionTags(tp2);
+        LinkedHashMap<String, String> tags1 = mkMap(mkEntry("topic", tp1.topic()), mkEntry("partition", String.valueOf(tp1.partition())));
+        LinkedHashMap<String, String> tags2 = mkMap(mkEntry("topic", tp2.topic()), mkEntry("partition", String.valueOf(tp2.partition())));
+        LinkedHashMap<String, String> deprecatedTags = topicPartitionTags(tp2);
         int initialMetricsSize = metrics.metrics().size();
 
         metricsManager.recordPartitionLead(tp1, 15);
@@ -318,9 +320,9 @@ public class FetchMetricsManagerTest {
         // Another 2 metrics get registered as deprecated metrics should be reported for tp2.
         assertEquals(3, metrics.metrics().size() - initialMetricsSize);
 
-        Map<String, String> tags1 = Map.of("topic", tp1.topic(), "partition", String.valueOf(tp1.partition()));
-        Map<String, String> tags2 = Map.of("topic", tp2.topic(), "partition", String.valueOf(tp2.partition()));
-        Map<String, String> deprecatedTags = topicPartitionTags(tp2);
+        LinkedHashMap<String, String> tags1 = mkMap(mkEntry("topic", tp1.topic()), mkEntry("partition", String.valueOf(tp1.partition())));
+        LinkedHashMap<String, String> tags2 = mkMap(mkEntry("topic", tp2.topic()), mkEntry("partition", String.valueOf(tp2.partition())));
+        LinkedHashMap<String, String> deprecatedTags = topicPartitionTags(tp2);
         // Validate preferred read replica metrics.
         assertEquals(-1, readReplicaMetricValue(metricsRegistry.partitionPreferredReadReplica, tags1), EPSILON);
         assertEquals(1, readReplicaMetricValue(metricsRegistry.partitionPreferredReadReplica, tags2), EPSILON);
@@ -390,7 +392,7 @@ public class FetchMetricsManagerTest {
         return metricValue(metricName);
     }
 
-    private double metricValue(MetricNameTemplate name, Map<String, String> tags) {
+    private double metricValue(MetricNameTemplate name, LinkedHashMap<String, String> tags) {
         MetricName metricName = metrics.metricInstance(name, tags);
         return metricValue(metricName);
     }
@@ -400,7 +402,7 @@ public class FetchMetricsManagerTest {
         return (Double) metric.metricValue();
     }
 
-    private Integer readReplicaMetricValue(MetricNameTemplate name, Map<String, String> tags) {
+    private Integer readReplicaMetricValue(MetricNameTemplate name, LinkedHashMap<String, String> tags) {
         MetricName metricName = metrics.metricInstance(name, tags);
         KafkaMetric metric = metrics.metric(metricName);
         return (Integer) metric.metricValue();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -134,6 +134,8 @@ import static java.util.Collections.singletonMap;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
 import static org.apache.kafka.test.TestUtils.assertOptional;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -1953,7 +1955,7 @@ public class FetchRequestManagerTest {
         subscriptions.seek(tp0, 0);
 
         MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("topic", tp0.topic());
         tags.put("partition", String.valueOf(tp0.partition()));
         MetricName partitionLagMetric = metrics.metricName("records-lag", metricGroup, tags);
@@ -1994,9 +1996,11 @@ public class FetchRequestManagerTest {
         subscriptions.seek(tp0, 0);
 
         MetricName minLeadMetric = metrics.metricInstance(metricsRegistry.recordsLeadMin);
-        Map<String, String> tags = new HashMap<>(2);
-        tags.put("topic", tp0.topic());
-        tags.put("partition", String.valueOf(tp0.partition()));
+        LinkedHashMap<String, String> tags = mkMap(
+            mkEntry("topic", tp0.topic()),
+            mkEntry("partition", String.valueOf(tp0.partition()))
+        );
+
         MetricName partitionLeadMetric = metrics.metricName("records-lead", metricGroup, "", tags);
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
@@ -2038,7 +2042,7 @@ public class FetchRequestManagerTest {
 
         MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
 
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("topic", tp0.topic());
         tags.put("partition", String.valueOf(tp0.partition()));
         MetricName partitionLagMetric = metrics.metricName("records-lag", metricGroup, tags);
@@ -2246,7 +2250,7 @@ public class FetchRequestManagerTest {
 
     @Test
     public void testFetcherMetricsTemplates() {
-        Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
+        LinkedHashMap<String, String> clientTags = mkMap(mkEntry("client-id", "clientA"));
         buildFetcher(new MetricConfig().tags(clientTags), AutoOffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
                 new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -129,6 +129,8 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.TestUtils.assertOptional;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1940,7 +1942,7 @@ public class FetcherTest {
         subscriptions.seek(tp0, 0);
 
         MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("topic", tp0.topic());
         tags.put("partition", String.valueOf(tp0.partition()));
         MetricName partitionLagMetric = metrics.metricName("records-lag", metricGroup, tags);
@@ -1981,7 +1983,7 @@ public class FetcherTest {
         subscriptions.seek(tp0, 0);
 
         MetricName minLeadMetric = metrics.metricInstance(metricsRegistry.recordsLeadMin);
-        Map<String, String> tags = new HashMap<>(2);
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("topic", tp0.topic());
         tags.put("partition", String.valueOf(tp0.partition()));
         MetricName partitionLeadMetric = metrics.metricName("records-lead", metricGroup, "", tags);
@@ -2025,7 +2027,7 @@ public class FetcherTest {
 
         MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
 
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("topic", tp0.topic());
         tags.put("partition", String.valueOf(tp0.partition()));
         MetricName partitionLagMetric = metrics.metricName("records-lag", metricGroup, tags);
@@ -2233,7 +2235,7 @@ public class FetcherTest {
 
     @Test
     public void testFetcherMetricsTemplates() {
-        Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
+        LinkedHashMap<String, String> clientTags = mkMap(mkEntry("client-id", "clientA"));
         buildFetcher(new MetricConfig().tags(clientTags), AutoOffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
                 new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2757,8 +2757,8 @@ public class KafkaProducerTest {
     private Map<MetricName, KafkaMetric> customMetrics() {
         MetricConfig metricConfig = new MetricConfig();
         Object lock = new Object();
-        MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new HashMap<>());
-        MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new HashMap<>());
+        MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new LinkedHashMap<>());
+        MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new LinkedHashMap<>());
 
         KafkaMetric streamClientMetricOne = new KafkaMetric(lock, metricNameOne, (Measurable) (m, now) -> 1.0, metricConfig, Time.SYSTEM);
         KafkaMetric streamClientMetricTwo = new KafkaMetric(lock, metricNameTwo, (Measurable) (m, now) -> 2.0, metricConfig, Time.SYSTEM);
@@ -2821,7 +2821,7 @@ public class KafkaProducerTest {
     }
 
     private MetricName expectedMetricName(String clientId, String config, Class<?> clazz) {
-        Map<String, String> expectedTags = new LinkedHashMap<>();
+        LinkedHashMap<String, String> expectedTags = new LinkedHashMap<>();
         expectedTags.put("client-id", clientId);
         expectedTags.put("config", config);
         expectedTags.put("class", clazz.getSimpleName());

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -117,6 +117,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.clients.producer.internals.ProducerTestUtils.runUntil;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -261,7 +263,7 @@ public class SenderTest {
     @Test
     public void testSenderMetricsTemplates() throws Exception {
         metrics.close();
-        Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
+        LinkedHashMap<String, String> clientTags = mkMap(mkEntry("client-id", "clientA"));
         metrics = new Metrics(new MetricConfig().tags(clientTags));
         SenderMetricsRegistry metricsRegistry = new SenderMetricsRegistry(metrics);
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
@@ -3242,7 +3244,7 @@ public class SenderTest {
     @Test
     public void testSenderShouldCloseWhenTransactionManagerInErrorState() {
         metrics.close();
-        Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
+        LinkedHashMap<String, String> clientTags = mkMap(mkEntry("client-id", "clientA"));
         metrics = new Metrics(new MetricConfig().tags(clientTags));
         TransactionManager transactionManager = mock(TransactionManager.class);
         SenderMetricsRegistry metricsRegistry = new SenderMetricsRegistry(metrics);
@@ -3654,7 +3656,7 @@ public class SenderTest {
     ) {
         long totalSize = 1024 * 1024;
         String metricGrpName = "producer-metrics";
-        MetricConfig metricConfig = new MetricConfig().tags(Collections.singletonMap("client-id", CLIENT_ID));
+        MetricConfig metricConfig = new MetricConfig().tags(mkMap(mkEntry("client-id", CLIENT_ID)));
         this.metrics = new Metrics(metricConfig, time);
         BufferPool pool = (customPool == null) ? new BufferPool(totalSize, batchSize, metrics, time, metricGrpName) : customPool;
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMetricTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMetricTest.java
@@ -21,8 +21,7 @@ import org.apache.kafka.common.utils.MockTime;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaMetricTest {
 
-    private static final MetricName METRIC_NAME = new MetricName("name", "group", "description", Collections.emptyMap());
+    private static final MetricName METRIC_NAME = new MetricName("name", "group", "description", mkMap());
 
     @Test
     public void testIsMeasurable() {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -58,6 +59,8 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -92,7 +95,7 @@ public class MetricsTest {
     @Test
     public void testMetricName() {
         MetricName n1 = metrics.metricName("name", "group", "description", "key1", "value1", "key2", "value2");
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("key1", "value1");
         tags.put("key2", "value2");
         MetricName n2 = metrics.metricName("name", "group", "description", tags);
@@ -674,7 +677,7 @@ public class MetricsTest {
     @Test
     public void testMetricInstances() {
         MetricName n1 = metrics.metricInstance(SampleMetrics.METRIC1, "key1", "value1", "key2", "value2");
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = mkMap();
         tags.put("key1", "value1");
         tags.put("key2", "value2");
         MetricName n2 = metrics.metricInstance(SampleMetrics.METRIC2, tags);
@@ -687,10 +690,10 @@ public class MetricsTest {
             // this is expected
         }
         
-        Map<String, String> parentTagsWithValues = new HashMap<>();
+        LinkedHashMap<String, String> parentTagsWithValues = mkMap();
         parentTagsWithValues.put("parent-tag", "parent-tag-value");
 
-        Map<String, String> childTagsWithValues = new HashMap<>();
+        LinkedHashMap<String, String> childTagsWithValues = mkMap();
         childTagsWithValues.put("child-tag", "child-tag-value");
 
         try (Metrics inherited = new Metrics(new MetricConfig().tags(parentTagsWithValues), singletonList(new JmxReporter()), time, true)) {
@@ -709,7 +712,7 @@ public class MetricsTest {
 
             try {
 
-                Map<String, String> runtimeTags = new HashMap<>();
+                LinkedHashMap<String, String> runtimeTags = mkMap();
                 runtimeTags.put("child-tag", "child-tag-value");
                 runtimeTags.put("tag-not-in-template", "unexpected-value");
 
@@ -882,7 +885,7 @@ public class MetricsTest {
 
         private Sensor createSensor(StatType statType, int index) {
             Sensor sensor = metrics.sensor("kafka.requests." + index);
-            Map<String, String> tags = Collections.singletonMap("tag", "tag" + index);
+            LinkedHashMap<String, String> tags = mkMap(mkEntry("tag", "tag" + index));
             switch (statType) {
                 case AVG:
                     sensor.add(metrics.metricName("test.metric.avg", "avg", tags), new Avg());

--- a/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
@@ -31,8 +31,8 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -134,7 +134,7 @@ public class SensorTest {
 
             assertTrue(sensor.add(metrics.metricName("test1", "grp1"), new Avg()));
 
-            Map<String, String> emptyTags = Collections.emptyMap();
+            LinkedHashMap<String, String> emptyTags = new LinkedHashMap<>();
             MetricName rateMetricName = new MetricName("rate", "test", "", emptyTags);
             MetricName totalMetricName = new MetricName("total", "test", "", emptyTags);
             Meter meter = new Meter(rateMetricName, totalMetricName);
@@ -231,14 +231,14 @@ public class SensorTest {
         assertFalse(sensor.hasMetrics());
 
         sensor.add(
-            new MetricName("name1", "group1", "description1", Collections.emptyMap()),
+            new MetricName("name1", "group1", "description1", new LinkedHashMap<>()),
             new WindowedSum()
         );
 
         assertTrue(sensor.hasMetrics());
 
         sensor.add(
-            new MetricName("name2", "group2", "description2", Collections.emptyMap()),
+            new MetricName("name2", "group2", "description2", new LinkedHashMap<>()),
             new CumulativeCount()
         );
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/internals/IntGaugeSuiteTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/internals/IntGaugeSuiteTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +40,7 @@ public class IntGaugeSuiteTest {
         return new IntGaugeSuite<>(log,
             "mySuite",
             metrics,
-            name -> new MetricName(name, "group", "myMetric", Collections.emptyMap()),
+            name -> new MetricName(name, "group", "myMetric", new LinkedHashMap<>()),
             3);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -165,7 +166,7 @@ public class FrequenciesTest {
     }
 
     private MetricName metricName(String name) {
-        return new MetricName(name, "group-id", "desc", Collections.emptyMap());
+        return new MetricName(name, "group-id", "desc", new LinkedHashMap<>());
     }
 
     private Frequency freq(String name, double value) {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/MeterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/MeterTest.java
@@ -22,9 +22,8 @@ import org.apache.kafka.common.metrics.MetricConfig;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -34,7 +33,7 @@ public class MeterTest {
 
     @Test
     public void testMeter() {
-        Map<String, String> emptyTags = Collections.emptyMap();
+        LinkedHashMap<String, String> emptyTags = new LinkedHashMap<>();
         MetricName rateMetricName = new MetricName("rate", "test", "", emptyTags);
         MetricName totalMetricName = new MetricName("total", "test", "", emptyTags);
         Meter meter = new Meter(rateMetricName, totalMetricName);

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -48,6 +48,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,6 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -685,7 +687,7 @@ public class SelectorTest {
         selector.close();
         MemoryPool pool = new SimpleMemoryPool(900, 900, false, null);
         selector = new Selector(NetworkReceive.UNLIMITED, CONNECTION_MAX_IDLE_MS, metrics, time, "MetricGroup",
-            new HashMap<>(), true, false, channelBuilder, pool, new LogContext());
+            mkMap(), true, false, channelBuilder, pool, new LogContext());
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
             ss.bind(new InetSocketAddress(0));
@@ -1119,7 +1121,7 @@ public class SelectorTest {
     }
 
     private KafkaMetric findUntaggedMetricByName(String name) {
-        MetricName metricName = new MetricName(name, METRIC_GROUP + "-metrics", "", new HashMap<>());
+        MetricName metricName = new MetricName(name, METRIC_GROUP + "-metrics", "", new LinkedHashMap<>());
         KafkaMetric metric = metrics.metrics().get(metricName);
         assertNotNull(metric);
         return metric;

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -53,6 +53,7 @@ import java.util.function.Consumer;
 
 import javax.net.ssl.SSLEngine;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -258,7 +259,7 @@ public abstract class SslSelectorTest extends SelectorTest {
         channelBuilder = new SslChannelBuilder(ConnectionMode.SERVER, null, false, new LogContext());
         channelBuilder.configure(sslServerConfigs);
         selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup",
-                new HashMap<>(), true, false, channelBuilder, pool, new LogContext());
+                mkMap(), true, false, channelBuilder, pool, new LogContext());
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
             ss.bind(new InetSocketAddress(0));

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -72,6 +72,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -770,7 +771,7 @@ public class SslTransportLayerTest {
         ChannelBuilder channelBuilder = new SslChannelBuilder(ConnectionMode.CLIENT, null, false, logContext);
         channelBuilder.configure(args.sslClientConfigs);
         try (Selector selector = new Selector(NetworkReceive.UNLIMITED, Selector.NO_IDLE_TIMEOUT_MS, new Metrics(), Time.SYSTEM,
-                "MetricGroup", new HashMap<>(), false, true, channelBuilder, MemoryPool.NONE, logContext)) {
+                "MetricGroup", mkMap(), false, true, channelBuilder, MemoryPool.NONE, logContext)) {
 
             String node = "0";
             server = createEchoServer(args, SecurityProtocol.SSL);

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/KafkaMetricsCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/KafkaMetricsCollectorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -43,16 +43,19 @@ import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class KafkaMetricsCollectorTest {
 
     private static final String DOMAIN = "test.domain";
 
     private MetricName metricName;
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
     private Metrics metrics;
     private MetricNamingStrategy<MetricName> metricNamingStrategy;
     private KafkaMetricsCollector collector;
@@ -63,7 +66,7 @@ public class KafkaMetricsCollectorTest {
     @BeforeEach
     public void setUp() {
         metrics = new Metrics();
-        tags = Collections.singletonMap("tag", "value");
+        tags = mkMap(mkEntry("tag", "value"));
         metricName = metrics.metricName("name1", "group1", tags);
         time = new MockTime(0, 1000L, TimeUnit.MILLISECONDS.toNanos(1000L));
         testEmitter = new TestEmitter();
@@ -575,7 +578,7 @@ public class KafkaMetricsCollectorTest {
             Collections.singleton("tag2")
         );
 
-        tags = new HashMap<>();
+        tags = mkMap();
         tags.put("tag1", "value1");
         tags.put("tag2", "value2");
 

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/TelemetryMetricNamingConventionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/TelemetryMetricNamingConventionTest.java
@@ -22,9 +22,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -41,16 +42,16 @@ public class TelemetryMetricNamingConventionTest {
     @Test
     public void testMetricKey() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.metricKey(metricName);
 
         assertEquals("org.apache.kafka.group.name", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
     public void testMetricKeyWithHyphenNameAndNonEmptyTags() {
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = new LinkedHashMap<>();
         tags.put("tag1", "value1");
         tags.put("tag2", "value2");
 
@@ -67,7 +68,7 @@ public class TelemetryMetricNamingConventionTest {
      */
     @Test
     public void testMetricKeyWithMixedNameAndMixedTags() {
-        Map<String, String> tags = new HashMap<>();
+        LinkedHashMap<String, String> tags = new LinkedHashMap<>();
         tags.put("tag1-Ab-2_(", "value1");
         tags.put("tag2-HELLO.@", "value2");
 
@@ -91,53 +92,53 @@ public class TelemetryMetricNamingConventionTest {
     @Test
     public void testMetricKeyWithEmptyName() {
         MetricName metricName = new MetricName("", "group-1A", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.metricKey(metricName);
 
         // If there is no name, then the telemetry metric name will have dot in the end though
         // metric names always have a name.
         assertEquals("org.apache.kafka.group.1a.", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
     public void testMetricKeyWithEmptyGroup() {
         MetricName metricName = new MetricName("name", "", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.metricKey(metricName);
 
         // If there is no group, then the telemetry metric name will have consecutive dots, though
         // metric names always have group name.
         assertEquals("org.apache.kafka..name", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
     public void testMetricKeyWithAdditionalMetricsSuffixInGroup() {
         MetricName metricName = new MetricName("name", "group-metrics", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.metricKey(metricName);
 
         // '-metrics' gets removed from the group name.
         assertEquals("org.apache.kafka.group.name", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
     public void testMetricKeyWithMultipleMetricsSuffixInGroup() {
         MetricName metricName = new MetricName("name-metrics", "group-metrics-metrics", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.metricKey(metricName);
 
         // '-metrics' gets removed from the group name.
         assertEquals("org.apache.kafka.group.name.metrics", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
     public void testMetricKeyWithNullTagKey() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.singletonMap(null, "value1"));
+            mkMap(mkEntry(null, "value1")));
         Exception e = assertThrows(NullPointerException.class, () -> metricNamingStrategy.metricKey(metricName));
         assertEquals("metric data cannot be null", e.getMessage());
     }
@@ -145,7 +146,7 @@ public class TelemetryMetricNamingConventionTest {
     @Test
     public void testMetricKeyWithBlankTagKey() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.singletonMap("", "value1"));
+                mkMap(mkEntry("", "value1")));
         MetricKey metricKey = metricNamingStrategy.metricKey(metricName);
 
         assertEquals("org.apache.kafka.group.name", metricKey.name());
@@ -155,18 +156,18 @@ public class TelemetryMetricNamingConventionTest {
     @Test
     public void testDerivedMetricKey() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.derivedMetricKey(
             metricNamingStrategy.metricKey(metricName), "delta");
 
         assertEquals("org.apache.kafka.group.name.delta", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
     public void testDerivedMetricKeyWithTags() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.singletonMap("tag1", "value1"));
+                mkMap(mkEntry("tag1", "value1")));
         MetricKey metricKey = metricNamingStrategy.derivedMetricKey(
             metricNamingStrategy.metricKey(metricName), "delta");
 
@@ -177,7 +178,7 @@ public class TelemetryMetricNamingConventionTest {
     @Test
     public void testDerivedMetricKeyWithNullComponent() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         Exception e = assertThrows(NullPointerException.class, () -> metricNamingStrategy.derivedMetricKey(
             metricNamingStrategy.metricKey(metricName), null));
         assertEquals("derived component cannot be null", e.getMessage());
@@ -186,13 +187,13 @@ public class TelemetryMetricNamingConventionTest {
     @Test
     public void testDerivedMetricKeyWithBlankComponent() {
         MetricName metricName = new MetricName("name", "group", "description",
-            Collections.emptyMap());
+            new LinkedHashMap<>());
         MetricKey metricKey = metricNamingStrategy.derivedMetricKey(
             metricNamingStrategy.metricKey(metricName), "");
 
         // Ends with dot, though derived component should not be blank, omitting the check in the code.
         assertEquals("org.apache.kafka.group.name.", metricKey.name());
-        assertEquals(Collections.emptyMap(), metricKey.tags());
+        assertEquals(new LinkedHashMap<>(), metricKey.tags());
     }
 
     @Test
@@ -210,35 +211,35 @@ public class TelemetryMetricNamingConventionTest {
     public void testStandardProducerMetrics() {
         assertEquals("org.apache.kafka.producer.connection.creation.rate",
             metricNamingStrategy.metricKey(new MetricName("connection-creation-rate",
-                "producer-metrics", "description", Collections.emptyMap())).name());
+                "producer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.connection.creation.total",
             metricNamingStrategy.metricKey(new MetricName("connection-creation-total",
-                "producer-metrics", "description", Collections.emptyMap())).name());
+                "producer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.node.request.latency.avg",
             metricNamingStrategy.metricKey(new MetricName("request-latency-avg",
-                "producer-node-metrics", "description", Collections.emptyMap())).name());
+                "producer-node-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.node.request.latency.max",
             metricNamingStrategy.metricKey(new MetricName("request-latency-max",
-                "producer-node-metrics", "description", Collections.emptyMap())).name());
+                "producer-node-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.produce.throttle.time.avg",
             metricNamingStrategy.metricKey(new MetricName("produce-throttle-time-avg",
-                "producer-metrics", "description", Collections.emptyMap())).name());
+                "producer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.produce.throttle.time.max",
             metricNamingStrategy.metricKey(new MetricName("produce-throttle-time-max",
-                "producer-metrics", "description", Collections.emptyMap())).name());
+                "producer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.record.queue.time.avg",
             metricNamingStrategy.metricKey(new MetricName("record-queue-time-avg",
-                "producer-metrics", "description", Collections.emptyMap())).name());
+                "producer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.producer.record.queue.time.max",
             metricNamingStrategy.metricKey(new MetricName("record-queue-time-max",
-                "producer-metrics", "description", Collections.emptyMap())).name());
+                "producer-metrics", "description", new LinkedHashMap<>())).name());
     }
 
     /**
@@ -249,54 +250,54 @@ public class TelemetryMetricNamingConventionTest {
     public void testStandardConsumerMetrics() {
         assertEquals("org.apache.kafka.consumer.connection.creation.rate",
             metricNamingStrategy.metricKey(new MetricName("connection-creation-rate",
-                "consumer-metrics", "description", Collections.emptyMap())).name());
+                "consumer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.connection.creation.total",
             metricNamingStrategy.metricKey(new MetricName("connection-creation-total",
-                "consumer-metrics", "description", Collections.emptyMap())).name());
+                "consumer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.node.request.latency.avg",
             metricNamingStrategy.metricKey(new MetricName("request-latency-avg",
-                "consumer-node-metrics", "description", Collections.emptyMap())).name());
+                "consumer-node-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.node.request.latency.max",
             metricNamingStrategy.metricKey(new MetricName("request-latency-max",
-                "consumer-node-metrics", "description", Collections.emptyMap())).name());
+                "consumer-node-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.poll.idle.ratio.avg",
             metricNamingStrategy.metricKey(new MetricName("poll-idle-ratio-avg",
-                "consumer-metrics", "description", Collections.emptyMap())).name());
+                "consumer-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.coordinator.commit.latency.avg",
             metricNamingStrategy.metricKey(new MetricName("commit-latency-avg",
-                "consumer-coordinator-metrics", "description", Collections.emptyMap())).name());
+                "consumer-coordinator-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.coordinator.commit.latency.max",
             metricNamingStrategy.metricKey(new MetricName("commit-latency-max",
-                "consumer-coordinator-metrics", "description", Collections.emptyMap())).name());
+                "consumer-coordinator-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.coordinator.assigned.partitions",
             metricNamingStrategy.metricKey(new MetricName("assigned-partitions",
-                "consumer-coordinator-metrics", "description", Collections.emptyMap())).name());
+                "consumer-coordinator-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.coordinator.rebalance.latency.avg",
             metricNamingStrategy.metricKey(new MetricName("rebalance-latency-avg",
-                "consumer-coordinator-metrics", "description", Collections.emptyMap())).name());
+                "consumer-coordinator-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.coordinator.rebalance.latency.max",
             metricNamingStrategy.metricKey(new MetricName("rebalance-latency-max",
-                "consumer-coordinator-metrics", "description", Collections.emptyMap())).name());
+                "consumer-coordinator-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.coordinator.rebalance.latency.total",
             metricNamingStrategy.metricKey(new MetricName("rebalance-latency-total",
-                "consumer-coordinator-metrics", "description", Collections.emptyMap())).name());
+                "consumer-coordinator-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.fetch.manager.fetch.latency.avg",
             metricNamingStrategy.metricKey(new MetricName("fetch-latency-avg",
-                "consumer-fetch-manager-metrics", "description", Collections.emptyMap())).name());
+                "consumer-fetch-manager-metrics", "description", new LinkedHashMap<>())).name());
 
         assertEquals("org.apache.kafka.consumer.fetch.manager.fetch.latency.max",
             metricNamingStrategy.metricKey(new MetricName("fetch-latency-max",
-                "consumer-fetch-manager-metrics", "description", Collections.emptyMap())).name());
+                "consumer-fetch-manager-metrics", "description", new LinkedHashMap<>())).name());
     }
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
@@ -93,7 +93,7 @@ class MirrorCheckpointMetrics implements AutoCloseable {
         private final Sensor checkpointLatencySensor;
 
         GroupMetrics(TopicPartition topicPartition, String group) {
-            Map<String, String> tags = new LinkedHashMap<>();
+            LinkedHashMap<String, String> tags = new LinkedHashMap<>();
             tags.put("source", source); 
             tags.put("target", target); 
             tags.put("group", group);

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
@@ -148,7 +148,7 @@ class MirrorSourceMetrics implements AutoCloseable {
         PartitionMetrics(TopicPartition topicPartition) {
             String prefix = topicPartition.topic() + "-" + topicPartition.partition() + "-";
 
-            Map<String, String> tags = new LinkedHashMap<>();
+            LinkedHashMap<String, String> tags = new LinkedHashMap<>();
             tags.put("source", source);
             tags.put("target", target); 
             tags.put("topic", topicPartition.topic());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -42,7 +42,6 @@ import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -153,7 +152,7 @@ public class ConnectMetrics {
     }
 
     protected MetricGroupId groupId(String groupName, String... tagKeyValues) {
-        Map<String, String> tags = MetricsUtils.getTags(tagKeyValues);
+        LinkedHashMap<String, String> tags = MetricsUtils.getTags(tagKeyValues);
         return new MetricGroupId(groupName, tags);
     }
 
@@ -245,15 +244,15 @@ public class ConnectMetrics {
 
     public static class MetricGroupId {
         private final String groupName;
-        private final Map<String, String> tags;
+        private final LinkedHashMap<String, String> tags;
         private final int hc;
         private final String str;
 
-        public MetricGroupId(String groupName, Map<String, String> tags) {
+        public MetricGroupId(String groupName, LinkedHashMap<String, String> tags) {
             Objects.requireNonNull(groupName);
             Objects.requireNonNull(tags);
             this.groupName = groupName;
-            this.tags = Collections.unmodifiableMap(new LinkedHashMap<>(tags));
+            this.tags = new LinkedHashMap<>(tags);
             this.hc = Objects.hash(this.groupName, this.tags);
             StringBuilder sb = new StringBuilder(this.groupName);
             for (Map.Entry<String, String> entry : this.tags.entrySet()) {
@@ -276,7 +275,7 @@ public class ConnectMetrics {
          *
          * @return the tags; never null
          */
-        public Map<String, String> tags() {
+        public LinkedHashMap<String, String> tags() {
             return tags;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -82,7 +82,7 @@ public class WorkerGroupMember {
             this.clientId = clientId;
             this.log = logContext.logger(WorkerGroupMember.class);
 
-            Map<String, String> metricsTags = new LinkedHashMap<>();
+            LinkedHashMap<String, String> metricsTags = new LinkedHashMap<>();
             metricsTags.put("client-id", clientId);
             MetricConfig metricConfig = new MetricConfig().samples(config.getInt(CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG))
                     .timeWindow(config.getLong(CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -419,6 +419,6 @@ public class ConnectMetricsTest {
     }
 
     static MetricName metricName(String name) {
-        return new MetricName(name, "test_group", "metrics for testing", Map.of());
+        return new MetricName(name, "test_group", "metrics for testing", new LinkedHashMap<>());
     }
 }

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/KafkaMetricHistogramTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/KafkaMetricHistogramTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.metrics.Metrics;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,11 +42,11 @@ public class KafkaMetricHistogramTest {
             );
 
             Set<MetricName> expected = Set.of(
-                new MetricName("test-metric-max", "test-group", "test description", Map.of()),
-                new MetricName("test-metric-p999", "test-group", "test description", Map.of()),
-                new MetricName("test-metric-p99", "test-group", "test description", Map.of()),
-                new MetricName("test-metric-p95", "test-group", "test description", Map.of()),
-                new MetricName("test-metric-p50", "test-group", "test description", Map.of())
+                new MetricName("test-metric-max", "test-group", "test description", new LinkedHashMap<>()),
+                new MetricName("test-metric-p999", "test-group", "test description", new LinkedHashMap<>()),
+                new MetricName("test-metric-p99", "test-group", "test description", new LinkedHashMap<>()),
+                new MetricName("test-metric-p95", "test-group", "test description", new LinkedHashMap<>()),
+                new MetricName("test-metric-p50", "test-group", "test description", new LinkedHashMap<>())
             );
             Set<MetricName> actual = histogram.stats().stream().map(CompoundStat.NamedMeasurable::name).collect(Collectors.toSet());
             assertEquals(expected, actual);

--- a/core/src/main/java/kafka/server/ClientRequestQuotaManager.java
+++ b/core/src/main/java/kafka/server/ClientRequestQuotaManager.java
@@ -29,10 +29,10 @@ import org.apache.kafka.server.quota.ClientQuotaCallback;
 import org.apache.kafka.server.quota.QuotaType;
 import org.apache.kafka.server.quota.QuotaUtils;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import scala.jdk.javaapi.CollectionConverters;
 import scala.jdk.javaapi.OptionConverters;
 
 @SuppressWarnings("this-escape")
@@ -97,8 +97,8 @@ public class ClientRequestQuotaManager extends ClientQuotaManager {
     }
 
     @Override
-    public MetricName clientQuotaMetricName(scala.collection.immutable.Map<String, String> quotaMetricTags) {
-        return metrics.metricName("request-time", QuotaType.REQUEST.toString(), "Tracking request-time per user/client-id", CollectionConverters.asJava(quotaMetricTags));
+    public MetricName clientQuotaMetricName(LinkedHashMap<String, String> quotaMetricTags) {
+        return metrics.metricName("request-time", QuotaType.REQUEST.toString(), "Tracking request-time per user/client-id", quotaMetricTags);
     }
 
     private double nanosToPercentage(long nanos) {

--- a/core/src/main/java/kafka/server/NetworkUtils.java
+++ b/core/src/main/java/kafka/server/NetworkUtils.java
@@ -31,7 +31,7 @@ import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
-import java.util.Collections;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class NetworkUtils {
 
@@ -62,7 +62,7 @@ public class NetworkUtils {
             metrics,
             time,
             metricGroupPrefix,
-            Collections.emptyMap(),
+            mkMap(),
             false,
             channelBuilder,
             logContext

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.metadata.MetadataCache
 import org.apache.kafka.server.common.RequestLocal
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{InterBrokerSendThread, RequestAndCompletionHandler}
+import org.apache.kafka.common.utils.Utils.mkMap
 
 import scala.collection.{concurrent, immutable}
 import scala.jdk.CollectionConverters._
@@ -76,7 +77,7 @@ object TransactionMarkerChannelManager {
       metrics,
       time,
       "txn-marker-channel",
-      Map.empty[String, String].asJava,
+      mkMap(),
       false,
       channelBuilder,
       logContext

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -44,6 +44,7 @@ import org.apache.kafka.common.requests.{ApiVersionsRequest, RequestContext, Req
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.{KafkaThread, LogContext, Time, Utils}
 import org.apache.kafka.common.{Endpoint, KafkaException, MetricName, Reconfigurable}
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.network.{ConnectionQuotaEntity, ConnectionThrottledException, SocketServerConfigs, TooManyConnectionsException}
 import org.apache.kafka.security.CredentialProvider
 import org.apache.kafka.server.ServerSocketFactory
@@ -852,10 +853,10 @@ private[kafka] class Processor(
   private val inflightResponses = mutable.Map[String, RequestChannel.Response]()
   private val responseQueue = new LinkedBlockingDeque[RequestChannel.Response]()
 
-  private[kafka] val metricTags = mutable.LinkedHashMap(
-    ListenerMetricTag -> listenerName.value,
-    NetworkProcessorMetricTag -> id.toString
-  ).asJava
+  private[kafka] val metricTags = mkMap(
+    mkEntry(ListenerMetricTag, listenerName.value),
+    mkEntry(NetworkProcessorMetricTag, id.toString)
+  )
 
   metricsGroup.newGauge(IdlePercentMetricName, () => {
     Option(metrics.metric(metrics.metricName("io-wait-ratio", MetricsGroup, metricTags))).fold(0.0)(m =>
@@ -1702,7 +1703,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
       val metricName = metrics.metricName(s"${throttlePrefix}connection-accept-throttle-time",
         MetricsGroup,
         "Tracking average throttle-time, out of non-zero throttle times, per listener",
-        Map(ListenerMetricTag -> listener.value).asJava)
+        mkMap(mkEntry(ListenerMetricTag, listener.value)))
       sensor.add(metricName, new Avg)
       sensor
     }

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -41,6 +41,7 @@ import org.apache.kafka.common.requests.RequestHeader
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.{LogContext, Time, Utils}
+import org.apache.kafka.common.utils.Utils.mkMap
 import org.apache.kafka.raft.{Endpoints, ExternalKRaftMetrics, FileQuorumStateStore, KafkaNetworkChannel, KafkaRaftClient, KafkaRaftClientDriver, LeaderAndEpoch, MetadataLogConfig, QuorumConfig, RaftClient, ReplicatedLog, TimingWheelExpirationService}
 import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.common.Feature
@@ -51,7 +52,6 @@ import org.apache.kafka.server.fault.FaultHandler
 import org.apache.kafka.server.util.timer.SystemTimer
 import org.apache.kafka.storage.internals.log.UnifiedLog
 
-import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
 object KafkaRaftManager {
@@ -268,7 +268,7 @@ class KafkaRaftManager[T](
       metrics,
       time,
       metricGroupPrefix,
-      Map.empty[String, String].asJava,
+      mkMap(),
       collectPerConnectionMetrics,
       channelBuilder,
       logContext

--- a/core/src/main/scala/kafka/server/BrokerBlockingSender.scala
+++ b/core/src/main/scala/kafka/server/BrokerBlockingSender.scala
@@ -23,12 +23,11 @@ import org.apache.kafka.common.network._
 import org.apache.kafka.common.requests.AbstractRequest
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.clients.{ApiVersions, ClientResponse, ManualMetadataUpdater, NetworkClient}
 import org.apache.kafka.common.{Node, Reconfigurable}
 import org.apache.kafka.common.requests.AbstractRequest.Builder
 import org.apache.kafka.server.network.BrokerEndPoint
-
-import scala.jdk.CollectionConverters._
 
 trait BlockingSend {
 
@@ -74,7 +73,7 @@ class BrokerBlockingSender(sourceBroker: BrokerEndPoint,
       metrics,
       time,
       "replica-fetcher",
-      Map("broker-id" -> sourceBroker.id.toString, "fetcher-id" -> fetcherId.toString).asJava,
+      mkMap(mkEntry("broker-id", sourceBroker.id.toString), mkEntry("fetcher-id", fetcherId.toString)),
       false,
       channelBuilder,
       logContext

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.stats.{Avg, CumulativeSum, Rate}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{Sanitizer, Time}
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.server.config.ClientQuotaManagerConfig
 import org.apache.kafka.server.quota.{ClientQuotaCallback, ClientQuotaEntity, ClientQuotaType, QuotaType, QuotaUtils, SensorAccess, ThrottleCallback, ThrottledChannel}
 import org.apache.kafka.server.util.ShutdownableThread
@@ -42,7 +43,7 @@ import scala.jdk.CollectionConverters._
  * @param quotaSensor @Sensor that tracks the quota
  * @param throttleTimeSensor @Sensor that tracks the throttle time
  */
-case class ClientSensors(metricTags: Map[String, String], quotaSensor: Sensor, throttleTimeSensor: Sensor)
+case class ClientSensors(metricTags: util.LinkedHashMap[String, String], quotaSensor: Sensor, throttleTimeSensor: Sensor)
 
 object QuotaTypes {
   val NoQuotas = 0
@@ -271,7 +272,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   def getMaxValueInQuotaWindow(session: Session, clientId: String): Double = {
     if (quotasEnabled) {
       val clientSensors = getOrCreateQuotaSensors(session, clientId)
-      Option(quotaCallback.quotaLimit(clientQuotaType, clientSensors.metricTags.asJava))
+      Option(quotaCallback.quotaLimit(clientQuotaType, clientSensors.metricTags))
         .map(_.toDouble * (config.numQuotaSamples - 1) * config.quotaWindowSizeSeconds)
         .getOrElse(Double.MaxValue)
     } else {
@@ -321,7 +322,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     Quota.upperBound(quotaLimit(metricTags))
   }
 
-  private def quotaLimit(metricTags: util.Map[String, String]): Double = {
+  private def quotaLimit(metricTags: util.LinkedHashMap[String, String]): Double = {
     Option(quotaCallback.quotaLimit(clientQuotaType, metricTags)).map(_.toDouble).getOrElse(Long.MaxValue)
   }
 
@@ -341,9 +342,9 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
    */
   def getOrCreateQuotaSensors(session: Session, clientId: String): ClientSensors = {
     // Use cached sanitized principal if using default callback
-    val metricTags = quotaCallback match {
+    val metricTags:util.LinkedHashMap[String, String] = quotaCallback match {
       case callback: DefaultQuotaCallback => callback.quotaMetricTags(session.sanitizedUser, clientId)
-      case _ => quotaCallback.quotaMetricTags(clientQuotaType, session.principal, clientId).asScala.toMap
+      case _ => quotaCallback.quotaMetricTags(clientQuotaType, session.principal, clientId)
     }
     // Names of the sensors to access
     val sensors = ClientSensors(
@@ -364,7 +365,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     sensors
   }
 
-  protected def registerQuotaMetrics(metricTags: Map[String, String])(sensor: Sensor): Unit = {
+  protected def registerQuotaMetrics(metricTags: util.LinkedHashMap[String, String])(sensor: Sensor): Unit = {
     sensor.add(
       clientQuotaMetricName(metricTags),
       new Rate,
@@ -372,17 +373,17 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     )
   }
 
-  private def metricTagsToSensorSuffix(metricTags: Map[String, String]): String =
-    metricTags.values.mkString(":")
+  private def metricTagsToSensorSuffix(metricTags: util.LinkedHashMap[String, String]): String =
+    String.join(":", metricTags.values())
 
-  private def getThrottleTimeSensorName(metricTags: Map[String, String]): String =
+  private def getThrottleTimeSensorName(metricTags: util.LinkedHashMap[String, String]): String =
     s"${quotaType}ThrottleTime-${metricTagsToSensorSuffix(metricTags)}"
 
-  private def getQuotaSensorName(metricTags: Map[String, String]): String =
+  private def getQuotaSensorName(metricTags: util.LinkedHashMap[String, String]): String =
     s"$quotaType-${metricTagsToSensorSuffix(metricTags)}"
 
-  protected def getQuotaMetricConfig(metricTags: Map[String, String]): MetricConfig = {
-    getQuotaMetricConfig(quotaLimit(metricTags.asJava))
+  protected def getQuotaMetricConfig(metricTags: util.LinkedHashMap[String, String]): MetricConfig = {
+    getQuotaMetricConfig(quotaLimit(metricTags))
   }
 
   private def getQuotaMetricConfig(quotaLimit: Double): MetricConfig = {
@@ -470,19 +471,19 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
       val quotaEntity = updatedQuotaEntity.getOrElse(throw new IllegalStateException("Quota entity not specified"))
       val user = quotaEntity.sanitizedUser
       val clientId = quotaEntity.clientId
-      val metricTags = Map(DefaultTags.User -> user, DefaultTags.ClientId -> clientId)
+      val metricTags = mkMap(mkEntry(DefaultTags.User, user), mkEntry(DefaultTags.ClientId, clientId))
 
       val quotaMetricName = clientQuotaMetricName(metricTags)
       // Change the underlying metric config if the sensor has been created
       val metric = allMetrics.get(quotaMetricName)
       if (metric != null) {
-        Option(quotaLimit(metricTags.asJava)).foreach { newQuota =>
+        Option(quotaLimit(metricTags)).foreach { newQuota =>
           info(s"Sensor for $quotaEntity already exists. Changing quota to $newQuota in MetricConfig")
           metric.config(getQuotaMetricConfig(newQuota))
         }
       }
     } else {
-      val quotaMetricName = clientQuotaMetricName(Map.empty)
+      val quotaMetricName = clientQuotaMetricName(mkMap())
       allMetrics.forEach { (metricName, metric) =>
         if (metricName.name == quotaMetricName.name && metricName.group == quotaMetricName.group) {
           val metricTags = metricName.tags
@@ -501,17 +502,17 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
    * Returns the MetricName of the metric used for the quota. The name is used to create the
    * metric but also to find the metric when the quota is changed.
    */
-  protected def clientQuotaMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+  protected def clientQuotaMetricName(quotaMetricTags: java.util.LinkedHashMap[String, String]): MetricName = {
     metrics.metricName("byte-rate", quotaType.toString,
       "Tracking byte-rate per user/client-id",
-      quotaMetricTags.asJava)
+      quotaMetricTags)
   }
 
-  private def throttleMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+  private def throttleMetricName(quotaMetricTags: java.util.LinkedHashMap[String, String]): MetricName = {
     metrics.metricName("throttle-time",
       quotaType.toString,
       "Tracking average throttle-time per user/client-id",
-      quotaMetricTags.asJava)
+      quotaMetricTags)
   }
 
   def initiateShutdown(): Unit = {
@@ -533,11 +534,11 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
 
     override def configure(configs: util.Map[String, _]): Unit = {}
 
-    override def quotaMetricTags(quotaType: ClientQuotaType, principal: KafkaPrincipal, clientId: String): util.Map[String, String] = {
-      quotaMetricTags(Sanitizer.sanitize(principal.getName), clientId).asJava
+    override def quotaMetricTags(quotaType: ClientQuotaType, principal: KafkaPrincipal, clientId: String): util.LinkedHashMap[String, String] = {
+      quotaMetricTags(Sanitizer.sanitize(principal.getName), clientId)
     }
 
-    override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.Map[String, String]): lang.Double = {
+    override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.LinkedHashMap[String, String]): lang.Double = {
       val sanitizedUser = metricTags.get(DefaultTags.User)
       val clientId = metricTags.get(DefaultTags.ClientId)
       var quota: Quota = null
@@ -598,7 +599,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
 
     override def quotaResetRequired(quotaType: ClientQuotaType): Boolean = false
 
-    def quotaMetricTags(sanitizedUser: String, clientId: String) : Map[String, String] = {
+    def quotaMetricTags(sanitizedUser: String, clientId: String) : util.LinkedHashMap[String, String] = {
       val (userTag, clientIdTag) = quotaTypesEnabled match {
         case QuotaTypes.NoQuotas | QuotaTypes.ClientIdQuotaEnabled =>
           ("", clientId)
@@ -639,7 +640,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
           }
           metricTags
       }
-      Map(DefaultTags.User -> userTag, DefaultTags.ClientId -> clientIdTag)
+      mkMap(mkEntry(DefaultTags.User, userTag), mkEntry(DefaultTags.ClientId, clientIdTag))
     }
 
     override def close(): Unit = {}

--- a/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
@@ -16,6 +16,8 @@
  */
 package kafka.server
 
+import java.util
+
 import kafka.network.RequestChannel
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.errors.ThrottlingQuotaExceededException
@@ -29,8 +31,6 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.network.Session
 import org.apache.kafka.server.quota.{ClientQuotaCallback, QuotaType}
 import org.apache.kafka.server.config.ClientQuotaManagerConfig
-
-import scala.jdk.CollectionConverters._
 
 /**
  * The ControllerMutationQuota trait defines a quota for a given user/clientId pair. Such
@@ -168,19 +168,19 @@ class ControllerMutationQuotaManager(private val config: ClientQuotaManagerConfi
                                      private val quotaCallback: Option[ClientQuotaCallback])
     extends ClientQuotaManager(config, metrics, QuotaType.CONTROLLER_MUTATION, time, threadNamePrefix, quotaCallback) {
 
-  override protected def clientQuotaMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+  override protected def clientQuotaMetricName(quotaMetricTags: util.LinkedHashMap[String, String]): MetricName = {
     metrics.metricName("tokens", QuotaType.CONTROLLER_MUTATION.toString,
       "Tracking remaining tokens in the token bucket per user/client-id",
-      quotaMetricTags.asJava)
+      quotaMetricTags)
   }
 
-  private def clientRateMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+  private def clientRateMetricName(quotaMetricTags: util.LinkedHashMap[String, String]): MetricName = {
     metrics.metricName("mutation-rate", QuotaType.CONTROLLER_MUTATION.toString,
       "Tracking mutation-rate per user/client-id",
-      quotaMetricTags.asJava)
+      quotaMetricTags)
   }
 
-  override protected def registerQuotaMetrics(metricTags: Map[String, String])(sensor: Sensor): Unit = {
+  override protected def registerQuotaMetrics(metricTags: util.LinkedHashMap[String, String])(sensor: Sensor): Unit = {
     sensor.add(
       clientRateMetricName(metricTags),
       new Rate

--- a/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.requests.AbstractRequest
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.common.{Node, Reconfigurable}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.util.{InterBrokerSendThread, RequestAndCompletionHandler}
@@ -136,7 +137,7 @@ class NodeToControllerChannelManagerImpl(
         metrics,
         time,
         channelName,
-        Map("BrokerId" -> config.brokerId.toString).asJava,
+        mkMap(mkEntry("BrokerId", config.brokerId.toString)),
         false,
         channelBuilder,
         logContext

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -215,7 +215,7 @@ abstract class QuotaTestClients(topic: String,
   def removeQuotaOverrides(): Unit
 
   protected def userPrincipal: KafkaPrincipal
-  protected def quotaMetricTags(clientId: String): Map[String, String]
+  protected def quotaMetricTags(clientId: String): util.LinkedHashMap[String, String]
 
   def produceUntilThrottled(maxRecords: Int, waitForRequestCompletion: Boolean = true): Int = {
     var numProduced = 0
@@ -299,7 +299,7 @@ abstract class QuotaTestClients(topic: String,
   private def throttleMetricName(quotaType: QuotaType, clientId: String): MetricName = {
     leaderNode.metrics.metricName("throttle-time",
       quotaType.toString,
-      quotaMetricTags(clientId).asJava)
+      quotaMetricTags(clientId))
   }
 
   def throttleMetric(quotaType: QuotaType, clientId: String): KafkaMetric = {
@@ -328,7 +328,7 @@ abstract class QuotaTestClients(topic: String,
   }
 
   private def verifyProducerClientThrottleTimeMetric(expectThrottle: Boolean): Unit = {
-    val tags = new util.HashMap[String, String]
+    val tags = new util.LinkedHashMap[String, String]
     tags.put("client-id", producerClientId)
     val avgMetric = producer.metrics.get(new MetricName("produce-throttle-time-avg", "producer-metrics", "", tags))
     val maxMetric = producer.metrics.get(new MetricName("produce-throttle-time-max", "producer-metrics", "", tags))
@@ -341,7 +341,7 @@ abstract class QuotaTestClients(topic: String,
   }
 
   def verifyConsumerClientThrottleTimeMetric(expectThrottle: Boolean, maxThrottleTime: Option[Double] = None): Unit = {
-    val tags = new util.HashMap[String, String]
+    val tags = new util.LinkedHashMap[String, String]
     tags.put("client-id", consumerClientId)
     val avgMetric = consumer.metrics.get(new MetricName("fetch-throttle-time-avg", "consumer-fetch-manager-metrics", "", tags))
     val maxMetric = consumer.metrics.get(new MetricName("fetch-throttle-time-max", "consumer-fetch-manager-metrics", "", tags))

--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -14,8 +14,10 @@
 
 package kafka.api
 
+import java.util
 import kafka.server.KafkaBroker
 import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
 class ClientIdQuotaTest extends BaseQuotaTest {
@@ -43,8 +45,8 @@ class ClientIdQuotaTest extends BaseQuotaTest {
     new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer, adminClient) {
       override def userPrincipal: KafkaPrincipal = KafkaPrincipal.ANONYMOUS
 
-      override def quotaMetricTags(clientId: String): Map[String, String] = {
-        Map("user" -> "", "client-id" -> clientId)
+      override def quotaMetricTags(clientId: String): util.LinkedHashMap[String, String] = {
+        mkMap(mkEntry("user", ""), mkEntry("client-id", clientId))
       }
 
       override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth._
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.common.{Cluster, Reconfigurable}
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.metadata.storage.Formatter
 import org.apache.kafka.server.config.{QuotaConfig, ServerConfigs}
 import org.apache.kafka.server.quota._
@@ -273,8 +274,8 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
 
     override def userPrincipal: KafkaPrincipal = GroupedUserPrincipal(user, userGroup)
 
-    override def quotaMetricTags(clientId: String): Map[String, String] = {
-      Map(GroupedUserQuotaCallback.QuotaGroupTag -> userGroup)
+    override def quotaMetricTags(clientId: String): util.LinkedHashMap[String, String] = {
+      mkMap(mkEntry(GroupedUserQuotaCallback.QuotaGroupTag, userGroup))
     }
 
     override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {
@@ -322,7 +323,7 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
 
     def removeThrottleMetrics(): Unit = {
       def removeSensors(quotaType: QuotaType, clientId: String): Unit = {
-        val sensorSuffix = quotaMetricTags(clientId).values.mkString(":")
+        val sensorSuffix = String.join(":", quotaMetricTags(clientId).values())
         leaderNode.metrics.removeSensor(s"${quotaType}ThrottleTime-$sensorSuffix")
         leaderNode.metrics.removeSensor(s"$quotaType-$sensorSuffix")
       }
@@ -366,7 +367,7 @@ object GroupedUserQuotaCallback {
   val QuotaGroupTag = "group"
   val DefaultProduceQuotaProp = "default.produce.quota"
   val DefaultFetchQuotaProp = "default.fetch.quota"
-  val UnlimitedQuotaMetricTags = new util.HashMap[String, String]
+  val UnlimitedQuotaMetricTags = new util.LinkedHashMap[String, String]
   val quotaLimitCalls = Map(
     ClientQuotaType.PRODUCE -> new AtomicInteger,
     ClientQuotaType.FETCH -> new AtomicInteger,
@@ -424,7 +425,7 @@ class GroupedUserQuotaCallback extends ClientQuotaCallback with Reconfigurable w
     if (value != null) Some(value.toString.toLong) else None
   }
 
-  override def quotaMetricTags(quotaType: ClientQuotaType, principal: KafkaPrincipal, clientId: String): util.Map[String, String] = {
+  override def quotaMetricTags(quotaType: ClientQuotaType, principal: KafkaPrincipal, clientId: String): util.LinkedHashMap[String, String] = {
     val user = principal.getName
     val userGroup = group(user)
     val newPrincipal = {
@@ -438,7 +439,7 @@ class GroupedUserQuotaCallback extends ClientQuotaCallback with Reconfigurable w
         val userGroup = groupPrincipal.userGroup
         val quotaLimit = quotaOrDefault(userGroup, quotaType)
         if (quotaLimit != null)
-          Map(QuotaGroupTag -> userGroup).asJava
+          mkMap(mkEntry(QuotaGroupTag, userGroup))
         else
           UnlimitedQuotaMetricTags
       case _ =>
@@ -446,7 +447,7 @@ class GroupedUserQuotaCallback extends ClientQuotaCallback with Reconfigurable w
     }
   }
 
-  override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.Map[String, String]): lang.Double = {
+  override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.LinkedHashMap[String, String]): lang.Double = {
     quotaLimitCalls(quotaType).incrementAndGet
     val group = metricTags.get(QuotaGroupTag)
     if (group != null) quotaOrDefault(group, quotaType) else null

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerPollTest.scala
@@ -198,7 +198,7 @@ class PlaintextConsumerPollTest extends AbstractConsumerTest {
     consumer.assign(List(tp).asJava)
     awaitNonEmptyRecords(consumer, tp)
 
-    val tags = new util.HashMap[String, String]()
+    val tags = new util.LinkedHashMap[String, String]()
     tags.put("client-id", "testPerPartitionLeadWithMaxPollRecords")
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))
@@ -221,7 +221,7 @@ class PlaintextConsumerPollTest extends AbstractConsumerTest {
     consumer.assign(List(tp).asJava)
     val records = awaitNonEmptyRecords(consumer, tp)
 
-    val tags = new util.HashMap[String, String]()
+    val tags = new util.LinkedHashMap[String, String]()
     tags.put("client-id", "testPerPartitionLagWithMaxPollRecords")
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.record.{CompressionType, TimestampType}
 import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.test.api.Flaky
 import org.apache.kafka.common.{MetricName, TopicPartition}
+import org.apache.kafka.common.utils.Utils.{mkEntry, mkMap}
 import org.apache.kafka.server.quota.QuotaType
 import org.apache.kafka.test.{MockConsumerInterceptor, MockProducerInterceptor}
 import org.junit.jupiter.api.Assertions._
@@ -428,15 +429,17 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val records = awaitNonEmptyRecords(consumer, tp)
     assertEquals(1, listener.callsToAssigned, "should be assigned once")
     // Verify the metric exist.
-    val tags1 = new util.HashMap[String, String]()
-    tags1.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
-    tags1.put("topic", tp.topic())
-    tags1.put("partition", String.valueOf(tp.partition()))
+    val tags1 = mkMap(
+      mkEntry("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe"),
+      mkEntry("topic", tp.topic()),
+      mkEntry("partition", String.valueOf(tp.partition()))
+    )
 
-    val tags2 = new util.HashMap[String, String]()
-    tags2.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
-    tags2.put("topic", tp2.topic())
-    tags2.put("partition", String.valueOf(tp2.partition()))
+    val tags2 = mkMap(
+      mkEntry("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe"),
+      mkEntry("topic", tp2.topic()),
+      mkEntry("partition", String.valueOf(tp2.partition())),
+    )
     val fetchLead0 = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1))
     assertNotNull(fetchLead0)
     assertEquals(records.count.toDouble, fetchLead0.metricValue(), s"The lead should be ${records.count}")
@@ -468,15 +471,18 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val records = awaitNonEmptyRecords(consumer, tp)
     assertEquals(1, listener.callsToAssigned, "should be assigned once")
     // Verify the metric exist.
-    val tags1 = new util.HashMap[String, String]()
-    tags1.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
-    tags1.put("topic", tp.topic())
-    tags1.put("partition", String.valueOf(tp.partition()))
+    val tags1 = mkMap(
+      mkEntry("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe"),
+      mkEntry("topic", tp.topic()),
+      mkEntry("partition", String.valueOf(tp.partition()))
+    )
 
-    val tags2 = new util.HashMap[String, String]()
-    tags2.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
-    tags2.put("topic", tp2.topic())
-    tags2.put("partition", String.valueOf(tp2.partition()))
+    val tags2 = mkMap(
+      mkEntry("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe"),
+      mkEntry("topic", tp2.topic()),
+      mkEntry("partition", String.valueOf(tp2.partition()))
+    )
+
     val fetchLag0 = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1))
     assertNotNull(fetchLag0)
     val expectedLag = numMessages - records.count
@@ -506,10 +512,11 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     val records = awaitNonEmptyRecords(consumer, tp)
     // Verify the metric exist.
-    val tags = new util.HashMap[String, String]()
-    tags.put("client-id", "testPerPartitionLeadMetricsCleanUpWithAssign")
-    tags.put("topic", tp.topic())
-    tags.put("partition", String.valueOf(tp.partition()))
+    val tags = mkMap(
+      mkEntry("client-id", "testPerPartitionLeadMetricsCleanUpWithAssign"),
+      mkEntry("topic", tp.topic()),
+      mkEntry("partition", String.valueOf(tp.partition()))
+    )
     val fetchLead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
     assertNotNull(fetchLead)
 
@@ -536,10 +543,11 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     val records = awaitNonEmptyRecords(consumer, tp)
     // Verify the metric exist.
-    val tags = new util.HashMap[String, String]()
-    tags.put("client-id", "testPerPartitionLagMetricsCleanUpWithAssign")
-    tags.put("topic", tp.topic())
-    tags.put("partition", String.valueOf(tp.partition()))
+    val tags = mkMap(
+      mkEntry("client-id", "testPerPartitionLagMetricsCleanUpWithAssign"),
+      mkEntry("topic", tp.topic()),
+      mkEntry("partition", String.valueOf(tp.partition()))
+    )
     val fetchLag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
     assertNotNull(fetchLag)
 
@@ -568,10 +576,11 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.assign(List(tp).asJava)
     awaitNonEmptyRecords(consumer, tp)
     // Verify the metric exist.
-    val tags = new util.HashMap[String, String]()
-    tags.put("client-id", "testPerPartitionLagMetricsCleanUpWithAssign")
-    tags.put("topic", tp.topic())
-    tags.put("partition", String.valueOf(tp.partition()))
+    val tags = mkMap(
+      mkEntry("client-id", "testPerPartitionLagMetricsCleanUpWithAssign"),
+      mkEntry("topic", tp.topic()),
+      mkEntry("partition", String.valueOf(tp.partition()))
+    )
     val fetchLag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
     assertNotNull(fetchLag)
   }

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -14,11 +14,13 @@
 
 package kafka.api
 
+import java.util
 import kafka.server._
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.Sanitizer
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
 class UserClientIdQuotaTest extends BaseQuotaTest {
@@ -50,8 +52,8 @@ class UserClientIdQuotaTest extends BaseQuotaTest {
     new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer, adminClient) {
       override def userPrincipal: KafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "O=A client,CN=localhost")
 
-      override def quotaMetricTags(clientId: String): Map[String, String] = {
-        Map("user" -> Sanitizer.sanitize(userPrincipal.getName), "client-id" -> clientId)
+      override def quotaMetricTags(clientId: String): util.LinkedHashMap[String, String] = {
+        mkMap(mkEntry("user", Sanitizer.sanitize(userPrincipal.getName)), mkEntry("client-id", clientId))
       }
 
       override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -14,10 +14,12 @@
 
 package kafka.api
 
+import java.util
 import kafka.security.JaasTestUtils
 import kafka.server.KafkaBroker
 import kafka.utils.TestUtils
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 
 class UserQuotaTest extends BaseQuotaTest with SaslSetup {
@@ -56,8 +58,8 @@ class UserQuotaTest extends BaseQuotaTest with SaslSetup {
     new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer, adminClient) {
       override val userPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KAFKA_CLIENT_PRINCIPAL_UNQUALIFIED_NAME_2)
 
-      override def quotaMetricTags(clientId: String): Map[String, String] = {
-        Map("user" -> userPrincipal.getName, "client-id" -> "")
+      override def quotaMetricTags(clientId: String): util.LinkedHashMap[String, String] = {
+        mkMap(mkEntry("user", userPrincipal.getName), mkEntry("client-id", ""))
       }
 
       override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.requests.{ApiError, DescribeClusterRequest, Descr
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.test.{KafkaClusterTestKit, TestKitNodes}
 import org.apache.kafka.common.{Cluster, Endpoint, Reconfigurable, TopicPartition, TopicPartitionInfo}
+import org.apache.kafka.common.utils.Utils.mkMap
 import org.apache.kafka.controller.{QuorumController, QuorumControllerIntegrationTestUtils}
 import org.apache.kafka.image.ClusterImage
 import org.apache.kafka.metadata.BrokerState
@@ -1675,9 +1676,9 @@ object DummyClientQuotaCallback {
 
 class DummyClientQuotaCallback extends ClientQuotaCallback with Reconfigurable {
   var value = 0
-  override def quotaMetricTags(quotaType: ClientQuotaType, principal: KafkaPrincipal, clientId: String): util.Map[String, String] = Collections.emptyMap()
+  override def quotaMetricTags(quotaType: ClientQuotaType, principal: KafkaPrincipal, clientId: String): util.LinkedHashMap[String, String] = mkMap()
 
-  override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.Map[String, String]): lang.Double = 1.0
+  override def quotaLimit(quotaType: ClientQuotaType, metricTags: util.LinkedHashMap[String, String]): lang.Double = 1.0
 
   override def updateQuota(quotaType: ClientQuotaType, quotaEntity: quota.ClientQuotaEntity, newValue: Double): Unit = {}
 

--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.metrics.internals.MetricsUtils
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Metrics}
 import org.apache.kafka.common.network._
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.network.{ConnectionThrottledException, SocketServerConfigs, TooManyConnectionsException}
 import org.apache.kafka.server.config.{QuotaConfig, ReplicationConfigs}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
@@ -573,7 +574,7 @@ class ConnectionQuotasTest {
     connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).configure(listenerConfig)
 
     // remove connection rate limit
-    connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).reconfigure(Map.empty.asJava)
+    connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).reconfigure(mkMap())
 
     // create connections as fast as possible, will timeout if connections get throttled with previous rate
     // (50s to create 1000 connections)
@@ -750,7 +751,7 @@ class ConnectionQuotasTest {
   }
 
   private def addListenersAndVerify(config: KafkaConfig, connectionQuotas: ConnectionQuotas) : Unit = {
-    addListenersAndVerify(config, Map.empty.asJava, connectionQuotas)
+    addListenersAndVerify(config, mkMap(), connectionQuotas)
   }
 
   private def addListenersAndVerify(config: KafkaConfig,
@@ -829,7 +830,7 @@ class ConnectionQuotasTest {
     val metricName = metrics.metricName(
       "connection-accept-throttle-time",
       SocketServer.MetricsGroup,
-      Collections.singletonMap(Processor.ListenerMetricTag, listener))
+      mkMap(mkEntry(Processor.ListenerMetricTag, listener)))
     metrics.metric(metricName)
   }
 
@@ -837,7 +838,7 @@ class ConnectionQuotasTest {
     val metricName = metrics.metricName(
       "ip-connection-accept-throttle-time",
       SocketServer.MetricsGroup,
-      Collections.singletonMap(Processor.ListenerMetricTag, listener))
+      mkMap(mkEntry(Processor.ListenerMetricTag, listener)))
     metrics.metric(metricName)
   }
 
@@ -845,7 +846,7 @@ class ConnectionQuotasTest {
     val metricName = metrics.metricName(
       "connection-accept-rate",
       SocketServer.MetricsGroup,
-      Collections.singletonMap(Processor.ListenerMetricTag, listener))
+      mkMap(mkEntry(Processor.ListenerMetricTag, listener)))
     metrics.metric(metricName)
   }
 
@@ -860,7 +861,7 @@ class ConnectionQuotasTest {
     val metricName = metrics.metricName(
       s"connection-accept-rate",
       SocketServer.MetricsGroup,
-      Collections.singletonMap("ip", ip))
+      mkMap(mkEntry("ip", ip)))
     metrics.metric(metricName)
   }
 

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.utils._
+import org.apache.kafka.common.utils.Utils.mkMap
 import org.apache.kafka.network.RequestConvertToJson
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.network.EndPoint
@@ -2060,7 +2061,7 @@ class SocketServerTest {
     private var conn: Option[Socket] = None
 
     override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
-      new TestableSelector(config, channelBuilder, time, metrics, metricTags.asScala)
+      new TestableSelector(config, channelBuilder, time, metrics, metricTags)
     }
 
     override private[network] def processException(errorMessage: String, throwable: Throwable): Unit = {
@@ -2158,9 +2159,9 @@ class SocketServerTest {
     case object CloseSelector extends SelectorOperation
   }
 
-  class TestableSelector(config: KafkaConfig, channelBuilder: ChannelBuilder, time: Time, metrics: Metrics, metricTags: mutable.Map[String, String] = mutable.Map.empty)
+  class TestableSelector(config: KafkaConfig, channelBuilder: ChannelBuilder, time: Time, metrics: Metrics, metricTags: util.LinkedHashMap[String, String] = mkMap())
     extends Selector(config.socketRequestMaxBytes, config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs,
-      metrics, time, "socket-server", metricTags.asJava, false, true, channelBuilder, MemoryPool.NONE, new LogContext()) {
+      metrics, time, "socket-server", metricTags, false, true, channelBuilder, MemoryPool.NONE, new LogContext()) {
 
     val failures = mutable.Map[SelectorOperation, Throwable]()
     val operationCounts = mutable.Map[SelectorOperation, Int]().withDefaultValue(0)

--- a/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metrics.KafkaMetric
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.utils.Utils.{mkMap, mkEntry}
 import org.apache.kafka.common.quota.ClientQuotaAlteration
 import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.requests.AlterClientQuotasRequest
@@ -402,7 +403,7 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
       "tokens",
       QuotaType.CONTROLLER_MUTATION.toString,
       "Tracking remaining tokens in the token bucket per user/client-id",
-      Map(DefaultTags.User -> user, DefaultTags.ClientId -> "").asJava)
+      mkMap(mkEntry(DefaultTags.User, user), mkEntry(DefaultTags.ClientId, "")))
     Option(metrics.metric(metricName))
   }
 

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerMetricsTest.scala
@@ -20,10 +20,11 @@ package unit.kafka.server
 import kafka.server.ForwardingManagerMetrics
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.utils.Utils.mkMap
+
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
-import java.util.Collections
 import scala.jdk.CollectionConverters._
 
 final class ForwardingManagerMetricsTest {
@@ -33,11 +34,11 @@ final class ForwardingManagerMetricsTest {
     val expectedGroup = "ForwardingManager"
 
     val expectedMetrics = Set(
-      new MetricName("QueueTimeMs.p99", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("QueueTimeMs.p999", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("QueueLength", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("RemoteTimeMs.p99", expectedGroup, "", Collections.emptyMap()),
-      new MetricName("RemoteTimeMs.p999", expectedGroup, "", Collections.emptyMap())
+      new MetricName("QueueTimeMs.p99", expectedGroup, "", mkMap()),
+      new MetricName("QueueTimeMs.p999", expectedGroup, "", mkMap()),
+      new MetricName("QueueLength", expectedGroup, "", mkMap()),
+      new MetricName("RemoteTimeMs.p99", expectedGroup, "", mkMap()),
+      new MetricName("RemoteTimeMs.p999", expectedGroup, "", mkMap())
     )
 
     var metricsMap = metrics.metrics().asScala.filter { case (name, _) => name.group == expectedGroup }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -41,6 +41,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
 /**
  * These are the metrics which are managed by the {@link org.apache.kafka.coordinator.group.GroupMetadataManager} class.
  * They generally pertain to aspects of group management, such as the number of groups in different states.
@@ -126,126 +129,126 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of groups using the classic rebalance protocol.",
-            Map.of(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.CLASSIC.toString())
+            mkMap(mkEntry(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.CLASSIC.toString()))
         );
 
         consumerGroupCountMetricName = metrics.metricName(
             GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of groups using the consumer rebalance protocol.",
-            Map.of(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.CONSUMER.toString())
+            mkMap(mkEntry(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.CONSUMER.toString()))
         );
 
         consumerGroupCountEmptyMetricName = metrics.metricName(
             CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in empty state.",
-            Map.of(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.EMPTY.toString())
+            mkMap(mkEntry(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.EMPTY.toString()))
         );
 
         consumerGroupCountAssigningMetricName = metrics.metricName(
             CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in assigning state.",
-            Map.of(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.ASSIGNING.toString())
+            mkMap(mkEntry(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.ASSIGNING.toString()))
         );
 
         consumerGroupCountReconcilingMetricName = metrics.metricName(
             CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in reconciling state.",
-            Map.of(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.RECONCILING.toString())
+            mkMap(mkEntry(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.RECONCILING.toString()))
         );
 
         consumerGroupCountStableMetricName = metrics.metricName(
             CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in stable state.",
-            Map.of(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.STABLE.toString())
+            mkMap(mkEntry(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.STABLE.toString()))
         );
 
         consumerGroupCountDeadMetricName = metrics.metricName(
             CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in dead state.",
-            Map.of(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.DEAD.toString())
+            mkMap(mkEntry(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.DEAD.toString()))
         );
 
         shareGroupCountMetricName = metrics.metricName(
             GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of share groups.",
-            Map.of(SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString())
+            mkMap(mkEntry(SHARE_GROUP_PROTOCOL_TAG, Group.GroupType.SHARE.toString()))
         );
 
         shareGroupCountEmptyMetricName = metrics.metricName(
             SHARE_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of share groups in empty state.",
-            Map.of(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.EMPTY.toString())
+            mkMap(mkEntry(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.EMPTY.toString()))
         );
 
         shareGroupCountStableMetricName = metrics.metricName(
             SHARE_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of share groups in stable state.",
-            Map.of(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.STABLE.toString())
+            mkMap(mkEntry(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.STABLE.toString()))
         );
 
         shareGroupCountDeadMetricName = metrics.metricName(
             SHARE_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of share groups in dead state.",
-            Map.of(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.DEAD.toString())
+            mkMap(mkEntry(SHARE_GROUP_COUNT_STATE_TAG, ShareGroup.ShareGroupState.DEAD.toString()))
         );
 
         streamsGroupCountMetricName = metrics.metricName(
             GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of groups using the streams rebalance protocol.",
-            Map.of(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.STREAMS.toString())
+            mkMap(mkEntry(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.STREAMS.toString()))
         );
 
         streamsGroupCountEmptyMetricName = metrics.metricName(
             STREAMS_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of streams groups in empty state.",
-            Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.EMPTY.toString())
+            mkMap(mkEntry(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.EMPTY.toString()))
         );
 
         streamsGroupCountAssigningMetricName = metrics.metricName(
             STREAMS_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of streams groups in assigning state.",
-            Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.ASSIGNING.toString())
+            mkMap(mkEntry(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.ASSIGNING.toString()))
         );
 
         streamsGroupCountReconcilingMetricName = metrics.metricName(
             STREAMS_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of streams groups in reconciling state.",
-            Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.RECONCILING.toString())
+            mkMap(mkEntry(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.RECONCILING.toString()))
         );
 
         streamsGroupCountStableMetricName = metrics.metricName(
             STREAMS_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of streams groups in stable state.",
-            Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.STABLE.toString())
+            mkMap(mkEntry(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.STABLE.toString()))
         );
 
         streamsGroupCountDeadMetricName = metrics.metricName(
             STREAMS_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of streams groups in dead state.",
-            Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.DEAD.toString())
+            mkMap(mkEntry(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.DEAD.toString()))
         );
 
         streamsGroupCountNotReadyMetricName = metrics.metricName(
             STREAMS_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of streams groups in not ready state.",
-            Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.NOT_READY.toString())
+            mkMap(mkEntry(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.NOT_READY.toString()))
         );
 
         registerGauges();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CONSUMER_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.METRICS_GROUP;
@@ -77,43 +79,43 @@ public class GroupCoordinatorMetricsTest {
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("protocol", "classic")),
+                mkMap(mkEntry("protocol", "classic"))),
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("protocol", "consumer")),
+                mkMap(mkEntry("protocol", "consumer"))),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", ConsumerGroupState.EMPTY.toString())),
+                mkMap(mkEntry("state", ConsumerGroupState.EMPTY.toString()))),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", ConsumerGroupState.ASSIGNING.toString())),
+                mkMap(mkEntry("state", ConsumerGroupState.ASSIGNING.toString()))),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", ConsumerGroupState.RECONCILING.toString())),
+                mkMap(mkEntry("state", ConsumerGroupState.RECONCILING.toString()))),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", ConsumerGroupState.STABLE.toString())),
+                mkMap(mkEntry("state", ConsumerGroupState.STABLE.toString()))),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", ConsumerGroupState.DEAD.toString())),
+                mkMap(mkEntry("state", ConsumerGroupState.DEAD.toString()))),
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("protocol", Group.GroupType.SHARE.toString())),
+                mkMap(mkEntry("protocol", Group.GroupType.SHARE.toString()))),
             metrics.metricName(
                 "rebalance-rate",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("protocol", Group.GroupType.SHARE.toString())),
+                mkMap(mkEntry("protocol", Group.GroupType.SHARE.toString()))),
             metrics.metricName(
                 "rebalance-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("protocol", Group.GroupType.SHARE.toString())),
+                mkMap(mkEntry("protocol", Group.GroupType.SHARE.toString()))),
             metrics.metricName(
                 "share-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
@@ -132,33 +134,33 @@ public class GroupCoordinatorMetricsTest {
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("protocol", Group.GroupType.STREAMS.toString())),
+                mkMap(mkEntry("protocol", Group.GroupType.STREAMS.toString()))),
             metrics.metricName("streams-group-rebalance-rate", GroupCoordinatorMetrics.METRICS_GROUP),
             metrics.metricName("streams-group-rebalance-count", GroupCoordinatorMetrics.METRICS_GROUP),
             metrics.metricName(
                 "streams-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", StreamsGroupState.EMPTY.toString())),
+                mkMap(mkEntry("state", StreamsGroupState.EMPTY.toString()))),
             metrics.metricName(
                 "streams-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", StreamsGroupState.ASSIGNING.toString())),
+                mkMap(mkEntry("state", StreamsGroupState.ASSIGNING.toString()))),
             metrics.metricName(
                 "streams-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", StreamsGroupState.RECONCILING.toString())),
+                mkMap(mkEntry("state", StreamsGroupState.RECONCILING.toString()))),
             metrics.metricName(
                 "streams-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", StreamsGroupState.STABLE.toString())),
+                mkMap(mkEntry("state", StreamsGroupState.STABLE.toString()))),
             metrics.metricName(
                 "streams-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", StreamsGroupState.DEAD.toString())),
+                mkMap(mkEntry("state", StreamsGroupState.DEAD.toString()))),
             metrics.metricName(
                 "streams-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Map.of("state", StreamsGroupState.NOT_READY.toString()))
+                mkMap(mkEntry("state", StreamsGroupState.NOT_READY.toString())))
         ));
 
         try {
@@ -240,7 +242,7 @@ public class GroupCoordinatorMetricsTest {
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 9);
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Map.of("protocol", "classic")),
+            metrics.metricName("group-count", METRICS_GROUP, mkMap(mkEntry("protocol", "classic"))),
             9
         );
 
@@ -256,7 +258,7 @@ public class GroupCoordinatorMetricsTest {
         assertEquals(1, shard1.numOffsets());
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Map.of("protocol", "consumer")),
+            metrics.metricName("group-count", METRICS_GROUP, mkMap(mkEntry("protocol", "consumer"))),
             7
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumOffsets"), 7);
@@ -265,7 +267,7 @@ public class GroupCoordinatorMetricsTest {
         assertEquals(6, shard1.numShareGroups());
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Map.of("protocol", "share")),
+            metrics.metricName("group-count", METRICS_GROUP, mkMap(mkEntry("protocol", "share"))),
             8
         );
         
@@ -273,7 +275,7 @@ public class GroupCoordinatorMetricsTest {
         assertEquals(3, shard1.numStreamsGroups());
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Map.of("protocol", "streams")),
+            metrics.metricName("group-count", METRICS_GROUP, mkMap(mkEntry("protocol", "streams"))),
             5
         );
     }

--- a/server-common/src/test/java/org/apache/kafka/server/quota/QuotaUtilsTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/quota/QuotaUtilsTest.java
@@ -28,9 +28,9 @@ import org.apache.kafka.common.utils.Time;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +40,7 @@ public class QuotaUtilsTest {
     private final Time time = new MockTime();
     private final int numSamples = 10;
     private final int maxThrottleTimeMs = 500;
-    private final MetricName metricName = new MetricName("test-metric", "groupA", "testA", Map.of());
+    private final MetricName metricName = new MetricName("test-metric", "groupA", "testA", mkMap());
 
     @Test
     public void testThrottleTimeObservedRateEqualsQuota() {

--- a/server/src/main/java/org/apache/kafka/network/ConnectionQuotaEntity.java
+++ b/server/src/main/java/org/apache/kafka/network/ConnectionQuotaEntity.java
@@ -17,8 +17,11 @@
 package org.apache.kafka.network;
 
 import java.net.InetAddress;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * Class for connection quota configuration. Connection quotas can be configured at the
@@ -36,29 +39,29 @@ public class ConnectionQuotaEntity {
         return new ConnectionQuotaEntity(CONNECTION_RATE_SENSOR_NAME + "-" + listenerName,
                 CONNECTION_RATE_METRIC_NAME,
                 Long.MAX_VALUE,
-                Map.of("listener", listenerName));
+                mkMap(mkEntry("listener", listenerName)));
     }
 
     public static ConnectionQuotaEntity brokerQuotaEntity() {
         return new ConnectionQuotaEntity(CONNECTION_RATE_SENSOR_NAME,
                 "broker-" + ConnectionQuotaEntity.CONNECTION_RATE_METRIC_NAME,
                 Long.MAX_VALUE,
-                Map.of());
+                mkMap());
     }
 
     public static ConnectionQuotaEntity ipQuotaEntity(InetAddress ip) {
         return new ConnectionQuotaEntity(CONNECTION_RATE_SENSOR_NAME + "-" + ip.getHostAddress(),
                 CONNECTION_RATE_METRIC_NAME,
                 TimeUnit.HOURS.toSeconds(1),
-                Map.of(IP_METRIC_TAG, ip.getHostAddress()));
+                mkMap(mkEntry(IP_METRIC_TAG, ip.getHostAddress())));
     }
 
     private final String sensorName;
     private final String metricName;
     private final long sensorExpiration;
-    private final Map<String, String> metricTags;
+    private final LinkedHashMap<String, String> metricTags;
 
-    private ConnectionQuotaEntity(String sensorName, String metricName, long sensorExpiration, Map<String, String> metricTags) {
+    private ConnectionQuotaEntity(String sensorName, String metricName, long sensorExpiration, LinkedHashMap<String, String> metricTags) {
         this.sensorName = sensorName;
         this.metricName = metricName;
         this.sensorExpiration = sensorExpiration;
@@ -89,7 +92,7 @@ public class ConnectionQuotaEntity {
     /**
      * Tags associated with this quota entity
      */
-    public Map<String, String> metricTags() {
+    public LinkedHashMap<String, String> metricTags() {
         return metricTags;
     }
 }

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,6 +77,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * Handles client telemetry metrics requests/responses, subscriptions and instance information.
@@ -596,7 +600,7 @@ public class ClientMetricsManager implements AutoCloseable {
             Sensor unknownSubscriptionRequestCountSensor = metrics.sensor(
                 ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST);
             unknownSubscriptionRequestCountSensor.add(createMeter(metrics, new WindowedCount(),
-                ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST, Map.of()));
+                ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST, mkMap()));
             sensorsName.add(unknownSubscriptionRequestCountSensor.name());
         }
 
@@ -607,7 +611,7 @@ public class ClientMetricsManager implements AutoCloseable {
                 return;
             }
 
-            Map<String, String> tags = Map.of(ClientMetricsConfigs.CLIENT_INSTANCE_ID, clientInstanceId.toString());
+            LinkedHashMap<String, String> tags = mkMap(mkEntry(ClientMetricsConfigs.CLIENT_INSTANCE_ID, clientInstanceId.toString()));
 
             Sensor throttleCount = metrics.sensor(ClientMetricsStats.THROTTLE + "-" + clientInstanceId);
             throttleCount.add(createMeter(metrics, new WindowedCount(), ClientMetricsStats.THROTTLE, tags));
@@ -660,7 +664,7 @@ public class ClientMetricsManager implements AutoCloseable {
             sensorsName.clear();
         }
 
-        private Meter createMeter(Metrics metrics, SampledStat stat, String name, Map<String, String> metricTags) {
+        private Meter createMeter(Metrics metrics, SampledStat stat, String name, LinkedHashMap<String, String> metricTags) {
             MetricName rateMetricName = metrics.metricName(name + "-rate", ClientMetricsStats.GROUP_NAME,
                 String.format("The number of %s per second", name), metricTags);
             MetricName totalMetricName = metrics.metricName(name + "-count", ClientMetricsStats.GROUP_NAME,

--- a/server/src/test/java/org/apache/kafka/server/metrics/BrokerServerMetricsTest.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/BrokerServerMetricsTest.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,12 +43,12 @@ public final class BrokerServerMetricsTest {
 
         // Metric description is not use for metric name equality
         Set<MetricName> expectedMetrics = new HashSet<>(Arrays.asList(
-                new MetricName("last-applied-record-offset", expectedGroup, "", Map.of()),
-                new MetricName("last-applied-record-timestamp", expectedGroup, "", Map.of()),
-                new MetricName("last-applied-record-lag-ms", expectedGroup, "", Map.of()),
-                new MetricName("metadata-load-error-count", expectedGroup, "", Map.of()),
-                new MetricName("metadata-apply-error-count", expectedGroup, "", Map.of()),
-                new MetricName("ignored-static-voters", expectedGroup, "", Map.of())
+                new MetricName("last-applied-record-offset", expectedGroup, "", mkMap()),
+                new MetricName("last-applied-record-timestamp", expectedGroup, "", mkMap()),
+                new MetricName("last-applied-record-lag-ms", expectedGroup, "", mkMap()),
+                new MetricName("metadata-load-error-count", expectedGroup, "", mkMap()),
+                new MetricName("metadata-apply-error-count", expectedGroup, "", mkMap()),
+                new MetricName("ignored-static-voters", expectedGroup, "", mkMap())
         ));
 
         try (BrokerServerMetrics ignored = new BrokerServerMetrics(metrics)) {

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -33,9 +33,13 @@ import com.yammer.metrics.core.MetricsRegistry;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoCloseable {
     //write (write-rate and write-total) Meter share-coordinator-metric The number of share-group state write calls per second.
@@ -168,9 +172,9 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
         ShareGroupPruneMetrics(TopicPartition tp) {
             String sensorNameSuffix = tp.toString();
-            Map<String, String> tags = Map.of(
-                "topic", tp.topic(),
-                "partition", Integer.toString(tp.partition())
+            LinkedHashMap<String, String> tags = mkMap(
+                mkEntry("topic", tp.topic()),
+                mkEntry("partition", Integer.toString(tp.partition()))
             );
 
             pruneSensor = metrics.sensor(SHARE_COORDINATOR_STATE_TOPIC_PRUNE_SENSOR_NAME + sensorNameSuffix);

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -55,7 +55,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -64,6 +63,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.common.runtime.TestUtil.requestContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -76,6 +77,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 class ShareCoordinatorServiceTest {
 
@@ -1917,8 +1919,8 @@ class ShareCoordinatorServiceTest {
             "last-pruned-offset",
             ShareCoordinatorMetrics.METRICS_GROUP,
             "The offset at which the share-group state topic was last pruned.",
-            Map.of("topic", topic, "partition", Integer.toString(partition))
-        ));
+            mkMap(mkEntry("topic", topic), mkEntry("partition", Integer.toString(partition))))
+        );
         assertEquals(checkPresence, isPresent);
     }
 }

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetricsTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetricsTest.java
@@ -28,13 +28,15 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.share.metrics.ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME;
 import static org.apache.kafka.coordinator.share.metrics.ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_SENSOR_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class ShareCoordinatorMetricsTest {
 
@@ -114,9 +116,9 @@ public class ShareCoordinatorMetricsTest {
             "last-pruned-offset",
             ShareCoordinatorMetrics.METRICS_GROUP,
             "The offset at which the share-group state topic was last pruned.",
-            Map.of(
-                "topic", topic,
-                "partition", Integer.toString(partition)
+            mkMap(
+                mkEntry("topic", topic),
+                mkEntry("partition", Integer.toString(partition))
             )
         );
     }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManager.java
@@ -32,10 +32,11 @@ import org.apache.kafka.server.quota.SensorAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 public class RLMQuotaManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RLMQuotaManager.class);
@@ -102,7 +103,7 @@ public class RLMQuotaManager {
     }
 
     private MetricName metricName() {
-        return metrics.metricName("byte-rate", quotaType.toString(), description, Collections.emptyMap());
+        return metrics.metricName("byte-rate", quotaType.toString(), description, mkMap());
     }
 
     private Sensor sensor() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -1066,7 +1066,7 @@ public class DefaultStateUpdater implements StateUpdater {
         private final Deque<MetricName> allMetricNames = new LinkedList<>();
 
         private StateUpdaterMetrics(final Metrics metrics, final String threadId) {
-            final Map<String, String> threadLevelTags = new LinkedHashMap<>();
+            final LinkedHashMap<String, String> threadLevelTags = new LinkedHashMap<>();
             threadLevelTags.put(THREAD_ID_TAG, threadId);
 
             MetricName metricName = metrics.metricName("active-restoring-tasks",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetrics.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.internals.metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.AVG_LATENCY_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_DESCRIPTION_SUFFIX;
@@ -136,7 +136,7 @@ public class ProcessorNodeMetrics {
                                           final StreamsMetricsImpl streamsMetrics) {
         final String sensorSuffix = processorNodeId + "-" + RECORD_E2E_LATENCY;
         final Sensor sensor = streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, sensorSuffix, RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
         addAvgAndMinAndMaxToSensor(
             sensor,
             PROCESSOR_NODE_LEVEL_GROUP,
@@ -155,7 +155,7 @@ public class ProcessorNodeMetrics {
                                                 final StreamsMetricsImpl streamsMetrics) {
         final String sensorSuffix = processorNodeId + "-" + EMIT_FINAL_LATENCY;
         final Sensor sensor = streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, sensorSuffix, RecordingLevel.DEBUG);
-        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
         addAvgAndMaxToSensor(
             sensor,
             PROCESSOR_NODE_LEVEL_GROUP,
@@ -173,7 +173,7 @@ public class ProcessorNodeMetrics {
                                               final StreamsMetricsImpl streamsMetrics) {
         final String sensorSuffix = processorNodeId + "-" + EMITTED_RECORDS;
         final Sensor sensor = streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, sensorSuffix, RecordingLevel.DEBUG);
-        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
         addRateOfSumAndSumMetricsToSensor(
             sensor,
             PROCESSOR_NODE_LEVEL_GROUP,
@@ -197,7 +197,7 @@ public class ProcessorNodeMetrics {
         // use operation name as sensor suffix and metric name prefix
         final Sensor sensor =
             streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, operationName, recordingLevel, parentSensors);
-        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
         addInvocationRateAndCountToSensor(
             sensor,
             PROCESSOR_NODE_LEVEL_GROUP,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -48,6 +48,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
 public class StreamsMetricsImpl implements StreamsMetrics {
 
     public enum Version {
@@ -232,12 +234,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                 final String description,
                                                 final String threadId,
                                                 final Gauge<T> valueProvider) {
-        addThreadLevelMutableMetric(name, description, threadId, Collections.emptyMap(), valueProvider);
+        addThreadLevelMutableMetric(name, description, threadId, mkMap(), valueProvider);
     }
     public <T> void addThreadLevelMutableMetric(final String name,
                                                 final String description,
                                                 final String threadId,
-                                                final Map<String, String> additionalTags,
+                                                final LinkedHashMap<String, String> additionalTags,
                                                 final Gauge<T> valueProvider) {
         final MetricName metricName = metrics.metricName(
             name, THREAD_LEVEL_GROUP, description, threadLevelTagMap(threadId, additionalTags));
@@ -278,19 +280,19 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return SENSOR_INTERNAL_LABEL + SENSOR_PREFIX_DELIMITER + threadId;
     }
 
-    public Map<String, String> clientLevelTagMap() {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+    public LinkedHashMap<String, String> clientLevelTagMap() {
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(CLIENT_ID_TAG, clientId);
         tagMap.put(PROCESS_ID_TAG, processId);
         return tagMap;
     }
 
-    public Map<String, String> threadLevelTagMap(final String threadId) {
-        return threadLevelTagMap(threadId, Collections.emptyMap());
+    public LinkedHashMap<String, String> threadLevelTagMap(final String threadId) {
+        return threadLevelTagMap(threadId, mkMap());
     }
 
-    public Map<String, String> threadLevelTagMap(final String threadId, final Map<String, String> additionalTags) {
-        final Map<String, String> tagMap = new LinkedHashMap<>(additionalTags);
+    public LinkedHashMap<String, String> threadLevelTagMap(final String threadId, final LinkedHashMap<String, String> additionalTags) {
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>(additionalTags);
         tagMap.put(THREAD_ID_TAG, threadId);
         return tagMap;
     }
@@ -335,28 +337,28 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    public Map<String, String> taskLevelTagMap(final String threadId, final String taskId) {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+    public LinkedHashMap<String, String> taskLevelTagMap(final String threadId, final String taskId) {
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, threadId);
         tagMap.put(TASK_ID_TAG, taskId);
         return tagMap;
     }
 
-    public Map<String, String> nodeLevelTagMap(final String threadId,
+    public LinkedHashMap<String, String> nodeLevelTagMap(final String threadId,
                                                final String taskId,
                                                final String processorNodeName) {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, threadId);
         tagMap.put(TASK_ID_TAG, taskId);
         tagMap.put(PROCESSOR_NODE_ID_TAG, processorNodeName);
         return tagMap;
     }
 
-    public Map<String, String> topicLevelTagMap(final String threadId,
+    public LinkedHashMap<String, String> topicLevelTagMap(final String threadId,
                                                 final String taskId,
                                                 final String processorNodeName,
                                                 final String topicName) {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, threadId);
         tagMap.put(TASK_ID_TAG, taskId);
         tagMap.put(PROCESSOR_NODE_ID_TAG, processorNodeName);
@@ -364,10 +366,10 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return tagMap;
     }
 
-    public Map<String, String> storeLevelTagMap(final String taskId,
+    public LinkedHashMap<String, String> storeLevelTagMap(final String taskId,
                                                 final String storeType,
                                                 final String storeName) {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, Thread.currentThread().getName());
         tagMap.put(TASK_ID_TAG, taskId);
         tagMap.put(storeType + "-" + STORE_ID_TAG, storeName);
@@ -476,10 +478,10 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    public Map<String, String> cacheLevelTagMap(final String threadId,
+    public LinkedHashMap<String, String> cacheLevelTagMap(final String threadId,
                                                 final String taskId,
                                                 final String storeName) {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, threadId);
         tagMap.put(TASK_ID_TAG, taskId);
         tagMap.put(RECORD_CACHE_ID_TAG, storeName);
@@ -586,11 +588,11 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return Collections.unmodifiableMap(this.metrics.metrics());
     }
 
-    private Map<String, String> customizedTags(final String threadId,
+    private LinkedHashMap<String, String> customizedTags(final String threadId,
                                                final String scopeName,
                                                final String entityName,
                                                final String... tags) {
-        final Map<String, String> tagMap = threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = threadLevelTagMap(threadId);
         tagMap.put(scopeName + "-id", entityName);
         if (tags != null) {
             if ((tags.length % 2) != 0) {
@@ -607,7 +609,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                       final String groupName,
                                                       final String entityName,
                                                       final String operationName,
-                                                      final Map<String, String> tags,
+                                                      final LinkedHashMap<String, String> tags,
                                                       final Sensor.RecordingLevel recordingLevel) {
         final Sensor sensor = metrics.sensor(externalChildSensorName(threadId, operationName, entityName), recordingLevel);
         addInvocationRateAndCountToSensor(
@@ -629,7 +631,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                             final String... tags) {
         final String threadId = Thread.currentThread().getName();
         final String group = groupNameFromScope(scopeName);
-        final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
+        final LinkedHashMap<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
         final Sensor sensor =
             customInvocationRateAndCountSensor(threadId, group, entityName, operationName, tagMap, recordingLevel);
         addAvgAndMaxToSensor(
@@ -651,7 +653,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                      final Sensor.RecordingLevel recordingLevel,
                                      final String... tags) {
         final String threadId = Thread.currentThread().getName();
-        final Map<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
+        final LinkedHashMap<String, String> tagMap = customizedTags(threadId, scopeName, entityName, tags);
         return customInvocationRateAndCountSensor(
             threadId,
             groupNameFromScope(scopeName),
@@ -670,7 +672,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addAvgAndMaxToSensor(final Sensor sensor,
                                             final String group,
-                                            final Map<String, String> tags,
+                                            final LinkedHashMap<String, String> tags,
                                             final String gaugeName,
                                             final String descriptionOfAvg,
                                             final String descriptionOfMax) {
@@ -694,7 +696,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addMinAndMaxToSensor(final Sensor sensor,
                                             final String group,
-                                            final Map<String, String> tags,
+                                            final LinkedHashMap<String, String> tags,
                                             final String operation,
                                             final String descriptionOfMin,
                                             final String descriptionOfMax) {
@@ -719,7 +721,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addAvgAndMaxLatencyToSensor(final Sensor sensor,
                                                    final String group,
-                                                   final Map<String, String> tags,
+                                                   final LinkedHashMap<String, String> tags,
                                                    final String operation) {
         sensor.add(
             new MetricName(
@@ -741,7 +743,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addAvgAndMinAndMaxToSensor(final Sensor sensor,
                                                   final String group,
-                                                  final Map<String, String> tags,
+                                                  final LinkedHashMap<String, String> tags,
                                                   final String gaugeName,
                                                   final String descriptionOfAvg,
                                                   final String descriptionOfMin,
@@ -759,7 +761,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addInvocationRateAndCountToSensor(final Sensor sensor,
                                                          final String group,
-                                                         final Map<String, String> tags,
+                                                         final LinkedHashMap<String, String> tags,
                                                          final String operation,
                                                          final String descriptionOfRate,
                                                          final String descriptionOfCount) {
@@ -777,7 +779,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addInvocationRateToSensor(final Sensor sensor,
                                                  final String group,
-                                                 final Map<String, String> tags,
+                                                 final LinkedHashMap<String, String> tags,
                                                  final String operation,
                                                  final String descriptionOfRate) {
         sensor.add(
@@ -793,7 +795,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addRateOfSumAndSumMetricsToSensor(final Sensor sensor,
                                                          final String group,
-                                                         final Map<String, String> tags,
+                                                         final LinkedHashMap<String, String> tags,
                                                          final String operation,
                                                          final String descriptionOfRate,
                                                          final String descriptionOfTotal) {
@@ -803,7 +805,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addRateOfSumMetricToSensor(final Sensor sensor,
                                                   final String group,
-                                                  final Map<String, String> tags,
+                                                  final LinkedHashMap<String, String> tags,
                                                   final String operation,
                                                   final String description) {
         sensor.add(new MetricName(operation + RATE_SUFFIX, group, description, tags),
@@ -812,7 +814,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addSumMetricToSensor(final Sensor sensor,
                                             final String group,
-                                            final Map<String, String> tags,
+                                            final LinkedHashMap<String, String> tags,
                                             final String operation,
                                             final String description) {
         addSumMetricToSensor(sensor, group, tags, operation, true, description);
@@ -820,7 +822,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addSumMetricToSensor(final Sensor sensor,
                                             final String group,
-                                            final Map<String, String> tags,
+                                            final LinkedHashMap<String, String> tags,
                                             final String operation,
                                             final boolean withSuffix,
                                             final String description) {
@@ -837,7 +839,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addValueMetricToSensor(final Sensor sensor,
                                               final String group,
-                                              final Map<String, String> tags,
+                                              final LinkedHashMap<String, String> tags,
                                               final String name,
                                               final String description) {
         sensor.add(new MetricName(name, group, description, tags), new Value());
@@ -845,7 +847,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addAvgAndSumMetricsToSensor(final Sensor sensor,
                                                    final String group,
-                                                   final Map<String, String> tags,
+                                                   final LinkedHashMap<String, String> tags,
                                                    final String metricNamePrefix,
                                                    final String descriptionOfAvg,
                                                    final String descriptionOfTotal) {
@@ -858,7 +860,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static void addTotalCountAndSumMetricsToSensor(final Sensor sensor,
                                                           final String group,
-                                                          final Map<String, String> tags,
+                                                          final LinkedHashMap<String, String> tags,
                                                           final String countMetricNamePrefix,
                                                           final String sumMetricNamePrefix,
                                                           final String descriptionOfCount,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.internals.metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATIO_SUFFIX;
@@ -133,7 +133,7 @@ public class TaskMetrics {
                                                        final String taskId,
                                                        final StreamsMetricsImpl streamsMetrics) {
         final String name = RESTORE + REMAINING_RECORDS + TOTAL_SUFFIX;
-        final Map<String, String> tags = streamsMetrics.taskLevelTagMap(threadId, taskId);
+        final LinkedHashMap<String, String> tags = streamsMetrics.taskLevelTagMap(threadId, taskId);
         final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, name, Sensor.RecordingLevel.INFO);
         addSumMetricToSensor(sensor, TASK_LEVEL_GROUP, tags, name, false, REMAINING_RECORDS_DESCRIPTION);
         return sensor;
@@ -290,7 +290,7 @@ public class TaskMetrics {
                                                        final StreamsMetricsImpl streamsMetrics,
                                                        final Sensor... parentSensors) {
         final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, operation, recordingLevel, parentSensors);
-        final Map<String, String> tags = streamsMetrics.taskLevelTagMap(threadId, taskId);
+        final LinkedHashMap<String, String> tags = streamsMetrics.taskLevelTagMap(threadId, taskId);
 
         addInvocationRateToSensor(sensor, TASK_LEVEL_GROUP, tags, operation, descriptionOfRate);
         addSumMetricToSensor(sensor, TASK_LEVEL_GROUP, tags, operation, true, descriptionOfTotal);
@@ -307,7 +307,7 @@ public class TaskMetrics {
                                           final Sensor... parentSensors) {
         // use latency name as sensor suffix and metric name prefix
         final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, gaugeName, recordingLevel, parentSensors);
-        final Map<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, taskId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, taskId);
         addAvgAndMaxToSensor(
             sensor,
             TASK_LEVEL_GROUP,
@@ -331,7 +331,7 @@ public class TaskMetrics {
                                                                           final Sensor... parentSensors) {
         // use operation name as sensor suffix and metric name prefix
         final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, operation, recordingLevel, parentSensors);
-        final Map<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, taskId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.taskLevelTagMap(threadId, taskId);
         addAvgAndMaxToSensor(
             sensor,
             TASK_LEVEL_GROUP,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -22,9 +22,10 @@ import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamThreadTotalBlockedTime;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESS_ID_TAG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_DESCRIPTION;
@@ -153,7 +154,7 @@ public class ThreadMetrics {
                                               final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + LATENCY_SUFFIX, RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -169,7 +170,7 @@ public class ThreadMetrics {
                                            final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, POLL + RECORDS_SUFFIX, RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -185,7 +186,7 @@ public class ThreadMetrics {
                                               final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + RECORDS_SUFFIX, RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -201,7 +202,7 @@ public class ThreadMetrics {
                                            final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + RATE_SUFFIX, RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addRateOfSumAndSumMetricsToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -231,7 +232,7 @@ public class ThreadMetrics {
                                             final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -246,7 +247,7 @@ public class ThreadMetrics {
                                               final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PUNCTUATE + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -261,7 +262,7 @@ public class ThreadMetrics {
                                          final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, POLL + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -276,7 +277,7 @@ public class ThreadMetrics {
                                            final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, COMMIT + RATIO_SUFFIX, Sensor.RecordingLevel.INFO);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
             THREAD_LEVEL_GROUP,
@@ -306,7 +307,7 @@ public class ThreadMetrics {
             THREAD_STATE,
             THREAD_STATE_DESCRIPTION,
             threadId,
-            Collections.singletonMap(PROCESS_ID_TAG, processId),
+            mkMap(mkEntry(PROCESS_ID_TAG, processId)),
             threadStateProvider
         );
     }
@@ -364,7 +365,7 @@ public class ThreadMetrics {
                                                                           final StreamsMetricsImpl streamsMetrics) {
         // use operation name as the sensor suffix, and metric names
         final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, operation, recordingLevel);
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addAvgAndMaxToSensor(
             sensor,
             THREAD_LEVEL_GROUP,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY;
@@ -284,7 +284,7 @@ public class StateStoreMetrics {
                                           final String storeType,
                                           final String storeName,
                                           final StreamsMetricsImpl streamsMetrics) {
-        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
         final Sensor sensor = streamsMetrics.storeLevelSensor(taskId, storeName, PREFIX_SCAN, RecordingLevel.DEBUG);
         addInvocationRateToSensor(
             sensor,
@@ -408,7 +408,7 @@ public class StateStoreMetrics {
                                           final String storeName,
                                           final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor = streamsMetrics.storeLevelSensor(taskId, storeName, RECORD_E2E_LATENCY, RecordingLevel.TRACE);
-        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
         addAvgAndMinAndMaxToSensor(
             sensor,
             STATE_STORE_LEVEL_GROUP,
@@ -426,7 +426,7 @@ public class StateStoreMetrics {
                                                 final String storeName,
                                                 final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor = streamsMetrics.storeLevelSensor(taskId, storeName, ITERATOR_DURATION, RecordingLevel.DEBUG);
-        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
         addAvgAndMaxToSensor(
             sensor,
             STATE_STORE_LEVEL_GROUP,
@@ -482,7 +482,7 @@ public class StateStoreMetrics {
         // use the gauge name (either size or count) as the sensor suffix, and metric name prefix
         final Sensor sensor = streamsMetrics.storeLevelSensor(taskId, storeName, gaugeName, recordingLevel);
         final String group;
-        final Map<String, String> tagMap;
+        final LinkedHashMap<String, String> tagMap;
         group = STATE_STORE_LEVEL_GROUP;
         tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
         addAvgAndMaxToSensor(sensor, group, tagMap, gaugeName, descriptionOfAvg, descriptionOfMax);
@@ -501,7 +501,7 @@ public class StateStoreMetrics {
         // use operation as the sensor suffix and metric name prefix
         final Sensor sensor;
         final String latencyMetricName = operation + LATENCY_SUFFIX;
-        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
+        final LinkedHashMap<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
         sensor = streamsMetrics.storeLevelSensor(taskId, storeName, operation, recordingLevel);
         addInvocationRateToSensor(sensor, STATE_STORE_LEVEL_GROUP, tagMap, operation, descriptionOfRate);
         addAvgAndMaxToSensor(

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -24,9 +24,10 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CLIENT_LEVEL_GROUP;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +42,7 @@ public class ClientMetricsTest {
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
     private final Sensor expectedSensor = mock(Sensor.class);
-    private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
+    private final LinkedHashMap<String, String> tagMap = mkMap(mkEntry("hello", "world"));
 
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsClientMetricsDelegatingReporterTest.java
@@ -29,9 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,13 +52,13 @@ class StreamsClientMetricsDelegatingReporterTest {
         mockAdminClient = new MockAdminClient();
         streamsClientMetricsDelegatingReporter = new StreamsClientMetricsDelegatingReporter(mockAdminClient, "adminClientId");
 
-        final Map<String, String> threadIdTagMap = new HashMap<>();
+        final LinkedHashMap<String, String> threadIdTagMap = new LinkedHashMap<>();
         final String threadId = "abcxyz-StreamThread-1";
         threadIdTagMap.put("thread-id", threadId);
 
-        final MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new HashMap<>());
-        final MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new HashMap<>());
-        final MetricName metricNameThree = new MetricName("metricThree", "stream-metrics", "description for metric three", new HashMap<>());
+        final MetricName metricNameOne = new MetricName("metricOne", "stream-metrics", "description for metric one", new LinkedHashMap<>());
+        final MetricName metricNameTwo = new MetricName("metricTwo", "stream-metrics", "description for metric two", new LinkedHashMap<>());
+        final MetricName metricNameThree = new MetricName("metricThree", "stream-metrics", "description for metric three", new LinkedHashMap<>());
         final MetricName metricNameFour = new MetricName("metricThree", "thread-metrics", "description for metric three", threadIdTagMap);
 
         streamClientMetricOne = new KafkaMetric(lock, metricNameOne, (Measurable) (m, now) -> 1.0, metricConfig, Time.SYSTEM);

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporterTest.java
@@ -30,9 +30,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -51,15 +50,15 @@ class StreamsThreadMetricsDelegatingReporterTest {
 
     @BeforeEach
     public void setUp() {
-        final Map<String, String> threadIdTagMap = new HashMap<>();
+        final LinkedHashMap<String, String> threadIdTagMap = new LinkedHashMap<>();
         final String threadId = "abcxyz-StreamThread-1";
         threadIdTagMap.put("thread-id", threadId);
 
-        final Map<String, String> threadIdWithStateUpdaterTagMap = new HashMap<>();
+        final LinkedHashMap<String, String> threadIdWithStateUpdaterTagMap = new LinkedHashMap<>();
         final String stateUpdaterId = "deftuv-StateUpdater-1";
         threadIdWithStateUpdaterTagMap.put("thread-id", stateUpdaterId);
 
-        final Map<String, String> noThreadIdTagMap = new HashMap<>();
+        final LinkedHashMap<String, String> noThreadIdTagMap = new LinkedHashMap<>();
         noThreadIdTagMap.put("client-id", "foo");
 
         mockConsumer = new MockConsumer<>(AutoOffsetResetStrategy.NONE.name());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -43,7 +43,7 @@ import org.mockito.quality.Strictness;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -214,7 +214,7 @@ public class ActiveTaskCreatorTest {
     private void shouldConstructStreamsProducerMetric() {
         createTasks();
 
-        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
+        final MetricName testMetricName = new MetricName("test_metric", "", "", new LinkedHashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),
             testMetricName,
@@ -297,6 +297,6 @@ public class ActiveTaskCreatorTest {
     }
 
     private MetricName metricName(final String name) {
-        return new MetricName(name, "", "", Collections.emptyMap());
+        return new MetricName(name, "", "", new LinkedHashMap<>());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -1613,7 +1613,7 @@ class DefaultStateUpdaterTest {
         verifyPausedTasks(activeTask2, standbyTask4);
         assertThat(metrics.metrics().size(), is(11));
 
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put("thread-id", "test-state-updater");
 
         MetricName metricName = new MetricName("active-restoring-tasks",

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -226,7 +226,7 @@ public class ProcessorNodeTest {
         final String threadId = Thread.currentThread().getName();
         final String[] latencyOperations = {"process", "punctuate", "create", "destroy"};
         final String groupName = "stream-processor-node-metrics";
-        final Map<String, String> metricTags = new LinkedHashMap<>();
+        final LinkedHashMap<String, String> metricTags = new LinkedHashMap<>();
         final String threadIdTagKey = "client-id";
         metricTags.put("processor-node-id", node.name());
         metricTags.put("task-id", context.taskId().toString());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -38,7 +38,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -105,7 +105,7 @@ public class SourceNodeTest {
 
         final String threadId = Thread.currentThread().getName();
         final String groupName = "stream-processor-node-metrics";
-        final Map<String, String> metricTags = mkMap(
+        final LinkedHashMap<String, String> metricTags = mkMap(
             mkEntry("thread-id", threadId),
             mkEntry("task-id", context.taskId().toString()),
             mkEntry("processor-node-id", node.name())

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -58,6 +58,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -591,7 +592,7 @@ public class StandbyTaskTest {
     }
 
     private MetricName setupCloseTaskMetric() {
-        final MetricName metricName = new MetricName("name", "group", "description", Collections.emptyMap());
+        final MetricName metricName = new MetricName("name", "group", "description", new LinkedHashMap<>());
         final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, "task-closed", Sensor.RecordingLevel.INFO);
         sensor.add(metricName, new CumulativeSum());
         return metricName;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -94,6 +94,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -3442,7 +3443,7 @@ public class StreamTaskTest {
     }
 
     private MetricName setupCloseTaskMetric() {
-        final MetricName metricName = new MetricName("name", "group", "description", Collections.emptyMap());
+        final MetricName metricName = new MetricName("name", "group", "description", new LinkedHashMap<>());
         final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, "task-closed", Sensor.RecordingLevel.INFO);
         sensor.add(metricName, new CumulativeSum());
         return metricName;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -117,6 +117,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -428,10 +429,7 @@ public class StreamThreadTest {
     public void shouldCreateMetricsAtStartup(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread(CLIENT_ID, new MockTime(1), stateUpdaterEnabled, processingThreadsEnabled);
         final String defaultGroupName = "stream-thread-metrics";
-        final Map<String, String> defaultTags = Collections.singletonMap(
-            "thread-id",
-            thread.getName()
-        );
+        final LinkedHashMap<String, String> defaultTags = mkMap(mkEntry("thread-id", thread.getName()));
         final String descriptionIsNotVerified = "";
 
         assertNotNull(metrics.metrics().get(metrics.metricName(
@@ -497,7 +495,7 @@ public class StreamThreadTest {
             "skipped-records-total", defaultGroupName, descriptionIsNotVerified, defaultTags)));
 
         final String taskGroupName = "stream-task-metrics";
-        final Map<String, String> taskTags =
+        final LinkedHashMap<String, String> taskTags =
             mkMap(mkEntry("task-id", "all"), mkEntry("thread-id", thread.getName()));
         assertNull(metrics.metrics().get(metrics.metricName(
             "commit-latency-avg", taskGroupName, descriptionIsNotVerified, taskTags)));
@@ -1189,7 +1187,7 @@ public class StreamThreadTest {
                     "commit-latency-max",
                     "stream-thread-metrics",
                     "",
-                    Collections.singletonMap("thread-id", CLIENT_ID))
+                    mkMap(mkEntry("thread-id", CLIENT_ID)))
                 ).metricValue()
             )
         );
@@ -1199,7 +1197,7 @@ public class StreamThreadTest {
                     "commit-latency-avg",
                     "stream-thread-metrics",
                     "",
-                    Collections.singletonMap("thread-id", CLIENT_ID))
+                    mkMap(mkEntry("thread-id", CLIENT_ID)))
                 ).metricValue()
             )
         );
@@ -1212,7 +1210,7 @@ public class StreamThreadTest {
                     "commit-latency-max",
                     "stream-thread-metrics",
                     "",
-                    Collections.singletonMap("thread-id", CLIENT_ID)
+                    mkMap(mkEntry("thread-id", CLIENT_ID))
                 )
             ).metricValue(),
             equalTo(10.0)
@@ -1223,7 +1221,7 @@ public class StreamThreadTest {
                     "commit-latency-avg",
                     "stream-thread-metrics",
                     "",
-                    Collections.singletonMap("thread-id", CLIENT_ID)
+                    mkMap(mkEntry("thread-id", CLIENT_ID))
                 )
             ).metricValue(),
             equalTo(10.0)
@@ -3092,7 +3090,7 @@ public class StreamThreadTest {
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final TaskManager taskManager = mock(TaskManager.class);
 
-        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
+        final MetricName testMetricName = new MetricName("test_metric", "", "", new LinkedHashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),
             testMetricName,
@@ -3152,7 +3150,7 @@ public class StreamThreadTest {
             HANDLER,
             null
         );
-        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
+        final MetricName testMetricName = new MetricName("test_metric", "", "", new LinkedHashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),
             testMetricName,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTimeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTimeTest.java
@@ -31,6 +31,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -90,7 +91,7 @@ public class StreamThreadTotalBlockedTimeTest {
         private final HashMap<MetricName, Metric> metrics = new HashMap<>();
 
         private MetricsBuilder addMetric(final String name, final double value) {
-            final MetricName metricName = new MetricName(name, "", "", Collections.emptyMap());
+            final MetricName metricName = new MetricName(name, "", "", new LinkedHashMap<>());
             metrics.put(
                 metricName,
                 new Metric() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -49,6 +49,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -942,7 +943,7 @@ public class StreamsProducerTest {
     }
 
     private MetricName metricName(final String name) {
-        return new MetricName(name, "", "", Collections.emptyMap());
+        return new MetricName(name, "", "", new LinkedHashMap<>());
     }
 
     private void addMetric(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -4435,7 +4436,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldTransmitProducerMetrics() {
-        final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
+        final MetricName testMetricName = new MetricName("test_metric", "", "", new LinkedHashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),
             testMetricName,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetricsTest.java
@@ -22,10 +22,11 @@ import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.hamcrest.CoreMatchers.is;
@@ -34,14 +35,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+
 public class ProcessorNodeMetricsTest {
 
     private static final String THREAD_ID = "test-thread";
     private static final String TASK_ID = "test-task";
     private static final String PROCESSOR_NODE_ID = "test-processor";
 
-    private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
-    private final Map<String, String> parentTagMap = Collections.singletonMap("hi", "universe");
+    private final LinkedHashMap<String, String> tagMap = mkMap(mkEntry("hello", "world"));
+    private final LinkedHashMap<String, String> parentTagMap = mkMap(mkEntry("hi", "universe"));
 
     private final Sensor expectedSensor = mock(Sensor.class);
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -41,6 +41,7 @@ import org.mockito.quality.Strictness;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -110,7 +111,7 @@ public class StreamsMetricsImplTest {
     private static final String STORE_ID_TAG = "-state-id";
     private static final String STORE_NAME1 = "store1";
     private static final String STORE_NAME2 = "store2";
-    private static final Map<String, String> STORE_LEVEL_TAG_MAP = mkMap(
+    private static final LinkedHashMap<String, String> STORE_LEVEL_TAG_MAP = mkMap(
         mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()),
         mkEntry(TASK_ID_TAG, TASK_ID1),
         mkEntry(SCOPE_NAME + STORE_ID_TAG, STORE_NAME1)
@@ -132,8 +133,8 @@ public class StreamsMetricsImplTest {
     private final Sensor sensor = metrics.sensor("dummy");
     private final String metricNamePrefix = "metric";
     private final String group = "group";
-    private final Map<String, String> tags = mkMap(mkEntry("tag", "value"));
-    private final Map<String, String> clientLevelTags = mkMap(mkEntry(CLIENT_ID_TAG, CLIENT_ID), mkEntry(PROCESS_ID_TAG, PROCESS_ID));
+    private final LinkedHashMap<String, String> tags = mkMap(mkEntry("tag", "value"));
+    private final LinkedHashMap<String, String> clientLevelTags = mkMap(mkEntry(CLIENT_ID_TAG, CLIENT_ID), mkEntry(PROCESS_ID_TAG, PROCESS_ID));
     private final MetricName metricName1 =
         new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION1, clientLevelTags);
     private final MetricName metricName2 =
@@ -761,13 +762,13 @@ public class StreamsMetricsImplTest {
 
         final String taskName = "taskName";
         final String operation = "operation";
-        final Map<String, String> taskTags = mkMap(mkEntry("tkey", "value"));
+        final LinkedHashMap<String, String> taskTags = mkMap(mkEntry("tkey", "value"));
 
         final String processorNodeName = "processorNodeName";
-        final Map<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
+        final LinkedHashMap<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
 
         final String topicName = "topicName";
-        final Map<String, String> topicTags = mkMap(mkEntry("tkey", "value"));
+        final LinkedHashMap<String, String> topicTags = mkMap(mkEntry("tkey", "value"));
 
         final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID1, taskName, operation, RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
@@ -929,7 +930,7 @@ public class StreamsMetricsImplTest {
             CUSTOM_TAG_KEY2,
             CUSTOM_TAG_VALUE2
         );
-        final Map<String, String> tags = customTags(streamsMetrics);
+        final LinkedHashMap<String, String> tags = customTags(streamsMetrics);
         shouldAddCustomSensorWithTags(
             sensor,
             Arrays.asList(
@@ -954,7 +955,7 @@ public class StreamsMetricsImplTest {
             CUSTOM_TAG_KEY2,
             CUSTOM_TAG_VALUE2
         );
-        final Map<String, String> tags = customTags(streamsMetrics);
+        final LinkedHashMap<String, String> tags = customTags(streamsMetrics);
         shouldAddCustomSensorWithTags(
             sensor,
             Arrays.asList(
@@ -968,13 +969,13 @@ public class StreamsMetricsImplTest {
     private void shouldAddCustomSensor(final Sensor sensor,
                                        final StreamsMetricsImpl streamsMetrics,
                                        final List<String> metricsNames) {
-        final Map<String, String> tags = tags(streamsMetrics);
+        final LinkedHashMap<String, String> tags = tags(streamsMetrics);
         shouldAddCustomSensorWithTags(sensor, metricsNames, tags);
     }
 
     private void shouldAddCustomSensorWithTags(final Sensor sensor,
                                                final List<String> metricsNames,
-                                               final Map<String, String> tags) {
+                                               final LinkedHashMap<String, String> tags) {
         final String group = "stream-" + SCOPE_NAME + "-metrics";
         assertTrue(sensor.hasMetrics());
         assertThat(
@@ -986,7 +987,7 @@ public class StreamsMetricsImplTest {
         }
     }
 
-    private Map<String, String> tags(final StreamsMetricsImpl streamsMetrics) {
+    private LinkedHashMap<String, String> tags(final StreamsMetricsImpl streamsMetrics) {
         return mkMap(
             mkEntry(
                 streamsMetrics.version() == Version.LATEST ? THREAD_ID_TAG : CLIENT_ID_TAG,
@@ -996,8 +997,8 @@ public class StreamsMetricsImplTest {
         );
     }
 
-    private Map<String, String> customTags(final StreamsMetricsImpl streamsMetrics) {
-        final Map<String, String> tags = tags(streamsMetrics);
+    private LinkedHashMap<String, String> customTags(final StreamsMetricsImpl streamsMetrics) {
+        final LinkedHashMap<String, String> tags = tags(streamsMetrics);
         tags.put(CUSTOM_TAG_KEY1, CUSTOM_TAG_VALUE1);
         tags.put(CUSTOM_TAG_KEY2, CUSTOM_TAG_VALUE2);
         return tags;
@@ -1299,7 +1300,7 @@ public class StreamsMetricsImplTest {
             "foobar",
             "test metric",
             "t1",
-            Collections.singletonMap("additional-tag", "additional-value"),
+            mkMap(mkEntry("additional-tag", "additional-value")),
             (c, t) -> measuredValue
         );
 
@@ -1332,7 +1333,7 @@ public class StreamsMetricsImplTest {
         final MetricName name = metrics.metricName(
             "foobar",
             THREAD_LEVEL_GROUP,
-            Collections.singletonMap("thread-id", "t1")
+            mkMap(mkEntry("thread-id", "t1"))
         );
         assertThat(metrics.metric(name), nullValue());
     }
@@ -1378,7 +1379,7 @@ public class StreamsMetricsImplTest {
         final MetricName name = metrics.metricName(
             "foobar",
             THREAD_LEVEL_GROUP,
-            Collections.singletonMap("thread-id", "t1")
+            mkMap(mkEntry("thread-id", "t1"))
         );
         assertThat(metrics.metric(name), nullValue());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetricsTest.java
@@ -22,9 +22,10 @@ import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +40,7 @@ public class TaskMetricsTest {
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
     private final Sensor expectedSensor = mock(Sensor.class);
-    private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
+    private final LinkedHashMap<String, String> tagMap = mkMap(mkEntry("hello", "world"));
 
     @Test
     public void shouldGetActiveProcessRatioSensor() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_SUFFIX;
 import static org.hamcrest.CoreMatchers.is;
@@ -47,7 +48,7 @@ public class ThreadMetricsTest {
 
     private final Sensor expectedSensor = mock(Sensor.class);
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
-    private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
+    private final LinkedHashMap<String, String> tagMap = mkMap(mkEntry("hello", "world"));
 
 
     @Test
@@ -428,7 +429,7 @@ public class ThreadMetricsTest {
                 "thread-state",
                 "The current state of the thread",
                 THREAD_ID,
-                Collections.singletonMap("process-id", PROCESS_ID),
+                mkMap(mkEntry("process-id", PROCESS_ID)),
                 threadStateProvider
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TopicMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TopicMetricsTest.java
@@ -23,16 +23,18 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_LEVEL_GROUP;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+
 
 public class TopicMetricsTest {
 
@@ -41,7 +43,7 @@ public class TopicMetricsTest {
     private static final String PROCESSOR_NODE_ID = "test-processor";
     private static final String TOPIC = "topic";
 
-    private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
+    private final LinkedHashMap<String, String> tagMap = mkMap(mkEntry("hello", "world"));
 
     private final Sensor expectedSensor = mock(Sensor.class);
     private static final MockedStatic<StreamsMetricsImpl> STREAMS_METRICS_STATIC_MOCK = mockStatic(StreamsMetricsImpl.class);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -47,8 +47,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -97,7 +97,7 @@ public class MeteredKeyValueStoreTest {
 
     private MeteredKeyValueStore<String, String> metered;
     private final Metrics metrics = new Metrics();
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
     private MockTime mockTime;
 
     public void setUpWithoutContext() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -50,8 +50,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -103,7 +103,7 @@ public class MeteredSessionStoreTest {
     @Mock
     private InternalProcessorContext<?, ?> context;
 
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
     
     public void setUpWithoutContext() {
         mockTime = new MockTime();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -50,6 +50,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -104,7 +105,7 @@ public class MeteredTimestampedKeyValueStoreTest {
         VALUE_AND_TIMESTAMP_BYTES
     );
     private final Metrics metrics = new Metrics();
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
 
     private void setUpWithoutContext() {
         mockTime = new MockTime();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
@@ -54,8 +54,8 @@ import org.mockito.quality.Strictness;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -103,7 +103,7 @@ public class MeteredVersionedKeyValueStoreTest {
     private final Time mockTime = new MockTime();
     private final String threadId = Thread.currentThread().getName();
     private final InternalProcessorContext<?, ?> context = mock(InternalProcessorContext.class);
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
 
     private MeteredVersionedKeyValueStore<String, String> store;
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -51,8 +51,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -107,7 +107,7 @@ public class MeteredWindowStoreTest {
         new SerdeThatDoesntHandleNull()
     );
     private final Metrics metrics = new Metrics(new MetricConfig().recordLevel(Sensor.RecordingLevel.DEBUG));
-    private Map<String, String> tags;
+    private LinkedHashMap<String, String> tags;
 
     {
         when(innerStoreMock.name()).thenReturn(STORE_NAME);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
@@ -42,8 +42,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -69,7 +69,7 @@ public class RocksDBVersionedStoreTest {
     private static final String TASK_LEVEL_GROUP = "stream-task-metrics";
 
     private InternalMockProcessorContext<String, String> context;
-    private Map<String, String> expectedMetricsTags;
+    private LinkedHashMap<String, String> expectedMetricsTags;
 
     private RocksDBVersionedStore store;
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -44,7 +44,7 @@ public class NamedCacheMetricsTest {
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
     private final Sensor expectedSensor = mock(Sensor.class);
-    private final Map<String, String> tagMap = mkMap(mkEntry("key", "value"));
+    private final LinkedHashMap<String, String> tagMap = mkMap(mkEntry("key", "value"));
 
     @Test
     public void shouldGetHitRatioSensorWithBuiltInMetricsVersionCurrent() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBBlockCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBBlockCacheMetricsTest.java
@@ -38,7 +38,6 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -124,22 +123,22 @@ public class RocksDBBlockCacheMetricsTest {
         assertEquals(expected, metric.metricValue(), String.format("Value for metric '%s-%s' was incorrect", group, metricName));
     }
 
-    public Map<String, String> threadLevelTagMap(final String threadId) {
-        final Map<String, String> tagMap = new LinkedHashMap<>();
+    public LinkedHashMap<String, String> threadLevelTagMap(final String threadId) {
+        final LinkedHashMap<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, threadId);
         return tagMap;
     }
 
-    public Map<String, String> taskLevelTagMap(final String threadId, final String taskId) {
-        final Map<String, String> tagMap = threadLevelTagMap(threadId);
+    public LinkedHashMap<String, String> taskLevelTagMap(final String threadId, final String taskId) {
+        final LinkedHashMap<String, String> tagMap = threadLevelTagMap(threadId);
         tagMap.put(TASK_ID_TAG, taskId);
         return tagMap;
     }
 
-    public Map<String, String> storeLevelTagMap(final String taskName,
+    public LinkedHashMap<String, String> storeLevelTagMap(final String taskName,
                                                 final String storeType,
                                                 final String storeName) {
-        final Map<String, String> tagMap = taskLevelTagMap(Thread.currentThread().getName(), taskName);
+        final LinkedHashMap<String, String> tagMap = taskLevelTagMap(Thread.currentThread().getName(), taskName);
         tagMap.put(storeType + "-" + STORE_ID_TAG, storeName);
         return tagMap;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
@@ -30,6 +30,7 @@ import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 
 import java.math.BigInteger;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -255,7 +256,7 @@ public class RocksDBMetricsRecorderGaugesTest {
                                final long expectedValue) {
 
         final Map<MetricName, ? extends Metric> metrics = streamsMetrics.metrics();
-        final Map<String, String> tagMap = mkMap(
+        final LinkedHashMap<String, String> tagMap = mkMap(
             mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()),
             mkEntry(TASK_ID_TAG, TASK_ID.toString()),
             mkEntry(METRICS_SCOPE + "-" + STORE_ID_TAG, STORE_NAME)

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
@@ -26,9 +26,10 @@ import org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.RocksDBMe
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.eq;
@@ -49,7 +50,7 @@ public class RocksDBMetricsTest {
     private final Metrics metrics = new Metrics();
     private final Sensor sensor = metrics.sensor("dummy");
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
-    private final Map<String, String> tags = Collections.singletonMap("hello", "world");
+    private final LinkedHashMap<String, String> tags = mkMap(mkEntry("hello", "world"));
 
     private interface SensorCreator {
         Sensor sensor(final StreamsMetricsImpl streamsMetrics, final RocksDBMetricContext metricContext);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
@@ -23,15 +23,17 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+
 
 public class StateStoreMetricsTest {
 
@@ -43,7 +45,7 @@ public class StateStoreMetricsTest {
 
     private final Sensor expectedSensor = mock(Sensor.class);
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
-    private final Map<String, String> storeTagMap = Collections.singletonMap("hello", "world");
+    private final LinkedHashMap<String, String> storeTagMap = mkMap(mkEntry("hello", "world"));
 
     @Test
     public void shouldGetPutSensor() {

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -248,7 +249,7 @@ public final class StreamsTestUtils {
     public static boolean containsMetric(final Metrics metrics,
                                          final String name,
                                          final String group,
-                                         final Map<String, String> tags) {
+                                         final LinkedHashMap<String, String> tags) {
         final MetricName metricName = metrics.metricName(name, group, tags);
         return metrics.metric(metricName) != null;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -679,7 +679,7 @@ public class ReplicaVerificationTool {
                 metrics,
                 time,
                 "replica-fetcher",
-                new HashMap<String, String>() {{
+                new LinkedHashMap<>() {{
                         put("broker-id", sourceNode.idString());
                         put("fetcher-id", String.valueOf(fetcherId));
                     }},

--- a/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
@@ -44,7 +44,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -52,6 +51,8 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,6 +64,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 public class PushHttpMetricsReporterTest {
 
@@ -186,35 +188,35 @@ public class PushHttpMetricsReporterTest {
         verifyConfigure();
         KafkaMetric metric1 = new KafkaMetric(
                 new Object(),
-                new MetricName("name1", "group1", "desc1", Collections.singletonMap("key1", "value1")),
+                new MetricName("name1", "group1", "desc1", mkMap(mkEntry("key1", "value1"))),
                 new ImmutableValue<>(1.0),
                 null,
                 time
         );
         KafkaMetric newMetric1 = new KafkaMetric(
                 new Object(),
-                new MetricName("name1", "group1", "desc1", Collections.singletonMap("key1", "value1")),
+                new MetricName("name1", "group1", "desc1", mkMap(mkEntry("key1", "value1"))),
                 new ImmutableValue<>(-1.0),
                 null,
                 time
         );
         KafkaMetric metric2 = new KafkaMetric(
                 new Object(),
-                new MetricName("name2", "group2", "desc2", Collections.singletonMap("key2", "value2")),
+                new MetricName("name2", "group2", "desc2", mkMap(mkEntry("key2", "value2"))),
                 new ImmutableValue<>(2.0),
                 null,
                 time
         );
         KafkaMetric metric3 = new KafkaMetric(
                 new Object(),
-                new MetricName("name3", "group3", "desc3", Collections.singletonMap("key3", "value3")),
+                new MetricName("name3", "group3", "desc3", mkMap(mkEntry("key3", "value3"))),
                 new ImmutableValue<>(3.0),
                 null,
                 time
         );
         KafkaMetric metric4 = new KafkaMetric(
             new Object(),
-            new MetricName("name4", "group4", "desc4", Collections.singletonMap("key4", "value4")),
+            new MetricName("name4", "group4", "desc4", mkMap(mkEntry("key4", "value4"))),
             new ImmutableValue<>("value4"),
             null,
             time


### PR DESCRIPTION
This PR would like to make tag order explicitly.
Having this implicit requirement and hoping people get it right is very error prone.

This PR do two things:
1. change SensorBuilder interface from `public SensorBuilder(Metrics metrics, String name, Supplier<Map<String, String>> tagsSupplier)` to `public SensorBuilder(Metrics metrics, String name, Supplier<LinkedHashMap<String, String>> tagsSupplier)`


2. do same thing in StreamsMetricsImpl and DefaultStateUpdater and use `mkMap` to make order implicitly.
Since MetricName is public api, we can't change interface directly.

Note: I used `grep --exclude="*Test.*" -nr "new MetricName(" *` to find all `MetricName` in this repo.

In this PR, we do't touch any test code since we don't change any interface and order is not required within test.