### PR TITLE
KAFKA-19118: Enable KIP-1071 in StandbyTaskCreationIntegrationTest

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopics.java
@@ -25,10 +25,8 @@ import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.OptionalInt;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -64,17 +62,15 @@ public class ChangelogTopics {
     }
 
     /**
-     * Determines the number of partitions for each non-source changelog topic in the requested topology.
+     * Determines the number of partitions for each changelog topic in the requested topology.
      *
      * @throws IllegalStateException If a source topic does not have a partition count defined through topicPartitionCountProvider.
      *
-     * @return the map of all non-source changelog topics for the requested topology to their required number of partitions.
+     * @return the map of all changelog topics for the requested topology to their required number of partitions.
      */
     public Map<String, Integer> setup() {
         final Map<String, Integer> changelogTopicPartitions = new HashMap<>();
         for (Subtopology subtopology : subtopologies) {
-            final Set<String> sourceTopics = new HashSet<>(subtopology.sourceTopics());
-
             final OptionalInt maxNumPartitions =
                 Stream.concat(
                     subtopology.sourceTopics().stream(),
@@ -85,9 +81,7 @@ public class ChangelogTopics {
                 throw new StreamsInvalidTopologyException("No source topics found for subtopology " + subtopology.subtopologyId());
             }
             for (final TopicInfo topicInfo : subtopology.stateChangelogTopics()) {
-                if (!sourceTopics.contains(topicInfo.name())) {
-                    changelogTopicPartitions.put(topicInfo.name(), maxNumPartitions.getAsInt());
-                }
+                changelogTopicPartitions.put(topicInfo.name(), maxNumPartitions.getAsInt());
             }
         }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopicsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/ChangelogTopicsTest.java
@@ -149,14 +149,14 @@ public class ChangelogTopicsTest {
     }
 
     @Test
-    public void shouldNotContainSourceBasedChangelogs() {
+    public void shouldContainSourceBasedChangelogs() {
         final List<Subtopology> subtopologies = List.of(SUBTOPOLOGY_SOURCE_CHANGELOG);
 
         final ChangelogTopics changelogTopics =
             new ChangelogTopics(LOG_CONTEXT, subtopologies, ChangelogTopicsTest::topicPartitionProvider);
         Map<String, Integer> setup = changelogTopics.setup();
 
-        assertEquals(Map.of(), setup);
+        assertEquals(Map.of(SOURCE_TOPIC_NAME, 3), setup);
     }
 
     @Test
@@ -167,6 +167,6 @@ public class ChangelogTopicsTest {
             new ChangelogTopics(LOG_CONTEXT, subtopologies, ChangelogTopicsTest::topicPartitionProvider);
         Map<String, Integer> setup = changelogTopics.setup();
 
-        assertEquals(Map.of(CHANGELOG_TOPIC_CONFIG.name(), 3), setup);
+        assertEquals(Map.of(CHANGELOG_TOPIC_CONFIG.name(), 3, SOURCE_TOPIC_NAME, 3), setup);
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StandbyTaskCreationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StandbyTaskCreationIntegrationTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -38,12 +39,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.function.Predicate;
 
@@ -54,7 +57,7 @@ import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 public class StandbyTaskCreationIntegrationTest {
     private static final int NUM_BROKERS = 1;
 
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    public static final EmbeddedKafkaCluster CLUSTER = EmbeddedKafkaCluster.withStreamsRebalanceProtocol(NUM_BROKERS);
 
     private String safeTestName;
 
@@ -87,19 +90,25 @@ public class StandbyTaskCreationIntegrationTest {
         client2.close(Duration.ofSeconds(60));
     }
 
-    private Properties streamsConfiguration() {
+    private Properties streamsConfiguration(boolean streamsProtocolEnabled) {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
-        streamsConfiguration.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        if (streamsProtocolEnabled) {
+            streamsConfiguration.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.name().toLowerCase(Locale.getDefault()));
+            CLUSTER.setStandbyReplicas("app-" + safeTestName, 1);
+        } else {
+            streamsConfiguration.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        }
         return streamsConfiguration;
     }
 
-    @Test
-    public void shouldNotCreateAnyStandByTasksForStateStoreWithLoggingDisabled() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void shouldNotCreateAnyStandByTasksForStateStoreWithLoggingDisabled(boolean streamsProtocolEnabled) throws Exception {
         final StreamsBuilder builder = new StreamsBuilder();
         final String stateStoreName = "myTransformState";
         final StoreBuilder<KeyValueStore<Integer, Integer>> keyValueStoreBuilder =
@@ -116,8 +125,9 @@ public class StandbyTaskCreationIntegrationTest {
                 }
             }, stateStoreName);
 
+
         final Topology topology = builder.build();
-        createClients(topology, streamsConfiguration(), topology, streamsConfiguration());
+        createClients(topology, streamsConfiguration(streamsProtocolEnabled), topology, streamsConfiguration(streamsProtocolEnabled));
 
         setStateListenersForVerification(thread -> thread.standbyTasks().isEmpty() && !thread.activeTasks().isEmpty());
 
@@ -128,11 +138,12 @@ public class StandbyTaskCreationIntegrationTest {
         );
     }
 
-    @Test
-    public void shouldCreateStandByTasksForMaterializedAndOptimizedSourceTables() throws Exception {
-        final Properties streamsConfiguration1 = streamsConfiguration();
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void shouldCreateStandByTasksForMaterializedAndOptimizedSourceTables(boolean streamsProtocolEnabled) throws Exception {
+        final Properties streamsConfiguration1 = streamsConfiguration(streamsProtocolEnabled);
         streamsConfiguration1.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
-        final Properties streamsConfiguration2 = streamsConfiguration();
+        final Properties streamsConfiguration2 = streamsConfiguration(streamsProtocolEnabled);
         streamsConfiguration2.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
 
         final StreamsBuilder builder = new StreamsBuilder();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StandbyTaskCreationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StandbyTaskCreationIntegrationTest.java
@@ -90,7 +90,7 @@ public class StandbyTaskCreationIntegrationTest {
         client2.close(Duration.ofSeconds(60));
     }
 
-    private Properties streamsConfiguration(boolean streamsProtocolEnabled) {
+    private Properties streamsConfiguration(final boolean streamsProtocolEnabled) {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
@@ -108,7 +108,7 @@ public class StandbyTaskCreationIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void shouldNotCreateAnyStandByTasksForStateStoreWithLoggingDisabled(boolean streamsProtocolEnabled) throws Exception {
+    public void shouldNotCreateAnyStandByTasksForStateStoreWithLoggingDisabled(final boolean streamsProtocolEnabled) throws Exception {
         final StreamsBuilder builder = new StreamsBuilder();
         final String stateStoreName = "myTransformState";
         final StoreBuilder<KeyValueStore<Integer, Integer>> keyValueStoreBuilder =
@@ -140,7 +140,7 @@ public class StandbyTaskCreationIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void shouldCreateStandByTasksForMaterializedAndOptimizedSourceTables(boolean streamsProtocolEnabled) throws Exception {
+    public void shouldCreateStandByTasksForMaterializedAndOptimizedSourceTables(final boolean streamsProtocolEnabled) throws Exception {
         final Properties streamsConfiguration1 = streamsConfiguration(streamsProtocolEnabled);
         streamsConfiguration1.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         final Properties streamsConfiguration2 = streamsConfiguration(streamsProtocolEnabled);


### PR DESCRIPTION
Enable KIP-1071 parameter in `StandbyTaskCreationIntegrationTest`.

Required a fix: In `ChangelogTopic.setup`, we actually need to return
both the source-topic (optimized) and the non-source-topic changelog
topics, since otherwise we will not find the partition number later on.

Extended `EmbeddedKafkaCluster` to set the number of standby replicas
dynamically for the group. We need to initialize it to one for the
integration test to go through.

Reviewers: Bill Bejeck <bbejeck@apache.org>
