### PR TITLE
KAFKA-19017: Changed consumer.config to command-config in verifiable_share_consumer.py

### DIFF
--- a/tests/kafkatest/services/verifiable_share_consumer.py
+++ b/tests/kafkatest/services/verifiable_share_consumer.py
@@ -236,7 +236,7 @@ class VerifiableShareConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Bac
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
 
-        cmd += " --consumer.config %s" % VerifiableShareConsumer.CONFIG_FILE
+        cmd += " --command-config %s" % VerifiableShareConsumer.CONFIG_FILE
         cmd += " 2>> %s | tee -a %s &" % (VerifiableShareConsumer.STDOUT_CAPTURE, VerifiableShareConsumer.STDOUT_CAPTURE)
         return cmd
 


### PR DESCRIPTION
In an earlier PR, the flag --consumer.config in VerifiableShareConsumer.java was changed to --command-config. This PR makes the same change when VerifiableShareConsumer is used in verifiable_share_consumer.py.