### PR TITLE
KAFKA-19098: Remove `lastOffset` from PartitionResponse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -71,8 +71,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.common.requests.ProduceResponse.INVALID_OFFSET;
-
 /**
  * The background thread that handles the sending of produce requests to the Kafka cluster. This thread makes metadata
  * requests to renew its view of the cluster and then sends produce requests to the appropriate nodes.
@@ -608,7 +606,6 @@ public class Sender implements Runnable {
                     ProduceResponse.PartitionResponse partResp = new ProduceResponse.PartitionResponse(
                             Errors.forCode(p.errorCode()),
                             p.baseOffset(),
-                            INVALID_OFFSET,
                             p.logAppendTimeMs(),
                             p.logStartOffset(),
                             p.recordErrors()

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -159,7 +159,6 @@ public class ProduceResponse extends AbstractResponse {
     public static final class PartitionResponse {
         public Errors error;
         public long baseOffset;
-        public long lastOffset;
         public long logAppendTime;
         public long logStartOffset;
         public List<RecordError> recordErrors;
@@ -183,17 +182,12 @@ public class ProduceResponse extends AbstractResponse {
         }
 
         public PartitionResponse(Errors error, long baseOffset, long logAppendTime, long logStartOffset, List<RecordError> recordErrors, String errorMessage) {
-            this(error, baseOffset, INVALID_OFFSET, logAppendTime, logStartOffset, recordErrors, errorMessage, new ProduceResponseData.LeaderIdAndEpoch());
-        }
-
-        public PartitionResponse(Errors error, long baseOffset, long lastOffset, long logAppendTime, long logStartOffset, List<RecordError> recordErrors, String errorMessage) {
-            this(error, baseOffset, lastOffset, logAppendTime, logStartOffset, recordErrors, errorMessage, new ProduceResponseData.LeaderIdAndEpoch());
+            this(error, baseOffset, logAppendTime, logStartOffset, recordErrors, errorMessage, new ProduceResponseData.LeaderIdAndEpoch());
         }
 
         public PartitionResponse(
             Errors error,
             long baseOffset,
-            long lastOffset,
             long logAppendTime,
             long logStartOffset,
             List<RecordError> recordErrors,
@@ -202,7 +196,6 @@ public class ProduceResponse extends AbstractResponse {
         ) {
             this.error = error;
             this.baseOffset = baseOffset;
-            this.lastOffset = lastOffset;
             this.logAppendTime = logAppendTime;
             this.logStartOffset = logStartOffset;
             this.recordErrors = recordErrors;
@@ -216,7 +209,6 @@ public class ProduceResponse extends AbstractResponse {
             if (o == null || getClass() != o.getClass()) return false;
             PartitionResponse that = (PartitionResponse) o;
             return baseOffset == that.baseOffset &&
-                    lastOffset == that.lastOffset &&
                     logAppendTime == that.logAppendTime &&
                     logStartOffset == that.logStartOffset &&
                     error == that.error &&
@@ -227,7 +219,7 @@ public class ProduceResponse extends AbstractResponse {
 
         @Override
         public int hashCode() {
-            return Objects.hash(error, baseOffset, lastOffset, logAppendTime, logStartOffset, recordErrors, errorMessage, currentLeader);
+            return Objects.hash(error, baseOffset, logAppendTime, logStartOffset, recordErrors, errorMessage, currentLeader);
         }
 
         @Override
@@ -238,8 +230,6 @@ public class ProduceResponse extends AbstractResponse {
             b.append(error);
             b.append(",offset: ");
             b.append(baseOffset);
-            b.append(",lastOffset: ");
-            b.append(lastOffset);
             b.append(",logAppendTime: ");
             b.append(logAppendTime);
             b.append(", logStartOffset: ");

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -890,7 +890,6 @@ class ReplicaManager(val config: KafkaConfig,
         new PartitionResponse(
           result.error,
           result.info.firstOffset,
-          result.info.lastOffset,
           result.info.logAppendTime,
           result.info.logStartOffset,
           result.info.recordErrors,


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-19098

The `lastOffset` is not used actually, so it can be removed.

Reviewers: Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Ken Huang
<s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
