### PR TITLE
KAFKA-19058 Running the streams/streams-scala module tests produces a streams-scala.log

### DIFF
--- a/streams/streams-scala/src/test/resources/log4j2.yaml
+++ b/streams/streams-scala/src/test/resources/log4j2.yaml
@@ -24,8 +24,8 @@ Configuration:
       name: A1
     RollingFile:
       - name: R
-        fileName: logs/kafka-streams-scala.log
-        filePattern: "streams-scala-%d{yyyy-MM-dd}.log"
+        fileName: build/logs/kafka-streams-scala.log
+        filePattern: "build/logs/streams-scala-%d{yyyy-MM-dd}.log"
         PatternLayout:
           pattern: "${logPattern}"
         SizeBasedTriggeringPolicy:

--- a/streams/streams-scala/src/test/resources/log4j2.yaml
+++ b/streams/streams-scala/src/test/resources/log4j2.yaml
@@ -22,19 +22,11 @@ Configuration:
   Appenders:
     Console:
       name: A1
-    RollingFile:
-      - name: R
-        fileName: build/logs/kafka-streams-scala.log
-        filePattern: "build/logs/streams-scala-%d{yyyy-MM-dd}.log"
-        PatternLayout:
-          pattern: "${logPattern}"
-        SizeBasedTriggeringPolicy:
-          size: "100KB"
-        DefaultRolloverStrategy:
-          max: 1
+      PatternLayout:
+        pattern: "${logPattern}"
 
   Loggers:
     Root:
       level: INFO
       AppenderRef:
-        - ref: R
+        - ref: A1

--- a/streams/streams-scala/src/test/resources/log4j2.yaml
+++ b/streams/streams-scala/src/test/resources/log4j2.yaml
@@ -21,7 +21,7 @@ Configuration:
 
   Appenders:
     Console:
-      name: A1
+      name: STDOUT
       PatternLayout:
         pattern: "${logPattern}"
 
@@ -29,4 +29,4 @@ Configuration:
     Root:
       level: INFO
       AppenderRef:
-        - ref: A1
+        - ref: STDOUT


### PR DESCRIPTION
Remove streams-scala module log4j2 file appender.

Reviewers: PoAn Yang <payang@apache.org>, Matthias J. Sax <matthias@confluent.io>