### PR TITLE
MINOR: Supress stdout when checking Log4j 1.x configuration compatibility mode

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -225,7 +225,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
   (( WINDOWS_OS_FORMAT )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
   KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=${LOG4J_DIR}"
 else
-  if echo "$KAFKA_LOG4J_OPTS" | grep -E "log4j\.[^[:space:]]+(\.properties|\.xml)$"; then
+  if echo "$KAFKA_LOG4J_OPTS" | grep -E "log4j\.[^[:space:]]+(\.properties|\.xml)$" >/dev/null; then
       # Enable Log4j 1.x configuration compatibility mode for Log4j 2
       export LOG4J_COMPATIBILITY=true
       echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2


### PR DESCRIPTION
when using log41 config, we are printing addtional line like below. This
PR is to fix that.

For example, cmd `bin/kafka-storage.sh random-uuid` gives

```
-Dlog4j.configuration=file:/Users/manikumar/releases/log4j.properties
DEPRECATED: A Log4j 1.x configuration file has been detected, which is
no longer recommended.
To use a Log4j 2.x configuration, please see
https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat
for details about Log4j configuration file migration.
You can also use the $KAFKA_HOME/config/tools-log4j2.yaml file as a
starting point. Make sure to remove the Log4j 1.x configuration after
completing the migration.
[2025-04-17 11:45:24,697] INFO Registered
kafka:type=kafka.Log4jController MBean
(kafka.utils.Log4jControllerRegistration$)
ul14bI6fSnmRYTWa6MnzOQ
```
