### PR TITLE
MINOR: Accept Throwables in DeferredEventQueue.failAll

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/deferred/DeferredEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/deferred/DeferredEventQueue.java
@@ -76,7 +76,7 @@ public class DeferredEventQueue {
      *
      * @param exception     The exception to fail the entries with.
      */
-    public void failAll(Exception exception) {
+    public void failAll(Throwable exception) {
         Iterator<Entry<Long, List<DeferredEvent>>> iter = pending.entrySet().iterator();
         while (iter.hasNext()) {
             Entry<Long, List<DeferredEvent>> entry = iter.next();


### PR DESCRIPTION
DeferredEvents take a Throwable and not an Exception. For consistency,
DeferredEventQueue.failAll should also accept a Throwable.

Reviewers: David Jacot <djacot@confluent.io>
