### PR TITLE
MINOR: Move FileRecord JavaDoc to comment

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -292,11 +292,6 @@ public class FileRecords extends AbstractRecords implements Closeable {
     /**
      * Search forward for the file position of the message batch whose last offset that is greater
      * than or equal to the target offset. If no such batch is found, return null.
-     * <p>
-     * The following logic is intentionally designed to minimize memory usage
-     * by avoiding unnecessary calls to {@link FileChannelRecordBatch#lastOffset()} for every batch.
-     * Instead, we use {@link FileChannelRecordBatch#baseOffset()} comparisons when possible, and only 
-     * check {@link FileChannelRecordBatch#lastOffset()} when absolutely necessary.
      *
      * @param targetOffset The offset to search for.
      * @param startingPosition The starting position in the file to begin searching from.
@@ -304,7 +299,9 @@ public class FileRecords extends AbstractRecords implements Closeable {
      */
     public LogOffsetPosition searchForOffsetFromPosition(long targetOffset, int startingPosition) {
         FileChannelRecordBatch prevBatch = null;
-
+        // The following logic is intentionally designed to minimize memory usage by avoiding 
+        // unnecessary calls to lastOffset() for every batch.
+        // Instead, we use baseOffset() comparisons when possible, and only check lastOffset() when absolutely necessary.
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
             // If baseOffset exactly equals targetOffset, return immediately
             if (batch.baseOffset() == targetOffset) {


### PR DESCRIPTION
See: https://github.com/apache/kafka/pull/19214#discussion_r2005945059

Move explaination from Javadoc to comment.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
