### PR TITLE
KAFKA-19075: Included other share group dynamic configs in extractShareGroupConfigMap method in ShareGroupConfig

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -553,7 +553,7 @@ public class GroupCoordinatorConfig {
     public Map<String, Integer> extractGroupConfigMap(ShareGroupConfig shareGroupConfig) {
         Map<String, Integer> defaultConfigs = new HashMap<>();
         defaultConfigs.putAll(extractConsumerGroupConfigMap());
-        defaultConfigs.putAll(shareGroupConfig.extractShareGroupConfigMap());
+        defaultConfigs.putAll(shareGroupConfig.extractShareGroupConfigMap(this));
         return Collections.unmodifiableMap(defaultConfigs);
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupConfig.java
@@ -161,9 +161,16 @@ public class ShareGroupConfig {
     }
 
     /**
-     * Copy the subset of properties that are relevant to share group.
+     * Copy the subset of properties that are relevant to share group. These configs include those which can be set
+     * statically (for all groups) or dynamically (for a specific group). In those cases, the default value for the
+     * group specific dynamic config (Ex. share.session.timeout.ms) should be the value set for the static config
+     * (Ex. group.share.session.timeout.ms).
      */
-    public Map<String, Integer> extractShareGroupConfigMap() {
-        return Map.of(GroupConfig.SHARE_RECORD_LOCK_DURATION_MS_CONFIG, shareGroupRecordLockDurationMs());
+    public Map<String, Integer> extractShareGroupConfigMap(GroupCoordinatorConfig groupCoordinatorConfig) {
+        return Map.of(
+            GroupConfig.SHARE_SESSION_TIMEOUT_MS_CONFIG, groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
+            GroupConfig.SHARE_HEARTBEAT_INTERVAL_MS_CONFIG, groupCoordinatorConfig.shareGroupHeartbeatIntervalMs(),
+            GroupConfig.SHARE_RECORD_LOCK_DURATION_MS_CONFIG, shareGroupRecordLockDurationMs()
+        );
     }
 }


### PR DESCRIPTION
This PR includes `share.session.timeout.ms` and `share.heartbeat.interval.ms` in the `extractShareGroupConfigMap` method in `ShareGroupConfig`. With this change, the default value of `share.session.timeout.ms` and `share.heartbeat.interval.ms` for every group will be set as the value of the static configs `group.share.session.timeout.ms` and `group.share.heartbeat.interval.ms` respectively