### PR TITLE
KAFKA-6416: Helm chart for deploying Kafka to Kubernetes

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: kafka
+description: A Helm chart to deploy Apache Kafka to Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "4.0.0"
+
+icon: https://kafka.apache.org/logos/kafka_logo--simple.png

--- a/chart/readme.md
+++ b/chart/readme.md
@@ -1,0 +1,100 @@
+## Helm Chart for deploying Kafka to Kubernetes
+
+This Helm chart deploys Kafka configured with KRaft to a Kubernetes cluster. It currently only supports separate pods for the controllers and brokers.
+
+The number of broker and controller pods is set using the values
+```Yaml
+broker:
+  replicas: 3
+controller:
+  replicas: 3
+```
+
+The brokers and controllers are deployed as Kubernetes [StatefulSets][statefulset].
+
+The node ids are set to `broker.baseId`/`controller.baseId` plus the instance id of the StatefuleSet pod. The baseIds default to 1 and 11, respectively.
+
+Using StatefuleSets ensures each pod has it's own dedicated storage. The type of storage will depend on the configuration of the Kubernetes cluster. By default, the default storage class will be used. To use a specific storage class override the value `storageClassName`. To specific the requested size for the storage set `logDirCapacity`, for example:
+```Yaml
+storageClassName: local-path
+logDirCapacity: 2Gi
+```
+
+Access to brokers and controllers is done using headless services so that workloads accessing Kafka can connect to the brokers using the Kubernetes internal DNS. A broker URL would therefore look like
+
+`kafka-0.brokers.kafka.svc.cluster.local:9092`
+
+### Setting Properties
+
+This helm chart work by templating the properties files into a [ConfigMap][configmap]. These are mounted into the running containers at the location `/mnt/config/`. The new launch script [`k8s_launch`](../docker/jvm/k8s_launch) copies the appropriate files to the location where Kafka needs them to run.
+
+Kafka properties are defined using a dot (`.`) as a name delimiter, e.g. `this.is.a.property.name`. Values in Helm are managed as Yaml and when setting values on the command line, the dot notation is used to specify nested values. Using `--set this.is.a.property.name=value` would therefore be defined as a nested Yaml value of
+
+```Yaml
+this:
+  is:
+    a:
+      property:
+        name: 'value'
+```
+
+This would be a complex (and somewhat strange) way to define Kafka properties so this Helm chart handles properties set with the dots as they would appear in the properties file.
+
+Properties can be set in a Yaml values file as:
+```Yaml
+properties:
+  network.threads: 3
+  num.io.threads: 8
+  partitions: 32
+```
+but can also be specified on the command line for example `--set properties.num.io.threads=8`.
+
+There are three sections in the value file for properties:
+```Yaml
+properties:
+  network.threads: 3
+  ...
+
+broker:
+  properties:
+    ...
+
+controller:
+  properties:
+    ...
+```
+
+Values in `properties` are applied to both controllers and brokers. Values in `broker.properties` apply to only the brokers, and are merged with the common properties with the broker specific value taking precedent, to prevent duplicate values. Likewise for the controllers.
+
+The following properties are calculated based on the deployment settings and cannot be overridden:
+  * `process.roles`
+  * `node.id`
+  * `controller.quorum.voters`
+  * `listeners`
+  * `controller.listener.names`
+  * `log.dirs`
+
+## Logging Configuration
+
+Now that Kafka uses log4j2, the configuration for logging matches that in the log4j2.yaml files.
+
+The two logging sections are:
+
+```Yaml
+logging:
+  Properties: ...
+  Appenders: ...
+  Loggers: ...
+
+toolLogging:
+  Properties: ...
+  Appenders: ...
+  Loggers: ...
+```
+
+So, for example, to override the console log pattern you could specify:
+
+`--set logging.Appenders.Console.PatternLayout.pattern="[%d] %p %m (%c)%n"`
+
+[configmap]: https://kubernetes.io/docs/concepts/configuration/configmap/ "A ConfigMap is an API object used to store non-confidential data in key-value pairs"
+[statefulset]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/ "A StatefulSet runs a group of Pods, and maintains a sticky identity for each of those Pods"

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,25 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{ if .Release.IsInstall }}
+Welcome to {{ .Chart.Name }} {{ .Chart.AppVersion }}!
+{{ else if .Release.IsUpgrade }}
+{{ .Chart.Name }} upgraded to {{ .Chart.AppVersion }} successfully!
+{{ end }}
+
+The Kafka bootstrap servers list is:
+{{ include "kafka.brokerUrls" . }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,192 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Allow the deployment namespace to be overridden.
+*/}}
+{{- define "kafka.namespace" -}}
+{{ default .Release.Namespace .Values.namespace }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "kafka.controller" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- printf "%s-ctl" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s-ctl" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "kafka.controller.service" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- "controllers" }}
+{{- else }}
+{{- printf "%s-controllers" .Release.Name | trunc 63 }}
+{{- end }}
+{{- end }}
+
+{{- define "kafka.broker.service" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- "brokers" }}
+{{- else }}
+{{- printf "%s-brokers" .Release.Name | trunc 63 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kafka.labels" -}}
+helm.sh/chart: {{ include "kafka.chart" . }}
+{{ include "kafka.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kafka.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kafka.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kafka.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kafka.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the image name
+*/}}
+{{- define "kafka.image" -}}
+{{- if .Values.image.registry }}
+{{- .Values.image.registry | trimSuffix "/" }}{{ "/" }}
+{{- end }}
+{{- .Values.image.repository }}{{ ":" }}
+{{- default .Chart.AppVersion .Values.image.tag }}
+{{- end }}
+
+{{/*
+Construct the static controller quorum voters string.
+*/}}
+{{- define "kafka.controller.quorum.voters" -}}
+{{- $ns := include "kafka.namespace" $ -}}
+{{- $serviceName := include "kafka.controller.service" . -}}
+{{- $baseId := int .Values.controller.baseId }}
+{{- range $i,$v := untilStep $baseId (int (add $baseId .Values.controller.replicas)) 1 }}
+{{- if gt $i 0 }},{{ end -}}
+{{- $v }}@{{ include "kafka.controller" $ }}-{{ $i }}.{{ $serviceName }}.{{ $ns }}.svc.cluster.local:9093
+{{- end }}
+{{- end }}
+
+
+{{/*
+Construct the static controller quorum voters string.
+*/}}
+{{- define "kafka.controller.quorum.bootstrap.servers" -}}
+{{- $ns := include "kafka.namespace" $ -}}
+{{- $serviceName := include "kafka.controller.service" . -}}
+{{- $baseId := int .Values.controller.baseId }}
+{{- range $i,$v := untilStep $baseId (int (add $baseId .Values.controller.replicas)) 1 }}
+{{- if gt $i 0 }},{{ end -}}
+{{ include "kafka.controller" $ }}-{{ $i }}.{{ $serviceName }}.{{ $ns }}.svc.cluster.local:9093
+{{- end }}
+{{- end }}
+
+{{/*
+Construct the list of broker URLs to be used for the bootstrap server list.
+*/}}
+{{- define "kafka.brokerUrls" -}}
+{{- $ns := include "kafka.namespace" $ -}}
+{{- $serviceName := include "kafka.broker.service" . -}}
+{{- range $i,$v := untilStep 1 (int (add 1 .Values.broker.replicas)) 1 }}
+{{- if gt $i 0 }},{{ end -}}
+{{ include "kafka.fullname" $ }}-{{ $i }}.{{ $serviceName }}.{{ $ns }}.svc.cluster.local:9092
+{{- end }}
+{{- end }}
+
+{{/*
+URL of the first broker.
+*/}}
+{{- define "kafka.broker0url" -}}
+{{- $ns := include "kafka.namespace" $ -}}
+{{- $serviceName := include "kafka.broker.service" . -}}
+{{ include "kafka.fullname" $ }}-0.{{ $serviceName }}.{{ $ns }}.svc.cluster.local:9092
+{{- end }}
+
+{{/*
+Initial Controllers list
+*/}}
+{{- define "kafka.initialControllers" -}}
+{{- $ns := include "kafka.namespace" $ -}}
+{{- $serviceName := include "kafka.controller.service" . -}}
+{{- $baseId := int .Values.controller.baseId }}
+{{- $port := int .Values.controller.port }}
+{{- range $i,$v := untilStep $baseId (int (add $baseId .Values.controller.replicas)) 1 }}
+{{- $dirId := randBytes 16 | trimAll "=" | replace "/" "_" | replace "+" "-" -}}
+{{- if gt $i 0 }},{{ end -}}
+{{- $v }}@{{ include "kafka.controller" $ }}-{{ $i }}.{{ $serviceName }}.{{ $ns }}.svc.cluster.local:{{ $port }}:{{ $dirId }}
+{{- end }}
+{{- end }}

--- a/chart/templates/_properties.tpl
+++ b/chart/templates/_properties.tpl
@@ -1,0 +1,296 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{/*
+The Apache licence header
+*/}}
+{{- define "kafka.apache.licence" -}}
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- end }}
+
+
+{{/*
+============================================================
+format a comma and space delimited list from an array.
+============================================================
+*/}}
+{{- define "kafka.comma-space-list" }}
+{{- if kindIs "slice" . }}
+{{- printf "%v" (first .) }}
+{{- range (rest .) }}
+{{- printf ", %v" . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+============================================================
+format a comma delimited list from an array.
+============================================================
+*/}}
+{{- define "kafka.comma-list" }}
+{{- if kindIs "slice" . }}
+{{- printf "%v" (first .) }}
+{{- range (rest .) }}
+{{- printf ",%v" . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+============================================================
+Format the property value, particularly integers and lists
+============================================================
+*/}}
+{{- define "kafka.property.value" }}
+{{- if not (kindIs "map" . ) }}
+{{- if and (kindIs "float64" . ) (eq (floor .) . ) }}
+{{- printf "%d" (int .) }}
+{{- else if kindIs "slice" . }}
+{{- include "kafka.comma-list" . }}
+{{- else }}
+{{- printf "%v" . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+
+
+{{/*
+============================================================
+Combine property values and output in properties format.
+============================================================
+*/}}
+{{- define "kafka.properties" }}
+{{- /* Input should be an array of objects to be merged */ -}}
+{{- if kindIs "slice" . }}
+{{- /* First we need to flatten the objects */ -}}
+{{- $flattened := include "kafka.properties.flatten" (first .) | fromYaml }}
+{{- range (rest .) }}
+{{- $flattened = merge (include "kafka.properties.flatten" . | fromYaml) $flattened }}
+{{- end }}
+{{- /* Now write out the values as properties */ -}}
+{{- range $key, $val := $flattened }}
+{{- printf "%s=%s" $key (include "kafka.property.value" $val) | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+============================================================
+Flatten a Yaml structure.
+If properties are set on the Helm command line with --set
+for example --set properties.log.retention.hours=336 then
+the Values will be
+properties:
+  log:
+    retention:
+      hours: 336
+whereas we actually want it to be
+properties:
+  log.retention.hours: 336
+============================================================
+Input should be a the properties object
+*/}}
+{{- define "kafka.properties.flatten" }}
+  {{- if kindIs "map" . }}
+    {{- /* First just the top level items. These could include items with dots in the name. */ -}}
+    {{- $topLevel := include "kafka.properties.flat-yaml" . | fromYaml }}
+    {{- /* Now the flattened structured items. */ -}}
+    {{- $deepItems := include "kafka.properties.deep-yaml" . | fromYaml }}
+    {{- merge $deepItems $topLevel | toYaml | nindent 0 }}
+  {{- end }}
+{{- end }}
+
+{{- define "kafka.properties.flat-yaml" }}
+  {{- range $key, $val := . }}
+    {{- if not (kindIs "map" $val) }}
+      {{- if kindIs "slice" $val }}
+        {{- printf "%s:%s" $key ($val | toYaml | nindent 2) | nindent 0 }}
+      {{- else }}
+        {{- printf "%s: %s" $key ($val | toYaml) | nindent 0 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "kafka.properties.deep-yaml" }}
+  {{- range $key, $val := . }}
+    {{- if kindIs "map" $val }}
+      {{- include "kafka.properties.flatten.recurse" (dict "name" $key "props" $val ) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "kafka.properties.flatten.recurse" }}
+  {{- range $key, $val := $.props }}
+    {{- if not (kindIs "map" $val) }}
+      {{- printf "%s.%s: %s" $.name $key ($val | toYaml) | nindent 0 }}
+    {{- else }}
+      {{- include "kafka.properties.flatten.recurse" (dict "name" (printf "%s.%s" $.name $key) "props" $val ) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+
+{{/*
+============================================================
+Generate a cluster id, if not specified
+The cluster identifier must be a base64 encoded UUID with 
+padding removed and '/' replaced by '_' and '+' replaced by '-'.
+============================================================
+*/}}
+{{- define "kafka.clusterid" }}
+{{- $configmap := (lookup "v1" "ConfigMap" (include "kafka.namespace" .) (printf "%s-settings" (include "kafka.fullname" .)) ) }}
+{{- with $configmap }}
+{{- $_ := set $.Values "clusterId" .data.clusterid }}
+{{- else }}
+{{- if not .Values.clusterId }}
+{{- $_ := set $.Values "clusterId" (randBytes 16 | trimAll "=" | replace "/" "_" | replace "+" "-") }}
+{{- end }}
+{{- end }}
+{{- .Values.clusterId }}
+{{- end }}
+
+
+{{/*
+============================================================
+Calculated properties for the controllers, in Yaml format
+============================================================
+*/}}
+{{- define "kafka.controller.property.values" }}
+{{- $ns := include "kafka.namespace" .root }}
+{{- $serviceName := include "kafka.controller.service" .root }}
+{{- $ctr := include "kafka.controller" .root }}
+{{- $nodeId := add (int .root.Values.controller.baseId) .instance }}
+process.roles: controller
+node.id: {{ $nodeId }}
+{{- if .root.Values.controller.staticQuorum }}
+controller.quorum.voters: {{ include "kafka.controller.quorum.voters" .root }}
+{{- else }}
+controller.quorum.bootstrap.servers: {{ include "kafka.controller.quorum.bootstrap.servers" .root }}
+{{- end }}
+listeners: {{ printf "CONTROLLER://%s-%d.%s.%s.svc.cluster.local:%d" $ctr .instance $serviceName $ns (int .root.Values.controller.port) }}
+controller.listener.names: CONTROLLER
+log.dirs: /mnt/kafka/controllers/{{ $nodeId }}
+{{- end }}
+
+
+{{/*
+============================================================
+Calculated properties for the brokers, in Yaml format
+============================================================
+*/}}
+{{- define "kafka.broker.property.values" }}
+{{- $ns := include "kafka.namespace" .root }}
+{{- $serviceName := include "kafka.broker.service" .root }}
+{{- $bkr := include "kafka.fullname" .root }}
+{{- $nodeId := add (int .root.Values.broker.baseId) .instance }}
+process.roles: broker
+node.id: {{ $nodeId }}
+{{- if .root.Values.controller.staticQuorum }}
+controller.quorum.voters: {{ include "kafka.controller.quorum.voters" .root }}
+{{- else }}
+controller.quorum.bootstrap.servers: {{ include "kafka.controller.quorum.bootstrap.servers" .root }}
+{{- end }}
+listeners: {{ printf "PLAINTEXT://%s-%d.%s.%s.svc.cluster.local:%d" $bkr .instance $serviceName $ns (int .root.Values.broker.port) }}
+controller.listener.names: CONTROLLER
+log.dirs: /mnt/kafka/brokers/{{ $nodeId }}
+{{- end }}
+
+
+{{/*
+============================================================
+Properties file for the controllers
+============================================================
+*/}}
+{{- define "kafka.controller.properties" }}
+{{- $computed := include "kafka.controller.property.values" . | fromYaml }}
+{{- include "kafka.apache.licence" .root }}
+{{ include "kafka.properties" (list .root.Values.properties .root.Values.controller.properties $computed ) }}
+{{ end }}
+
+{{/*
+============================================================
+Properties file for the brokers
+============================================================
+*/}}
+{{- define "kafka.broker.properties" }}
+{{- $computed := include "kafka.broker.property.values" . | fromYaml }}
+{{- include "kafka.apache.licence" .root }}
+{{ include "kafka.properties" (list .root.Values.properties .root.Values.broker.properties $computed ) }}
+{{ end }}
+
+
+{{/*
+============================================================
+Properties file for log4j
+============================================================
+*/}}
+{{- define "kafka.log4j2.yaml" }}
+{{- include "kafka.apache.licence" . }}
+
+Configuration:
+{{- .Values.logging | toYaml | nindent 2 }}
+
+{{- end }}
+
+
+{{/*
+============================================================
+Properties file for log4j for tools (i.e. storage tool)
+============================================================
+*/}}
+{{- define "kafka.tools-log4j2.yaml" }}
+{{- include "kafka.apache.licence" . }}
+
+Configuration:
+{{- .Values.toolLogging | toYaml | nindent 2 }}
+
+{{- end }}
+
+
+{{/*
+============================================================
+Script to format the storage for the controllers that
+bootstraps all the controllers
+============================================================
+*/}}
+{{- define "kafka.controller.bootstrap.script" }}
+${KAFKA_ROOT}/bin/kafka-storage.sh format --cluster-id {{ include "kafka.clusterid" . | quote }} \
+    --initial-controllers {{ include "kafka.initialControllers" . | quote }} \
+    --config ${KAFKA_ROOT}/config/kafka.properties \
+    --feature kraft.version=1 \
+    --ignore-formatted $@
+{{ end }}

--- a/chart/templates/broker-service.yaml
+++ b/chart/templates/broker-service.yaml
@@ -1,0 +1,36 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka.broker.service" . }}
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.broker.port }}
+      targetPort: broker
+      protocol: TCP
+      name: broker
+  selector:
+    app.kubernetes.io/component: "broker"
+    {{- include "kafka.selectorLabels" . | nindent 4 }}

--- a/chart/templates/broker-statefulset.yaml
+++ b/chart/templates/broker-statefulset.yaml
@@ -1,0 +1,106 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "kafka.fullname" . }}
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "kafka.broker.service" . }}
+  replicas: {{ .Values.broker.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: "broker"
+      {{- include "kafka.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: "broker"
+        {{- include "kafka.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if not .Values.serviceAccount.create }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "kafka.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kafka.fullname" . }}-config
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "kafka.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /etc/kafka/docker/k8s_launch
+          args:
+            - -r
+            - broker
+            - -i
+            - {{ include "kafka.clusterid" . | quote }}
+            - -b
+            - {{ int .Values.broker.baseId | quote }}
+          ports:
+            - name: broker
+              containerPort: {{ .Values.broker.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: "/mnt/config"
+            - name: broker-pv-claim
+              mountPath: "/mnt/kafka"
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: broker-pv-claim
+    spec:
+      storageClassName: {{ .Values.storageClassName | quote }}
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: {{ .Values.logDirCapacity | quote }}

--- a/chart/templates/controller-service.yaml
+++ b/chart/templates/controller-service.yaml
@@ -1,0 +1,36 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka.controller.service" . }}
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.controller.port }}
+      targetPort: controller
+      protocol: TCP
+      name: controller
+  selector:
+    app.kubernetes.io/component: "controller"
+    {{- include "kafka.selectorLabels" . | nindent 4 }}

--- a/chart/templates/controller-statefulset.yaml
+++ b/chart/templates/controller-statefulset.yaml
@@ -1,0 +1,106 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "kafka.controller" . }}
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "kafka.controller.service" . }}
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: "controller"
+      {{- include "kafka.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: "controller"
+        {{- include "kafka.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if not .Values.serviceAccount.create }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "kafka.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kafka.fullname" . }}-config
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "kafka.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /etc/kafka/docker/k8s_launch
+          args:
+            - -r
+            - controller
+            - -i
+            - {{ include "kafka.clusterid" . | quote }}
+            - -b
+            - {{ int .Values.controller.baseId | quote }}
+          ports:
+            - name: controller
+              containerPort: {{ .Values.controller.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: "/mnt/config"
+            - name: controller-pv-claim
+              mountPath: "/mnt/kafka"
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: controller-pv-claim
+    spec:
+      storageClassName: {{ .Values.storageClassName | quote }}
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: {{ .Values.logDirCapacity | quote }}

--- a/chart/templates/kafka-config.yaml
+++ b/chart/templates/kafka-config.yaml
@@ -1,0 +1,32 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{/*
+This is to store settings that we want persisted between deployments
+for example, the cluster id.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka.fullname" . }}-settings
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  clusterid: {{ include "kafka.clusterid" . | quote }}

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -1,0 +1,31 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.namespace -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.namespaceLabels }}
+    {{- toYaml .Values.namespaceLabels | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/chart/templates/properties-configmap.yaml
+++ b/chart/templates/properties-configmap.yaml
@@ -1,0 +1,45 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka.fullname" . }}-config
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+data:
+{{- /*
+{{- range $path, $bytes := .Files.Glob "config/*.properties" }}
+{{- $file := trimPrefix "config/" $path }}
+{{- $file | nindent 2 }}: |- {{- tpl ($.Files.Get $path) $ | nindent 4 }}
+{{- end }}
+*/ -}}
+
+{{- range $i := until (int .Values.controller.replicas) }}
+{{- printf "controller-%d.properties" $i | nindent 2 }}: |- {{- include "kafka.controller.properties" (dict "root" $ "instance" $i) | nindent 4 }}
+{{- end }}
+
+{{- range $i := until (int .Values.broker.replicas) }}
+{{- printf "broker-%d.properties" $i | nindent 2 }}: |- {{- include "kafka.broker.properties" (dict "root" $ "instance" $i) | nindent 4 }}
+{{- end }}
+
+  log4j2.yaml: |- {{- include "kafka.tools-log4j2.yaml" . | nindent 4 }}
+
+  tools-log4j2.yaml: |- {{- include "kafka.tools-log4j2.yaml" . | nindent 4 }}
+
+  format-controllers.sh: |- {{- include "kafka.controller.bootstrap.script" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,36 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kafka.serviceAccountName" . }}
+  {{- with .Values.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.image.pullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,284 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+image:
+  registry: ""
+  repository: apache/kafka
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+broker:
+  baseId: 1
+  replicas: 3
+  port: 9092
+  # These properties will be set in the broker property file. Any values will override the same setting in properties:
+  properties:
+    listener.security.protocol.map:
+    - CONTROLLER:PLAINTEXT
+    - PLAINTEXT:PLAINTEXT
+    - SSL:SSL
+    - SASL_PLAINTEXT:SASL_PLAINTEXT
+    - SASL_SSL:SASL_SSL
+
+controller:
+  baseId: 11
+  replicas: 3
+  staticQuorum: false
+  port: 9093
+  # These properties will be set in the controller property file. Any values will override the same setting in properties:
+  properties: {}
+
+# These properties will be set in BOTH the broker and controller property files.
+properties:
+  # The number of threads that the server uses for receiving requests from the network and sending responses to the network
+  network.threads: 3
+  # The number of threads that the server uses for processing requests, which may include disk I/O
+  num.io.threads: 8
+  # The default number of log partitions per topic. More partitions allow greater
+  # parallelism for consumption, but this will also result in more files across
+  # the brokers.
+  partitions: 1
+  # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+  # This value is recommended to be increased for installations with data dirs located in RAID array.
+  num.recovery.threads.per.data.dir: 1
+  # The send buffer (SO_SNDBUF) used by the socket server
+  socket.send.buffer.bytes: 102400
+  # The receive buffer (SO_RCVBUF) used by the socket server
+  socket.receive.buffer.bytes: 102400
+  # The maximum size of a request that the socket server will accept (protection against OOM)
+  socket.request.max.bytes: 104857600
+
+  # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+  # For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
+  offsets.topic.replication.factor: 1
+  transaction.state.log.replication.factor: 1
+  transaction.state.log.min.isr: 1
+
+  # The number of messages to accept before forcing a flush of data to disk
+  #log.flush.interval.messages: 10000
+  # The maximum amount of time a message can sit in a log before we force a flush
+  #log.flush.interval.ms: 1000
+
+  # The minimum age of a log file to be eligible for deletion due to age
+  log.retention.hours: 168
+  # The interval at which log segments are checked to see if they can be deleted according
+  # to the retention policies
+  log.retention.check.interval.ms: 300000
+  # The maximum size of a log segment file. When this size is reached a new log segment will be created.
+  log.segment.bytes: 1073741824
+
+
+nameOverride: ""
+fullnameOverride: ""
+
+logDirCapacity: "1Gi"
+
+# Storage class to use for the kafka logs.
+storageClassName: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+logging:
+  Properties:
+    Property:
+      # Fallback if the system property is not set
+      - name: "kafka.logs.dir"
+        value: "."
+      - name: "logPattern"
+        value: "[%d] %p %m (%c)%n"
+
+  # Appenders configuration
+  # See: https://logging.apache.org/log4j/2.x/manual/appenders.html
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+    RollingFile:
+      - name: KafkaAppender
+        fileName: "${sys:kafka.logs.dir}/server.log"
+        filePattern: "${sys:kafka.logs.dir}/server.log.%d{yyyy-MM-dd-HH}"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+      # State Change appender
+      - name: StateChangeAppender
+        fileName: "${sys:kafka.logs.dir}/state-change.log"
+        filePattern: "${sys:kafka.logs.dir}/stage-change.log.%d{yyyy-MM-dd-HH}"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+      # Request appender
+      - name: RequestAppender
+        fileName: "${sys:kafka.logs.dir}/kafka-request.log"
+        filePattern: "${sys:kafka.logs.dir}/kafka-request.log.%d{yyyy-MM-dd-HH}"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+      # Cleaner appender
+      - name: CleanerAppender
+        fileName: "${sys:kafka.logs.dir}/log-cleaner.log"
+        filePattern: "${sys:kafka.logs.dir}/log-cleaner.log.%d{yyyy-MM-dd-HH}"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+      # Controller appender
+      - name: ControllerAppender
+        fileName: "${sys:kafka.logs.dir}/controller.log"
+        filePattern: "${sys:kafka.logs.dir}/controller.log.%d{yyyy-MM-dd-HH}"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+      # Authorizer appender
+      - name: AuthorizerAppender
+        fileName: "${sys:kafka.logs.dir}/kafka-authorizer.log"
+        filePattern: "${sys:kafka.logs.dir}/kafka-authorizer.log.%d{yyyy-MM-dd-HH}"
+        PatternLayout:
+          pattern: "${logPattern}"
+        TimeBasedTriggeringPolicy:
+          modulate: true
+          interval: 1
+
+  # Loggers configuration
+  # See: https://logging.apache.org/log4j/2.x/manual/configuration.html#configuring-loggers
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+        - ref: KafkaAppender
+    Logger:
+      # Kafka logger
+      - name: kafka
+        level: INFO
+      # Kafka org.apache logger
+      - name: org.apache.kafka
+        level: INFO
+      # Kafka request logger
+      - name: kafka.request.logger
+        level: WARN
+        additivity: false
+        AppenderRef:
+          ref: RequestAppender
+      # Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE
+      # for additional output related to the handling of requests
+#      - name: kafka.network.Processor
+#        level: TRACE
+#        additivity: false
+#        AppenderRef:
+#          ref: RequestAppender
+#      - name: kafka.server.KafkaApis
+#        level: TRACE
+#        additivity: false
+#        AppenderRef:
+#          ref: RequestAppender
+      # Kafka network RequestChannel$ logger
+      - name: kafka.network.RequestChannel$
+        level: WARN
+        additivity: false
+        AppenderRef:
+          ref: RequestAppender
+      # Controller logger
+      - name: org.apache.kafka.controller
+        level: INFO
+        additivity: false
+        AppenderRef:
+          ref: ControllerAppender
+      # LogCleaner logger
+      - name: kafka.log.LogCleaner
+        level: INFO
+        additivity: false
+        AppenderRef:
+          ref: CleanerAppender
+      # State change logger
+      - name: state.change.logger
+        level: INFO
+        additivity: false
+        AppenderRef:
+          ref: StateChangeAppender
+      # Authorizer logger
+      - name: kafka.authorizer.logger
+        level: INFO
+        additivity: false
+        AppenderRef:
+          ref: AuthorizerAppender
+
+
+toolLogging:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c)%n"
+
+  Appenders:
+    Console:
+      name: STDERR
+      target: SYSTEM_ERR
+      PatternLayout:
+        pattern: "${logPattern}"
+  Loggers:
+    Root:
+      level: WARN
+      AppenderRef:
+        - ref: STDERR

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -87,7 +87,7 @@ COPY server.properties /etc/kafka/docker/server.properties
 COPY --from=build-jsa kafka.jsa /opt/kafka/kafka.jsa
 COPY --from=build-jsa storage.jsa /opt/kafka/storage.jsa
 COPY --chown=appuser:appuser resources/common-scripts /etc/kafka/docker
-COPY --chown=appuser:appuser launch /etc/kafka/docker/launch
+COPY --chown=appuser:appuser --chmod=755 launch k8s_launch /etc/kafka/docker/
 
 USER appuser
 

--- a/docker/jvm/k8s_launch
+++ b/docker/jvm/k8s_launch
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is designed to start Kafka in a Kubernetes cluster when
+# deployed using the Kafka Helm chart.
+
+function usage()
+{
+  echo "Usage: $(basename $BASH_SOURCE) -r <server/controller/broker> -i clusterid -b baseId" 1>&2
+  echo 1>&2
+  echo 'For example:' 1>&2
+  echo "./$(basename $BASH_SOURCE) -r controller -i abcdefghijklmnopqrstuv -b 100" 1>&2
+  echo 1>&2
+  exit 1
+}
+
+declare ROLE=${ROLE:-server}
+declare -i BASE_ID=${BASE_ID:-0}
+declare CLUSTER_ID
+declare -rx KAFKA_ROOT=/opt/kafka
+
+while getopts ":b:i:r:h" arg; do
+  case "${arg}" in
+    b) BASE_ID=${OPTARG,,};;
+    i) CLUSTER_ID=${OPTARG};;
+    r) ROLE=${OPTARG,,};;
+    h) usage;;
+    ?) echo "Invalid option: -${OPTARG}"; usage;;
+  esac
+done
+
+if [[ "${ROLE}" != "server" && "${ROLE}" != "controller" && "${ROLE}" != "broker" ]]; then
+  echo "ROLE must be one of server, controller or broker" 1>&2
+  exit 1
+fi
+
+declare POD_ID_FROMHOSTNAME=${HOSTNAME##*-}
+declare -i POD_ID=${POD_ID_FROMHOSTNAME:-0}
+declare -i NODE_ID=$((BASE_ID+POD_ID))
+
+function format_storage() {
+  local clusterId="${1:-}"
+  local perfOpts="${KAFKA_JVM_PERFORMANCE_OPTS:-}"
+
+  set --
+
+  # We will first use CDS for storage to format storage
+  export KAFKA_JVM_PERFORMANCE_OPTS="${perfOpts} -XX:SharedArchiveFile=${KAFKA_ROOT}/storage.jsa"
+
+  if [[ "${ROLE}" == "server" || "${ROLE}" == "controller" ]] && [[ -f /mnt/config/format-controllers.sh ]]; then
+      source /mnt/config/format-controllers.sh
+  else
+    if [[ "${clusterId}" ]]; then
+      # Format Log Directories with the cluster id
+      ${KAFKA_ROOT}/bin/kafka-storage.sh format -t "${clusterId}" \
+        -c ${KAFKA_ROOT}/config/kafka.properties \
+        --ignore-formatted $@
+    else
+      CLUSTER_ID=$(${KAFKA_ROOT}/bin/kafka-storage.sh random-uuid)
+      echo $CLUSTER_ID > /mnt/kafka/cluster_id
+    fi
+  fi
+
+  # Reset the KAFKA_JVM_PERFORMANCE_OPTS without the storage CDS
+  export KAFKA_JVM_PERFORMANCE_OPTS="${perfOpts}"
+}
+
+function create_log_dir() {
+    mkdir -p "/mnt/kafka/${ROLE@L}s/${NODE_ID}"
+}
+
+
+# Copy the config files from the mounted configmap to the local folder.
+function copy_config_files() {
+    if [ -d /mnt/config ]; then
+        # Clear out the default properties files.
+        rm -rf ${KAFKA_ROOT}/config/*
+        # Copy the log4j properties files to the local folder.
+        cp -rL /mnt/config/*log4j* ${KAFKA_ROOT}/config
+        # Copy the role specific properties files to the local folder.
+        echo "Using property file /mnt/config/${ROLE@L}-${POD_ID}.properties"
+        cp -L /mnt/config/${ROLE@L}-${POD_ID}.properties ${KAFKA_ROOT}/config/kafka.properties
+    fi
+}
+
+# Generate a cluster identifier, if needed.
+function get_cluster_id() {
+    # Use the identifier from file, if there is one. It can't be changed once set.
+    if [[ -f "/mnt/kafka/cluster_id" ]]; then
+        CLUSTER_ID=$(cat /mnt/kafka/cluster_id)
+    else
+        # Use the identifier from the environment variable, if there is one.
+        if [[ -n "${CLUSTER_ID:-}" ]]; then
+            echo "${CLUSTER_ID}" > /mnt/kafka/cluster_id
+        fi
+    fi
+    echo "${CLUSTER_ID:-}"
+}
+
+create_log_dir
+copy_config_files
+format_storage "$(get_cluster_id)"
+
+# Start the Kafka Server
+export KAFKA_JVM_PERFORMANCE_OPTS="${KAFKA_JVM_PERFORMANCE_OPTS:-} -XX:SharedArchiveFile=${KAFKA_ROOT}/kafka.jsa"
+
+exec ${KAFKA_ROOT}/bin/kafka-server-start.sh ${KAFKA_ROOT}/config/kafka.properties


### PR DESCRIPTION
This PR adds a [Helm][helm] chart for deploying [Kafka][Kafka] to [Kubernetes][Kubernetes].

[[KIP-1149]][kip] has been created for discussion.

It is designed to run brokers and controllers in separate pods.

All the configuration is templated from Helm values and stored in ConfigMaps. These are mounted in the running containers.

The new [`k8s_launch`](docker/jvm/k8s_launch) script is used to copy the config files into the right place, format the storage and start Kafka. Specific storage classes can be set in the Helm values and will depend on the Kubernetes distribution/Cloud provider being used. The brokers and controllers are run as stateful sets so each one get its own persistent storage. I'm not sure I have the initialization quite right as the KRaft version shows as 0, as per the docs at [Provisioning Nodes](https://kafka.apache.org/documentation/#kraft_storage). I may need some assistance with this.

[helm]: https://helm.sh/
[Kubernetes]: https://kubernetes.io/
[Kafka]: https://kafka.apache.org
[kip]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-1149%3A+Helm+Chart+for+Apache+Kafka "KIP-1149: Helm Chart for Apache Kafka"

Reviewers: Brandon (github:igloo12)
