### PR TITLE
KAFKA-18796-3: Increased the default acquisition lock timeout in SharePartition from 100ms to 2 seconds

### DIFF
--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -110,8 +110,8 @@ public class SharePartitionTest {
     private static final String MEMBER_ID = "member-1";
     private static final Time MOCK_TIME = new MockTime();
     private static final short MAX_IN_FLIGHT_MESSAGES = 200;
-    private static final int ACQUISITION_LOCK_TIMEOUT_MS = 100;
-    private static final int DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS = 300;
+    private static final int ACQUISITION_LOCK_TIMEOUT_MS = 2000;
+    private static final int DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS = 6000;
     private static final int BATCH_SIZE = 500;
     private static final int DEFAULT_FETCH_OFFSET = 0;
     private static final int MAX_FETCH_RECORDS = Integer.MAX_VALUE;


### PR DESCRIPTION
This PR increases the default acquisition lock timeout in
SharePartitionTest from 100ms to 2 seconds in an attempt to remove
flakiness from the respective tests. The test reports suggest some of
the acquisition lock timeout do not get expired, even when the tests
wait for a longer duration than the expiration timeout. This might be
because the SystemTimeReaper thread advances the clock every 200ms which
is large as compared to the acquisition lock timeout for the acquired
records in the test class.
