### PR TITLE
MINOR VerifableProducer ducktape can set idempotency and retries

### DIFF
--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -147,9 +147,10 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.enable_idempotence:
             self.logger.info("Setting up an idempotent producer")
             producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
-            producer_prop_file += "\nretries=1000000\n"
             producer_prop_file += "\nenable.idempotence=true\n"
-        elif self.retries is not None:
+            if self.retries is None:
+                producer_prop_file += "\nretries=1000000\n"
+        if self.retries is not None:
             self.logger.info("VerifiableProducer (index = %d) will use retries = %s", idx, self.retries)
             producer_prop_file += "\nretries=%s\n" % self.retries
             producer_prop_file += "\ndelivery.timeout.ms=%s\n" % (self.request_timeout_sec * 1000 * self.retries)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -154,8 +154,8 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         elif self.enable_idempotence:
             self.logger.info("Setting up an idempotent producer")
             producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
-            producer_prop_file += "\nenable.idempotence=true\n"
             producer_prop_file += "\nretries=1000000\n"
+            producer_prop_file += "\nenable.idempotence=true\n"
         elif self.retries is not None:
             self.logger.info("VerifiableProducer (index = %d) will use retries = %s", idx, self.retries)
             producer_prop_file += "\nretries=%s\n" % self.retries

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -144,13 +144,19 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
             self.logger.info("VerifiableProducer (index = %d) will use acks = %s", idx, self.acks)
             producer_prop_file += "\nacks=%s\n" % self.acks
 
-        if self.enable_idempotence:
+        if self.enable_idempotence and self.retries is not None:
+            assert self.retries > 0, "Retries must be greater than 0 when used with idempotence"
+            self.logger.info("VerifiableProducer (index = %d) will use idempotence and retries = %s", idx, self.retries)
+            producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
+            producer_prop_file += "\nenable.idempotence=true\n"
+            producer_prop_file += "\nretries=%s\n" % self.retries
+            producer_prop_file += "\ndelivery.timeout.ms=%s\n" % (self.request_timeout_sec * 1000 * self.retries)
+        elif self.enable_idempotence:
             self.logger.info("Setting up an idempotent producer")
             producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
             producer_prop_file += "\nenable.idempotence=true\n"
-            if self.retries is None:
-                producer_prop_file += "\nretries=1000000\n"
-        if self.retries is not None:
+            producer_prop_file += "\nretries=1000000\n"
+        elif self.retries is not None:
             self.logger.info("VerifiableProducer (index = %d) will use retries = %s", idx, self.retries)
             producer_prop_file += "\nretries=%s\n" % self.retries
             producer_prop_file += "\ndelivery.timeout.ms=%s\n" % (self.request_timeout_sec * 1000 * self.retries)


### PR DESCRIPTION
It is currently impossible to set both number of retries and idempotency
in the DucktapeVerifiable producer. This change allows that to occur.
