### PR TITLE
KAFKA-18874: Fix KRaft controller registration retry on timeout

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
@@ -267,6 +267,7 @@ class ControllerRegistrationManager(
     }
 
     override def onTimeout(): Unit = {
+      pendingRpc = false
       error(s"RegistrationResponseHandler: channel manager timed out before sending the request.")
       scheduleNextCommunicationAfterFailure()
     }


### PR DESCRIPTION
There is a flag which is set when scheduling KRaft controller
registration request to be send. When a timeout occurs while the request
is in the queue but not yet sent, this flag is not deleted and thus the
registration request is not rescheduled. This patch addresses the above
issue by setting the flag to false on timeout.
