### PR TITLE
MINOR Mar 19 flaky tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -98,6 +99,7 @@ public class CoordinatorRequestManagerTest {
      *
      * @see CoordinatorRequestManager#markCoordinatorUnknown(String, long)
      */
+    @Flaky("KAFKA-18776")
     @Test
     public void testMarkCoordinatorUnknownLoggingAccuracy() {
         long oneMinute = 60000;

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -601,6 +601,7 @@ public class QuorumControllerTest {
         }
     }
 
+    @Flaky("KAFKA-18981")
     @Test
     public void testMinIsrUpdateWithElr() throws Throwable {
         List<Integer> allBrokers = List.of(1, 2, 3);


### PR DESCRIPTION
CoordinatorRequestManagerTest#testMarkCoordinatorUnknownLoggingAccuracy has become flaky again. Last 30 days report shows a sudden re-occurrence 

https://develocity.apache.org/scans/tests?search.relativeStartTime=P28D&search.rootProjectNames=kafka&search.tags=github,trunk,not:flaky,not:new&search.tasks=test&search.timeZoneId=America%2FNew_York&tests.container=org.apache.kafka.clients.consumer.internals.CoordinatorRequestManagerTest&tests.sortField=FLAKY#

Also mark QuorumControllerTest.testMinIsrUpdateWithElr as flaky.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
