### PR TITLE
KAFKA-19049: Remove the `@ExtendWith(ClusterTestExtensions.class)` from code base

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DescribeAuthorizedOperationsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DescribeAuthorizedOperationsTest.java
@@ -36,11 +36,8 @@ import org.apache.kafka.common.test.JaasUtils;
 import org.apache.kafka.common.test.api.ClusterConfig;
 import org.apache.kafka.common.test.api.ClusterTemplate;
 import org.apache.kafka.common.test.api.Type;
-import org.apache.kafka.common.test.junit.ClusterTestExtensions;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.security.authorizer.AclEntry;
-
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.List;
@@ -57,7 +54,6 @@ import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@ExtendWith(ClusterTestExtensions.class)
 public class DescribeAuthorizedOperationsTest {
     private static final String GROUP1 = "group1";
     private static final String GROUP2 = "group2";

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/StaticBrokerConfigTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/StaticBrokerConfigTest.java
@@ -23,10 +23,7 @@ import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.Type;
-import org.apache.kafka.common.test.junit.ClusterTestExtensions;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
-
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Map;
@@ -35,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-@ExtendWith(value = ClusterTestExtensions.class)
 public class StaticBrokerConfigTest {
     private static final String TOPIC = "topic";
     private static final String CUSTOM_VALUE = "1048576";

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/server/quota/CustomQuotaCallbackTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/server/quota/CustomQuotaCallbackTest.java
@@ -26,10 +26,7 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
-import org.apache.kafka.common.test.junit.ClusterTestExtensions;
 import org.apache.kafka.server.config.QuotaConfig;
-
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +41,6 @@ import java.util.concurrent.atomic.AtomicInteger;
         @ClusterConfigProperty(id = 3002, key = QuotaConfig.CLIENT_QUOTA_CALLBACK_CLASS_CONFIG, value = "org.apache.kafka.server.quota.CustomQuotaCallbackTest$CustomQuotaCallback"),
     }
 )
-@ExtendWith(ClusterTestExtensions.class)
 public class CustomQuotaCallbackTest {
 
     private final ClusterInstance cluster;

--- a/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
@@ -22,15 +22,12 @@ import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.test.api.{ClusterTest, Type}
 import org.apache.kafka.common.test.ClusterInstance
-import org.apache.kafka.common.test.junit.ClusterTestExtensions
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.extension.ExtendWith
 
 import java.net.Socket
 import java.util.Collections
 import scala.jdk.CollectionConverters._
 
-@ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class SaslApiVersionsRequestTest(cluster: ClusterInstance) extends AbstractApiVersionsRequestTest(cluster) {
 
   @ClusterTest(types = Array(Type.KRAFT),

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
@@ -78,7 +78,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * For example:
  *
  * <pre>
- * &#64;ExtendWith(value = Array(classOf[ClusterTestExtensions]))
  * class SomeIntegrationTest {
  *   &#64;ClusterTest(brokers = 1, controllers = 1, clusterType = ClusterType.Both)
  *   def someTest(): Unit = {

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestBeforeEachTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestBeforeEachTest.java
@@ -22,13 +22,11 @@ import org.apache.kafka.common.test.api.AutoStart;
 import org.apache.kafka.common.test.api.ClusterTest;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(ClusterTestExtensions.class)
 public class ClusterTestBeforeEachTest {
     private final ClusterInstance clusterInstance;
 


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-19049

[KAFKA-18617](https://issues.apache.org/jira/browse/KAFKA-18617) introduced the mechanism to inject the cluster test at runtime, so the integration tests don't need to use `@ExtendWith(ClusterTestExtensions.class)` any more.

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
