### PR TITLE
KAFKA-18945: Enhance the docs for Admin APIs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -345,6 +345,9 @@ public interface Admin extends AutoCloseable {
 
     /**
      * Get information about the nodes in the cluster.
+     * <p>
+     * To obtain broker cluster information, you must configure {@link AdminClientConfig#BOOTSTRAP_SERVERS_CONFIG}.
+     * To obtain controller cluster information, you must configure {@link AdminClientConfig#BOOTSTRAP_CONTROLLERS_CONFIG}.
      *
      * @param options The options to use when getting information about the cluster.
      * @return The DescribeClusterResult.
@@ -472,6 +475,9 @@ public interface Admin extends AutoCloseable {
      *     will throw a {@link org.apache.kafka.common.errors.TimeoutException} exception</li>
      *     <li>{@link ConfigResource.Type#CLIENT_METRICS}: will return empty configs</li>
      * </ul>
+     * <p>
+     * Note that you cannot describe broker configs or broker logger using {@link AdminClientConfig#BOOTSTRAP_CONTROLLERS_CONFIG},
+     * and you cannot describe controller configs or controller logger using {@link AdminClientConfig#BOOTSTRAP_SERVERS_CONFIG}.
      * <p>
      * This operation is supported by brokers with version 0.11.0.0 or higher.
      *

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
@@ -51,8 +51,10 @@ public class DescribeClusterResult {
     }
 
     /**
-     * Returns a future which yields the current controller id.
-     * Note that this may yield null, if the controller ID is not yet known.
+     * Returns a future which yields the current controller node.
+     * <p>
+     * When using {@link AdminClientConfig#BOOTSTRAP_SERVERS_CONFIG}, the controller refer to a random broker.
+     * When using {@link AdminClientConfig#BOOTSTRAP_CONTROLLERS_CONFIG}, it refers to the current voter leader.
      */
     public KafkaFuture<Node> controller() {
         return controller;


### PR DESCRIPTION
Enhance the documentation for Admin#describeCluster and Admin#describeConfigs to clarify their behavior when using bootstrap.controllers and bootstrap.servers.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
