### PR TITLE
KAFKA-15853: Move static functions from KafkaConfig to AbstractKafkaConfig (wip)

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -22,7 +22,6 @@ import java.util.concurrent._
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
 import kafka.network
-import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.memory.MemoryPool
@@ -36,6 +35,7 @@ import org.apache.kafka.network.metrics.{RequestChannelMetrics, RequestMetrics}
 import org.apache.kafka.server.common.RequestLocal
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.network.RequestConvertToJson
+import org.apache.kafka.server.config.AbstractKafkaConfig
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
@@ -171,7 +171,7 @@ object RequestChannel extends Logging {
           newData.resources().forEach(resource => {
             val resourceType = ConfigResource.Type.forId(resource.resourceType())
             resource.configs().forEach(config => {
-              config.setValue(KafkaConfig.loggableValue(resourceType, config.name(), config.value()))
+              config.setValue(AbstractKafkaConfig.loggableValue(resourceType, config.name(), config.value()))
             })
           })
           new AlterConfigsRequest(newData, alterConfigs.version())
@@ -181,7 +181,7 @@ object RequestChannel extends Logging {
           newData.resources().forEach(resource => {
             val resourceType = ConfigResource.Type.forId(resource.resourceType())
             resource.configs().forEach(config => {
-              config.setValue(KafkaConfig.loggableValue(resourceType, config.name(), config.value()))
+              config.setValue(AbstractKafkaConfig.loggableValue(resourceType, config.name(), config.value()))
             })
           })
           new IncrementalAlterConfigsRequest.Builder(newData).build(alterConfigs.version())

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.protocol.Errors.{INVALID_REQUEST, UNKNOWN_SERVER_
 import org.apache.kafka.common.requests.ApiError
 import org.apache.kafka.common.resource.{Resource, ResourceType}
 import org.apache.kafka.metadata.ConfigRepository
+import org.apache.kafka.server.config.AbstractKafkaConfig
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.{Map, Seq}
@@ -400,7 +401,7 @@ object ConfigAdminManager {
    */
   def toLoggableProps(resource: ConfigResource, configProps: Properties): Map[String, String] = {
     configProps.asScala.map {
-      case (key, value) => (key, KafkaConfig.loggableValue(resource.`type`, key, value))
+      case (key, value) => (key, AbstractKafkaConfig.loggableValue(resource.`type`, key, value))
     }
   }
 

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -20,7 +20,7 @@ package kafka.server
 import kafka.network.RequestChannel
 
 import java.util.{Collections, Properties}
-import kafka.utils.{LoggingController, Logging}
+import kafka.utils.{Logging, LoggingController}
 import org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigResource}
 import org.apache.kafka.common.errors.{ApiException, InvalidRequestException}
@@ -34,7 +34,7 @@ import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC}
 import org.apache.kafka.coordinator.group.GroupConfig
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
-import org.apache.kafka.server.config.ServerTopicConfigSynonyms
+import org.apache.kafka.server.config.{AbstractKafkaConfig, ServerTopicConfigSynonyms}
 import org.apache.kafka.server.metrics.ClientMetricsConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
 
@@ -179,9 +179,9 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
   private def createGroupConfigEntry(groupConfig: GroupConfig, groupProps: Properties, includeSynonyms: Boolean, includeDocumentation: Boolean)
                                     (name: String, value: Any): DescribeConfigsResponseData.DescribeConfigsResourceResult = {
     val allNames = brokerSynonyms(name)
-    val configEntryType = GroupConfig.configType(name).toScala
-    val isSensitive = KafkaConfig.maybeSensitive(configEntryType)
-    val valueAsString = if (isSensitive) null else ConfigDef.convertToString(value, configEntryType.orNull)
+    val configEntryType = GroupConfig.configType(name)
+    val isSensitive = AbstractKafkaConfig.maybeSensitive(configEntryType)
+    val valueAsString = if (isSensitive) null else ConfigDef.convertToString(value, configEntryType.orElse(null))
     val allSynonyms = {
       val list = configSynonyms(name, allNames, isSensitive)
       if (!groupProps.containsKey(name))
@@ -193,7 +193,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     }
     val source = if (allSynonyms.isEmpty) ConfigSource.DEFAULT_CONFIG.id else allSynonyms.head.source
     val synonyms = if (!includeSynonyms) List.empty else allSynonyms
-    val dataType = configResponseType(configEntryType)
+    val dataType = configResponseType(configEntryType.toScala)
     val configDocumentation = if (includeDocumentation) groupConfig.documentationOf(name) else null
     new DescribeConfigsResponseData.DescribeConfigsResourceResult()
       .setName(name).setValue(valueAsString).setConfigSource(source)
@@ -225,9 +225,9 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
 
   def createTopicConfigEntry(logConfig: LogConfig, topicProps: Properties, includeSynonyms: Boolean, includeDocumentation: Boolean)
                             (name: String, value: Any): DescribeConfigsResponseData.DescribeConfigsResourceResult = {
-    val configEntryType = LogConfig.configType(name).toScala
-    val isSensitive = KafkaConfig.maybeSensitive(configEntryType)
-    val valueAsString = if (isSensitive) null else ConfigDef.convertToString(value, configEntryType.orNull)
+    val configEntryType = LogConfig.configType(name)
+    val isSensitive = AbstractKafkaConfig.maybeSensitive(configEntryType)
+    val valueAsString = if (isSensitive) null else ConfigDef.convertToString(value, configEntryType.orElse(null))
     val allSynonyms = {
       val list = Option(ServerTopicConfigSynonyms.TOPIC_CONFIG_SYNONYMS.get(name))
         .map(s => configSynonyms(s, brokerSynonyms(s), isSensitive))
@@ -240,7 +240,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     }
     val source = if (allSynonyms.isEmpty) ConfigSource.DEFAULT_CONFIG.id else allSynonyms.head.source
     val synonyms = if (!includeSynonyms) List.empty else allSynonyms
-    val dataType = configResponseType(configEntryType)
+    val dataType = configResponseType(configEntryType.toScala)
     val configDocumentation = if (includeDocumentation) logConfig.documentationOf(name) else null
     new DescribeConfigsResponseData.DescribeConfigsResourceResult()
       .setName(name).setValue(valueAsString).setConfigSource(source)
@@ -251,13 +251,13 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
   private def createBrokerConfigEntry(perBrokerConfig: Boolean, includeSynonyms: Boolean, includeDocumentation: Boolean)
                                      (name: String, value: Any): DescribeConfigsResponseData.DescribeConfigsResourceResult = {
     val allNames = brokerSynonyms(name)
-    val configEntryType = KafkaConfig.configType(name)
-    val isSensitive = KafkaConfig.maybeSensitive(configEntryType)
+    val configEntryType = AbstractKafkaConfig.configType(name)
+    val isSensitive = AbstractKafkaConfig.maybeSensitive(configEntryType)
     val valueAsString = if (isSensitive)
       null
     else value match {
       case v: String => v
-      case _ => ConfigDef.convertToString(value, configEntryType.orNull)
+      case _ => ConfigDef.convertToString(value, configEntryType.orElse(null))
     }
     val allSynonyms = configSynonyms(name, allNames, isSensitive)
       .filter(perBrokerConfig || _.source == ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG.id)
@@ -265,7 +265,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
     val source = if (allSynonyms.isEmpty) ConfigSource.DEFAULT_CONFIG.id else allSynonyms.head.source
     val readOnly = !DynamicBrokerConfig.AllDynamicConfigs.contains(name)
 
-    val dataType = configResponseType(configEntryType)
+    val dataType = configResponseType(configEntryType.toScala)
     val configDocumentation = if (includeDocumentation) brokerDocumentation(name) else null
     new DescribeConfigsResponseData.DescribeConfigsResourceResult().setName(name).setValue(valueAsString).setConfigSource(source)
       .setIsSensitive(isSensitive).setReadOnly(readOnly).setSynonyms(synonyms.asJava)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -23,10 +23,9 @@ import java.util.Properties
 import kafka.utils.{CoreUtils, Logging}
 import kafka.utils.Implicits._
 import org.apache.kafka.common.Reconfigurable
-import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource, TopicConfig}
+import org.apache.kafka.common.config.{ConfigException, TopicConfig}
 import org.apache.kafka.common.config.ConfigDef.ConfigKey
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
-import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.security.auth.KafkaPrincipalSerde
@@ -35,7 +34,7 @@ import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.network.EndPoint
 import org.apache.kafka.coordinator.group.Group.GroupType
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig
-import org.apache.kafka.coordinator.group.{GroupConfig, GroupCoordinatorConfig}
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.share.ShareCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.{AddPartitionsToTxnConfig, TransactionStateManagerConfig}
 import org.apache.kafka.network.SocketServerConfigs
@@ -48,11 +47,10 @@ import org.apache.kafka.server.config.{AbstractKafkaConfig, KRaftConfigs, QuotaC
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.MetricConfigs
 import org.apache.kafka.server.util.Csv
-import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
+import org.apache.kafka.storage.internals.log.CleanerConfig
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq}
-import scala.jdk.OptionConverters.RichOptional
 
 object KafkaConfig {
 
@@ -84,51 +82,6 @@ object KafkaConfig {
   }
 
   def apply(props: java.util.Map[_, _], doLog: Boolean = true): KafkaConfig = new KafkaConfig(props, doLog)
-
-  private def typeOf(name: String): Option[ConfigDef.Type] = Option(configDef.configKeys.get(name)).map(_.`type`)
-
-  def configType(configName: String): Option[ConfigDef.Type] = {
-    val configType = configTypeExact(configName)
-    if (configType.isDefined) {
-      return configType
-    }
-    typeOf(configName) match {
-      case Some(t) => Some(t)
-      case None =>
-        DynamicBrokerConfig.brokerConfigSynonyms(configName, matchListenerOverride = true).flatMap(typeOf).headOption
-    }
-  }
-
-  private def configTypeExact(exactName: String): Option[ConfigDef.Type] = {
-    val configType = typeOf(exactName).orNull
-    if (configType != null) {
-      Some(configType)
-    } else {
-      val configKey = DynamicConfig.Broker.configKeys.get(exactName)
-      if (configKey != null) {
-        Some(configKey.`type`)
-      } else {
-        None
-      }
-    }
-  }
-
-  def maybeSensitive(configType: Option[ConfigDef.Type]): Boolean = {
-    // If we can't determine the config entry type, treat it as a sensitive config to be safe
-    configType.isEmpty || configType.contains(ConfigDef.Type.PASSWORD)
-  }
-
-  def loggableValue(resourceType: ConfigResource.Type, name: String, value: String): String = {
-    val maybeSensitive = resourceType match {
-      case ConfigResource.Type.BROKER => KafkaConfig.maybeSensitive(KafkaConfig.configType(name))
-      case ConfigResource.Type.TOPIC => KafkaConfig.maybeSensitive(LogConfig.configType(name).toScala)
-      case ConfigResource.Type.GROUP => KafkaConfig.maybeSensitive(GroupConfig.configType(name).toScala)
-      case ConfigResource.Type.BROKER_LOGGER => false
-      case ConfigResource.Type.CLIENT_METRICS => false
-      case _ => true
-    }
-    if (maybeSensitive) Password.HIDDEN else value
-  }
 
   /**
    * Copy a configuration map, populating some keys that we want to treat as synonyms.

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -18,8 +18,12 @@ package org.apache.kafka.server.config;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.group.GroupConfig;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 import org.apache.kafka.coordinator.share.ShareCoordinatorConfig;
@@ -35,6 +39,10 @@ import org.apache.kafka.storage.internals.log.LogConfig;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * During moving {@link kafka.server.KafkaConfig} out of core AbstractKafkaConfig will be the future KafkaConfig
@@ -63,6 +71,84 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         DelegationTokenManagerConfigs.CONFIG_DEF,
         AddPartitionsToTxnConfig.CONFIG_DEF
     ));
+
+    public static boolean maybeSensitive(Optional<ConfigDef.Type> configType) {
+        return configType.isEmpty() || configType.get().equals(ConfigDef.Type.PASSWORD);
+    }
+
+    public static String loggableValue(ConfigResource.Type resourceType, String name, String value) {
+        boolean isSensitive = switch (resourceType) {
+            case BROKER -> maybeSensitive(configType(name));
+            case TOPIC -> maybeSensitive(LogConfig.configType(name));
+            case GROUP -> maybeSensitive(GroupConfig.configType(name));
+            case BROKER_LOGGER, CLIENT_METRICS -> false;
+            default -> true;
+        };
+        return isSensitive ? Password.HIDDEN : value;
+    }
+
+    public static Optional<ConfigDef.Type> configType(String configName) {
+        Optional<ConfigDef.Type> configType = configTypeExact(configName);
+        if (configType.isPresent()) {
+            return configType;
+        }
+        return configDefTypeOf(configName).or(() ->
+            brokerConfigSynonyms(configName, true)
+                .stream()
+                .map(AbstractKafkaConfig::configDefTypeOf)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+        );
+    }
+
+    public static List<String> brokerConfigSynonyms(String name, boolean matchListenerOverride) {
+        Matcher matcher = LISTENER_CONFIG_REGEX.matcher(name);
+        if (name.equals(ServerLogConfigs.LOG_ROLL_TIME_MILLIS_CONFIG) || name.equals(ServerLogConfigs.LOG_ROLL_TIME_HOURS_CONFIG)) {
+            return List.of(ServerLogConfigs.LOG_ROLL_TIME_MILLIS_CONFIG, ServerLogConfigs.LOG_ROLL_TIME_HOURS_CONFIG);
+        } else if (name.equals(ServerLogConfigs.LOG_ROLL_TIME_JITTER_MILLIS_CONFIG) || name.equals(ServerLogConfigs.LOG_ROLL_TIME_JITTER_HOURS_CONFIG)) {
+            return List.of(ServerLogConfigs.LOG_ROLL_TIME_JITTER_MILLIS_CONFIG, ServerLogConfigs.LOG_ROLL_TIME_JITTER_HOURS_CONFIG);
+        } else if (name.equals(ServerLogConfigs.LOG_FLUSH_INTERVAL_MS_CONFIG)) {
+            return List.of(ServerLogConfigs.LOG_FLUSH_INTERVAL_MS_CONFIG, ServerLogConfigs.LOG_FLUSH_SCHEDULER_INTERVAL_MS_CONFIG);
+        } else if (name.equals(ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG) ||
+            name.equals(ServerLogConfigs.LOG_RETENTION_TIME_MINUTES_CONFIG) ||
+            name.equals(ServerLogConfigs.LOG_RETENTION_TIME_HOURS_CONFIG)) {
+            return List.of(ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG, ServerLogConfigs.LOG_RETENTION_TIME_MINUTES_CONFIG, ServerLogConfigs.LOG_RETENTION_TIME_HOURS_CONFIG);
+        } else if (matcher.matches() && matchListenerOverride) {
+            String baseName = matcher.group(1);
+            Optional<String> mechanismConfig = Set.of(
+                SaslConfigs.SASL_JAAS_CONFIG,
+                SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                SaslConfigs.SASL_LOGIN_CLASS,
+                BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS_CONFIG,
+                BrokerSecurityConfigs.CONNECTIONS_MAX_REAUTH_MS_CONFIG
+            ).stream().filter(baseName::endsWith).findFirst();
+            return List.of(name, mechanismConfig.orElse(baseName));
+        } else {
+            return List.of(name);
+        }
+    }
+
+    private static final Pattern LISTENER_CONFIG_REGEX = Pattern.compile("listener\\.name\\.[^.]*\\.(.*)");
+
+    private static Optional<ConfigDef.Type> configTypeExact(String exactName) {
+        ConfigDef.Type configType = configDefTypeOf(exactName).orElse(null);
+        if (configType != null) {
+            return Optional.of(configType);
+        } else {
+            ConfigDef.ConfigKey configKey = DynamicConfig.Broker.configKeys().get(exactName);
+            if (configKey != null) {
+                return Optional.of(configKey.type);
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    private static Optional<ConfigDef.Type> configDefTypeOf(String name) {
+        return Optional.ofNullable(CONFIG_DEF.configKeys().get(name))
+            .map(ConfigDef.ConfigKey::type);
+    }
 
     public AbstractKafkaConfig(ConfigDef definition, Map<?, ?> originals, Map<String, ?> configProviderProps, boolean doLog) {
         super(definition, originals, configProviderProps, doLog);

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicConfig.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.config;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.transaction.TransactionLogConfig;
+import org.apache.kafka.network.SocketServerConfigs;
+import org.apache.kafka.server.DynamicThreadPool;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.server.metrics.MetricConfigs;
+import org.apache.kafka.storage.internals.log.LogCleaner;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class DynamicConfig {
+    public static final Set<String> ALL_DYNAMIC_CONFIGS;
+
+    static {
+        Set<String> allDynamicConfigs = new HashSet<>(SslConfigs.RECONFIGURABLE_CONFIGS);
+        allDynamicConfigs.addAll(LogCleaner.RECONFIGURABLE_CONFIGS);
+        allDynamicConfigs.addAll(ServerTopicConfigSynonyms.TOPIC_CONFIG_SYNONYMS.values());
+        allDynamicConfigs.addAll(DynamicThreadPool.RECONFIGURABLE_CONFIGS);
+        allDynamicConfigs.add(MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG);
+        allDynamicConfigs.addAll(Set.of(
+            // Listener configs
+            SocketServerConfigs.LISTENERS_CONFIG,
+            SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG,
+
+            // SSL configs
+            BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG,
+            SslConfigs.SSL_PROTOCOL_CONFIG,
+            SslConfigs.SSL_PROVIDER_CONFIG,
+            SslConfigs.SSL_CIPHER_SUITES_CONFIG,
+            SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
+            SslConfigs.SSL_KEYSTORE_TYPE_CONFIG,
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG,
+            SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG,
+            SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG,
+            SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG,
+            BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG,
+            SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG,
+
+            // SASL configs
+            BrokerSecurityConfigs.SASL_MECHANISM_INTER_BROKER_PROTOCOL_CONFIG,
+            SaslConfigs.SASL_JAAS_CONFIG,
+            BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
+            SaslConfigs.SASL_KERBEROS_SERVICE_NAME,
+            SaslConfigs.SASL_KERBEROS_KINIT_CMD,
+            SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR,
+            SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER,
+            SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN,
+            BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_CONFIG,
+            SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR,
+            SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER,
+            SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS,
+            SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS,
+
+            // Connection limit configs
+            SocketServerConfigs.MAX_CONNECTIONS_CONFIG,
+            SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG,
+
+            // Network threads
+            SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG
+        ));
+        allDynamicConfigs.addAll(Set.of(
+            TransactionLogConfig.PRODUCER_ID_EXPIRATION_MS_CONFIG,
+            TransactionLogConfig.TRANSACTION_PARTITION_VERIFICATION_ENABLE_CONFIG
+        ));
+        allDynamicConfigs.addAll(Set.of(
+            SocketServerConfigs.MAX_CONNECTIONS_PER_IP_CONFIG,
+            SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG,
+            SocketServerConfigs.MAX_CONNECTIONS_CONFIG,
+            SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG
+        ));
+        allDynamicConfigs.addAll(Set.of(
+            RemoteLogManagerConfig.REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP,
+            RemoteLogManagerConfig.REMOTE_FETCH_MAX_WAIT_MS_PROP,
+            RemoteLogManagerConfig.REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND_PROP,
+            RemoteLogManagerConfig.REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND_PROP,
+            RemoteLogManagerConfig.REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_PROP,
+            RemoteLogManagerConfig.REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE_PROP,
+            RemoteLogManagerConfig.REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE_PROP,
+            RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP
+        ));
+        ALL_DYNAMIC_CONFIGS = Collections.unmodifiableSet(allDynamicConfigs);
+    }
+
+    public static class Broker {
+        private static final ConfigDef BROKER_CONFIGS;
+
+        static {
+            ConfigDef configs = QuotaConfig.brokerQuotaConfigs();
+
+            // Filter and define all dynamic configurations
+            AbstractKafkaConfig.CONFIG_DEF.configKeys().forEach((configName, value) -> {
+                if (ALL_DYNAMIC_CONFIGS.contains(configName)) {
+                    configs.define(value);
+                }
+            });
+            BROKER_CONFIGS = configs;
+        }
+
+        // In order to avoid circular reference, all DynamicBrokerConfig's variables which are initialized by
+        // `DynamicConfig.Broker` should be moved to `DynamicConfig.Broker`.
+        // Otherwise, those variables of DynamicBrokerConfig will see intermediate state of `DynamicConfig.Broker`,
+        // because `brokerConfigs` is created by `DynamicBrokerConfig.AllDynamicConfigs`
+
+        public static final Set<String> NON_DYNAMIC_PROPS;
+
+        static {
+            Set<String> props = new TreeSet<>(AbstractKafkaConfig.CONFIG_DEF.names());
+            props.removeAll(BROKER_CONFIGS.names());
+            NON_DYNAMIC_PROPS = Collections.unmodifiableSet(props);
+        }
+
+        public static Map<String, ConfigDef.ConfigKey> configKeys() {
+            return BROKER_CONFIGS.configKeys();
+        }
+
+        public static Set<String> names() {
+            return BROKER_CONFIGS.names();
+        }
+
+        public static Map<String, Object> validate(Properties props) {
+            return DynamicConfig.validate(BROKER_CONFIGS, props, true);
+        }
+    }
+
+    private static Map<String, Object> validate(ConfigDef configDef, Properties props, boolean customPropsAllowed) {
+        // Validate Names
+        Set<String> names = configDef.names();
+        Set<String> propKeys = new HashSet<>();
+        for (Object key : props.keySet()) {
+            propKeys.add((String) key);
+        }
+        if (!customPropsAllowed) {
+            Set<String> unknownKeys = new HashSet<>(propKeys);
+            unknownKeys.removeAll(names);
+            if (!unknownKeys.isEmpty()) {
+                throw new IllegalArgumentException("Unknown Dynamic Configuration: " + unknownKeys);
+            }
+        }
+        Properties propResolved = resolveVariableConfigs(props);
+        // Validate Values
+        return configDef.parse(propResolved);
+    }
+
+    private static Properties resolveVariableConfigs(Properties propsOriginal) {
+        Properties props = new Properties();
+        AbstractConfig config = new AbstractConfig(new ConfigDef(), propsOriginal,
+            Utils.castToStringObjectMap(propsOriginal), false);
+        config.originals().forEach((key, value) -> {
+            if (!key.startsWith(AbstractConfig.CONFIG_PROVIDERS_CONFIG)) {
+                props.put(key, value);
+            }
+        });
+        return props;
+    }
+}


### PR DESCRIPTION
Move following static functions from KafkaConfig to AbstractKafkaConfig.
* maybeSensitive
* loggableValue
* configType
