### PR TITLE
MINOR: Move candidateClients set creation outside of task loop for StickyTaskAssignor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/assignors/StickyTaskAssignor.java
@@ -178,10 +178,10 @@ public class StickyTaskAssignor implements TaskAssignor {
         // assign any remaining unassigned tasks
         final List<TaskId> sortedTasks = new ArrayList<>(unassigned);
         Collections.sort(sortedTasks);
-        for (final TaskId taskId : sortedTasks) {
-            final Set<ProcessId> candidateClients = clients.stream()
+        final Set<ProcessId> candidateClients = clients.stream()
                 .map(KafkaStreamsState::processId)
                 .collect(Collectors.toSet());
+        for (final TaskId taskId : sortedTasks) {
             final ProcessId bestClient = assignmentState.findBestClientForTask(taskId, candidateClients);
             assignmentState.finalizeAssignment(taskId, bestClient, AssignedTask.Type.ACTIVE);
         }


### PR DESCRIPTION
This PR moves the computation of the "client list", which is the same
for all tasks,  out of the loop, to avoid unnecessary re-computation.

Reviewers: Matthias J. Sax <matthias@confluent.io>
