### PR TITLE
KAFKA-15853: Move ShareCoordinatorConfig and GroupCoordinatorConfig out of KafkaConfig

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopi
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{CreateTopicsRequest, RequestContext, RequestHeader}
 import org.apache.kafka.coordinator.group.GroupCoordinator
-import org.apache.kafka.coordinator.share.ShareCoordinator
+import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 
@@ -198,14 +198,15 @@ class DefaultAutoTopicCreationManager(
           .setConfigs(convertToTopicConfigCollections(
             txnCoordinator.transactionTopicConfigs))
       case SHARE_GROUP_STATE_TOPIC_NAME =>
+        val shareCoordinatorConfig = new ShareCoordinatorConfig(config)
         val props = shareCoordinator match {
           case Some(coordinator) => coordinator.shareGroupStateTopicConfigs()
           case None => new Properties()
         }
         new CreatableTopic()
           .setName(topic)
-          .setNumPartitions(config.shareCoordinatorConfig.shareCoordinatorStateTopicNumPartitions())
-          .setReplicationFactor(config.shareCoordinatorConfig.shareCoordinatorStateTopicReplicationFactor())
+          .setNumPartitions(shareCoordinatorConfig.shareCoordinatorStateTopicNumPartitions())
+          .setReplicationFactor(shareCoordinatorConfig.shareCoordinatorStateTopicReplicationFactor())
           .setConfigs(convertToTopicConfigCollections(props))
       case topicName =>
         new CreatableTopic()

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, 
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{CreateTopicsRequest, RequestContext, RequestHeader}
-import org.apache.kafka.coordinator.group.GroupCoordinator
+import org.apache.kafka.coordinator.group.{GroupCoordinator, GroupCoordinatorConfig}
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
@@ -184,10 +184,11 @@ class DefaultAutoTopicCreationManager(
   private def creatableTopic(topic: String): CreatableTopic = {
     topic match {
       case GROUP_METADATA_TOPIC_NAME =>
+        val groupCoordinatorConfig = new GroupCoordinatorConfig(config)
         new CreatableTopic()
           .setName(topic)
-          .setNumPartitions(config.groupCoordinatorConfig.offsetsTopicPartitions)
-          .setReplicationFactor(config.groupCoordinatorConfig.offsetsTopicReplicationFactor)
+          .setNumPartitions(groupCoordinatorConfig.offsetsTopicPartitions)
+          .setReplicationFactor(groupCoordinatorConfig.offsetsTopicReplicationFactor)
           .setConfigs(convertToTopicConfigCollections(groupCoordinator.groupMetadataTopicConfigs))
       case TRANSACTION_STATE_TOPIC_NAME =>
         val transactionLogConfig = new TransactionLogConfig(config)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.common.{ClusterResource, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord
 import org.apache.kafka.coordinator.group.metrics.{GroupCoordinatorMetrics, GroupCoordinatorRuntimeMetrics}
-import org.apache.kafka.coordinator.group.{GroupConfigManager, GroupCoordinator, GroupCoordinatorRecordSerde, GroupCoordinatorService}
+import org.apache.kafka.coordinator.group.{GroupConfigManager, GroupCoordinator, GroupCoordinatorConfig, GroupCoordinatorRecordSerde, GroupCoordinatorService}
 import org.apache.kafka.coordinator.share.metrics.{ShareCoordinatorMetrics, ShareCoordinatorRuntimeMetrics}
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig, ShareCoordinatorRecordSerde, ShareCoordinatorService}
 import org.apache.kafka.coordinator.transaction.ProducerIdManager
@@ -77,6 +77,7 @@ class BrokerServer(
 ) extends KafkaBroker {
   val config: KafkaConfig = sharedServer.brokerConfig
   val shareCoordinatorConfig: ShareCoordinatorConfig = new ShareCoordinatorConfig(config)
+  val groupCoordinatorConfig: GroupCoordinatorConfig = new GroupCoordinatorConfig(config)
   val time: Time = sharedServer.time
   def metrics: Metrics = sharedServer.metrics
 
@@ -359,7 +360,7 @@ class BrokerServer(
       tokenManager = new DelegationTokenManager(config, tokenCache, time)
 
       /* initializing the groupConfigManager */
-      groupConfigManager = new GroupConfigManager(config.groupCoordinatorConfig.extractGroupConfigMap(config.shareGroupConfig))
+      groupConfigManager = new GroupConfigManager(groupCoordinatorConfig.extractGroupConfigMap(config.shareGroupConfig))
 
       /* create share coordinator */
       shareCoordinator = createShareCoordinator()
@@ -429,7 +430,7 @@ class BrokerServer(
       val fetchManager = new FetchManager(Time.SYSTEM, new FetchSessionCache(fetchSessionCacheShards))
 
       val shareFetchSessionCache : ShareSessionCache = new ShareSessionCache(
-        config.shareGroupConfig.shareGroupMaxGroups * config.groupCoordinatorConfig.shareGroupMaxSize,
+        config.shareGroupConfig.shareGroupMaxGroups * groupCoordinatorConfig.shareGroupMaxSize,
         KafkaBroker.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS)
 
       sharePartitionManager = new SharePartitionManager(
@@ -633,12 +634,12 @@ class BrokerServer(
       time,
       replicaManager,
       serde,
-      config.groupCoordinatorConfig.offsetsLoadBufferSize
+      groupCoordinatorConfig.offsetsLoadBufferSize
     )
     val writer = new CoordinatorPartitionWriter(
       replicaManager
     )
-    new GroupCoordinatorService.Builder(config.brokerId, config.groupCoordinatorConfig)
+    new GroupCoordinatorService.Builder(config.brokerId, groupCoordinatorConfig)
       .withTime(time)
       .withTimer(timer)
       .withLoader(loader)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -38,7 +38,7 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord
 import org.apache.kafka.coordinator.group.metrics.{GroupCoordinatorMetrics, GroupCoordinatorRuntimeMetrics}
 import org.apache.kafka.coordinator.group.{GroupConfigManager, GroupCoordinator, GroupCoordinatorRecordSerde, GroupCoordinatorService}
 import org.apache.kafka.coordinator.share.metrics.{ShareCoordinatorMetrics, ShareCoordinatorRuntimeMetrics}
-import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorRecordSerde, ShareCoordinatorService}
+import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig, ShareCoordinatorRecordSerde, ShareCoordinatorService}
 import org.apache.kafka.coordinator.transaction.ProducerIdManager
 import org.apache.kafka.image.publisher.{BrokerRegistrationTracker, MetadataPublisher}
 import org.apache.kafka.metadata.{BrokerState, ListenerInfo}
@@ -76,6 +76,7 @@ class BrokerServer(
   val sharedServer: SharedServer
 ) extends KafkaBroker {
   val config: KafkaConfig = sharedServer.brokerConfig
+  val shareCoordinatorConfig: ShareCoordinatorConfig = new ShareCoordinatorConfig(config)
   val time: Time = sharedServer.time
   def metrics: Metrics = sharedServer.metrics
 
@@ -664,12 +665,12 @@ class BrokerServer(
         time,
         replicaManager,
         serde,
-        config.shareCoordinatorConfig.shareCoordinatorLoadBufferSize()
+        shareCoordinatorConfig.shareCoordinatorLoadBufferSize()
       )
       val writer = new CoordinatorPartitionWriter(
         replicaManager
       )
-      Some(new ShareCoordinatorService.Builder(config.brokerId, config.shareCoordinatorConfig)
+      Some(new ShareCoordinatorService.Builder(config.brokerId, shareCoordinatorConfig)
         .withTimer(timer)
         .withTime(time)
         .withLoader(loader)

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -20,7 +20,7 @@ package kafka.server
 import kafka.network.RequestChannel
 
 import java.util.{Collections, Properties}
-import kafka.utils.{LoggingController, Logging}
+import kafka.utils.{Logging, LoggingController}
 import org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigResource}
 import org.apache.kafka.common.errors.{ApiException, InvalidRequestException}
@@ -32,7 +32,7 @@ import org.apache.kafka.common.requests.{ApiError, DescribeConfigsRequest, Descr
 import org.apache.kafka.common.requests.DescribeConfigsResponse.ConfigSource
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC}
-import org.apache.kafka.coordinator.group.GroupConfig
+import org.apache.kafka.coordinator.group.{GroupConfig, GroupCoordinatorConfig}
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
 import org.apache.kafka.server.config.ServerTopicConfigSynonyms
 import org.apache.kafka.server.metrics.ClientMetricsConfigs
@@ -149,8 +149,9 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
             if (group == null || group.isEmpty) {
               throw new InvalidRequestException("Group name must not be empty")
             } else {
+              val groupCoordinatorConfig = new GroupCoordinatorConfig(config)
               val groupProps = configRepository.groupConfig(group)
-              val groupConfig = GroupConfig.fromProps(config.groupCoordinatorConfig.extractGroupConfigMap(config.shareGroupConfig), groupProps)
+              val groupConfig = GroupConfig.fromProps(groupCoordinatorConfig.extractGroupConfigMap(config.shareGroupConfig), groupProps)
               createResponseConfig(allConfigs(groupConfig), createGroupConfigEntry(groupConfig, groupProps, includeSynonyms, includeDocumentation))
             }
 

--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, CLIENT_METRIC
 import org.apache.kafka.controller.ConfigurationValidator
 import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException}
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.coordinator.group.GroupConfigManager
+import org.apache.kafka.coordinator.group.{GroupConfigManager, GroupCoordinatorConfig}
 import org.apache.kafka.server.metrics.ClientMetricsConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
 
@@ -139,7 +139,8 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
           throw new InvalidConfigurationException("Null value not supported for group configs: " +
             nullGroupConfigs.mkString(","))
         }
-        GroupConfigManager.validate(properties, kafkaConfig.groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
+        val groupCoordinatorConfig = new GroupCoordinatorConfig(kafkaConfig)
+        GroupConfigManager.validate(properties, groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
       case _ => throwExceptionForUnknownResourceType(resource)
     }
   }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -193,10 +193,6 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   private val _quorumConfig = new QuorumConfig(this)
   def quorumConfig: QuorumConfig = _quorumConfig
 
-  private val _groupCoordinatorConfig = new GroupCoordinatorConfig(this)
-
-  def groupCoordinatorConfig: GroupCoordinatorConfig = _groupCoordinatorConfig
-
   private val _shareGroupConfig = new ShareGroupConfig(this)
   def shareGroupConfig: ShareGroupConfig = _shareGroupConfig
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -36,7 +36,6 @@ import org.apache.kafka.network.EndPoint
 import org.apache.kafka.coordinator.group.Group.GroupType
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig
 import org.apache.kafka.coordinator.group.{GroupConfig, GroupCoordinatorConfig}
-import org.apache.kafka.coordinator.share.ShareCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.{AddPartitionsToTxnConfig, TransactionStateManagerConfig}
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.QuorumConfig
@@ -200,9 +199,6 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
 
   private val _shareGroupConfig = new ShareGroupConfig(this)
   def shareGroupConfig: ShareGroupConfig = _shareGroupConfig
-
-  private val _shareCoordinatorConfig = new ShareCoordinatorConfig(this)
-  def shareCoordinatorConfig: ShareCoordinatorConfig = _shareCoordinatorConfig
 
   private val _transactionStateManagerConfig = new TransactionStateManagerConfig(this)
   private val _addPartitionsToTxnConfig = new AddPartitionsToTxnConfig(this)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.coordinator.group.GroupCoordinator
-import org.apache.kafka.coordinator.share.ShareCoordinator
+import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.publisher.MetadataPublisher
@@ -341,9 +341,10 @@ class BrokerMetadataPublisher(
     }
     if (config.shareGroupConfig.isShareGroupEnabled && shareCoordinator.isDefined) {
       try {
+        val shareCoordinatorConfig = new ShareCoordinatorConfig(config)
         // Start the share coordinator.
         shareCoordinator.get.startup(() => metadataCache.numPartitions(
-          Topic.SHARE_GROUP_STATE_TOPIC_NAME).orElse(config.shareCoordinatorConfig.shareCoordinatorStateTopicNumPartitions()))
+          Topic.SHARE_GROUP_STATE_TOPIC_NAME).orElse(shareCoordinatorConfig.shareCoordinatorStateTopicNumPartitions()))
       } catch {
         case t: Throwable => fatalFaultHandler.handleFault("Error starting Share coordinator", t)
       }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -25,7 +25,7 @@ import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.coordinator.group.GroupCoordinator
+import org.apache.kafka.coordinator.group.{GroupCoordinator, GroupCoordinatorConfig}
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.image.loader.LoaderManifest
@@ -325,9 +325,10 @@ class BrokerMetadataPublisher(
       case t: Throwable => fatalFaultHandler.handleFault("Error starting ReplicaManager", t)
     }
     try {
+      val groupCoordinatorConfig = new GroupCoordinatorConfig(config)
       // Start the group coordinator.
       groupCoordinator.startup(() => metadataCache.numPartitions(Topic.GROUP_METADATA_TOPIC_NAME)
-        .orElse(config.groupCoordinatorConfig.offsetsTopicPartitions))
+        .orElse(groupCoordinatorConfig.offsetsTopicPartitions))
     } catch {
       case t: Throwable => fatalFaultHandler.handleFault("Error starting GroupCoordinator", t)
     }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -54,6 +54,7 @@ import org.apache.kafka.common.network.CertStores.{KEYSTORE_PROPS, TRUSTSTORE_PR
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerConfigs, ServerLogConfigs, ServerTopicConfigSynonyms}
@@ -127,7 +128,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     TestUtils.createTopicWithAdmin(adminClients.head, topic, servers, controllerServers, numPartitions, replicationFactor = numServers)
     TestUtils.createTopicWithAdmin(adminClients.head, Topic.GROUP_METADATA_TOPIC_NAME, servers, controllerServers,
-      numPartitions = servers.head.config.groupCoordinatorConfig.offsetsTopicPartitions,
+      numPartitions = new GroupCoordinatorConfig(servers.head.config).offsetsTopicPartitions,
       replicationFactor = numServers,
       topicConfig = servers.head.groupCoordinator.groupMetadataTopicConfigs)
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1171,7 +1171,7 @@ class KafkaConfigTest {
     assertEquals(11 * 60L * 1000L * 60, config.logRollTimeJitterMillis)
     assertEquals(10 * 60L * 1000L * 60, config.logRetentionTimeMillis)
     assertEquals(123L, config.logFlushIntervalMs)
-    assertEquals(CompressionType.SNAPPY, config.groupCoordinatorConfig.offsetTopicCompressionType)
+    assertEquals(CompressionType.SNAPPY, new GroupCoordinatorConfig(config).offsetTopicCompressionType)
     assertEquals(Sensor.RecordingLevel.DEBUG.toString, config.metricRecordingLevel)
     assertEquals(false, config.tokenAuthEnabled)
     assertEquals(7 * 24 * 60L * 60L * 1000L, config.delegationTokenMaxLifeMs)
@@ -1777,14 +1777,14 @@ class KafkaConfigTest {
     ConsumerGroupMigrationPolicy.values.foreach { policy =>
       props.put(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, policy.toString)
       val config = KafkaConfig.fromProps(props)
-      assertEquals(policy, config.groupCoordinatorConfig.consumerGroupMigrationPolicy)
+      assertEquals(policy, new GroupCoordinatorConfig(config).consumerGroupMigrationPolicy)
     }
 
     // The config is case-insensitive.
     ConsumerGroupMigrationPolicy.values.foreach { policy =>
       props.put(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, policy.toString.toUpperCase())
       val config = KafkaConfig.fromProps(props)
-      assertEquals(policy, config.groupCoordinatorConfig.consumerGroupMigrationPolicy)
+      assertEquals(policy, new GroupCoordinatorConfig(config).consumerGroupMigrationPolicy)
     }
   }
 


### PR DESCRIPTION
Since GroupCoordinatorConfig and GroupCoordinatorConfig are not
reconfigurable, they don't need to be integrated in KafkaConfig.
