### PR TITLE
MINOR: remove unused function BrokerRegistration#isMigratingZkBroker

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -256,10 +256,6 @@ public class BrokerRegistration {
         return inControlledShutdown;
     }
 
-    public boolean isMigratingZkBroker() {
-        return isMigratingZkBroker;
-    }
-
     public List<Uuid> directories() {
         return directories;
     }


### PR DESCRIPTION
The `BrokerRegistration#isMigratingZkBroker` is not used by any
production function. Remove it.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
