### PR TITLE
MINOR: Modify KafkaEventQueue VoidEvent to as singleton and use more proper function interface

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 
 import java.util.OptionalLong;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 
 public interface EventQueue extends AutoCloseable {
@@ -66,8 +66,12 @@ public interface EventQueue extends AutoCloseable {
         }
     }
 
-    class NoDeadlineFunction implements Function<OptionalLong, OptionalLong> {
+    class NoDeadlineFunction implements UnaryOperator<OptionalLong> {
         public static final NoDeadlineFunction INSTANCE = new NoDeadlineFunction();
+        
+        private NoDeadlineFunction() {
+            
+        }
 
         @Override
         public OptionalLong apply(OptionalLong ignored) {
@@ -75,7 +79,7 @@ public interface EventQueue extends AutoCloseable {
         }
     }
 
-    class DeadlineFunction implements Function<OptionalLong, OptionalLong> {
+    class DeadlineFunction implements UnaryOperator<OptionalLong> {
         private final long deadlineNs;
 
         public DeadlineFunction(long deadlineNs) {
@@ -88,7 +92,7 @@ public interface EventQueue extends AutoCloseable {
         }
     }
 
-    class EarliestDeadlineFunction implements Function<OptionalLong, OptionalLong> {
+    class EarliestDeadlineFunction implements UnaryOperator<OptionalLong> {
         private final long newDeadlineNs;
 
         public EarliestDeadlineFunction(long newDeadlineNs) {
@@ -107,7 +111,7 @@ public interface EventQueue extends AutoCloseable {
         }
     }
 
-    class LatestDeadlineFunction implements Function<OptionalLong, OptionalLong> {
+    class LatestDeadlineFunction implements UnaryOperator<OptionalLong> {
         private final long newDeadlineNs;
 
         public LatestDeadlineFunction(long newDeadlineNs) {
@@ -186,7 +190,7 @@ public interface EventQueue extends AutoCloseable {
      * @param event                 The event to schedule.
      */
     default void scheduleDeferred(String tag,
-                                  Function<OptionalLong, OptionalLong> deadlineNsCalculator,
+                                  UnaryOperator<OptionalLong> deadlineNsCalculator,
                                   Event event) {
         enqueue(EventInsertionType.DEFERRED, tag, deadlineNsCalculator, event);
     }
@@ -228,7 +232,7 @@ public interface EventQueue extends AutoCloseable {
      */
     void enqueue(EventInsertionType insertionType,
                  String tag,
-                 Function<OptionalLong, OptionalLong> deadlineNsCalculator,
+                 UnaryOperator<OptionalLong> deadlineNsCalculator,
                  Event event);
 
     /**

--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
@@ -128,7 +128,11 @@ public interface EventQueue extends AutoCloseable {
 
     class VoidEvent implements Event {
         public static final VoidEvent INSTANCE = new VoidEvent();
-
+        
+        private VoidEvent(){
+            
+        }
+        
         @Override
         public void run() throws Exception {
         }

--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
@@ -129,7 +129,7 @@ public interface EventQueue extends AutoCloseable {
     class VoidEvent implements Event {
         public static final VoidEvent INSTANCE = new VoidEvent();
         
-        private VoidEvent(){
+        private VoidEvent() {
             
         }
         

--- a/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/EventQueue.java
@@ -17,10 +17,8 @@
 
 package org.apache.kafka.queue;
 
-import org.slf4j.Logger;
 
 import java.util.OptionalLong;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.function.UnaryOperator;
 
 
@@ -42,28 +40,6 @@ public interface EventQueue extends AutoCloseable {
          *              Otherwise, it will be whatever exception was thrown by run().
          */
         default void handleException(Throwable e) {}
-    }
-
-    abstract class FailureLoggingEvent implements Event {
-        private final Logger log;
-
-        public FailureLoggingEvent(Logger log) {
-            this.log = log;
-        }
-
-        @Override
-        public void handleException(Throwable e) {
-            if (e instanceof RejectedExecutionException) {
-                log.info("Not processing {} because the event queue is closed.", this);
-            } else {
-                log.error("Unexpected error handling {}", this, e);
-            }
-        }
-
-        @Override
-        public String toString() {
-            return this.getClass().getSimpleName();
-        }
     }
 
     class NoDeadlineFunction implements UnaryOperator<OptionalLong> {
@@ -104,25 +80,6 @@ public interface EventQueue extends AutoCloseable {
             if (prevDeadlineNs.isEmpty()) {
                 return OptionalLong.of(newDeadlineNs);
             } else if (prevDeadlineNs.getAsLong() < newDeadlineNs) {
-                return prevDeadlineNs;
-            } else {
-                return OptionalLong.of(newDeadlineNs);
-            }
-        }
-    }
-
-    class LatestDeadlineFunction implements UnaryOperator<OptionalLong> {
-        private final long newDeadlineNs;
-
-        public LatestDeadlineFunction(long newDeadlineNs) {
-            this.newDeadlineNs = newDeadlineNs;
-        }
-
-        @Override
-        public OptionalLong apply(OptionalLong prevDeadlineNs) {
-            if (prevDeadlineNs.isEmpty()) {
-                return OptionalLong.of(newDeadlineNs);
-            } else if (prevDeadlineNs.getAsLong() > newDeadlineNs) {
                 return prevDeadlineNs;
             } else {
                 return OptionalLong.of(newDeadlineNs);

--- a/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
@@ -444,7 +444,7 @@ public final class KafkaEventQueue implements EventQueue {
         LogContext logContext,
         String threadNamePrefix
     ) {
-        this(time, logContext, threadNamePrefix, VoidEvent::new);
+        this(time, logContext, threadNamePrefix, VoidEvent.INSTANCE);
     }
 
     public KafkaEventQueue(

--- a/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
@@ -34,6 +34,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 
 public final class KafkaEventQueue implements EventQueue {
@@ -472,7 +473,7 @@ public final class KafkaEventQueue implements EventQueue {
     @Override
     public void enqueue(EventInsertionType insertionType,
                         String tag,
-                        Function<OptionalLong, OptionalLong> deadlineNsCalculator,
+                        UnaryOperator<OptionalLong> deadlineNsCalculator,
                         Event event) {
         EventContext eventContext = new EventContext(event, insertionType, tag);
         Exception e = eventHandler.enqueue(eventContext, deadlineNsCalculator);

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManagerDeadlineFunction.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManagerDeadlineFunction.java
@@ -20,14 +20,14 @@ package org.apache.kafka.server;
 import org.apache.kafka.common.utils.ExponentialBackoff;
 
 import java.util.OptionalLong;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static org.apache.kafka.common.requests.AssignReplicasToDirsRequest.MAX_ASSIGNMENTS_PER_REQUEST;
 
 /**
  * This class calculates when the MaybeSendAssignmentsEvent should run for AssignmentsManager.
  */
-public class AssignmentsManagerDeadlineFunction implements Function<OptionalLong, OptionalLong> {
+public class AssignmentsManagerDeadlineFunction implements UnaryOperator<OptionalLong> {
 
     /**
      * The exponential backoff to use.


### PR DESCRIPTION
class `VoidEvent` provides singleton object , but nobody use it.  I
think we should private `VoidEvent` constructor and only use singleton.
use `UnaryOperator<OptionalLong>` instead
`Function<OptionalLong,OptionalLong>`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
