### PR TITLE
KAFKA-12744: dependency upgrade: `argparse4j` 0.7.0 -->> 0.9.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -297,7 +297,7 @@ see: licenses/CDDL+GPL-1.1
 ---------------------------------------
 MIT License
 
-- argparse4j-0.7.0, see: licenses/argparse-MIT
+- argparse4j-0.9.0, see: licenses/argparse-MIT
 - classgraph-4.8.173, see: licenses/classgraph-MIT
 - jopt-simple-5.0.4, see: licenses/jopt-simple-MIT
 - slf4j-api-1.7.36, see: licenses/slf4j-MIT

--- a/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
@@ -18,11 +18,11 @@
 package org.apache.kafka.message.checker;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.io.PrintStream;
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ versions += [
   activation: "1.1.1",
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
-  argparse4j: "0.7.0",
+  argparse4j: "0.9.0",
   bcpkix: "1.78.1",
   caffeine: "3.1.8",
   bndlib: "7.0.0",

--- a/shell/src/main/java/org/apache/kafka/shell/command/Commands.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/Commands.java
@@ -21,12 +21,12 @@ import org.apache.kafka.shell.InteractiveShell;
 import org.apache.kafka.shell.state.MetadataShellState;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import org.jline.reader.Candidate;
 


### PR DESCRIPTION
Corresponding JIRA ticket: https://issues.apache.org/jira/browse/KAFKA-12744

Related unmerged PR: #10626 

Release notes:
- https://github.com/argparse4j/argparse4j/releases/tag/argparse4j-0.8.0
- https://github.com/argparse4j/argparse4j/releases/tag/argparse4j-0.8.1
- https://github.com/argparse4j/argparse4j/releases/tag/argparse4j-0.9.0

Only one class import has been changed:
- https://github.com/argparse4j/argparse4j/blob/argparse4j-0.7.0/src/main/java/net/sourceforge/argparse4j/internal/HelpScreenException.java 
- https://github.com/argparse4j/argparse4j/blob/argparse4j-0.9.0/main/src/main/java/net/sourceforge/argparse4j/helper/HelpScreenException.java

Note: I opted to leave deprecated `argparse4j` **_ArgumentParsers.newArgumentParser_** [method](https://github.com/argparse4j/argparse4j/pull/73/files#diff-323147dbff2561c34143f89493b7a8fd5f69652d47e929518936097d7ae6ac4f) in Kafka code **_as-is_** and postpone [argparse4j code migration](https://argparse4j.github.io/migration.html#to-0-8-0)  for some future PR (or maybe even to use some other library for parsing: https://github.com/timtiemens/javacommandlineparser?tab=readme-ov-file#java-command-line-parsing-libraries).

@mimaison feel free to review.