### PR TITLE
MINOR: Cleanups in connect:runtime

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -73,7 +73,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1082,12 +1081,8 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     private String trace(Throwable t) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        try {
-            t.printStackTrace(new PrintStream(output, false, StandardCharsets.UTF_8.name()));
-            return output.toString(StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            return null;
-        }
+        t.printStackTrace(new PrintStream(output, false, StandardCharsets.UTF_8));
+        return output.toString(StandardCharsets.UTF_8);
     }
 
     /*

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/CachedConnectors.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/CachedConnectors.java
@@ -54,7 +54,7 @@ public class CachedConnectors {
         }
     }
 
-    private Connector lookup(String connectorName, VersionRange range) throws Exception {
+    private Connector lookup(String connectorName, VersionRange range) {
         String version = range == null ? LATEST_VERSION : range.toString();
         if (connectors.containsKey(connectorName) && connectors.get(connectorName).containsKey(version)) {
             return connectors.get(connectorName).get(version);
@@ -73,7 +73,7 @@ public class CachedConnectors {
         }
     }
 
-    public Connector getConnector(String connectorName, VersionRange range) throws Exception {
+    public Connector getConnector(String connectorName, VersionRange range) {
         validate(connectorName, range);
         return lookup(connectorName, range);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -372,7 +372,7 @@ public class ConnectorConfig extends AbstractConfig {
             try {
                 final String typeConfig = prefix + "type";
                 final String versionConfig = prefix + WorkerConfig.PLUGIN_VERSION_SUFFIX;
-                @SuppressWarnings("unchecked") final Transformation<R> transformation = getTransformationOrPredicate(plugins, typeConfig, versionConfig);
+                final Transformation<R> transformation = getTransformationOrPredicate(plugins, typeConfig, versionConfig);
                 Map<String, Object> configs = originalsWithPrefix(prefix);
                 Object predicateAlias = configs.remove(TransformationStage.PREDICATE_CONFIG);
                 Object negate = configs.remove(TransformationStage.NEGATE_CONFIG);
@@ -382,7 +382,6 @@ public class ConnectorConfig extends AbstractConfig {
                     String predicatePrefix = PREDICATES_PREFIX + predicateAlias + ".";
                     final String predicateTypeConfig = predicatePrefix + "type";
                     final String predicateVersionConfig = predicatePrefix + WorkerConfig.PLUGIN_VERSION_SUFFIX;
-                    @SuppressWarnings("unchecked")
                     Predicate<R> predicate = getTransformationOrPredicate(plugins, predicateTypeConfig, predicateVersionConfig);
                     predicate.configure(originalsWithPrefix(predicatePrefix));
                     Plugin<Predicate<R>> predicatePlugin = metrics.wrap(predicate, connectorTaskId, (String) predicateAlias);
@@ -781,22 +780,7 @@ public class ConnectorConfig extends AbstractConfig {
         }
     }
 
-    private static class ConverterDefaults {
-        private final String type;
-        private final String version;
-
-        public ConverterDefaults(String type, String version) {
-            this.type = type;
-            this.version = version;
-        }
-
-        public String type() {
-            return type;
-        }
-
-        public String version() {
-            return version;
-        }
+    private record ConverterDefaults(String type, String version) {
     }
 
     public static class PluginVersionValidator implements ConfigDef.Validator {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -428,24 +428,22 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
             SourceConnectorConfig sourceConfig,
             WorkerTransactionContext transactionContext) {
         TransactionBoundary boundary = sourceConfig.transactionBoundary();
-        switch (boundary) {
-            case POLL:
-                return new TransactionBoundaryManager() {
-                    @Override
-                    protected boolean shouldCommitTransactionForBatch(long currentTimeMs) {
-                        return true;
-                    }
+        return switch (boundary) {
+            case POLL -> new TransactionBoundaryManager() {
+                @Override
+                protected boolean shouldCommitTransactionForBatch(long currentTimeMs) {
+                    return true;
+                }
 
-                    @Override
-                    protected boolean shouldCommitFinalTransaction() {
-                        return true;
-                    }
-                };
-
-            case INTERVAL:
+                @Override
+                protected boolean shouldCommitFinalTransaction() {
+                    return true;
+                }
+            };
+            case INTERVAL -> {
                 long transactionBoundaryInterval = Optional.ofNullable(sourceConfig.transactionBoundaryInterval())
                         .orElse(workerConfig.offsetCommitInterval());
-                return new TransactionBoundaryManager() {
+                yield new TransactionBoundaryManager() {
                     private final long commitInterval = transactionBoundaryInterval;
                     private long lastCommit;
 
@@ -465,14 +463,14 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                     }
 
                     @Override
-                    protected  boolean shouldCommitFinalTransaction() {
+                    protected boolean shouldCommitFinalTransaction() {
                         return true;
                     }
                 };
-
-            case CONNECTOR:
+            }
+            case CONNECTOR -> {
                 Objects.requireNonNull(transactionContext, "Transaction context must be provided when using connector-defined transaction boundaries");
-                return new TransactionBoundaryManager() {
+                yield new TransactionBoundaryManager() {
                     @Override
                     protected boolean shouldCommitFinalTransaction() {
                         return shouldCommitTransactionForBatch(time.milliseconds());
@@ -513,9 +511,8 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
                         transactionOpen = false;
                     }
                 };
-            default:
-                throw new IllegalArgumentException("Unrecognized transaction boundary: " + boundary);
-        }
+            }
+        };
     }
 
     TransactionMetricsGroup transactionMetricsGroup() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -37,7 +37,6 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * <p>
@@ -392,35 +391,7 @@ public interface Herder {
         RESTART
     }
 
-    class Created<T> {
-        private final boolean created;
-        private final T result;
+    record Created<T>(boolean created, T result) {
 
-        public Created(boolean created, T result) {
-            this.created = created;
-            this.result = result;
-        }
-
-        public boolean created() {
-            return created;
-        }
-
-        public T result() {
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Created<?> created1 = (Created<?>) o;
-            return Objects.equals(created, created1.created) &&
-                    Objects.equals(result, created1.result);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(created, result);
-        }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -392,6 +392,5 @@ public interface Herder {
     }
 
     record Created<T>(boolean created, T result) {
-
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -22,9 +22,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * An immutable restart plan per connector.
@@ -45,13 +43,10 @@ public class RestartPlan {
         this.request = Objects.requireNonNull(request, "RestartRequest name may not be null");
         this.stateInfo = Objects.requireNonNull(restartStateInfo, "ConnectorStateInfo name may not be null");
         // Collect the task IDs to stop and restart (may be none)
-        this.idsToRestart = Collections.unmodifiableList(
-                stateInfo.tasks()
-                        .stream()
-                        .filter(this::isRestarting)
-                        .map(taskState -> new ConnectorTaskId(request.connectorName(), taskState.id()))
-                        .collect(Collectors.toList())
-        );
+        this.idsToRestart = stateInfo.tasks()
+                .stream()
+                .filter(this::isRestarting)
+                .map(taskState -> new ConnectorTaskId(request.connectorName(), taskState.id())).toList();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.connect.connector.Connector;
-import org.apache.kafka.connect.connector.Task;
 
 import java.util.Objects;
 
@@ -37,36 +36,6 @@ public record RestartRequest(String connectorName,
 
     public RestartRequest {
         Objects.requireNonNull(connectorName, "Connector name may not be null");
-    }
-
-    /**
-     * Get the name of the connector.
-     *
-     * @return the connector name; never null
-     */
-    @Override
-    public String connectorName() {
-        return connectorName;
-    }
-
-    /**
-     * Determine whether only failed instances be restarted.
-     *
-     * @return true if only failed instances should be restarted, or false if all applicable instances should be restarted
-     */
-    @Override
-    public boolean onlyFailed() {
-        return onlyFailed;
-    }
-
-    /**
-     * Determine whether {@link Task} instances should also be restarted in addition to the {@link Connector} instance.
-     *
-     * @return true if the connector and task instances should be restarted, or false if just the connector should be restarted
-     */
-    @Override
-    public boolean includeTasks() {
-        return includeTasks;
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -27,22 +27,16 @@ import java.util.Objects;
  * The natural order is based first upon the connector name and then requested restart behaviors.
  * If two requests have the same connector name, then the requests are ordered based on the
  * probable number of tasks/connector this request is going to restart.
+ * @param connectorName the name of the connector; may not be null
+ * @param onlyFailed    true if only failed instances should be restarted
+ * @param includeTasks  true if tasks should be restarted, or false if only the connector should be restarted
  */
 public record RestartRequest(String connectorName,
                              boolean onlyFailed,
                              boolean includeTasks) implements Comparable<RestartRequest> {
 
-    /**
-     * Create a new request to restart a connector and optionally its tasks.
-     *
-     * @param connectorName the name of the connector; may not be null
-     * @param onlyFailed    true if only failed instances should be restarted
-     * @param includeTasks  true if tasks should be restarted, or false if only the connector should be restarted
-     */
-    public RestartRequest(String connectorName, boolean onlyFailed, boolean includeTasks) {
-        this.connectorName = Objects.requireNonNull(connectorName, "Connector name may not be null");
-        this.onlyFailed = onlyFailed;
-        this.includeTasks = includeTasks;
+    public RestartRequest {
+        Objects.requireNonNull(connectorName, "Connector name may not be null");
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -25,14 +25,12 @@ import java.util.Objects;
  * A request to restart a connector and/or task instances.
  * <p>
  * The natural order is based first upon the connector name and then requested restart behaviors.
- * If two requests have the same connector name, then the requests are ordered based on the 
+ * If two requests have the same connector name, then the requests are ordered based on the
  * probable number of tasks/connector this request is going to restart.
  */
-public class RestartRequest implements Comparable<RestartRequest> {
-
-    private final String connectorName;
-    private final boolean onlyFailed;
-    private final boolean includeTasks;
+public record RestartRequest(String connectorName,
+                             boolean onlyFailed,
+                             boolean includeTasks) implements Comparable<RestartRequest> {
 
     /**
      * Create a new request to restart a connector and optionally its tasks.
@@ -52,6 +50,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
      *
      * @return the connector name; never null
      */
+    @Override
     public String connectorName() {
         return connectorName;
     }
@@ -61,6 +60,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
      *
      * @return true if only failed instances should be restarted, or false if all applicable instances should be restarted
      */
+    @Override
     public boolean onlyFailed() {
         return onlyFailed;
     }
@@ -70,6 +70,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
      *
      * @return true if the connector and task instances should be restarted, or false if just the connector should be restarted
      */
+    @Override
     public boolean includeTasks() {
         return includeTasks;
     }
@@ -108,6 +109,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
         int result = connectorName.compareTo(o.connectorName);
         return result == 0 ? impactRank() - o.impactRank() : result;
     }
+
     //calculates an internal rank for the restart request based on the probable number of tasks/connector this request is going to restart
     private int impactRank() {
         if (onlyFailed && !includeTasks) { //restarts only failed connector so least impactful
@@ -119,23 +121,6 @@ public class RestartRequest implements Comparable<RestartRequest> {
         }
         //onlyFailed==false&&includeTasks  restarts both connector and tasks in any state so highest impact
         return 3;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RestartRequest that = (RestartRequest) o;
-        return onlyFailed == that.onlyFailed && includeTasks == that.includeTasks && Objects.equals(connectorName, that.connectorName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(connectorName, onlyFailed, includeTasks);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SessionKey.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SessionKey.java
@@ -23,14 +23,12 @@ import javax.crypto.SecretKey;
 /**
  * A session key, which can be used to validate internal REST requests between workers.
  */
-public class SessionKey {
-
-    private final SecretKey key;
-    private final long creationTimestamp;
+public record SessionKey(SecretKey key, long creationTimestamp) {
 
     /**
      * Create a new session key with the given key value and creation timestamp
-     * @param key the actual cryptographic key to use for request validation; may not be null
+     *
+     * @param key               the actual cryptographic key to use for request validation; may not be null
      * @param creationTimestamp the time at which the key was generated
      */
     public SessionKey(SecretKey key, long creationTimestamp) {
@@ -43,6 +41,7 @@ public class SessionKey {
      *
      * @return the cryptographic key; may not be null
      */
+    @Override
     public SecretKey key() {
         return key;
     }
@@ -52,23 +51,9 @@ public class SessionKey {
      *
      * @return the time at which the key was generated
      */
+    @Override
     public long creationTimestamp() {
         return creationTimestamp;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        SessionKey that = (SessionKey) o;
-        return creationTimestamp == that.creationTimestamp
-            && key.equals(that.key);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(key, creationTimestamp);
-    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SessionKey.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SessionKey.java
@@ -22,38 +22,12 @@ import javax.crypto.SecretKey;
 
 /**
  * A session key, which can be used to validate internal REST requests between workers.
+ * @param key               the actual cryptographic key to use for request validation; may not be null
+ * @param creationTimestamp the time at which the key was generated
  */
 public record SessionKey(SecretKey key, long creationTimestamp) {
 
-    /**
-     * Create a new session key with the given key value and creation timestamp
-     *
-     * @param key               the actual cryptographic key to use for request validation; may not be null
-     * @param creationTimestamp the time at which the key was generated
-     */
-    public SessionKey(SecretKey key, long creationTimestamp) {
-        this.key = Objects.requireNonNull(key, "Key may not be null");
-        this.creationTimestamp = creationTimestamp;
+    public SessionKey {
+        Objects.requireNonNull(key, "Key may not be null");
     }
-
-    /**
-     * Get the cryptographic key to use for request validation.
-     *
-     * @return the cryptographic key; may not be null
-     */
-    @Override
-    public SecretKey key() {
-        return key;
-    }
-
-    /**
-     * Get the time at which the key was generated.
-     *
-     * @return the time at which the key was generated
-     */
-    @Override
-    public long creationTimestamp() {
-        return creationTimestamp;
-    }
-
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -228,19 +228,17 @@ class SubmittedRecords {
      * Contains a snapshot of offsets that can be committed for a source task and metadata for that offset commit
      * (such as the number of messages for which offsets can and cannot be committed).
      */
-    static class CommittableOffsets {
+    record CommittableOffsets(Map<Map<String, Object>, Map<String, Object>> offsets,
+                              int numCommittableMessages,
+                              int numUncommittableMessages,
+                              int numDeques,
+                              int largestDequeSize,
+                              Map<String, Object> largestDequePartition) {
 
         /**
          * An "empty" snapshot that contains no offsets to commit and whose metadata contains no committable or uncommitable messages.
          */
         public static final CommittableOffsets EMPTY = new CommittableOffsets(Collections.emptyMap(), 0, 0, 0, 0, null);
-
-        private final Map<Map<String, Object>, Map<String, Object>> offsets;
-        private final int numCommittableMessages;
-        private final int numUncommittableMessages;
-        private final int numDeques;
-        private final int largestDequeSize;
-        private final Map<String, Object> largestDequePartition;
 
         CommittableOffsets(
                 Map<Map<String, Object>, Map<String, Object>> offsets,
@@ -261,6 +259,7 @@ class SubmittedRecords {
         /**
          * @return the offsets that can be committed at the time of the snapshot
          */
+        @Override
         public Map<Map<String, Object>, Map<String, Object>> offsets() {
             return Collections.unmodifiableMap(offsets);
         }
@@ -269,6 +268,7 @@ class SubmittedRecords {
          * @return the number of committable messages at the time of the snapshot, where a committable message is both
          * acknowledged and not preceded by any unacknowledged messages in the deque for its source partition
          */
+        @Override
         public int numCommittableMessages() {
             return numCommittableMessages;
         }
@@ -277,6 +277,7 @@ class SubmittedRecords {
          * @return the number of uncommittable messages at the time of the snapshot, where an uncommittable message
          * is either unacknowledged, or preceded in the deque for its source partition by an unacknowledged message
          */
+        @Override
         public int numUncommittableMessages() {
             return numUncommittableMessages;
         }
@@ -284,6 +285,7 @@ class SubmittedRecords {
         /**
          * @return the number of non-empty deques tracking uncommittable messages at the time of the snapshot
          */
+        @Override
         public int numDeques() {
             return numDeques;
         }
@@ -291,15 +293,18 @@ class SubmittedRecords {
         /**
          * @return the size of the largest deque at the time of the snapshot
          */
+        @Override
         public int largestDequeSize() {
             return largestDequeSize;
         }
 
         /**
          * Get the partition for the deque with the most uncommitted messages at the time of the snapshot.
+         *
          * @return the applicable partition, which may be null, or null if there are no uncommitted messages;
          * it is the caller's responsibility to distinguish between these two cases via {@link #hasPending()}
          */
+        @Override
         public Map<String, Object> largestDequePartition() {
             return largestDequePartition;
         }
@@ -323,6 +328,7 @@ class SubmittedRecords {
          * Offsets are combined (giving precedence to the newer snapshot in case of conflict), the total number of
          * committable messages is summed across the two snapshots, and the newer snapshot's information on pending
          * messages (num deques, largest deque size, etc.) is used.
+         *
          * @param newerOffsets the newer snapshot to combine with this snapshot
          * @return the new offset snapshot containing information from this snapshot and the newer snapshot; never null
          */

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SubmittedRecords.java
@@ -227,6 +227,18 @@ class SubmittedRecords {
     /**
      * Contains a snapshot of offsets that can be committed for a source task and metadata for that offset commit
      * (such as the number of messages for which offsets can and cannot be committed).
+     * @param offsets the offsets that can be committed at the time of the snapshot
+     * @param numCommittableMessages the number of committable messages at the time of the snapshot, where a
+     *                               committable message is both acknowledged and not preceded by any unacknowledged
+     *                               messages in the deque for its source partition
+     * @param numUncommittableMessages the number of uncommittable messages at the time of the snapshot, where an
+     *                                 uncommittable message is either unacknowledged, or preceded in the deque for its
+     *                                 source partition by an unacknowledged message
+     * @param numDeques the number of non-empty deques tracking uncommittable messages at the time of the snapshot
+     * @param largestDequeSize the size of the largest deque at the time of the snapshot
+     * @param largestDequePartition the applicable partition, which may be null, or null if there are no uncommitted
+     *                              messages; it is the caller's responsibility to distinguish between these two cases
+     *                              via {@link #hasPending()}
      */
     record CommittableOffsets(Map<Map<String, Object>, Map<String, Object>> offsets,
                               int numCommittableMessages,
@@ -240,73 +252,8 @@ class SubmittedRecords {
          */
         public static final CommittableOffsets EMPTY = new CommittableOffsets(Collections.emptyMap(), 0, 0, 0, 0, null);
 
-        CommittableOffsets(
-                Map<Map<String, Object>, Map<String, Object>> offsets,
-                int numCommittableMessages,
-                int numUncommittableMessages,
-                int numDeques,
-                int largestDequeSize,
-                Map<String, Object> largestDequePartition
-        ) {
-            this.offsets = offsets != null ? new HashMap<>(offsets) : Collections.emptyMap();
-            this.numCommittableMessages = numCommittableMessages;
-            this.numUncommittableMessages = numUncommittableMessages;
-            this.numDeques = numDeques;
-            this.largestDequeSize = largestDequeSize;
-            this.largestDequePartition = largestDequePartition;
-        }
-
-        /**
-         * @return the offsets that can be committed at the time of the snapshot
-         */
-        @Override
-        public Map<Map<String, Object>, Map<String, Object>> offsets() {
-            return Collections.unmodifiableMap(offsets);
-        }
-
-        /**
-         * @return the number of committable messages at the time of the snapshot, where a committable message is both
-         * acknowledged and not preceded by any unacknowledged messages in the deque for its source partition
-         */
-        @Override
-        public int numCommittableMessages() {
-            return numCommittableMessages;
-        }
-
-        /**
-         * @return the number of uncommittable messages at the time of the snapshot, where an uncommittable message
-         * is either unacknowledged, or preceded in the deque for its source partition by an unacknowledged message
-         */
-        @Override
-        public int numUncommittableMessages() {
-            return numUncommittableMessages;
-        }
-
-        /**
-         * @return the number of non-empty deques tracking uncommittable messages at the time of the snapshot
-         */
-        @Override
-        public int numDeques() {
-            return numDeques;
-        }
-
-        /**
-         * @return the size of the largest deque at the time of the snapshot
-         */
-        @Override
-        public int largestDequeSize() {
-            return largestDequeSize;
-        }
-
-        /**
-         * Get the partition for the deque with the most uncommitted messages at the time of the snapshot.
-         *
-         * @return the applicable partition, which may be null, or null if there are no uncommitted messages;
-         * it is the caller's responsibility to distinguish between these two cases via {@link #hasPending()}
-         */
-        @Override
-        public Map<String, Object> largestDequePartition() {
-            return largestDequePartition;
+        CommittableOffsets {
+            offsets = Collections.unmodifiableMap(offsets);
         }
 
         /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -982,7 +982,7 @@ public final class Worker {
         );
         List<ConfigValue> configValues = connectorClientConfigOverridePolicy.validate(connectorClientConfigRequest);
         List<ConfigValue> errorConfigs = configValues.stream().
-            filter(configValue -> configValue.errorMessages().size() > 0).collect(Collectors.toList());
+            filter(configValue -> configValue.errorMessages().size() > 0).toList();
         // These should be caught when the herder validates the connector configuration, but just in case
         if (errorConfigs.size() > 0) {
             throw new ConnectException("Client Config Overrides not allowed " + errorConfigs);
@@ -1141,10 +1141,6 @@ public final class Worker {
      */
     public Set<ConnectorTaskId> taskIds() {
         return tasks.keySet();
-    }
-
-    public Converter getInternalKeyConverter() {
-        return internalKeyConverter;
     }
 
     public Converter getInternalValueConverter() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/ConnectProtocolCompatibility.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/ConnectProtocolCompatibility.java
@@ -99,16 +99,12 @@ public enum ConnectProtocolCompatibility {
      * @return the enum that corresponds to the protocol compatibility mode
      */
     public static ConnectProtocolCompatibility fromProtocolVersion(short protocolVersion) {
-        switch (protocolVersion) {
-            case CONNECT_PROTOCOL_V0:
-                return EAGER;
-            case CONNECT_PROTOCOL_V1:
-                return COMPATIBLE;
-            case CONNECT_PROTOCOL_V2:
-                return SESSIONED;
-            default:
-                throw new IllegalArgumentException("Unknown Connect protocol version: " + protocolVersion);
-        }
+        return switch (protocolVersion) {
+            case CONNECT_PROTOCOL_V0 -> EAGER;
+            case CONNECT_PROTOCOL_V1 -> COMPATIBLE;
+            case CONNECT_PROTOCOL_V2 -> SESSIONED;
+            default -> throw new IllegalArgumentException("Unknown Connect protocol version: " + protocolVersion);
+        };
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1545,7 +1545,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
                 doRestartConnectorAndTasks(restartRequest);
             } catch (Exception e) {
-                log.warn("Unexpected error while trying to process " + restartRequest + ", the restart request will be skipped.", e);
+                log.warn("Unexpected error while trying to process {}, the restart request will be skipped.", restartRequest, e);
             }
         });
     }
@@ -2113,11 +2113,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             try {
                 startConnector(connectorName, (error, result) -> {
                     if (error != null) {
-                        log.error("Failed to start connector '" + connectorName + "'", error);
+                        log.error("Failed to start connector '{}'", connectorName, error);
                     }
                 });
             } catch (Throwable t) {
-                log.error("Unexpected error while trying to start connector " + connectorName, t);
+                log.error("Unexpected error while trying to start connector {}", connectorName, t);
                 onFailure(connectorName, t);
             }
             return null;
@@ -2129,7 +2129,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             try {
                 worker.stopAndAwaitConnector(connectorName);
             } catch (Throwable t) {
-                log.error("Failed to shut down connector " + connectorName, t);
+                log.error("Failed to shut down connector {}", connectorName, t);
             }
             return null;
         };
@@ -2576,11 +2576,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     private static Callback<Void> forwardErrorAndTickThreadStages(final Callback<?> callback) {
-        Callback<Void> cb = callback.chainStaging((error, result) -> {
+        return callback.chainStaging((error, result) -> {
             if (error != null)
                 callback.onCompletion(error, null);
         });
-        return cb;
     }
 
     private void updateDeletedConnectorStatus() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -448,8 +448,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         }
 
         final long now = time.milliseconds();
-        log.debug("Found the following connectors and tasks missing from previous assignments: "
-                + lostAssignments);
+        log.debug("Found the following connectors and tasks missing from previous assignments: {}", lostAssignments);
 
         Set<String> activeMembers = completeWorkerAssignment.stream()
                 .map(WorkerLoad::worker)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -184,16 +184,11 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         configSnapshot = configStorage.snapshot();
         final ExtendedAssignment localAssignmentSnapshot = assignmentSnapshot;
         ExtendedWorkerState workerState = new ExtendedWorkerState(restUrl, configSnapshot.offset(), localAssignmentSnapshot);
-        switch (protocolCompatibility) {
-            case EAGER:
-                return ConnectProtocol.metadataRequest(workerState);
-            case COMPATIBLE:
-                return IncrementalCooperativeConnectProtocol.metadataRequest(workerState, false);
-            case SESSIONED:
-                return IncrementalCooperativeConnectProtocol.metadataRequest(workerState, true);
-            default:
-                throw new IllegalStateException("Unknown Connect protocol compatibility mode " + protocolCompatibility);
-        }
+        return switch (protocolCompatibility) {
+            case EAGER -> ConnectProtocol.metadataRequest(workerState);
+            case COMPATIBLE -> IncrementalCooperativeConnectProtocol.metadataRequest(workerState, false);
+            case SESSIONED -> IncrementalCooperativeConnectProtocol.metadataRequest(workerState, true);
+        };
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -152,7 +152,7 @@ public class DeadLetterQueueReporter implements ErrorReporter<ConsumerRecord<byt
 
         return this.kafkaProducer.send(producerRecord, (metadata, exception) -> {
             if (exception != null) {
-                log.error("Could not produce message to dead letter queue. topic=" + dlqTopicName, exception);
+                log.error("Could not produce message to dead letter queue. topic={}", dlqTopicName, exception);
                 errorHandlingMetrics.recordDeadLetterQueueProduceFailed();
             }
         });
@@ -184,7 +184,7 @@ public class DeadLetterQueueReporter implements ErrorReporter<ConsumerRecord<byt
     private byte[] stacktrace(Throwable error) {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try {
-            PrintStream stream = new PrintStream(bos, true, StandardCharsets.UTF_8.name());
+            PrintStream stream = new PrintStream(bos, true, StandardCharsets.UTF_8);
             error.printStackTrace(stream);
             bos.close();
             return bos.toByteArray();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -311,7 +311,7 @@ public class RetryWithToleranceOperator<T> implements AutoCloseable {
         try {
             stopRequestedLatch.await(delay, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            return;
+            // ignore
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
@@ -19,16 +19,6 @@ package org.apache.kafka.connect.runtime.health;
 
 import org.apache.kafka.connect.health.ConnectClusterDetails;
 
-public class ConnectClusterDetailsImpl implements ConnectClusterDetails {
+public record ConnectClusterDetailsImpl(String kafkaClusterId) implements ConnectClusterDetails {
 
-    private final String kafkaClusterId;
-
-    public ConnectClusterDetailsImpl(String kafkaClusterId) {
-        this.kafkaClusterId = kafkaClusterId;
-    }
-
-    @Override
-    public String kafkaClusterId() {
-        return kafkaClusterId;
-    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/health/ConnectClusterDetailsImpl.java
@@ -20,5 +20,4 @@ package org.apache.kafka.connect.runtime.health;
 import org.apache.kafka.connect.health.ConnectClusterDetails;
 
 public record ConnectClusterDetailsImpl(String kafkaClusterId) implements ConnectClusterDetails {
-
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -241,7 +241,7 @@ public class DelegatingClassLoader extends URLClassLoader {
                 .filter(pluginDesc -> pluginDesc.location().equals("classpath"))
                 .map(PluginDesc::version)
                 .distinct()
-                .collect(Collectors.toList());
+                .toList();
 
         if (classpathPlugins.size() > 1) {
             throw new VersionedPluginLoadingException(String.format(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanner.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanner.java
@@ -198,7 +198,7 @@ public abstract class PluginScanner {
                 return ((Versioned) pluginImpl).version();
             }
         } catch (Throwable t) {
-            log.error("Failed to get plugin version for " + pluginImpl.getClass(), t);
+            log.error("Failed to get plugin version for {}", pluginImpl.getClass(), t);
         }
         return PluginDesc.UNDEFINED_VERSION;
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginSource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginSource.java
@@ -21,38 +21,13 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class PluginSource {
+public record PluginSource(Path location,
+                           org.apache.kafka.connect.runtime.isolation.PluginSource.Type type,
+                           ClassLoader loader,
+                           URL[] urls) {
 
     public enum Type {
         CLASSPATH, MULTI_JAR, SINGLE_JAR, CLASS_HIERARCHY
-    }
-
-    private final Path location;
-    private final Type type;
-    private final ClassLoader loader;
-    private final URL[] urls;
-
-    public PluginSource(Path location, Type type, ClassLoader loader, URL[] urls) {
-        this.location = location;
-        this.type = type;
-        this.loader = loader;
-        this.urls = urls;
-    }
-
-    public Path location() {
-        return location;
-    }
-
-    public Type type() {
-        return type;
-    }
-
-    public ClassLoader loader() {
-        return loader;
-    }
-
-    public URL[] urls() {
-        return urls;
     }
 
     public boolean isolated() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -410,13 +410,10 @@ public class PluginUtils {
      */
     public static String prunedName(PluginDesc<?> plugin) {
         // It's currently simpler to switch on type than do pattern matching.
-        switch (plugin.type()) {
-            case SOURCE:
-            case SINK:
-                return prunePluginName(plugin, "Connector");
-            default:
-                return prunePluginName(plugin, plugin.type().simpleName());
-        }
+        return switch (plugin.type()) {
+            case SOURCE, SINK -> prunePluginName(plugin, "Connector");
+            default -> prunePluginName(plugin, plugin.type().simpleName());
+        };
     }
 
     private static String prunePluginName(PluginDesc<?> plugin, String suffix) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -166,7 +166,6 @@ public class Plugins {
         );
     }
 
-    @SuppressWarnings("unchecked")
     protected static <U> Class<? extends U> pluginClass(
             DelegatingClassLoader loader,
             String classOrAlias,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginsRecommenders.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginsRecommenders.java
@@ -87,7 +87,6 @@ public class PluginsRecommenders {
 
     public class ConnectorPluginVersionRecommender implements ConfigDef.Recommender {
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
         @Override
         public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
             if (plugins == null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestExtensionContextImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestExtensionContextImpl.java
@@ -22,26 +22,7 @@ import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 
 import jakarta.ws.rs.core.Configurable;
 
-public class ConnectRestExtensionContextImpl implements ConnectRestExtensionContext {
+public record ConnectRestExtensionContextImpl(Configurable<? extends Configurable<?>> configurable,
+                                              ConnectClusterState clusterState) implements ConnectRestExtensionContext {
 
-    private final Configurable<? extends Configurable<?>> configurable;
-    private final ConnectClusterState clusterState;
-
-    public ConnectRestExtensionContextImpl(
-        Configurable<? extends Configurable<?>> configurable,
-        ConnectClusterState clusterState
-    ) {
-        this.configurable = configurable;
-        this.clusterState = clusterState;
-    }
-
-    @Override
-    public Configurable<? extends Configurable<?>> configurable() {
-        return configurable;
-    }
-
-    @Override
-    public ConnectClusterState clusterState() {
-        return clusterState;
-    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestExtensionContextImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestExtensionContextImpl.java
@@ -24,5 +24,4 @@ import jakarta.ws.rs.core.Configurable;
 
 public record ConnectRestExtensionContextImpl(Configurable<? extends Configurable<?>> configurable,
                                               ConnectClusterState clusterState) implements ConnectRestExtensionContext {
-
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
@@ -141,7 +141,7 @@ public class HerderRequestHandler {
 
     public void completeOrForwardRequest(FutureCallback<Void> cb, String path, String method, HttpHeaders headers, Object body,
                                           Boolean forward) throws Throwable {
-        completeOrForwardRequest(cb, path, method, headers, body, new TypeReference<Void>() { }, new IdentityTranslator<>(), forward);
+        completeOrForwardRequest(cb, path, method, headers, body, new TypeReference<>() { }, new IdentityTranslator<>(), forward);
     }
 
     public interface Translator<T, U> {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -254,27 +254,6 @@ public class RestClient {
         return headers;
     }
 
-    public static class HttpResponse<T> {
-        private final int status;
-        private final Map<String, String> headers;
-        private final T body;
-
-        public HttpResponse(int status, Map<String, String> headers, T body) {
-            this.status = status;
-            this.headers = headers;
-            this.body = body;
-        }
-
-        public int status() {
-            return status;
-        }
-
-        public Map<String, String> headers() {
-            return headers;
-        }
-
-        public T body() {
-            return body;
-        }
+    public record HttpResponse<T>(int status, Map<String, String> headers, T body) {
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -35,14 +35,12 @@ import org.apache.maven.artifact.versioning.VersionRange;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -144,9 +142,8 @@ public class ConnectorPluginsResource {
     ) {
         synchronized (this) {
             if (connectorsOnly) {
-                return Collections.unmodifiableList(connectorPlugins.stream()
-                        .filter(p -> PluginType.SINK.toString().equals(p.type()) || PluginType.SOURCE.toString().equals(p.type()))
-                        .collect(Collectors.toList()));
+                return connectorPlugins.stream()
+                        .filter(p -> PluginType.SINK.toString().equals(p.type()) || PluginType.SOURCE.toString().equals(p.type())).toList();
             } else {
                 return List.copyOf(connectorPlugins);
             }
@@ -159,7 +156,7 @@ public class ConnectorPluginsResource {
     public List<ConfigKeyInfo> getConnectorConfigDef(final @PathParam("pluginName") String pluginName,
                                                      final @QueryParam("version") @DefaultValue("latest") String version) {
 
-        VersionRange range = null;
+        VersionRange range;
         try {
             range = PluginUtils.connectorVersionRequirement(version);
         } catch (InvalidVersionSpecificationException e) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -151,7 +151,7 @@ public class ConnectorsResource {
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
         herder.putConnectorConfig(name, configs, createRequest.initialTargetState(), false, cb);
         Herder.Created<ConnectorInfo> info = requestHandler.completeOrForwardRequest(cb, "/connectors", "POST", headers, createRequest,
-                new TypeReference<ConnectorInfo>() { }, new CreatedConnectorInfoTranslator(), forward);
+                new TypeReference<>() { }, new CreatedConnectorInfoTranslator(), forward);
 
         URI location = UriBuilder.fromUri("/connectors").path(name).build();
         return Response.created(location).entity(info.result()).build();
@@ -222,7 +222,7 @@ public class ConnectorsResource {
 
         herder.putConnectorConfig(connector, connectorConfig, true, cb);
         Herder.Created<ConnectorInfo> createdInfo = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/config",
-                "PUT", headers, connectorConfig, new TypeReference<ConnectorInfo>() { }, new CreatedConnectorInfoTranslator(), forward);
+                "PUT", headers, connectorConfig, new TypeReference<>() { }, new CreatedConnectorInfoTranslator(), forward);
         Response.ResponseBuilder response;
         if (createdInfo.created()) {
             URI location = UriBuilder.fromUri("/connectors").path(connector).build();
@@ -242,7 +242,7 @@ public class ConnectorsResource {
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
         herder.patchConnectorConfig(connector, connectorConfigPatch, cb);
         Herder.Created<ConnectorInfo> createdInfo = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/config",
-                "PATCH", headers, connectorConfigPatch, new TypeReference<ConnectorInfo>() { }, new CreatedConnectorInfoTranslator(), forward);
+                "PATCH", headers, connectorConfigPatch, new TypeReference<>() { }, new CreatedConnectorInfoTranslator(), forward);
         return Response.ok().entity(createdInfo.result()).build();
     }
 
@@ -270,7 +270,7 @@ public class ConnectorsResource {
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put("includeTasks", includeTasks.toString());
         queryParameters.put("onlyFailed", onlyFailed.toString());
-        ConnectorStateInfo stateInfo = requestHandler.completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<ConnectorStateInfo>() {
+        ConnectorStateInfo stateInfo = requestHandler.completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<>() {
         }, new IdentityTranslator<>(), forward);
         return Response.accepted().entity(stateInfo).build();
     }
@@ -334,7 +334,7 @@ public class ConnectorsResource {
         FutureCallback<Void> cb = new FutureCallback<>();
         ConnectorTaskId taskId = new ConnectorTaskId(connector, task);
         herder.restartTask(taskId, cb);
-        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks/" + task + "/restart", "POST", headers, null, new TypeReference<Void>() { }, forward);
+        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks/" + task + "/restart", "POST", headers, null, new TypeReference<>() { }, forward);
     }
 
     @DELETE
@@ -345,7 +345,7 @@ public class ConnectorsResource {
                                  final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
         herder.deleteConnectorConfig(connector, cb);
-        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector, "DELETE", headers, null, new TypeReference<Herder.Created<ConnectorInfo>>() { }, forward);
+        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector, "DELETE", headers, null, new TypeReference<>() { }, forward);
     }
 
     @GET
@@ -370,7 +370,7 @@ public class ConnectorsResource {
         FutureCallback<Message> cb = new FutureCallback<>();
         herder.alterConnectorOffsets(connector, offsets.toMap(), cb);
         Message msg = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/offsets", "PATCH", headers, offsets,
-                new TypeReference<Message>() { }, new IdentityTranslator<>(), forward);
+                new TypeReference<>() { }, new IdentityTranslator<>(), forward);
         return Response.ok().entity(msg).build();
     }
 
@@ -382,7 +382,7 @@ public class ConnectorsResource {
         FutureCallback<Message> cb = new FutureCallback<>();
         herder.resetConnectorOffsets(connector, cb);
         Message msg = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/offsets", "DELETE", headers, null,
-                new TypeReference<Message>() { }, new IdentityTranslator<>(), forward);
+                new TypeReference<>() { }, new IdentityTranslator<>(), forward);
         return Response.ok().entity(msg).build();
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
@@ -51,7 +51,7 @@ import jakarta.ws.rs.core.UriInfo;
 public abstract class InternalClusterResource {
 
     private static final TypeReference<List<Map<String, String>>> TASK_CONFIGS_TYPE =
-            new TypeReference<List<Map<String, String>>>() { };
+            new TypeReference<>() { };
 
     private final HerderRequestHandler requestHandler;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -489,28 +489,26 @@ public final class StandaloneHerder extends AbstractHerder {
     }
 
     private boolean startTask(ConnectorTaskId taskId, Map<String, String> connProps) {
-        switch (connectorType(connProps)) {
-            case SINK:
-                return worker.startSinkTask(
-                        taskId,
-                        configState,
-                        connProps,
-                        configState.taskConfig(taskId),
-                        this,
-                        configState.targetState(taskId.connector())
-                );
-            case SOURCE:
-                return worker.startSourceTask(
-                        taskId,
-                        configState,
-                        connProps,
-                        configState.taskConfig(taskId),
-                        this,
-                        configState.targetState(taskId.connector())
-                );
-            default:
-                throw new ConnectException("Failed to start task " + taskId + " since it is not a recognizable type (source or sink)");
-        }
+        return switch (connectorType(connProps)) {
+            case SINK -> worker.startSinkTask(
+                    taskId,
+                    configState,
+                    connProps,
+                    configState.taskConfig(taskId),
+                    this,
+                    configState.targetState(taskId.connector())
+            );
+            case SOURCE -> worker.startSourceTask(
+                    taskId,
+                    configState,
+                    connProps,
+                    configState.taskConfig(taskId),
+                    this,
+                    configState.targetState(taskId.connector())
+            );
+            default ->
+                    throw new ConnectException("Failed to start task " + taskId + " since it is not a recognizable type (source or sink)");
+        };
     }
 
     private void removeConnectorTasks(String connName) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConnectorOffsetBackingStore.java
@@ -210,7 +210,7 @@ public class ConnectorOffsetBackingStore implements OffsetBackingStore {
         Future<Map<ByteBuffer, ByteBuffer>> workerGetFuture = getFromStore(workerStore, keys);
         Future<Map<ByteBuffer, ByteBuffer>> connectorGetFuture = getFromStore(connectorStore, keys);
 
-        return new Future<Map<ByteBuffer, ByteBuffer>>() {
+        return new Future<>() {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 // Note the use of | instead of || here; this causes cancel to be invoked on both futures,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -854,14 +854,7 @@ public final class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore i
         }
     }
 
-    private static class ProducerKeyValue {
-        final String key;
-        final byte[] value;
-
-        ProducerKeyValue(String key, byte[] value) {
-            this.key = key;
-            this.value = value;
-        }
+    private record ProducerKeyValue(String key, byte[] value) {
     }
 
     private void relinquishWritePrivileges() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -265,7 +265,7 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
 
     @Override
     public Future<Map<ByteBuffer, ByteBuffer>> get(final Collection<ByteBuffer> keys) {
-        ConvertingFutureCallback<Void, Map<ByteBuffer, ByteBuffer>> future = new ConvertingFutureCallback<Void, Map<ByteBuffer, ByteBuffer>>() {
+        ConvertingFutureCallback<Void, Map<ByteBuffer, ByteBuffer>> future = new ConvertingFutureCallback<>() {
             @Override
             public Map<ByteBuffer, ByteBuffer> convert(Void result) {
                 Map<ByteBuffer, ByteBuffer> values = new HashMap<>();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryConfigBackingStore.java
@@ -22,9 +22,6 @@ import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,8 +35,6 @@ import java.util.concurrent.TimeUnit;
  * aren't persisted and will be wiped if the worker is restarted).
  */
 public class MemoryConfigBackingStore implements ConfigBackingStore {
-
-    private static final Logger log = LoggerFactory.getLogger(MemoryConfigBackingStore.class);
 
     private final Map<String, ConnectorState> connectors = new HashMap<>();
     private UpdateListener updateListener;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/PrivilegedWriteException.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/PrivilegedWriteException.java
@@ -22,9 +22,6 @@ import org.apache.kafka.connect.errors.ConnectException;
  * Used when a write that requires {@link ConfigBackingStore#claimWritePrivileges() special privileges} fails
  */
 public class PrivilegedWriteException extends ConnectException {
-    public PrivilegedWriteException(String message) {
-        super(message);
-    }
 
     public PrivilegedWriteException(String message, Throwable cause) {
         super(message, cause);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/PredicateDoc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/PredicateDoc.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class PredicateDoc {
 
@@ -50,7 +49,7 @@ public class PredicateDoc {
             }
         })
         .sorted(Comparator.comparing(docInfo -> docInfo.predicateName))
-        .collect(Collectors.toList());
+        .toList();
 
     private static String toHtml() {
         StringBuilder b = new StringBuilder();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
@@ -39,16 +39,7 @@ import java.util.List;
 
 public class TransformationDoc {
 
-    private static final class DocInfo {
-        final String transformationName;
-        final String overview;
-        final ConfigDef configDef;
-
-        private DocInfo(String transformationName, String overview, ConfigDef configDef) {
-            this.transformationName = transformationName;
-            this.overview = overview;
-            this.configDef = configDef;
-        }
+    private record DocInfo(String transformationName, String overview, ConfigDef configDef) {
     }
 
     private static final List<DocInfo> TRANSFORMATIONS = Arrays.asList(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectorTaskId.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectorTaskId.java
@@ -20,52 +20,28 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 /**
  * Unique ID for a single task. It includes a unique connector ID and a task ID that is unique within
  * the connector.
  */
-public class ConnectorTaskId implements Serializable, Comparable<ConnectorTaskId> {
-    private final String connector;
-    private final int task;
-
+public record ConnectorTaskId(String connector, int task) implements Serializable, Comparable<ConnectorTaskId> {
     @JsonCreator
     public ConnectorTaskId(@JsonProperty("connector") String connector, @JsonProperty("task") int task) {
         this.connector = connector;
         this.task = task;
     }
 
+    @Override
     @JsonProperty
     public String connector() {
         return connector;
     }
 
+    @Override
     @JsonProperty
     public int task() {
         return task;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        ConnectorTaskId that = (ConnectorTaskId) o;
-
-        if (task != that.task)
-            return false;
-
-        return Objects.equals(connector, that.connector);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = connector != null ? connector.hashCode() : 0;
-        result = 31 * result + task;
-        return result;
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -1199,7 +1199,7 @@ public class ExactlyOnceSourceIntegrationTest {
                 .mapToObj(i -> transactionalProducer(
                         "simulated-task-producer-" + CONNECTOR_NAME + "-" + i,
                         Worker.taskTransactionalId(CLUSTER_GROUP_ID, CONNECTOR_NAME, i)
-                )).collect(Collectors.toList());
+                )).toList();
 
         producers.forEach(KafkaProducer::initTransactions);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.kafka.connect.integration.TestableSourceConnector.TOPIC_CONFIG;
@@ -333,10 +332,10 @@ public class RebalanceSourceConnectorsIntegrationTest {
 
             assertNotEquals(0, maxConnectors, "Found no connectors running!");
             assertNotEquals(0, maxTasks, "Found no tasks running!");
-            assertEquals(connectors.values().size(),
+            assertEquals(connectors.size(),
                     connectors.values().stream().distinct().count(),
                     "Connector assignments are not unique: " + connectors);
-            assertEquals(tasks.values().size(),
+            assertEquals(tasks.size(),
                     tasks.values().stream().distinct().count(),
                     "Task assignments are not unique: " + tasks);
             assertTrue(maxConnectors - minConnectors < 2, "Connectors are imbalanced: " + formatAssignment(connectors));
@@ -350,7 +349,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
 
     private static String formatAssignment(Map<String, Collection<String>> assignment) {
         StringBuilder result = new StringBuilder();
-        for (String worker : assignment.keySet().stream().sorted().collect(Collectors.toList())) {
+        for (String worker : assignment.keySet().stream().sorted().toList()) {
             result.append(String.format("\n%s=%s", worker, assignment.getOrDefault(worker,
                     Collections.emptyList())));
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartsAndStops.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartsAndStops.java
@@ -18,5 +18,4 @@
 package org.apache.kafka.connect.integration;
 
 public record StartsAndStops(int starts, int stops) {
-
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartsAndStops.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartsAndStops.java
@@ -17,21 +17,6 @@
 
 package org.apache.kafka.connect.integration;
 
-public class StartsAndStops {
-    private final int starts;
-    private final int stops;
-
-    public StartsAndStops(int starts, int stops) {
-        this.starts = starts;
-        this.stops = stops;
-    }
-
-    public int starts() {
-        return starts;
-    }
-
-    public int stops() {
-        return stops;
-    }
+public record StartsAndStops(int starts, int stops) {
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TestableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TestableSourceConnector.java
@@ -134,33 +134,23 @@ public class TestableSourceConnector extends SampleSourceConnector {
     @Override
     public ExactlyOnceSupport exactlyOnceSupport(Map<String, String> connectorConfig) {
         String supportLevel = connectorConfig.getOrDefault(CUSTOM_EXACTLY_ONCE_SUPPORT_CONFIG, "null").toLowerCase(Locale.ROOT);
-        switch (supportLevel) {
-            case EXACTLY_ONCE_SUPPORTED:
-                return ExactlyOnceSupport.SUPPORTED;
-            case EXACTLY_ONCE_UNSUPPORTED:
-                return ExactlyOnceSupport.UNSUPPORTED;
-            case EXACTLY_ONCE_FAIL:
-                throw new ConnectException("oops");
-            default:
-            case EXACTLY_ONCE_NULL:
-                return null;
-        }
+        return switch (supportLevel) {
+            case EXACTLY_ONCE_SUPPORTED -> ExactlyOnceSupport.SUPPORTED;
+            case EXACTLY_ONCE_UNSUPPORTED -> ExactlyOnceSupport.UNSUPPORTED;
+            case EXACTLY_ONCE_FAIL -> throw new ConnectException("oops");
+            default -> null;
+        };
     }
 
     @Override
     public ConnectorTransactionBoundaries canDefineTransactionBoundaries(Map<String, String> connectorConfig) {
         String supportLevel = connectorConfig.getOrDefault(CUSTOM_TRANSACTION_BOUNDARIES_CONFIG, TRANSACTION_BOUNDARIES_UNSUPPORTED).toLowerCase(Locale.ROOT);
-        switch (supportLevel) {
-            case TRANSACTION_BOUNDARIES_SUPPORTED:
-                return ConnectorTransactionBoundaries.SUPPORTED;
-            case TRANSACTION_BOUNDARIES_FAIL:
-                throw new ConnectException("oh no :(");
-            case TRANSACTION_BOUNDARIES_NULL:
-                return null;
-            default:
-            case TRANSACTION_BOUNDARIES_UNSUPPORTED:
-                return ConnectorTransactionBoundaries.UNSUPPORTED;
-        }
+        return switch (supportLevel) {
+            case TRANSACTION_BOUNDARIES_SUPPORTED -> ConnectorTransactionBoundaries.SUPPORTED;
+            case TRANSACTION_BOUNDARIES_FAIL -> throw new ConnectException("oh no :(");
+            case TRANSACTION_BOUNDARIES_NULL -> null;
+            default -> ConnectorTransactionBoundaries.UNSUPPORTED;
+        };
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -584,7 +584,7 @@ public class AbstractHerderTest {
         config.put("required", "value"); // connector required config
         ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
 
-        assertEquals(herder.connectorType(config), ConnectorType.SOURCE);
+        assertEquals(ConnectorType.SOURCE, herder.connectorType(config));
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
         // the config fields for SourceConnectorConfig, but we expect these to change rarely.
@@ -709,7 +709,7 @@ public class AbstractHerderTest {
         config.put(saslConfigKey, "jaas_config");
 
         ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
-        assertEquals(herder.connectorType(config), ConnectorType.SOURCE);
+        assertEquals(ConnectorType.SOURCE, herder.connectorType(config));
 
         // We expect there to be errors due to now allowed override policy for ACKS.... Note that these assertions depend heavily on
         // the config fields for SourceConnectorConfig, but we expect these to change rarely.
@@ -768,7 +768,7 @@ public class AbstractHerderTest {
         overriddenClientConfigs.add(loginCallbackHandlerConfigKey);
 
         ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
-        assertEquals(herder.connectorType(config), ConnectorType.SOURCE);
+        assertEquals(ConnectorType.SOURCE, herder.connectorType(config));
 
         Map<String, String> validatedOverriddenClientConfigs = new HashMap<>();
         for (ConfigInfo configInfo : result.values()) {
@@ -860,7 +860,7 @@ public class AbstractHerderTest {
                 .filter(configValue -> configValue.name().equals(testKey))
                 .map(ConfigValueInfo::errors)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                .toList();
 
         assertEquals(1, errorsForKey.size());
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
@@ -915,8 +915,8 @@ public class AbstractWorkerSourceTaskTest {
         when(valueConverter.fromConnectData(eq(topic), any(Headers.class), eq(RECORD_SCHEMA),
                 eq(RECORD)))
                 .thenReturn(SERIALIZED_RECORD);
-        assertEquals(keyConverter.fromConnectData(topic, headers, KEY_SCHEMA, KEY), SERIALIZED_KEY);
-        assertEquals(valueConverter.fromConnectData(topic, headers, RECORD_SCHEMA, RECORD), SERIALIZED_RECORD);
+        assertEquals(SERIALIZED_KEY, keyConverter.fromConnectData(topic, headers, KEY_SCHEMA, KEY));
+        assertEquals(SERIALIZED_RECORD, valueConverter.fromConnectData(topic, headers, RECORD_SCHEMA, RECORD));
     }
 
     private void throwExceptionWhenConvertKey(Headers headers, String topic) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
@@ -596,17 +596,11 @@ public class WorkerConnectorTest {
     }
 
     protected void assertInitializedMetric(WorkerConnector workerConnector) {
-        String expectedType;
-        switch (connectorType) {
-            case SINK:
-                expectedType = "sink";
-                break;
-            case SOURCE:
-                expectedType = "source";
-                break;
-            default:
-                throw new IllegalStateException("Unexpected connector type: " + connectorType);
-        }
+        String expectedType = switch (connectorType) {
+            case SINK -> "sink";
+            case SOURCE -> "source";
+            default -> throw new IllegalStateException("Unexpected connector type: " + connectorType);
+        };
         assertInitializedMetric(workerConnector, expectedType);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -3159,16 +3159,12 @@ public class WorkerTest {
      */
     private Object workerTaskMethod(InvocationOnMock invocation) {
         // provide implementations of three methods used during testing
-        switch (invocation.getMethod().getName()) {
-            case "id":
-                return TASK_ID;
-            case "loader":
-                return pluginLoader;
-            case "awaitStop":
-                return true;
-            default:
-                return null;
-        }
+        return switch (invocation.getMethod().getName()) {
+            case "id" -> TASK_ID;
+            case "loader" -> pluginLoader;
+            case "awaitStop" -> true;
+            default -> null;
+        };
     }
 
     private static class TestSourceTask extends SourceTask {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTestUtils.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTestUtils.java
@@ -198,8 +198,7 @@ public class WorkerTestUtils {
                 false,
                 transformationPlugin,
                 TestPlugins.noOpLoaderSwap());
-        TransformationChain<T, R> realTransformationChainRetriableException = new TransformationChain(List.of(stage), toleranceOperator);
-        TransformationChain<T, R> transformationChainRetriableException = Mockito.spy(realTransformationChainRetriableException);
-        return transformationChainRetriableException;
+        TransformationChain<T, R> realTransformationChainRetriableException = new TransformationChain<>(List.of(stage), toleranceOperator);
+        return Mockito.spy(realTransformationChainRetriableException);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
@@ -232,10 +232,10 @@ public class ErrorReporterTest {
     @Test
     public void testSetDLQConfigs() {
         SinkConnectorConfig configuration = config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC));
-        assertEquals(configuration.dlqTopicName(), DLQ_TOPIC);
+        assertEquals(DLQ_TOPIC, configuration.dlqTopicName());
 
         configuration = config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "7"));
-        assertEquals(configuration.dlqTopicReplicationFactor(), 7);
+        assertEquals(7, configuration.dlqTopicReplicationFactor());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -397,9 +397,9 @@ public class RetryWithToleranceOperatorTest {
     @Test
     public void testDefaultConfigs() {
         ConnectorConfig configuration = config(emptyMap());
-        assertEquals(configuration.errorRetryTimeout(), ERRORS_RETRY_TIMEOUT_DEFAULT);
-        assertEquals(configuration.errorMaxDelayInMillis(), ERRORS_RETRY_MAX_DELAY_DEFAULT);
-        assertEquals(configuration.errorToleranceType(), ERRORS_TOLERANCE_DEFAULT);
+        assertEquals(ERRORS_RETRY_TIMEOUT_DEFAULT, configuration.errorRetryTimeout());
+        assertEquals(ERRORS_RETRY_MAX_DELAY_DEFAULT, configuration.errorMaxDelayInMillis());
+        assertEquals(ERRORS_TOLERANCE_DEFAULT, configuration.errorToleranceType());
     }
 
     ConnectorConfig config(Map<String, String> connProps) {
@@ -414,13 +414,13 @@ public class RetryWithToleranceOperatorTest {
     public void testSetConfigs() {
         ConnectorConfig configuration;
         configuration = config(singletonMap(ERRORS_RETRY_TIMEOUT_CONFIG, "100"));
-        assertEquals(configuration.errorRetryTimeout(), 100);
+        assertEquals(100, configuration.errorRetryTimeout());
 
         configuration = config(singletonMap(ERRORS_RETRY_MAX_DELAY_CONFIG, "100"));
-        assertEquals(configuration.errorMaxDelayInMillis(), 100);
+        assertEquals(100, configuration.errorMaxDelayInMillis());
 
         configuration = config(singletonMap(ERRORS_TOLERANCE_CONFIG, "none"));
-        assertEquals(configuration.errorToleranceType(), ToleranceType.NONE);
+        assertEquals(ToleranceType.NONE, configuration.errorToleranceType());
     }
 
     @Test
@@ -438,7 +438,7 @@ public class RetryWithToleranceOperatorTest {
         CountDownLatch exitLatch = mock(CountDownLatch.class);
         RetryWithToleranceOperator<ConsumerRecord<byte[], byte[]>> retryWithToleranceOperator = new RetryWithToleranceOperator<>(-1, ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, time, errorHandlingMetrics, exitLatch);
         ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>("t", 0, 0, null, null);
-        List<CompletableFuture<RecordMetadata>> fs = IntStream.range(0, numberOfReports).mapToObj(i -> new CompletableFuture<RecordMetadata>()).collect(Collectors.toList());
+        List<CompletableFuture<RecordMetadata>> fs = IntStream.range(0, numberOfReports).mapToObj(i -> new CompletableFuture<RecordMetadata>()).toList();
         List<ErrorReporter<ConsumerRecord<byte[], byte[]>>> reporters = IntStream.range(0, numberOfReports).mapToObj(i -> (ErrorReporter<ConsumerRecord<byte[], byte[]>>) c -> fs.get(i)).collect(Collectors.toList());
         retryWithToleranceOperator.reporters(reporters);
         ProcessingContext<ConsumerRecord<byte[], byte[]>> context = new ProcessingContext<>(consumerRecord);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/SynchronizationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/SynchronizationTest.java
@@ -457,7 +457,6 @@ public class SynchronizationTest {
         }
     }
 
-    @SuppressWarnings("removal")
     private static ThreadFactory threadFactoryWithNamedThreads(String threadPrefix) {
         AtomicInteger threadNumber = new AtomicInteger(1);
         return r -> {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
@@ -296,7 +296,7 @@ public class TestPlugins {
         try {
             for (TestPackage testPackage : TestPackage.values()) {
                 if (pluginJars.containsKey(testPackage)) {
-                    log.debug("Skipping recompilation of " + testPackage.resourceDir());
+                    log.debug("Skipping recompilation of {}", testPackage.resourceDir());
                 }
                 pluginJars.put(testPackage, createPluginJar(testPackage.resourceDir(), testPackage.removeRuntimeClasses()));
             }
@@ -376,9 +376,7 @@ public class TestPlugins {
     }
 
     public static Function<ClassLoader, LoaderSwap> noOpLoaderSwap() {
-        return classLoader -> {
-            return new LoaderSwap(Thread.currentThread().getContextClassLoader());
-        };
+        return classLoader -> new LoaderSwap(Thread.currentThread().getContextClassLoader());
     }
 
     private static TestPlugin[] defaultPlugins() {
@@ -430,7 +428,7 @@ public class TestPlugins {
             classFiles = stream
                     .sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
-                    .collect(Collectors.toList());
+                    .toList();
         }
         for (File classFile : classFiles) {
             if (!classFile.delete()) {
@@ -487,7 +485,7 @@ public class TestPlugins {
                     .filter(Files::isRegularFile)
                     .filter(path -> !path.toFile().getName().endsWith(".java"))
                     .filter(path -> !removeRuntimeClasses.test(path.toFile().getName()))
-                    .collect(Collectors.toList());
+                    .toList();
         }
         for (Path path : paths) {
             try (InputStream in = new BufferedInputStream(Files.newInputStream(path))) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestClientTest.java
@@ -39,7 +39,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
@@ -332,29 +331,11 @@ public class RestClientTest {
         return assertDoesNotThrow(() -> OBJECT_MAPPER.writeValueAsString(obj));
     }
 
-    private static class TestDTO {
-        private final String content;
-
+    private record TestDTO(String content) {
         @JsonCreator
         private TestDTO(@JsonProperty(value = "content") String content) {
             this.content = content;
         }
 
-        public String getContent() {
-            return content;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            TestDTO testDTO = (TestDTO) o;
-            return content.equals(testDTO.content);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(content);
-        }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/util/SSLUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/util/SSLUtilsTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SSLUtilsTest {
 
-    private Map<String, Object> sslConfig;
     private String keystorePath;
     private String truststorePath;
     private Password keystorePassword;
@@ -45,7 +44,7 @@ public class SSLUtilsTest {
     @BeforeEach
     public void before() throws Exception {
         CertStores serverCertStores = new CertStores(true, "localhost");
-        sslConfig = serverCertStores.getUntrustingConfig();
+        Map<String, Object> sslConfig = serverCertStores.getUntrustingConfig();
         keystorePath = sslConfig.get("ssl.keystore.location").toString();
         truststorePath = sslConfig.get("ssl.truststore.location").toString();
         keystorePassword = (Password) sslConfig.get("ssl.keystore.password");
@@ -61,12 +60,12 @@ public class SSLUtilsTest {
         Map<String, Object> map = new HashMap<>();
         map.put("exists", "value");
 
-        assertEquals(SSLUtils.getOrDefault(map, existingKey, defaultValue), value);
-        assertEquals(SSLUtils.getOrDefault(map, missingKey, defaultValue), defaultValue);
+        assertEquals(value, SSLUtils.getOrDefault(map, existingKey, defaultValue));
+        assertEquals(defaultValue, SSLUtils.getOrDefault(map, missingKey, defaultValue));
     }
 
     @Test
-    public void testCreateServerSideSslContextFactory() throws Exception {
+    public void testCreateServerSideSslContextFactory() {
         Map<String, String> configMap = new HashMap<>();
         configMap.put("ssl.keystore.location", keystorePath);
         configMap.put("ssl.keystore.password", keystorePassword.value());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -788,7 +788,7 @@ public class StandaloneHerderTest {
 
         ArgumentCaptor<NotFoundException> exceptionCaptor = ArgumentCaptor.forClass(NotFoundException.class);
         verify(patchCallback).onCompletion(exceptionCaptor.capture(), isNull());
-        assertEquals(exceptionCaptor.getValue().getMessage(), "Connector " + CONNECTOR_NAME + " not found");
+        assertEquals("Connector " + CONNECTOR_NAME + " not found", exceptionCaptor.getValue().getMessage());
     }
 
     @Test
@@ -899,10 +899,10 @@ public class StandaloneHerderTest {
         Throwable cause = e.getCause();
         assertInstanceOf(BadRequestException.class, cause);
         assertEquals(
-            cause.getMessage(),
-            "Connector configuration is invalid and contains the following 1 error(s):\n" +
-                error + "\n" +
-                "You can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"
+                "Connector configuration is invalid and contains the following 1 error(s):\n" +
+                    error + "\n" +
+                    "You can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`",
+                cause.getMessage()
         );
         verify(loaderSwap).close();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
@@ -1010,7 +1010,7 @@ abstract class EmbeddedConnect {
                     .entity(res.getContentAsString())
                     .build();
         } catch (Exception e) {
-            log.error("Could not execute " + httpMethod + " request to " + url, e);
+            log.error("Could not execute {} request to {}", httpMethod, url, e);
             throw new ConnectException(e);
         }
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -182,7 +182,7 @@ public class EmbeddedConnectCluster extends EmbeddedConnect {
     /**
      * Get the provisioned workers.
      *
-     * @return the list of handles of the provisioned workers
+     * @return the set of handles of the provisioned workers
      */
     public Set<WorkerHandle> workers() {
         return new LinkedHashSet<>(connectCluster);


### PR DESCRIPTION
Various cleanups in Connect:
- use enhanced switch
- remove dead code
- convert classes to records

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Ken Huang <s7133700@gmail.com>
