### PR TITLE
MINOR: Cleanup Core Module

### DIFF
--- a/core/src/main/java/kafka/docker/Log4jConfiguration.java
+++ b/core/src/main/java/kafka/docker/Log4jConfiguration.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,7 +120,7 @@ class Appenders {
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Loggers {
     private Root root;
-    private List<Logger> logger = Collections.emptyList();
+    private List<Logger> logger = List.of();
 
     @JsonProperty("Root")
     public Root getRoot() {

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1707,7 +1707,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             RecordBatch firstBatch = enrichedRecordBatch.batch;
             if (firstBatch == null)
                 return new FetchDataInfo(new LogOffsetMetadata(offset), MemoryRecords.EMPTY, false,
-                        includeAbortedTxns ? Optional.of(Collections.emptyList()) : Optional.empty());
+                        includeAbortedTxns ? Optional.of(List.of()) : Optional.empty());
 
             int firstBatchSize = firstBatch.sizeInBytes();
             // An empty record is sent instead of an incomplete batch when
@@ -1783,7 +1783,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         return new FetchDataInfo(fetchInfo.fetchOffsetMetadata,
                 fetchInfo.records,
                 fetchInfo.firstEntryIncomplete,
-                Optional.of(abortedTransactions.isEmpty() ? Collections.emptyList() : new ArrayList<>(abortedTransactions)));
+                Optional.of(abortedTransactions.isEmpty() ? List.of() : new ArrayList<>(abortedTransactions)));
     }
 
     /**

--- a/core/src/main/java/kafka/server/NetworkUtils.java
+++ b/core/src/main/java/kafka/server/NetworkUtils.java
@@ -31,7 +31,7 @@ import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
-import java.util.Collections;
+import java.util.Map;
 
 public class NetworkUtils {
 
@@ -62,7 +62,7 @@ public class NetworkUtils {
             metrics,
             time,
             metricGroupPrefix,
-            Collections.emptyMap(),
+            Map.of(),
             false,
             channelBuilder,
             logContext

--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -41,7 +41,7 @@ import org.apache.kafka.server.ClientMetricsManager;
 import org.apache.kafka.server.authorizer.Authorizer;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import scala.jdk.javaapi.OptionConverters;
@@ -195,7 +195,7 @@ public class KafkaApisBuilder {
         if (txnCoordinator == null) throw new RuntimeException("You must set txnCoordinator");
         if (autoTopicCreationManager == null)
             throw new RuntimeException("You must set autoTopicCreationManager");
-        if (config == null) config = new KafkaConfig(Collections.emptyMap());
+        if (config == null) config = new KafkaConfig(Map.of());
         if (configRepository == null) throw new RuntimeException("You must set configRepository");
         if (metadataCache == null) throw new RuntimeException("You must set metadataCache");
         if (metrics == null) throw new RuntimeException("You must set metrics");

--- a/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
@@ -30,7 +30,6 @@ import org.apache.kafka.storage.internals.log.ProducerStateManagerConfig;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import scala.jdk.javaapi.CollectionConverters;
@@ -39,7 +38,7 @@ import scala.jdk.javaapi.CollectionConverters;
 public class LogManagerBuilder {
     private static final int PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS = 600000;
     private List<File> logDirs = null;
-    private List<File> initialOfflineDirs = Collections.emptyList();
+    private List<File> initialOfflineDirs = List.of();
     private ConfigRepository configRepository = null;
     private LogConfig initialDefaultConfig = null;
     private CleanerConfig cleanerConfig = null;

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -32,12 +32,10 @@ import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import scala.Option;
-
-
 
 public class ReplicaManagerBuilder {
     private KafkaConfig config = null;
@@ -102,7 +100,7 @@ public class ReplicaManagerBuilder {
     }
 
     public ReplicaManager build() {
-        if (config == null) config = new KafkaConfig(Collections.emptyMap());
+        if (config == null) config = new KafkaConfig(Map.of());
         if (logManager == null) throw new RuntimeException("You must set logManager");
         if (metadataCache == null) throw new RuntimeException("You must set metadataCache");
         if (logDirFailureChannel == null) throw new RuntimeException("You must set logDirFailureChannel");

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.requests.DescribeTopicPartitionsRequest;
 import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.metadata.MetadataCache;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -96,7 +95,7 @@ public class DescribeTopicPartitionsRequestHandler {
             if (!fetchAllTopics && !isAuthorized) {
                 // We should not return topicId when on unauthorized error, so we return zero uuid.
                 unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
-                    Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, Collections.emptyList())
+                    Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
                 );
             }
             return isAuthorized;

--- a/core/src/main/java/kafka/server/share/ShareFetchUtils.java
+++ b/core/src/main/java/kafka/server/share/ShareFetchUtils.java
@@ -41,7 +41,6 @@ import org.apache.kafka.server.storage.log.FetchPartitionData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -87,7 +86,7 @@ public class ShareFetchUtils {
                     .setRecords(null)
                     .setErrorCode(fetchPartitionData.error.code())
                     .setErrorMessage(fetchPartitionData.error.message())
-                    .setAcquiredRecords(Collections.emptyList());
+                    .setAcquiredRecords(List.of());
 
                 // In case we get OFFSET_OUT_OF_RANGE error, that's because the Log Start Offset is later than the fetch offset.
                 // So, we would update the start and end offset of the share partition and still return an empty
@@ -124,7 +123,7 @@ public class ShareFetchUtils {
                 if (shareAcquiredRecords.acquiredRecords().isEmpty()) {
                     partitionData
                         .setRecords(null)
-                        .setAcquiredRecords(Collections.emptyList());
+                        .setAcquiredRecords(List.of());
                 } else {
                     partitionData
                         .setRecords(maybeSliceFetchRecords(fetchPartitionData.records, shareAcquiredRecords))

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -1672,7 +1672,7 @@ public class SharePartition {
         return switch (acknowledgeType) {
             case 1 /* ACCEPT */ -> RecordState.ACKNOWLEDGED;
             case 2 /* RELEASE */ -> RecordState.AVAILABLE;
-            case 3, 0 /* REJECT GAP */ -> RecordState.ARCHIVED;
+            case 3, 0 /* REJECT / GAP */ -> RecordState.ARCHIVED;
             default -> throw new IllegalArgumentException("Invalid acknowledge type: " + acknowledgeType);
         };
     }
@@ -2448,7 +2448,7 @@ public class SharePartition {
         }
     }
 
-    private long startOffsetDuringInitialization(long partitionDataStartOffset) throws Exception {
+    private long startOffsetDuringInitialization(long partitionDataStartOffset) {
         // Set the state epoch and end offset from the persisted state.
         if (partitionDataStartOffset != PartitionFactory.UNINITIALIZED_START_OFFSET) {
             return partitionDataStartOffset;

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2276,11 +2276,16 @@ public class SharePartition {
         return switch (error) {
             case NOT_COORDINATOR, COORDINATOR_NOT_AVAILABLE, COORDINATOR_LOAD_IN_PROGRESS ->
                 new CoordinatorNotAvailableException(errorMessage);
-            case GROUP_ID_NOT_FOUND -> new GroupIdNotFoundException(errorMessage);
-            case UNKNOWN_TOPIC_OR_PARTITION -> new UnknownTopicOrPartitionException(errorMessage);
-            case FENCED_STATE_EPOCH -> new FencedStateEpochException(errorMessage);
-            case FENCED_LEADER_EPOCH -> new NotLeaderOrFollowerException(errorMessage);
-            default -> new UnknownServerException(errorMessage);
+            case GROUP_ID_NOT_FOUND ->
+                new GroupIdNotFoundException(errorMessage);
+            case UNKNOWN_TOPIC_OR_PARTITION ->
+                new UnknownTopicOrPartitionException(errorMessage);
+            case FENCED_STATE_EPOCH ->
+                new FencedStateEpochException(errorMessage);
+            case FENCED_LEADER_EPOCH ->
+                new NotLeaderOrFollowerException(errorMessage);
+            default ->
+                new UnknownServerException(errorMessage);
         };
     }
 

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -63,7 +63,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -175,18 +174,13 @@ public class SharePartition {
         }
 
         public static RecordState forId(byte id) {
-            switch (id) {
-                case 0:
-                    return AVAILABLE;
-                case 1:
-                    return ACQUIRED;
-                case 2:
-                    return ACKNOWLEDGED;
-                case 4:
-                    return ARCHIVED;
-                default:
-                    throw new IllegalArgumentException("Unknown record state id: " + id);
-            }
+            return switch (id) {
+                case 0 -> AVAILABLE;
+                case 1 -> ACQUIRED;
+                case 2 -> ACKNOWLEDGED;
+                case 4 -> ARCHIVED;
+                default -> throw new IllegalArgumentException("Unknown record state id: " + id);
+            };
         }
 
         public byte id() {
@@ -440,8 +434,8 @@ public class SharePartition {
         persister.readState(new ReadShareGroupStateParameters.Builder()
             .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionIdLeaderEpochData>()
                 .setGroupId(this.groupId)
-                .setTopicsData(Collections.singletonList(new TopicData<>(topicIdPartition.topicId(),
-                    Collections.singletonList(PartitionFactory.newPartitionIdLeaderEpochData(topicIdPartition.partition(), leaderEpoch)))))
+                .setTopicsData(List.of(new TopicData<>(topicIdPartition.topicId(),
+                    List.of(PartitionFactory.newPartitionIdLeaderEpochData(topicIdPartition.partition(), leaderEpoch)))))
                 .build())
             .build()
         ).whenComplete((result, exception) -> {
@@ -1675,17 +1669,12 @@ public class SharePartition {
     }
 
     private static RecordState fetchRecordState(byte acknowledgeType) {
-        switch (acknowledgeType) {
-            case 1 /* ACCEPT */:
-                return RecordState.ACKNOWLEDGED;
-            case 2 /* RELEASE */:
-                return RecordState.AVAILABLE;
-            case 3 /* REJECT */:
-            case 0 /* GAP */:
-                return RecordState.ARCHIVED;
-            default:
-                throw new IllegalArgumentException("Invalid acknowledge type: " + acknowledgeType);
-        }
+        return switch (acknowledgeType) {
+            case 1 /* ACCEPT */ -> RecordState.ACKNOWLEDGED;
+            case 2 /* RELEASE */ -> RecordState.AVAILABLE;
+            case 3, 0 /* REJECT GAP */ -> RecordState.ARCHIVED;
+            default -> throw new IllegalArgumentException("Invalid acknowledge type: " + acknowledgeType);
+        };
     }
 
     private NavigableMap<Long, InFlightBatch> fetchSubMapForAcknowledgementBatch(
@@ -2239,8 +2228,8 @@ public class SharePartition {
         persister.writeState(new WriteShareGroupStateParameters.Builder()
             .setGroupTopicPartitionData(new GroupTopicPartitionData.Builder<PartitionStateBatchData>()
                 .setGroupId(this.groupId)
-                .setTopicsData(Collections.singletonList(new TopicData<>(topicIdPartition.topicId(),
-                    Collections.singletonList(PartitionFactory.newPartitionStateBatchData(
+                .setTopicsData(List.of(new TopicData<>(topicIdPartition.topicId(),
+                    List.of(PartitionFactory.newPartitionStateBatchData(
                         topicIdPartition.partition(), stateEpoch, startOffset, leaderEpoch, stateBatches))))
                 ).build()).build())
             .whenComplete((result, exception) -> {
@@ -2284,22 +2273,15 @@ public class SharePartition {
 
     private KafkaException fetchPersisterError(short errorCode, String errorMessage) {
         Errors error = Errors.forCode(errorCode);
-        switch (error) {
-            case NOT_COORDINATOR:
-            case COORDINATOR_NOT_AVAILABLE:
-            case COORDINATOR_LOAD_IN_PROGRESS:
-                return new CoordinatorNotAvailableException(errorMessage);
-            case GROUP_ID_NOT_FOUND:
-                return new GroupIdNotFoundException(errorMessage);
-            case UNKNOWN_TOPIC_OR_PARTITION:
-                return new UnknownTopicOrPartitionException(errorMessage);
-            case FENCED_STATE_EPOCH:
-                return new FencedStateEpochException(errorMessage);
-            case FENCED_LEADER_EPOCH:
-                return new NotLeaderOrFollowerException(errorMessage);
-            default:
-                return new UnknownServerException(errorMessage);
-        }
+        return switch (error) {
+            case NOT_COORDINATOR, COORDINATOR_NOT_AVAILABLE, COORDINATOR_LOAD_IN_PROGRESS ->
+                new CoordinatorNotAvailableException(errorMessage);
+            case GROUP_ID_NOT_FOUND -> new GroupIdNotFoundException(errorMessage);
+            case UNKNOWN_TOPIC_OR_PARTITION -> new UnknownTopicOrPartitionException(errorMessage);
+            case FENCED_STATE_EPOCH -> new FencedStateEpochException(errorMessage);
+            case FENCED_LEADER_EPOCH -> new NotLeaderOrFollowerException(errorMessage);
+            default -> new UnknownServerException(errorMessage);
+        };
     }
 
     // Visible for testing

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -63,7 +63,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -357,7 +356,7 @@ public class SharePartitionManager implements AutoCloseable {
 
         // Additionally release the acquired records for the respective member.
         if (topicIdPartitions.isEmpty()) {
-            return CompletableFuture.completedFuture(Collections.emptyMap());
+            return CompletableFuture.completedFuture(Map.of());
         }
 
         Map<TopicIdPartition, CompletableFuture<Throwable>> futuresMap = new HashMap<>();
@@ -537,7 +536,7 @@ public class SharePartitionManager implements AutoCloseable {
         ShareSessionKey key = shareSessionKey(groupId, memberId);
         ShareSession shareSession = cache.get(key);
         if (shareSession == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         List<TopicIdPartition> cachedTopicIdPartitions = new ArrayList<>();
         shareSession.partitionMap().forEach(cachedSharePartition -> cachedTopicIdPartitions.add(
@@ -570,7 +569,7 @@ public class SharePartitionManager implements AutoCloseable {
     void processShareFetch(ShareFetch shareFetch) {
         if (shareFetch.topicIdPartitions().isEmpty()) {
             // If there are no partitions to fetch then complete the future with an empty map.
-            shareFetch.maybeComplete(Collections.emptyMap());
+            shareFetch.maybeComplete(Map.of());
             return;
         }
 
@@ -633,7 +632,7 @@ public class SharePartitionManager implements AutoCloseable {
 
         // If all the partitions in the request errored out, then complete the fetch request with an exception.
         if (shareFetch.errorInAllPartitions()) {
-            shareFetch.maybeComplete(Collections.emptyMap());
+            shareFetch.maybeComplete(Map.of());
             // Do not proceed with share fetch processing as all the partitions errored out.
             return;
         }
@@ -654,7 +653,7 @@ public class SharePartitionManager implements AutoCloseable {
                     // to identify the respective share partition.
                     SharePartitionListener listener = new SharePartitionListener(sharePartitionKey, replicaManager, partitionCacheMap);
                     replicaManager.maybeAddListener(sharePartitionKey.topicIdPartition().topicPartition(), listener);
-                    SharePartition partition = new SharePartition(
+                    return new SharePartition(
                             sharePartitionKey.groupId(),
                             sharePartitionKey.topicIdPartition(),
                             leaderEpoch,
@@ -668,7 +667,6 @@ public class SharePartitionManager implements AutoCloseable {
                             groupConfigManager,
                             listener
                     );
-                    return partition;
                 });
     }
 

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -351,7 +351,7 @@ public class SharePartitionManager implements AutoCloseable {
             log.error("Share session error for {}: no such share session found", key);
             return FutureUtils.failedFuture(Errors.SHARE_SESSION_NOT_FOUND.exception());
         } else {
-            log.debug("Removed share session with key " + key);
+            log.debug("Removed share session with key {}", key);
         }
 
         // Additionally release the acquired records for the respective member.

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -220,7 +220,7 @@ public class RemoteLogManagerTest {
     private final EpochEntry epochEntry0 = new EpochEntry(0, 0);
     private final EpochEntry epochEntry1 = new EpochEntry(1, 100);
     private final EpochEntry epochEntry2 = new EpochEntry(2, 200);
-    private final List<EpochEntry> totalEpochEntries = Arrays.asList(epochEntry0, epochEntry1, epochEntry2);
+    private final List<EpochEntry> totalEpochEntries = List.of(epochEntry0, epochEntry1, epochEntry2);
     private LeaderEpochCheckpointFile checkpoint;
     private final AtomicLong currentLogStartOffset = new AtomicLong(0L);
 
@@ -288,7 +288,7 @@ public class RemoteLogManagerTest {
 
     @Test
     void testFindHighestRemoteOffsetOnEmptyRemoteStorage() throws  RemoteStorageException {
-        List<EpochEntry> totalEpochEntries = Arrays.asList(
+        List<EpochEntry> totalEpochEntries = List.of(
                 new EpochEntry(0, 0),
                 new EpochEntry(1, 500)
         );
@@ -302,7 +302,7 @@ public class RemoteLogManagerTest {
 
     @Test
     void testFindHighestRemoteOffset() throws RemoteStorageException {
-        List<EpochEntry> totalEpochEntries = Arrays.asList(
+        List<EpochEntry> totalEpochEntries = List.of(
                 new EpochEntry(0, 0),
                 new EpochEntry(1, 500)
         );
@@ -324,7 +324,7 @@ public class RemoteLogManagerTest {
 
     @Test
     void testFindHighestRemoteOffsetWithUncleanLeaderElection() throws RemoteStorageException {
-        List<EpochEntry> totalEpochEntries = Arrays.asList(
+        List<EpochEntry> totalEpochEntries = List.of(
                 new EpochEntry(0, 0),
                 new EpochEntry(1, 150),
                 new EpochEntry(2, 300)
@@ -523,7 +523,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -577,7 +577,7 @@ public class RemoteLogManagerTest {
         assertEquals(remoteLogSegmentMetadataArg.getValue(), remoteLogSegmentMetadataArg2.getValue());
         // The old segment should only contain leader epoch [0->0, 1->100] since its offset range is [0, 149]
         verifyLogSegmentData(logSegmentDataArg.getValue(), idx, timeIdx, txnIndex, tempFile, mockProducerSnapshotIndex,
-            Arrays.asList(epochEntry0, epochEntry1));
+            List.of(epochEntry0, epochEntry1));
 
         // verify remoteLogMetadataManager did add the expected RemoteLogSegmentMetadataUpdate
         ArgumentCaptor<RemoteLogSegmentMetadataUpdate> remoteLogSegmentMetadataUpdateArg = ArgumentCaptor.forClass(RemoteLogSegmentMetadataUpdate.class);
@@ -637,7 +637,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -729,7 +729,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -780,7 +780,7 @@ public class RemoteLogManagerTest {
     void testLeadershipChangesWithoutRemoteLogManagerConfiguring() {
         assertThrows(KafkaException.class, () ->
             remoteLogManager.onLeadershipChange(
-                Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds),
+                Set.of(mockPartition(leaderTopicIdPartition)), Set.of(mockPartition(followerTopicIdPartition)), topicIds),
                 "RemoteLogManager is not configured when remote storage system is enabled");
     }
 
@@ -817,7 +817,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -872,7 +872,7 @@ public class RemoteLogManagerTest {
         assertEquals(0, safeLongYammerMetricValue("RemoteLogSizeBytes,topic=" + leaderTopic));
         assertEquals(0, safeLongYammerMetricValue("RemoteLogMetadataCount"));
         assertEquals(0, safeLongYammerMetricValue("RemoteLogSizeBytes"));
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.singleton(mockFollowerPartition), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockLeaderPartition), Set.of(mockFollowerPartition), topicIds);
         assertTrue((double) yammerMetricValue("RemoteLogManagerTasksAvgIdlePercent") < 1.0);
 
         copyLogSegmentLatch.countDown();
@@ -938,7 +938,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -981,7 +981,7 @@ public class RemoteLogManagerTest {
         when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 2)).thenReturn(metadataList.iterator());
 
         // leadership change to log in dir1
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.emptySet(), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockLeaderPartition), Set.of(), topicIds);
 
         TestUtils.waitForCondition(() -> {
             ArgumentCaptor<Long> argument = ArgumentCaptor.forClass(Long.class);
@@ -998,7 +998,7 @@ public class RemoteLogManagerTest {
         when(mockLog.config()).thenReturn(logConfig);
         when(mockLog.logEndOffset()).thenReturn(500L);
 
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.emptySet(), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockLeaderPartition), Set.of(), topicIds);
 
         // after copyLogSegment completes for log (in dir1), updateHighestOffsetInRemoteStorage will be triggered with new offset
         // even though the leader replica has changed to log in dir2
@@ -1059,7 +1059,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldestSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldestSegment, olderSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldestSegment, olderSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -1134,7 +1134,7 @@ public class RemoteLogManagerTest {
         assertEquals(0L, yammerMetricValue("RemoteCopyLagSegments"));
         assertEquals(0L, yammerMetricValue("RemoteLogSizeComputationTime"));
 
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.emptySet(), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockLeaderPartition), Set.of(), topicIds);
         TestUtils.waitForCondition(
                 () -> 75 == safeLongYammerMetricValue("RemoteCopyLagBytes") && 75 == safeLongYammerMetricValue("RemoteCopyLagBytes,topic=" + leaderTopic),
                 String.format("Expected to find 75 for RemoteCopyLagBytes metric value, but found %d for topic 'Leader' and %d for all topics.",
@@ -1215,7 +1215,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
@@ -1284,7 +1284,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
         when(mockLog.lastStableOffset()).thenReturn(250L);
 
         // Ensure the metrics for remote write requests/failures is zero before attempt to copy log segment
@@ -1392,18 +1392,18 @@ public class RemoteLogManagerTest {
             .thenReturn(Optional.empty());
         verifyNotInCache(followerTopicIdPartition, leaderTopicIdPartition);
         // Load topicId cache
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.singleton(mockFollowerPartition), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockLeaderPartition), Set.of(mockFollowerPartition), topicIds);
         verify(remoteLogMetadataManager, times(1))
-            .onPartitionLeadershipChanges(Collections.singleton(leaderTopicIdPartition), Collections.singleton(followerTopicIdPartition));
+            .onPartitionLeadershipChanges(Set.of(leaderTopicIdPartition), Set.of(followerTopicIdPartition));
         verifyInCache(followerTopicIdPartition, leaderTopicIdPartition);
 
         // Evicts from topicId cache
-        remoteLogManager.stopPartitions(Collections.singleton(new StopPartition(leaderTopicIdPartition.topicPartition(), true, true, true)), (tp, ex) -> { });
+        remoteLogManager.stopPartitions(Set.of(new StopPartition(leaderTopicIdPartition.topicPartition(), true, true, true)), (tp, ex) -> { });
         verifyNotInCache(leaderTopicIdPartition);
         verifyInCache(followerTopicIdPartition);
 
         // Evicts from topicId cache
-        remoteLogManager.stopPartitions(Collections.singleton(new StopPartition(followerTopicIdPartition.topicPartition(), true, true, true)), (tp, ex) -> { });
+        remoteLogManager.stopPartitions(Set.of(new StopPartition(followerTopicIdPartition.topicPartition(), true, true, true)), (tp, ex) -> { });
         verifyNotInCache(leaderTopicIdPartition, followerTopicIdPartition);
     }
 
@@ -1411,7 +1411,7 @@ public class RemoteLogManagerTest {
     void testFetchRemoteLogSegmentMetadata() throws RemoteStorageException {
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-            Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+            Set.of(mockPartition(leaderTopicIdPartition)), Set.of(mockPartition(followerTopicIdPartition)), topicIds);
         remoteLogManager.fetchRemoteLogSegmentMetadata(leaderTopicIdPartition.topicPartition(), 10, 100L);
         remoteLogManager.fetchRemoteLogSegmentMetadata(followerTopicIdPartition.topicPartition(), 20, 200L);
 
@@ -1425,7 +1425,7 @@ public class RemoteLogManagerTest {
     public void testFetchNextSegmentWithTxnIndex() throws RemoteStorageException {
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-            Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+            Set.of(mockPartition(leaderTopicIdPartition)), Set.of(mockPartition(followerTopicIdPartition)), topicIds);
         remoteLogManager.fetchNextSegmentWithTxnIndex(leaderTopicIdPartition.topicPartition(), 10, 100L);
         remoteLogManager.fetchNextSegmentWithTxnIndex(followerTopicIdPartition.topicPartition(), 20, 200L);
 
@@ -1458,7 +1458,7 @@ public class RemoteLogManagerTest {
 
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-                Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+                Set.of(mockPartition(leaderTopicIdPartition)), Set.of(mockPartition(followerTopicIdPartition)), topicIds);
 
         // For offset-10, epoch is 0.
         remoteLogManager.findNextSegmentWithTxnIndex(leaderTopicIdPartition.topicPartition(), 10, cache);
@@ -1493,7 +1493,7 @@ public class RemoteLogManagerTest {
 
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-                Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+                Set.of(mockPartition(leaderTopicIdPartition)), Set.of(mockPartition(followerTopicIdPartition)), topicIds);
 
         // For offset-10, epoch is 0.
         //  1. For epoch 0 and 1, it returns empty and
@@ -1512,13 +1512,13 @@ public class RemoteLogManagerTest {
         remoteLogManager.startup();
         RemoteLogManager spyRemoteLogManager = spy(remoteLogManager);
         spyRemoteLogManager.onLeadershipChange(
-            Collections.emptySet(), Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+            Set.of(), Set.of(mockPartition(followerTopicIdPartition)), topicIds);
         verify(spyRemoteLogManager).doHandleFollowerPartition(eq(followerTopicIdPartition));
 
         Mockito.reset(spyRemoteLogManager);
 
         spyRemoteLogManager.onLeadershipChange(
-            Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.emptySet(), topicIds);
+            Set.of(mockPartition(leaderTopicIdPartition)), Set.of(), topicIds);
         verify(spyRemoteLogManager).doHandleLeaderPartition(eq(leaderTopicIdPartition), eq(false));
     }
 
@@ -1664,7 +1664,7 @@ public class RemoteLogManagerTest {
                 .thenAnswer(ans -> {
                     int leaderEpoch = ans.<Integer>getArgument(1);
                     if (leaderEpoch == targetLeaderEpoch)
-                        return Collections.singleton(segmentMetadata).iterator();
+                        return Set.of(segmentMetadata).iterator();
                     else
                         return Collections.emptyIterator();
                 });
@@ -1678,14 +1678,14 @@ public class RemoteLogManagerTest {
 
         when(mockLog.logEndOffset()).thenReturn(600L);
 
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.emptySet(), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockPartition(leaderTopicIdPartition)), Set.of(), topicIds);
     }
 
     @Test
     void testFetchOffsetByTimestampWithTieredStorageDoesNotFetchIndexWhenExistsLocally() throws Exception {
         TopicPartition tp = new TopicPartition("sample", 0);
         TopicIdPartition tpId = new TopicIdPartition(Uuid.randomUuid(), tp);
-        Map<String, Uuid> topicIds = Collections.singletonMap(tp.topic(), tpId.topicId());
+        Map<String, Uuid> topicIds = Map.of(tp.topic(), tpId.topicId());
 
         List<EpochEntry> epochEntries = new ArrayList<>();
         epochEntries.add(new EpochEntry(0, 0L));
@@ -1710,9 +1710,9 @@ public class RemoteLogManagerTest {
             .thenAnswer(ans -> {
                 int epoch = ans.getArgument(1);
                 if (epoch < 4) {
-                    return Collections.singletonList(metadata0).iterator();
+                    return List.of(metadata0).iterator();
                 } else if (epoch == 4) {
-                    return Arrays.asList(metadata1, metadata2).iterator();
+                    return List.of(metadata1, metadata2).iterator();
                 } else {
                     throw new IllegalArgumentException("Unexpected call!");
                 }
@@ -1736,11 +1736,11 @@ public class RemoteLogManagerTest {
 
         when(mockLog.logSegments()).thenAnswer(invocation -> {
             if (localLogOffsetState.get() == twoSegmentsBaseOffsets50and100) {
-                return Arrays.asList(logSegmentBaseOffset50, logSegmentBaseOffset100);
+                return List.of(logSegmentBaseOffset50, logSegmentBaseOffset100);
             } else if (localLogOffsetState.get() == oneSegmentBaseOffset100) {
-                return Collections.singletonList(logSegmentBaseOffset100);
+                return List.of(logSegmentBaseOffset100);
             } else if (localLogOffsetState.get() == oneSegmentBaseOffset101) {
-                return Collections.singletonList(logSegmentBaseOffset101);
+                return List.of(logSegmentBaseOffset101);
             } else {
                 throw new IllegalStateException("Unexpected localLogOffsetState");
             }
@@ -1761,7 +1761,7 @@ public class RemoteLogManagerTest {
             }
         };
         remoteLogManager.startup();
-        remoteLogManager.onLeadershipChange(Collections.emptySet(), Collections.singleton(mockFollowerPartition), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(), Set.of(mockFollowerPartition), topicIds);
 
         // Read the offset from the remote storage, since the local-log starts from offset 50L and the message with `timestamp` does not exist in the local log
         assertEquals(Optional.of(expectedRemoteResult), remoteLogManager.findOffsetByTimestamp(tp, timestamp, 0L, cache));
@@ -1822,7 +1822,7 @@ public class RemoteLogManagerTest {
             KafkaMetricsGroup mockRlmMetricsGroup = mockMetricsGroupCtor.constructed().get(0);
             KafkaMetricsGroup mockThreadPoolMetricsGroup = mockMetricsGroupCtor.constructed().get(1);
 
-            List<MetricName> remoteLogManagerMetricNames = Arrays.asList(
+            List<MetricName> remoteLogManagerMetricNames = List.of(
                     REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC,
                     REMOTE_LOG_READER_FETCH_RATE_AND_TIME_METRIC);
             Set<String> remoteStorageThreadPoolMetricNames = REMOTE_STORAGE_THREAD_POOL_METRICS;
@@ -2049,11 +2049,11 @@ public class RemoteLogManagerTest {
         when(segment2.baseOffset()).thenReturn(10L);
         when(activeSegment.baseOffset()).thenReturn(15L);
 
-        when(log.logSegments(5L, Long.MAX_VALUE)).thenReturn(Arrays.asList(segment1, segment2, activeSegment));
+        when(log.logSegments(5L, Long.MAX_VALUE)).thenReturn(List.of(segment1, segment2, activeSegment));
 
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         List<RemoteLogManager.EnrichedLogSegment> expected =
-                Arrays.asList(
+                List.of(
                         new RemoteLogManager.EnrichedLogSegment(segment1, 10L),
                         new RemoteLogManager.EnrichedLogSegment(segment2, 15L)
                 );
@@ -2074,11 +2074,11 @@ public class RemoteLogManagerTest {
         when(segment3.baseOffset()).thenReturn(15L);
         when(activeSegment.baseOffset()).thenReturn(20L);
 
-        when(log.logSegments(5L, Long.MAX_VALUE)).thenReturn(Arrays.asList(segment1, segment2, segment3, activeSegment));
+        when(log.logSegments(5L, Long.MAX_VALUE)).thenReturn(List.of(segment1, segment2, segment3, activeSegment));
 
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         List<RemoteLogManager.EnrichedLogSegment> expected =
-                Arrays.asList(
+                List.of(
                         new RemoteLogManager.EnrichedLogSegment(segment1, 10L),
                         new RemoteLogManager.EnrichedLogSegment(segment2, 15L)
                 );
@@ -2122,8 +2122,8 @@ public class RemoteLogManagerTest {
         Set<StopPartition> partitions = new HashSet<>();
         partitions.add(new StopPartition(leaderTopicIdPartition.topicPartition(), true, false, false));
         partitions.add(new StopPartition(followerTopicIdPartition.topicPartition(), true, false, false));
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockPartition(leaderTopicIdPartition)),
-                Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockPartition(leaderTopicIdPartition)),
+                Set.of(mockPartition(followerTopicIdPartition)), topicIds);
         assertNotNull(remoteLogManager.leaderCopyTask(leaderTopicIdPartition));
         assertNotNull(remoteLogManager.leaderExpirationTask(leaderTopicIdPartition));
         assertNotNull(remoteLogManager.followerTask(followerTopicIdPartition));
@@ -2155,8 +2155,8 @@ public class RemoteLogManagerTest {
         when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any()))
                 .thenReturn(dummyFuture);
 
-        remoteLogManager.onLeadershipChange(Collections.singleton(mockPartition(leaderTopicIdPartition)),
-                Collections.singleton(mockPartition(followerTopicIdPartition)), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(mockPartition(leaderTopicIdPartition)),
+                Set.of(mockPartition(followerTopicIdPartition)), topicIds);
         assertNotNull(remoteLogManager.leaderCopyTask(leaderTopicIdPartition));
         assertNotNull(remoteLogManager.leaderExpirationTask(leaderTopicIdPartition));
         assertNotNull(remoteLogManager.followerTask(followerTopicIdPartition));
@@ -2188,7 +2188,7 @@ public class RemoteLogManagerTest {
 
         long timestamp = time.milliseconds();
         int segmentSize = 1024;
-        List<RemoteLogSegmentMetadata> segmentMetadataList = Arrays.asList(
+        List<RemoteLogSegmentMetadata> segmentMetadataList = List.of(
                 new RemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
                         500, 539, timestamp, brokerId, timestamp, segmentSize, truncateAndGetLeaderEpochs(epochEntries, 500L, 539L)),
                 new RemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
@@ -2255,7 +2255,7 @@ public class RemoteLogManagerTest {
                 .thenAnswer(invocation -> {
                     int epoch = invocation.getArgument(1);
                     if (epoch == 2)
-                        return Collections.singletonList(metadata).iterator();
+                        return List.of(metadata).iterator();
                     else
                         return Collections.emptyIterator();
                 });
@@ -2345,7 +2345,7 @@ public class RemoteLogManagerTest {
         when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
 
         // leader epoch preparation
-        checkpoint.write(Collections.singletonList(epochEntry0));
+        checkpoint.write(List.of(epochEntry0));
         LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
 
@@ -2365,7 +2365,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         File mockProducerSnapshotIndex = TestUtils.tempFile();
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
@@ -2449,7 +2449,7 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(mockLogConfig);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
         checkpoint.write(epochEntries);
         LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
@@ -2501,7 +2501,7 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(mockLogConfig);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
         checkpoint.write(epochEntries);
         LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
@@ -2569,7 +2569,7 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(mockLogConfig);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
         checkpoint.write(epochEntries);
         LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
@@ -2616,7 +2616,7 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(mockLogConfig);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
         checkpoint.write(epochEntries);
         LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
@@ -2654,7 +2654,7 @@ public class RemoteLogManagerTest {
                 listRemoteLogSegmentMetadata(leaderTopicIdPartition, 11, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
 
         List<RemoteLogSegmentMetadata> metadataList = new LinkedList<>();
-        metadataList.addAll(Arrays.asList(s1, s2, s3, s4CopyStarted));
+        metadataList.addAll(List.of(s1, s2, s3, s4CopyStarted));
         metadataList.addAll(s5);
 
         when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
@@ -2679,7 +2679,7 @@ public class RemoteLogManagerTest {
         // RUN 2
         // update the metadata list to remove deleted s1, s3, and set the state in s4 to COPY_SEGMENT_FINISHED
         List<RemoteLogSegmentMetadata> updatedMetadataList = new LinkedList<>();
-        updatedMetadataList.addAll(Arrays.asList(s2, s4CopyFinished));
+        updatedMetadataList.addAll(List.of(s2, s4CopyFinished));
         updatedMetadataList.addAll(s5);
         when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
                 .thenReturn(updatedMetadataList.iterator());
@@ -2702,7 +2702,7 @@ public class RemoteLogManagerTest {
         when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
         when(mockLog.logEndOffset()).thenReturn(200L);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
 
         List<RemoteLogSegmentMetadata> metadataList =
                 listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
@@ -2772,7 +2772,7 @@ public class RemoteLogManagerTest {
         when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
         when(mockLog.logEndOffset()).thenReturn(200L);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
 
         List<RemoteLogSegmentMetadata> metadataList =
             listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
@@ -2800,7 +2800,7 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(mockLogConfig);
 
-        List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
         checkpoint.write(epochEntries);
         LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
@@ -2852,7 +2852,7 @@ public class RemoteLogManagerTest {
             throws RemoteStorageException, ExecutionException, InterruptedException {
         int recordsPerSegment = 100;
         int segmentSize = 1024;
-        List<EpochEntry> epochEntries = Arrays.asList(
+        List<EpochEntry> epochEntries = List.of(
                 new EpochEntry(0, 0L),
                 new EpochEntry(1, 20L),
                 new EpochEntry(3, 50L),
@@ -2890,7 +2890,7 @@ public class RemoteLogManagerTest {
             throws RemoteStorageException, ExecutionException, InterruptedException {
         int recordsPerSegment = 100;
         int segmentSize = 1024;
-        List<EpochEntry> epochEntries = Arrays.asList(
+        List<EpochEntry> epochEntries = List.of(
                 new EpochEntry(0, 0L),
                 new EpochEntry(1, 20L),
                 new EpochEntry(3, 50L),
@@ -2985,7 +2985,7 @@ public class RemoteLogManagerTest {
             when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
             when(mockLog.logEndOffset()).thenReturn(200L);
 
-            List<EpochEntry> epochEntries = Collections.singletonList(epochEntry0);
+            List<EpochEntry> epochEntries = List.of(epochEntry0);
 
             List<RemoteLogSegmentMetadata> remoteLogSegmentMetadatas = listRemoteLogSegmentMetadata(
                     leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED);
@@ -3023,7 +3023,7 @@ public class RemoteLogManagerTest {
                                                                         int recordsPerSegment,
                                                                         int segmentSize,
                                                                         RemoteLogSegmentState state) {
-        return listRemoteLogSegmentMetadata(topicIdPartition, segmentCount, recordsPerSegment, segmentSize, Collections.emptyList(), state);
+        return listRemoteLogSegmentMetadata(topicIdPartition, segmentCount, recordsPerSegment, segmentSize, List.of(), state);
     }
 
     private List<RemoteLogSegmentMetadata> listRemoteLogSegmentMetadata(TopicIdPartition topicIdPartition,
@@ -3389,7 +3389,7 @@ public class RemoteLogManagerTest {
         int expectedEpoch = 0;
         long expectedStartOffset = 1L;
         int expectedVersion = 0;
-        List<EpochEntry> epochs = Arrays.asList(new EpochEntry(expectedEpoch, expectedStartOffset));
+        List<EpochEntry> epochs = List.of(new EpochEntry(expectedEpoch, expectedStartOffset));
         ByteBuffer buffer = RemoteLogManager.epochEntriesAsByteBuffer(epochs);
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(buffer.array()), StandardCharsets.UTF_8));
 
@@ -3450,7 +3450,7 @@ public class RemoteLogManagerTest {
         remoteLogManager.startup();
         setupRLMTask(true);
         remoteLogManager.onLeadershipChange(
-            Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.emptySet(), topicIds);
+            Set.of(mockPartition(leaderTopicIdPartition)), Set.of(), topicIds);
         // Ensure the copy operation is waiting for quota to be available
         TestUtils.waitForCondition(() -> {
             verify(rlmCopyQuotaManager, atLeast(1)).getThrottleTimeMs();
@@ -3493,7 +3493,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(oldSegment, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(oldSegment, activeSegment));
 
         File mockProducerSnapshotIndex = TestUtils.tempFile();
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
@@ -3562,7 +3562,7 @@ public class RemoteLogManagerTest {
 
         when(mockLog.activeSegment()).thenReturn(activeSegment);
         when(mockLog.logStartOffset()).thenReturn(oldestSegmentStartOffset);
-        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(Arrays.asList(segmentToCopy, segmentToThrottle, activeSegment));
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(List.of(segmentToCopy, segmentToThrottle, activeSegment));
 
         File mockProducerSnapshotIndex = TestUtils.tempFile();
         ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
@@ -3610,15 +3610,15 @@ public class RemoteLogManagerTest {
     public void testTierLagResetsToZeroOnBecomingFollower() {
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-                Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.emptySet(), topicIds);
+                Set.of(mockPartition(leaderTopicIdPartition)), Set.of(), topicIds);
         RemoteLogManager.RLMCopyTask rlmTask = (RemoteLogManager.RLMCopyTask) remoteLogManager.rlmCopyTask(leaderTopicIdPartition);
         assertNotNull(rlmTask);
         rlmTask.recordLagStats(1024, 2);
         assertEquals(1024, brokerTopicStats.topicStats(leaderTopicIdPartition.topic()).remoteCopyLagBytes());
         assertEquals(2, brokerTopicStats.topicStats(leaderTopicIdPartition.topic()).remoteCopyLagSegments());
         // The same node becomes follower now which was the previous leader
-        remoteLogManager.onLeadershipChange(Collections.emptySet(),
-                Collections.singleton(mockPartition(leaderTopicIdPartition)), topicIds);
+        remoteLogManager.onLeadershipChange(Set.of(),
+                Set.of(mockPartition(leaderTopicIdPartition)), topicIds);
         assertEquals(0, brokerTopicStats.topicStats(leaderTopicIdPartition.topic()).remoteCopyLagBytes());
         assertEquals(0, brokerTopicStats.topicStats(leaderTopicIdPartition.topic()).remoteCopyLagSegments());
 
@@ -3664,7 +3664,7 @@ public class RemoteLogManagerTest {
         };
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-                Collections.singleton(mockPartition(leaderTopicIdPartition)), Collections.emptySet(), topicIds);
+                Set.of(mockPartition(leaderTopicIdPartition)), Set.of(), topicIds);
 
         long fetchOffset = 10;
         FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(
@@ -3721,8 +3721,8 @@ public class RemoteLogManagerTest {
                 });
         remoteLogManager.startup();
         remoteLogManager.onLeadershipChange(
-                Collections.singleton(mockPartition(leaderTopicIdPartition)),
-                Collections.singleton(mockPartition(followerTopicIdPartition)),
+                Set.of(mockPartition(leaderTopicIdPartition)),
+                Set.of(mockPartition(followerTopicIdPartition)),
                 topicIds
         );
         assertNotNull(remoteLogManager.rlmCopyTask(leaderTopicIdPartition));

--- a/core/src/test/java/kafka/security/JaasModule.java
+++ b/core/src/test/java/kafka/security/JaasModule.java
@@ -16,7 +16,6 @@
  */
 package kafka.security;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +61,7 @@ public class JaasModule {
     }
 
     public static JaasModule plainLoginModule(String username, String password) {
-        return plainLoginModule(username, password, false, Collections.emptyMap());
+        return plainLoginModule(username, password, false, Map.of());
     }
 
     public static JaasModule plainLoginModule(String username, String password, boolean debug, Map<String, String> validUsers) {
@@ -81,7 +80,7 @@ public class JaasModule {
     }
 
     public static JaasModule scramLoginModule(String username, String password) {
-        return scramLoginModule(username, password, false, Collections.emptyMap());
+        return scramLoginModule(username, password, false, Map.of());
     }
 
     public static JaasModule scramLoginModule(String username, String password, boolean debug, Map<String, String> tokenProps) {

--- a/core/src/test/java/kafka/security/JaasModule.java
+++ b/core/src/test/java/kafka/security/JaasModule.java
@@ -60,10 +60,6 @@ public class JaasModule {
         );
     }
 
-    public static JaasModule plainLoginModule(String username, String password) {
-        return plainLoginModule(username, password, false, Map.of());
-    }
-
     public static JaasModule plainLoginModule(String username, String password, boolean debug, Map<String, String> validUsers) {
         String name = "org.apache.kafka.common.security.plain.PlainLoginModule";
 

--- a/core/src/test/java/kafka/security/JaasTestUtils.java
+++ b/core/src/test/java/kafka/security/JaasTestUtils.java
@@ -255,23 +255,17 @@ public class JaasTestUtils {
     }
 
     public static boolean usesSslTransportLayer(SecurityProtocol securityProtocol) {
-        switch (securityProtocol) {
-            case SSL:
-            case SASL_SSL:
-                return true;
-            default:
-                return false;
-        }
+        return switch (securityProtocol) {
+            case SSL, SASL_SSL -> true;
+            default -> false;
+        };
     }
 
     public static boolean usesSaslAuthentication(SecurityProtocol securityProtocol) {
-        switch (securityProtocol) {
-            case SASL_PLAINTEXT:
-            case SASL_SSL:
-                return true;
-            default:
-                return false;
-        }
+        return switch (securityProtocol) {
+            case SASL_PLAINTEXT, SASL_SSL -> true;
+            default -> false;
+        };
     }
 
     public static Properties sslConfigs(ConnectionMode mode,

--- a/core/src/test/java/kafka/security/JaasTestUtils.java
+++ b/core/src/test/java/kafka/security/JaasTestUtils.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -246,7 +245,7 @@ public class JaasTestUtils {
                         KAFKA_SCRAM_PASSWORD_2,
                         KAFKA_OAUTH_BEARER_USER_2,
                         SERVICE_NAME)
-                ).map(Collections::singletonList).orElse(Collections.emptyList()));
+                ).map(List::of).orElse(List.of()));
     }
 
     private static void writeToFile(File file, List<JaasSection> jaasSections) throws IOException {

--- a/core/src/test/java/kafka/security/minikdc/MiniKdc.java
+++ b/core/src/test/java/kafka/security/minikdc/MiniKdc.java
@@ -64,7 +64,6 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.MessageFormat;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,7 +73,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Mini KDC based on Apache Directory Server that can be embedded in tests or used from command line as a standalone
@@ -138,7 +136,7 @@ public class MiniKdc {
      *                MiniKdc.
      */
     public MiniKdc(Properties config, File workDir) {
-        Set<String> requiredProperties = new HashSet<>(Arrays.asList(ORG_NAME, ORG_DOMAIN, KDC_BIND_ADDRESS, KDC_PORT,
+        Set<String> requiredProperties = new HashSet<>(List.of(ORG_NAME, ORG_DOMAIN, KDC_BIND_ADDRESS, KDC_PORT,
                 INSTANCE, TRANSPORT, MAX_TICKET_LIFETIME, MAX_RENEWABLE_LIFETIME));
         if (!config.keySet().containsAll(requiredProperties)) {
             throw new IllegalArgumentException("Missing required properties: " + requiredProperties);
@@ -181,7 +179,7 @@ public class MiniKdc {
         config.putAll(userConfig);
         File keytabFile = new File(keytabPath).getAbsoluteFile();
 
-        start(workDir, config, keytabFile, Arrays.asList(principals));
+        start(workDir, config, keytabFile, List.of(principals));
     }
 
     /**
@@ -304,7 +302,7 @@ public class MiniKdc {
                 byte keyVersion = (byte) encryptionKey.getKeyVersion();
                 return new KeytabEntry(principalWithRealm, 1, timestamp, keyVersion, encryptionKey);
             });
-        }).collect(Collectors.toList());
+        }).toList();
         keytab.setEntries(entries);
         keytab.write(keytabFile);
     }

--- a/core/src/test/java/kafka/security/minikdc/MiniKdc.java
+++ b/core/src/test/java/kafka/security/minikdc/MiniKdc.java
@@ -403,16 +403,11 @@ public class MiniKdc {
         // transport
         AbstractTransport absTransport;
         String transport = config.getProperty(TRANSPORT).trim();
-        switch (transport) {
-            case "TCP":
-                absTransport = new TcpTransport(bindAddress, port, 3, 50);
-                break;
-            case "UDP":
-                absTransport = new UdpTransport(port);
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid transport: " + transport);
-        }
+        absTransport = switch (transport) {
+            case "TCP" -> new TcpTransport(bindAddress, port, 3, 50);
+            case "UDP" -> new UdpTransport(port);
+            default -> throw new IllegalArgumentException("Invalid transport: " + transport);
+        };
         kdc.addTransports(absTransport);
         kdc.setServiceName(config.getProperty(INSTANCE));
         kdc.start();

--- a/core/src/test/java/kafka/security/minikdc/MiniKdcTest.java
+++ b/core/src/test/java/kafka/security/minikdc/MiniKdcTest.java
@@ -21,7 +21,7 @@ import kafka.utils.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 public class MiniKdcTest {
@@ -38,7 +38,7 @@ public class MiniKdcTest {
         config.setProperty(MiniKdc.MAX_RENEWABLE_LIFETIME, "604800000");
         config.setProperty(MiniKdc.INSTANCE, "DefaultKrbServer");
 
-        MiniKdc minikdc = MiniKdc.start(TestUtils.tempDir(), config, TestUtils.tempFile(), Collections.singletonList("foo"));
+        MiniKdc minikdc = MiniKdc.start(TestUtils.tempDir(), config, TestUtils.tempFile(), List.of("foo"));
         boolean running = System.getProperty(MiniKdc.JAVA_SECURITY_KRB5_CONF) != null;
         try {
             Assertions.assertTrue(running, "MiniKdc stopped immediately; it should not have");

--- a/core/src/test/java/kafka/server/ReconfigurableQuorumIntegrationTest.java
+++ b/core/src/test/java/kafka/server/ReconfigurableQuorumIntegrationTest.java
@@ -29,10 +29,10 @@ import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -119,7 +119,7 @@ public class ReconfigurableQuorumIntegrationTest {
             try (Admin admin = Admin.create(cluster.clientProperties())) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
-                    assertEquals(new HashSet<>(Arrays.asList(3000, 3001, 3002)), voters.keySet());
+                    assertEquals(new HashSet<>(List.of(3000, 3001, 3002)), voters.keySet());
                     for (int replicaId : new int[] {3000, 3001, 3002}) {
                         assertNotEquals(Uuid.ZERO_UUID, voters.get(replicaId));
                     }
@@ -144,7 +144,7 @@ public class ReconfigurableQuorumIntegrationTest {
             try (Admin admin = Admin.create(cluster.clientProperties())) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
-                    assertEquals(new HashSet<>(Arrays.asList(3000, 3001, 3002, 3003)), voters.keySet());
+                    assertEquals(new HashSet<>(List.of(3000, 3001, 3002, 3003)), voters.keySet());
                     for (int replicaId : new int[] {3000, 3001, 3002, 3003}) {
                         assertNotEquals(Uuid.ZERO_UUID, voters.get(replicaId));
                     }
@@ -153,7 +153,7 @@ public class ReconfigurableQuorumIntegrationTest {
                 admin.removeRaftVoter(3000, dirId).all().get();
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
-                    assertEquals(new HashSet<>(Arrays.asList(3001, 3002, 3003)), voters.keySet());
+                    assertEquals(new HashSet<>(List.of(3001, 3002, 3003)), voters.keySet());
                     for (int replicaId : new int[] {3001, 3002, 3003}) {
                         assertNotEquals(Uuid.ZERO_UUID, voters.get(replicaId));
                     }
@@ -161,7 +161,7 @@ public class ReconfigurableQuorumIntegrationTest {
                 admin.addRaftVoter(
                     3000,
                     dirId,
-                    Collections.singleton(new RaftVoterEndpoint("CONTROLLER", "example.com", 8080))
+                    Set.of(new RaftVoterEndpoint("CONTROLLER", "example.com", 8080))
                 ).all().get();
             }
         }

--- a/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
+++ b/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
@@ -490,7 +490,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
             image.delegationTokens()
         );
         MetadataDelta delta = new MetadataDelta.Builder().setImage(partialImage).build();
-        records.stream().forEach(record -> delta.replay(record));
+        records.forEach(delta::replay);
         kRaftMetadataCache.setImage(delta.apply(new MetadataProvenance(100L, 10, 1000L, true)));
     }
 

--- a/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
+++ b/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
@@ -71,13 +71,11 @@ import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -132,7 +130,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
                         return AuthorizationResult.ALLOWED;
                     else
                         return AuthorizationResult.DENIED;
-                }).collect(Collectors.toList());
+                }).toList();
             });
 
         // 2. Set up MetadataCache
@@ -145,7 +143,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         BrokerEndpointCollection collection = new BrokerEndpointCollection();
         collection.add(brokerEndpoint);
-        List<ApiMessage> records = Arrays.asList(
+        List<ApiMessage> records = List.of(
             new RegisterBrokerRecord()
                 .setBrokerId(brokerId)
                 .setBrokerEpoch(0)
@@ -158,33 +156,33 @@ class DescribeTopicPartitionsRequestHandlerTest {
             new PartitionRecord()
                 .setTopicId(authorizedTopicId)
                 .setPartitionId(1)
-                .setReplicas(Arrays.asList(0, 1, 2))
+                .setReplicas(List.of(0, 1, 2))
                 .setLeader(0)
-                .setIsr(Arrays.asList(0))
-                .setEligibleLeaderReplicas(Arrays.asList(1))
-                .setLastKnownElr(Arrays.asList(2))
+                .setIsr(List.of(0))
+                .setEligibleLeaderReplicas(List.of(1))
+                .setLastKnownElr(List.of(2))
                 .setLeaderEpoch(0)
                 .setPartitionEpoch(1)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()),
             new PartitionRecord()
                 .setTopicId(authorizedTopicId)
                 .setPartitionId(0)
-                .setReplicas(Arrays.asList(0, 1, 2))
+                .setReplicas(List.of(0, 1, 2))
                 .setLeader(0)
-                .setIsr(Arrays.asList(0))
-                .setEligibleLeaderReplicas(Arrays.asList(1))
-                .setLastKnownElr(Arrays.asList(2))
+                .setIsr(List.of(0))
+                .setEligibleLeaderReplicas(List.of(1))
+                .setLastKnownElr(List.of(2))
                 .setLeaderEpoch(0)
                 .setPartitionEpoch(1)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()),
             new PartitionRecord()
                 .setTopicId(unauthorizedTopicId)
                 .setPartitionId(0)
-                .setReplicas(Arrays.asList(0, 1, 3))
+                .setReplicas(List.of(0, 1, 3))
                 .setLeader(0)
-                .setIsr(Arrays.asList(0))
-                .setEligibleLeaderReplicas(Arrays.asList(1))
-                .setLastKnownElr(Arrays.asList(3))
+                .setIsr(List.of(0))
+                .setEligibleLeaderReplicas(List.of(1))
+                .setLastKnownElr(List.of(3))
                 .setLeaderEpoch(0)
                 .setPartitionEpoch(2)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value())
@@ -197,7 +195,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
         // 3.1 Basic test
         DescribeTopicPartitionsRequest describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(
             new DescribeTopicPartitionsRequestData()
-                .setTopics(Arrays.asList(
+                .setTopics(List.of(
                     new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic),
                     new DescribeTopicPartitionsRequestData.TopicRequest().setName(unauthorizedTopic)
                 ))
@@ -225,7 +223,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         // 3.2 With cursor
         describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(new DescribeTopicPartitionsRequestData()
-            .setTopics(Arrays.asList(
+            .setTopics(List.of(
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic),
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(unauthorizedTopic)
                 ))
@@ -329,7 +327,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
                         return AuthorizationResult.ALLOWED;
                     else
                         return AuthorizationResult.DENIED;
-                }).collect(Collectors.toList());
+                }).toList();
             });
 
         // 2. Set up MetadataCache
@@ -342,7 +340,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         BrokerEndpointCollection collection = new BrokerEndpointCollection();
         collection.add(brokerEndpoint);
-        List<ApiMessage> records = Arrays.asList(
+        List<ApiMessage> records = List.of(
             new RegisterBrokerRecord()
                 .setBrokerId(brokerId)
                 .setBrokerEpoch(0)
@@ -355,33 +353,33 @@ class DescribeTopicPartitionsRequestHandlerTest {
             new PartitionRecord()
                 .setTopicId(authorizedTopicId)
                 .setPartitionId(0)
-                .setReplicas(Arrays.asList(0, 1, 2))
+                .setReplicas(List.of(0, 1, 2))
                 .setLeader(0)
-                .setIsr(Arrays.asList(0))
-                .setEligibleLeaderReplicas(Arrays.asList(1))
-                .setLastKnownElr(Arrays.asList(2))
+                .setIsr(List.of(0))
+                .setEligibleLeaderReplicas(List.of(1))
+                .setLastKnownElr(List.of(2))
                 .setLeaderEpoch(0)
                 .setPartitionEpoch(1)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()),
             new PartitionRecord()
                 .setTopicId(authorizedTopicId)
                 .setPartitionId(1)
-                .setReplicas(Arrays.asList(0, 1, 2))
+                .setReplicas(List.of(0, 1, 2))
                 .setLeader(0)
-                .setIsr(Arrays.asList(0))
-                .setEligibleLeaderReplicas(Arrays.asList(1))
-                .setLastKnownElr(Arrays.asList(2))
+                .setIsr(List.of(0))
+                .setEligibleLeaderReplicas(List.of(1))
+                .setLastKnownElr(List.of(2))
                 .setLeaderEpoch(0)
                 .setPartitionEpoch(1)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()),
             new PartitionRecord()
                 .setTopicId(authorizedTopicId2)
                 .setPartitionId(0)
-                .setReplicas(Arrays.asList(0, 1, 3))
+                .setReplicas(List.of(0, 1, 3))
                 .setLeader(0)
-                .setIsr(Arrays.asList(0))
-                .setEligibleLeaderReplicas(Arrays.asList(1))
-                .setLastKnownElr(Arrays.asList(3))
+                .setIsr(List.of(0))
+                .setEligibleLeaderReplicas(List.of(1))
+                .setLastKnownElr(List.of(3))
                 .setLeaderEpoch(0)
                 .setPartitionEpoch(2)
                 .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value())
@@ -393,7 +391,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         // 3.1 With cursor point to the first one
         DescribeTopicPartitionsRequest describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(new DescribeTopicPartitionsRequestData()
-            .setTopics(Arrays.asList(
+            .setTopics(List.of(
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic),
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic2)
                 ))
@@ -424,7 +422,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         // 3.2 With cursor point to the second one. The first topic should be ignored.
         describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(new DescribeTopicPartitionsRequestData()
-            .setTopics(Arrays.asList(
+            .setTopics(List.of(
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic),
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic2)
                 ))
@@ -448,7 +446,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         // 3.3 With cursor point to a non existing topic. Exception should be thrown if not querying all the topics.
         describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(new DescribeTopicPartitionsRequestData()
-            .setTopics(Arrays.asList(
+            .setTopics(List.of(
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic),
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic2)
                 ))
@@ -463,7 +461,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
 
         // 3.4 With cursor point to a negative partition id. Exception should be thrown if not querying all the topics.
         describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(new DescribeTopicPartitionsRequestData()
-            .setTopics(Arrays.asList(
+            .setTopics(List.of(
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic),
                 new DescribeTopicPartitionsRequestData.TopicRequest().setName(authorizedTopic2)
             ))

--- a/core/src/test/java/kafka/server/integration/EligibleLeaderReplicasIntegrationTest.java
+++ b/core/src/test/java/kafka/server/integration/EligibleLeaderReplicasIntegrationTest.java
@@ -73,6 +73,7 @@ import scala.collection.mutable.HashMap;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarness implements Logging {
@@ -270,7 +271,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             // Restart one broker of the ELR and it should be the leader.
 
             int expectLeader = topicPartitionInfo.elr().stream()
-                .filter(node -> node.id() != expectLastKnownLeader).collect(Collectors.toList()).get(0).id();
+                .filter(node -> node.id() != expectLastKnownLeader).toList().get(0).id();
 
             startBroker(expectLeader);
             waitForIsrAndElr((isrSize, elrSize) -> {
@@ -350,7 +351,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             });
             topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
-            assertTrue(topicPartitionInfo.leader() == null);
+            assertNull(topicPartitionInfo.leader());
             assertEquals(1, topicPartitionInfo.lastKnownElr().size());
         } finally {
             restartDeadBrokers(false);
@@ -408,7 +409,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
 
 
             // After remove the clean shutdown file, the broker should report unclean shutdown during restart.
-            topicPartitionInfo.replicas().stream().forEach(replica -> {
+            topicPartitionInfo.replicas().forEach(replica -> {
                 if (replica.id() != lastKnownLeader) startBroker(replica.id());
             });
             waitForIsrAndElr((isrSize, elrSize) -> {
@@ -416,7 +417,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             });
             topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
-            assertTrue(topicPartitionInfo.leader() == null);
+            assertNull(topicPartitionInfo.leader());
             assertEquals(1, topicPartitionInfo.lastKnownElr().size());
 
             // Now if the last known leader goes through unclean shutdown, it will still be elected.

--- a/core/src/test/java/kafka/server/integration/EligibleLeaderReplicasIntegrationTest.java
+++ b/core/src/test/java/kafka/server/integration/EligibleLeaderReplicasIntegrationTest.java
@@ -58,7 +58,6 @@ import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -141,19 +140,19 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
     @ValueSource(strings = {"kraft"})
     public void testHighWatermarkShouldNotAdvanceIfUnderMinIsr(String quorum) throws ExecutionException, InterruptedException {
         adminClient.createTopics(
-            Collections.singletonList(new NewTopic(testTopicName, 1, (short) 4))).all().get();
+            List.of(new NewTopic(testTopicName, 1, (short) 4))).all().get();
         TestUtils.waitForPartitionMetadata(brokers(), testTopicName, 0, 1000);
 
         ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, testTopicName);
         Collection<AlterConfigOp> ops = new ArrayList<>();
         ops.add(new AlterConfigOp(new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3"), AlterConfigOp.OpType.SET));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Map.of(configResource, ops);
         // alter configs on target cluster
         adminClient.incrementalAlterConfigs(configOps).all().get();
         Producer producer = null;
         Consumer consumer = null;
         try {
-            TopicDescription testTopicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            TopicDescription testTopicDescription = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName);
             TopicPartitionInfo topicPartitionInfo = testTopicDescription.partitions().get(0);
             List<Node> initialReplicas = topicPartitionInfo.replicas();
@@ -177,7 +176,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             consumerProps.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             consumerProps.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             consumer = new KafkaConsumer<>(consumerProps);
-            consumer.subscribe(Collections.singleton(testTopicName));
+            consumer.subscribe(Set.of(testTopicName));
 
             producer.send(new ProducerRecord<>(testTopicName, "0", "0")).get();
             waitUntilOneMessageIsConsumed(consumer);
@@ -228,18 +227,18 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
     @ValueSource(strings = {"kraft"})
     public void testElrMemberCanBeElected(String quorum) throws ExecutionException, InterruptedException {
         adminClient.createTopics(
-            Collections.singletonList(new NewTopic(testTopicName, 1, (short) 4))).all().get();
+            List.of(new NewTopic(testTopicName, 1, (short) 4))).all().get();
         TestUtils.waitForPartitionMetadata(brokers(), testTopicName, 0, 1000);
 
         ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, testTopicName);
         Collection<AlterConfigOp> ops = new ArrayList<>();
         ops.add(new AlterConfigOp(new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3"), AlterConfigOp.OpType.SET));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Map.of(configResource, ops);
         // alter configs on target cluster
         adminClient.incrementalAlterConfigs(configOps).all().get();
 
         try {
-            TopicDescription testTopicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            TopicDescription testTopicDescription = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName);
             TopicPartitionInfo topicPartitionInfo = testTopicDescription.partitions().get(0);
             List<Node> initialReplicas = topicPartitionInfo.replicas();
@@ -261,7 +260,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
                 return isrSize == 0 && elrSize == 3;
             });
 
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
             assertEquals(1, topicPartitionInfo.lastKnownElr().size(), topicPartitionInfo.toString());
             int expectLastKnownLeader = initialReplicas.get(3).id();
@@ -278,7 +277,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
                 return isrSize == 1 && elrSize == 2;
             });
 
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
             assertEquals(0, topicPartitionInfo.lastKnownElr().size(), topicPartitionInfo.toString());
             assertEquals(expectLeader, topicPartitionInfo.leader().id(), topicPartitionInfo.toString());
@@ -291,7 +290,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
                 return isrSize == 3 && elrSize == 0;
             });
 
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
             assertEquals(0, topicPartitionInfo.lastKnownElr().size(), topicPartitionInfo.toString());
             assertEquals(expectLeader, topicPartitionInfo.leader().id(), topicPartitionInfo.toString());
@@ -304,18 +303,18 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
     @ValueSource(strings = {"kraft"})
     public void testElrMemberShouldBeKickOutWhenUncleanShutdown(String quorum) throws ExecutionException, InterruptedException {
         adminClient.createTopics(
-            Collections.singletonList(new NewTopic(testTopicName, 1, (short) 4))).all().get();
+            List.of(new NewTopic(testTopicName, 1, (short) 4))).all().get();
         TestUtils.waitForPartitionMetadata(brokers(), testTopicName, 0, 1000);
 
         ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, testTopicName);
         Collection<AlterConfigOp> ops = new ArrayList<>();
         ops.add(new AlterConfigOp(new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3"), AlterConfigOp.OpType.SET));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Map.of(configResource, ops);
         // alter configs on target cluster
         adminClient.incrementalAlterConfigs(configOps).all().get();
 
         try {
-            TopicDescription testTopicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            TopicDescription testTopicDescription = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName);
             TopicPartitionInfo topicPartitionInfo = testTopicDescription.partitions().get(0);
             List<Node> initialReplicas = topicPartitionInfo.replicas();
@@ -331,7 +330,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             waitForIsrAndElr((isrSize, elrSize) -> {
                 return isrSize == 0 && elrSize == 3;
             });
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
 
             int brokerToBeUncleanShutdown = topicPartitionInfo.elr().get(0).id();
@@ -349,7 +348,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             waitForIsrAndElr((isrSize, elrSize) -> {
                 return isrSize == 0 && elrSize == 2;
             });
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
             assertTrue(topicPartitionInfo.leader() == null);
             assertEquals(1, topicPartitionInfo.lastKnownElr().size());
@@ -365,18 +364,18 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
     @ValueSource(strings = {"kraft"})
     public void testLastKnownLeaderShouldBeElectedIfEmptyElr(String quorum) throws ExecutionException, InterruptedException {
         adminClient.createTopics(
-            Collections.singletonList(new NewTopic(testTopicName, 1, (short) 4))).all().get();
+            List.of(new NewTopic(testTopicName, 1, (short) 4))).all().get();
         TestUtils.waitForPartitionMetadata(brokers(), testTopicName, 0, 1000);
 
         ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, testTopicName);
         Collection<AlterConfigOp> ops = new ArrayList<>();
         ops.add(new AlterConfigOp(new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3"), AlterConfigOp.OpType.SET));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Map.of(configResource, ops);
         // alter configs on target cluster
         adminClient.incrementalAlterConfigs(configOps).all().get();
 
         try {
-            TopicDescription testTopicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            TopicDescription testTopicDescription = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName);
             TopicPartitionInfo topicPartitionInfo = testTopicDescription.partitions().get(0);
             List<Node> initialReplicas = topicPartitionInfo.replicas();
@@ -392,7 +391,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             waitForIsrAndElr((isrSize, elrSize) -> {
                 return isrSize == 0 && elrSize == 3;
             });
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
             int lastKnownLeader = topicPartitionInfo.lastKnownElr().get(0).id();
 
@@ -415,7 +414,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             waitForIsrAndElr((isrSize, elrSize) -> {
                 return isrSize == 0 && elrSize == 1;
             });
-            topicPartitionInfo = adminClient.describeTopics(Collections.singletonList(testTopicName))
+            topicPartitionInfo = adminClient.describeTopics(List.of(testTopicName))
                 .allTopicNames().get().get(testTopicName).partitions().get(0);
             assertTrue(topicPartitionInfo.leader() == null);
             assertEquals(1, topicPartitionInfo.lastKnownElr().size());
@@ -429,7 +428,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
             TestUtils.waitUntilTrue(
                 () -> {
                     try {
-                        TopicPartitionInfo partition = adminClient.describeTopics(Collections.singletonList(testTopicName))
+                        TopicPartitionInfo partition = adminClient.describeTopics(List.of(testTopicName))
                             .allTopicNames().get().get(testTopicName).partitions().get(0);
                         if (partition.leader() == null) return false;
                         return partition.lastKnownElr().isEmpty() && partition.elr().isEmpty() && partition.leader().id() == lastKnownLeader;
@@ -449,7 +448,7 @@ public class EligibleLeaderReplicasIntegrationTest extends KafkaServerTestHarnes
         TestUtils.waitUntilTrue(
             () -> {
                 try {
-                    TopicDescription topicDescription = adminClient.describeTopics(Collections.singletonList(testTopicName))
+                    TopicDescription topicDescription = adminClient.describeTopics(List.of(testTopicName))
                         .allTopicNames().get().get(testTopicName);
                     TopicPartitionInfo partition = topicDescription.partitions().get(0);
                     return isIsrAndElrSizeSatisfied.apply(partition.isr().size(), partition.elr().size());

--- a/core/src/test/java/kafka/server/logger/RuntimeLoggerManagerTest.java
+++ b/core/src/test/java/kafka/server/logger/RuntimeLoggerManagerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -42,7 +42,7 @@ public class RuntimeLoggerManagerTest {
 
     @Test
     public void testValidateSetLogLevelConfig() {
-        MANAGER.validateLogLevelConfigs(Arrays.asList(new AlterableConfig().
+        MANAGER.validateLogLevelConfigs(List.of(new AlterableConfig().
             setName(LOG.getName()).
             setConfigOperation(OpType.SET.id()).
             setValue("TRACE")));
@@ -50,7 +50,7 @@ public class RuntimeLoggerManagerTest {
 
     @Test
     public void testValidateDeleteLogLevelConfig() {
-        MANAGER.validateLogLevelConfigs(Arrays.asList(new AlterableConfig().
+        MANAGER.validateLogLevelConfigs(List.of(new AlterableConfig().
             setName(LOG.getName()).
             setConfigOperation(OpType.DELETE.id()).
             setValue("")));
@@ -62,7 +62,7 @@ public class RuntimeLoggerManagerTest {
         OpType opType = AlterConfigOp.OpType.forId(id);
         assertEquals(opType + " operation is not allowed for the BROKER_LOGGER resource",
             Assertions.assertThrows(InvalidRequestException.class,
-                () -> MANAGER.validateLogLevelConfigs(Arrays.asList(new AlterableConfig().
+                () -> MANAGER.validateLogLevelConfigs(List.of(new AlterableConfig().
                     setName(LOG.getName()).
                     setConfigOperation(id).
                     setValue("TRACE")))).getMessage());
@@ -73,7 +73,7 @@ public class RuntimeLoggerManagerTest {
         assertEquals("Cannot set the log level of " + LOG.getName() + " to BOGUS as it is not " +
             "a supported log level. Valid log levels are DEBUG, ERROR, FATAL, INFO, TRACE, WARN",
             Assertions.assertThrows(InvalidConfigurationException.class,
-                () -> MANAGER.validateLogLevelConfigs(Arrays.asList(new AlterableConfig().
+                () -> MANAGER.validateLogLevelConfigs(List.of(new AlterableConfig().
                     setName(LOG.getName()).
                     setConfigOperation(OpType.SET.id()).
                     setValue("BOGUS")))).getMessage());
@@ -81,7 +81,7 @@ public class RuntimeLoggerManagerTest {
 
     @Test
     public void testValidateSetRootLogLevelConfig() {
-        MANAGER.validateLogLevelConfigs(Arrays.asList(new AlterableConfig().
+        MANAGER.validateLogLevelConfigs(List.of(new AlterableConfig().
                 setName(LoggingController.ROOT_LOGGER()).
                 setConfigOperation(OpType.SET.id()).
                 setValue("TRACE")));
@@ -92,7 +92,7 @@ public class RuntimeLoggerManagerTest {
         assertEquals("Removing the log level of the " + LoggingController.ROOT_LOGGER() +
             " logger is not allowed",
             Assertions.assertThrows(InvalidRequestException.class,
-                () -> MANAGER.validateLogLevelConfigs(Arrays.asList(new AlterableConfig().
+                () -> MANAGER.validateLogLevelConfigs(List.of(new AlterableConfig().
                     setName(LoggingController.ROOT_LOGGER()).
                     setConfigOperation(OpType.DELETE.id()).
                     setValue("")))).getMessage());

--- a/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
+++ b/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -197,7 +196,7 @@ public class DelayedShareFetchTest {
         doAnswer(invocation -> buildLogReadResult(List.of(tp0))).when(replicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
         BiConsumer<SharePartitionKey, Throwable> exceptionHandler = mockExceptionHandler();
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp0));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp0));
 
         Time time = mock(Time.class);
         when(time.hiResClockMs()).thenReturn(100L).thenReturn(110L);
@@ -313,7 +312,7 @@ public class DelayedShareFetchTest {
         when(sp0.fetchOffsetMetadata(anyLong())).thenReturn(Optional.of(new LogOffsetMetadata(0, 1, 0)));
         mockTopicIdPartitionToReturnDataEqualToMinBytes(replicaManager, tp0, 1);
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp0));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp0));
 
         Time time = mock(Time.class);
         when(time.hiResClockMs()).thenReturn(120L).thenReturn(140L);
@@ -423,7 +422,7 @@ public class DelayedShareFetchTest {
             createShareAcquiredRecords(new ShareFetchResponseData.AcquiredRecords().setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1)));
         doAnswer(invocation -> buildLogReadResult(List.of(tp0))).when(replicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp0));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp0));
 
         Time time = mock(Time.class);
         when(time.hiResClockMs()).thenReturn(10L).thenReturn(140L);
@@ -564,7 +563,7 @@ public class DelayedShareFetchTest {
 
         doAnswer(invocation -> buildLogReadResult(List.of(tp1))).when(replicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp1));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp1));
 
         LinkedHashMap<TopicIdPartition, SharePartition> sharePartitions2 = new LinkedHashMap<>();
         sharePartitions2.put(tp0, sp0);
@@ -619,7 +618,7 @@ public class DelayedShareFetchTest {
                 1, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()), groupId, Uuid.randomUuid().toString(),
             future, List.of(tp0, tp1), BATCH_SIZE, MAX_FETCH_RECORDS, BROKER_TOPIC_STATS);
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp1));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp1));
 
         DelayedShareFetch delayedShareFetch = DelayedShareFetchBuilder.builder()
             .withShareFetchData(shareFetch)
@@ -686,7 +685,7 @@ public class DelayedShareFetchTest {
         when(replicaManager.getPartitionOrException(tp0.topicPartition())).thenReturn(partition);
         when(partition.fetchOffsetSnapshot(any(), anyBoolean())).thenThrow(new RuntimeException("Exception thrown"));
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp0));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp0));
 
         BiConsumer<SharePartitionKey, Throwable> exceptionHandler = mockExceptionHandler();
         Time time = mock(Time.class);
@@ -756,7 +755,7 @@ public class DelayedShareFetchTest {
         doAnswer(invocation -> buildLogReadResult(List.of(tp0))).when(replicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
         mockTopicIdPartitionToReturnDataEqualToMinBytes(replicaManager, tp0, 1);
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp0));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp0));
         DelayedShareFetch delayedShareFetch = spy(DelayedShareFetchBuilder.builder()
             .withShareFetchData(shareFetch)
             .withSharePartitions(sharePartitions)
@@ -793,7 +792,7 @@ public class DelayedShareFetchTest {
             new CompletableFuture<>(), List.of(tp0), BATCH_SIZE, MAX_FETCH_RECORDS,
             BROKER_TOPIC_STATS);
 
-        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Collections.singleton(tp0));
+        PartitionMaxBytesStrategy partitionMaxBytesStrategy = mockPartitionMaxBytes(Set.of(tp0));
 
         DelayedShareFetch delayedShareFetch = DelayedShareFetchTest.DelayedShareFetchBuilder.builder()
             .withShareFetchData(shareFetch)

--- a/core/src/test/java/kafka/server/share/ShareFetchUtilsTest.java
+++ b/core/src/test/java/kafka/server/share/ShareFetchUtilsTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,10 +142,10 @@ public class ShareFetchUtilsTest {
         assertEquals(1, resultData.get(tp1).partitionIndex());
         assertEquals(Errors.NONE.code(), resultData.get(tp0).errorCode());
         assertEquals(Errors.NONE.code(), resultData.get(tp1).errorCode());
-        assertEquals(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+        assertEquals(List.of(new ShareFetchResponseData.AcquiredRecords()
                         .setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1)),
                 resultData.get(tp0).acquiredRecords());
-        assertEquals(Collections.singletonList(new ShareFetchResponseData.AcquiredRecords()
+        assertEquals(List.of(new ShareFetchResponseData.AcquiredRecords()
                         .setFirstOffset(100).setLastOffset(103).setDeliveryCount((short) 1)),
                 resultData.get(tp1).acquiredRecords());
     }
@@ -192,8 +191,8 @@ public class ShareFetchUtilsTest {
         assertEquals(1, resultData.get(tp1).partitionIndex());
         assertEquals(Errors.NONE.code(), resultData.get(tp0).errorCode());
         assertEquals(Errors.NONE.code(), resultData.get(tp1).errorCode());
-        assertEquals(Collections.emptyList(), resultData.get(tp0).acquiredRecords());
-        assertEquals(Collections.emptyList(), resultData.get(tp1).acquiredRecords());
+        assertEquals(List.of(), resultData.get(tp0).acquiredRecords());
+        assertEquals(List.of(), resultData.get(tp1).acquiredRecords());
     }
 
     @Test

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -93,7 +93,6 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -161,7 +160,7 @@ public class SharePartitionManagerTest {
     private BrokerTopicStats brokerTopicStats;
     private SharePartitionManager sharePartitionManager;
 
-    private static final List<TopicIdPartition> EMPTY_PART_LIST = Collections.unmodifiableList(new ArrayList<>());
+    private static final List<TopicIdPartition> EMPTY_PART_LIST = List.of();
 
     @BeforeEach
     public void setUp() {

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -93,7 +93,6 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -592,19 +591,19 @@ public class SharePartitionManagerTest {
 
         ShareFetchContext context1 = sharePartitionManager.newContext(groupId, reqData1, EMPTY_PART_LIST, reqMetadata1, false);
         assertInstanceOf(ShareSessionContext.class, context1);
-        assertPartitionsPresent((ShareSessionContext) context1, Arrays.asList(foo, bar));
+        assertPartitionsPresent((ShareSessionContext) context1, List.of(foo, bar));
 
         mockUpdateAndGenerateResponseData(context1, groupId, reqMetadata1.memberId());
 
-        ShareFetchContext context2 = sharePartitionManager.newContext(groupId, List.of(), Collections.singletonList(foo),
+        ShareFetchContext context2 = sharePartitionManager.newContext(groupId, List.of(), List.of(foo),
                 new ShareRequestMetadata(reqMetadata1.memberId(), 1), true);
 
         // So foo is removed but not the others.
-        assertPartitionsPresent((ShareSessionContext) context2, Collections.singletonList(bar));
+        assertPartitionsPresent((ShareSessionContext) context2, List.of(bar));
 
         mockUpdateAndGenerateResponseData(context2, groupId, reqMetadata1.memberId());
 
-        ShareFetchContext context3 = sharePartitionManager.newContext(groupId, List.of(), Collections.singletonList(bar),
+        ShareFetchContext context3 = sharePartitionManager.newContext(groupId, List.of(), List.of(bar),
                 new ShareRequestMetadata(reqMetadata1.memberId(), 2), true);
         assertPartitionsPresent((ShareSessionContext) context3, List.of());
     }
@@ -685,7 +684,7 @@ public class SharePartitionManagerTest {
         ShareFetchContext context2 = sharePartitionManager.newContext(groupId, reqData2, EMPTY_PART_LIST, reqMetadata2, false);
         assertInstanceOf(ShareSessionContext.class, context2);
         assertFalse(((ShareSessionContext) context2).isSubsequent());
-        assertErroneousAndValidTopicIdPartitions(context2.getErroneousAndValidTopicIdPartitions(), Collections.singletonList(tpNull1), Arrays.asList(tp0, tp1));
+        assertErroneousAndValidTopicIdPartitions(context2.getErroneousAndValidTopicIdPartitions(), List.of(tpNull1), List.of(tp0, tp1));
 
         LinkedHashMap<TopicIdPartition, ShareFetchResponseData.PartitionData> respData2 = new LinkedHashMap<>();
         respData2.put(tp0, new ShareFetchResponseData.PartitionData().setPartitionIndex(0));
@@ -716,7 +715,7 @@ public class SharePartitionManagerTest {
         assertInstanceOf(ShareSessionContext.class, context5);
         assertTrue(((ShareSessionContext) context5).isSubsequent());
 
-        assertErroneousAndValidTopicIdPartitions(context5.getErroneousAndValidTopicIdPartitions(), Collections.singletonList(tpNull1), Arrays.asList(tp0, tp1));
+        assertErroneousAndValidTopicIdPartitions(context5.getErroneousAndValidTopicIdPartitions(), List.of(tpNull1), List.of(tp0, tp1));
 
         ShareFetchResponse resp5 = context5.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData2);
         assertEquals(Errors.NONE, resp5.error());
@@ -734,7 +733,7 @@ public class SharePartitionManagerTest {
         assertEquals(Errors.NONE, resp7.error());
         assertEquals(100, resp7.throttleTimeMs());
 
-        assertErroneousAndValidTopicIdPartitions(context7.getErroneousAndValidTopicIdPartitions(), Arrays.asList(tpNull1, tpNull2), Arrays.asList(tp0, tp1));
+        assertErroneousAndValidTopicIdPartitions(context7.getErroneousAndValidTopicIdPartitions(), List.of(tpNull1, tpNull2), List.of(tp0, tp1));
 
         // Get the final share session.
         ShareFetchContext context8 = sharePartitionManager.newContext(groupId, List.of(), EMPTY_PART_LIST,
@@ -903,7 +902,7 @@ public class SharePartitionManagerTest {
         ShareFetchResponse resp1 = context1.updateAndGenerateResponseData(groupId, reqMetadata1.memberId(), respData1);
         assertEquals(Errors.NONE, resp1.error());
 
-        assertEquals(new HashSet<>(Arrays.asList(tp0, tp1)),
+        assertEquals(new HashSet<>(List.of(tp0, tp1)),
                 new HashSet<>(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId1)));
 
         // Create a new share session with an initial share fetch request.
@@ -923,7 +922,7 @@ public class SharePartitionManagerTest {
         ShareFetchResponse resp2 = context2.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData2);
         assertEquals(Errors.NONE, resp2.error());
 
-        assertEquals(Collections.singletonList(tp2), sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId2));
+        assertEquals(List.of(tp2), sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId2));
 
         // Continue the first share session we created.
         List<TopicIdPartition> reqData3 = List.of(tp2);
@@ -937,12 +936,12 @@ public class SharePartitionManagerTest {
         ShareFetchResponse resp3 = context3.updateAndGenerateResponseData(groupId, reqMetadata1.memberId(), respData3);
         assertEquals(Errors.NONE, resp3.error());
 
-        assertEquals(new HashSet<>(Arrays.asList(tp0, tp1, tp2)),
+        assertEquals(new HashSet<>(List.of(tp0, tp1, tp2)),
                 new HashSet<>(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId1)));
 
         // Continue the second session we created.
         List<TopicIdPartition> reqData4 = List.of(tp3);
-        ShareFetchContext context4 = sharePartitionManager.newContext(groupId, reqData4, Collections.singletonList(tp2),
+        ShareFetchContext context4 = sharePartitionManager.newContext(groupId, reqData4, List.of(tp2),
                 new ShareRequestMetadata(shareSessionKey2.memberId(), 1), true);
         assertInstanceOf(ShareSessionContext.class, context4);
         assertTrue(((ShareSessionContext) context4).isSubsequent());
@@ -952,7 +951,7 @@ public class SharePartitionManagerTest {
         ShareFetchResponse resp4 = context4.updateAndGenerateResponseData(groupId, reqMetadata2.memberId(), respData4);
         assertEquals(Errors.NONE, resp4.error());
 
-        assertEquals(Collections.singletonList(tp3), sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId2));
+        assertEquals(List.of(tp3), sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId2));
 
         // Get the final share session.
         ShareFetchContext context5 = sharePartitionManager.newContext(groupId, List.of(), EMPTY_PART_LIST,
@@ -970,7 +969,7 @@ public class SharePartitionManagerTest {
         assertTrue(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, memberId1).isEmpty());
 
         // Continue the second share session .
-        ShareFetchContext context6 = sharePartitionManager.newContext(groupId, List.of(), Collections.singletonList(tp3),
+        ShareFetchContext context6 = sharePartitionManager.newContext(groupId, List.of(), List.of(tp3),
                 new ShareRequestMetadata(shareSessionKey2.memberId(), 2), true);
         assertInstanceOf(ShareSessionContext.class, context6);
         assertTrue(((ShareSessionContext) context6).isSubsequent());
@@ -1445,9 +1444,9 @@ public class SharePartitionManagerTest {
             .build();
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp, Arrays.asList(
-            new ShareAcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
-            new ShareAcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
+        acknowledgeTopics.put(tp, List.of(
+            new ShareAcknowledgementBatch(12, 20, List.of((byte) 1)),
+            new ShareAcknowledgementBatch(24, 56, List.of((byte) 1))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);
@@ -1494,17 +1493,17 @@ public class SharePartitionManagerTest {
             .build();
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp1, Arrays.asList(
-                new ShareAcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
+        acknowledgeTopics.put(tp1, List.of(
+                new ShareAcknowledgementBatch(12, 20, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(24, 56, List.of((byte) 1))
         ));
-        acknowledgeTopics.put(tp2, Arrays.asList(
-                new ShareAcknowledgementBatch(15, 26, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(34, 56, Collections.singletonList((byte) 2))
+        acknowledgeTopics.put(tp2, List.of(
+                new ShareAcknowledgementBatch(15, 26, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(34, 56, List.of((byte) 2))
         ));
-        acknowledgeTopics.put(tp3, Arrays.asList(
-                new ShareAcknowledgementBatch(4, 15, Collections.singletonList((byte) 3)),
-                new ShareAcknowledgementBatch(16, 21, Collections.singletonList((byte) 3))
+        acknowledgeTopics.put(tp3, List.of(
+                new ShareAcknowledgementBatch(4, 15, List.of((byte) 3)),
+                new ShareAcknowledgementBatch(16, 21, List.of((byte) 3))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);
@@ -1606,9 +1605,9 @@ public class SharePartitionManagerTest {
             .build();
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp, Arrays.asList(
-            new ShareAcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
-            new ShareAcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
+        acknowledgeTopics.put(tp, List.of(
+            new ShareAcknowledgementBatch(12, 20, List.of((byte) 1)),
+            new ShareAcknowledgementBatch(24, 56, List.of((byte) 1))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId2, acknowledgeTopics);
@@ -1648,9 +1647,9 @@ public class SharePartitionManagerTest {
             .build();
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp, Arrays.asList(
-            new ShareAcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
-            new ShareAcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
+        acknowledgeTopics.put(tp, List.of(
+            new ShareAcknowledgementBatch(12, 20, List.of((byte) 1)),
+            new ShareAcknowledgementBatch(24, 56, List.of((byte) 1))
         ));
 
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
@@ -1680,9 +1679,9 @@ public class SharePartitionManagerTest {
             .build();
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp, Arrays.asList(
-                new ShareAcknowledgementBatch(78, 90, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(94, 99, Collections.singletonList((byte) 2))
+        acknowledgeTopics.put(tp, List.of(
+                new ShareAcknowledgementBatch(78, 90, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(94, 99, List.of((byte) 2))
         ));
         CompletableFuture<Map<TopicIdPartition, ShareAcknowledgeResponseData.PartitionData>> resultFuture =
                 sharePartitionManager.acknowledge(memberId, groupId, acknowledgeTopics);
@@ -1781,9 +1780,9 @@ public class SharePartitionManagerTest {
         doAnswer(invocation -> buildLogReadResult(topicIdPartitions)).when(mockReplicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp1, Arrays.asList(
-                new ShareAcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
+        acknowledgeTopics.put(tp1, List.of(
+                new ShareAcknowledgementBatch(12, 20, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(24, 56, List.of((byte) 1))
         ));
 
         assertEquals(2, delayedShareFetchPurgatory.watched());
@@ -1888,9 +1887,9 @@ public class SharePartitionManagerTest {
         assertEquals(2, delayedShareFetchPurgatory.watched());
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
-        acknowledgeTopics.put(tp3, Arrays.asList(
-                new ShareAcknowledgementBatch(12, 20, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(24, 56, Collections.singletonList((byte) 1))
+        acknowledgeTopics.put(tp3, List.of(
+                new ShareAcknowledgementBatch(12, 20, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(24, 56, List.of((byte) 1))
         ));
 
         // Acknowledgement request for sp3.
@@ -1992,7 +1991,7 @@ public class SharePartitionManagerTest {
         assertEquals(2, delayedShareFetchPurgatory.watched());
 
         // The share session for this share group member returns tp1 and tp3, tp1 is common in both the delayed fetch request and the share session.
-        when(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, Uuid.fromString(memberId))).thenReturn(Arrays.asList(tp1, tp3));
+        when(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, Uuid.fromString(memberId))).thenReturn(List.of(tp1, tp3));
 
         doAnswer(invocation -> buildLogReadResult(List.of(tp1))).when(mockReplicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
         when(sp1.acquire(anyString(), anyInt(), anyInt(), anyLong(), any())).thenReturn(new ShareAcquiredRecords(List.of(), 0));
@@ -2099,7 +2098,7 @@ public class SharePartitionManagerTest {
 
         // The share session for this share group member returns tp1 and tp3. No topic partition is common in
         // both the delayed fetch request and the share session.
-        when(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, Uuid.fromString(memberId))).thenReturn(Collections.singletonList(tp3));
+        when(sharePartitionManager.cachedTopicIdPartitionsInShareSession(groupId, Uuid.fromString(memberId))).thenReturn(List.of(tp3));
 
         // Release acquired records on session close for sp3.
         sharePartitionManager.releaseSession(groupId, memberId);
@@ -2974,12 +2973,12 @@ public class SharePartitionManagerTest {
 
     private void validateShareFetchFutureException(CompletableFuture<Map<TopicIdPartition, PartitionData>> future,
         TopicIdPartition topicIdPartition, Errors error) {
-        validateShareFetchFutureException(future, Collections.singletonList(topicIdPartition), error, null);
+        validateShareFetchFutureException(future, List.of(topicIdPartition), error, null);
     }
 
     private void validateShareFetchFutureException(CompletableFuture<Map<TopicIdPartition, PartitionData>> future,
         TopicIdPartition topicIdPartition, Errors error, String message) {
-        validateShareFetchFutureException(future, Collections.singletonList(topicIdPartition), error, message);
+        validateShareFetchFutureException(future, List.of(topicIdPartition), error, message);
     }
 
     private void validateShareFetchFutureException(CompletableFuture<Map<TopicIdPartition, PartitionData>> future,

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -73,8 +73,6 @@ import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -176,10 +174,10 @@ public class SharePartitionTest {
     public void testMaybeInitialize() throws InterruptedException {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 5L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -227,14 +225,14 @@ public class SharePartitionTest {
     public void testMaybeInitializeDefaultStartEpochGroupConfigReturnsEarliest() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -277,14 +275,14 @@ public class SharePartitionTest {
     public void testMaybeInitializeDefaultStartEpochGroupConfigReturnsLatest() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -328,14 +326,14 @@ public class SharePartitionTest {
         throws InterruptedException {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -393,14 +391,14 @@ public class SharePartitionTest {
     public void testMaybeInitializeDefaultStartEpochGroupConfigNotPresent() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -441,14 +439,14 @@ public class SharePartitionTest {
     public void testMaybeInitializeFetchOffsetForLatestTimestampThrowsError() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -485,14 +483,14 @@ public class SharePartitionTest {
     public void testMaybeInitializeFetchOffsetForEarliestTimestampThrowsError() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -531,14 +529,14 @@ public class SharePartitionTest {
     public void testMaybeInitializeFetchOffsetForByDurationThrowsError() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(
                     0, PartitionFactory.DEFAULT_STATE_EPOCH,
                     PartitionFactory.UNINITIALIZED_START_OFFSET,
                     PartitionFactory.DEFAULT_ERROR_CODE,
                     PartitionFactory.DEFAULT_ERR_MESSAGE,
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
 
         GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -584,10 +582,10 @@ public class SharePartitionTest {
     public void testMaybeInitializeSharePartitionAgain() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 5L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -612,10 +610,10 @@ public class SharePartitionTest {
     public void testMaybeInitializeSharePartitionAgainConcurrentRequests() throws InterruptedException {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 5L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -647,9 +645,9 @@ public class SharePartitionTest {
     public void testMaybeInitializeWithEmptyStateBatches() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
-                PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.NONE.code(), Errors.NONE.message(), Collections.emptyList()))))
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
+                PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.NONE.code(), Errors.NONE.message(), List.of()))))
         );
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
@@ -672,10 +670,10 @@ public class SharePartitionTest {
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
 
         // Mock NOT_COORDINATOR error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.NOT_COORDINATOR.code(), Errors.NOT_COORDINATOR.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -686,10 +684,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock COORDINATOR_NOT_AVAILABLE error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.COORDINATOR_NOT_AVAILABLE.code(), Errors.COORDINATOR_NOT_AVAILABLE.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -700,10 +698,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock COORDINATOR_LOAD_IN_PROGRESS error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.COORDINATOR_LOAD_IN_PROGRESS.code(), Errors.COORDINATOR_LOAD_IN_PROGRESS.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -714,10 +712,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock GROUP_ID_NOT_FOUND error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -728,10 +726,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock UNKNOWN_TOPIC_OR_PARTITION error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), Errors.UNKNOWN_TOPIC_OR_PARTITION.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -742,10 +740,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock FENCED_STATE_EPOCH error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.FENCED_STATE_EPOCH.code(), Errors.FENCED_STATE_EPOCH.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -756,10 +754,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock FENCED_LEADER_EPOCH error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.FENCED_LEADER_EPOCH.code(), Errors.FENCED_LEADER_EPOCH.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -770,10 +768,10 @@ public class SharePartitionTest {
         assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
 
         // Mock UNKNOWN_SERVER_ERROR error.
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 5, 10L, Errors.UNKNOWN_SERVER_ERROR.code(), Errors.UNKNOWN_SERVER_ERROR.message(),
-                    Collections.emptyList())))));
+                    List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -788,10 +786,10 @@ public class SharePartitionTest {
     public void testMaybeInitializeWithInvalidStartOffsetStateBatches() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 6L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -808,10 +806,10 @@ public class SharePartitionTest {
     public void testMaybeInitializeWithInvalidTopicIdResponse() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(Uuid.randomUuid(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(Uuid.randomUuid(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 5L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -828,10 +826,10 @@ public class SharePartitionTest {
     public void testMaybeInitializeWithInvalidPartitionResponse() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(1, 3, 5L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -897,7 +895,7 @@ public class SharePartitionTest {
     public void testMaybeInitializeWithEmptyTopicsData() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.emptyList());
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of());
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
         SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
@@ -936,7 +934,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 10L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(15L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 10 to 14
                         new PersisterStateBatch(21L, 30L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -981,7 +979,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 10L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(15L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 10 to 14
                         new PersisterStateBatch(30L, 40L, RecordState.ARCHIVED.id, (short) 3))))))); // There is a gap from 21 to 29
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -1026,7 +1024,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 15L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(15L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2),
                         new PersisterStateBatch(30L, 40L, RecordState.ARCHIVED.id, (short) 3))))))); // There is a gap from 21 to 29
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -1067,7 +1065,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 15L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(15L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2),
                         new PersisterStateBatch(21L, 30L, RecordState.ARCHIVED.id, (short) 3)))))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -1669,7 +1667,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(1, 1, Collections.singletonList((byte) 1))));
+            List.of(new ShareAcknowledgementBatch(1, 1, List.of((byte) 1))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
@@ -1690,7 +1688,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(5, 14, Collections.singletonList((byte) 1))));
+            List.of(new ShareAcknowledgementBatch(5, 14, List.of((byte) 1))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
@@ -1720,9 +1718,9 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Arrays.asList(
-                new ShareAcknowledgementBatch(5, 6, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(10, 18, Arrays.asList(
+            List.of(
+                new ShareAcknowledgementBatch(5, 6, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(10, 18, List.of(
                     (byte) 2, (byte) 2, (byte) 2,
                     (byte) 2, (byte) 2, (byte) 0,
                     (byte) 0, (byte) 0, (byte) 1
@@ -1778,7 +1776,7 @@ public class SharePartitionTest {
         // Acknowledging over subset of both batch with subset of gap offsets.
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(6, 18, Arrays.asList(
+            List.of(new ShareAcknowledgementBatch(6, 18, List.of(
                 (byte) 1, (byte) 1, (byte) 1,
                 (byte) 1, (byte) 1, (byte) 1,
                 (byte) 0, (byte) 0, (byte) 1,
@@ -1819,7 +1817,7 @@ public class SharePartitionTest {
         // Acknowledge a batch when cache is empty.
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(0, 15, Collections.singletonList((byte) 3))));
+            List.of(new ShareAcknowledgementBatch(0, 15, List.of((byte) 3))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
 
@@ -1833,7 +1831,7 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(20, 25, Collections.singletonList((byte) 3))));
+            List.of(new ShareAcknowledgementBatch(20, 25, List.of((byte) 3))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRequestException.class, ackResult);
     }
@@ -1855,9 +1853,9 @@ public class SharePartitionTest {
         assertEquals(1, acquiredRecordsList.size());
 
         // Acknowledge a batch when first batch violates the range.
-        List<ShareAcknowledgementBatch> acknowledgeBatches = Arrays.asList(
-            new ShareAcknowledgementBatch(0, 10, Collections.singletonList((byte) 1)),
-            new ShareAcknowledgementBatch(20, 24, Collections.singletonList((byte) 1)));
+        List<ShareAcknowledgementBatch> acknowledgeBatches = List.of(
+            new ShareAcknowledgementBatch(0, 10, List.of((byte) 1)),
+            new ShareAcknowledgementBatch(20, 24, List.of((byte) 1)));
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID, acknowledgeBatches);
         assertTrue(ackResult.isCompletedExceptionally());
@@ -1889,7 +1887,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             "member-2",
-            Collections.singletonList(new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 3))));
+            List.of(new ShareAcknowledgementBatch(5, 9, List.of((byte) 3))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
     }
@@ -1907,14 +1905,14 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2))));
+            List.of(new ShareAcknowledgementBatch(5, 9, List.of((byte) 2))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
         // Acknowledge the same batch again but with ACCEPT type.
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 1))));
+            List.of(new ShareAcknowledgementBatch(5, 9, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
 
@@ -1925,14 +1923,14 @@ public class SharePartitionTest {
 
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(6, 8, Collections.singletonList((byte) 3))));
+            List.of(new ShareAcknowledgementBatch(6, 8, List.of((byte) 3))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
         // Re-acknowledge the subset batch with REJECT type.
         ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(6, 8, Collections.singletonList((byte) 3))));
+            List.of(new ShareAcknowledgementBatch(6, 8, List.of((byte) 3))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
     }
@@ -1959,12 +1957,12 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Arrays.asList(
-                new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(15, 19, Collections.singletonList((byte) 1)),
+            List.of(
+                new ShareAcknowledgementBatch(5, 9, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(15, 19, List.of((byte) 1)),
                 // Add another batch which should fail the request.
-                new ShareAcknowledgementBatch(15, 19, Collections.singletonList((byte) 1))));
+                new ShareAcknowledgementBatch(15, 19, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
 
@@ -1997,12 +1995,12 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Arrays.asList(
-                new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(15, 19, Collections.singletonList((byte) 1)),
+            List.of(
+                new ShareAcknowledgementBatch(5, 9, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(15, 19, List.of((byte) 1)),
                 // Add another batch which should fail the request.
-                new ShareAcknowledgementBatch(16, 19, Collections.singletonList((byte) 1))));
+                new ShareAcknowledgementBatch(16, 19, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
 
@@ -2027,7 +2025,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            Collections.singletonList(new ShareAcknowledgementBatch(12, 13, Collections.singletonList((byte) 2))));
+            List.of(new ShareAcknowledgementBatch(12, 13, List.of((byte) 2))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
@@ -2093,7 +2091,7 @@ public class SharePartitionTest {
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
             MEMBER_ID,
-            List.of(new ShareAcknowledgementBatch(12, 30, Collections.singletonList((byte) 2))));
+            List.of(new ShareAcknowledgementBatch(12, 30, List.of((byte) 2))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
@@ -2175,7 +2173,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1)
                     ))))));
@@ -2214,7 +2212,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1)
                     ))))));
@@ -2253,7 +2251,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.AVAILABLE.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1)
                     ))))));
@@ -2306,7 +2304,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(11L, 20L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 21-30
                     ))))));
@@ -2350,7 +2348,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(41L, 50L, RecordState.AVAILABLE.id, (short) 1), // There is a gap from 31 to 40
                         new PersisterStateBatch(61L, 70L, RecordState.ARCHIVED.id, (short) 1), // There is a gap from 51 to 60
@@ -2407,7 +2405,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.AVAILABLE.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(41L, 50L, RecordState.ACKNOWLEDGED.id, (short) 1), // There is a gap from 31 to 40
                         new PersisterStateBatch(61L, 70L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 51 to 60
@@ -2451,7 +2449,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(41L, 50L, RecordState.AVAILABLE.id, (short) 1), // There is a gap from 31 to 40
                         new PersisterStateBatch(61L, 70L, RecordState.ARCHIVED.id, (short) 1), // There is a gap from 51 to 60
@@ -2503,7 +2501,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(11L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2),
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 21-30
                     ))))));
@@ -2553,7 +2551,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.AVAILABLE.id, (short) 2), // There is a gap from 11-20
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1)
                     ))))));
@@ -2601,7 +2599,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(11L, 20L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(31L, 40L, RecordState.AVAILABLE.id, (short) 1) // There is a gap from 21-30
                     ))))));
@@ -2649,7 +2647,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 10L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(15L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 10 to 14
                         new PersisterStateBatch(30L, 40L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 21-29
                     ))))));
@@ -2698,7 +2696,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(41L, 50L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 31-40
                     ))))));
@@ -2742,7 +2740,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(41L, 50L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 31-40
                     ))))));
@@ -2788,7 +2786,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(41L, 50L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 31-40
                     ))))));
@@ -2837,7 +2835,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(11L, 20L, RecordState.ACKNOWLEDGED.id, (short) 2),
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 21 to 30
                     ))))));
@@ -3016,7 +3014,7 @@ public class SharePartitionTest {
         assertNotNull(sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(0, 0, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(0, 0, List.of((byte) 2))));
 
         assertNull(sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask());
         assertEquals(0, sharePartition.timer().size());
@@ -3048,7 +3046,7 @@ public class SharePartitionTest {
         assertNotNull(sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask());
         assertEquals(1, sharePartition.timer().size());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(5, 14, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(5, 14, List.of((byte) 2))));
 
         assertEquals(5, sharePartition.nextFetchOffset());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
@@ -3099,7 +3097,7 @@ public class SharePartitionTest {
 
         sharePartition.acknowledge(MEMBER_ID,
                 // Do not send gap offsets to verify that they are ignored and accepted as per client ack.
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 18, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(5, 18, List.of((byte) 1))));
 
         assertNull(sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(10L).batchAcquisitionLockTimeoutTask());
@@ -3214,8 +3212,8 @@ public class SharePartitionTest {
         assertEquals(2, sharePartition.timer().size());
 
         // Acknowledging over subset of both batch with subset of gap offsets.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(
-                        6, 18, Arrays.asList(
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(
+                        6, 18, List.of(
                         (byte) 1, (byte) 1, (byte) 1,
                         (byte) 1, (byte) 1, (byte) 1,
                         (byte) 0, (byte) 0, (byte) 1,
@@ -3463,7 +3461,7 @@ public class SharePartitionTest {
 
         // Acknowledge with ACCEPT type should throw InvalidRecordStateException since they've been released due to acquisition lock timeout.
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(5, 9, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
         assertNull(sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask());
@@ -3471,7 +3469,7 @@ public class SharePartitionTest {
 
         // Try acknowledging with REJECT type should throw InvalidRecordStateException since they've been released due to acquisition lock timeout.
         ackResult = sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 3))));
+                List.of(new ShareAcknowledgementBatch(5, 9, List.of((byte) 3))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
         assertNull(sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask());
@@ -3491,7 +3489,7 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
 
         // Acknowledge with REJECT type.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(5, 6, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(5, 6, List.of((byte) 2))));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -3501,7 +3499,7 @@ public class SharePartitionTest {
         assertEquals(3, sharePartition.timer().size());
 
         // Acknowledge with ACCEPT type.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(8, 9, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(8, 9, List.of((byte) 1))));
 
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(5L).acquisitionLockTimeoutTask());
         assertNull(sharePartition.cachedState().get(5L).offsetState().get(6L).acquisitionLockTimeoutTask());
@@ -3545,8 +3543,8 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns false.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -3577,8 +3575,8 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns true for acknowledge to pass.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -3587,11 +3585,11 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.timer().size());
         assertNotNull(sharePartition.cachedState().get(5L).batchAcquisitionLockTimeoutTask());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(8, 9, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(8, 9, List.of((byte) 1))));
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns false.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -3665,7 +3663,7 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records1, 2);
         fetchAcquiredRecords(sharePartition, records2, 9);
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(5, 18, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(5, 18, List.of((byte) 1))));
 
         CompletableFuture<Void> releaseResult = sharePartition.releaseAcquiredRecords(MEMBER_ID);
         assertNull(releaseResult.join());
@@ -3697,7 +3695,7 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records2, 11);
 
         // Acknowledging over subset of both batch with subset of gap offsets.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(6, 18, Arrays.asList(
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(6, 18, List.of(
                 (byte) 1, (byte) 1, (byte) 1,
                 (byte) 1, (byte) 1, (byte) 1,
                 (byte) 0, (byte) 0, (byte) 1,
@@ -3748,7 +3746,7 @@ public class SharePartitionTest {
         sharePartition.acquire(MEMBER_ID, BATCH_SIZE, MAX_FETCH_RECORDS, 10, fetchPartitionData(records2));
 
         // Acknowledging over subset of second batch with subset of gap offsets.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(10, 18, Arrays.asList(
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(10, 18, List.of(
                 (byte) 1, (byte) 1, (byte) 0, (byte) 0,
                 (byte) 1, (byte) 0, (byte) 1, (byte) 0,
                 (byte) 1))));
@@ -3818,7 +3816,7 @@ public class SharePartitionTest {
         sharePartition.acquire(MEMBER_ID, BATCH_SIZE, MAX_FETCH_RECORDS, 10, fetchPartitionData(records2));
 
         // Acknowledging over subset of second batch with subset of gap offsets.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(new ShareAcknowledgementBatch(10, 18, Arrays.asList(
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(10, 18, List.of(
                 (byte) 1, (byte) 1, (byte) 0, (byte) 0,
                 (byte) 1, (byte) 0, (byte) 1, (byte) 0,
                 (byte) 1))));
@@ -3848,7 +3846,7 @@ public class SharePartitionTest {
 
         // Ack subset of records by "member-2".
         sharePartition.acknowledge("member-2",
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 5, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(5, 5, List.of((byte) 1))));
 
         // Release acquired records for "member-2".
         releaseResult = sharePartition.releaseAcquiredRecords("member-2");
@@ -3893,10 +3891,10 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 5), 5);
 
         sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 6, Collections.singletonList((byte) 2))));
+                List.of(new ShareAcknowledgementBatch(5, 6, List.of((byte) 2))));
 
         sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(8, 9, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(8, 9, List.of((byte) 1))));
 
         CompletableFuture<Void> releaseResult = sharePartition.releaseAcquiredRecords(MEMBER_ID);
         assertNull(releaseResult.join());
@@ -3924,8 +3922,8 @@ public class SharePartitionTest {
         MemoryRecords records2 = memoryRecords(5, 10);
         fetchAcquiredRecords(sharePartition, records2, 5);
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 2))));
 
         fetchAcquiredRecords(sharePartition, records2, 5);
 
@@ -3956,10 +3954,10 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records2, 5);
         fetchAcquiredRecords(sharePartition, records3, 5);
 
-        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(Arrays.asList(
-                new ShareAcknowledgementBatch(13, 16, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(17, 19, Collections.singletonList((byte) 3)),
-                new ShareAcknowledgementBatch(20, 24, Collections.singletonList((byte) 2))
+        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(List.of(
+                new ShareAcknowledgementBatch(13, 16, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(17, 19, List.of((byte) 3)),
+                new ShareAcknowledgementBatch(20, 24, List.of((byte) 2))
         )));
 
         // Send next batch from offset 13, only 2 records should be acquired.
@@ -4017,11 +4015,11 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records2, 5);
         fetchAcquiredRecords(sharePartition, records3, 5);
 
-        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(Arrays.asList(
-                new ShareAcknowledgementBatch(10, 12, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(13, 16, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(17, 19, Collections.singletonList((byte) 3)),
-                new ShareAcknowledgementBatch(20, 24, Collections.singletonList((byte) 2))
+        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(List.of(
+                new ShareAcknowledgementBatch(10, 12, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(13, 16, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(17, 19, List.of((byte) 3)),
+                new ShareAcknowledgementBatch(20, 24, List.of((byte) 2))
         )));
 
         // Send next batch from offset 13, only 2 records should be acquired.
@@ -4045,7 +4043,7 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(7, 5), 7);
 
         sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 7, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(5, 7, List.of((byte) 1))));
 
         // Release acquired records subset with another member.
         CompletableFuture<Void> releaseResult = sharePartition.releaseAcquiredRecords("member-2");
@@ -4074,8 +4072,8 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns false.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -4102,19 +4100,19 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns true for acknowledge to pass.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(6, 5), 6);
 
         sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(8, 9, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(8, 9, List.of((byte) 1))));
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns false.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -4181,7 +4179,7 @@ public class SharePartitionTest {
 
         // Acknowledging over subset of both batch with subset of gap offsets.
         sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(6, 18, Arrays.asList(
+                List.of(new ShareAcknowledgementBatch(6, 18, List.of(
                         (byte) 1, (byte) 1, (byte) 1,
                         (byte) 1, (byte) 1, (byte) 1,
                         (byte) 0, (byte) 0, (byte) 1,
@@ -4260,11 +4258,11 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 27), 5);
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 32), 5);
 
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(2, 6, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(12, 16, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(22, 26, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(27, 31, Collections.singletonList((byte) 3))
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(2, 6, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(12, 16, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(22, 26, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(27, 31, List.of((byte) 3))
         ));
 
         // LSO is at 20.
@@ -4309,8 +4307,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 2), 5);
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 7), 5);
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(4, 8, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(4, 8, List.of((byte) 1))));
 
         // LSO at is 5.
         sharePartition.updateCacheAndOffsets(5);
@@ -4444,8 +4442,8 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
         // Acknowledge with ACCEPT action.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(7, 8, List.of((byte) 1))));
 
         // LSO is at 7.
         sharePartition.updateCacheAndOffsets(7);
@@ -4490,8 +4488,8 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(2L).batchState());
 
         // Acknowledge with RELEASE action.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(7, 8, List.of((byte) 2))));
 
         // LSO is at 7.
         sharePartition.updateCacheAndOffsets(7);
@@ -4522,8 +4520,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 7), 5);
 
         // Acknowledge with RELEASE action.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(7, 8, List.of((byte) 2))));
 
         // LSO is at 11.
         sharePartition.updateCacheAndOffsets(11);
@@ -4554,9 +4552,9 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 7), 5);
 
         // Acknowledge with RELEASE action.
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(11, 11, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(7, 8, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(11, 11, List.of((byte) 2))));
 
         // LSO is at 11.
         sharePartition.updateCacheAndOffsets(11);
@@ -4587,8 +4585,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 7), 5);
 
         // Acknowledge with RELEASE action.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(7, 8, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(7, 8, List.of((byte) 2))));
 
         // LSO is at 12.
         sharePartition.updateCacheAndOffsets(12);
@@ -4677,8 +4675,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records2, 5);
 
         // Acknowledge with RELEASE action.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 2))));
 
         // LSO is at 10.
         sharePartition.updateCacheAndOffsets(10);
@@ -4709,9 +4707,9 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records1, 2);
         fetchAcquiredRecords(sharePartition, records2, 9);
 
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(5, 6, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(10, 18, Arrays.asList(
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(5, 6, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(10, 18, List.of(
                         (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 0, (byte) 0, (byte) 0, (byte) 2
                 ))));
 
@@ -4755,11 +4753,11 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 35), 5);
 
         // Acknowledge records.
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(6, 7, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(8, 8, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(25, 29, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(35, 37, Collections.singletonList((byte) 2))
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(6, 7, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(8, 8, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(25, 29, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(35, 37, List.of((byte) 2))
         ));
 
         // LSO is at 24.
@@ -4893,11 +4891,11 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 35), 5);
 
         // Acknowledge records.
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(6, 7, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(8, 8, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(25, 29, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(35, 37, Collections.singletonList((byte) 2))
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(6, 7, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(8, 8, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(25, 29, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(35, 37, List.of((byte) 2))
         ));
 
         // LSO is at 24.
@@ -5081,9 +5079,9 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(10L).batchState());
 
         // Acknowledge with RELEASE action.
-        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(2, 6, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 2))));
+        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(2, 6, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 2))));
 
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
@@ -5139,8 +5137,8 @@ public class SharePartitionTest {
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(20L).batchState());
 
         // Acknowledge with ACCEPT action.
-        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(2, 14, Collections.singletonList((byte) 1))));
+        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(2, 14, List.of((byte) 1))));
         assertNull(ackResult.join());
         assertFalse(ackResult.isCompletedExceptionally());
 
@@ -5203,8 +5201,8 @@ public class SharePartitionTest {
         assertEquals(1, sharePartition.cachedState().size());
 
         // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(2, 14, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(2, 14, List.of((byte) 2))));
 
         assertEquals(10, sharePartition.nextFetchOffset());
         assertEquals(10, sharePartition.startOffset());
@@ -5253,8 +5251,8 @@ public class SharePartitionTest {
         assertEquals(2, sharePartition.cachedState().size());
 
         // Acknowledge with RELEASE action. This contains a batch that doesn't exist at all.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(1, 7, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(1, 7, List.of((byte) 2))));
 
         assertEquals(3, sharePartition.nextFetchOffset());
         assertEquals(3, sharePartition.startOffset());
@@ -5277,7 +5275,7 @@ public class SharePartitionTest {
         SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(null));
-        CompletableFuture<Void> result = sharePartition.writeShareGroupState(Collections.emptyList());
+        CompletableFuture<Void> result = sharePartition.writeShareGroupState(List.of());
         assertTrue(result.isCompletedExceptionally());
         assertFutureThrows(IllegalStateException.class, result);
     }
@@ -5304,32 +5302,32 @@ public class SharePartitionTest {
 
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
         // TopicsData is empty.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.emptyList());
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of());
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         CompletableFuture<Void> writeResult = sharePartition.writeShareGroupState(anyList());
         assertTrue(writeResult.isCompletedExceptionally());
         assertFutureThrows(IllegalStateException.class, writeResult);
 
         // TopicsData contains more results than expected.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Arrays.asList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.emptyList()),
-                new TopicData<>(Uuid.randomUuid(), Collections.emptyList())));
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of()),
+                new TopicData<>(Uuid.randomUuid(), List.of())));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         writeResult = sharePartition.writeShareGroupState(anyList());
         assertTrue(writeResult.isCompletedExceptionally());
         assertFutureThrows(IllegalStateException.class, writeResult);
 
         // TopicsData contains no partition data.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.emptyList())));
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of())));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         writeResult = sharePartition.writeShareGroupState(anyList());
         assertTrue(writeResult.isCompletedExceptionally());
         assertFutureThrows(IllegalStateException.class, writeResult);
 
         // TopicsData contains wrong topicId.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(Uuid.randomUuid(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(Uuid.randomUuid(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         writeResult = sharePartition.writeShareGroupState(anyList());
@@ -5337,8 +5335,8 @@ public class SharePartitionTest {
         assertFutureThrows(IllegalStateException.class, writeResult);
 
         // TopicsData contains more partition data than expected.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Arrays.asList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message()),
                         PartitionFactory.newPartitionErrorData(1, Errors.NONE.code(), Errors.NONE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
@@ -5347,8 +5345,8 @@ public class SharePartitionTest {
         assertFutureThrows(IllegalStateException.class, writeResult);
 
         // TopicsData contains wrong partition.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(1, Errors.NONE.code(), Errors.NONE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
         writeResult = sharePartition.writeShareGroupState(anyList());
@@ -5383,8 +5381,8 @@ public class SharePartitionTest {
         SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
 
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5403,8 +5401,8 @@ public class SharePartitionTest {
             .build();
         // Mock Write state RPC to return error response, NOT_COORDINATOR.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.NOT_COORDINATOR.code(), Errors.NOT_COORDINATOR.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5413,8 +5411,8 @@ public class SharePartitionTest {
         assertFutureThrows(CoordinatorNotAvailableException.class, result);
 
         // Mock Write state RPC to return error response, COORDINATOR_NOT_AVAILABLE.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.COORDINATOR_NOT_AVAILABLE.code(), Errors.COORDINATOR_NOT_AVAILABLE.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5423,8 +5421,8 @@ public class SharePartitionTest {
         assertFutureThrows(CoordinatorNotAvailableException.class, result);
 
         // Mock Write state RPC to return error response, COORDINATOR_LOAD_IN_PROGRESS.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.COORDINATOR_LOAD_IN_PROGRESS.code(), Errors.COORDINATOR_LOAD_IN_PROGRESS.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5433,8 +5431,8 @@ public class SharePartitionTest {
         assertFutureThrows(CoordinatorNotAvailableException.class, result);
 
         // Mock Write state RPC to return error response, GROUP_ID_NOT_FOUND.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5443,8 +5441,8 @@ public class SharePartitionTest {
         assertFutureThrows(GroupIdNotFoundException.class, result);
 
         // Mock Write state RPC to return error response, UNKNOWN_TOPIC_OR_PARTITION.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), Errors.UNKNOWN_TOPIC_OR_PARTITION.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5453,8 +5451,8 @@ public class SharePartitionTest {
         assertFutureThrows(UnknownTopicOrPartitionException.class, result);
 
         // Mock Write state RPC to return error response, FENCED_STATE_EPOCH.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.FENCED_STATE_EPOCH.code(), Errors.FENCED_STATE_EPOCH.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5463,8 +5461,8 @@ public class SharePartitionTest {
         assertFutureThrows(FencedStateEpochException.class, result);
 
         // Mock Write state RPC to return error response, FENCED_LEADER_EPOCH.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.FENCED_LEADER_EPOCH.code(), Errors.FENCED_LEADER_EPOCH.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5473,8 +5471,8 @@ public class SharePartitionTest {
         assertFutureThrows(NotLeaderOrFollowerException.class, result);
 
         // Mock Write state RPC to return error response, UNKNOWN_SERVER_ERROR.
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.UNKNOWN_SERVER_ERROR.code(), Errors.UNKNOWN_SERVER_ERROR.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
@@ -5486,7 +5484,7 @@ public class SharePartitionTest {
     @Test
     public void testWriteShareGroupStateWithNoOpStatePersister() {
         SharePartition sharePartition = SharePartitionBuilder.builder().withState(SharePartitionState.ACTIVE).build();
-        List<PersisterStateBatch> stateBatches = Arrays.asList(
+        List<PersisterStateBatch> stateBatches = List.of(
                 new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
                 new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3));
 
@@ -5503,8 +5501,8 @@ public class SharePartitionTest {
 
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                        new ShareAcknowledgementBatch(0, 249, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                        new ShareAcknowledgementBatch(0, 249, List.of((byte) 1))));
 
         assertEquals(250, sharePartition.nextFetchOffset());
         // The SPSO should only move when the initial records in cached state are acknowledged with type ACKNOWLEDGE or ARCHIVED.
@@ -5523,8 +5521,8 @@ public class SharePartitionTest {
 
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 249, Collections.singletonList((byte) 3))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 249, List.of((byte) 3))));
 
         assertEquals(250, sharePartition.nextFetchOffset());
         // The SPSO should only move when the initial records in cached state are acknowledged with type ACKNOWLEDGE or ARCHIVED.
@@ -5542,8 +5540,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(250, 0), 250);
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 249, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 249, List.of((byte) 2))));
 
         // The SPSO should only move when the initial records in cached state are acknowledged with type ACKNOWLEDGE or ARCHIVED.
         assertEquals(0, sharePartition.startOffset());
@@ -5569,8 +5567,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(15, 15), 15);
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 12, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 12, List.of((byte) 1))));
 
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(0L).offsetState().get(12L).state());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).offsetState().get(13L).state());
@@ -5594,8 +5592,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(15, 15), 15);
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 14, Collections.singletonList((byte) 3))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 14, List.of((byte) 3))));
 
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(15L).batchState());
         assertEquals(MEMBER_ID, sharePartition.cachedState().get(15L).batchMemberId());
@@ -5620,8 +5618,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(15, 15), 15);
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 3))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 3))));
 
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).offsetState().get(9L).state());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(0L).offsetState().get(10L).state());
@@ -5649,8 +5647,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(15, 15), 15);
         assertFalse(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 29, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 29, List.of((byte) 1))));
 
         assertTrue(sharePartition.canAcquireRecords());
         assertEquals(30, sharePartition.startOffset());
@@ -5675,8 +5673,8 @@ public class SharePartitionTest {
         assertTrue(sharePartition.canAcquireRecords());
 
         // First Acknowledgement for the first batch of records 0-19.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 19, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 19, List.of((byte) 1))));
 
         assertTrue(sharePartition.canAcquireRecords());
         assertEquals(20, sharePartition.startOffset());
@@ -5686,8 +5684,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(20, 60), 20);
         assertTrue(sharePartition.canAcquireRecords());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(20, 49, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(20, 49, List.of((byte) 1))));
 
         assertEquals(RecordState.ACKNOWLEDGED, sharePartition.cachedState().get(40L).offsetState().get(49L).state());
         assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(40L).offsetState().get(50L).state());
@@ -5701,8 +5699,8 @@ public class SharePartitionTest {
         assertFalse(sharePartition.canAcquireRecords());
 
         // Final Acknowledgment, all records are acknowledged here.
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(50, 179, Collections.singletonList((byte) 3))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(50, 179, List.of((byte) 3))));
 
         assertEquals(0, sharePartition.cachedState().size());
         assertTrue(sharePartition.canAcquireRecords());
@@ -5727,7 +5725,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(11L, 20L, RecordState.AVAILABLE.id, (short) 2),
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1) // There is a gap from 21 to 30
                     ))))));
@@ -5796,8 +5794,8 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.startOffset());
         assertEquals(249, sharePartition.endOffset());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 249, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 249, List.of((byte) 1))));
 
         assertTrue(sharePartition.canAcquireRecords());
         assertEquals(250, sharePartition.startOffset());
@@ -5818,8 +5816,8 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.startOffset());
         assertEquals(249, sharePartition.endOffset());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 89, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 89, List.of((byte) 2))));
 
         // The SPSO should only move when the initial records in cached state are acknowledged with type ACKNOWLEDGE or ARCHIVED.
         assertEquals(0, sharePartition.startOffset());
@@ -5842,8 +5840,8 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.startOffset());
         assertEquals(249, sharePartition.endOffset());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 89, Collections.singletonList((byte) 3))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 89, List.of((byte) 3))));
 
         // The SPSO should only move when the initial records in cached state are acknowledged with type ACKNOWLEDGE or ARCHIVED.
         assertEquals(90, sharePartition.startOffset());
@@ -5865,8 +5863,8 @@ public class SharePartitionTest {
         assertEquals(0, sharePartition.startOffset());
         assertEquals(249, sharePartition.endOffset());
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                        new ShareAcknowledgementBatch(0, 89, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                        new ShareAcknowledgementBatch(0, 89, List.of((byte) 1))));
 
         // The SPSO should only move when the initial records in cached state are acknowledged with type ACKNOWLEDGE or ARCHIVED.
         assertEquals(90, sharePartition.startOffset());
@@ -5885,15 +5883,15 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns false.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.UNKNOWN_TOPIC_OR_PARTITION.code(), Errors.UNKNOWN_TOPIC_OR_PARTITION.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(10, 5), 10);
 
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 14, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(5, 14, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(UnknownTopicOrPartitionException.class, ackResult);
 
@@ -5914,15 +5912,15 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns false.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
         Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
 
         fetchAcquiredRecords(sharePartition, memoryRecords(6, 5), 6);
         CompletableFuture<Void> ackResult = sharePartition.acknowledge(
                 MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(8, 10, Collections.singletonList((byte) 3))));
+                List.of(new ShareAcknowledgementBatch(8, 10, List.of((byte) 3))));
         assertTrue(ackResult.isCompletedExceptionally());
 
         // Due to failure in writeShareGroupState, the cached state should not be updated.
@@ -5948,11 +5946,11 @@ public class SharePartitionTest {
 
         fetchAcquiredRecords(sharePartition, memoryRecords(7, 5), 7);
         sharePartition.acknowledge(MEMBER_ID,
-                Collections.singletonList(new ShareAcknowledgementBatch(5, 7, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(5, 7, List.of((byte) 1))));
 
         // Acknowledge subset with another member.
         CompletableFuture<Void> ackResult = sharePartition.acknowledge("member-2",
-                Collections.singletonList(new ShareAcknowledgementBatch(9, 11, Collections.singletonList((byte) 1))));
+                List.of(new ShareAcknowledgementBatch(9, 11, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
     }
@@ -5967,11 +5965,11 @@ public class SharePartitionTest {
 
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 15), 5);
 
-        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2)),
+        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(5, 9, List.of((byte) 2)),
                 // Acknowledging batch with another member will cause failure and rollback.
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(15, 19, Collections.singletonList((byte) 1))));
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(15, 19, List.of((byte) 1))));
 
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
@@ -5996,11 +5994,11 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 10), 5);
         sharePartition.acquire("member-2", BATCH_SIZE, MAX_FETCH_RECORDS, 15, fetchPartitionData(memoryRecords(5, 15)));
 
-        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(10, 14, Collections.singletonList((byte) 1)),
+        CompletableFuture<Void> ackResult = sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(5, 9, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(10, 14, List.of((byte) 1)),
                 // Acknowledging subset with another member will cause failure and rollback.
-                new ShareAcknowledgementBatch(16, 18, Collections.singletonList((byte) 1))));
+                new ShareAcknowledgementBatch(16, 18, List.of((byte) 1))));
         assertTrue(ackResult.isCompletedExceptionally());
         assertFutureThrows(InvalidRecordStateException.class, ackResult);
 
@@ -6026,12 +6024,12 @@ public class SharePartitionTest {
         MemoryRecords records = memoryRecords(10, 5);
 
         fetchAcquiredRecords(sharePartition, records, 10);
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(5, 14, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(5, 14, List.of((byte) 2))));
 
         fetchAcquiredRecords(sharePartition, records, 10);
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(5, 14, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(5, 14, List.of((byte) 2))));
 
         // All the records in the batch reached the max delivery count, hence they got archived and the cached state cleared.
         assertEquals(15, sharePartition.nextFetchOffset());
@@ -6054,18 +6052,18 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records1, 5);
         fetchAcquiredRecords(sharePartition, records2, 5);
 
-        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(Arrays.asList(
-                new ShareAcknowledgementBatch(10, 12, Collections.singletonList((byte) 1)),
-                new ShareAcknowledgementBatch(13, 16, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(17, 19, Collections.singletonList((byte) 1)))));
+        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(List.of(
+                new ShareAcknowledgementBatch(10, 12, List.of((byte) 1)),
+                new ShareAcknowledgementBatch(13, 16, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(17, 19, List.of((byte) 1)))));
 
         // Send next batch from offset 13, only 2 records should be acquired.
         fetchAcquiredRecords(sharePartition, records1, 2);
         // Send next batch from offset 15, only 2 records should be acquired.
         fetchAcquiredRecords(sharePartition, records2, 2);
 
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(13, 16, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(13, 16, List.of((byte) 2))));
 
         assertEquals(20, sharePartition.nextFetchOffset());
         // Cached state will be empty because after the second release, the acquired records will now have moved to
@@ -6084,13 +6082,13 @@ public class SharePartitionTest {
         MemoryRecords records1 = memoryRecords(5, 0);
 
         fetchAcquiredRecords(sharePartition, records1, 5);
-        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 1, Collections.singletonList((byte) 2)))));
+        sharePartition.acknowledge(MEMBER_ID, new ArrayList<>(List.of(
+                new ShareAcknowledgementBatch(0, 1, List.of((byte) 2)))));
 
         // Send next batch from offset 0, only 2 records should be acquired.
         fetchAcquiredRecords(sharePartition, memoryRecords(2, 0), 2);
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 4, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(0, 4, List.of((byte) 2))));
 
         assertEquals(2, sharePartition.nextFetchOffset());
         assertEquals(1, sharePartition.cachedState().size());
@@ -6121,8 +6119,8 @@ public class SharePartitionTest {
         assertFalse(sharePartition.findNextFetchOffset());
         assertEquals(20, sharePartition.nextFetchOffset());
 
-        sharePartition.acknowledge(memberId1, Collections.singletonList(
-                new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(memberId1, List.of(
+                new ShareAcknowledgementBatch(5, 9, List.of((byte) 2))));
 
         assertTrue(sharePartition.findNextFetchOffset());
         assertEquals(5, sharePartition.nextFetchOffset());
@@ -6147,8 +6145,8 @@ public class SharePartitionTest {
         sharePartition.acquire(memberId1, BATCH_SIZE, MAX_FETCH_RECORDS, DEFAULT_FETCH_OFFSET, fetchPartitionData(records1));
         assertEquals(3, sharePartition.nextFetchOffset());
 
-        sharePartition.acknowledge(memberId1, Collections.singletonList(
-                new ShareAcknowledgementBatch(0, 2, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(memberId1, List.of(
+                new ShareAcknowledgementBatch(0, 2, List.of((byte) 2))));
         assertEquals(0, sharePartition.nextFetchOffset());
 
         sharePartition.acquire(memberId2, BATCH_SIZE, MAX_FETCH_RECORDS, 3, fetchPartitionData(memoryRecords(2, 3)));
@@ -6157,8 +6155,8 @@ public class SharePartitionTest {
         sharePartition.acquire(memberId1, BATCH_SIZE, MAX_FETCH_RECORDS, DEFAULT_FETCH_OFFSET, fetchPartitionData(records1));
         assertEquals(5, sharePartition.nextFetchOffset());
 
-        sharePartition.acknowledge(memberId2, Collections.singletonList(
-                new ShareAcknowledgementBatch(3, 4, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(memberId2, List.of(
+                new ShareAcknowledgementBatch(3, 4, List.of((byte) 2))));
         assertEquals(3, sharePartition.nextFetchOffset());
     }
 
@@ -6169,8 +6167,8 @@ public class SharePartitionTest {
             .build());
 
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 2), 5);
-        sharePartition.acknowledge(MEMBER_ID, Collections.singletonList(
-                new ShareAcknowledgementBatch(2, 6, Collections.singletonList((byte) 1))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(2, 6, List.of((byte) 1))));
         // Acknowledge records will induce 1 write state RPC call via function isWriteShareGroupStateSuccessful.
         Mockito.verify(sharePartition, Mockito.times(1)).writeShareGroupState(anyList());
 
@@ -6188,11 +6186,11 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, records1, 5);
         fetchAcquiredRecords(sharePartition, memoryRecords(12, 10), 12);
 
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
-                new ShareAcknowledgementBatch(5, 11, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(12, 13, Collections.singletonList((byte) 0)),
-                new ShareAcknowledgementBatch(14, 15, Collections.singletonList((byte) 2)),
-                new ShareAcknowledgementBatch(17, 20, Collections.singletonList((byte) 2))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(
+                new ShareAcknowledgementBatch(5, 11, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(12, 13, List.of((byte) 0)),
+                new ShareAcknowledgementBatch(14, 15, List.of((byte) 2)),
+                new ShareAcknowledgementBatch(17, 20, List.of((byte) 2))));
 
         // Reacquire with another member.
         sharePartition.acquire("member-2", BATCH_SIZE, MAX_FETCH_RECORDS, 5, fetchPartitionData(records1));
@@ -6237,8 +6235,8 @@ public class SharePartitionTest {
 
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionAllData(0, 3, 233L, Errors.NONE.code(), Errors.NONE.message(),
                                 stateBatches)))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
@@ -6265,8 +6263,8 @@ public class SharePartitionTest {
 
         // Mock persister writeState method so that sharePartition.isWriteShareGroupStateSuccessful() returns true with a delay of 5 sec.
         WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
-        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-            new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
 
         CompletableFuture<WriteShareGroupStateResult> future = new CompletableFuture<>();
@@ -6277,8 +6275,8 @@ public class SharePartitionTest {
         fetchAcquiredRecords(sharePartition, memoryRecords(5, 5), 5);
 
         List<ShareAcknowledgementBatch> acknowledgementBatches = new ArrayList<>();
-        acknowledgementBatches.add(new ShareAcknowledgementBatch(2, 3, Collections.singletonList((byte) 2)));
-        acknowledgementBatches.add(new ShareAcknowledgementBatch(5, 9, Collections.singletonList((byte) 2)));
+        acknowledgementBatches.add(new ShareAcknowledgementBatch(2, 3, List.of((byte) 2)));
+        acknowledgementBatches.add(new ShareAcknowledgementBatch(5, 9, List.of((byte) 2)));
         // Acknowledge 2-3, 5-9 offsets with RELEASE acknowledge type.
         sharePartition.acknowledge(MEMBER_ID, acknowledgementBatches);
 
@@ -6324,7 +6322,7 @@ public class SharePartitionTest {
         Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
             new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                 PartitionFactory.newPartitionAllData(0, 3, 11L, Errors.NONE.code(), Errors.NONE.message(),
-                    Arrays.asList(
+                    List.of(
                         new PersisterStateBatch(21L, 30L, RecordState.ACKNOWLEDGED.id, (short) 2), // There is a gap from 11 to 20
                         new PersisterStateBatch(31L, 40L, RecordState.ARCHIVED.id, (short) 1)
                     ))))));
@@ -6372,7 +6370,7 @@ public class SharePartitionTest {
         // Complete batch from 5-16 will be acquired, hence 12 records.
         fetchAcquiredRecords(sharePartition, records, 12);
         // Partially acknowledge the batch from 5-16.
-        sharePartition.acknowledge(MEMBER_ID, Arrays.asList(
+        sharePartition.acknowledge(MEMBER_ID, List.of(
             new ShareAcknowledgementBatch(5, 9, List.of(ACKNOWLEDGE_TYPE_GAP_ID)),
             new ShareAcknowledgementBatch(10, 11, List.of(AcknowledgeType.ACCEPT.id)),
             new ShareAcknowledgementBatch(12, 14, List.of(AcknowledgeType.REJECT.id)),
@@ -6721,7 +6719,7 @@ public class SharePartitionTest {
     }
 
     private List<AcquiredRecords> expectedAcquiredRecord(long baseOffset, long lastOffset, int deliveryCount) {
-        return Collections.singletonList(new AcquiredRecords()
+        return List.of(new AcquiredRecords()
             .setFirstOffset(baseOffset)
             .setLastOffset(lastOffset)
             .setDeliveryCount((short) deliveryCount));
@@ -6749,10 +6747,10 @@ public class SharePartitionTest {
 
     public void mockPersisterReadStateMethod(Persister persister) {
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
-        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(Collections.singletonList(
-                new TopicData<>(TOPIC_ID_PARTITION.topicId(), Collections.singletonList(
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
                         PartitionFactory.newPartitionAllData(0, 0, 0L, Errors.NONE.code(), Errors.NONE.message(),
-                                Collections.emptyList())))));
+                                List.of())))));
         Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
     }
 


### PR DESCRIPTION
Now that Kafka Brokers support Java 17, this PR makes some changes in
core module. The changes in this PR are limited to only the Java files
in the Core module. Scala related changes may follow next.
The changes mostly include:
- Collections.emptyList(), Collections.singletonList() and
Arrays.asList() are replaced with List.of()
- Collections.emptyMap() and Collections.singletonMap() are replaced
with Map.of()
- Collections.singleton() is replaced with Set.of()
- Some changes to use enhanced switch statement.
