### PR TITLE
MINOR: Update Mockito on 3.9 for Java 23 support

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ String mockitoVersion
 if (scalaVersion == "2.12")
   mockitoVersion = "4.9.0"
 else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11))
-  mockitoVersion = "5.10.0"
+  mockitoVersion = "5.14.2"
 else
   mockitoVersion = "4.11.0"
 


### PR DESCRIPTION
This was done on trunk in 6a37d5ccebaa6bbfc1d1b943f0ff761cf978da7d