### PR TITLE
MINOR: Consolidated message formatter for share group records

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ShareGroupMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ShareGroupMessageFormatter.java
@@ -14,25 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.kafka.tools.consumer.group.share;
+package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.coordinator.group.GroupCoordinatorRecordSerde;
 import org.apache.kafka.coordinator.group.generated.CoordinatorRecordJsonConverters;
 import org.apache.kafka.coordinator.group.generated.CoordinatorRecordType;
-import org.apache.kafka.tools.consumer.CoordinatorRecordMessageFormatter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Set;
 
-public class ShareGroupStatePartitionMetadataFormatter extends CoordinatorRecordMessageFormatter {
+/**
+ * Formatter for use with tools such as console consumer: Consumer should also set exclude.internal.topics to false.
+ * Formats the records on the __consumer_offsets topic which pertain to share groups.
+ */
+public class ShareGroupMessageFormatter extends CoordinatorRecordMessageFormatter {
     private static final Set<Short> ALLOWED_RECORDS = Set.of(
+        CoordinatorRecordType.SHARE_GROUP_PARTITION_METADATA.id(),
+        CoordinatorRecordType.SHARE_GROUP_MEMBER_METADATA.id(),
+        CoordinatorRecordType.SHARE_GROUP_METADATA.id(),
+        CoordinatorRecordType.SHARE_GROUP_TARGET_ASSIGNMENT_METADATA.id(),
+        CoordinatorRecordType.SHARE_GROUP_TARGET_ASSIGNMENT_MEMBER.id(),
+        CoordinatorRecordType.SHARE_GROUP_CURRENT_MEMBER_ASSIGNMENT.id(),
         CoordinatorRecordType.SHARE_GROUP_STATE_PARTITION_METADATA.id()
     );
 
-    public ShareGroupStatePartitionMetadataFormatter() {
+    public ShareGroupMessageFormatter() {
         super(new GroupCoordinatorRecordSerde());
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ShareGroupMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ShareGroupMessageFormatterTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.MessageUtil;
+
+import org.apache.kafka.coordinator.group.generated.ShareGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupPartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupStatePartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupStatePartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataValue;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ShareGroupMessageFormatterTest extends CoordinatorRecordMessageFormatterTest {
+
+    private static final ShareGroupPartitionMetadataKey SHARE_GROUP_PARTITION_METADATA_KEY = new ShareGroupPartitionMetadataKey()
+        .setGroupId("group-id");
+    private static final ShareGroupPartitionMetadataValue SHARE_GROUP_PARTITION_METADATA_VALUE = new ShareGroupPartitionMetadataValue()
+        .setTopics(List.of(new ShareGroupPartitionMetadataValue.TopicMetadata()
+            .setTopicId(Uuid.ONE_UUID)
+            .setTopicName("topic")
+            .setNumPartitions(1)
+            .setPartitionMetadata(List.of()))
+        );
+    private static final ShareGroupMemberMetadataKey SHARE_GROUP_MEMBER_METADATA_KEY = new ShareGroupMemberMetadataKey()
+        .setGroupId("group-id")
+        .setMemberId("member-id");
+    private static final ShareGroupMemberMetadataValue SHARE_GROUP_MEMBER_METADATA_VALUE = new ShareGroupMemberMetadataValue()
+        .setRackId("rack-a")
+        .setClientId("client-id")
+        .setClientHost("1.2.3.4")
+        .setSubscribedTopicNames(List.of("topic"));
+    private static final ShareGroupMetadataKey SHARE_GROUP_METADATA_KEY = new ShareGroupMetadataKey()
+        .setGroupId("group-id");
+    private static final ShareGroupMetadataValue SHARE_GROUP_METADATA_VALUE = new ShareGroupMetadataValue()
+        .setEpoch(1);
+    private static final ShareGroupTargetAssignmentMetadataKey SHARE_GROUP_TARGET_ASSIGNMENT_METADATA_KEY = new ShareGroupTargetAssignmentMetadataKey()
+        .setGroupId("group-id");
+    private static final ShareGroupTargetAssignmentMetadataValue SHARE_GROUP_TARGET_ASSIGNMENT_METADATA_VALUE = new ShareGroupTargetAssignmentMetadataValue()
+        .setAssignmentEpoch(1);
+    private static final ShareGroupTargetAssignmentMemberKey SHARE_GROUP_TARGET_ASSIGNMENT_MEMBER_KEY = new ShareGroupTargetAssignmentMemberKey()
+        .setGroupId("group-id")
+        .setMemberId("member-id");
+    private static final ShareGroupTargetAssignmentMemberValue SHARE_GROUP_TARGET_ASSIGNMENT_MEMBER_VALUE = new ShareGroupTargetAssignmentMemberValue()
+        .setTopicPartitions(List.of(new ShareGroupTargetAssignmentMemberValue.TopicPartition()
+            .setTopicId(Uuid.ONE_UUID)
+            .setPartitions(List.of(0, 1)))
+        );
+    private static final ShareGroupCurrentMemberAssignmentKey SHARE_GROUP_CURRENT_MEMBER_ASSIGNMENT_KEY = new ShareGroupCurrentMemberAssignmentKey()
+        .setGroupId("group-id")
+        .setMemberId("member-id");
+    private static final ShareGroupCurrentMemberAssignmentValue SHARE_GROUP_CURRENT_MEMBER_ASSIGNMENT_VALUE = new ShareGroupCurrentMemberAssignmentValue()
+        .setMemberEpoch(1)
+        .setPreviousMemberEpoch(0)
+        .setState((byte) 0)
+        .setAssignedPartitions(List.of(new ShareGroupCurrentMemberAssignmentValue.TopicPartitions()
+            .setTopicId(Uuid.ONE_UUID)
+            .setPartitions(List.of(0, 1)))
+        );
+    private static final ShareGroupStatePartitionMetadataKey SHARE_GROUP_STATE_PARTITION_METADATA_KEY = new ShareGroupStatePartitionMetadataKey()
+        .setGroupId("group-id");
+    private static final ShareGroupStatePartitionMetadataValue SHARE_GROUP_STATE_PARTITION_METADATA_VALUE = new ShareGroupStatePartitionMetadataValue()
+        .setInitializingTopics(List.of(new ShareGroupStatePartitionMetadataValue.TopicPartitionsInfo()
+            .setTopicId(Uuid.ONE_UUID)
+            .setTopicName("topic")
+            .setPartitions(List.of(1)))
+        )
+        .setInitializedTopics(List.of(new ShareGroupStatePartitionMetadataValue.TopicPartitionsInfo()
+            .setTopicId(Uuid.ONE_UUID)
+            .setTopicName("topic")
+            .setPartitions(List.of(0)))
+        )
+        .setDeletingTopics(List.of(new ShareGroupStatePartitionMetadataValue.TopicInfo()
+            .setTopicId(Uuid.ONE_UUID)
+            .setTopicName("topic"))
+        );
+
+    @Override
+    protected CoordinatorRecordMessageFormatter formatter() {
+        return new ShareGroupMessageFormatter();
+    }
+
+    @Override
+    protected Stream<Arguments> parameters() {
+        return Stream.of(
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 9, SHARE_GROUP_PARTITION_METADATA_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_PARTITION_METADATA_VALUE).array(),
+                """
+                    {"key":{"type":9,"data":{"groupId":"group-id"}},
+                     "value":{"version":0,
+                              "data":{"topics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ",
+                                                 "topicName":"topic",
+                                                 "numPartitions":1,
+                                                 "partitionMetadata":[]}]}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 9, SHARE_GROUP_PARTITION_METADATA_KEY).array(),
+                null,
+                """
+                    {"key":{"type":9,"data":{"groupId":"group-id"}},"value":null}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 10, SHARE_GROUP_MEMBER_METADATA_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_MEMBER_METADATA_VALUE).array(),
+                """
+                    {"key":{"type":10,"data":{"groupId":"group-id","memberId":"member-id"}},
+                     "value":{"version":0,
+                              "data":{"rackId":"rack-a",
+                                      "clientId":"client-id",
+                                      "clientHost":"1.2.3.4",
+                                      "subscribedTopicNames":["topic"]}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 10, SHARE_GROUP_MEMBER_METADATA_KEY).array(),
+                null,
+                """
+                    {"key":{"type":10,"data":{"groupId":"group-id","memberId":"member-id"}},"value":null}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 11, SHARE_GROUP_METADATA_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_METADATA_VALUE).array(),
+                """
+                    {"key":{"type":11,"data":{"groupId":"group-id"}},
+                     "value":{"version":0,
+                              "data":{"epoch":1}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 11, SHARE_GROUP_METADATA_KEY).array(),
+                null,
+                """
+                    {"key":{"type":11,"data":{"groupId":"group-id"}},"value":null}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 12, SHARE_GROUP_TARGET_ASSIGNMENT_METADATA_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_TARGET_ASSIGNMENT_METADATA_VALUE).array(),
+                """
+                    {"key":{"type":12,"data":{"groupId":"group-id"}},
+                     "value":{"version":0,
+                              "data":{"assignmentEpoch":1}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 12, SHARE_GROUP_TARGET_ASSIGNMENT_METADATA_KEY).array(),
+                null,
+                """
+                    {"key":{"type":12,"data":{"groupId":"group-id"}},"value":null}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 13, SHARE_GROUP_TARGET_ASSIGNMENT_MEMBER_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_TARGET_ASSIGNMENT_MEMBER_VALUE).array(),
+                """
+                    {"key":{"type":13,"data":{"groupId":"group-id","memberId":"member-id"}},
+                     "value":{"version":0,
+                              "data":{"topicPartitions":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ",
+                                                          "partitions":[0,1]}]}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 13, SHARE_GROUP_TARGET_ASSIGNMENT_MEMBER_KEY).array(),
+                null,
+                """
+                    {"key":{"type":13,"data":{"groupId":"group-id","memberId":"member-id"}},"value":null}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 14, SHARE_GROUP_CURRENT_MEMBER_ASSIGNMENT_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_CURRENT_MEMBER_ASSIGNMENT_VALUE).array(),
+                """
+                    {"key":{"type":14,"data":{"groupId":"group-id","memberId":"member-id"}},
+                     "value":{"version":0,
+                              "data":{"memberEpoch":1,
+                                      "previousMemberEpoch":0,
+                                      "state":0,
+                                      "assignedPartitions":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ",
+                                                             "partitions":[0,1]}]}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 14, SHARE_GROUP_CURRENT_MEMBER_ASSIGNMENT_KEY).array(),
+                null,
+                """
+                    {"key":{"type":14,"data":{"groupId":"group-id","memberId":"member-id"}},"value":null}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 15, SHARE_GROUP_STATE_PARTITION_METADATA_KEY).array(),
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_GROUP_STATE_PARTITION_METADATA_VALUE).array(),
+                """
+                    {"key":{"type":15,"data":{"groupId":"group-id"}},
+                     "value":{"version":0,
+                              "data":{"initializingTopics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ",
+                                                             "topicName":"topic",
+                                                             "partitions":[1]}],
+                                      "initializedTopics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ",
+                                                            "topicName":"topic",
+                                                            "partitions":[0]}],
+                                      "deletingTopics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ",
+                                                         "topicName":"topic"}]}}}
+                """
+            ),
+            Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 15, SHARE_GROUP_STATE_PARTITION_METADATA_KEY).array(),
+                null,
+                """
+                    {"key":{"type":15,"data":{"groupId":"group-id"}},"value":null}
+                """
+            )
+        );
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ShareGroupMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ShareGroupMessageFormatterTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.MessageUtil;
-
 import org.apache.kafka.coordinator.group.generated.ShareGroupCurrentMemberAssignmentKey;
 import org.apache.kafka.coordinator.group.generated.ShareGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
@@ -33,6 +32,7 @@ import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMe
 import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataValue;
+
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.List;

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/share/ShareGroupStateMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/share/ShareGroupStateMessageFormatterTest.java
@@ -157,6 +157,13 @@ public class ShareGroupStateMessageFormatterTest extends CoordinatorRecordMessag
                 """
             ),
             Arguments.of(
+                MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_SNAPSHOT_KEY).array(),
+                null,
+                """
+                    {"key":{"type":0,"data":{"groupId":"gs1","topicId":"gtb2stGYRk-vWZ2zAozmoA","partition":0}},"value":null}
+                """
+            ),
+            Arguments.of(
                 MessageUtil.toVersionPrefixedByteBuffer((short) 1, SHARE_UPDATE_KEY).array(),
                 MessageUtil.toVersionPrefixedByteBuffer((short) 0, SHARE_UPDATE_VALUE).array(),
                 """


### PR DESCRIPTION
Create a single formatter for use with `kafka-console-consumer.sh` that
formats all record types for share groups on the `__consumer_offsets`
topic.
