### PR TITLE
KAFKA-17723 Fix "this-escape" compiler warnings (MultiThreadedEventPr…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -255,6 +255,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
      * @param uponShutdown       any {@link AutoCloseable} objects that should be closed when this herder is {@link #stop() stopped},
      *                           after all services and resources owned by this herder are stopped
      */
+    @SuppressWarnings("this-escape")
     public DistributedHerder(DistributedConfig config,
                              Time time,
                              Worker worker,
@@ -272,6 +273,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     // visible for testing
+    @SuppressWarnings("this-escape")
     DistributedHerder(DistributedConfig config,
                       Worker worker,
                       String workerId,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -34,7 +34,7 @@ import java.util.stream.IntStream;
  * A multithreaded {{@link CoordinatorEvent}} processor which uses a {{@link EventAccumulator}}
  * which guarantees that events sharing a partition key are not processed concurrently.
  */
-public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
+public final class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
 
     /**
      * The poll timeout to wait for an event by the EventProcessorThread.


### PR DESCRIPTION
…ocessor and DistributedHerder) for JDK 23 (3.9 backport)

Cherry picked from commit 2353a7c5081b53402d5092afd255e2bdf7aa2d20