### PR TITLE
MINOR: Update kafka-console-share-consumer to pass in delivery count.

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumer.java
@@ -111,7 +111,7 @@ public class ConsoleShareConsumer {
             messageCount += 1;
             try {
                 formatter.writeTo(new ConsumerRecord<>(msg.topic(), msg.partition(), msg.offset(), msg.timestamp(), msg.timestampType(),
-                        0, 0, msg.key(), msg.value(), msg.headers(), Optional.empty()), output);
+                        0, 0, msg.key(), msg.value(), msg.headers(), Optional.empty(), msg.deliveryCount()), output);
                 consumer.acknowledge(msg, acknowledgeType);
             } catch (Throwable t) {
                 if (rejectMessageOnError) {


### PR DESCRIPTION
*What*

- There was a bug in `ConsoleShareConsumer` where the delivery count received in the `ShareFetchResponse` was not sent to the formatter to be shown to the user. PR fixes the bug by passing in the delivery count in a different constructor for `ConsumerRecord`.
- 
- Added unit test to verify the change.
- Tested using the kafka-console-share-consumer.sh tool as well.

```
➜  kafka git:(minor-fix-console-share-consumer) ✗ bin/kafka-console-share-consumer.sh --bootstrap-server localhost:9092 --topic T1 --property print.offset=true --property print.delivery=true
[2025-04-11 16:05:42,824] WARN Share groups and KafkaShareConsumer are part of the early access of KIP-932 and MUST NOT be used in production. (org.apache.kafka.clients.consumer.internals.ShareConsumerDelegateCreator)
[2025-04-11 16:05:43,009] WARN [ShareConsumer clientId=console-share-consumer, groupId=console-share-consumer] The metadata response from the cluster reported a recoverable issue with correlation id 28 : {T1=UNKNOWN_TOPIC_OR_PARTITION} (org.apache.kafka.clients.NetworkClient)
Offset:0	Delivery:1	1
Offset:1	Delivery:1	2
Offset:2	Delivery:1	3
Offset:3	Delivery:1	4
Offset:4	Delivery:1	5
Offset:5	Delivery:1	6
```