### PR TITLE
KAFKA-18845: Remove flaky tag on QuorumControllerTest#testUncleanShutdownBrokerElrEnabled

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -374,7 +374,6 @@ public class QuorumControllerTest {
         }
     }
 
-    @Flaky("KAFKA-18845")
     @Test
     public void testUncleanShutdownBrokerElrEnabled() throws Throwable {
         List<Integer> allBrokers = List.of(1, 2, 3);


### PR DESCRIPTION
It has been around two weeks since fixing
QuorumControllerTest#testUncleanShutdownBrokerElrEnabled PR
https://github.com/apache/kafka/pull/19240 was merged. There is no flaky
result after 2025/03/21, so it has enough evidence to prove the flaky is
fixed. It's good to remove flaky tag.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
