### PR TITLE
KAFKA-17722 Fix "this-escape" compiler warnings (BrokerTopicMetrics) …

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/log/metrics/BrokerTopicMetrics.java
+++ b/storage/src/main/java/org/apache/kafka/storage/log/metrics/BrokerTopicMetrics.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class BrokerTopicMetrics {
+public final class BrokerTopicMetrics {
     public static final String MESSAGE_IN_PER_SEC = "MessagesInPerSec";
     public static final String BYTES_IN_PER_SEC = "BytesInPerSec";
     public static final String BYTES_OUT_PER_SEC = "BytesOutPerSec";


### PR DESCRIPTION
…for JDK 23 (3.9 backport)

Cherry picked from commit a880c846ae3d786f8f3259b34dadfecf0b2d0d06
