### PR TITLE
KAFKA-18981: Fix flaky QuorumControllerTest.testMinIsrUpdateWithElr

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -136,8 +136,11 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -615,13 +618,14 @@ public class QuorumControllerTest {
         List<Integer> brokersToFence = List.of(2, 3);
         short replicationFactor = (short) allBrokers.size();
         long sessionTimeoutMillis = 300;
+        ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
 
         try (
                 MockRaftClientTestEnv clientEnv = new MockRaftClientTestEnv.Builder(1).build();
                 QuorumControllerTestEnv controlEnv = new QuorumControllerTestEnv.Builder(clientEnv).
                 setSessionTimeoutMillis(OptionalLong.of(sessionTimeoutMillis)).
                 setBootstrapMetadata(BootstrapMetadata.fromVersion(MetadataVersion.IBP_4_0_IV1, "test-provided bootstrap ELR enabled")).
-                build()
+                build();
         ) {
             ListenerCollection listeners = new ListenerCollection();
             listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
@@ -650,6 +654,19 @@ public class QuorumControllerTest {
 
             // Unfence all brokers and create a topic foo (min ISR 2)
             sendBrokerHeartbeatToUnfenceBrokers(active, allBrokers, brokerEpochs);
+            AtomicBoolean onlyKeepUnfenced = new AtomicBoolean(false);
+            exec.scheduleAtFixedRate(() -> {
+                try {
+                    if (onlyKeepUnfenced.get()) {
+                        sendBrokerHeartbeatToUnfenceBrokers(active, brokersToKeepUnfenced, brokerEpochs);
+                    } else {
+                        sendBrokerHeartbeatToUnfenceBrokers(active, allBrokers, brokerEpochs);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, 0L, 100L, TimeUnit.MILLISECONDS);
+
             CreateTopicsRequestData createTopicsRequestData = new CreateTopicsRequestData().setTopics(
                 new CreatableTopicCollection(List.of(
                     new CreatableTopic().setName("foo").setNumPartitions(1).
@@ -672,8 +689,8 @@ public class QuorumControllerTest {
             RecordTestUtils.replayAll(active.configurationControl(), List.of(new ApiMessageAndVersion(configRecord, (short) 0)));
 
             // Fence brokers
+            onlyKeepUnfenced.set(true);
             TestUtils.waitForCondition(() -> {
-                    sendBrokerHeartbeatToUnfenceBrokers(active, brokersToKeepUnfenced, brokerEpochs);
                     for (Integer brokerId : brokersToFence) {
                         if (active.clusterControl().isUnfenced(brokerId)) {
                             return false;
@@ -684,9 +701,6 @@ public class QuorumControllerTest {
                 "Fencing of brokers did not process within expected time"
             );
 
-            // Send another heartbeat to the brokers we want to keep alive
-            sendBrokerHeartbeatToUnfenceBrokers(active, brokersToKeepUnfenced, brokerEpochs);
-
             // At this point only the brokers we want to fence (broker 2, 3) should be fenced.
             brokersToKeepUnfenced.forEach(brokerId -> {
                 assertTrue(active.clusterControl().isUnfenced(brokerId),
@@ -696,7 +710,6 @@ public class QuorumControllerTest {
                 assertFalse(active.clusterControl().isUnfenced(brokerId),
                     "Broker " + brokerId + " should have been fenced");
             });
-            sendBrokerHeartbeatToUnfenceBrokers(active, brokersToKeepUnfenced, brokerEpochs);
 
             // Verify the isr and elr for the topic partition
             PartitionRegistration partition = active.replicationControl().getPartition(topicIdFoo, 0);
@@ -732,6 +745,8 @@ public class QuorumControllerTest {
             partition = active.replicationControl().getPartition(topicIdBar, 0);
             assertEquals(0, partition.elr.length, partition.toString());
             assertArrayEquals(new int[]{1}, partition.isr, partition.toString());
+        } finally {
+            exec.shutdown();
         }
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -625,7 +625,7 @@ public class QuorumControllerTest {
                 QuorumControllerTestEnv controlEnv = new QuorumControllerTestEnv.Builder(clientEnv).
                 setSessionTimeoutMillis(OptionalLong.of(sessionTimeoutMillis)).
                 setBootstrapMetadata(BootstrapMetadata.fromVersion(MetadataVersion.IBP_4_0_IV1, "test-provided bootstrap ELR enabled")).
-                build();
+                build()
         ) {
             ListenerCollection listeners = new ListenerCollection();
             listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));


### PR DESCRIPTION
If broker 1 doesn't get heartbeat promptly and it's fenced after the
topic creation, the broker 1 cannot be ISR. The session timeout is
300ms. Following logs are from
https://develocity.apache.org/s/tjs4dzxiphmwc/tests/task/:metadata:test/details/org.apache.kafka.controller.QuorumControllerTest/testMinIsrUpdateWithElr()/1/output:

```
[2025-03-18 07:14:45,121] DEBUG [QuorumController id=0] Processed
processBrokerHeartbeat(1474681863) in 140186 us
(org.apache.kafka.controller.QuorumController:542) <-- heartbeat for
broker 1
...
[2025-03-18 07:14:45,147] DEBUG [QuorumController id=0] Processed
processBrokerHeartbeat(399642596) in 10723 us
(org.apache.kafka.controller.QuorumController:542) <-- heartbeat for
broker 2
...
[2025-03-18 07:14:45,172] DEBUG [QuorumController id=0] Processed
processBrokerHeartbeat(168471181) in 13236 us
(org.apache.kafka.controller.QuorumController:542) <-- heartbeat for
broker 3
...
[2025-03-18 07:14:45,288] INFO [QuorumController id=0] CreateTopics
result(s): CreatableTopic(name='foo', ...)
(org.apache.kafka.metalog.LocalLogManager$SharedLogData:258) <-- topic
creation
...
[2025-03-18 07:14:45,455] INFO [QuorumController id=0] Fencing broker 1
at epoch 6 because its session has timed out.
(org.apache.kafka.controller.ReplicationControlManager:1693) <-- broker
1 session timeout
```

At 07:14:45,121, the broker 1 gets heartbeat and it's active. However,
it doesn't get another heartbeat before 07:14:45,421, so it's fenced at
07:14:45,455.

The case can be reproduced by adding Thread.sleep(300) just after
`active.creatTopics` [0]. To solve the root cause, use another thread to
send heartbeat request, so broker 1 doesn't have chance to get fenced.

[0]
https://github.com/apache/kafka/blob/1ded681684e771b16aa98ae751f39b9816345a83/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java#L663-L665
