### PR TITLE
KAFKA-19151: docs: clarify that flush.ms requires log.flush.scheduler.interval.ms config

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -59,7 +59,7 @@ public class TopicConfig {
     public static final String FLUSH_MS_DOC = "This setting allows specifying a time interval at which we will " +
         "force an fsync of data written to the log. For example if this was set to 1000 " +
         "we would fsync after 1000 ms had passed. Note that this setting depends on the broker-level " +
-        "configuration <code>log.flush.scheduler.interval.ms</code>, which controls how frequently the flush check occurs." +
+        "configuration <code>log.flush.scheduler.interval.ms</code>, which controls how frequently the flush check occurs. " +
         "In general we recommend you not set this and use replication for durability and allow the operating system's " +
         "background flush capabilities as it is more efficient.";
 

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -59,8 +59,9 @@ public class TopicConfig {
     public static final String FLUSH_MS_DOC = "This setting allows specifying a time interval at which we will " +
         "force an fsync of data written to the log. For example if this was set to 1000 " +
         "we would fsync after 1000 ms had passed. Note that this setting depends on the broker-level " +
-        "configuration <code>log.flush.scheduler.interval.ms</code>, git  for durability and allow the operating system's background " +
-        "flush capabilities as it is more efficient.";
+        "configuration <code>log.flush.scheduler.interval.ms</code>, which controls how frequently the flush check occurs." +
+        "In general we recommend you not set this and use replication for durability and allow the operating system's " +
+        "background flush capabilities as it is more efficient.";
 
     public static final String RETENTION_BYTES_CONFIG = "retention.bytes";
     public static final String RETENTION_BYTES_DOC = "This configuration controls the maximum size a partition " +

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -58,8 +58,10 @@ public class TopicConfig {
     public static final String FLUSH_MS_CONFIG = "flush.ms";
     public static final String FLUSH_MS_DOC = "This setting allows specifying a time interval at which we will " +
         "force an fsync of data written to the log. For example if this was set to 1000 " +
-        "we would fsync after 1000 ms had passed. In general we recommend you not set " +
-        "this and use replication for durability and allow the operating system's background " +
+        "we would fsync after 1000 ms had passed. Note that this setting depends on the broker-level " +
+        "configuration \"log.flush.scheduler.interval.ms\", which controls how frequently the flush check occurs. " +
+        "If \"log.flush.scheduler.interval.ms\" is not configured, the topic config \"flush.ms\" will not be triggered. " +
+        "In general we recommend you not set this and use replication for durability and allow the operating system's background " +
         "flush capabilities as it is more efficient.";
 
     public static final String RETENTION_BYTES_CONFIG = "retention.bytes";

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -59,9 +59,7 @@ public class TopicConfig {
     public static final String FLUSH_MS_DOC = "This setting allows specifying a time interval at which we will " +
         "force an fsync of data written to the log. For example if this was set to 1000 " +
         "we would fsync after 1000 ms had passed. Note that this setting depends on the broker-level " +
-        "configuration \"log.flush.scheduler.interval.ms\", which controls how frequently the flush check occurs. " +
-        "If \"log.flush.scheduler.interval.ms\" is not configured, the topic config \"flush.ms\" will not be triggered. " +
-        "In general we recommend you not set this and use replication for durability and allow the operating system's background " +
+        "configuration <code>log.flush.scheduler.interval.ms</code>, git  for durability and allow the operating system's background " +
         "flush capabilities as it is more efficient.";
 
     public static final String RETENTION_BYTES_CONFIG = "retention.bytes";


### PR DESCRIPTION
Enhanced docs of `flush.ms` to remind users the flush is triggered by
`log.flush.scheduler.interval.ms`.

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, TengYao Chi <kitingiao@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
