### PR TITLE
MINOR: Use readable interface to parse response

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ByteBufferAccessor.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ByteBufferAccessor.java
@@ -145,6 +145,11 @@ public class ByteBufferAccessor implements Readable, Writable {
         return buf.remaining();
     }
 
+    @Override
+    public Readable slice() {
+        return new ByteBufferAccessor(buf.slice());
+    }
+
     public void flip() {
         buf.flip();
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
@@ -38,6 +38,7 @@ public interface Readable {
     int readVarint();
     long readVarlong();
     int remaining();
+    Readable slice();
 
     default String readString(int length) {
         byte[] arr = readArray(length);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
@@ -38,6 +38,14 @@ public interface Readable {
     int readVarint();
     long readVarlong();
     int remaining();
+
+    /**
+     * Returns a new Readable object whose content will be shared with this object.
+     * <br>
+     * The content of the new Readable object will start at this Readable's current
+     * position. The two Readable position will be independent, so read from one will
+     * not impact the other.
+     */
     Readable slice();
 
     default String readString(int length) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.SendBuilder;
@@ -51,8 +52,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
     }
 
     // Visible for testing
-    final ByteBuffer serialize(short version) {
-        return MessageUtil.toByteBufferAccessor(data(), version).buffer();
+    final ByteBufferAccessor serialize(short version) {
+        return MessageUtil.toByteBufferAccessor(data(), version);
     }
 
     /**
@@ -106,189 +107,189 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 requestHeader.correlationId(), responseHeader.correlationId());
         }
 
-        return AbstractResponse.parseResponse(apiKey, buffer, apiVersion);
+        return AbstractResponse.parseResponse(apiKey, new ByteBufferAccessor(buffer), apiVersion);
     }
 
-    public static AbstractResponse parseResponse(ApiKeys apiKey, ByteBuffer responseBuffer, short version) {
+    public static AbstractResponse parseResponse(ApiKeys apiKey, ByteBufferAccessor readable, short version) {
         switch (apiKey) {
             case PRODUCE:
-                return ProduceResponse.parse(responseBuffer, version);
+                return ProduceResponse.parse(readable, version);
             case FETCH:
-                return FetchResponse.parse(responseBuffer, version);
+                return FetchResponse.parse(readable, version);
             case LIST_OFFSETS:
-                return ListOffsetsResponse.parse(responseBuffer, version);
+                return ListOffsetsResponse.parse(readable, version);
             case METADATA:
-                return MetadataResponse.parse(responseBuffer, version);
+                return MetadataResponse.parse(readable, version);
             case OFFSET_COMMIT:
-                return OffsetCommitResponse.parse(responseBuffer, version);
+                return OffsetCommitResponse.parse(readable, version);
             case OFFSET_FETCH:
-                return OffsetFetchResponse.parse(responseBuffer, version);
+                return OffsetFetchResponse.parse(readable, version);
             case FIND_COORDINATOR:
-                return FindCoordinatorResponse.parse(responseBuffer, version);
+                return FindCoordinatorResponse.parse(readable, version);
             case JOIN_GROUP:
-                return JoinGroupResponse.parse(responseBuffer, version);
+                return JoinGroupResponse.parse(readable, version);
             case HEARTBEAT:
-                return HeartbeatResponse.parse(responseBuffer, version);
+                return HeartbeatResponse.parse(readable, version);
             case LEAVE_GROUP:
-                return LeaveGroupResponse.parse(responseBuffer, version);
+                return LeaveGroupResponse.parse(readable, version);
             case SYNC_GROUP:
-                return SyncGroupResponse.parse(responseBuffer, version);
+                return SyncGroupResponse.parse(readable, version);
             case DESCRIBE_GROUPS:
-                return DescribeGroupsResponse.parse(responseBuffer, version);
+                return DescribeGroupsResponse.parse(readable, version);
             case LIST_GROUPS:
-                return ListGroupsResponse.parse(responseBuffer, version);
+                return ListGroupsResponse.parse(readable, version);
             case SASL_HANDSHAKE:
-                return SaslHandshakeResponse.parse(responseBuffer, version);
+                return SaslHandshakeResponse.parse(readable, version);
             case API_VERSIONS:
-                return ApiVersionsResponse.parse(responseBuffer, version);
+                return ApiVersionsResponse.parse(readable, version);
             case CREATE_TOPICS:
-                return CreateTopicsResponse.parse(responseBuffer, version);
+                return CreateTopicsResponse.parse(readable, version);
             case DELETE_TOPICS:
-                return DeleteTopicsResponse.parse(responseBuffer, version);
+                return DeleteTopicsResponse.parse(readable, version);
             case DELETE_RECORDS:
-                return DeleteRecordsResponse.parse(responseBuffer, version);
+                return DeleteRecordsResponse.parse(readable, version);
             case INIT_PRODUCER_ID:
-                return InitProducerIdResponse.parse(responseBuffer, version);
+                return InitProducerIdResponse.parse(readable, version);
             case OFFSET_FOR_LEADER_EPOCH:
-                return OffsetsForLeaderEpochResponse.parse(responseBuffer, version);
+                return OffsetsForLeaderEpochResponse.parse(readable, version);
             case ADD_PARTITIONS_TO_TXN:
-                return AddPartitionsToTxnResponse.parse(responseBuffer, version);
+                return AddPartitionsToTxnResponse.parse(readable, version);
             case ADD_OFFSETS_TO_TXN:
-                return AddOffsetsToTxnResponse.parse(responseBuffer, version);
+                return AddOffsetsToTxnResponse.parse(readable, version);
             case END_TXN:
-                return EndTxnResponse.parse(responseBuffer, version);
+                return EndTxnResponse.parse(readable, version);
             case WRITE_TXN_MARKERS:
-                return WriteTxnMarkersResponse.parse(responseBuffer, version);
+                return WriteTxnMarkersResponse.parse(readable, version);
             case TXN_OFFSET_COMMIT:
-                return TxnOffsetCommitResponse.parse(responseBuffer, version);
+                return TxnOffsetCommitResponse.parse(readable, version);
             case DESCRIBE_ACLS:
-                return DescribeAclsResponse.parse(responseBuffer, version);
+                return DescribeAclsResponse.parse(readable, version);
             case CREATE_ACLS:
-                return CreateAclsResponse.parse(responseBuffer, version);
+                return CreateAclsResponse.parse(readable, version);
             case DELETE_ACLS:
-                return DeleteAclsResponse.parse(responseBuffer, version);
+                return DeleteAclsResponse.parse(readable, version);
             case DESCRIBE_CONFIGS:
-                return DescribeConfigsResponse.parse(responseBuffer, version);
+                return DescribeConfigsResponse.parse(readable, version);
             case ALTER_CONFIGS:
-                return AlterConfigsResponse.parse(responseBuffer, version);
+                return AlterConfigsResponse.parse(readable, version);
             case ALTER_REPLICA_LOG_DIRS:
-                return AlterReplicaLogDirsResponse.parse(responseBuffer, version);
+                return AlterReplicaLogDirsResponse.parse(readable, version);
             case DESCRIBE_LOG_DIRS:
-                return DescribeLogDirsResponse.parse(responseBuffer, version);
+                return DescribeLogDirsResponse.parse(readable, version);
             case SASL_AUTHENTICATE:
-                return SaslAuthenticateResponse.parse(responseBuffer, version);
+                return SaslAuthenticateResponse.parse(readable, version);
             case CREATE_PARTITIONS:
-                return CreatePartitionsResponse.parse(responseBuffer, version);
+                return CreatePartitionsResponse.parse(readable, version);
             case CREATE_DELEGATION_TOKEN:
-                return CreateDelegationTokenResponse.parse(responseBuffer, version);
+                return CreateDelegationTokenResponse.parse(readable, version);
             case RENEW_DELEGATION_TOKEN:
-                return RenewDelegationTokenResponse.parse(responseBuffer, version);
+                return RenewDelegationTokenResponse.parse(readable, version);
             case EXPIRE_DELEGATION_TOKEN:
-                return ExpireDelegationTokenResponse.parse(responseBuffer, version);
+                return ExpireDelegationTokenResponse.parse(readable, version);
             case DESCRIBE_DELEGATION_TOKEN:
-                return DescribeDelegationTokenResponse.parse(responseBuffer, version);
+                return DescribeDelegationTokenResponse.parse(readable, version);
             case DELETE_GROUPS:
-                return DeleteGroupsResponse.parse(responseBuffer, version);
+                return DeleteGroupsResponse.parse(readable, version);
             case ELECT_LEADERS:
-                return ElectLeadersResponse.parse(responseBuffer, version);
+                return ElectLeadersResponse.parse(readable, version);
             case INCREMENTAL_ALTER_CONFIGS:
-                return IncrementalAlterConfigsResponse.parse(responseBuffer, version);
+                return IncrementalAlterConfigsResponse.parse(readable, version);
             case ALTER_PARTITION_REASSIGNMENTS:
-                return AlterPartitionReassignmentsResponse.parse(responseBuffer, version);
+                return AlterPartitionReassignmentsResponse.parse(readable, version);
             case LIST_PARTITION_REASSIGNMENTS:
-                return ListPartitionReassignmentsResponse.parse(responseBuffer, version);
+                return ListPartitionReassignmentsResponse.parse(readable, version);
             case OFFSET_DELETE:
-                return OffsetDeleteResponse.parse(responseBuffer, version);
+                return OffsetDeleteResponse.parse(readable, version);
             case DESCRIBE_CLIENT_QUOTAS:
-                return DescribeClientQuotasResponse.parse(responseBuffer, version);
+                return DescribeClientQuotasResponse.parse(readable, version);
             case ALTER_CLIENT_QUOTAS:
-                return AlterClientQuotasResponse.parse(responseBuffer, version);
+                return AlterClientQuotasResponse.parse(readable, version);
             case DESCRIBE_USER_SCRAM_CREDENTIALS:
-                return DescribeUserScramCredentialsResponse.parse(responseBuffer, version);
+                return DescribeUserScramCredentialsResponse.parse(readable, version);
             case ALTER_USER_SCRAM_CREDENTIALS:
-                return AlterUserScramCredentialsResponse.parse(responseBuffer, version);
+                return AlterUserScramCredentialsResponse.parse(readable, version);
             case VOTE:
-                return VoteResponse.parse(responseBuffer, version);
+                return VoteResponse.parse(readable, version);
             case BEGIN_QUORUM_EPOCH:
-                return BeginQuorumEpochResponse.parse(responseBuffer, version);
+                return BeginQuorumEpochResponse.parse(readable, version);
             case END_QUORUM_EPOCH:
-                return EndQuorumEpochResponse.parse(responseBuffer, version);
+                return EndQuorumEpochResponse.parse(readable, version);
             case DESCRIBE_QUORUM:
-                return DescribeQuorumResponse.parse(responseBuffer, version);
+                return DescribeQuorumResponse.parse(readable, version);
             case ALTER_PARTITION:
-                return AlterPartitionResponse.parse(responseBuffer, version);
+                return AlterPartitionResponse.parse(readable, version);
             case UPDATE_FEATURES:
-                return UpdateFeaturesResponse.parse(responseBuffer, version);
+                return UpdateFeaturesResponse.parse(readable, version);
             case ENVELOPE:
-                return EnvelopeResponse.parse(responseBuffer, version);
+                return EnvelopeResponse.parse(readable, version);
             case FETCH_SNAPSHOT:
-                return FetchSnapshotResponse.parse(responseBuffer, version);
+                return FetchSnapshotResponse.parse(readable, version);
             case DESCRIBE_CLUSTER:
-                return DescribeClusterResponse.parse(responseBuffer, version);
+                return DescribeClusterResponse.parse(readable, version);
             case DESCRIBE_PRODUCERS:
-                return DescribeProducersResponse.parse(responseBuffer, version);
+                return DescribeProducersResponse.parse(readable, version);
             case BROKER_REGISTRATION:
-                return BrokerRegistrationResponse.parse(responseBuffer, version);
+                return BrokerRegistrationResponse.parse(readable, version);
             case BROKER_HEARTBEAT:
-                return BrokerHeartbeatResponse.parse(responseBuffer, version);
+                return BrokerHeartbeatResponse.parse(readable, version);
             case UNREGISTER_BROKER:
-                return UnregisterBrokerResponse.parse(responseBuffer, version);
+                return UnregisterBrokerResponse.parse(readable, version);
             case DESCRIBE_TRANSACTIONS:
-                return DescribeTransactionsResponse.parse(responseBuffer, version);
+                return DescribeTransactionsResponse.parse(readable, version);
             case LIST_TRANSACTIONS:
-                return ListTransactionsResponse.parse(responseBuffer, version);
+                return ListTransactionsResponse.parse(readable, version);
             case ALLOCATE_PRODUCER_IDS:
-                return AllocateProducerIdsResponse.parse(responseBuffer, version);
+                return AllocateProducerIdsResponse.parse(readable, version);
             case CONSUMER_GROUP_HEARTBEAT:
-                return ConsumerGroupHeartbeatResponse.parse(responseBuffer, version);
+                return ConsumerGroupHeartbeatResponse.parse(readable, version);
             case CONSUMER_GROUP_DESCRIBE:
-                return ConsumerGroupDescribeResponse.parse(responseBuffer, version);
+                return ConsumerGroupDescribeResponse.parse(readable, version);
             case CONTROLLER_REGISTRATION:
-                return ControllerRegistrationResponse.parse(responseBuffer, version);
+                return ControllerRegistrationResponse.parse(readable, version);
             case GET_TELEMETRY_SUBSCRIPTIONS:
-                return GetTelemetrySubscriptionsResponse.parse(responseBuffer, version);
+                return GetTelemetrySubscriptionsResponse.parse(readable, version);
             case PUSH_TELEMETRY:
-                return PushTelemetryResponse.parse(responseBuffer, version);
+                return PushTelemetryResponse.parse(readable, version);
             case ASSIGN_REPLICAS_TO_DIRS:
-                return AssignReplicasToDirsResponse.parse(responseBuffer, version);
+                return AssignReplicasToDirsResponse.parse(readable, version);
             case LIST_CLIENT_METRICS_RESOURCES:
-                return ListClientMetricsResourcesResponse.parse(responseBuffer, version);
+                return ListClientMetricsResourcesResponse.parse(readable, version);
             case DESCRIBE_TOPIC_PARTITIONS:
-                return DescribeTopicPartitionsResponse.parse(responseBuffer, version);
+                return DescribeTopicPartitionsResponse.parse(readable, version);
             case SHARE_GROUP_HEARTBEAT:
-                return ShareGroupHeartbeatResponse.parse(responseBuffer, version);
+                return ShareGroupHeartbeatResponse.parse(readable, version);
             case SHARE_GROUP_DESCRIBE:
-                return ShareGroupDescribeResponse.parse(responseBuffer, version);
+                return ShareGroupDescribeResponse.parse(readable, version);
             case SHARE_FETCH:
-                return ShareFetchResponse.parse(responseBuffer, version);
+                return ShareFetchResponse.parse(readable, version);
             case SHARE_ACKNOWLEDGE:
-                return ShareAcknowledgeResponse.parse(responseBuffer, version);
+                return ShareAcknowledgeResponse.parse(readable, version);
             case ADD_RAFT_VOTER:
-                return AddRaftVoterResponse.parse(responseBuffer, version);
+                return AddRaftVoterResponse.parse(readable, version);
             case REMOVE_RAFT_VOTER:
-                return RemoveRaftVoterResponse.parse(responseBuffer, version);
+                return RemoveRaftVoterResponse.parse(readable, version);
             case UPDATE_RAFT_VOTER:
-                return UpdateRaftVoterResponse.parse(responseBuffer, version);
+                return UpdateRaftVoterResponse.parse(readable, version);
             case INITIALIZE_SHARE_GROUP_STATE:
-                return InitializeShareGroupStateResponse.parse(responseBuffer, version);
+                return InitializeShareGroupStateResponse.parse(readable, version);
             case READ_SHARE_GROUP_STATE:
-                return ReadShareGroupStateResponse.parse(responseBuffer, version);
+                return ReadShareGroupStateResponse.parse(readable, version);
             case WRITE_SHARE_GROUP_STATE:
-                return WriteShareGroupStateResponse.parse(responseBuffer, version);
+                return WriteShareGroupStateResponse.parse(readable, version);
             case DELETE_SHARE_GROUP_STATE:
-                return DeleteShareGroupStateResponse.parse(responseBuffer, version);
+                return DeleteShareGroupStateResponse.parse(readable, version);
             case READ_SHARE_GROUP_STATE_SUMMARY:
-                return ReadShareGroupStateSummaryResponse.parse(responseBuffer, version);
+                return ReadShareGroupStateSummaryResponse.parse(readable, version);
             case STREAMS_GROUP_HEARTBEAT:
-                return StreamsGroupHeartbeatResponse.parse(responseBuffer, version);
+                return StreamsGroupHeartbeatResponse.parse(readable, version);
             case STREAMS_GROUP_DESCRIBE:
-                return StreamsGroupDescribeResponse.parse(responseBuffer, version);
+                return StreamsGroupDescribeResponse.parse(readable, version);
             case DESCRIBE_SHARE_GROUP_OFFSETS:
-                return DescribeShareGroupOffsetsResponse.parse(responseBuffer, version);
+                return DescribeShareGroupOffsetsResponse.parse(readable, version);
             case ALTER_SHARE_GROUP_OFFSETS:
-                return AlterShareGroupOffsetsResponse.parse(responseBuffer, version);
+                return AlterShareGroupOffsetsResponse.parse(readable, version);
             case DELETE_SHARE_GROUP_OFFSETS:
-                return DeleteShareGroupOffsetsResponse.parse(responseBuffer, version);
+                return DeleteShareGroupOffsetsResponse.parse(readable, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.SendBuilder;
 
 import java.nio.ByteBuffer;
@@ -110,7 +111,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
         return AbstractResponse.parseResponse(apiKey, new ByteBufferAccessor(buffer), apiVersion);
     }
 
-    public static AbstractResponse parseResponse(ApiKeys apiKey, ByteBufferAccessor readable, short version) {
+    public static AbstractResponse parseResponse(ApiKeys apiKey, Readable readable, short version) {
         switch (apiKey) {
             case PRODUCE:
                 return ProduceResponse.parse(readable, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AddOffsetsToTxnResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -66,8 +65,8 @@ public class AddOffsetsToTxnResponse extends AbstractResponse {
         return data;
     }
 
-    public static AddOffsetsToTxnResponse parse(ByteBuffer buffer, short version) {
-        return new AddOffsetsToTxnResponse(new AddOffsetsToTxnResponseData(new ByteBufferAccessor(buffer), version));
+    public static AddOffsetsToTxnResponse parse(Readable readable, short version) {
+        return new AddOffsetsToTxnResponse(new AddOffsetsToTxnResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddPartitionsToTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddPartitionsToTxnResponse.java
@@ -24,10 +24,9 @@ import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartiti
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnTopicResult;
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnTopicResultCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -150,8 +149,8 @@ public class AddPartitionsToTxnResponse extends AbstractResponse {
         return data;
     }
 
-    public static AddPartitionsToTxnResponse parse(ByteBuffer buffer, short version) {
-        return new AddPartitionsToTxnResponse(new AddPartitionsToTxnResponseData(new ByteBufferAccessor(buffer), version));
+    public static AddPartitionsToTxnResponse parse(Readable readable, short version) {
+        return new AddPartitionsToTxnResponse(new AddPartitionsToTxnResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AddRaftVoterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -58,8 +57,8 @@ public class AddRaftVoterResponse extends AbstractResponse {
         }
     }
 
-    public static AddRaftVoterResponse parse(ByteBuffer buffer, short version) {
+    public static AddRaftVoterResponse parse(Readable readable, short version) {
         return new AddRaftVoterResponse(
-            new AddRaftVoterResponseData(new ByteBufferAccessor(buffer), version));
+            new AddRaftVoterResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AllocateProducerIdsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -65,8 +64,8 @@ public class AllocateProducerIdsResponse extends AbstractResponse {
         return Errors.forCode(data.errorCode());
     }
 
-    public static AllocateProducerIdsResponse parse(ByteBuffer buffer, short version) {
+    public static AllocateProducerIdsResponse parse(Readable readable, short version) {
         return new AllocateProducerIdsResponse(new AllocateProducerIdsResponseData(
-                new ByteBufferAccessor(buffer), version));
+                readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
@@ -21,11 +21,10 @@ import org.apache.kafka.common.message.AlterClientQuotasResponseData;
 import org.apache.kafka.common.message.AlterClientQuotasResponseData.EntityData;
 import org.apache.kafka.common.message.AlterClientQuotasResponseData.EntryData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -97,8 +96,8 @@ public class AlterClientQuotasResponse extends AbstractResponse {
         return entityData;
     }
 
-    public static AlterClientQuotasResponse parse(ByteBuffer buffer, short version) {
-        return new AlterClientQuotasResponse(new AlterClientQuotasResponseData(new ByteBufferAccessor(buffer), version));
+    public static AlterClientQuotasResponse parse(Readable readable, short version) {
+        return new AlterClientQuotasResponse(new AlterClientQuotasResponseData(readable, version));
     }
 
     public static AlterClientQuotasResponse fromQuotaEntities(Map<ClientQuotaEntity, ApiError> result, int throttleTimeMs) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsResponse.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.AlterConfigsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -65,8 +64,8 @@ public class AlterConfigsResponse extends AbstractResponse {
         return data;
     }
 
-    public static AlterConfigsResponse parse(ByteBuffer buffer, short version) {
-        return new AlterConfigsResponse(new AlterConfigsResponseData(new ByteBufferAccessor(buffer), version));
+    public static AlterConfigsResponse parse(Readable readable, short version) {
+        return new AlterConfigsResponse(new AlterConfigsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -35,9 +34,9 @@ public class AlterPartitionReassignmentsResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public static AlterPartitionReassignmentsResponse parse(ByteBuffer buffer, short version) {
+    public static AlterPartitionReassignmentsResponse parse(Readable readable, short version) {
         return new AlterPartitionReassignmentsResponse(
-            new AlterPartitionReassignmentsResponseData(new ByteBufferAccessor(buffer), version));
+            new AlterPartitionReassignmentsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterPartitionResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -60,7 +59,7 @@ public class AlterPartitionResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static AlterPartitionResponse parse(ByteBuffer buffer, short version) {
-        return new AlterPartitionResponse(new AlterPartitionResponseData(new ByteBufferAccessor(buffer), version));
+    public static AlterPartitionResponse parse(Readable readable, short version) {
+        return new AlterPartitionResponse(new AlterPartitionResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaLogDirsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -67,8 +66,8 @@ public class AlterReplicaLogDirsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static AlterReplicaLogDirsResponse parse(ByteBuffer buffer, short version) {
-        return new AlterReplicaLogDirsResponse(new AlterReplicaLogDirsResponseData(new ByteBufferAccessor(buffer), version));
+    public static AlterReplicaLogDirsResponse parse(Readable readable, short version) {
+        return new AlterReplicaLogDirsResponse(new AlterReplicaLogDirsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterShareGroupOffsetsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -59,9 +58,9 @@ public class AlterShareGroupOffsetsResponse extends AbstractResponse {
         return data;
     }
 
-    public static AlterShareGroupOffsetsResponse parse(ByteBuffer buffer, short version) {
+    public static AlterShareGroupOffsetsResponse parse(Readable readable, short version) {
         return new AlterShareGroupOffsetsResponse(
-            new AlterShareGroupOffsetsResponseData(new ByteBufferAccessor(buffer), version)
+            new AlterShareGroupOffsetsResponseData(readable, version)
         );
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterUserScramCredentialsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterUserScramCredentialsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class AlterUserScramCredentialsResponse extends AbstractResponse {
@@ -58,7 +57,7 @@ public class AlterUserScramCredentialsResponse extends AbstractResponse {
         return errorCounts(data.results().stream().map(r -> Errors.forCode(r.errorCode())));
     }
 
-    public static AlterUserScramCredentialsResponse parse(ByteBuffer buffer, short version) {
-        return new AlterUserScramCredentialsResponse(new AlterUserScramCredentialsResponseData(new ByteBufferAccessor(buffer), version));
+    public static AlterUserScramCredentialsResponse parse(Readable readable, short version) {
+        return new AlterUserScramCredentialsResponse(new AlterUserScramCredentialsResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -29,8 +29,8 @@ import org.apache.kafka.common.message.ApiVersionsResponseData.FinalizedFeatureK
 import org.apache.kafka.common.message.ApiVersionsResponseData.SupportedFeatureKey;
 import org.apache.kafka.common.message.ApiVersionsResponseData.SupportedFeatureKeyCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import java.util.Map;
 import java.util.Objects;
@@ -151,19 +151,18 @@ public class ApiVersionsResponse extends AbstractResponse {
         return data.zkMigrationReady();
     }
 
-    public static ApiVersionsResponse parse(ByteBufferAccessor readable, short version) {
+    public static ApiVersionsResponse parse(Readable readable, short version) {
         // Fallback to version 0 for ApiVersions response. If a client sends an ApiVersionsRequest
         // using a version higher than that supported by the broker, a version 0 response is sent
         // to the client indicating UNSUPPORTED_VERSION. When the client receives the response, it
         // falls back while parsing it which means that the version received by this
         // method is not necessarily the real one. It may be version 0 as well.
-        int prev = readable.buffer().position();
+        Readable redableCopy = readable.slice();
         try {
             return new ApiVersionsResponse(new ApiVersionsResponseData(readable, version));
         } catch (RuntimeException e) {
-            readable.buffer().position(prev);
             if (version != 0)
-                return new ApiVersionsResponse(new ApiVersionsResponseData(readable, (short) 0));
+                return new ApiVersionsResponse(new ApiVersionsResponseData(redableCopy, (short) 0));
             else
                 throw e;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -157,12 +157,12 @@ public class ApiVersionsResponse extends AbstractResponse {
         // to the client indicating UNSUPPORTED_VERSION. When the client receives the response, it
         // falls back while parsing it which means that the version received by this
         // method is not necessarily the real one. It may be version 0 as well.
-        Readable redableCopy = readable.slice();
+        Readable readableCopy = readable.slice();
         try {
             return new ApiVersionsResponse(new ApiVersionsResponseData(readable, version));
         } catch (RuntimeException e) {
             if (version != 0)
-                return new ApiVersionsResponse(new ApiVersionsResponseData(redableCopy, (short) 0));
+                return new ApiVersionsResponse(new ApiVersionsResponseData(readableCopy, (short) 0));
             else
                 throw e;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -152,19 +151,19 @@ public class ApiVersionsResponse extends AbstractResponse {
         return data.zkMigrationReady();
     }
 
-    public static ApiVersionsResponse parse(ByteBuffer buffer, short version) {
+    public static ApiVersionsResponse parse(ByteBufferAccessor readable, short version) {
         // Fallback to version 0 for ApiVersions response. If a client sends an ApiVersionsRequest
         // using a version higher than that supported by the broker, a version 0 response is sent
         // to the client indicating UNSUPPORTED_VERSION. When the client receives the response, it
         // falls back while parsing it which means that the version received by this
         // method is not necessarily the real one. It may be version 0 as well.
-        int prev = buffer.position();
+        int prev = readable.buffer().position();
         try {
-            return new ApiVersionsResponse(new ApiVersionsResponseData(new ByteBufferAccessor(buffer), version));
+            return new ApiVersionsResponse(new ApiVersionsResponseData(readable, version));
         } catch (RuntimeException e) {
-            buffer.position(prev);
+            readable.buffer().position(prev);
             if (version != 0)
-                return new ApiVersionsResponse(new ApiVersionsResponseData(new ByteBufferAccessor(buffer), (short) 0));
+                return new ApiVersionsResponse(new ApiVersionsResponseData(readable, (short) 0));
             else
                 throw e;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -54,8 +53,8 @@ public class AssignReplicasToDirsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static AssignReplicasToDirsResponse parse(ByteBuffer buffer, short version) {
+    public static AssignReplicasToDirsResponse parse(Readable readable, short version) {
         return new AssignReplicasToDirsResponse(new AssignReplicasToDirsResponseData(
-                new ByteBufferAccessor(buffer), version));
+                readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -77,8 +76,8 @@ public class BeginQuorumEpochResponse extends AbstractResponse {
         // Not supported by the response schema
     }
 
-    public static BeginQuorumEpochResponse parse(ByteBuffer buffer, short version) {
-        return new BeginQuorumEpochResponse(new BeginQuorumEpochResponseData(new ByteBufferAccessor(buffer), version));
+    public static BeginQuorumEpochResponse parse(Readable readable, short version) {
+        return new BeginQuorumEpochResponse(new BeginQuorumEpochResponseData(readable, version));
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerHeartbeatResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.BrokerHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -56,8 +55,8 @@ public class BrokerHeartbeatResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static BrokerHeartbeatResponse parse(ByteBuffer buffer, short version) {
-        return new BrokerHeartbeatResponse(new BrokerHeartbeatResponseData(new ByteBufferAccessor(buffer), version));
+    public static BrokerHeartbeatResponse parse(Readable readable, short version) {
+        return new BrokerHeartbeatResponse(new BrokerHeartbeatResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.BrokerRegistrationResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -56,8 +55,8 @@ public class BrokerRegistrationResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static BrokerRegistrationResponse parse(ByteBuffer buffer, short version) {
-        return new BrokerRegistrationResponse(new BrokerRegistrationResponseData(new ByteBufferAccessor(buffer), version));
+    public static BrokerRegistrationResponse parse(Readable readable, short version) {
+        return new BrokerRegistrationResponse(new BrokerRegistrationResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -70,9 +69,9 @@ public class ConsumerGroupDescribeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static ConsumerGroupDescribeResponse parse(ByteBuffer buffer, short version) {
+    public static ConsumerGroupDescribeResponse parse(Readable readable, short version) {
         return new ConsumerGroupDescribeResponse(
-            new ConsumerGroupDescribeResponseData(new ByteBufferAccessor(buffer), version)
+            new ConsumerGroupDescribeResponseData(readable, version)
         );
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -69,8 +68,8 @@ public class ConsumerGroupHeartbeatResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static ConsumerGroupHeartbeatResponse parse(ByteBuffer buffer, short version) {
+    public static ConsumerGroupHeartbeatResponse parse(Readable readable, short version) {
         return new ConsumerGroupHeartbeatResponse(new ConsumerGroupHeartbeatResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ControllerRegistrationResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -54,8 +53,8 @@ public class ControllerRegistrationResponse extends AbstractResponse {
         return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
     }
 
-    public static ControllerRegistrationResponse parse(ByteBuffer buffer, short version) {
+    public static ControllerRegistrationResponse parse(Readable readable, short version) {
         return new ControllerRegistrationResponse(
-                new ControllerRegistrationResponseData(new ByteBufferAccessor(buffer), version));
+                new ControllerRegistrationResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateAclsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -57,8 +56,8 @@ public class CreateAclsResponse extends AbstractResponse {
         return errorCounts(results().stream().map(r -> Errors.forCode(r.errorCode())));
     }
 
-    public static CreateAclsResponse parse(ByteBuffer buffer, short version) {
-        return new CreateAclsResponse(new CreateAclsResponseData(new ByteBufferAccessor(buffer), version));
+    public static CreateAclsResponse parse(Readable readable, short version) {
+        return new CreateAclsResponse(new CreateAclsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenResponse.java
@@ -18,8 +18,8 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import java.nio.ByteBuffer;
@@ -34,9 +34,9 @@ public class CreateDelegationTokenResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public static CreateDelegationTokenResponse parse(ByteBuffer buffer, short version) {
+    public static CreateDelegationTokenResponse parse(Readable readable, short version) {
         return new CreateDelegationTokenResponse(
-            new CreateDelegationTokenResponseData(new ByteBufferAccessor(buffer), version));
+            new CreateDelegationTokenResponseData(readable, version));
     }
 
     public static CreateDelegationTokenResponse prepareResponse(int version,

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreatePartitionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -49,8 +48,8 @@ public class CreatePartitionsResponse extends AbstractResponse {
         return counts;
     }
 
-    public static CreatePartitionsResponse parse(ByteBuffer buffer, short version) {
-        return new CreatePartitionsResponse(new CreatePartitionsResponseData(new ByteBufferAccessor(buffer), version));
+    public static CreatePartitionsResponse parse(Readable readable, short version) {
+        return new CreatePartitionsResponse(new CreatePartitionsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -74,8 +73,8 @@ public class CreateTopicsResponse extends AbstractResponse {
         return counts;
     }
 
-    public static CreateTopicsResponse parse(ByteBuffer buffer, short version) {
-        return new CreateTopicsResponse(new CreateTopicsResponseData(new ByteBufferAccessor(buffer), version));
+    public static CreateTopicsResponse parse(Readable readable, short version) {
+        return new CreateTopicsResponse(new CreateTopicsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsResponse.java
@@ -25,8 +25,8 @@ import org.apache.kafka.common.message.DeleteAclsResponseData;
 import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsFilterResult;
 import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsMatchingAcl;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
@@ -35,7 +35,6 @@ import org.apache.kafka.server.authorizer.AclDeleteResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -75,8 +74,8 @@ public class DeleteAclsResponse extends AbstractResponse {
         return errorCounts(filterResults().stream().map(r -> Errors.forCode(r.errorCode())));
     }
 
-    public static DeleteAclsResponse parse(ByteBuffer buffer, short version) {
-        return new DeleteAclsResponse(new DeleteAclsResponseData(new ByteBufferAccessor(buffer), version), version);
+    public static DeleteAclsResponse parse(Readable readable, short version) {
+        return new DeleteAclsResponse(new DeleteAclsResponseData(readable, version), version);
     }
 
     public String toString() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,8 +76,8 @@ public class DeleteGroupsResponse extends AbstractResponse {
         return counts;
     }
 
-    public static DeleteGroupsResponse parse(ByteBuffer buffer, short version) {
-        return new DeleteGroupsResponse(new DeleteGroupsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DeleteGroupsResponse parse(Readable readable, short version) {
+        return new DeleteGroupsResponse(new DeleteGroupsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DeleteRecordsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -72,8 +71,8 @@ public class DeleteRecordsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DeleteRecordsResponse parse(ByteBuffer buffer, short version) {
-        return new DeleteRecordsResponse(new DeleteRecordsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DeleteRecordsResponse parse(Readable readable, short version) {
+        return new DeleteRecordsResponse(new DeleteRecordsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -61,9 +60,9 @@ public class DeleteShareGroupOffsetsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static DeleteShareGroupOffsetsResponse parse(ByteBuffer buffer, short version) {
+    public static DeleteShareGroupOffsetsResponse parse(Readable readable, short version) {
         return new DeleteShareGroupOffsetsResponse(
-            new DeleteShareGroupOffsetsResponseData(new ByteBufferAccessor(buffer), version)
+            new DeleteShareGroupOffsetsResponseData(readable, version)
         );
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupStateResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.DeleteShareGroupStateRequestData;
 import org.apache.kafka.common.message.DeleteShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,9 +64,9 @@ public class DeleteShareGroupStateResponse extends AbstractResponse {
         // No op
     }
 
-    public static DeleteShareGroupStateResponse parse(ByteBuffer buffer, short version) {
+    public static DeleteShareGroupStateResponse parse(Readable readable, short version) {
         return new DeleteShareGroupStateResponse(
-                new DeleteShareGroupStateResponseData(new ByteBufferAccessor(buffer), version)
+                new DeleteShareGroupStateResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DeleteTopicsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -69,8 +68,8 @@ public class DeleteTopicsResponse extends AbstractResponse {
         return counts;
     }
 
-    public static DeleteTopicsResponse parse(ByteBuffer buffer, short version) {
-        return new DeleteTopicsResponse(new DeleteTopicsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DeleteTopicsResponse parse(Readable readable, short version) {
+        return new DeleteTopicsResponse(new DeleteTopicsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
@@ -26,13 +26,12 @@ import org.apache.kafka.common.message.DescribeAclsResponseData;
 import org.apache.kafka.common.message.DescribeAclsResponseData.AclDescription;
 import org.apache.kafka.common.message.DescribeAclsResponseData.DescribeAclsResource;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,8 +88,8 @@ public class DescribeAclsResponse extends AbstractResponse {
         return data.resources();
     }
 
-    public static DescribeAclsResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeAclsResponse(new DescribeAclsResponseData(new ByteBufferAccessor(buffer), version), version);
+    public static DescribeAclsResponse parse(Readable readable, short version) {
+        return new DescribeAclsResponse(new DescribeAclsResponseData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasResponse.java
@@ -22,11 +22,10 @@ import org.apache.kafka.common.message.DescribeClientQuotasResponseData.EntityDa
 import org.apache.kafka.common.message.DescribeClientQuotasResponseData.EntryData;
 import org.apache.kafka.common.message.DescribeClientQuotasResponseData.ValueData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,8 +84,8 @@ public class DescribeClientQuotasResponse extends AbstractResponse {
         return errorCounts(Errors.forCode(data.errorCode()));
     }
 
-    public static DescribeClientQuotasResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeClientQuotasResponse(new DescribeClientQuotasResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeClientQuotasResponse parse(Readable readable, short version) {
+        return new DescribeClientQuotasResponse(new DescribeClientQuotasResponseData(readable, version));
     }
 
     public static DescribeClientQuotasResponse fromQuotaEntities(Map<ClientQuotaEntity, Map<String, Double>> entities,

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClusterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClusterResponse.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.message.DescribeClusterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -63,7 +62,7 @@ public class DescribeClusterResponse extends AbstractResponse {
         return data;
     }
 
-    public static DescribeClusterResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeClusterResponse(new DescribeClusterResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeClusterResponse parse(Readable readable, short version) {
+        return new DescribeClusterResponse(new DescribeClusterResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.DescribeConfigsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
@@ -248,8 +247,8 @@ public class DescribeConfigsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DescribeConfigsResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeConfigsResponse(new DescribeConfigsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeConfigsResponse parse(Readable readable, short version) {
+        return new DescribeConfigsResponse(new DescribeConfigsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeDelegationTokenResponse.java
@@ -20,13 +20,12 @@ import org.apache.kafka.common.message.DescribeDelegationTokenResponseData;
 import org.apache.kafka.common.message.DescribeDelegationTokenResponseData.DescribedDelegationToken;
 import org.apache.kafka.common.message.DescribeDelegationTokenResponseData.DescribedDelegationTokenRenewer;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -76,9 +75,9 @@ public class DescribeDelegationTokenResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public static DescribeDelegationTokenResponse parse(ByteBuffer buffer, short version) {
+    public static DescribeDelegationTokenResponse parse(Readable readable, short version) {
         return new DescribeDelegationTokenResponse(new DescribeDelegationTokenResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
@@ -20,11 +20,10 @@ import org.apache.kafka.common.message.DescribeGroupsResponseData;
 import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroup;
 import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroupMember;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.utils.Utils;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -145,8 +144,8 @@ public class DescribeGroupsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DescribeGroupsResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeGroupsResponse(new DescribeGroupsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeGroupsResponse parse(Readable readable, short version) {
+        return new DescribeGroupsResponse(new DescribeGroupsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -64,8 +63,8 @@ public class DescribeLogDirsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DescribeLogDirsResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeLogDirsResponse(new DescribeLogDirsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeLogDirsResponse parse(Readable readable, short version) {
+        return new DescribeLogDirsResponse(new DescribeLogDirsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersResponse.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.message.DescribeProducersResponseData;
 import org.apache.kafka.common.message.DescribeProducersResponseData.PartitionResponse;
 import org.apache.kafka.common.message.DescribeProducersResponseData.TopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,9 +50,9 @@ public class DescribeProducersResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DescribeProducersResponse parse(ByteBuffer buffer, short version) {
+    public static DescribeProducersResponse parse(Readable readable, short version) {
         return new DescribeProducersResponse(new DescribeProducersResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
@@ -106,7 +105,7 @@ public class DescribeQuorumResponse extends AbstractResponse {
         return res;
     }
 
-    public static DescribeQuorumResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeQuorumResponse(new DescribeQuorumResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeQuorumResponse parse(Readable readable, short version) {
+        return new DescribeQuorumResponse(new DescribeQuorumResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeShareGroupOffsetsResponse.java
@@ -20,10 +20,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeShareGroupOffsetsResponseData;
 import org.apache.kafka.common.message.DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseGroup;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -98,7 +97,7 @@ public class DescribeShareGroupOffsetsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static DescribeShareGroupOffsetsResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeShareGroupOffsetsResponse(new DescribeShareGroupOffsetsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeShareGroupOffsetsResponse parse(Readable readable, short version) {
+        return new DescribeShareGroupOffsetsResponse(new DescribeShareGroupOffsetsResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -79,9 +78,9 @@ public class DescribeTopicPartitionsResponse extends AbstractResponse {
         return new DescribeTopicPartitionsResponse(responseData);
     }
 
-    public static DescribeTopicPartitionsResponse parse(ByteBuffer buffer, short version) {
+    public static DescribeTopicPartitionsResponse parse(Readable readable, short version) {
         return new DescribeTopicPartitionsResponse(
-            new DescribeTopicPartitionsResponseData(new ByteBufferAccessor(buffer), version));
+            new DescribeTopicPartitionsResponseData(readable, version));
     }
 
     public static TopicPartitionInfo partitionToTopicPartitionInfo(

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTransactionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTransactionsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DescribeTransactionsResponseData;
 import org.apache.kafka.common.message.DescribeTransactionsResponseData.TransactionState;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -49,9 +48,9 @@ public class DescribeTransactionsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DescribeTransactionsResponse parse(ByteBuffer buffer, short version) {
+    public static DescribeTransactionsResponse parse(Readable readable, short version) {
         return new DescribeTransactionsResponse(new DescribeTransactionsResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeUserScramCredentialsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeUserScramCredentialsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class DescribeUserScramCredentialsResponse extends AbstractResponse {
@@ -58,7 +57,7 @@ public class DescribeUserScramCredentialsResponse extends AbstractResponse {
         return errorCounts(data.results().stream().map(r -> Errors.forCode(r.errorCode())));
     }
 
-    public static DescribeUserScramCredentialsResponse parse(ByteBuffer buffer, short version) {
-        return new DescribeUserScramCredentialsResponse(new DescribeUserScramCredentialsResponseData(new ByteBufferAccessor(buffer), version));
+    public static DescribeUserScramCredentialsResponse parse(Readable readable, short version) {
+        return new DescribeUserScramCredentialsResponse(new DescribeUserScramCredentialsResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ElectLeadersResponseData.ReplicaElectionResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -80,8 +79,8 @@ public class ElectLeadersResponse extends AbstractResponse {
         return counts;
     }
 
-    public static ElectLeadersResponse parse(ByteBuffer buffer, short version) {
-        return new ElectLeadersResponse(new ElectLeadersResponseData(new ByteBufferAccessor(buffer), version));
+    public static ElectLeadersResponse parse(Readable readable, short version) {
+        return new ElectLeadersResponse(new ElectLeadersResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -76,7 +75,7 @@ public class EndQuorumEpochResponse extends AbstractResponse {
         // Not supported by the response schema
     }
 
-    public static EndQuorumEpochResponse parse(ByteBuffer buffer, short version) {
-        return new EndQuorumEpochResponse(new EndQuorumEpochResponseData(new ByteBufferAccessor(buffer), version));
+    public static EndQuorumEpochResponse parse(Readable readable, short version) {
+        return new EndQuorumEpochResponse(new EndQuorumEpochResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndTxnResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.EndTxnResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -69,8 +68,8 @@ public class EndTxnResponse extends AbstractResponse {
         return data;
     }
 
-    public static EndTxnResponse parse(ByteBuffer buffer, short version) {
-        return new EndTxnResponse(new EndTxnResponseData(new ByteBufferAccessor(buffer), version));
+    public static EndTxnResponse parse(Readable readable, short version) {
+        return new EndTxnResponse(new EndTxnResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/EnvelopeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EnvelopeResponse.java
@@ -18,8 +18,8 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.EnvelopeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -72,8 +72,8 @@ public class EnvelopeResponse extends AbstractResponse {
         // Not supported by the response schema
     }
 
-    public static EnvelopeResponse parse(ByteBuffer buffer, short version) {
-        return new EnvelopeResponse(new EnvelopeResponseData(new ByteBufferAccessor(buffer), version));
+    public static EnvelopeResponse parse(Readable readable, short version) {
+        return new EnvelopeResponse(new EnvelopeResponseData(readable, version));
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class ExpireDelegationTokenResponse extends AbstractResponse {
@@ -33,8 +32,8 @@ public class ExpireDelegationTokenResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public static ExpireDelegationTokenResponse parse(ByteBuffer buffer, short version) {
-        return new ExpireDelegationTokenResponse(new ExpireDelegationTokenResponseData(new ByteBufferAccessor(buffer),
+    public static ExpireDelegationTokenResponse parse(Readable readable, short version) {
+        return new ExpireDelegationTokenResponse(new ExpireDelegationTokenResponseData(readable,
             version));
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -22,13 +22,12 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -145,8 +144,8 @@ public class FetchResponse extends AbstractResponse {
      *
      * <p><strong>This method should only be used in client-side.</strong></p>
      */
-    public static FetchResponse parse(ByteBuffer buffer, short version) {
-        return new FetchResponse(new FetchResponseData(new ByteBufferAccessor(buffer), version));
+    public static FetchResponse parse(Readable readable, short version) {
+        return new FetchResponse(new FetchResponseData(readable, version));
     }
 
     // Fetch versions 13 and above should have topic IDs for all topics.

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
@@ -99,7 +98,7 @@ public final class FetchSnapshotResponse extends AbstractResponse {
             .findAny();
     }
 
-    public static FetchSnapshotResponse parse(ByteBuffer buffer, short version) {
-        return new FetchSnapshotResponse(new FetchSnapshotResponseData(new ByteBufferAccessor(buffer), version));
+    public static FetchSnapshotResponse parse(Readable readable, short version) {
+        return new FetchSnapshotResponse(new FetchSnapshotResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData.Coordinator;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -108,8 +107,8 @@ public class FindCoordinatorResponse extends AbstractResponse {
         }
     }
 
-    public static FindCoordinatorResponse parse(ByteBuffer buffer, short version) {
-        return new FindCoordinatorResponse(new FindCoordinatorResponseData(new ByteBufferAccessor(buffer), version));
+    public static FindCoordinatorResponse parse(Readable readable, short version) {
+        return new FindCoordinatorResponse(new FindCoordinatorResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionsResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -65,8 +64,8 @@ public class GetTelemetrySubscriptionsResponse extends AbstractResponse {
         return Errors.forCode(data.errorCode());
     }
 
-    public static GetTelemetrySubscriptionsResponse parse(ByteBuffer buffer, short version) {
+    public static GetTelemetrySubscriptionsResponse parse(Readable readable, short version) {
         return new GetTelemetrySubscriptionsResponse(new GetTelemetrySubscriptionsResponseData(
-                new ByteBufferAccessor(buffer), version));
+                readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class HeartbeatResponse extends AbstractResponse {
@@ -67,8 +66,8 @@ public class HeartbeatResponse extends AbstractResponse {
         return data;
     }
 
-    public static HeartbeatResponse parse(ByteBuffer buffer, short version) {
-        return new HeartbeatResponse(new HeartbeatResponseData(new ByteBufferAccessor(buffer), version));
+    public static HeartbeatResponse parse(Readable readable, short version) {
+        return new HeartbeatResponse(new HeartbeatResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -96,8 +95,8 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static IncrementalAlterConfigsResponse parse(ByteBuffer buffer, short version) {
+    public static IncrementalAlterConfigsResponse parse(Readable readable, short version) {
         return new IncrementalAlterConfigsResponse(new IncrementalAlterConfigsResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.InitProducerIdResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -63,8 +62,8 @@ public class InitProducerIdResponse extends AbstractResponse {
         return data;
     }
 
-    public static InitProducerIdResponse parse(ByteBuffer buffer, short version) {
-        return new InitProducerIdResponse(new InitProducerIdResponseData(new ByteBufferAccessor(buffer), version));
+    public static InitProducerIdResponse parse(Readable readable, short version) {
+        return new InitProducerIdResponse(new InitProducerIdResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitializeShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitializeShareGroupStateResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.InitializeShareGroupStateRequestData;
 import org.apache.kafka.common.message.InitializeShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -64,9 +63,9 @@ public class InitializeShareGroupStateResponse extends AbstractResponse {
         // No op
     }
 
-    public static InitializeShareGroupStateResponse parse(ByteBuffer buffer, short version) {
+    public static InitializeShareGroupStateResponse parse(Readable readable, short version) {
         return new InitializeShareGroupStateResponse(
-            new InitializeShareGroupStateResponseData(new ByteBufferAccessor(buffer), version)
+            new InitializeShareGroupStateResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class JoinGroupResponse extends AbstractResponse {
@@ -73,8 +72,8 @@ public class JoinGroupResponse extends AbstractResponse {
         return errorCounts(Errors.forCode(data.errorCode()));
     }
 
-    public static JoinGroupResponse parse(ByteBuffer buffer, short version) {
-        return new JoinGroupResponse(new JoinGroupResponseData(new ByteBufferAccessor(buffer), version), version);
+    public static JoinGroupResponse parse(Readable readable, short version) {
+        return new JoinGroupResponse(new JoinGroupResponseData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupResponse.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -149,8 +148,8 @@ public class LeaveGroupResponse extends AbstractResponse {
         return data;
     }
 
-    public static LeaveGroupResponse parse(ByteBuffer buffer, short version) {
-        return new LeaveGroupResponse(new LeaveGroupResponseData(new ByteBufferAccessor(buffer), version));
+    public static LeaveGroupResponse parse(Readable readable, short version) {
+        return new LeaveGroupResponse(new LeaveGroupResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListClientMetricsResourcesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListClientMetricsResourcesResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.clients.admin.ClientMetricsResourceListing;
 import org.apache.kafka.common.message.ListClientMetricsResourcesResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,9 +47,9 @@ public class ListClientMetricsResourcesResponse extends AbstractResponse {
         return errorCounts(Errors.forCode(data.errorCode()));
     }
 
-    public static ListClientMetricsResourcesResponse parse(ByteBuffer buffer, short version) {
+    public static ListClientMetricsResourcesResponse parse(Readable readable, short version) {
         return new ListClientMetricsResourcesResponse(new ListClientMetricsResourcesResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class ListGroupsResponse extends AbstractResponse {
@@ -53,8 +52,8 @@ public class ListGroupsResponse extends AbstractResponse {
         return errorCounts(Errors.forCode(data.errorCode()));
     }
 
-    public static ListGroupsResponse parse(ByteBuffer buffer, short version) {
-        return new ListGroupsResponse(new ListGroupsResponseData(new ByteBufferAccessor(buffer), version));
+    public static ListGroupsResponse parse(Readable readable, short version) {
+        return new ListGroupsResponse(new ListGroupsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsResponse.java
@@ -21,11 +21,10 @@ import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.RecordBatch;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -89,8 +88,8 @@ public class ListOffsetsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static ListOffsetsResponse parse(ByteBuffer buffer, short version) {
-        return new ListOffsetsResponse(new ListOffsetsResponseData(new ByteBufferAccessor(buffer), version));
+    public static ListOffsetsResponse parse(Readable readable, short version) {
+        return new ListOffsetsResponse(new ListOffsetsResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class ListPartitionReassignmentsResponse extends AbstractResponse {
@@ -33,9 +32,9 @@ public class ListPartitionReassignmentsResponse extends AbstractResponse {
         this.data = responseData;
     }
 
-    public static ListPartitionReassignmentsResponse parse(ByteBuffer buffer, short version) {
+    public static ListPartitionReassignmentsResponse parse(Readable readable, short version) {
         return new ListPartitionReassignmentsResponse(new ListPartitionReassignmentsResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ListTransactionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -44,9 +43,9 @@ public class ListTransactionsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static ListTransactionsResponse parse(ByteBuffer buffer, short version) {
+    public static ListTransactionsResponse parse(Readable readable, short version) {
         return new ListTransactionsResponse(new ListTransactionsResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -26,10 +26,9 @@ import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBrok
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -281,8 +280,8 @@ public class MetadataResponse extends AbstractResponse {
         return version >= 9;
     }
 
-    public static MetadataResponse parse(ByteBuffer buffer, short version) {
-        return new MetadataResponse(new MetadataResponseData(new ByteBufferAccessor(buffer), version),
+    public static MetadataResponse parse(Readable readable, short version) {
+        return new MetadataResponse(new MetadataResponseData(readable, version),
             hasReliableLeaderEpochs(version));
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponsePartition;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -99,8 +98,8 @@ public class OffsetCommitResponse extends AbstractResponse {
                         Errors.forCode(partitionResult.errorCode()))));
     }
 
-    public static OffsetCommitResponse parse(ByteBuffer buffer, short version) {
-        return new OffsetCommitResponse(new OffsetCommitResponseData(new ByteBufferAccessor(buffer), version));
+    public static OffsetCommitResponse parse(Readable readable, short version) {
+        return new OffsetCommitResponse(new OffsetCommitResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponsePartition;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -150,8 +149,8 @@ public class OffsetDeleteResponse extends AbstractResponse {
         return counts;
     }
 
-    public static OffsetDeleteResponse parse(ByteBuffer buffer, short version) {
-        return new OffsetDeleteResponse(new OffsetDeleteResponseData(new ByteBufferAccessor(buffer), version));
+    public static OffsetDeleteResponse parse(Readable readable, short version) {
+        return new OffsetDeleteResponse(new OffsetDeleteResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -25,10 +25,9 @@ import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchRespon
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -391,8 +390,8 @@ public class OffsetFetchResponse extends AbstractResponse {
         return buildResponseData(groupId);
     }
 
-    public static OffsetFetchResponse parse(ByteBuffer buffer, short version) {
-        return new OffsetFetchResponse(new OffsetFetchResponseData(new ByteBufferAccessor(buffer), version), version);
+    public static OffsetFetchResponse parse(Readable readable, short version) {
+        return new OffsetFetchResponse(new OffsetFetchResponseData(readable, version), version);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -73,8 +72,8 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static OffsetsForLeaderEpochResponse parse(ByteBuffer buffer, short version) {
-        return new OffsetsForLeaderEpochResponse(new OffsetForLeaderEpochResponseData(new ByteBufferAccessor(buffer), version));
+    public static OffsetsForLeaderEpochResponse parse(Readable readable, short version) {
+        return new OffsetsForLeaderEpochResponse(new OffsetForLeaderEpochResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -21,11 +21,10 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ProduceResponseData.LeaderIdAndEpoch;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.RecordBatch;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -286,8 +285,8 @@ public class ProduceResponse extends AbstractResponse {
         }
     }
 
-    public static ProduceResponse parse(ByteBuffer buffer, short version) {
-        return new ProduceResponse(new ProduceResponseData(new ByteBufferAccessor(buffer), version));
+    public static ProduceResponse parse(Readable readable, short version) {
+        return new ProduceResponse(new ProduceResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.PushTelemetryResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -65,8 +64,8 @@ public class PushTelemetryResponse  extends AbstractResponse {
         return Errors.forCode(data.errorCode());
     }
 
-    public static PushTelemetryResponse parse(ByteBuffer buffer, short version) {
+    public static PushTelemetryResponse parse(Readable readable, short version) {
         return new PushTelemetryResponse(new PushTelemetryResponseData(
-                new ByteBufferAccessor(buffer), version));
+                readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -65,9 +64,9 @@ public class ReadShareGroupStateResponse extends AbstractResponse {
         // No op
     }
 
-    public static ReadShareGroupStateResponse parse(ByteBuffer buffer, short version) {
+    public static ReadShareGroupStateResponse parse(Readable readable, short version) {
         return new ReadShareGroupStateResponse(
-                new ReadShareGroupStateResponseData(new ByteBufferAccessor(buffer), version)
+                new ReadShareGroupStateResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateSummaryResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ReadShareGroupStateSummaryResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ReadShareGroupStateSummaryRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateSummaryResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -64,9 +63,9 @@ public class ReadShareGroupStateSummaryResponse extends AbstractResponse {
         // No op
     }
 
-    public static ReadShareGroupStateSummaryResponse parse(ByteBuffer buffer, short version) {
+    public static ReadShareGroupStateSummaryResponse parse(Readable readable, short version) {
         return new ReadShareGroupStateSummaryResponse(
-            new ReadShareGroupStateSummaryResponseData(new ByteBufferAccessor(buffer), version)
+            new ReadShareGroupStateSummaryResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -58,8 +57,8 @@ public class RemoveRaftVoterResponse extends AbstractResponse {
         }
     }
 
-    public static RemoveRaftVoterResponse parse(ByteBuffer buffer, short version) {
+    public static RemoveRaftVoterResponse parse(Readable readable, short version) {
         return new RemoveRaftVoterResponse(
-            new RemoveRaftVoterResponseData(new ByteBufferAccessor(buffer), version));
+            new RemoveRaftVoterResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class RenewDelegationTokenResponse extends AbstractResponse {
@@ -33,9 +32,9 @@ public class RenewDelegationTokenResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public static RenewDelegationTokenResponse parse(ByteBuffer buffer, short version) {
+    public static RenewDelegationTokenResponse parse(Readable readable, short version) {
         return new RenewDelegationTokenResponse(new RenewDelegationTokenResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -77,7 +76,7 @@ public class SaslAuthenticateResponse extends AbstractResponse {
         return data;
     }
 
-    public static SaslAuthenticateResponse parse(ByteBuffer buffer, short version) {
-        return new SaslAuthenticateResponse(new SaslAuthenticateResponseData(new ByteBufferAccessor(buffer), version));
+    public static SaslAuthenticateResponse parse(Readable readable, short version) {
+        return new SaslAuthenticateResponse(new SaslAuthenticateResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +70,7 @@ public class SaslHandshakeResponse extends AbstractResponse {
         return data.mechanisms();
     }
 
-    public static SaslHandshakeResponse parse(ByteBuffer buffer, short version) {
-        return new SaslHandshakeResponse(new SaslHandshakeResponseData(new ByteBufferAccessor(buffer), version));
+    public static SaslHandshakeResponse parse(Readable readable, short version) {
+        return new SaslHandshakeResponse(new SaslHandshakeResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.Iterator;
@@ -84,9 +83,9 @@ public class ShareAcknowledgeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static ShareAcknowledgeResponse parse(ByteBuffer buffer, short version) {
+    public static ShareAcknowledgeResponse parse(Readable readable, short version) {
         return new ShareAcknowledgeResponse(
-                new ShareAcknowledgeResponseData(new ByteBufferAccessor(buffer), version)
+                new ShareAcknowledgeResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
@@ -22,13 +22,12 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -110,9 +109,9 @@ public class ShareFetchResponse extends AbstractResponse {
      *
      * <p><strong>This method should only be used in client-side.</strong></p>
      */
-    public static ShareFetchResponse parse(ByteBuffer buffer, short version) {
+    public static ShareFetchResponse parse(Readable readable, short version) {
         return new ShareFetchResponse(
-                new ShareFetchResponseData(new ByteBufferAccessor(buffer), version)
+                new ShareFetchResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ShareGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -70,9 +69,9 @@ public class ShareGroupDescribeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static ShareGroupDescribeResponse parse(ByteBuffer buffer, short version) {
+    public static ShareGroupDescribeResponse parse(Readable readable, short version) {
         return new ShareGroupDescribeResponse(
-                new ShareGroupDescribeResponseData(new ByteBufferAccessor(buffer), version)
+                new ShareGroupDescribeResponseData(readable, version)
         );
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -65,8 +64,8 @@ public class ShareGroupHeartbeatResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static ShareGroupHeartbeatResponse parse(ByteBuffer buffer, short version) {
+    public static ShareGroupHeartbeatResponse parse(Readable readable, short version) {
         return new ShareGroupHeartbeatResponse(new ShareGroupHeartbeatResponseData(
-                new ByteBufferAccessor(buffer), version));
+                readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -70,9 +69,9 @@ public class StreamsGroupDescribeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static StreamsGroupDescribeResponse parse(ByteBuffer buffer, short version) {
+    public static StreamsGroupDescribeResponse parse(Readable readable, short version) {
         return new StreamsGroupDescribeResponse(
-            new StreamsGroupDescribeResponseData(new ByteBufferAccessor(buffer), version)
+            new StreamsGroupDescribeResponseData(readable, version)
         );
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -72,9 +71,9 @@ public class StreamsGroupHeartbeatResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    public static StreamsGroupHeartbeatResponse parse(ByteBuffer buffer, short version) {
+    public static StreamsGroupHeartbeatResponse parse(Readable readable, short version) {
         return new StreamsGroupHeartbeatResponse(new StreamsGroupHeartbeatResponseData(
-            new ByteBufferAccessor(buffer), version));
+            readable, version));
     }
 
     public enum Status {

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
@@ -18,10 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class SyncGroupResponse extends AbstractResponse {
@@ -62,8 +61,8 @@ public class SyncGroupResponse extends AbstractResponse {
         return data.toString();
     }
 
-    public static SyncGroupResponse parse(ByteBuffer buffer, short version) {
-        return new SyncGroupResponse(new SyncGroupResponseData(new ByteBufferAccessor(buffer), version));
+    public static SyncGroupResponse parse(Readable readable, short version) {
+        return new SyncGroupResponse(new SyncGroupResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData.TxnOffsetCommitResponsePartition;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData.TxnOffsetCommitResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -191,8 +190,8 @@ public class TxnOffsetCommitResponse extends AbstractResponse {
         return errorMap;
     }
 
-    public static TxnOffsetCommitResponse parse(ByteBuffer buffer, short version) {
-        return new TxnOffsetCommitResponse(new TxnOffsetCommitResponseData(new ByteBufferAccessor(buffer), version));
+    public static TxnOffsetCommitResponse parse(Readable readable, short version) {
+        return new TxnOffsetCommitResponse(new TxnOffsetCommitResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/UnregisterBrokerResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UnregisterBrokerResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.UnregisterBrokerResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -58,8 +57,8 @@ public class UnregisterBrokerResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static UnregisterBrokerResponse parse(ByteBuffer buffer, short version) {
-        return new UnregisterBrokerResponse(new UnregisterBrokerResponseData(new ByteBufferAccessor(buffer), version));
+    public static UnregisterBrokerResponse parse(Readable readable, short version) {
+        return new UnregisterBrokerResponse(new UnregisterBrokerResponseData(readable, version));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesResponse.java
@@ -20,10 +20,9 @@ import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData.UpdatableFeatureResult;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData.UpdatableFeatureResultCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
@@ -79,8 +78,8 @@ public class UpdateFeaturesResponse extends AbstractResponse {
         return data;
     }
 
-    public static UpdateFeaturesResponse parse(ByteBuffer buffer, short version) {
-        return new UpdateFeaturesResponse(new UpdateFeaturesResponseData(new ByteBufferAccessor(buffer), version));
+    public static UpdateFeaturesResponse parse(Readable readable, short version) {
+        return new UpdateFeaturesResponse(new UpdateFeaturesResponseData(readable, version));
     }
 
     public static UpdateFeaturesResponse createWithErrors(ApiError topLevelError, Set<String> updates, int throttleTimeMs) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.UpdateRaftVoterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -58,8 +57,8 @@ public class UpdateRaftVoterResponse extends AbstractResponse {
         }
     }
 
-    public static UpdateRaftVoterResponse parse(ByteBuffer buffer, short version) {
+    public static UpdateRaftVoterResponse parse(Readable readable, short version) {
         return new UpdateRaftVoterResponse(
-            new UpdateRaftVoterResponseData(new ByteBufferAccessor(buffer), version));
+            new UpdateRaftVoterResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteResponse.java
@@ -19,10 +19,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -76,7 +75,7 @@ public class VoteResponse extends AbstractResponse {
         // Not supported by the response schema
     }
 
-    public static VoteResponse parse(ByteBuffer buffer, short version) {
-        return new VoteResponse(new VoteResponseData(new ByteBufferAccessor(buffer), version));
+    public static VoteResponse parse(Readable readable, short version) {
+        return new VoteResponse(new VoteResponseData(readable, version));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteShareGroupStateResponse.java
@@ -21,10 +21,9 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.WriteShareGroupStateRequestData;
 import org.apache.kafka.common.message.WriteShareGroupStateResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,9 +64,9 @@ public class WriteShareGroupStateResponse extends AbstractResponse {
         // No op
     }
 
-    public static WriteShareGroupStateResponse parse(ByteBuffer buffer, short version) {
+    public static WriteShareGroupStateResponse parse(Readable readable, short version) {
         return new WriteShareGroupStateResponse(
-                new WriteShareGroupStateResponseData(new ByteBufferAccessor(buffer), version)
+                new WriteShareGroupStateResponseData(readable, version)
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersResponse.java
@@ -22,10 +22,9 @@ import org.apache.kafka.common.message.WriteTxnMarkersResponseData.WritableTxnMa
 import org.apache.kafka.common.message.WriteTxnMarkersResponseData.WritableTxnMarkerResult;
 import org.apache.kafka.common.message.WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -126,7 +125,7 @@ public class WriteTxnMarkersResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static WriteTxnMarkersResponse parse(ByteBuffer buffer, short version) {
-        return new WriteTxnMarkersResponse(new WriteTxnMarkersResponseData(new ByteBufferAccessor(buffer), version));
+    public static WriteTxnMarkersResponse parse(Readable readable, short version) {
+        return new WriteTxnMarkersResponse(new WriteTxnMarkersResponseData(readable, version));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopi
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
@@ -43,7 +44,6 @@ import org.apache.kafka.test.MockClusterResourceListener;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -209,8 +209,8 @@ public class MetadataTest {
                 .setBrokers(new MetadataResponseBrokerCollection());
 
         for (short version = ApiKeys.METADATA.oldestVersion(); version < 9; version++) {
-            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
-            MetadataResponse response = MetadataResponse.parse(buffer, version);
+            Readable readable = MessageUtil.toByteBufferAccessor(data, version);
+            MetadataResponse response = MetadataResponse.parse(readable, version);
             assertFalse(response.hasReliableLeaderEpochs());
             metadata.updateWithCurrentRequestVersion(response, false, 100);
             assertTrue(metadata.partitionMetadataIfCurrent(tp).isPresent());
@@ -219,8 +219,8 @@ public class MetadataTest {
         }
 
         for (short version = 9; version <= ApiKeys.METADATA.latestVersion(); version++) {
-            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
-            MetadataResponse response = MetadataResponse.parse(buffer, version);
+            Readable readable = MessageUtil.toByteBufferAccessor(data, version);
+            MetadataResponse response = MetadataResponse.parse(readable, version);
             assertTrue(response.hasReliableLeaderEpochs());
             metadata.updateWithCurrentRequestVersion(response, false, 100);
             assertTrue(metadata.partitionMetadataIfCurrent(tp).isPresent());

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsResponseTest.java
@@ -22,12 +22,11 @@ import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.DeleteAclsResponseData;
 import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsFilterResult;
 import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsMatchingAcl;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourceType;
 
 import org.junit.jupiter.api.Test;
-
-import java.nio.ByteBuffer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -98,9 +97,9 @@ public class DeleteAclsResponseTest {
                 .setThrottleTimeMs(10)
                 .setFilterResults(asList(LITERAL_RESPONSE, PREFIXED_RESPONSE)),
             V1);
-        final ByteBuffer buffer = original.serialize(V1);
+        final Readable readable = original.serialize(V1);
 
-        final DeleteAclsResponse result = DeleteAclsResponse.parse(buffer, V1);
+        final DeleteAclsResponse result = DeleteAclsResponse.parse(readable, V1);
         assertEquals(original.filterResults(), result.filterResults());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsResponseTest.java
@@ -25,13 +25,13 @@ import org.apache.kafka.common.message.DescribeAclsResponseData;
 import org.apache.kafka.common.message.DescribeAclsResponseData.AclDescription;
 import org.apache.kafka.common.message.DescribeAclsResponseData.DescribeAclsResource;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,9 +90,9 @@ public class DescribeAclsResponseTest {
     public void shouldRoundTripV1() {
         List<DescribeAclsResource> resources = Arrays.asList(LITERAL_ACL1, PREFIXED_ACL1);
         final DescribeAclsResponse original = buildResponse(100, Errors.NONE, resources);
-        final ByteBuffer buffer = original.serialize(V1);
+        final Readable readable = original.serialize(V1);
 
-        final DescribeAclsResponse result = DescribeAclsResponse.parse(buffer, V1);
+        final DescribeAclsResponse result = DescribeAclsResponse.parse(readable, V1);
         assertResponseEquals(original, result);
 
         final DescribeAclsResponse result2 = buildResponse(100, Errors.NONE, DescribeAclsResponse.aclsResources(

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupResponseTest.java
@@ -22,13 +22,13 @@ import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -111,9 +111,9 @@ public class LeaveGroupResponseTest {
                 .setThrottleTimeMs(throttleTimeMs);
         for (short version : ApiKeys.LEAVE_GROUP.allVersions()) {
             LeaveGroupResponse primaryResponse = LeaveGroupResponse.parse(
-                MessageUtil.toByteBufferAccessor(responseData, version).buffer(), version);
+                MessageUtil.toByteBufferAccessor(responseData, version), version);
             LeaveGroupResponse secondaryResponse = LeaveGroupResponse.parse(
-                MessageUtil.toByteBufferAccessor(responseData, version).buffer(), version);
+                MessageUtil.toByteBufferAccessor(responseData, version), version);
 
             assertEquals(primaryResponse, primaryResponse);
             assertEquals(primaryResponse, secondaryResponse);
@@ -130,7 +130,7 @@ public class LeaveGroupResponseTest {
             .setThrottleTimeMs(throttleTimeMs);
 
         for (short version : ApiKeys.LEAVE_GROUP.allVersions()) {
-            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
+            Readable buffer = MessageUtil.toByteBufferAccessor(data, version);
             LeaveGroupResponse leaveGroupResponse = LeaveGroupResponse.parse(buffer, version);
             assertEquals(expectedErrorCounts, leaveGroupResponse.errorCounts());
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitResponseTest.java
@@ -23,11 +23,11 @@ import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResp
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.Readable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -88,8 +88,8 @@ public class OffsetCommitResponseTest {
             .setThrottleTimeMs(throttleTimeMs);
 
         for (short version : ApiKeys.OFFSET_COMMIT.allVersions()) {
-            ByteBuffer buffer = MessageUtil.toByteBufferAccessor(data, version).buffer();
-            OffsetCommitResponse response = OffsetCommitResponse.parse(buffer, version);
+            Readable readable = MessageUtil.toByteBufferAccessor(data, version);
+            OffsetCommitResponse response = OffsetCommitResponse.parse(readable, version);
             assertEquals(expectedErrorCounts, response.errorCounts());
 
             if (version >= 3) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchRespon
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
@@ -197,7 +196,7 @@ public class OffsetFetchResponseTest {
 
                 OffsetFetchResponse latestResponse = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
                 OffsetFetchResponseData data = new OffsetFetchResponseData(
-                    new ByteBufferAccessor(latestResponse.serialize(version)), version);
+                    latestResponse.serialize(version), version);
 
                 OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
 
@@ -252,7 +251,7 @@ public class OffsetFetchResponseTest {
                     Collections.singletonMap(groupOne, Errors.NONE),
                     Collections.singletonMap(groupOne, partitionDataMap));
                 OffsetFetchResponseData data = new OffsetFetchResponseData(
-                    new ByteBufferAccessor(latestResponse.serialize(version)), version);
+                    latestResponse.serialize(version), version);
                 OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
                 assertEquals(Errors.NONE.code(), data.groups().get(0).errorCode());
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -84,7 +84,7 @@ public class RequestContextTest {
         assertEquals(correlationId, responseHeader.correlationId());
 
         ApiVersionsResponse response = (ApiVersionsResponse) AbstractResponse.parseResponse(ApiKeys.API_VERSIONS,
-            responseBuffer, (short) 0);
+            new ByteBufferAccessor(responseBuffer), (short) 0);
         assertEquals(Errors.UNSUPPORTED_VERSION.code(), response.data().errorCode());
         assertTrue(response.data().apiKeys().isEmpty());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -663,7 +663,7 @@ public class RequestResponseTest {
         ResponseHeader responseHeader = ResponseHeader.parse(channel.buffer(), responseHeaderVersion);
         assertEquals(correlationId, responseHeader.correlationId());
 
-        assertEquals(fetchResponse.serialize(version), buf);
+        assertEquals(fetchResponse.serialize(version).buffer(), buf);
         FetchResponseData deserialized = new FetchResponseData(new ByteBufferAccessor(buf), version);
         ObjectSerializationCache serializationCache = new ObjectSerializationCache();
         assertEquals(size, responseHeader.size() + deserialized.size(serializationCache, version));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -915,8 +915,8 @@ public class RequestResponseTest {
     @Test
     public void testApiVersionResponseParsingFallback() {
         for (short version : API_VERSIONS.allVersions()) {
-            ByteBuffer buffer = defaultApiVersionsResponse().serialize((short) 0);
-            ApiVersionsResponse response = ApiVersionsResponse.parse(buffer, version);
+            ByteBufferAccessor readable = defaultApiVersionsResponse().serialize((short) 0);
+            ApiVersionsResponse response = ApiVersionsResponse.parse(readable, version);
             assertEquals(Errors.NONE.code(), response.data().errorCode());
         }
     }
@@ -924,15 +924,16 @@ public class RequestResponseTest {
     @Test
     public void testApiVersionResponseParsingFallbackException() {
         for (final short version : API_VERSIONS.allVersions()) {
-            assertThrows(BufferUnderflowException.class, () -> ApiVersionsResponse.parse(ByteBuffer.allocate(0), version));
+            assertThrows(BufferUnderflowException.class,
+                () -> ApiVersionsResponse.parse(new ByteBufferAccessor(ByteBuffer.allocate(0)), version));
         }
     }
 
     @Test
     public void testApiVersionResponseParsing() {
         for (short version : API_VERSIONS.allVersions()) {
-            ByteBuffer buffer = defaultApiVersionsResponse().serialize(version);
-            ApiVersionsResponse response = ApiVersionsResponse.parse(buffer, version);
+            ByteBufferAccessor readable = defaultApiVersionsResponse().serialize(version);
+            ApiVersionsResponse response = ApiVersionsResponse.parse(readable, version);
             assertEquals(Errors.NONE.code(), response.data().errorCode());
         }
     }
@@ -1998,9 +1999,10 @@ public class RequestResponseTest {
         // Check for equality and hashCode of the Struct only if indicated (it is likely to fail if any of the fields
         // in the response is a HashMap with multiple elements since ordering of the elements may vary)
         try {
-            ByteBuffer serializedBytes = response.serialize(version);
-            AbstractResponse deserialized = AbstractResponse.parseResponse(response.apiKey(), serializedBytes, version);
-            ByteBuffer serializedBytes2 = deserialized.serialize(version);
+            ByteBufferAccessor readable = response.serialize(version);
+            ByteBuffer serializedBytes = readable.buffer();
+            AbstractResponse deserialized = AbstractResponse.parseResponse(response.apiKey(), readable, version);
+            ByteBuffer serializedBytes2 = deserialized.serialize(version).buffer();
             serializedBytes.rewind();
             assertEquals(serializedBytes, serializedBytes2, "Response " + response + "failed equality test");
         } catch (Exception e) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitResponseTest.java
@@ -57,7 +57,7 @@ public class TxnOffsetCommitResponseTest extends OffsetCommitResponseTest {
 
         for (short version : ApiKeys.TXN_OFFSET_COMMIT.allVersions()) {
             TxnOffsetCommitResponse response = TxnOffsetCommitResponse.parse(
-                MessageUtil.toByteBufferAccessor(data, version).buffer(), version);
+                MessageUtil.toByteBufferAccessor(data, version), version);
             assertEquals(expectedErrorCounts, response.errorCounts());
             assertEquals(throttleTimeMs, response.throttleTimeMs());
             assertEquals(version >= 1, response.shouldClientThrottle(version));

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -51,6 +51,7 @@ import org.apache.kafka.common.network.SaslChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.requests.AbstractRequest;
@@ -763,7 +764,7 @@ public class SaslAuthenticatorTest {
         selector.send(new NetworkSend(node, request.toSend(header)));
         ByteBuffer responseBuffer = waitForResponse();
         ResponseHeader.parse(responseBuffer, ApiKeys.API_VERSIONS.responseHeaderVersion((short) 0));
-        ApiVersionsResponse response = ApiVersionsResponse.parse(responseBuffer, (short) 0);
+        ApiVersionsResponse response = ApiVersionsResponse.parse(new ByteBufferAccessor(responseBuffer), (short) 0);
         assertEquals(Errors.UNSUPPORTED_VERSION.code(), response.data().errorCode());
 
         ApiVersion apiVersion = response.data().apiKeys().find(ApiKeys.API_VERSIONS.id);
@@ -822,7 +823,7 @@ public class SaslAuthenticatorTest {
         ByteBuffer responseBuffer = waitForResponse();
         ResponseHeader.parse(responseBuffer, ApiKeys.API_VERSIONS.responseHeaderVersion(version));
         ApiVersionsResponse response =
-            ApiVersionsResponse.parse(responseBuffer, version);
+            ApiVersionsResponse.parse(new ByteBufferAccessor(responseBuffer), version);
         assertEquals(Errors.INVALID_REQUEST.code(), response.data().errorCode());
 
         // Send ApiVersionsRequest with a supported version. This should succeed.
@@ -861,7 +862,7 @@ public class SaslAuthenticatorTest {
         selector.send(new NetworkSend(node, request.toSend(header)));
         ByteBuffer responseBuffer = waitForResponse();
         ResponseHeader.parse(responseBuffer, ApiKeys.API_VERSIONS.responseHeaderVersion(version));
-        ApiVersionsResponse response = ApiVersionsResponse.parse(responseBuffer, version);
+        ApiVersionsResponse response = ApiVersionsResponse.parse(new ByteBufferAccessor(responseBuffer), version);
         assertEquals(Errors.NONE.code(), response.data().errorCode());
 
         // Test that client can authenticate successfully

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.network.DefaultChannelMetadataRegistry;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
@@ -198,7 +199,7 @@ public class SaslServerAuthenticatorTest {
 
             ByteBuffer secondResponseSent = getResponses(transportLayer).get(1);
             consumeSizeAndHeader(secondResponseSent);
-            SaslAuthenticateResponse response = SaslAuthenticateResponse.parse(secondResponseSent, (short) 2);
+            SaslAuthenticateResponse response = SaslAuthenticateResponse.parse(new ByteBufferAccessor(secondResponseSent), (short) 2);
             assertEquals(tokenExpirationDuration.toMillis(), response.sessionLifetimeMs());
         }
     }
@@ -231,7 +232,7 @@ public class SaslServerAuthenticatorTest {
 
             ByteBuffer secondResponseSent = getResponses(transportLayer).get(1);
             consumeSizeAndHeader(secondResponseSent);
-            SaslAuthenticateResponse response = SaslAuthenticateResponse.parse(secondResponseSent, (short) 2);
+            SaslAuthenticateResponse response = SaslAuthenticateResponse.parse(new ByteBufferAccessor(secondResponseSent), (short) 2);
             assertEquals(maxReauthMs, response.sessionLifetimeMs());
         }
     }
@@ -264,7 +265,7 @@ public class SaslServerAuthenticatorTest {
 
             ByteBuffer secondResponseSent = getResponses(transportLayer).get(1);
             consumeSizeAndHeader(secondResponseSent);
-            SaslAuthenticateResponse response = SaslAuthenticateResponse.parse(secondResponseSent, (short) 2);
+            SaslAuthenticateResponse response = SaslAuthenticateResponse.parse(new ByteBufferAccessor(secondResponseSent), (short) 2);
             assertEquals(tokenExpiryShorterThanMaxReauth.toMillis(), response.sessionLifetimeMs());
         }
     }

--- a/core/src/test/scala/integration/kafka/server/IntegrationTestUtils.scala
+++ b/core/src/test/scala/integration/kafka/server/IntegrationTestUtils.scala
@@ -19,7 +19,7 @@ package kafka.server
 
 import kafka.network.SocketServer
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestHeader, ResponseHeader}
 import org.apache.kafka.common.utils.Utils
 
@@ -72,7 +72,7 @@ object IntegrationTestUtils {
     val responseBuffer = ByteBuffer.wrap(responseBytes)
     ResponseHeader.parse(responseBuffer, apiKey.responseHeaderVersion(version))
 
-    AbstractResponse.parseResponse(apiKey, responseBuffer, version) match {
+    AbstractResponse.parseResponse(apiKey, new ByteBufferAccessor(responseBuffer), version) match {
       case response: T => response
       case response =>
         throw new ClassCastException(s"Expected response with type ${classTag.runtimeClass}, but found ${response.getClass}")

--- a/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
@@ -505,7 +505,7 @@ class AlterPartitionManagerTest {
       null,
       // Response is serialized and deserialized to ensure that its does
       // not contain ignorable fields used by other versions.
-      AlterPartitionResponse.parse(MessageUtil.toByteBufferAccessor(response.data, version).buffer(), version)
+      AlterPartitionResponse.parse(MessageUtil.toByteBufferAccessor(response.data, version), version)
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
@@ -20,7 +20,7 @@ package kafka.server
 import kafka.api.IntegrationTestHarness
 import kafka.network.SocketServer
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestHeader, ResponseHeader}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.BrokerState
@@ -96,7 +96,7 @@ abstract class BaseRequestTest extends IntegrationTestHarness {
     val responseBuffer = ByteBuffer.wrap(responseBytes)
     ResponseHeader.parse(responseBuffer, apiKey.responseHeaderVersion(version))
 
-    AbstractResponse.parseResponse(apiKey, responseBuffer, version) match {
+    AbstractResponse.parseResponse(apiKey, new ByteBufferAccessor(responseBuffer), version) match {
       case response: T => response
       case response =>
         throw new ClassCastException(s"Expected response with type ${classTag.runtimeClass}, but found ${response.getClass}")

--- a/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.message.ProduceRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.types.Type
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor, Errors}
 import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.{ProduceResponse, ResponseHeader}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -152,7 +152,7 @@ class EdgeCaseRequestTest extends KafkaServerTestHarness {
 
     val responseBuffer = ByteBuffer.wrap(response)
     val responseHeader = ResponseHeader.parse(responseBuffer, responseHeaderVersion)
-    val produceResponse = ProduceResponse.parse(responseBuffer, version)
+    val produceResponse = ProduceResponse.parse(new ByteBufferAccessor(responseBuffer), version)
 
     assertEquals(0, responseBuffer.remaining, "The response should parse completely")
     assertEquals(correlationId, responseHeader.correlationId, "The correlationId should match request")

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -9104,13 +9104,13 @@ class KafkaApisTest extends Logging {
       any()
     )
     val response = capturedResponse.getValue
-    val buffer = MessageUtil.toByteBufferAccessor(
+    val readable = MessageUtil.toByteBufferAccessor(
       response.data,
       request.context.header.apiVersion
-    ).buffer()
+    )
     AbstractResponse.parseResponse(
       request.context.header.apiKey,
-      buffer,
+      readable,
       request.context.header.apiVersion,
     ).asInstanceOf[T]
   }
@@ -9125,10 +9125,10 @@ class KafkaApisTest extends Logging {
       any()
     )
     val response = capturedResponse.getValue
-    val buffer = MessageUtil.toByteBufferAccessor(
+    val readable = MessageUtil.toByteBufferAccessor(
       response.data,
       request.context.header.apiVersion
-    ).buffer()
+    )
 
     // Create the RequestChannel.Response that is created when sendResponse is called in order to update the metrics.
     val sendResponse = new RequestChannel.SendResponse(
@@ -9141,7 +9141,7 @@ class KafkaApisTest extends Logging {
 
     AbstractResponse.parseResponse(
       request.context.header.apiKey,
-      buffer,
+      readable,
       request.context.header.apiVersion,
     ).asInstanceOf[T]
   }

--- a/server/src/test/java/org/apache/kafka/network/RequestConvertToJsonTest.java
+++ b/server/src/test/java/org/apache/kafka/network/RequestConvertToJsonTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.Readable;
@@ -35,7 +36,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -87,8 +87,8 @@ public class RequestConvertToJsonTest {
                     message = ApiMessageType.fromApiKey(key.id).newResponse();
                 }
 
-                ByteBuffer bytes = MessageUtil.toByteBufferAccessor(message, version).buffer();
-                AbstractResponse response = AbstractResponse.parseResponse(key, bytes, version);
+                ByteBufferAccessor readable = MessageUtil.toByteBufferAccessor(message, version);
+                AbstractResponse response = AbstractResponse.parseResponse(key, readable, version);
                 try {
                     RequestConvertToJson.response(response, version);
                 } catch (IllegalStateException e) {
@@ -106,8 +106,8 @@ public class RequestConvertToJsonTest {
             if (key.hasValidVersion()) {
                 short version = key.latestVersion();
                 ApiMessage message = ApiMessageType.fromApiKey(key.id).newResponse();
-                ByteBuffer bytes = MessageUtil.toByteBufferAccessor(message, version).buffer();
-                AbstractResponse res = AbstractResponse.parseResponse(key, bytes, version);
+                ByteBufferAccessor readable = MessageUtil.toByteBufferAccessor(message, version);
+                AbstractResponse res = AbstractResponse.parseResponse(key, readable, version);
                 try {
                     RequestConvertToJson.response(res, version);
                 } catch (IllegalStateException e) {


### PR DESCRIPTION
The generated response data classes take Readable as input to parse the
Response. However, the associated response objects take ByteBuffer as
input and thus convert them to Readable using `new ByteBufferAccessor`
call.

This PR changes the parse method of all the response classes to take the
Readable interface instead so that no such conversion is needed.

To support parsing the ApiVersionsResponse twice for different version
this change adds the "slice" method to the Readable interface.

Reviewers: José Armando García Sancio <jsancio@apache.org>, Truc Nguyen
 <[trnguyen@confluent.io](mailto:trnguyen@confluent.io)>, Aadithya
 Chandra <[aadithya.c@gmail.com](mailto:aadithya.c@gmail.com)>
