### PR TITLE
KAFKA-19130: Do not add fenced brokers to BrokerRegistrationTracker on startup

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -309,8 +309,10 @@ public class ClusterControlManager {
         long nowNs = time.nanoseconds();
         for (BrokerRegistration registration : brokerRegistrations.values()) {
             heartbeatManager.register(registration.id(), registration.fenced());
-            heartbeatManager.tracker().updateContactTime(
-                new BrokerIdAndEpoch(registration.id(), registration.epoch()), nowNs);
+            if (!registration.fenced()) {
+                heartbeatManager.tracker().updateContactTime(
+                    new BrokerIdAndEpoch(registration.id(), registration.epoch()), nowNs);
+            }
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -353,10 +353,10 @@ public class ClusterControlManager {
         if (existing != null) {
             prevIncarnationId = existing.incarnationId();
             storedBrokerEpoch = existing.epoch();
-            if (heartbeatManager.hasValidSession(brokerId, existing.epoch()) && !existing.inControlledShutdown()) {
+            if (heartbeatManager.hasValidSession(brokerId, existing.epoch())) {
                 if (!request.incarnationId().equals(prevIncarnationId)) {
-                    throw new DuplicateBrokerRegistrationException("Another broker is registered with that broker id. If the broker " + 
-                            "was recently restarted this should self-resolve once the heartbeat manager expires the broker's session.");
+                    throw new DuplicateBrokerRegistrationException("Another broker is " +
+                        "registered with that broker id.");
                 }
             }
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -355,8 +355,8 @@ public class ClusterControlManager {
             storedBrokerEpoch = existing.epoch();
             if (heartbeatManager.hasValidSession(brokerId, existing.epoch())) {
                 if (!request.incarnationId().equals(prevIncarnationId)) {
-                    throw new DuplicateBrokerRegistrationException("Another broker is " +
-                        "registered with that broker id.");
+                    throw new DuplicateBrokerRegistrationException("Another broker is registered with that broker id. If the broker " +
+                            "was recently restarted this should self-resolve once the heartbeat manager expires the broker's session.");
                 }
             }
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.controller;
 import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.InconsistentClusterIdException;
 import org.apache.kafka.common.errors.InvalidRegistrationException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
@@ -70,6 +71,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -977,6 +979,130 @@ public class ClusterControlManagerTest {
             contactTime(new BrokerIdAndEpoch(1, 124)));
         assertEquals(OptionalLong.empty(), clusterControl.heartbeatManager().tracker().
             contactTime(new BrokerIdAndEpoch(2, 100)));
+    }
+
+    @Test
+    public void testDuplicateBrokerRegistrationWithActiveOldBroker() {
+        // active here means brokerHeartbeatManager last recorded the broker as unfenced and not in controlled shutdown
+        long brokerSessionTimeoutMs = 1000;
+        MockTime time = new MockTime(0L, 20L, 1000L);
+        FinalizedControllerFeatures finalizedFeatures = new FinalizedControllerFeatures(
+            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.LATEST_PRODUCTION.featureLevel()), 456L);
+        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
+            setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+            setFeatureControlManager(createFeatureControlManager()).
+            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
+            setSessionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(brokerSessionTimeoutMs)).
+            setTime(time).
+            build();
+        clusterControl.replay(new RegisterBrokerRecord().
+            setBrokerEpoch(100).
+            setBrokerId(0).
+            setLogDirs(List.of(Uuid.fromString("Mj3CW3OSRi29cFeNJlXuAQ"))).
+            setFenced(false), 10002);
+        clusterControl.activate();
+        assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
+            contactTime(new BrokerIdAndEpoch(0, 100)));
+
+        // while session is still valid for old broker, duplicate requests should fail
+        time.sleep(brokerSessionTimeoutMs / 2);
+        assertThrows(DuplicateBrokerRegistrationException.class, () ->
+            clusterControl.registerBroker(new BrokerRegistrationRequestData().
+                    setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+                    setBrokerId(0).
+                    setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))).
+                    setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
+                        Set.of(new BrokerRegistrationRequestData.Feature().
+                            setName(MetadataVersion.FEATURE_NAME).
+                            setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
+                            setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
+                setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
+                101L,
+                finalizedFeatures,
+                false));
+
+        // if session expires for broker, even if the broker was active the new registration will succeed
+        time.sleep(brokerSessionTimeoutMs);
+        clusterControl.registerBroker(new BrokerRegistrationRequestData().
+                setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+                setBrokerId(0).
+                setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))).
+                setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
+                    Set.of(new BrokerRegistrationRequestData.Feature().
+                        setName(MetadataVersion.FEATURE_NAME).
+                        setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
+                        setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
+                setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
+            101L,
+            finalizedFeatures,
+            false);
+    }
+
+    @Test
+    public void testDuplicateBrokerRegistrationWithInactiveBroker() {
+        // inactive here means brokerHeartbeatManager last recorded the broker as fenced or in controlled shutdown
+        long brokerSessionTimeoutMs = 1000;
+        MockTime time = new MockTime(0L, 20L, 1000L);
+        FinalizedControllerFeatures finalizedFeatures = new FinalizedControllerFeatures(
+            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.LATEST_PRODUCTION.featureLevel()), 456L);
+        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
+            setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+            setFeatureControlManager(createFeatureControlManager()).
+            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
+            setSessionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(brokerSessionTimeoutMs)).
+            setTime(time).
+            build();
+        // first broker is fenced
+        clusterControl.replay(new RegisterBrokerRecord().
+            setBrokerEpoch(100).
+            setBrokerId(0).
+            setLogDirs(List.of(Uuid.fromString("Mj3CW3OSRi29cFeNJlXuAQ"))).
+            setFenced(true).
+            setInControlledShutdown(false), 10002);
+        // second broker is in controlled shutdown
+        clusterControl.replay(new RegisterBrokerRecord().
+            setBrokerEpoch(200).
+            setBrokerId(1).
+            setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))).
+            setFenced(false).
+            setInControlledShutdown(true), 20002);
+        clusterControl.activate();
+        clusterControl.heartbeatManager().maybeUpdateControlledShutdownOffset(1, 20002);
+
+        assertEquals(OptionalLong.empty(), clusterControl.heartbeatManager().tracker().
+            contactTime(new BrokerIdAndEpoch(0, 100)));
+        assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
+            contactTime(new BrokerIdAndEpoch(1, 200)));
+
+        time.sleep(brokerSessionTimeoutMs / 2);
+        clusterControl.registerBroker(new BrokerRegistrationRequestData().
+                setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+                setBrokerId(0).
+                setLogDirs(List.of(Uuid.fromString("yJGxmjfbQZSVFAlNM3uXZg"))).
+                setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
+                    Set.of(new BrokerRegistrationRequestData.Feature().
+                        setName(MetadataVersion.FEATURE_NAME).
+                        setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
+                        setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
+                setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
+            101L,
+            finalizedFeatures,
+            false);
+        assertThrows(DuplicateBrokerRegistrationException.class, () -> {
+            clusterControl.registerBroker(new BrokerRegistrationRequestData().
+                    setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
+                    setBrokerId(1).
+                    setLogDirs(List.of(Uuid.fromString("b66ybsWIQoygs01vdjH07A"))).
+                    setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
+                        Set.of(new BrokerRegistrationRequestData.Feature().
+                            setName(MetadataVersion.FEATURE_NAME).
+                            setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
+                            setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
+                    setIncarnationId(Uuid.fromString("vZKYST0pSA2HO5x_6hoO2Q")),
+                201L,
+                finalizedFeatures,
+                false);
+        });
     }
 
     private FeatureControlManager createFeatureControlManager() {

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -966,9 +966,10 @@ public class ClusterControlManagerTest {
         clusterControl.replay(new RegisterBrokerRecord().
             setBrokerEpoch(123).
             setBrokerId(1).
+            setFenced(false).
             setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))), 10005);
         clusterControl.activate();
-        assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
+        assertEquals(OptionalLong.empty(), clusterControl.heartbeatManager().tracker().
             contactTime(new BrokerIdAndEpoch(0, 100)));
         assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
             contactTime(new BrokerIdAndEpoch(1, 123)));

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -20,7 +20,6 @@ package org.apache.kafka.controller;
 import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.InconsistentClusterIdException;
 import org.apache.kafka.common.errors.InvalidRegistrationException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
@@ -71,7 +70,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -978,131 +976,6 @@ public class ClusterControlManagerTest {
             contactTime(new BrokerIdAndEpoch(1, 124)));
         assertEquals(OptionalLong.empty(), clusterControl.heartbeatManager().tracker().
             contactTime(new BrokerIdAndEpoch(2, 100)));
-    }
-
-    @Test
-    public void testDuplicateBrokerRegistrationWithActiveOldBroker() {
-        // active here means brokerHeartbeatManager last recorded the broker as unfenced and not in controlled shutdown
-        long brokerSessionTimeoutMs = 1000;
-        MockTime time = new MockTime(0L, 20L, 1000L);
-        FinalizedControllerFeatures finalizedFeatures = new FinalizedControllerFeatures(
-            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.LATEST_PRODUCTION.featureLevel()), 456L);
-        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
-            setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-            setFeatureControlManager(createFeatureControlManager()).
-            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
-            setSessionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(brokerSessionTimeoutMs)).
-            setTime(time).
-            build();
-        clusterControl.replay(new RegisterBrokerRecord().
-            setBrokerEpoch(100).
-            setBrokerId(0).
-            setLogDirs(List.of(Uuid.fromString("Mj3CW3OSRi29cFeNJlXuAQ"))).
-            setFenced(false), 10002);
-        clusterControl.activate();
-        assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
-            contactTime(new BrokerIdAndEpoch(0, 100)));
-
-        // while session is still valid for old broker, duplicate requests should fail
-        time.sleep(brokerSessionTimeoutMs / 2);
-        assertThrows(DuplicateBrokerRegistrationException.class, () ->
-            clusterControl.registerBroker(new BrokerRegistrationRequestData().
-                    setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-                    setBrokerId(0).
-                    setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))).
-                    setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
-                        Set.of(new BrokerRegistrationRequestData.Feature().
-                            setName(MetadataVersion.FEATURE_NAME).
-                            setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
-                            setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
-                setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
-                101L,
-                finalizedFeatures,
-                false));
-
-        // if session expires for broker, even if the broker was active the new registration will succeed
-        time.sleep(brokerSessionTimeoutMs);
-        clusterControl.registerBroker(new BrokerRegistrationRequestData().
-                setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-                setBrokerId(0).
-                setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))).
-                setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
-                    Set.of(new BrokerRegistrationRequestData.Feature().
-                        setName(MetadataVersion.FEATURE_NAME).
-                        setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
-                        setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
-                setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
-            101L,
-            finalizedFeatures,
-            false);
-    }
-
-    @Test
-    public void testDuplicateBrokerRegistrationWithInactiveBroker() {
-        // inactive here means brokerHeartbeatManager last recorded the broker as fenced or in controlled shutdown
-        long brokerSessionTimeoutMs = 1000;
-        MockTime time = new MockTime(0L, 20L, 1000L);
-        FinalizedControllerFeatures finalizedFeatures = new FinalizedControllerFeatures(
-            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.LATEST_PRODUCTION.featureLevel()), 456L);
-        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
-            setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-            setFeatureControlManager(createFeatureControlManager()).
-            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
-            setSessionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(brokerSessionTimeoutMs)).
-            setTime(time).
-            build();
-        // first broker is fenced
-        clusterControl.replay(new RegisterBrokerRecord().
-            setBrokerEpoch(100).
-            setBrokerId(0).
-            setLogDirs(List.of(Uuid.fromString("Mj3CW3OSRi29cFeNJlXuAQ"))).
-            setFenced(true).
-            setInControlledShutdown(false), 10002);
-        // second broker is in controlled shutdown
-        clusterControl.replay(new RegisterBrokerRecord().
-            setBrokerEpoch(200).
-            setBrokerId(1).
-            setLogDirs(List.of(Uuid.fromString("TyNK6XSSQJaJc2q9uflNHg"))).
-            setFenced(false).
-            setInControlledShutdown(true), 20002);
-        clusterControl.activate();
-        clusterControl.heartbeatManager().maybeUpdateControlledShutdownOffset(1, 20002);
-
-        assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
-            contactTime(new BrokerIdAndEpoch(0, 100)));
-        assertEquals(OptionalLong.of(1000L), clusterControl.heartbeatManager().tracker().
-            contactTime(new BrokerIdAndEpoch(1, 200)));
-
-        time.sleep(brokerSessionTimeoutMs / 2);
-        assertThrows(DuplicateBrokerRegistrationException.class, () ->
-            clusterControl.registerBroker(new BrokerRegistrationRequestData().
-                    setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-                    setBrokerId(0).
-                    setLogDirs(List.of(Uuid.fromString("yJGxmjfbQZSVFAlNM3uXZg"))).
-                    setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
-                        Set.of(new BrokerRegistrationRequestData.Feature().
-                            setName(MetadataVersion.FEATURE_NAME).
-                            setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
-                            setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
-                    setIncarnationId(Uuid.fromString("0H4fUu1xQEKXFYwB1aBjhg")),
-                101L,
-                finalizedFeatures,
-                false));
-        // new registration should succeed immediatelly only if the broker is in controlled shutdown, 
-        // even if the last heartbeat was within the session timeout 
-        clusterControl.registerBroker(new BrokerRegistrationRequestData().
-                setClusterId("pjvUwj3ZTEeSVQmUiH3IJw").
-                setBrokerId(1).
-                setLogDirs(List.of(Uuid.fromString("b66ybsWIQoygs01vdjH07A"))).
-                setFeatures(new BrokerRegistrationRequestData.FeatureCollection(
-                    Set.of(new BrokerRegistrationRequestData.Feature().
-                        setName(MetadataVersion.FEATURE_NAME).
-                        setMinSupportedVersion(MetadataVersion.MINIMUM_VERSION.featureLevel()).
-                        setMaxSupportedVersion(MetadataVersion.LATEST_PRODUCTION.featureLevel())).iterator())).
-                setIncarnationId(Uuid.fromString("vZKYST0pSA2HO5x_6hoO2Q")),
-            201L,
-            finalizedFeatures,
-            false);
     }
 
     private FeatureControlManager createFeatureControlManager() {


### PR DESCRIPTION
When the controller starts up (or becomes active after being inactive),
we add all of the registered brokers to BrokerRegistrationTracker so
that they will not be accidentally fenced the next time we are looking
for a broker to fence. We do this because the state in
BrokerRegistrationTracker is "soft state" (it doesn't appear in the
metadata log), and the newly active controller starts off with no soft
state. (Its soft state will be populated by the brokers sending
heartbeat requests to it over time.)

In the case of fenced brokers, we are not worried about accidentally
fencing the broker due to it being missing from
BrokerRegistrationTracker for a while (it's already fenced). Therefore,
it should be reasonable to just not add fenced brokers to the tracker
initially.

One case where this change will have a positive impact is for people
running single-node demonstration clusters in combined KRaft mode. In
that case, when the single-node cluster is taken down and restarted, it
currently will have to wait about 9 seconds for the broker to come up
and re-register. With this change, the broker should be able to
re-register immediately (assuming the previous shutdown happened cleanly
through controller shutdown.)

One possible negative impact is that if there is a controller failover,
it will open a small window where a broker with the same ID as a fenced
broker could re-register. However, our detection of duplicate broker IDs
is best-effort (and duplicate broker IDs are an administrative mistake),
so this downside seems acceptable.
