### PR TITLE
KAFKA-19070:: Adding task number to user provided client id to ensure each consumer has a unique client ID to avoid metric registration conflicts.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsOptions;
@@ -1901,7 +1900,7 @@ public final class Worker {
             String overrideClientId = connectorConfig.getString(
                     ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + ConsumerConfig.CLIENT_ID_CONFIG
             );
-            if (StringUtils.isNotBlank(overrideClientId)) {
+            if (null != overrideClientId && !"".equalsIgnoreCase(overrideClientId)) {
                 // Ensure each consumer has a unique client ID to avoid metric registration conflicts.
                 consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, overrideClientId + "-" + id.task());
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1897,10 +1897,10 @@ public final class Worker {
             Map<String, Object> consumerProps = baseConsumerConfigs(
                     id.connector(),  "connector-consumer-" + id, config, connectorConfig, connectorClass,
                     connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
-            String overrideClientId = connectorConfig.getString(
-                    ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + ConsumerConfig.CLIENT_ID_CONFIG
+            String overrideClientId = connectorConfig.originalsStrings().getOrDefault(
+                    ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + ConsumerConfig.CLIENT_ID_CONFIG, ""
             );
-            if (null != overrideClientId && !"".equalsIgnoreCase(overrideClientId)) {
+            if (!overrideClientId.isEmpty()) {
                 // Ensure each consumer has a unique client ID to avoid metric registration conflicts.
                 consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, overrideClientId + "-" + id.task());
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsOptions;
@@ -1897,6 +1898,13 @@ public final class Worker {
             Map<String, Object> consumerProps = baseConsumerConfigs(
                     id.connector(),  "connector-consumer-" + id, config, connectorConfig, connectorClass,
                     connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
+            String overrideClientId = connectorConfig.getString(
+                    ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + ConsumerConfig.CLIENT_ID_CONFIG
+            );
+            if (StringUtils.isNotBlank(overrideClientId)) {
+                // Ensure each consumer has a unique client ID to avoid metric registration conflicts.
+                consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, overrideClientId + "-" + id.task());
+            }
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
             return new WorkerSinkTask(id, (SinkTask) task, statusListener, initialState, config, configState, metrics, keyConverterPlugin,


### PR DESCRIPTION
**What**
This PR updates the behavior of client.id assignment when a user provides a custom value via override configs in Kafka Connect.

**Why**
Currently, if a user overrides the client.id, all tasks or consumers inherit the same client ID. While this doesn't cause an immediate failure in Kafka, it leads to the following issues:

- Metrics and logs are merged or overwritten, making observability inaccurate.

- Quotas and throttling may be applied incorrectly.

- Debugging becomes harder due to lack of per-task identity.

**According to Kafka core behavior**, client.id should be unique per client instance for proper tracking and diagnostics.

**How**
This PR appends the **task number** to the user-provided client.id to ensure uniqueness across tasks.

**For example:**

- User provides: client.id=my-custom-client

- Final client.id used by task 2: my-custom-client-2

**This approach:**

- Respects the user’s original intent in naming

- Guarantees unique client.id values per task

- Improves metrics, logging, and debugging consistency

