### PR TITLE
MINOR: ShutdownableThread: log on error level on FatalExitError

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
@@ -137,7 +137,7 @@ public abstract class ShutdownableThread extends Thread {
         } catch (FatalExitError e) {
             shutdownInitiated.countDown();
             shutdownComplete.countDown();
-            log.info("Stopped");
+            log.error("Stopped due to fatal error with exit code {}", e.statusCode(), e);
             Exit.exit(e.statusCode());
         } catch (Throwable e) {
             if (isRunning())


### PR DESCRIPTION
This would potentially help debugging the error as the stacktrace would be valuable in identifying its origin.