### PR TITLE
MINOR: FindCoordinator API should return INVALID_REQUEST when share partition key is invalid

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1169,7 +1169,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         } catch {
           case e: IllegalArgumentException =>
             error(s"Share coordinator key is invalid", e)
-            (Errors.INVALID_REQUEST, Node.noNode())
+            return (Errors.INVALID_REQUEST, Node.noNode)
         }
       }
       val (partition, internalTopicName) = CoordinatorType.forId(keyType) match {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -766,6 +766,32 @@ class KafkaApisTest extends Logging {
   }
 
   @Test
+  def testFindCoordinatorWithInvalidSharePartitionKey(): Unit = {
+    setupBrokerMetadata(true, 3)
+
+    val request = new FindCoordinatorRequestData()
+      .setKeyType(CoordinatorType.SHARE.id)
+      .setCoordinatorKeys(asList(""))
+
+    val requestChannelRequest = buildRequest(new FindCoordinatorRequest.Builder(request).build())
+
+    kafkaApis = createKafkaApis()
+    kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
+
+    val expectedResponse = new FindCoordinatorResponseData()
+      .setCoordinators(asList(
+        new FindCoordinatorResponseData.Coordinator()
+          .setKey("")
+          .setErrorCode(Errors.INVALID_REQUEST.code)
+          .setNodeId(-1)
+          .setHost("")
+          .setPort(-1)))
+
+    val response = verifyNoThrottling[FindCoordinatorResponse](requestChannelRequest)
+    assertEquals(expectedResponse, response.data)
+  }
+
+  @Test
   def testMetadataAutoTopicCreationForOffsetTopic(): Unit = {
     testMetadataAutoTopicCreation(Topic.GROUP_METADATA_TOPIC_NAME, enableAutoTopicCreation = true,
       expectedError = Errors.UNKNOWN_TOPIC_OR_PARTITION)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -767,8 +767,6 @@ class KafkaApisTest extends Logging {
 
   @Test
   def testFindCoordinatorWithInvalidSharePartitionKey(): Unit = {
-    setupBrokerMetadata(true, 3)
-
     val request = new FindCoordinatorRequestData()
       .setKeyType(CoordinatorType.SHARE.id)
       .setCoordinatorKeys(asList(""))


### PR DESCRIPTION
At the moment, the FindCoordinator API returns an `UNKNOWN_SERVER_ERROR` error when the share partition key is invalid. It seems that the aim was to return an `INVALID_REQUEST` error but the code has a small bug preventing it from working as expected.

Reviewers: Apoorv Mittal <amittal@confluent.io>, Andrew Schofield <aschofield@confluent.io>
