### PR TITLE
KAFKA-18796: Added more information to error message when assertion fails for acquisition lock timeout

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -187,6 +187,10 @@ public class SharePartition {
                     throw new IllegalArgumentException("Unknown record state id: " + id);
             }
         }
+
+        public byte id() {
+            return this.id;
+        }
     }
 
     /**

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -117,7 +117,6 @@ public class SharePartitionTest {
     private static final int MAX_FETCH_RECORDS = Integer.MAX_VALUE;
     private static final byte ACKNOWLEDGE_TYPE_GAP_ID = 0;
     private static Timer mockTimer;
-    private static final String TIMER_NAME_PREFIX = "share-partition-manager";
     private SharePartitionMetrics sharePartitionMetrics;
 
     @BeforeEach

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -2912,7 +2912,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null &&
                         sharePartition.timer().size() == 0,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of())));
 
         assertEquals(1, sharePartitionMetrics.acquisitionLockTimeoutPerSec().count());
         assertTrue(sharePartitionMetrics.acquisitionLockTimeoutPerSec().meanRate() > 0);
@@ -2938,7 +2938,7 @@ public class SharePartitionTest {
                         && sharePartition.cachedState().get(10L).batchDeliveryCount() == 1
                         && sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(10L, List.of())));
 
         assertEquals(5, sharePartitionMetrics.acquisitionLockTimeoutPerSec().count());
         assertTrue(sharePartitionMetrics.acquisitionLockTimeoutPerSec().meanRate() > 0);
@@ -2973,7 +2973,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of(), 5L, List.of())));
 
         assertEquals(10, sharePartitionMetrics.acquisitionLockTimeoutPerSec().count());
         assertTrue(sharePartitionMetrics.acquisitionLockTimeoutPerSec().meanRate() > 0);
@@ -2997,7 +2997,7 @@ public class SharePartitionTest {
                         sharePartition.nextFetchOffset() == 10 &&
                         sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(10L, List.of())));
 
         // Acquire the same batch again.
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 10), 5);
@@ -3036,7 +3036,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of())));
     }
 
     @Test
@@ -3065,7 +3065,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of())));
     }
 
     @Test
@@ -3115,7 +3115,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(1L, List.of(), 5L, List.of(), 10L, List.of())));
 
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(1L).batchState());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).batchState());
@@ -3142,7 +3142,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(10L, List.of())));
 
         // Acquire subset of records again.
         fetchAcquiredRecords(sharePartition, memoryRecords(3, 12), 3);
@@ -3176,7 +3176,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(10L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(10L, List.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L))));
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(10L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(11L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(12L).acquisitionLockTimeoutTask());
@@ -3264,7 +3264,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap2.equals(sharePartition.cachedState().get(10L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of(5L, 6L), 10L, List.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L))));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -3308,7 +3308,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(10L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(10L, List.of())));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(10, 10), 10);
 
@@ -3326,7 +3326,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(10L).batchDeliveryCount() == 2 &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(10L, List.of())));
     }
 
     @Test
@@ -3350,7 +3350,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of())));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 0), 5);
 
@@ -3384,7 +3384,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(0L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L))));
 
         assertNull(sharePartition.cachedState().get(0L).offsetState().get(0L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(0L).offsetState().get(1L).acquisitionLockTimeoutTask());
@@ -3422,7 +3422,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of())));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(10, 0), 10);
 
@@ -3437,7 +3437,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().isEmpty() &&
                         sharePartition.nextFetchOffset() == 10,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of()));
     }
 
     @Test
@@ -3459,7 +3459,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of())));
 
         // Acknowledge with ACCEPT type should throw InvalidRecordStateException since they've been released due to acquisition lock timeout.
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID,
@@ -3525,7 +3525,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(5L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of(5L, 6L, 7L, 8L, 9L))));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -3563,7 +3563,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of())));
     }
 
     @Test
@@ -3609,7 +3609,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(5L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of(5L, 6L, 7L, 8L, 9L, 10L))));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -4939,7 +4939,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(35L).offsetState().equals(expectedOffsetStateMap3);
             },
             DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-            () -> assertionFailedMessage(sharePartition));
+            () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of(5L, 6L, 7L, 8L, 9L), 20L, List.of(20L, 21L, 22L, 23L, 24L), 25L, List.of(), 30L, List.of(), 35L, List.of(35L, 36L, 37L, 38L, 39L))));
 
         assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
@@ -4973,7 +4973,7 @@ public class SharePartitionTest {
                     sharePartition.cachedState().get(10L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
                     sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
             DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-            () -> assertionFailedMessage(sharePartition));
+            () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of(), 10L, List.of())));
     }
 
     @Test
@@ -5008,7 +5008,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED;
             },
             DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-            () -> assertionFailedMessage(sharePartition));
+            () -> assertionFailedMessage(sharePartition, Map.of(5L, List.of(), 10L, List.of(10L, 11L, 12L, 13L, 14L))));
     }
 
     @Test
@@ -5193,7 +5193,7 @@ public class SharePartitionTest {
                 () -> sharePartition.nextFetchOffset() == 7 && sharePartition.cachedState().isEmpty() &&
                             sharePartition.startOffset() == 7 && sharePartition.endOffset() == 7,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of()));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 10), 5);
 
@@ -5242,7 +5242,7 @@ public class SharePartitionTest {
                 () -> sharePartition.nextFetchOffset() == 3 && sharePartition.cachedState().isEmpty() &&
                         sharePartition.startOffset() == 3 && sharePartition.endOffset() == 3,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> assertionFailedMessage(sharePartition));
+                () -> assertionFailedMessage(sharePartition, Map.of()));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(2, 3), 2);
         fetchAcquiredRecords(sharePartition, memoryRecords(3, 5), 3);
@@ -6649,13 +6649,26 @@ public class SharePartitionTest {
         });
     }
     
-    private String assertionFailedMessage(SharePartition sharePartition) {
-        return ACQUISITION_LOCK_NEVER_GOT_RELEASED + String.format(
-            " timer size: %d, next fetch offset: %d, batch state: %d, acquisition lock timeout task: %b",
+    private String assertionFailedMessage(SharePartition sharePartition, Map<Long, List<Long>> offsets) {
+        StringBuilder errorMessage = new StringBuilder(ACQUISITION_LOCK_NEVER_GOT_RELEASED + String.format(
+            " timer size: %d, next fetch offset: %d\n",
             sharePartition.timer().size(),
-            sharePartition.nextFetchOffset(),
-            sharePartition.cachedState().get(5L).batchState().id(),
-            sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null);
+            sharePartition.nextFetchOffset()));
+        for (Map.Entry<Long, List<Long>> entry : offsets.entrySet()) {
+            if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+                errorMessage.append(String.format("batch start offset: %d\n", entry.getKey()));
+                for (Long offset : entry.getValue()) {
+                    errorMessage.append(String.format("\toffset: %d, offset state: %s, offset acquisition lock timeout task present: %b\n",
+                        offset, sharePartition.cachedState().get(entry.getKey()).offsetState().get(offset).state().id(),
+                        sharePartition.cachedState().get(entry.getKey()).offsetState().get(offset).acquisitionLockTimeoutTask() == null));
+                }
+            } else {
+                errorMessage.append(String.format("batch start offset: %d, batch state: %s, batch acquisition lock timeout task present: %b\n",
+                    entry.getKey(), sharePartition.cachedState().get(entry.getKey()).batchState().id(),
+                    sharePartition.cachedState().get(entry.getKey()).batchAcquisitionLockTimeoutTask() == null));
+            }
+        }
+        return errorMessage.toString();
     }
 
     private FetchPartitionData fetchPartitionData(Records records) {

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -117,6 +117,7 @@ public class SharePartitionTest {
     private static final int MAX_FETCH_RECORDS = Integer.MAX_VALUE;
     private static final byte ACKNOWLEDGE_TYPE_GAP_ID = 0;
     private static Timer mockTimer;
+    private static final String TIMER_NAME_PREFIX = "share-partition-manager";
     private SharePartitionMetrics sharePartitionMetrics;
 
     @BeforeEach
@@ -2912,7 +2913,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null &&
                         sharePartition.timer().size() == 0,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertEquals(1, sharePartitionMetrics.acquisitionLockTimeoutPerSec().count());
         assertTrue(sharePartitionMetrics.acquisitionLockTimeoutPerSec().meanRate() > 0);
@@ -2938,7 +2939,7 @@ public class SharePartitionTest {
                         && sharePartition.cachedState().get(10L).batchDeliveryCount() == 1
                         && sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertEquals(5, sharePartitionMetrics.acquisitionLockTimeoutPerSec().count());
         assertTrue(sharePartitionMetrics.acquisitionLockTimeoutPerSec().meanRate() > 0);
@@ -2973,7 +2974,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertEquals(10, sharePartitionMetrics.acquisitionLockTimeoutPerSec().count());
         assertTrue(sharePartitionMetrics.acquisitionLockTimeoutPerSec().meanRate() > 0);
@@ -2997,7 +2998,7 @@ public class SharePartitionTest {
                         sharePartition.nextFetchOffset() == 10 &&
                         sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         // Acquire the same batch again.
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 10), 5);
@@ -3036,7 +3037,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -3065,7 +3066,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -3115,7 +3116,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(1L).batchState());
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(5L).batchState());
@@ -3142,7 +3143,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         // Acquire subset of records again.
         fetchAcquiredRecords(sharePartition, memoryRecords(3, 12), 3);
@@ -3176,7 +3177,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(10L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(10L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(11L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).offsetState().get(12L).acquisitionLockTimeoutTask());
@@ -3264,7 +3265,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap2.equals(sharePartition.cachedState().get(10L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -3308,7 +3309,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(10L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(10, 10), 10);
 
@@ -3326,7 +3327,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(10L).batchDeliveryCount() == 2 &&
                         sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -3350,7 +3351,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchDeliveryCount() == 1 &&
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 0), 5);
 
@@ -3384,7 +3385,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(0L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertNull(sharePartition.cachedState().get(0L).offsetState().get(0L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(0L).offsetState().get(1L).acquisitionLockTimeoutTask());
@@ -3422,7 +3423,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(0L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(10, 0), 10);
 
@@ -3437,7 +3438,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().isEmpty() &&
                         sharePartition.nextFetchOffset() == 10,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -3459,7 +3460,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         // Acknowledge with ACCEPT type should throw InvalidRecordStateException since they've been released due to acquisition lock timeout.
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID,
@@ -3525,7 +3526,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(5L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -3563,7 +3564,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchState() == RecordState.AVAILABLE &&
                         sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -3609,7 +3610,7 @@ public class SharePartitionTest {
                             expectedOffsetStateMap.equals(sharePartition.cachedState().get(5L).offsetState());
                 },
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -4939,7 +4940,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(35L).offsetState().equals(expectedOffsetStateMap3);
             },
             DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-            () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+            () -> assertionFailedMessage(sharePartition));
 
         assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(10L).batchMemberId());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
@@ -4973,7 +4974,7 @@ public class SharePartitionTest {
                     sharePartition.cachedState().get(10L).batchMemberId().equals(EMPTY_MEMBER_ID) &&
                     sharePartition.cachedState().get(10L).batchState() == RecordState.AVAILABLE,
             DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-            () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+            () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -5008,7 +5009,7 @@ public class SharePartitionTest {
                         sharePartition.cachedState().get(5L).batchState() == RecordState.ARCHIVED;
             },
             DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-            () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+            () -> assertionFailedMessage(sharePartition));
     }
 
     @Test
@@ -5193,7 +5194,7 @@ public class SharePartitionTest {
                 () -> sharePartition.nextFetchOffset() == 7 && sharePartition.cachedState().isEmpty() &&
                             sharePartition.startOffset() == 7 && sharePartition.endOffset() == 7,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 10), 5);
 
@@ -5242,7 +5243,7 @@ public class SharePartitionTest {
                 () -> sharePartition.nextFetchOffset() == 3 && sharePartition.cachedState().isEmpty() &&
                         sharePartition.startOffset() == 3 && sharePartition.endOffset() == 3,
                 DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
-                () -> ACQUISITION_LOCK_NEVER_GOT_RELEASED);
+                () -> assertionFailedMessage(sharePartition));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(2, 3), 2);
         fetchAcquiredRecords(sharePartition, memoryRecords(3, 5), 3);
@@ -6647,6 +6648,15 @@ public class SharePartitionTest {
                 assertEquals(recordState, offsetState.state());
             });
         });
+    }
+    
+    private String assertionFailedMessage(SharePartition sharePartition) {
+        return ACQUISITION_LOCK_NEVER_GOT_RELEASED + String.format(
+            " timer size: %d, next fetch offset: %d, batch state: %d, acquisition lock timeout task: %b",
+            sharePartition.timer().size(),
+            sharePartition.nextFetchOffset(),
+            sharePartition.cachedState().get(5L).batchState().id(),
+            sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask() == null);
     }
 
     private FetchPartitionData fetchPartitionData(Records records) {


### PR DESCRIPTION
This PR adds extra information in assertion failed messages for tests in SharePartitionTest revolving around acquisition lock timeouts functionality.