### PR TITLE
KAFKA-19055: Cleanup the 0.10.x information from clients module

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
@@ -61,8 +61,7 @@ public class DescribeClusterResult {
     }
 
     /**
-     * Returns a future which yields the current cluster id. The future value will be non-null if the
-     * broker version is 0.10.1.0 or higher and null otherwise.
+     * Returns a future which yields the current cluster id.
      */
     public KafkaFuture<String> clusterId() {
         return clusterId;

--- a/clients/src/main/java/org/apache/kafka/common/ClusterResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/ClusterResource.java
@@ -28,8 +28,7 @@ public class ClusterResource {
 
     /**
      * Create {@link ClusterResource} with a cluster id. Note that cluster id may be {@code null} if the
-     * metadata request was sent to a broker without support for cluster ids. The first version of Kafka
-     * to support cluster id is 0.10.1.0.
+     * metadata request was sent to a broker without support for cluster ids.
      * @param clusterId The cluster id
      */
     public ClusterResource(String clusterId) {
@@ -38,7 +37,7 @@ public class ClusterResource {
 
     /**
      * Return the cluster id. Note that it may be {@code null} if the metadata request was sent to a broker without
-     * support for cluster ids. The first version of Kafka to support cluster id is 0.10.1.0.
+     * support for cluster ids.
      */
     public String clusterId() {
         return clusterId;

--- a/clients/src/main/java/org/apache/kafka/common/ClusterResourceListener.java
+++ b/clients/src/main/java/org/apache/kafka/common/ClusterResourceListener.java
@@ -24,7 +24,7 @@ package org.apache.kafka.common;
  * <p>
  * <h4>Clients</h4>
  * There will be one invocation of {@link ClusterResourceListener#onUpdate(ClusterResource)} after each metadata response.
- * Note the minimum supported broker version is 2.1. If you receive a null cluster id, you can expect it to always be null unless you have a cluster with multiple broker versions which can happen if the cluster is being upgraded while the client is running.
+ * Note the minimum supported broker version is 2.1.
  * <p>
  * {@link org.apache.kafka.clients.producer.ProducerInterceptor} : The {@link ClusterResourceListener#onUpdate(ClusterResource)} method will be invoked after {@link org.apache.kafka.clients.producer.ProducerInterceptor#onSend(org.apache.kafka.clients.producer.ProducerRecord)}
  * but before {@link org.apache.kafka.clients.producer.ProducerInterceptor#onAcknowledgement(org.apache.kafka.clients.producer.RecordMetadata, Exception)} .

--- a/clients/src/main/java/org/apache/kafka/common/ClusterResourceListener.java
+++ b/clients/src/main/java/org/apache/kafka/common/ClusterResourceListener.java
@@ -24,7 +24,7 @@ package org.apache.kafka.common;
  * <p>
  * <h4>Clients</h4>
  * There will be one invocation of {@link ClusterResourceListener#onUpdate(ClusterResource)} after each metadata response.
- * Note that the cluster id may be null when the Kafka broker version is below 0.10.1.0. If you receive a null cluster id, you can expect it to always be null unless you have a cluster with multiple broker versions which can happen if the cluster is being upgraded while the client is running.
+ * Note the minimum supported broker version is 2.1. If you receive a null cluster id, you can expect it to always be null unless you have a cluster with multiple broker versions which can happen if the cluster is being upgraded while the client is running.
  * <p>
  * {@link org.apache.kafka.clients.producer.ProducerInterceptor} : The {@link ClusterResourceListener#onUpdate(ClusterResource)} method will be invoked after {@link org.apache.kafka.clients.producer.ProducerInterceptor#onSend(org.apache.kafka.clients.producer.ProducerRecord)}
  * but before {@link org.apache.kafka.clients.producer.ProducerInterceptor#onAcknowledgement(org.apache.kafka.clients.producer.RecordMetadata, Exception)} .

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -107,8 +107,6 @@ public class TopicConfig {
     public static final String MAX_MESSAGE_BYTES_CONFIG = "max.message.bytes";
     public static final String MAX_MESSAGE_BYTES_DOC =
         "The largest record batch size allowed by Kafka (after compression if compression is enabled). " +
-        "If this is increased and there are consumers older than 0.10.2, the consumers' fetch " +
-        "size must also be increased so that they can fetch record batches this large. " +
         "In the latest message format version, records are always grouped into batches for efficiency. " +
         "In previous message format versions, uncompressed records are not grouped into batches and this " +
         "limit only applies to a single record in that case.";


### PR DESCRIPTION
Removes outdated references to Kafka 0.10.x in the clients module documentation. Since the baseline version is now 2.1, any mentions of versions earlier than this are unnecessary and have been removed or updated accordingly.

Changes:
- Updated `ClusterResource`, `ClusterResourceListener`, and `DescribeClusterResult` Javadoc to reflect the minimum supported broker version as 2.1.
- Updated `TopicConfig` documentation: Removed references to consumers older than 0.10.2.
- Removed references to 0.10.x and adjusted explanations to remain relevant for newer versions.

Testing & Impact:
- This PR only modifies Javadoc comments—no functional code changes.
- No impact on existing functionality.

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
