### PR TITLE
KAFKA-19005: improve the documentation of DescribeTopicsOptions#partitionSizeLimitPerResponse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
@@ -43,8 +43,19 @@ public class DescribeTopicsOptions extends AbstractOptions<DescribeTopicsOptions
         return this;
     }
 
-    // Note that, partitionSizeLimitPerResponse will not be effective if it is larger than the config
-    // max.request.partition.size.limit on the server side.
+    /**
+     * Sets the maximum number of partitions to be returned in a single response.
+     * <p>
+     * <strong>This option:</strong>
+     * <ul>
+     *   <li>Is only effective when using topic names (not topic IDs).</li>
+     *   <li>Will not be effective if it is larger than the server-side configuration
+     *       {@code max.request.partition.size.limit}.
+     *   </li>
+     * </ul>
+     * 
+     * @param partitionSizeLimitPerResponse the maximum number of partitions per response
+     */
     public DescribeTopicsOptions partitionSizeLimitPerResponse(int partitionSizeLimitPerResponse) {
         this.partitionSizeLimitPerResponse = partitionSizeLimitPerResponse;
         return this;


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-19005

This PR includes following changes:
1. refine the format
2. highligh that it is supported by topic names

<img width="857" alt="999" src="https://github.com/user-attachments/assets/6eec9e2f-b839-430c-b111-2be3a8538593" />

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
