### PR TITLE
KAFKA-14487: Move LogManager static methods/fields to storage module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2228,6 +2228,7 @@ project(':storage') {
   }
 
   dependencies {
+    implementation project(':metadata')
     implementation project(':storage:storage-api')
     implementation project(':server-common')
     implementation project(':clients')

--- a/checkstyle/import-control-storage.xml
+++ b/checkstyle/import-control-storage.xml
@@ -89,6 +89,8 @@
         <allow pkg="com.yammer.metrics.core" />
         <allow pkg="org.apache.kafka.common" />
         <allow pkg="org.apache.kafka.config" />
+        <allow pkg="org.apache.kafka.image" />
+        <allow pkg="org.apache.kafka.metadata" />
         <allow pkg="org.apache.kafka.server"/>
         <allow pkg="org.apache.kafka.storage.internals"/>
         <allow pkg="org.apache.kafka.storage.log.metrics"/>

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -24,7 +24,6 @@ import java.util.OptionalInt
 import java.util.concurrent.CompletableFuture
 import java.util.{Map => JMap}
 import java.util.{Collection => JCollection}
-import kafka.log.LogManager
 import kafka.server.KafkaConfig
 import kafka.utils.CoreUtils
 import kafka.utils.Logging
@@ -49,7 +48,7 @@ import org.apache.kafka.server.config.ServerLogConfigs
 import org.apache.kafka.server.util.{FileLock, KafkaScheduler}
 import org.apache.kafka.server.fault.FaultHandler
 import org.apache.kafka.server.util.timer.SystemTimer
-import org.apache.kafka.storage.internals.log.UnifiedLog
+import org.apache.kafka.storage.internals.log.{LogManager, UnifiedLog}
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
@@ -63,7 +62,7 @@ object KafkaRaftManager {
   }
 
   private def lockDataDir(dataDir: File): FileLock = {
-    val lock = new FileLock(new File(dataDir, LogManager.LockFileName))
+    val lock = new FileLock(new File(dataDir, LogManager.LOCK_FILE_NAME))
 
     if (!lock.tryLock()) {
       throw new KafkaException(

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.image.{MetadataDelta, MetadataImage, TopicDelta}
 import org.apache.kafka.metadata.publisher.AclPublisher
 import org.apache.kafka.server.common.RequestLocal
 import org.apache.kafka.server.fault.FaultHandler
+import org.apache.kafka.storage.internals.log.{LogManager => JLogManager}
 
 import java.util.concurrent.CompletableFuture
 import scala.collection.mutable
@@ -300,7 +301,7 @@ class BrokerMetadataPublisher(
       // recovery-from-unclean-shutdown if required.
       logManager.startup(
         metadataCache.getAllTopics().asScala,
-        isStray = log => LogManager.isStrayKraftReplica(brokerId, newImage.topics(), log)
+        isStray = log => JLogManager.isStrayKraftReplica(brokerId, newImage.topics(), log)
       )
 
       // Rename all future replicas which are in the same directory as the

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -22,7 +22,6 @@ import java.nio.channels.OverlappingFileLockException
 import java.nio.file.{Files, Path, StandardOpenOption}
 import java.util.Properties
 import java.util.concurrent.CompletableFuture
-import kafka.log.LogManager
 import kafka.server.KafkaConfig
 import kafka.tools.TestRaftServer.ByteArraySerde
 import kafka.utils.TestUtils
@@ -36,6 +35,7 @@ import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerLogConfigs}
 import org.apache.kafka.server.fault.FaultHandler
+import org.apache.kafka.storage.internals.log.LogManager
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -165,7 +165,7 @@ class RaftManagerTest {
       )
     )
 
-    val lockPath = metadataDir.getOrElse(logDir.head).resolve(LogManager.LockFileName)
+    val lockPath = metadataDir.getOrElse(logDir.head).resolve(LogManager.LOCK_FILE_NAME)
     assertTrue(fileLocked(lockPath))
 
     raftManager.shutdown()
@@ -189,7 +189,7 @@ class RaftManagerTest {
       )
     )
 
-    val lockPath = metadataDir.getOrElse(logDir.head).resolve(LogManager.LockFileName)
+    val lockPath = metadataDir.getOrElse(logDir.head).resolve(LogManager.LOCK_FILE_NAME)
     assertTrue(fileLocked(lockPath))
 
     raftManager.shutdown()

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -21,7 +21,6 @@ import kafka.utils.{CoreUtils, TestInfoUtils, TestUtils}
 import java.io.File
 import java.util.concurrent.CancellationException
 import kafka.integration.KafkaServerTestHarness
-import kafka.log.LogManager
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -29,6 +28,7 @@ import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerial
 import org.apache.kafka.common.utils.Exit
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.config.{KRaftConfigs, ServerLogConfigs}
+import org.apache.kafka.storage.internals.log.LogManager
 import org.junit.jupiter.api.{BeforeEach, TestInfo, Timeout}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.function.Executable
@@ -105,7 +105,7 @@ class ServerShutdownTest extends KafkaServerTestHarness {
     // do a clean shutdown and check that offset checkpoint file exists
     shutdownBroker()
     for (logDir <- config.logDirs) {
-      val OffsetCheckpointFile = new File(logDir, LogManager.RecoveryPointCheckpointFile)
+      val OffsetCheckpointFile = new File(logDir, LogManager.RECOVERY_POINT_CHECKPOINT_FILE)
       assertTrue(OffsetCheckpointFile.exists)
       assertTrue(OffsetCheckpointFile.length() > 0)
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogManager.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.storage.internals.log;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.metadata.PartitionRegistration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class LogManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LogManager.class);
+
+    public static final String LOCK_FILE_NAME = ".lock";
+    public static final String RECOVERY_POINT_CHECKPOINT_FILE = "recovery-point-offset-checkpoint";
+    public static final String LOG_START_OFFSET_CHECKPOINT_FILE = "log-start-offset-checkpoint";
+
+    /**
+     * Wait for all jobs to complete
+     * @param jobs The jobs
+     * @param callback This will be called to handle the exception caused by each Future#get
+     * @return true if all pass. Otherwise, false
+     */
+    public static boolean waitForAllToComplete(List<Future<?>> jobs, Consumer<Throwable> callback) {
+        List<Future<?>> failed = new ArrayList<>();
+        for (Future<?> job : jobs) {
+            try {
+                job.get();
+            } catch (Exception e) {
+                callback.accept(e);
+                failed.add(job);
+            }
+        }
+        return failed.isEmpty();
+    }
+
+    /**
+     * Returns true if the given log should not be on the current broker
+     * according to the metadata image.
+     *
+     * @param brokerId       The ID of the current broker.
+     * @param newTopicsImage The new topics image after broker has been reloaded
+     * @param log            The log object to check
+     * @return true if the log should not exist on the broker, false otherwise.
+     */
+    public static boolean isStrayKraftReplica(int brokerId, TopicsImage newTopicsImage, UnifiedLog log) {
+        if (log.topicId().isEmpty()) {
+            // Missing topic ID could result from storage failure or unclean shutdown after topic creation but before flushing
+            // data to the `partition.metadata` file. And before appending data to the log, the `partition.metadata` is always
+            // flushed to disk. So if the topic ID is missing, it mostly means no data was appended, and we can treat this as
+            // a stray log.
+            LOG.info("The topicId does not exist in {}, treat it as a stray log.", log);
+            return true;
+        }
+
+        Uuid topicId = log.topicId().get();
+        int partitionId = log.topicPartition().partition();
+        PartitionRegistration partition = newTopicsImage.getPartition(topicId, partitionId);
+        if (partition == null) {
+            LOG.info("Found stray log dir {}: the topicId {} does not exist in the metadata image.", log, topicId);
+            return true;
+        } else {
+            List<Integer> replicas = Arrays.stream(partition.replicas).boxed().toList();
+            if (!replicas.contains(brokerId)) {
+                LOG.info("Found stray log dir {}: the current replica assignment {} does not contain the local brokerId {}.",
+                        log, replicas.stream().map(String::valueOf).collect(Collectors.joining(", ", "[", "]")), brokerId);
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogManagerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.storage.internals.log;
+
+import org.apache.kafka.common.DirectoryId;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.metadata.LeaderRecoveryState;
+import org.apache.kafka.metadata.PartitionRegistration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LogManagerTest {
+
+    private static final TopicIdPartition FOO_0 = new TopicIdPartition(Uuid.fromString("Sl08ZXU2QW6uF5hIoSzc8w"), new TopicPartition("foo", 0));
+    private static final TopicIdPartition FOO_1 = new TopicIdPartition(Uuid.fromString("Sl08ZXU2QW6uF5hIoSzc8w"), new TopicPartition("foo", 1));
+    private static final TopicIdPartition BAR_0 = new TopicIdPartition(Uuid.fromString("69O438ZkTSeqqclTtZO2KA"), new TopicPartition("bar", 0));
+    private static final TopicIdPartition BAR_1 = new TopicIdPartition(Uuid.fromString("69O438ZkTSeqqclTtZO2KA"), new TopicPartition("bar", 1));
+    private static final TopicIdPartition QUUX_0 = new TopicIdPartition(Uuid.fromString("YS9owjv5TG2OlsvBM0Qw6g"), new TopicPartition("quux", 0));
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testWaitForAllToComplete() throws ExecutionException, InterruptedException {
+        AtomicInteger invokedCount = new AtomicInteger(0);
+        Future<Boolean> success = mock(Future.class);
+        when(success.get()).thenAnswer(a -> {
+            invokedCount.incrementAndGet();
+            return true;
+        });
+        Future<Boolean> failure = mock(Future.class);
+        when(failure.get()).thenAnswer(a -> {
+            invokedCount.incrementAndGet();
+            throw new RuntimeException();
+        });
+
+        AtomicInteger failureCount = new AtomicInteger(0);
+        // all futures should be evaluated
+        assertFalse(LogManager.waitForAllToComplete(List.of(success, failure), t -> failureCount.incrementAndGet()));
+        assertEquals(2, invokedCount.get());
+        assertEquals(1, failureCount.get());
+        assertFalse(LogManager.waitForAllToComplete(List.of(failure, success), t -> failureCount.incrementAndGet()));
+        assertEquals(4, invokedCount.get());
+        assertEquals(2, failureCount.get());
+        assertTrue(LogManager.waitForAllToComplete(List.of(success, success), t -> failureCount.incrementAndGet()));
+        assertEquals(6, invokedCount.get());
+        assertEquals(2, failureCount.get());
+        assertFalse(LogManager.waitForAllToComplete(List.of(failure, failure), t -> failureCount.incrementAndGet()));
+        assertEquals(8, invokedCount.get());
+        assertEquals(4, failureCount.get());
+    }
+
+    @Test
+    public void testIsStrayKraftReplicaWithEmptyImage() {
+        TopicsImage image = topicsImage(List.of());
+        List<UnifiedLog> onDisk = Stream.of(FOO_0, FOO_1, BAR_0, BAR_1, QUUX_0).map(this::mockLog).toList();
+        assertTrue(onDisk.stream().allMatch(log -> LogManager.isStrayKraftReplica(0, image, log)));
+    }
+
+    @Test
+    public void testIsStrayKraftReplicaInImage() {
+        TopicsImage image = topicsImage(List.of(
+            topicImage(Map.of(
+                    FOO_0, List.of(0, 1, 2))),
+            topicImage(Map.of(
+                    BAR_0, List.of(0, 1, 2),
+                    BAR_1, List.of(0, 1, 2)))
+        ));
+        List<UnifiedLog> onDisk = Stream.of(FOO_0, FOO_1, BAR_0, BAR_1, QUUX_0).map(this::mockLog).toList();
+        Set<TopicPartition> expectedStrays = Stream.of(FOO_1, QUUX_0).map(TopicIdPartition::topicPartition).collect(Collectors.toSet());
+
+        onDisk.forEach(log -> assertEquals(expectedStrays.contains(log.topicPartition()), LogManager.isStrayKraftReplica(0, image, log)));
+    }
+
+    @Test
+    public void testIsStrayKraftReplicaInImageWithRemoteReplicas() {
+        TopicsImage image = topicsImage(List.of(
+            topicImage(Map.of(
+                    FOO_0, List.of(0, 1, 2))),
+            topicImage(Map.of(
+                    BAR_0, List.of(1, 2, 3),
+                    BAR_1, List.of(2, 3, 0)))
+        ));
+        List<UnifiedLog> onDisk = Stream.of(FOO_0, BAR_0, BAR_1).map(this::mockLog).toList();
+        Set<TopicPartition> expectedStrays = Stream.of(BAR_0).map(TopicIdPartition::topicPartition).collect(Collectors.toSet());
+        onDisk.forEach(log -> assertEquals(expectedStrays.contains(log.topicPartition()), LogManager.isStrayKraftReplica(0, image, log)));
+    }
+
+    @Test
+    public void testIsStrayKraftMissingTopicId() {
+        UnifiedLog log = mock(UnifiedLog.class);
+        when(log.topicId()).thenReturn(Optional.empty());
+        assertTrue(LogManager.isStrayKraftReplica(0, topicsImage(List.of()), log));
+    }
+
+    private TopicsImage topicsImage(List<TopicImage> topics) {
+        TopicsImage retval = TopicsImage.EMPTY;
+        for (TopicImage topic : topics) {
+            retval = retval.including(topic);
+        }
+        return retval;
+    }
+
+    private TopicImage topicImage(Map<TopicIdPartition, List<Integer>> partitions) {
+        String topicName = null;
+        Uuid topicId = null;
+        for (TopicIdPartition partition : partitions.keySet()) {
+            if (topicId == null) {
+                topicId = partition.topicId();
+            } else if (!topicId.equals(partition.topicId())) {
+                throw new IllegalArgumentException("partition topic IDs did not match");
+            }
+            if (topicName == null) {
+                topicName = partition.topic();
+            } else if (!topicName.equals(partition.topic())) {
+                throw new IllegalArgumentException("partition topic names did not match");
+            }
+        }
+        if (topicId == null) {
+            throw new IllegalArgumentException("Invalid empty partitions map.");
+        }
+        Map<Integer, PartitionRegistration> partitionRegistrations = partitions.entrySet().stream().collect(
+                Collectors.toMap(
+                        entry -> entry.getKey().partition(),
+                        entry -> new PartitionRegistration.Builder()
+                                .setReplicas(entry.getValue().stream().mapToInt(Integer::intValue).toArray())
+                                .setDirectories(DirectoryId.unassignedArray(entry.getValue().size()))
+                                .setIsr(entry.getValue().stream().mapToInt(Integer::intValue).toArray())
+                                .setLeader(entry.getValue().get(0))
+                                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+                                .setLeaderEpoch(0)
+                                .setPartitionEpoch(0)
+                                .build()));
+        return new TopicImage(topicName, topicId, partitionRegistrations);
+    }
+
+    private UnifiedLog mockLog(TopicIdPartition topicIdPartition) {
+        UnifiedLog log = mock(UnifiedLog.class);
+        when(log.topicId()).thenReturn(Optional.of(topicIdPartition.topicId()));
+        when(log.topicPartition()).thenReturn(topicIdPartition.topicPartition());
+        return log;
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.tiered.storage.integration;
 
-import kafka.log.LogManager;
 import kafka.server.ReplicaManager;
 
 import org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler;
+import org.apache.kafka.storage.internals.log.LogManager;
 import org.apache.kafka.tiered.storage.TieredStorageTestBuilder;
 import org.apache.kafka.tiered.storage.TieredStorageTestHarness;
 import org.apache.kafka.tiered.storage.specs.KeyValueSpec;
@@ -50,7 +50,7 @@ public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTes
         final Map<Integer, List<Integer>> assignment = mkMap(mkEntry(p0, List.of(broker0, broker1)));
         final List<String> checkpointFiles = List.of(
                 ReplicaManager.HighWatermarkFilename(),
-                LogManager.RecoveryPointCheckpointFile(),
+                LogManager.RECOVERY_POINT_CHECKPOINT_FILE,
                 CleanShutdownFileHandler.CLEAN_SHUTDOWN_FILE_NAME);
 
         builder.createTopic(topicA, partitionCount, replicationFactor, maxBatchCountPerSegment, assignment,


### PR DESCRIPTION
Move the static fields/methods

Reviewers: Luke Chen <showuon@gmail.com>
