### PR TITLE
KAFKA-15873: Filter topics before sorting

### DIFF
--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -89,7 +89,7 @@ public class DescribeTopicPartitionsRequestHandler {
         // Do not disclose the existence of topics unauthorized for Describe, so we've not even checked if they exist or not
         Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
 
-        Stream<String> authorizedTopicsStream = topics.stream().sorted().filter(topicName -> {
+        Stream<String> authorizedTopicsStream = topics.stream().filter(topicName -> {
             boolean isAuthorized = authHelper.authorize(
                 abstractRequest.context(), DESCRIBE, TOPIC, topicName, true, true, 1);
             if (!fetchAllTopics && !isAuthorized) {
@@ -99,7 +99,7 @@ public class DescribeTopicPartitionsRequestHandler {
                 );
             }
             return isAuthorized;
-        });
+        }).sorted();
 
         DescribeTopicPartitionsResponseData response = metadataCache.describeTopicResponse(
             authorizedTopicsStream.iterator(),


### PR DESCRIPTION
Partially addresses KAFKA-15873. When filtering and sorting, we should
be applying the filter before the sort of topics. Order that
unauthorizedForDescribeTopicMetadata is added to not relevant as it is a
HashSet.

Reviewers: TaiJuWu <tjwu1217@gmail.com>, Calvin Liu
 <caliu@confluent.io>, Matthias J. Sax <matthias@confluent.io>
