### PR TITLE
MINOR: refactoring periodic tasks to wrap a ControllerWriteOperation

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PeriodicTask.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PeriodicTask.java
@@ -17,7 +17,10 @@
 
 package org.apache.kafka.controller;
 
+import org.apache.kafka.controller.errors.PeriodicControlTaskException;
+
 import java.util.EnumSet;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -29,11 +32,12 @@ class PeriodicTask {
     private final String name;
 
     /**
-     * The callback for this task. If ControllerResult.response is true, we will schedule the
-     * task again after only a very short delay. This is useful if we only finished part of the
-     * work we wanted to finish.
+     * The write operation for this periodic task. It contains two callbacks, one for generating records
+     * and a controller result, and one for processing the end offset of the batch.
+     * If ControllerResult.response is true, we will schedule the task again after only a very short delay.
+     * This is useful if we only finished part of the work we wanted to finish.
      */
-    private final Supplier<ControllerResult<Boolean>> op;
+    private final QuorumController.ControllerWriteOperation<Boolean> writeOp;
 
     /**
      * The period of the task when ControllerResult.response is true, in nanoseconds.
@@ -54,29 +58,25 @@ class PeriodicTask {
 
     PeriodicTask(
         String name,
-        Supplier<ControllerResult<Boolean>> op,
+        QuorumController.ControllerWriteOperation<Boolean> writeOp,
         long periodNs,
         EnumSet<PeriodicTaskFlag> flags
     ) {
-        this.name = name;
-        this.op = op;
-        this.immediatePeriodNs = DEFAULT_IMMEDIATE_PERIOD_NS;
-        this.periodNs = periodNs;
-        this.flags = flags;
+        this(name, writeOp, periodNs, flags, DEFAULT_IMMEDIATE_PERIOD_NS);
     }
 
     PeriodicTask(
         String name,
-        Supplier<ControllerResult<Boolean>> op,
+        QuorumController.ControllerWriteOperation<Boolean> writeOp,
         long periodNs,
         EnumSet<PeriodicTaskFlag> flags,
         long immediatePeriodNs
     ) {
         this.name = name;
-        this.op = op;
-        this.immediatePeriodNs = immediatePeriodNs;
+        this.writeOp = writeOp;
         this.periodNs = periodNs;
         this.flags = flags;
+        this.immediatePeriodNs = immediatePeriodNs;
     }
 
     String name() {
@@ -84,7 +84,18 @@ class PeriodicTask {
     }
 
     Supplier<ControllerResult<Boolean>> op() {
-        return op;
+        return () -> {
+            try {
+                return writeOp.generateRecordsAndResult();
+            } catch (Exception e) {
+                throw new PeriodicControlTaskException(name + ": periodic task failed: " +
+                    e.getMessage(), e);
+            }
+        };
+    }
+
+    Consumer<Long> processBatchEndOffsetOp() {
+        return writeOp::processBatchEndOffset;
     }
 
     long immediatePeriodNs() {

--- a/metadata/src/main/java/org/apache/kafka/controller/PeriodicTaskControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PeriodicTaskControlManager.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -66,13 +65,13 @@ class PeriodicTaskControlManager {
         void scheduleDeferred(
             String tag,
             long deadlineNs,
-            Supplier<ControllerResult<Void>> op
+            QuorumController.ControllerWriteOperation<Void> op
         );
 
         void cancelDeferred(String tag);
     }
 
-    class PeriodicTaskOperation implements Supplier<ControllerResult<Void>> {
+    class PeriodicTaskOperation implements QuorumController.ControllerWriteOperation<Void> {
         private final PeriodicTask task;
 
         PeriodicTaskOperation(PeriodicTask task) {
@@ -80,7 +79,7 @@ class PeriodicTaskControlManager {
         }
 
         @Override
-        public ControllerResult<Void> get() {
+        public ControllerResult<Void> generateRecordsAndResult() {
             long startNs = 0;
             if (log.isDebugEnabled() || task.flags().contains(PeriodicTaskFlag.VERBOSE)) {
                 startNs = time.nanoseconds();
@@ -114,6 +113,11 @@ class PeriodicTaskControlManager {
             } else {
                 return ControllerResult.of(result.records(), null);
             }
+        }
+
+        @Override
+        public void processBatchEndOffset(long offset) {
+            task.processBatchEndOffsetOp().accept(offset);
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -518,12 +518,12 @@ public final class QuorumController implements Controller {
         public void scheduleDeferred(
             String tag,
             long deadlineNs,
-            Supplier<ControllerResult<Void>> op
+            QuorumController.ControllerWriteOperation<Void> op
         ) {
             EnumSet<ControllerOperationFlag> flags = EnumSet.of(DOES_NOT_UPDATE_QUEUE_TIME);
             queue.scheduleDeferred(tag,
                 new EarliestDeadlineFunction(deadlineNs),
-                new ControllerWriteEvent<>(tag, op::get, flags));
+                new ControllerWriteEvent<>(tag, op, flags));
         }
 
         @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/PeriodicTaskControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PeriodicTaskControlManagerTest.java
@@ -102,14 +102,21 @@ public class PeriodicTaskControlManagerTest {
         public void scheduleDeferred(
             String tag,
             long deadlineNs,
-            Supplier<ControllerResult<Void>> op
+            QuorumController.ControllerWriteOperation<Void> op
         ) {
             if (numCalls <= 0) {
                 throw new RuntimeException("too many deferred calls.");
             }
             numCalls--;
             cancelDeferred(tag);
-            TrackedTask task = new TrackedTask(tag, deadlineNs, op);
+            Supplier<ControllerResult<Void>> taskOp = () -> {
+                try {
+                    return op.generateRecordsAndResult();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            TrackedTask task = new TrackedTask(tag, deadlineNs, taskOp);
             tasks.computeIfAbsent(deadlineNs, __ -> new ArrayList<>()).add(task);
         }
 


### PR DESCRIPTION
Refactor periodic tasks framework to wrap a `ControllerWriteOperation`, not just a `Supplier<ControllerResult<Boolean>>`.
