### PR TITLE
KAFKA-19039: The refresh_collaborators.py script messes .asf.yaml

### DIFF
--- a/committer-tools/refresh_collaborators.py
+++ b/committer-tools/refresh_collaborators.py
@@ -116,6 +116,7 @@ def update_local_yaml_content(yaml_file_path: str, collaborators: List[str]) -> 
     with open(yaml_file_path, "r", encoding="utf-8") as file:
         yaml: YAML = YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml.representer.add_representer(type(None), represent_none)
         yaml_content: dict = yaml.load(file)
 
     yaml_content["github"]["collaborators"] = collaborators
@@ -125,6 +126,8 @@ def update_local_yaml_content(yaml_file_path: str, collaborators: List[str]) -> 
 
     logging.info(f"Local file {yaml_file_path} updated successfully")
 
+def represent_none(self, data):
+    return self.represent_scalar('tag:yaml.org,2002:null', '~')
 
 def main() -> None:
     github_client: Github = get_github_client()

--- a/committer-tools/refresh_collaborators.py
+++ b/committer-tools/refresh_collaborators.py
@@ -26,7 +26,7 @@ import io
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from bs4 import BeautifulSoup
 from github import Github
@@ -35,6 +35,7 @@ from github.ContentFile import ContentFile
 from github.PaginatedList import PaginatedList
 from github.Repository import Repository
 from ruamel.yaml import YAML
+from ruamel.yaml.representer import RoundTripRepresenter
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
@@ -113,6 +114,9 @@ def update_local_yaml_content(yaml_file_path: str, collaborators: List[str]) -> 
 
     collaborators.sort(key=str.casefold)
 
+    def represent_none(self: RoundTripRepresenter, _: Any):
+        return self.represent_scalar('tag:yaml.org,2002:null', '~')
+
     with open(yaml_file_path, "r", encoding="utf-8") as file:
         yaml: YAML = YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)
@@ -126,8 +130,6 @@ def update_local_yaml_content(yaml_file_path: str, collaborators: List[str]) -> 
 
     logging.info(f"Local file {yaml_file_path} updated successfully")
 
-def represent_none(self, data):
-    return self.represent_scalar('tag:yaml.org,2002:null', '~')
 
 def main() -> None:
     github_client: Github = get_github_client()

--- a/committer-tools/refresh_collaborators.py
+++ b/committer-tools/refresh_collaborators.py
@@ -115,7 +115,7 @@ def update_local_yaml_content(yaml_file_path: str, collaborators: List[str]) -> 
     collaborators.sort(key=str.casefold)
 
     def represent_none(self: RoundTripRepresenter, _: Any):
-        return self.represent_scalar('tag:yaml.org,2002:null', '~')
+        return self.represent_scalar("tag:yaml.org,2002:null", "~")
 
     with open(yaml_file_path, "r", encoding="utf-8") as file:
         yaml: YAML = YAML()


### PR DESCRIPTION
`update_local_yaml_content` in `refresh_collaborators.py` instantiates a
YAML object with no arguments. As such, the YAML object defaults to
using a `RoundTripRepresenter` under the hood, which serializes `None`
into an empty string.

This PR updates the YAML object's serialization behaviour to return
`"~"` for `None`.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Ming-Yen Chung
 <mingyen066@gmail.com>
