### PR TITLE
KAFKA-19077: Propagate shutdownRequested field

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2195,7 +2195,7 @@ public class GroupMetadataManager {
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
         if (shutdownApplication) {
-            group.setShutdownRequested(memberId);
+            group.setShutdownRequestMemberId(memberId);
         }
 
         // Prepare the response.
@@ -2224,15 +2224,14 @@ public class GroupMetadataManager {
             );
         }
 
-        if (group.isShutdownRequested()) {
-            returnedStatus.add(
-                new StreamsGroupHeartbeatResponseData.Status()
-                    .setStatusCode(StreamsGroupHeartbeatResponse.Status.SHUTDOWN_APPLICATION.code())
-                    .setStatusDetail(
-                        "A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application."
-                    )
-            );
-        }
+        group.getShutdownRequestMemberId().ifPresent(requestingMemberId -> returnedStatus.add(
+            new Status()
+                .setStatusCode(StreamsGroupHeartbeatResponse.Status.SHUTDOWN_APPLICATION.code())
+                .setStatusDetail(
+                    String.format("Streams group member %s encountered a fatal error and requested a shutdown for the entire application.",
+                        requestingMemberId)
+                )
+        ));
 
         if (!returnedStatus.isEmpty()) {
             response.setStatus(returnedStatus);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2194,7 +2194,7 @@ public class GroupMetadataManager {
         );
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
-        group.maybeSetShutdownRequestedOnAllMembers(memberId, shutdownApplication);
+        group.maybeSetShutdownRequested(memberId, shutdownApplication);
 
         // Prepare the response.
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()
@@ -2222,7 +2222,7 @@ public class GroupMetadataManager {
             );
         }
 
-        if (group.isShutdownRequested(memberId)) {
+        if (group.isShutdownRequested()) {
             returnedStatus.add(
                 new StreamsGroupHeartbeatResponseData.Status()
                     .setStatusCode(StreamsGroupHeartbeatResponse.Status.SHUTDOWN_APPLICATION.code())

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2194,7 +2194,9 @@ public class GroupMetadataManager {
         );
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
-        group.maybeSetShutdownRequested(memberId, shutdownApplication);
+        if (shutdownApplication) {
+            group.setShutdownRequested(memberId);
+        }
 
         // Prepare the response.
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -61,7 +61,6 @@ import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.Endpoint;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.KeyValue;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.TaskIds;
-import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.TaskOffset;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData.Topology;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData.Status;
@@ -2049,8 +2048,6 @@ public class GroupMetadataManager {
      * @param ownedWarmupTasks    The list of owned warmup tasks from the request or null.
      * @param userEndpoint        User-defined endpoint for Interactive Queries, or null.
      * @param clientTags          Used for rack-aware assignment algorithm, or null.
-     * @param taskEndOffsets      Cumulative changelog offsets for tasks, or null.
-     * @param taskOffsets         Cumulative changelog end-offsets for tasks, or null.
      * @param shutdownApplication Whether all Streams clients in the group should shut down.
      * @return A result containing the StreamsGroupHeartbeat response and a list of records to update the state machine.
      */
@@ -2070,8 +2067,6 @@ public class GroupMetadataManager {
         String processId,
         Endpoint userEndpoint,
         List<KeyValue> clientTags,
-        List<TaskOffset> taskOffsets,
-        List<TaskOffset> taskEndOffsets,
         boolean shutdownApplication
     ) throws ApiException {
         final long currentTimeMs = time.milliseconds();
@@ -2199,6 +2194,7 @@ public class GroupMetadataManager {
         );
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
+        group.maybeSetShutdownRequestedOnAllMembers(memberId, shutdownApplication);
 
         // Prepare the response.
         StreamsGroupHeartbeatResponseData response = new StreamsGroupHeartbeatResponseData()
@@ -2223,6 +2219,16 @@ public class GroupMetadataManager {
                 new StreamsGroupHeartbeatResponseData.Status()
                     .setStatusCode(exception.status().code())
                     .setStatusDetail(exception.getMessage())
+            );
+        }
+
+        if (group.isShutdownRequested(memberId)) {
+            returnedStatus.add(
+                new StreamsGroupHeartbeatResponseData.Status()
+                    .setStatusCode(StreamsGroupHeartbeatResponse.Status.SHUTDOWN_APPLICATION.code())
+                    .setStatusDetail(
+                        "A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application."
+                    )
             );
         }
 
@@ -3037,7 +3043,7 @@ public class GroupMetadataManager {
         }
         return member;
     }
-    
+
     /**
      * Gets or subscribes a static consumer group member. This method also replaces the
      * previous static member if allowed.
@@ -4817,8 +4823,6 @@ public class GroupMetadataManager {
                 request.processId(),
                 request.userEndpoint(),
                 request.clientTags(),
-                request.taskOffsets(),
-                request.taskEndOffsets(),
                 request.shutdownApplication()
             );
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -199,8 +199,9 @@ public class StreamsGroup implements Group {
 
     /**
      * A flag to indicate whether a shutdown has been requested for this group.
-     * This has no direct effect inside the group coordinator, but is propagated to all members of the group.
-     * This is not persisted in the log.
+     * This has no direct effect inside the group coordinator, but is propagated to old and new members of the group.
+     * It is cleared once the group is empty.
+     * This is not persisted in the log, as the flag is best-effort.
      */
     private boolean shutdownRequested = false;
 
@@ -1057,11 +1058,9 @@ public class StreamsGroup implements Group {
         return describedGroup;
     }
 
-    public void maybeSetShutdownRequested(final String memberId, final boolean shutdownApplication) {
-        if (shutdownApplication) {
-            log.info("[GroupId {}][MemberId {}] Shutdown requested for the streams application.", groupId, memberId);
-            shutdownRequested = true;
-        }
+    public void setShutdownRequested(final String memberId) {
+        log.info("[GroupId {}][MemberId {}] Shutdown requested for the streams application.", groupId, memberId);
+        shutdownRequested = true;
     }
 
     public boolean isShutdownRequested() {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -198,12 +198,12 @@ public class StreamsGroup implements Group {
     private DeadlineAndEpoch metadataRefreshDeadline = DeadlineAndEpoch.EMPTY;
 
     /**
-     * A flag to indicate whether a shutdown has been requested for this group.
+     * Keeps a member ID that requested a shutdown for this group.
      * This has no direct effect inside the group coordinator, but is propagated to old and new members of the group.
      * It is cleared once the group is empty.
-     * This is not persisted in the log, as the flag is best-effort.
+     * This is not persisted in the log, as the shutdown request is best-effort.
      */
-    private boolean shutdownRequested = false;
+    private Optional<String> shutdownRequestMemberId = Optional.empty();
 
     public StreamsGroup(
         LogContext logContext,
@@ -832,7 +832,7 @@ public class StreamsGroup implements Group {
         StreamsGroupState newState = STABLE;
         if (members.isEmpty()) {
             newState = EMPTY;
-            clearShutdownRequested();
+            clearShutdownRequestMemberId();
         } else if (topology().isEmpty() || configuredTopology().isEmpty() || !configuredTopology().get().isReady()) {
             newState = NOT_READY;
         } else if (groupEpoch.get() > targetAssignmentEpoch.get()) {
@@ -1058,19 +1058,21 @@ public class StreamsGroup implements Group {
         return describedGroup;
     }
 
-    public void setShutdownRequested(final String memberId) {
-        log.info("[GroupId {}][MemberId {}] Shutdown requested for the streams application.", groupId, memberId);
-        shutdownRequested = true;
+    public void setShutdownRequestMemberId(final String memberId) {
+        if (shutdownRequestMemberId.isEmpty()) {
+            log.info("[GroupId {}][MemberId {}] Shutdown requested for the streams application.", groupId, memberId);
+            shutdownRequestMemberId = Optional.of(memberId);
+        }
     }
 
-    public boolean isShutdownRequested() {
-        return shutdownRequested;
+    public Optional<String> getShutdownRequestMemberId() {
+        return shutdownRequestMemberId;
     }
 
-    private void clearShutdownRequested() {
-        if (shutdownRequested) {
+    private void clearShutdownRequestMemberId() {
+        if (shutdownRequestMemberId.isPresent()) {
             log.info("[GroupId {}] Clearing shutdown requested for the streams application.", groupId);
-            shutdownRequested = false;
+            shutdownRequestMemberId = Optional.empty();
         }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -197,6 +197,13 @@ public class StreamsGroup implements Group {
      */
     private DeadlineAndEpoch metadataRefreshDeadline = DeadlineAndEpoch.EMPTY;
 
+    /**
+     * A map to indicate member IDs which are expected to shutdown.
+     * This has no direct effect inside the group coordinator, but is propagated to the member in the group.
+     * This is not persisted in the log.
+     */
+    private Set<String> shutdownRequestedMemberIds = new HashSet<>();
+
     public StreamsGroup(
         LogContext logContext,
         SnapshotRegistry snapshotRegistry,
@@ -434,6 +441,7 @@ public class StreamsGroup implements Group {
         maybeRemoveTaskProcessId(oldMember);
         removeStaticMember(oldMember);
         maybeUpdateGroupState();
+        clearShutdownRequested(memberId);
     }
 
     /**
@@ -1049,4 +1057,21 @@ public class StreamsGroup implements Group {
         return describedGroup;
     }
 
+    public void maybeSetShutdownRequestedOnAllMembers(final String memberId, final boolean shutdownApplication) {
+        if (shutdownApplication) {
+            log.info("[GroupId {}][MemberId {}] Shutdown requested for the streams application.", groupId, memberId);
+            shutdownRequestedMemberIds.addAll(members.keySet());
+            shutdownRequestedMemberIds.add(memberId); // ensure the current member is also added to the shutdown requested list
+        }
+    }
+
+    public boolean isShutdownRequested(final String memberId) {
+        return shutdownRequestedMemberIds.contains(memberId);
+    }
+
+    private void clearShutdownRequested(final String memberId) {
+        if (shutdownRequestedMemberIds.remove(memberId)) {
+            log.info("[GroupId {}] Clearing shutdown requested flag for member {}.", groupId, memberId);
+        }
+    }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -198,11 +198,11 @@ public class StreamsGroup implements Group {
     private DeadlineAndEpoch metadataRefreshDeadline = DeadlineAndEpoch.EMPTY;
 
     /**
-     * A map to indicate member IDs which are expected to shutdown.
-     * This has no direct effect inside the group coordinator, but is propagated to the member in the group.
+     * A flag to indicate whether a shutdown has been requested for this group.
+     * This has no direct effect inside the group coordinator, but is propagated to all members of the group.
      * This is not persisted in the log.
      */
-    private Set<String> shutdownRequestedMemberIds = new HashSet<>();
+    private boolean shutdownRequested = false;
 
     public StreamsGroup(
         LogContext logContext,
@@ -441,7 +441,6 @@ public class StreamsGroup implements Group {
         maybeRemoveTaskProcessId(oldMember);
         removeStaticMember(oldMember);
         maybeUpdateGroupState();
-        clearShutdownRequested(memberId);
     }
 
     /**
@@ -832,6 +831,7 @@ public class StreamsGroup implements Group {
         StreamsGroupState newState = STABLE;
         if (members.isEmpty()) {
             newState = EMPTY;
+            clearShutdownRequested();
         } else if (topology().isEmpty() || configuredTopology().isEmpty() || !configuredTopology().get().isReady()) {
             newState = NOT_READY;
         } else if (groupEpoch.get() > targetAssignmentEpoch.get()) {
@@ -1057,21 +1057,21 @@ public class StreamsGroup implements Group {
         return describedGroup;
     }
 
-    public void maybeSetShutdownRequestedOnAllMembers(final String memberId, final boolean shutdownApplication) {
+    public void maybeSetShutdownRequested(final String memberId, final boolean shutdownApplication) {
         if (shutdownApplication) {
             log.info("[GroupId {}][MemberId {}] Shutdown requested for the streams application.", groupId, memberId);
-            shutdownRequestedMemberIds.addAll(members.keySet());
-            shutdownRequestedMemberIds.add(memberId); // ensure the current member is also added to the shutdown requested list
+            shutdownRequested = true;
         }
     }
 
-    public boolean isShutdownRequested(final String memberId) {
-        return shutdownRequestedMemberIds.contains(memberId);
+    public boolean isShutdownRequested() {
+        return shutdownRequested;
     }
 
-    private void clearShutdownRequested(final String memberId) {
-        if (shutdownRequestedMemberIds.remove(memberId)) {
-            log.info("[GroupId {}] Clearing shutdown requested flag for member {}.", groupId, memberId);
+    private void clearShutdownRequested() {
+        if (shutdownRequested) {
+            log.info("[GroupId {}] Clearing shutdown requested for the streams application.", groupId);
+            shutdownRequested = false;
         }
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -16305,7 +16305,6 @@ public class GroupMetadataManagerTest {
                 .setGroupId(groupId)
                 .setMemberId(memberId2)
                 .setMemberEpoch(10)
-                .setShutdownApplication(true)
         );
 
         assertResponseEquals(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -134,6 +134,7 @@ import org.apache.kafka.server.share.persister.PartitionFactory;
 import org.apache.kafka.server.share.persister.PartitionIdData;
 import org.apache.kafka.server.share.persister.PartitionStateData;
 import org.apache.kafka.server.share.persister.TopicData;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -134,7 +134,6 @@ import org.apache.kafka.server.share.persister.PartitionFactory;
 import org.apache.kafka.server.share.persister.PartitionIdData;
 import org.apache.kafka.server.share.persister.PartitionStateData;
 import org.apache.kafka.server.share.persister.TopicData;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -16231,6 +16230,97 @@ public class GroupMetadataManagerTest {
         );
 
         assertRecordsEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testStreamsGroupMemberRequestingShutdownApplication() {
+        String groupId = "fooup";
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        String subtopology1 = "subtopology1";
+        String fooTopicName = "foo";
+        Uuid fooTopicId = Uuid.randomUuid();
+        Topology topology = new Topology().setSubtopologies(List.of(
+            new Subtopology().setSubtopologyId(subtopology1).setSourceTopics(List.of(fooTopicName))
+        ));
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .build())
+            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10)
+                .withMember(streamsGroupMemberBuilderWithDefaults(memberId1)
+                    .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                        TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)))
+                    .build())
+                .withMember(streamsGroupMemberBuilderWithDefaults(memberId2)
+                    .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                        TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5)))
+                    .build())
+                .withTargetAssignment(memberId1, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)))
+                .withTargetAssignment(memberId2, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5)))
+                .withTargetAssignmentEpoch(10)
+                .withTopology(StreamsTopology.fromHeartbeatRequest(topology))
+                .withPartitionMetadata(Map.of(
+                    fooTopicName, new org.apache.kafka.coordinator.group.streams.TopicMetadata(fooTopicId, fooTopicName, 6)
+                ))
+            )
+            .build();
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result1 = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId1)
+                .setMemberEpoch(10)
+                .setShutdownApplication(true)
+        );
+
+        assertResponseEquals(
+            new StreamsGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setStatus(List.of(
+                    new StreamsGroupHeartbeatResponseData.Status()
+                        .setStatusCode(Status.SHUTDOWN_APPLICATION.code())
+                        .setStatusDetail("A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.")
+                )),
+            result1.response().data()
+        );
+        assertRecordsEquals(List.of(), result1.records());
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result2 = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setMemberEpoch(10)
+                .setShutdownApplication(true)
+        );
+
+        assertResponseEquals(
+            new StreamsGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setStatus(List.of(
+                    new StreamsGroupHeartbeatResponseData.Status()
+                        .setStatusCode(Status.SHUTDOWN_APPLICATION.code())
+                        .setStatusDetail("A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.")
+                )),
+            result2.response().data()
+        );
+
+        assertRecordsEquals(List.of(), result2.records());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -16286,6 +16286,8 @@ public class GroupMetadataManagerTest {
                 .setShutdownApplication(true)
         );
 
+        String statusDetail = String.format("Streams group member %s encountered a fatal error and requested a shutdown for the entire application.", memberId1);
+
         assertResponseEquals(
             new StreamsGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
@@ -16294,7 +16296,7 @@ public class GroupMetadataManagerTest {
                 .setStatus(List.of(
                     new StreamsGroupHeartbeatResponseData.Status()
                         .setStatusCode(Status.SHUTDOWN_APPLICATION.code())
-                        .setStatusDetail("A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.")
+                        .setStatusDetail(statusDetail)
                 )),
             result1.response().data()
         );
@@ -16315,7 +16317,7 @@ public class GroupMetadataManagerTest {
                 .setStatus(List.of(
                     new StreamsGroupHeartbeatResponseData.Status()
                         .setStatusCode(Status.SHUTDOWN_APPLICATION.code())
-                        .setStatusDetail("A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.")
+                        .setStatusDetail(statusDetail)
                 )),
             result2.response().data()
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -1120,19 +1120,22 @@ public class StreamsGroupTest {
         streamsGroup.updateMember(streamsGroup.getOrCreateDefaultMember(memberId2));
 
         // Initially, shutdown should not be requested
-        assertFalse(streamsGroup.isShutdownRequested());
+        assertTrue(streamsGroup.getShutdownRequestMemberId().isEmpty());
 
         // Set shutdown requested
-        streamsGroup.setShutdownRequested(memberId1);
-        assertTrue(streamsGroup.isShutdownRequested());
+        streamsGroup.setShutdownRequestMemberId(memberId1);
+        assertEquals(Optional.of(memberId1), streamsGroup.getShutdownRequestMemberId());
+
+        // Setting shutdown requested again will be ignored
+        streamsGroup.setShutdownRequestMemberId(memberId2);
+        assertEquals(Optional.of(memberId1), streamsGroup.getShutdownRequestMemberId());
 
         // As long as group not empty, remain in shutdown requested state
         streamsGroup.removeMember(memberId1);
-        assertTrue(streamsGroup.isShutdownRequested());
+        assertEquals(Optional.of(memberId1), streamsGroup.getShutdownRequestMemberId());
 
         // As soon as the group is empty, clear the shutdown requested state
         streamsGroup.removeMember(memberId2);
-        assertFalse(streamsGroup.isShutdownRequested());
+        assertEquals(Optional.empty(), streamsGroup.getShutdownRequestMemberId());
     }
-
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -1120,22 +1120,18 @@ public class StreamsGroupTest {
         streamsGroup.updateMember(streamsGroup.getOrCreateDefaultMember(memberId2));
 
         // Initially, shutdown should not be requested
-        assertFalse(streamsGroup.isShutdownRequested(memberId1));
-        assertFalse(streamsGroup.isShutdownRequested(memberId2));
+        assertFalse(streamsGroup.isShutdownRequested());
 
         // Set shutdown requested
-        streamsGroup.maybeSetShutdownRequestedOnAllMembers(memberId1, true);
-        assertTrue(streamsGroup.isShutdownRequested(memberId1));
-        assertTrue(streamsGroup.isShutdownRequested(memberId2));
+        streamsGroup.maybeSetShutdownRequested(memberId1, true);
+        assertTrue(streamsGroup.isShutdownRequested());
 
-        // Removing a member should clear it from shutdown requested state only if it is the last member in the group.
+        // As long as group not empty, remain in shutdown requested state
         streamsGroup.removeMember(memberId1);
-        assertFalse(streamsGroup.isShutdownRequested(memberId1));
-        assertTrue(streamsGroup.isShutdownRequested(memberId2));
+        assertTrue(streamsGroup.isShutdownRequested());
 
-        // Now remove the second member, which should clear the shutdown requested state for both members.
+        // As soon as the group is empty, clear the shutdown requested state
         streamsGroup.removeMember(memberId2);
-        assertFalse(streamsGroup.isShutdownRequested(memberId1));
-        assertFalse(streamsGroup.isShutdownRequested(memberId2));
+        assertFalse(streamsGroup.isShutdownRequested());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -1106,4 +1106,36 @@ public class StreamsGroupTest {
         assertTrue(streamsGroup.isSubscribedToTopic("test-topic2"));
         assertFalse(streamsGroup.isSubscribedToTopic("non-existent-topic"));
     }
+
+    @Test
+    public void testShutdownRequestedMethods() {
+        String memberId1 = "test-member-id1";
+        String memberId2 = "test-member-id2";
+        LogContext logContext = new LogContext();
+        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(logContext);
+        GroupCoordinatorMetricsShard metricsShard = mock(GroupCoordinatorMetricsShard.class);
+        StreamsGroup streamsGroup = new StreamsGroup(logContext, snapshotRegistry, "test-group", metricsShard);
+
+        streamsGroup.updateMember(streamsGroup.getOrCreateDefaultMember(memberId1));
+        streamsGroup.updateMember(streamsGroup.getOrCreateDefaultMember(memberId2));
+
+        // Initially, shutdown should not be requested
+        assertFalse(streamsGroup.isShutdownRequested(memberId1));
+        assertFalse(streamsGroup.isShutdownRequested(memberId2));
+
+        // Set shutdown requested
+        streamsGroup.maybeSetShutdownRequestedOnAllMembers(memberId1, true);
+        assertTrue(streamsGroup.isShutdownRequested(memberId1));
+        assertTrue(streamsGroup.isShutdownRequested(memberId2));
+
+        // Removing a member should clear it from shutdown requested state only if it is the last member in the group.
+        streamsGroup.removeMember(memberId1);
+        assertFalse(streamsGroup.isShutdownRequested(memberId1));
+        assertTrue(streamsGroup.isShutdownRequested(memberId2));
+
+        // Now remove the second member, which should clear the shutdown requested state for both members.
+        streamsGroup.removeMember(memberId2);
+        assertFalse(streamsGroup.isShutdownRequested(memberId1));
+        assertFalse(streamsGroup.isShutdownRequested(memberId2));
+    }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -1123,7 +1123,7 @@ public class StreamsGroupTest {
         assertFalse(streamsGroup.isShutdownRequested());
 
         // Set shutdown requested
-        streamsGroup.maybeSetShutdownRequested(memberId1, true);
+        streamsGroup.setShutdownRequested(memberId1);
         assertTrue(streamsGroup.isShutdownRequested());
 
         // As long as group not empty, remain in shutdown requested state
@@ -1134,4 +1134,5 @@ public class StreamsGroupTest {
         streamsGroup.removeMember(memberId2);
         assertFalse(streamsGroup.isShutdownRequested());
     }
+
 }


### PR DESCRIPTION
When a member indicates that the application should shut down, set a
soft-state flag on the streams group and continuously set the status
`SHUTDOWN_APPLICATION` to all members, until the group is empty, which
resets the flag.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Chia-Ping Tsai
<chia7712@gmail.com>, Jeff Kim <jeff.kim@confluent.io>
