### PR TITLE
MINOR: small optimization by judgment

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LocalLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LocalLog.java
@@ -469,9 +469,10 @@ public class LocalLog {
         return maybeHandleIOException(
                 () -> "Exception while reading from " + topicPartition + " in dir " + dir.getParent(),
                 () -> {
-                    logger.trace("Reading maximum {} bytes at offset {} from log with total length {} bytes",
-                            maxLength, startOffset, segments.sizeInBytes());
-
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Reading maximum {} bytes at offset {} from log with total length {} bytes",
+                                maxLength, startOffset, segments.sizeInBytes());
+                    }
                     LogOffsetMetadata endOffsetMetadata = nextOffsetMetadata;
                     long endOffset = endOffsetMetadata.messageOffset;
                     Optional<LogSegment> segmentOpt = segments.floorSegment(startOffset);


### PR DESCRIPTION
judgments can help avoid unnecessary `segments.sizeInBytes()`  loops

by https://github.com/apache/kafka/pull/18393/files#r2029925512

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai
<chia7712@gmail.com>
