### PR TITLE
KAFKA-18170: Add create and write timestamp fields in share snapshot [1/N]

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -1037,6 +1037,7 @@ class DumpLogSegmentsTest {
   @Test
   def testShareGroupStateMessageParser(): Unit = {
     val parser = new ShareGroupStateMessageParser()
+    val timestamp = System.currentTimeMillis
 
     // The key is mandatory.
     assertEquals(
@@ -1051,7 +1052,7 @@ class DumpLogSegmentsTest {
     assertEquals(
       (
         Some("{\"type\":\"0\",\"data\":{\"groupId\":\"gs1\",\"topicId\":\"Uj5wn_FqTXirEASvVZRY1w\",\"partition\":0}}"),
-        Some("{\"version\":\"0\",\"data\":{\"snapshotEpoch\":0,\"stateEpoch\":0,\"leaderEpoch\":0,\"startOffset\":0,\"stateBatches\":[{\"firstOffset\":0,\"lastOffset\":4,\"deliveryState\":2,\"deliveryCount\":1}]}}")
+        Some(s"{\"version\":\"0\",\"data\":{\"snapshotEpoch\":0,\"stateEpoch\":0,\"leaderEpoch\":0,\"startOffset\":0,\"createTimestamp\":$timestamp,\"writeTimestamp\":$timestamp,\"stateBatches\":[{\"firstOffset\":0,\"lastOffset\":4,\"deliveryState\":2,\"deliveryCount\":1}]}}")
       ),
       parser.parse(serializedRecord(
         new ShareSnapshotKey()
@@ -1063,6 +1064,8 @@ class DumpLogSegmentsTest {
           .setStateEpoch(0)
           .setLeaderEpoch(0)
           .setStartOffset(0)
+          .setCreateTimestamp(timestamp)
+          .setWriteTimestamp(timestamp)
           .setStateBatches(List[ShareSnapshotValue.StateBatch](
             new ShareSnapshotValue.StateBatch()
               .setFirstOffset(0)

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordHelpers.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordHelpers.java
@@ -24,7 +24,6 @@ import org.apache.kafka.coordinator.share.generated.ShareUpdateKey;
 import org.apache.kafka.coordinator.share.generated.ShareUpdateValue;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.util.stream.Collectors;
 
 public class ShareCoordinatorRecordHelpers {
     public static CoordinatorRecord newShareSnapshotRecord(String groupId, Uuid topicId, int partitionId, ShareGroupOffset offsetData) {
@@ -44,7 +43,9 @@ public class ShareCoordinatorRecordHelpers {
                         .setLastOffset(batch.lastOffset())
                         .setDeliveryCount(batch.deliveryCount())
                         .setDeliveryState(batch.deliveryState()))
-                    .collect(Collectors.toList())),
+                    .toList())
+                .setCreateTimestamp(offsetData.createTimestamp())
+                .setWriteTimestamp(offsetData.writeTimestamp()),
                 (short) 0
             )
         );
@@ -66,7 +67,7 @@ public class ShareCoordinatorRecordHelpers {
                         .setLastOffset(batch.lastOffset())
                         .setDeliveryCount(batch.deliveryCount())
                         .setDeliveryState(batch.deliveryState()))
-                    .collect(Collectors.toList())),
+                    .toList()),
                 (short) 0
             )
         );

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareGroupOffset.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareGroupOffset.java
@@ -34,6 +34,8 @@ import java.util.Objects;
  */
 public class ShareGroupOffset {
     public static final int NO_TIMESTAMP = -1;
+    public static final int UNINITIALIZED_EPOCH = -1;
+    public static final int DEFAULT_EPOCH = 0;
 
     private final int snapshotEpoch;
     private final int stateEpoch;
@@ -104,7 +106,7 @@ public class ShareGroupOffset {
             record.leaderEpoch(),
             record.startOffset(),
             record.stateBatches().stream()
-            .map(ShareGroupOffset::toPersisterOffsetsStateBatch)
+                .map(ShareGroupOffset::toPersisterOffsetsStateBatch)
                 .toList(),
             record.createTimestamp(),
             record.writeTimestamp()
@@ -114,10 +116,11 @@ public class ShareGroupOffset {
     public static ShareGroupOffset fromRecord(ShareUpdateValue record) {
         return new ShareGroupOffset(
             record.snapshotEpoch(),
-            -1, record.leaderEpoch(),
+            UNINITIALIZED_EPOCH,
+            record.leaderEpoch(),
             record.startOffset(),
             record.stateBatches().stream()
-            .map(ShareGroupOffset::toPersisterOffsetsStateBatch)
+                .map(ShareGroupOffset::toPersisterOffsetsStateBatch)
                 .toList(),
             NO_TIMESTAMP,
             NO_TIMESTAMP
@@ -125,7 +128,7 @@ public class ShareGroupOffset {
     }
 
     public static ShareGroupOffset fromRequest(WriteShareGroupStateRequestData.PartitionData data, long timestamp) {
-        return fromRequest(data, 0, timestamp);
+        return fromRequest(data, DEFAULT_EPOCH, timestamp);
     }
 
     public static ShareGroupOffset fromRequest(WriteShareGroupStateRequestData.PartitionData data, int snapshotEpoch, long timestamp) {
@@ -143,14 +146,14 @@ public class ShareGroupOffset {
     }
 
     public static ShareGroupOffset fromRequest(InitializeShareGroupStateRequestData.PartitionData data, long timestamp) {
-        return fromRequest(data, 0, timestamp);
+        return fromRequest(data, DEFAULT_EPOCH, timestamp);
     }
 
     public static ShareGroupOffset fromRequest(InitializeShareGroupStateRequestData.PartitionData data, int snapshotEpoch, long timestamp) {
         return new ShareGroupOffset(
             snapshotEpoch,
             data.stateEpoch(),
-            -1,
+            UNINITIALIZED_EPOCH,
             data.startOffset(),
             List.of(),
             timestamp,
@@ -237,9 +240,9 @@ public class ShareGroupOffset {
             ", stateEpoch=" + stateEpoch +
             ", leaderEpoch=" + leaderEpoch +
             ", startOffset=" + startOffset +
-            ", stateBatches=" + stateBatches +
             ", createTimestamp=" + createTimestamp +
             ", writeTimestamp=" + writeTimestamp +
+            ", stateBatches=" + stateBatches +
             '}';
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareGroupOffset.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareGroupOffset.java
@@ -27,29 +27,38 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Container class to represent data encapsulated in {@link ShareSnapshotValue} and {@link ShareUpdateValue}
  * This class is immutable (state batches is not modified out of context).
  */
 public class ShareGroupOffset {
+    public static final int NO_TIMESTAMP = -1;
+
     private final int snapshotEpoch;
     private final int stateEpoch;
     private final int leaderEpoch;
     private final long startOffset;
     private final List<PersisterStateBatch> stateBatches;
+    private final long createTimestamp;
+    private final long writeTimestamp;
 
-    private ShareGroupOffset(int snapshotEpoch,
-                            int stateEpoch,
-                            int leaderEpoch,
-                            long startOffset,
-                            List<PersisterStateBatch> stateBatches) {
+    private ShareGroupOffset(
+        int snapshotEpoch,
+        int stateEpoch,
+        int leaderEpoch,
+        long startOffset,
+        List<PersisterStateBatch> stateBatches,
+        long createTimestamp,
+        long writeTimestamp
+    ) {
         this.snapshotEpoch = snapshotEpoch;
         this.stateEpoch = stateEpoch;
         this.leaderEpoch = leaderEpoch;
         this.startOffset = startOffset;
         this.stateBatches = stateBatches;
+        this.createTimestamp = createTimestamp;
+        this.writeTimestamp = writeTimestamp;
     }
 
     public int snapshotEpoch() {
@@ -68,6 +77,14 @@ public class ShareGroupOffset {
         return startOffset;
     }
 
+    public long createTimestamp() {
+        return createTimestamp;
+    }
+
+    public long writeTimestamp() {
+        return writeTimestamp;
+    }
+
     public List<PersisterStateBatch> stateBatches() {
         return Collections.unmodifiableList(stateBatches);
     }
@@ -81,20 +98,37 @@ public class ShareGroupOffset {
     }
 
     public static ShareGroupOffset fromRecord(ShareSnapshotValue record) {
-        return new ShareGroupOffset(record.snapshotEpoch(), record.stateEpoch(), record.leaderEpoch(), record.startOffset(), record.stateBatches().stream()
-            .map(ShareGroupOffset::toPersisterOffsetsStateBatch).collect(Collectors.toList()));
+        return new ShareGroupOffset(
+            record.snapshotEpoch(),
+            record.stateEpoch(),
+            record.leaderEpoch(),
+            record.startOffset(),
+            record.stateBatches().stream()
+            .map(ShareGroupOffset::toPersisterOffsetsStateBatch)
+                .toList(),
+            record.createTimestamp(),
+            record.writeTimestamp()
+        );
     }
 
     public static ShareGroupOffset fromRecord(ShareUpdateValue record) {
-        return new ShareGroupOffset(record.snapshotEpoch(), -1, record.leaderEpoch(), record.startOffset(), record.stateBatches().stream()
-            .map(ShareGroupOffset::toPersisterOffsetsStateBatch).collect(Collectors.toList()));
+        return new ShareGroupOffset(
+            record.snapshotEpoch(),
+            -1, record.leaderEpoch(),
+            record.startOffset(),
+            record.stateBatches().stream()
+            .map(ShareGroupOffset::toPersisterOffsetsStateBatch)
+                .toList(),
+            NO_TIMESTAMP,
+            NO_TIMESTAMP
+        );
     }
 
-    public static ShareGroupOffset fromRequest(WriteShareGroupStateRequestData.PartitionData data) {
-        return fromRequest(data, 0);
+    public static ShareGroupOffset fromRequest(WriteShareGroupStateRequestData.PartitionData data, long timestamp) {
+        return fromRequest(data, 0, timestamp);
     }
 
-    public static ShareGroupOffset fromRequest(WriteShareGroupStateRequestData.PartitionData data, int snapshotEpoch) {
+    public static ShareGroupOffset fromRequest(WriteShareGroupStateRequestData.PartitionData data, int snapshotEpoch, long timestamp) {
         return new ShareGroupOffset(
             snapshotEpoch,
             data.stateEpoch(),
@@ -102,21 +136,25 @@ public class ShareGroupOffset {
             data.startOffset(),
             data.stateBatches().stream()
                 .map(PersisterStateBatch::from)
-                .toList()
+                .toList(),
+            timestamp,
+            timestamp
         );
     }
 
-    public static ShareGroupOffset fromRequest(InitializeShareGroupStateRequestData.PartitionData data) {
-        return fromRequest(data, 0);
+    public static ShareGroupOffset fromRequest(InitializeShareGroupStateRequestData.PartitionData data, long timestamp) {
+        return fromRequest(data, 0, timestamp);
     }
 
-    public static ShareGroupOffset fromRequest(InitializeShareGroupStateRequestData.PartitionData data, int snapshotEpoch) {
+    public static ShareGroupOffset fromRequest(InitializeShareGroupStateRequestData.PartitionData data, int snapshotEpoch, long timestamp) {
         return new ShareGroupOffset(
             snapshotEpoch,
             data.stateEpoch(),
             -1,
             data.startOffset(),
-            List.of()
+            List.of(),
+            timestamp,
+            timestamp
         );
     }
 
@@ -130,6 +168,8 @@ public class ShareGroupOffset {
         private int leaderEpoch;
         private long startOffset;
         private List<PersisterStateBatch> stateBatches;
+        private long createTimestamp = NO_TIMESTAMP;
+        private long writeTimestamp = NO_TIMESTAMP;
 
         public Builder setSnapshotEpoch(int snapshotEpoch) {
             this.snapshotEpoch = snapshotEpoch;
@@ -156,8 +196,18 @@ public class ShareGroupOffset {
             return this;
         }
 
+        public Builder setCreateTimestamp(long createTimestamp) {
+            this.createTimestamp = createTimestamp;
+            return this;
+        }
+
+        public Builder setWriteTimestamp(long writeTimestamp) {
+            this.writeTimestamp = writeTimestamp;
+            return this;
+        }
+
         public ShareGroupOffset build() {
-            return new ShareGroupOffset(snapshotEpoch, stateEpoch, leaderEpoch, startOffset, stateBatches);
+            return new ShareGroupOffset(snapshotEpoch, stateEpoch, leaderEpoch, startOffset, stateBatches, createTimestamp, writeTimestamp);
         }
     }
 
@@ -170,12 +220,14 @@ public class ShareGroupOffset {
             stateEpoch == that.stateEpoch &&
             leaderEpoch == that.leaderEpoch &&
             startOffset == that.startOffset &&
-            Objects.equals(stateBatches, that.stateBatches);
+            Objects.equals(stateBatches, that.stateBatches) &&
+            createTimestamp == that.createTimestamp &&
+            writeTimestamp == that.writeTimestamp;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotEpoch, stateEpoch, leaderEpoch, startOffset, stateBatches);
+        return Objects.hash(snapshotEpoch, stateEpoch, leaderEpoch, startOffset, stateBatches, createTimestamp, writeTimestamp);
     }
 
     @Override
@@ -186,6 +238,8 @@ public class ShareGroupOffset {
             ", leaderEpoch=" + leaderEpoch +
             ", startOffset=" + startOffset +
             ", stateBatches=" + stateBatches +
+            ", createTimestamp=" + createTimestamp +
+            ", writeTimestamp=" + writeTimestamp +
             '}';
     }
 }

--- a/share-coordinator/src/main/resources/common/message/ShareSnapshotValue.json
+++ b/share-coordinator/src/main/resources/common/message/ShareSnapshotValue.json
@@ -30,6 +30,10 @@
       "about": "The leader epoch of the share-partition." },
     { "name": "StartOffset", "type": "int64", "versions": "0",
       "about": "The share-partition start offset." },
+    { "name": "CreateTimestamp", "type": "int64", "versions": "0",
+      "about": "The time at which the state was created." },
+    { "name": "WriteTimestamp", "type": "int64", "versions": "0",
+      "about": "The time at which the state was written or rewritten." },
     { "name": "StateBatches", "type": "[]StateBatch", "versions": "0",
       "about": "The state batches.", "fields": [
       { "name": "FirstOffset", "type": "int64", "versions": "0",

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordHelpersTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorRecordHelpersTest.java
@@ -36,6 +36,7 @@ public class ShareCoordinatorRecordHelpersTest {
     public void testNewShareSnapshotRecord() {
         String groupId = "test-group";
         Uuid topicId = Uuid.randomUuid();
+        long timestamp = System.currentTimeMillis();
         int partitionId = 1;
         PersisterStateBatch batch = new PersisterStateBatch(1L, 10L, (byte) 0, (short) 1);
         CoordinatorRecord record = ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
@@ -47,6 +48,8 @@ public class ShareCoordinatorRecordHelpersTest {
                 .setStateEpoch(1)
                 .setLeaderEpoch(5)
                 .setStartOffset(0)
+                .setCreateTimestamp(timestamp)
+                .setWriteTimestamp(timestamp)
                 .setStateBatches(List.of(batch))
                 .build()
         );
@@ -62,6 +65,8 @@ public class ShareCoordinatorRecordHelpersTest {
                     .setStateEpoch(1)
                     .setLeaderEpoch(5)
                     .setStartOffset(0)
+                    .setCreateTimestamp(timestamp)
+                    .setWriteTimestamp(timestamp)
                     .setStateBatches(List.of(
                         new ShareSnapshotValue.StateBatch()
                             .setFirstOffset(1L)

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/share/ShareGroupStateMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/share/ShareGroupStateMessageFormatterTest.java
@@ -41,7 +41,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
@@ -105,6 +104,8 @@ public class ShareGroupStateMessageFormatterTest extends CoordinatorRecordMessag
         .setStateEpoch(SHARE_GROUP_OFFSET_1.stateEpoch())
         .setLeaderEpoch(SHARE_GROUP_OFFSET_1.leaderEpoch())
         .setStartOffset(SHARE_GROUP_OFFSET_1.startOffset())
+        .setCreateTimestamp(1744279603)
+        .setWriteTimestamp(1744279603)
         .setStateBatches(
             SHARE_GROUP_OFFSET_1.stateBatches().stream()
                 .map(batch -> new ShareSnapshotValue.StateBatch()
@@ -112,7 +113,7 @@ public class ShareGroupStateMessageFormatterTest extends CoordinatorRecordMessag
                     .setLastOffset(batch.lastOffset())
                     .setDeliveryState(batch.deliveryState())
                     .setDeliveryCount(batch.deliveryCount()))
-                .collect(Collectors.toList())
+                .toList()
         );
 
     private static final ShareUpdateKey SHARE_UPDATE_KEY = new ShareUpdateKey()
@@ -131,7 +132,7 @@ public class ShareGroupStateMessageFormatterTest extends CoordinatorRecordMessag
                     .setLastOffset(batch.lastOffset())
                     .setDeliveryState(batch.deliveryState())
                     .setDeliveryCount(batch.deliveryCount()))
-                .collect(Collectors.toList())
+                .toList()
         );
 
     @Override
@@ -152,6 +153,8 @@ public class ShareGroupStateMessageFormatterTest extends CoordinatorRecordMessag
                                       "stateEpoch":1,
                                       "leaderEpoch":20,
                                       "startOffset":50,
+                                      "createTimestamp": 1744279603,
+                                      "writeTimestamp": 1744279603,
                                       "stateBatches":[{"firstOffset":100,"lastOffset":200,"deliveryState":1,"deliveryCount":10},
                                                       {"firstOffset":201,"lastOffset":210,"deliveryState":2,"deliveryCount":10}]}}}
                 """


### PR DESCRIPTION
* We wish to track the time of creation of the `ShareSnapshot` records
so that automated jobs could force their creation if a share partition
has gone cold (no updates for a specified time interval).
* To accomplish this, we have added 2 new fields `CreateTimestamp` and
`WriteTimestamp` in the `ShareSnapshot` record.
* The former tracks snapshot creation due to regular RPC calls while the
latter will track snapshots created by periodic jobs.
* In this PR we have made the requisite changes.
* This is a first of a series of PRs to create the automated jobs and
associated scaffolding.
* Existing tests have been updated to take time into account. Further
unit tests will be added in subsequent PRs.
