### PR TITLE
KAFKA-18983 Ensure all README.md(s) are mentioned by the root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ fail due to code changes. You can just run:
  
     ./gradlew processMessages processTestMessages
 
-See [Apache Kafka Message Definitions](/clients/src/main/resources/common/message/README.md) for details on Apache Kafka message protocol.
+See [Apache Kafka Message Definitions](clients/src/main/resources/common/message/README.md) for details on Apache Kafka message protocol.
 
 ### Running a Kafka broker
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ fail due to code changes. You can just run:
  
     ./gradlew processMessages processTestMessages
 
+See [Apache Kafka Message Definitions](/clients/src/main/resources/common/message/README.md) for details on Apache Kafka message protocol
+
 ### Running a Kafka broker
 
 Using compiled files:
@@ -110,6 +112,8 @@ Using compiled files:
 Using docker image:
 
     docker run -p 9092:9092 apache/kafka:3.7.0
+
+See [docker/README.md] for detailed information.
 
 ### Cleaning the build ###
     ./gradlew clean
@@ -263,9 +267,27 @@ default. See https://www.lightbend.com/blog/scala-inliner-optimizer for more det
 
 See [tests/README.md](tests/README.md).
 
+### Using Trogdor for testing ###
+
+We Trogdor as a test framework for Apache Kafka. You can use it to run benchmarks and other workloads.
+
+See [trogdor/README.md](trogdor/README.md).
+
 ### Running in Vagrant ###
 
 See [vagrant/README.md](vagrant/README.md).
+
+### Release Kafka ###
+
+See [release/README.md](release/README.md).
+
+### Official Documentation ###
+
+See [docs/README.md](docs/README.md).
+
+### Kafka client examples ###
+
+See [examples/README.md](examples/README.md).
 
 ### Contribution ###
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ fail due to code changes. You can just run:
  
     ./gradlew processMessages processTestMessages
 
-See [Apache Kafka Message Definitions](/clients/src/main/resources/common/message/README.md) for details on Apache Kafka message protocol
+See [Apache Kafka Message Definitions](/clients/src/main/resources/common/message/README.md) for details on Apache Kafka message protocol.
 
 ### Running a Kafka broker
 
@@ -113,7 +113,7 @@ Using docker image:
 
     docker run -p 9092:9092 apache/kafka:3.7.0
 
-See [docker/README.md] for detailed information.
+See [docker/README.md](docker/README.md) for detailed information.
 
 ### Cleaning the build ###
     ./gradlew clean
@@ -269,7 +269,7 @@ See [tests/README.md](tests/README.md).
 
 ### Using Trogdor for testing ###
 
-We Trogdor as a test framework for Apache Kafka. You can use it to run benchmarks and other workloads.
+We use Trogdor as a test framework for Apache Kafka. You can use it to run benchmarks and other workloads.
 
 See [trogdor/README.md](trogdor/README.md).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ Building image and running tests using github actions
 
 - image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow.
   - `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/display/KAFKA/KIP-975%3A+Docker+Image+for+Apache+Kafka)
-  - `native` image type is for graalvm based `native` kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/display/KAFKA/KIP-974%3A+Docker+Image+for+GraalVM+based+Native+Kafka+Broker#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming)
+  - `native` image type is for graalvm based `native` kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/display/KAFKA/KIP-974%3A+Docker+Image+for+GraalVM+based+Native+Kafka+Broker#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming). Or you can see [native/README.md](native/README.md) for more information.
 
 - Example(jvm):-
 To build and test a jvm image type ensuring kafka to be containerised should be https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz (it is recommended to use scala 2.13 binary tarball), following inputs in github actions workflow are recommended.

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,11 +27,11 @@ Building image and running tests using github actions
 - This is the recommended way to build, test and get a CVE report for the docker image.
 - Just choose the image type and provide kafka url to `Docker Build Test` workflow. It will generate a test report and CVE report that can be shared with the community.
 
-- kafka-url - This is the url to download kafka tarball from. For example kafka tarball url from (https://archive.apache.org/dist/kafka). For building RC image this will be an RC tarball url.
+- kafka-url - This is the url to download kafka tarball from. For example kafka tarball url from [Kafka archive](https://archive.apache.org/dist/kafka). For building RC image this will be an RC tarball url.
 
 - image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow.
   - `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/x/z5izDw)
-  - `native` image type is for graalvm based `native` kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming). Or you can see [native/README.md](native/README.md) for more information.
+  - `native` image type is for graalvm based `native` Kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming). Or you can see [native/README.md](native/README.md) for more information.
 
 - Example(jvm):-
 To build and test a jvm image type ensuring kafka to be containerised should be https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz (it is recommended to use scala 2.13 binary tarball), following inputs in github actions workflow are recommended.

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ Building image and running tests using github actions
 
 - image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow.
   - `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/x/z5izDw)
-  - `native` image type is for graalvm based `native` Kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming). Or you can see [native/README.md](native/README.md) for more information.
+  - `native` image type is for graalvm based `native` Kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw). Or you can see [native/README.md](native/README.md) for more information.
 
 - Example(jvm):-
 To build and test a jvm image type ensuring kafka to be containerised should be https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz (it is recommended to use scala 2.13 binary tarball), following inputs in github actions workflow are recommended.

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,8 +30,8 @@ Building image and running tests using github actions
 - kafka-url - This is the url to download kafka tarball from. For example kafka tarball url from (https://archive.apache.org/dist/kafka). For building RC image this will be an RC tarball url.
 
 - image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow.
-  - `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/display/KAFKA/KIP-975%3A+Docker+Image+for+Apache+Kafka)
-  - `native` image type is for graalvm based `native` kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/display/KAFKA/KIP-974%3A+Docker+Image+for+GraalVM+based+Native+Kafka+Broker#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming). Or you can see [native/README.md](native/README.md) for more information.
+  - `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/x/z5izDw)
+  - `native` image type is for graalvm based `native` kafka docker image (to be hosted on apache/kafka-native) as described in [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw#KIP974:DockerImageforGraalVMbasedNativeKafkaBroker-ImageNaming). Or you can see [native/README.md](native/README.md) for more information.
 
 - Example(jvm):-
 To build and test a jvm image type ensuring kafka to be containerised should be https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz (it is recommended to use scala 2.13 binary tarball), following inputs in github actions workflow are recommended.
@@ -210,6 +210,6 @@ python generate_kafka_pr_template.py --image-type=jvm
 ```
 
 - kafka-version - This is the version to create the Docker official images static Dockerfile and assets for, as well as the version to build and test the Docker official image for.
-- image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow. `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/display/KAFKA/KIP-975%3A+Docker+Image+for+Apache+Kafka). 
-  - **NOTE:** As of now [KIP-1028](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1028%3A+Docker+Official+Image+for+Apache+Kafka) only aims to release JVM based Docker Official Images and not GraalVM based native Apache Kafka docker image.
+- image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow. `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/x/z5izDw). 
+  - **NOTE:** As of now [KIP-1028](https://cwiki.apache.org/confluence/x/0AmpEQ) only aims to release JVM based Docker Official Images and not GraalVM based native Apache Kafka docker image.
 

--- a/docker/native/README.md
+++ b/docker/native/README.md
@@ -4,7 +4,7 @@
 - The Native Apache Kafka Docker Image can launch brokers with sub-second startup time and minimal memory footprint by leveraging native Kafka executable.
 - The native Kafka executable is built by compiling Apache Kafka code ahead-of-time using the [GraalVM native-image tool](https://www.graalvm.org/jdk21/reference-manual/native-image/).
 - This image is experimental and intended for local development and testing purposes only; it is not recommended for production use.
-- This is introduced with [KIP-974](https://cwiki.apache.org/confluence/display/KAFKA/KIP-974%3A+Docker+Image+for+GraalVM+based+Native+Kafka+Broker).
+- This is introduced with [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw).
 
 ## Native-Image reachability metadata
 The native-image tool performs static analysis while building a native binary to determine the dynamic features(the dynamic language features of the JVM, including reflection and resource handling, compute the dynamically-accessed program elements such as invoked methods or resource URLs at runtime), but it cannot always exhaustively predict all uses. 

--- a/trogdor/README.md
+++ b/trogdor/README.md
@@ -6,9 +6,9 @@ Trogdor can run benchmarks and other workloads. Trogdor can also inject faults i
 
 Quickstart
 =========================================================
-First, we want to [start a single-node Kafka cluster in KRaft mode](https://github.com/apache/kafka/blob/trunk/README.md#running-a-kafka-broker-in-kraft-mode)
+First, we want to [start a single-node Kafka cluster](https://github.com/apache/kafka/blob/trunk/README.md#running-a-kafka-broker)
 
-Running Kafka in Kraft mode:
+Running Kafka:
 
 ```
 KAFKA_CLUSTER_ID="$(./bin/kafka-storage.sh random-uuid)"


### PR DESCRIPTION
There are few README not added because I am not sure if they need to be mentioned in root README.
```
./test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/README.md
./storage/src/test/java/org/apache/kafka/tiered/storage/README.md
./.github/workflows/README.md
./raft/README.md
./committer-tools/README.md
```

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi <kitingiao@gmail.com>, PoAn Yang <payang@apache.org>, Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
