### PR TITLE
Minor: Add functionalinterface to the producer callback 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgementCommitCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgementCommitCallback.java
@@ -34,7 +34,6 @@ import java.util.Set;
  * The callback may be executed in any thread calling {@link ShareConsumer#poll(java.time.Duration)}.
  */
 @InterfaceStability.Evolving
-@FunctionalInterface
 public interface AcknowledgementCommitCallback {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgementCommitCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/AcknowledgementCommitCallback.java
@@ -34,6 +34,7 @@ import java.util.Set;
  * The callback may be executed in any thread calling {@link ShareConsumer#poll(java.time.Duration)}.
  */
 @InterfaceStability.Evolving
+@FunctionalInterface
 public interface AcknowledgementCommitCallback {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Callback.java
@@ -20,6 +20,7 @@ package org.apache.kafka.clients.producer;
  * A callback interface that the user can implement to allow code to execute when the request is complete. This callback
  * will generally execute in the background I/O thread so it should be fast.
  */
+@FunctionalInterface
 public interface Callback {
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/Callback.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/Callback.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.util;
 /**
  * Generic interface for callbacks
  */
+@FunctionalInterface
 public interface Callback<V> {
     /**
      * Invoked upon completion of the operation.


### PR DESCRIPTION
The Callback interface is a perfect example of a place that can use the functionalinterface in Java.  Strictly for Java, this isn't "required" since Java will automatically coerce, but for Clojure (and other JVM languages I belive) to interop with Java lambdas it needs the FunctionalInterface annotation. 

Since FunctionalInterface doesn't add any overhead and provides compiler-enforced documentation, I don't see any reason *not* to have this.  This has already been added into Kafka Streams here: https://github.com/apache/kafka/pull/19234#pullrequestreview-2740742487

I am happy to add it to any other spots in that might be useful too.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
