### PR TITLE
KAFKA-18390: Use LinkedHashMap instead of Map in creating MetricName and SensorBuilder (1/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkSeqMap;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 
 /**
  * The {@link FetchMetricsManager} class provides wrapper methods to record lag, lead, latency, and fetch metrics.
@@ -106,7 +106,7 @@ public class FetchMetricsManager {
         String name = topicBytesFetchedMetricName(topic);
         maybeRecordDeprecatedBytesFetched(name, topic, bytes);
 
-        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
+        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicFetchSizeAvg)
             .withMax(metricsRegistry.topicFetchSizeMax)
             .withMeter(metricsRegistry.topicBytesConsumedRate, metricsRegistry.topicBytesConsumedTotal)
@@ -118,7 +118,7 @@ public class FetchMetricsManager {
         String name = topicRecordsFetchedMetricName(topic);
         maybeRecordDeprecatedRecordsFetched(name, topic, records);
 
-        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
+        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicRecordsPerRequestAvg)
             .withMeter(metricsRegistry.topicRecordsConsumedRate, metricsRegistry.topicRecordsConsumedTotal)
             .build();
@@ -131,7 +131,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLagMetricName(tp);
         maybeRecordDeprecatedPartitionLag(name, tp, lag);
 
-        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLag)
             .withMax(metricsRegistry.partitionRecordsLagMax)
             .withAvg(metricsRegistry.partitionRecordsLagAvg)
@@ -146,7 +146,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLeadMetricName(tp);
         maybeRecordDeprecatedPartitionLead(name, tp, lead);
 
-        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLead)
             .withMin(metricsRegistry.partitionRecordsLeadMin)
             .withAvg(metricsRegistry.partitionRecordsLeadAvg)
@@ -284,7 +284,7 @@ public class FetchMetricsManager {
     }
 
     private MetricName partitionPreferredReadReplicaMetricName(TopicPartition tp) {
-        Map<String, String> metricTags = mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
+        Map<String, String> metricTags = mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
         return this.metrics.metricInstance(metricsRegistry.partitionPreferredReadReplica, metricTags);
     }
 
@@ -296,12 +296,12 @@ public class FetchMetricsManager {
 
     @Deprecated
     static LinkedHashMap<String, String> topicTags(String topic) {
-        return mkSeqMap(mkEntry("topic", topic.replace('.', '_')));
+        return mkMap(mkEntry("topic", topic.replace('.', '_')));
     }
 
     @Deprecated
     static LinkedHashMap<String, String> topicPartitionTags(TopicPartition tp) {
-        return mkSeqMap(mkEntry("topic", tp.topic().replace('.', '_')),
+        return mkMap(mkEntry("topic", tp.topic().replace('.', '_')),
             mkEntry("partition", String.valueOf(tp.partition())));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
@@ -24,11 +24,12 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSeqMap;
 
 /**
  * The {@link FetchMetricsManager} class provides wrapper methods to record lag, lead, latency, and fetch metrics.
@@ -105,7 +106,7 @@ public class FetchMetricsManager {
         String name = topicBytesFetchedMetricName(topic);
         maybeRecordDeprecatedBytesFetched(name, topic, bytes);
 
-        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> Map.of("topic", topic))
+        Sensor bytesFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicFetchSizeAvg)
             .withMax(metricsRegistry.topicFetchSizeMax)
             .withMeter(metricsRegistry.topicBytesConsumedRate, metricsRegistry.topicBytesConsumedTotal)
@@ -117,7 +118,7 @@ public class FetchMetricsManager {
         String name = topicRecordsFetchedMetricName(topic);
         maybeRecordDeprecatedRecordsFetched(name, topic, records);
 
-        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> Map.of("topic", topic))
+        Sensor recordsFetched = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", topic)))
             .withAvg(metricsRegistry.topicRecordsPerRequestAvg)
             .withMeter(metricsRegistry.topicRecordsConsumedRate, metricsRegistry.topicRecordsConsumedTotal)
             .build();
@@ -130,7 +131,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLagMetricName(tp);
         maybeRecordDeprecatedPartitionLag(name, tp, lag);
 
-        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLag)
             .withMax(metricsRegistry.partitionRecordsLagMax)
             .withAvg(metricsRegistry.partitionRecordsLagAvg)
@@ -145,7 +146,7 @@ public class FetchMetricsManager {
         String name = partitionRecordsLeadMetricName(tp);
         maybeRecordDeprecatedPartitionLead(name, tp, lead);
 
-        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
+        Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLead)
             .withMin(metricsRegistry.partitionRecordsLeadMin)
             .withAvg(metricsRegistry.partitionRecordsLeadAvg)
@@ -283,7 +284,7 @@ public class FetchMetricsManager {
     }
 
     private MetricName partitionPreferredReadReplicaMetricName(TopicPartition tp) {
-        Map<String, String> metricTags = mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
+        Map<String, String> metricTags = mkSeqMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition())));
         return this.metrics.metricInstance(metricsRegistry.partitionPreferredReadReplica, metricTags);
     }
 
@@ -294,13 +295,13 @@ public class FetchMetricsManager {
     }
 
     @Deprecated
-    static Map<String, String> topicTags(String topic) {
-        return Map.of("topic", topic.replace('.', '_'));
+    static LinkedHashMap<String, String> topicTags(String topic) {
+        return mkSeqMap(mkEntry("topic", topic.replace('.', '_')));
     }
 
     @Deprecated
-    static Map<String, String> topicPartitionTags(TopicPartition tp) {
-        return mkMap(mkEntry("topic", tp.topic().replace('.', '_')),
+    static LinkedHashMap<String, String> topicPartitionTags(TopicPartition tp) {
+        return mkSeqMap(mkEntry("topic", tp.topic().replace('.', '_')),
             mkEntry("partition", String.valueOf(tp.partition())));
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SensorBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SensorBuilder.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.metrics.stats.SampledStat;
 import org.apache.kafka.common.metrics.stats.Value;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -46,10 +47,10 @@ public class SensorBuilder {
     private final Map<String, String> tags;
 
     public SensorBuilder(Metrics metrics, String name) {
-        this(metrics, name, Collections::emptyMap);
+        this(metrics, name, LinkedHashMap::new);
     }
 
-    public SensorBuilder(Metrics metrics, String name, Supplier<Map<String, String>> tagsSupplier) {
+    public SensorBuilder(Metrics metrics, String name, Supplier<LinkedHashMap<String, String>> tagsSupplier) {
         this.metrics = metrics;
         Sensor s = metrics.getSensor(name);
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -821,6 +821,23 @@ public final class Utils {
     }
 
     /**
+     * Creates a map from a sequence of entries
+     *
+     * @param entries The entries to map
+     * @param <K>     The key type
+     * @param <V>     The value type
+     * @return A linked map
+     */
+    @SafeVarargs
+    public static <K, V> LinkedHashMap<K, V> mkSeqMap(final Map.Entry<K, V>... entries) {
+        final LinkedHashMap<K, V> result = new LinkedHashMap<>();
+        for (final Map.Entry<K, V> entry : entries) {
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
+    /**
      * Creates a {@link Properties} from a map
      *
      * @param properties A map of properties to add

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -812,7 +812,7 @@ public final class Utils {
      * @return A map
      */
     @SafeVarargs
-    public static <K, V> Map<K, V> mkMap(final Map.Entry<K, V>... entries) {
+    public static <K, V> LinkedHashMap<K, V> mkMap(final Map.Entry<K, V>... entries) {
         final LinkedHashMap<K, V> result = new LinkedHashMap<>();
         for (final Map.Entry<K, V> entry : entries) {
             result.put(entry.getKey(), entry.getValue());
@@ -820,22 +820,6 @@ public final class Utils {
         return result;
     }
 
-    /**
-     * Creates a map from a sequence of entries
-     *
-     * @param entries The entries to map
-     * @param <K>     The key type
-     * @param <V>     The value type
-     * @return A linked map
-     */
-    @SafeVarargs
-    public static <K, V> LinkedHashMap<K, V> mkSeqMap(final Map.Entry<K, V>... entries) {
-        final LinkedHashMap<K, V> result = new LinkedHashMap<>();
-        for (final Map.Entry<K, V> entry : entries) {
-            result.put(entry.getKey(), entry.getValue());
-        }
-        return result;
-    }
 
     /**
      * Creates a {@link Properties} from a map


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-18390

This is the first part related `SensorBuilder`.

In this PR, changed `SensorBuilder(Metrics metrics, String name, Supplier<Map<String, String>> tagsSupplier)` to `public SensorBuilder(Metrics metrics, String name, Supplier<LinkedHashMap<String, String>> tagsSupplier)`