### PR TITLE
[draft] KAFKA-19047: Allow quickly re-registering brokers that were shutdown

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -220,6 +220,10 @@ public class BrokerHeartbeatManager {
         }
     }
 
+    void removeSession(BrokerIdAndEpoch brokerIdAndEpoch) {
+        tracker.removeSession(brokerIdAndEpoch);
+    }
+
     /**
      * Stop tracking the broker in the unfenced list and active set, if it was tracked
      * in either of these.

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatTracker.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatTracker.java
@@ -120,6 +120,10 @@ class BrokerHeartbeatTracker {
         return Optional.empty();
     }
 
+    void removeSession(BrokerIdAndEpoch idAndEpoch) {
+        contactTimes.remove(idAndEpoch);
+    }
+
     /**
      * Return true if the given time is outside the expiration window.
      * If the timestamp has undergone 64-bit rollover, we will not expire anything.

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -353,7 +353,7 @@ public class ClusterControlManager {
         if (existing != null) {
             prevIncarnationId = existing.incarnationId();
             storedBrokerEpoch = existing.epoch();
-            if (heartbeatManager.hasValidSession(brokerId, existing.epoch()) && !existing.inControlledShutdown()) {
+            if (heartbeatManager.hasValidSession(brokerId, existing.epoch()) && !existing.fenced()) {
                 if (!request.incarnationId().equals(prevIncarnationId)) {
                     throw new DuplicateBrokerRegistrationException("Another broker is registered with that broker id. If the broker " + 
                             "was recently restarted this should self-resolve once the heartbeat manager expires the broker's session.");

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -353,7 +353,7 @@ public class ClusterControlManager {
         if (existing != null) {
             prevIncarnationId = existing.incarnationId();
             storedBrokerEpoch = existing.epoch();
-            if (heartbeatManager.hasValidSession(brokerId, existing.epoch()) && !existing.fenced()) {
+            if (heartbeatManager.hasValidSession(brokerId, existing.epoch())) {
                 if (!request.incarnationId().equals(prevIncarnationId)) {
                     throw new DuplicateBrokerRegistrationException("Another broker is registered with that broker id. If the broker " + 
                             "was recently restarted this should self-resolve once the heartbeat manager expires the broker's session.");

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -136,6 +136,8 @@ import static org.apache.kafka.common.protocol.Errors.NO_REASSIGNMENT_IN_PROGRES
 import static org.apache.kafka.common.protocol.Errors.TOPIC_AUTHORIZATION_FAILED;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
+import static org.apache.kafka.controller.BrokerControlState.CONTROLLED_SHUTDOWN;
+import static org.apache.kafka.controller.BrokerControlState.SHUTDOWN_NOW;
 import static org.apache.kafka.controller.PartitionReassignmentReplicas.isReassignmentInProgress;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
@@ -1625,14 +1627,12 @@ public class ReplicationControlManager {
                     break;
             }
         }
-        // skip updating session if broker is about to shutdown
         if (states.current().equals(CONTROLLED_SHUTDOWN) && states.next().equals(SHUTDOWN_NOW)) {
-            // do nothing
-        } else {
-            heartbeatManager.touch(brokerId,
+            heartbeatManager.removeSession(new BrokerIdAndEpoch(brokerId, brokerEpoch));
+        }
+        heartbeatManager.touch(brokerId,
             states.next().fenced(),
             request.currentMetadataOffset());
-        }
         if (featureControl.metadataVersionOrThrow().isDirectoryAssignmentSupported()) {
             handleDirectoriesOffline(brokerId, brokerEpoch, request.offlineLogDirs(), records);
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -136,8 +136,6 @@ import static org.apache.kafka.common.protocol.Errors.NO_REASSIGNMENT_IN_PROGRES
 import static org.apache.kafka.common.protocol.Errors.TOPIC_AUTHORIZATION_FAILED;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
-import static org.apache.kafka.controller.BrokerControlState.CONTROLLED_SHUTDOWN;
-import static org.apache.kafka.controller.BrokerControlState.SHUTDOWN_NOW;
 import static org.apache.kafka.controller.PartitionReassignmentReplicas.isReassignmentInProgress;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1625,9 +1625,14 @@ public class ReplicationControlManager {
                     break;
             }
         }
-        heartbeatManager.touch(brokerId,
+        // skip updating session if broker is about to shutdown
+        if (states.current().equals(CONTROLLED_SHUTDOWN) && states.next().equals(SHUTDOWN_NOW)) {
+            // do nothing
+        } else {
+            heartbeatManager.touch(brokerId,
             states.next().fenced(),
             request.currentMetadataOffset());
+        }
         if (featureControl.metadataVersionOrThrow().isDirectoryAssignmentSupported()) {
             handleDirectoriesOffline(brokerId, brokerEpoch, request.offlineLogDirs(), records);
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -136,6 +136,8 @@ import static org.apache.kafka.common.protocol.Errors.NO_REASSIGNMENT_IN_PROGRES
 import static org.apache.kafka.common.protocol.Errors.TOPIC_AUTHORIZATION_FAILED;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
+import static org.apache.kafka.controller.BrokerControlState.CONTROLLED_SHUTDOWN;
+import static org.apache.kafka.controller.BrokerControlState.SHUTDOWN_NOW;
 import static org.apache.kafka.controller.PartitionReassignmentReplicas.isReassignmentInProgress;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -1074,35 +1074,37 @@ public class ClusterControlManagerTest {
             contactTime(new BrokerIdAndEpoch(1, 200)));
 
         time.sleep(brokerSessionTimeoutMs / 2);
-        assertThrows(DuplicateBrokerRegistrationException.class, () ->
-            clusterControl.registerBroker(new BrokerRegistrationRequestData().
-                    setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-                    setBrokerId(0).
-                    setLogDirs(List.of(Uuid.fromString("yJGxmjfbQZSVFAlNM3uXZg"))).
-                    setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
-                        Set.of(new BrokerRegistrationRequestData.Feature().
-                            setName(MetadataVersion.FEATURE_NAME).
-                            setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
-                            setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
-                    setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
-                101L,
-                finalizedFeatures,
-                false));
-        // new registration should succeed immediatelly only if the broker is in controlled shutdown, 
-        // even if the last heartbeat was within the session timeout 
+        // new registration should succeed immediately only if the broker is fenced. (brokers which completed
+        // controlled shutdown will end up in fenced state)
         clusterControl.registerBroker(new BrokerRegistrationRequestData().
                 setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-                setBrokerId(1).
-                setLogDirs(List.of(Uuid.fromString("b66ybsWIQoygs01vdjH07A"))).
+                setBrokerId(0).
+                setLogDirs(List.of(Uuid.fromString("yJGxmjfbQZSVFAlNM3uXZg"))).
                 setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
                     Set.of(new BrokerRegistrationRequestData.Feature().
                         setName(MetadataVersion.FEATURE_NAME).
                         setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
                         setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
-                setIncarnationId(Uuid.fromString("vZKYST0pSA2HO5x_6hoO2Q")),
-            201L,
+                setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
+            101L,
             finalizedFeatures,
             false);
+        // there is no guarantee a broker that was in controlled shutdown state finished shutting down.
+        // controller should wait the session timeout before allowing re-registrations
+        assertThrows(DuplicateBrokerRegistrationException.class, () ->
+            clusterControl.registerBroker(new BrokerRegistrationRequestData().
+                    setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+                    setBrokerId(1).
+                    setLogDirs(List.of(Uuid.fromString("b66ybsWIQoygs01vdjH07A"))).
+                    setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
+                        Set.of(new BrokerRegistrationRequestData.Feature().
+                            setName(MetadataVersion.FEATURE_NAME).
+                            setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
+                            setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
+                    setIncarnationId(Uuid.fromString("vZKYST0pSA2HO5x_6hoO2Q")),
+                201L,
+                finalizedFeatures,
+                false));
     }
 
     private FeatureControlManager createFeatureControlManager() {


### PR DESCRIPTION
https://github.com/confluentinc/ce-kafka/pull/20044 fails to account
that brokers finishing controlled shutdown eventually become fenced and
clear their inControlledShutdown bool.
