### PR TITLE
KAFKA-19070: add taskId to consumer override clientId

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -167,6 +167,8 @@ public final class Worker {
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
     private final Function<Map<String, Object>, Admin> adminFactory;
 
+    private static final String DEFAULT_CONNECTOR_CONSUMER = "connector-consumer-";
+
     public Worker(
         String workerId,
         Time time,
@@ -922,8 +924,20 @@ public final class Worker {
                                            connectorType, ConnectorClientConfigRequest.ClientType.CONSUMER,
                                            connectorClientConfigOverridePolicy);
         consumerProps.putAll(consumerOverrides);
+        addTaskToConnectorConsumerOverride(consumerProps, defaultClientId);
 
         return consumerProps;
+    }
+
+    private static void addTaskToConnectorConsumerOverride(final Map<String, Object> consumerProps, final String defaultClientId) {
+        if (defaultClientId.startsWith(DEFAULT_CONNECTOR_CONSUMER)) {
+            String clientIdConfig = consumerProps.get(ConsumerConfig.CLIENT_ID_CONFIG).toString();
+            if (!clientIdConfig.equals(defaultClientId)) {
+                var parts = defaultClientId.split("-");
+                String taskID = parts[parts.length - 1];
+                consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, clientIdConfig + "-" + taskID);
+            }
+        }
     }
 
     static Map<String, Object> adminConfigs(String connName,
@@ -1278,7 +1292,7 @@ public final class Worker {
                 kafkaClusterId,
                 ConnectorType.SINK);
         String groupId = (String) baseConsumerConfigs(
-                connName, "connector-consumer-", config, new SinkConnectorConfig(plugins, connectorConfig),
+                connName, DEFAULT_CONNECTOR_CONSUMER, config, new SinkConnectorConfig(plugins, connectorConfig),
                 connector.getClass(), connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK).get(ConsumerConfig.GROUP_ID_CONFIG);
         Admin admin = adminFactory.apply(adminConfig);
         try {
@@ -1400,7 +1414,7 @@ public final class Worker {
                         ConnectorType.SINK);
 
                 String groupId = (String) baseConsumerConfigs(
-                        connName, "connector-consumer-", config, sinkConnectorConfig,
+                        connName, DEFAULT_CONNECTOR_CONSUMER, config, sinkConnectorConfig,
                         sinkConnectorClass, connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK).get(ConsumerConfig.GROUP_ID_CONFIG);
 
                 Admin admin = adminFactory.apply(adminConfig);
@@ -1895,7 +1909,7 @@ public final class Worker {
                     keyConverterPlugin.get(), valueConverterPlugin.get(), headerConverterPlugin.get());
 
             Map<String, Object> consumerProps = baseConsumerConfigs(
-                    id.connector(),  "connector-consumer-" + id, config, connectorConfig, connectorClass,
+                    id.connector(),  DEFAULT_CONNECTOR_CONSUMER + id, config, connectorConfig, connectorClass,
                     connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
@@ -2064,7 +2078,7 @@ public final class Worker {
 
         if (usesConnectorSpecificStore) {
             Map<String, Object> consumerProps = regularSourceOffsetsConsumerConfigs(
-                        connName, "connector-consumer-" + connName, config, sourceConfig, connector.getClass(),
+                        connName, DEFAULT_CONNECTOR_CONSUMER + connName, config, sourceConfig, connector.getClass(),
                         connectorClientConfigOverridePolicy, kafkaClusterId);
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
@@ -2136,7 +2150,7 @@ public final class Worker {
                 connectorClientConfigOverridePolicy, kafkaClusterId);
 
         Map<String, Object> consumerProps = exactlyOnceSourceOffsetsConsumerConfigs(
-                    connName, "connector-consumer-" + connName, config, sourceConfig, connector.getClass(),
+                    connName, DEFAULT_CONNECTOR_CONSUMER + connName, config, sourceConfig, connector.getClass(),
                     connectorClientConfigOverridePolicy, kafkaClusterId);
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
@@ -2191,7 +2205,7 @@ public final class Worker {
             Objects.requireNonNull(topicAdmin, "Source tasks require a non-null topic admin when configured to use their own offsets topic");
 
             Map<String, Object> consumerProps = regularSourceOffsetsConsumerConfigs(
-                    id.connector(), "connector-consumer-" + id, config, sourceConfig, connectorClass,
+                    id.connector(), DEFAULT_CONNECTOR_CONSUMER + id, config, sourceConfig, connectorClass,
                     connectorClientConfigOverridePolicy, kafkaClusterId);
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
@@ -2242,9 +2256,9 @@ public final class Worker {
             TopicAdmin topicAdmin
     ) {
         Objects.requireNonNull(topicAdmin, "Source tasks require a non-null topic admin when exactly-once support is enabled");
-
+        // Lorcan
         Map<String, Object> consumerProps = exactlyOnceSourceOffsetsConsumerConfigs(
-                id.connector(), "connector-consumer-" + id, config, sourceConfig, connectorClass,
+                id.connector(), DEFAULT_CONNECTOR_CONSUMER + id, config, sourceConfig, connectorClass,
                 connectorClientConfigOverridePolicy, kafkaClusterId);
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -177,7 +177,8 @@ import static org.mockito.Mockito.when;
 public class WorkerTest {
 
     private static final String CONNECTOR_ID = "test-connector";
-    private static final ConnectorTaskId TASK_ID = new ConnectorTaskId("job", 0);
+    private static final int TASK = 0;
+    private static final ConnectorTaskId TASK_ID = new ConnectorTaskId("job", TASK);
     private static final String WORKER_ID = "localhost:8083";
     private static final String CLUSTER_ID = "test-cluster";
     private final ConnectorClientConfigOverridePolicy noneConnectorClientConfigOverridePolicy = new NoneConnectorClientConfigOverridePolicy();
@@ -1113,7 +1114,7 @@ public class WorkerTest {
         setup(enableTopicCreation);
         Map<String, String> expectedConfigs = new HashMap<>(defaultConsumerConfigs);
         expectedConfigs.put("group.id", "connect-test-connector");
-        expectedConfigs.put("client.id", "connector-consumer-job-0");
+        expectedConfigs.put("client.id", "connector-consumer-job" + "-" + TASK);
         expectedConfigs.put("metrics.context.connect.kafka.cluster.id", CLUSTER_ID);
 
         when(connectorConfig.originalsWithPrefix(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX)).thenReturn(new HashMap<>());
@@ -1137,7 +1138,7 @@ public class WorkerTest {
         expectedConfigs.put("group.id", "connect-test");
         expectedConfigs.put("auto.offset.reset", "latest");
         expectedConfigs.put("max.poll.records", "1000");
-        expectedConfigs.put("client.id", "consumer-test-id");
+        expectedConfigs.put("client.id", "consumer-test-id" + "-" + TASK);
         expectedConfigs.put("metrics.context.connect.kafka.cluster.id", CLUSTER_ID);
 
         when(connectorConfig.originalsWithPrefix(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX)).thenReturn(new HashMap<>());
@@ -1161,7 +1162,7 @@ public class WorkerTest {
         expectedConfigs.put("auto.offset.reset", "latest");
         expectedConfigs.put("max.poll.records", "5000");
         expectedConfigs.put("max.poll.interval.ms", "1000");
-        expectedConfigs.put("client.id", "connector-consumer-job-0");
+        expectedConfigs.put("client.id", "connector-consumer-job" + "-" + TASK);
         expectedConfigs.put("metrics.context.connect.kafka.cluster.id", CLUSTER_ID);
 
         Map<String, Object> connConfig = new HashMap<>();


### PR DESCRIPTION
Addresses: [KAFKA-19070](https://issues.apache.org/jira/browse/KAFKA-19070)

The default clientId for the connector consumer is 'connector-consumer-' plus the task id value. When a user overrides this the task id value is not used and it's not possible to differentiate between the different tasks using the overridden clientId.

The idea is to append the taskId that is used in the default clientId to the user defined value.