### PR TITLE
KAFKA-19117: Client Throttling Log messages should be of log level - WARN (Java client)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -994,7 +994,7 @@ public class NetworkClient implements KafkaClient {
         if (throttleTimeMs > 0 && response.shouldClientThrottle(apiVersion)) {
             inFlightRequests.incrementThrottleTime(nodeId, throttleTimeMs);
             connectionStates.throttle(nodeId, now + throttleTimeMs);
-            log.trace("Connection to node {} is throttled for {} ms until timestamp {}", nodeId, throttleTimeMs,
+            log.warn("Connection to node {} is throttled for {} ms until timestamp {}", nodeId, throttleTimeMs,
                       now + throttleTimeMs);
         }
     }


### PR DESCRIPTION
KAFKA-19117 Issue description:

We experienced an outage in our application due to a built up Kafka lag,
which we eventually discovered to be the problem with Kafka Clients
being throttled.

Even when using the confluent cluster, the dashboard does point to
exceeding the quota of the principal.

It will be nice, if the log message on the client side is a WARNING.
This helps those who don't have visibility to cluster, and just look at
the problem from the client side, setup alerts etc. (instead of enabling
TRACE to figure out where the problem is)

NetworkClient#maybeThrottle in the class NetworkClient:

Changed from:   `log.trace("Connection to node {} is throttled for {} ms
until timestamp {}", nodeId, throttleTimeMs, now + throttleTimeMs); `

 to

 `log.warn("Connection to node {} is throttled for {} ms until timestamp
{}", nodeId, throttleTimeMs, now + throttleTimeMs);`

Reviewers: Kirk True <kirk@kirktrue.pro>, Chia-Ping Tsai
 <chia7712@gmail.com>, PoAn Yang <payang@apache.org>
