### PR TITLE
WIP: Test against Java 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: 23
+          java-version: 24
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         # If we change these, make sure to adjust ci-complete.yml
-        java: [ 23, 17 ]
+        java: [ 24, 17 ]
         run-flaky: [ true, false ]
         run-new: [ true, false ]
         exclude:
@@ -270,7 +270,7 @@ jobs:
           python .github/scripts/junit.py \
            --path build/junit-xml >> $GITHUB_STEP_SUMMARY
 
-  # This job downloads all the JUnit XML files and thread dumps from the JDK 23 test runs.
+  # This job downloads all the JUnit XML files and thread dumps from the JDK 24 test runs.
   # If any test job fails, we will not run this job. Also, if any thread dump artifacts
   # are present, this means there was a timeout in the tests and so we will not proceed
   # with catalog creation.
@@ -288,7 +288,7 @@ jobs:
       - name: Download Thread Dumps
         uses: actions/download-artifact@v4
         with:
-          pattern: junit-thread-dumps-23-*
+          pattern: junit-thread-dumps-24-*
           path: thread-dumps
           merge-multiple: true
       - name: Check For Thread Dump
@@ -302,7 +302,7 @@ jobs:
       - name: Download JUnit XMLs
         uses: actions/download-artifact@v4
         with:
-          pattern: junit-xml-23-*  # Only look at JDK 23 tests for the test catalog
+          pattern: junit-xml-24-*  # Only look at JDK 24 tests for the test catalog
           path: junit-xml
           merge-multiple: true
       - name: Collate Test Catalog

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # Make sure these match build.yml
-        java: [ 23, 17 ]
+        java: [ 24, 17 ]
         run-flaky: [ true, false ]
         run-new: [ true, false ]
         exclude:

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -247,9 +247,9 @@ License Version 2.0:
 - opentelemetry-proto-1.0.0-alpha
 - plexus-utils-3.5.1
 - rocksdbjni-9.7.3
-- scala-library-2.13.15
+- scala-library-2.13.16
 - scala-logging_2.13-3.9.5
-- scala-reflect-2.13.15
+- scala-reflect-2.13.16
 - snappy-java-1.1.10.5
 - snakeyaml-2.2
 - swagger-annotations-2.2.25

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-We build and test Apache Kafka with 17 and 23. The `release` parameter in javac is set to `11` for the clients 
+We build and test Apache Kafka with 17 and 24. The `release` parameter in javac is set to `11` for the clients 
 and streams modules, and `17` for the rest, ensuring compatibility with their respective
 minimum Java versions. Similarly, the `release` parameter in scalac is set to `11` for the streams modules and `17`
 for the rest.

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -49,7 +49,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.13.15
+  SCALA_VERSION=2.13.16
   if [[ -f "$base_dir/gradle.properties" ]]; then
     SCALA_VERSION=`grep "^scalaVersion=" "$base_dir/gradle.properties" | cut -d= -f 2`
   fi

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.13.15
+  set SCALA_VERSION=2.13.16
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
-  id "com.github.spotbugs" version '6.0.25' apply false
+  id "com.github.spotbugs" version '6.1.7' apply false
   id 'org.scoverage' version '8.0.3' apply false
   id 'com.gradleup.shadow' version '8.3.6' apply false
   id 'com.diffplug.spotless' version "6.25.0"
@@ -163,6 +163,7 @@ ext {
 allprojects {
 
   repositories {
+    mavenLocal()
     mavenCentral()
   }
 

--- a/docs/documentation/compatibility.html
+++ b/docs/documentation/compatibility.html
@@ -30,7 +30,7 @@
                 <th>Kafka Version</th>
                 <th>Java 11</th>
                 <th>Java 17</th>
-                <th>Java 23</th>
+                <th>Java 24</th>
             </tr>
             <tr>
                 <td>Clients</td>

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ group=org.apache.kafka
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
 version=4.1.0-SNAPSHOT
-scalaVersion=2.13.15
+scalaVersion=2.13.16
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.25
 task=build

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
 }
 
 // Add Scala version
-def defaultScala213Version = '2.13.15'
+def defaultScala213Version = '2.13.16'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.13') {
     versions["scala"] = defaultScala213Version
@@ -121,7 +121,7 @@ versions += [
   scoverage: "2.0.11",
   slf4j: "1.7.36",
   snappy: "1.1.10.5",
-  spotbugs: "4.8.6",
+  spotbugs: "4.9.4-SNAPSHOT",
   zinc: "1.9.2",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -550,4 +550,153 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
     </Match>
 
+    <Match>
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.3.
+        These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading to Java 24.
+         -->
+        <Or>
+            <Class name="org.apache.kafka.clients.producer.MockProducer"/>
+            <Class name="org.apache.kafka.clients.producer.internals.ProducerBatch"/>
+            <Class name="org.apache.kafka.common.utils.ChunkedBytesStream"/>
+            <Class name="org.apache.kafka.common.security.authenticator.LoginManager"/>
+            <Class name="org.apache.kafka.storage.internals.log.AbstractIndex"/>
+            <Class name="org.apache.kafka.server.AssignmentsManager"/>
+            <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
+            <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
+            <Class name="org.apache.kafka.streams.state.internals.AbstractDualSchemaRocksDBSegmentedBytesStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemorySessionStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemoryWindowStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.ThreadCache"/>
+            <Class name="org.apache.kafka.connect.runtime.WorkerSinkTask"/>
+            <Class name="org.apache.kafka.tools.VerifiableProducer"/>
+            <Class name="kafka.coordinator.transaction.TransactionMetadata"/>
+            <Class name="org.apache.kafka.tools.VerifiableShareConsumer"/>
+        </Or>
+        <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+    </Match>
+
+    <Match>
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.3.
+        These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading to Java 24.
+         -->
+        <Or>
+            <Class name="org.apache.kafka.clients.producer.internals.ProducerBatch"/>
+            <Class name="org.apache.kafka.clients.producer.internals.RecordAccumulator"/>
+            <Class name="org.apache.kafka.common.security.kerberos.KerberosLogin"/>
+            <Class name="org.apache.kafka.server.util.timer.TimingWheel"/>
+            <Class name="org.apache.kafka.server.log.remote.metadata.storage.ConsumerTask"/>
+            <Class name="org.apache.kafka.storage.internals.log.LogSegment"/>
+            <Class name="org.apache.kafka.storage.internals.log.ProducerStateManager"/>
+            <Class name="org.apache.kafka.image.publisher.SnapshotGenerator"/>
+            <Class name="org.apache.kafka.image.publisher.SnapshotGenerator$Builder"/>
+            <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
+            <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer"/>
+            <Class name="org.apache.kafka.connect.runtime.WorkerSinkTask"/>
+            <Class name="org.apache.kafka.tools.ConsumerPerformance$ConsumerPerfRebListener"/>
+            <Class name="kafka.coordinator.transaction.TransactionMetadata"/>
+            <Class name="kafka.server.BrokerLifecycleManager"/>
+            <Class name="kafka.server.CachedPartition"/>
+            <Class name="kafka.server.ControllerRegistrationManager"/>
+            <Class name="kafka.server.FetchSession"/>
+            <Class name="kafka.server.share.SharePartition"/>
+        </Or>
+        <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.3.
+        These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading to Java 24.
+         -->
+        <Or>
+            <Class name="org.apache.kafka.clients.consumer.MockConsumer"/>
+            <Class name="org.apache.kafka.clients.consumer.internals.AbstractMembershipManager"/>
+            <Class name="org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer"/>
+            <Class name="org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer"/>
+            <Class name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator"/>
+            <Class name="org.apache.kafka.clients.consumer.internals.ShareConsumeRequestManager"/>
+            <Class name="org.apache.kafka.clients.consumer.internals.StreamsMembershipManager"/>
+            <Class name="org.apache.kafka.clients.producer.MockProducer"/>
+            <Class name="org.apache.kafka.clients.producer.internals.ProducerBatch"/>
+            <Class name="org.apache.kafka.clients.producer.internals.TransactionManager"/>
+            <Class name="org.apache.kafka.common.network.Selector"/>
+            <Class name="org.apache.kafka.common.security.authenticator.LoginManager"/>
+            <Class name="org.apache.kafka.common.security.authenticator.SaslClientAuthenticator"/>
+            <Class name="org.apache.kafka.common.security.kerberos.KerberosLogin"/>
+            <Class name="org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler"/>
+            <Class name="org.apache.kafka.common.security.oauthbearer.internals.secured.RefreshingHttpsJwks"/>
+            <Class name="org.apache.kafka.common.utils.ChunkedBytesStream"/>
+            <Class name="org.apache.kafka.common.utils.Shell"/>
+            <Class name="org.apache.kafka.clients.producer.internals.TransactionManager$TxnRequestHandler"/>
+            <Class name="org.apache.kafka.server.log.remote.metadata.storage.ConsumerTask"/>
+            <Class name="org.apache.kafka.storage.internals.log.LogSegment"/>
+            <Class name="org.apache.kafka.image.publisher.SnapshotGenerator$Builder"/>
+            <Class name="org.apache.kafka.server.AssignmentsManager"/>
+            <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
+            <Class name="org.apache.kafka.streams.processor.internals.InternalTopologyBuilder"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
+            <Class name="org.apache.kafka.streams.processor.internals.TaskManager"/>
+            <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer"/>
+            <Class name="org.apache.kafka.streams.state.internals.RocksDBStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.TimeOrderedCachingWindowStore"/>
+            <Class name="org.apache.kafka.connect.runtime.AbstractWorkerSourceTask"/>
+            <Class name="org.apache.kafka.connect.runtime.ExactlyOnceWorkerSourceTask"/>
+            <Class name="org.apache.kafka.connect.runtime.WorkerSinkTask"/>
+            <Class name="org.apache.kafka.connect.runtime.distributed.DistributedHerder"/>
+            <Class name="org.apache.kafka.connect.runtime.distributed.WorkerCoordinator"/>
+            <Class name="org.apache.kafka.connect.runtime.distributed.WorkerGroupMember"/>
+            <Class name="org.apache.kafka.connect.util.KafkaBasedLog"/>
+            <Class name="org.apache.kafka.tools.VerifiableProducer"/>
+            <Class name="kafka.coordinator.transaction.TransactionMetadata"/>
+            <Class name="kafka.network.Acceptor"/>
+            <Class name="kafka.network.Processor"/>
+            <Class name="kafka.server.BrokerLifecycleManager"/>
+            <Class name="kafka.server.BrokerServer"/>
+            <Class name="kafka.server.CachedPartition"/>
+            <Class name="kafka.server.ControllerRegistrationManager"/>
+            <Class name="kafka.server.FetchSession"/>
+            <Class name="kafka.server.KafkaConfig"/>
+            <Class name="kafka.server.metadata.BrokerMetadataPublisher"/>
+            <Class name="kafka.server.metadata.DelegationTokenPublisher"/>
+            <Class name="org.apache.kafka.connect.mirror.MirrorSourceConnector"/>
+        </Or>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.3.
+        These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading to Java 24.
+         -->
+        <Or>
+            <Class name="kafka.coordinator.transaction.CompleteCommit"/>
+            <Class name="kafka.coordinator.transaction.CompleteAbort"/>
+            <Class name="kafka.coordinator.transaction.Dead"/>
+            <Class name="kafka.coordinator.transaction.Empty"/>
+            <Class name="kafka.coordinator.transaction.Ongoing"/>
+            <Class name="kafka.coordinator.transaction.PrepareAbort"/>
+            <Class name="kafka.coordinator.transaction.PrepareCommit"/>
+            <Class name="kafka.coordinator.transaction.PrepareEpochFence"/>
+            <Class name="kafka.server.Fetching"/>
+            <Class name="kafka.server.Truncating"/>
+            <Class name="kafka.server.addPartition"/>
+            <Class name="kafka.server.defaultError"/>
+            <Class name="kafka.server.genericErrorSupported"/>
+            <Class name="kafka.server.metadata.DefaultClientIdEntity"/>
+            <Class name="kafka.server.metadata.DefaultIpEntity"/>
+            <Class name="kafka.server.metadata.DefaultUserDefaultClientIdEntity"/>
+            <Class name="kafka.server.metadata.DefaultUserEntity"/>
+            <Class name="org.apache.kafka.connect.runtime.SinkConnectorConfig"/>
+            <Class name="org.apache.kafka.connect.runtime.SourceConnectorConfig"/>
+        </Or>
+        <Bug pattern="HSM_HIDING_METHOD"/>
+    </Match>
+
 </FindBugsFilter>

--- a/gradlew
+++ b/gradlew
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ##############################################################################
 #
@@ -55,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -84,7 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -112,20 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-
-# Loop in case we encounter an error.
-for attempt in 1 2 3; do
-  if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.14.0/gradle/wrapper/gradle-wrapper.jar"; then
-      rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
-      # Pause for a bit before looping in case the server throttled us.
-      sleep 5
-      continue
-    fi
-  fi
-done
-
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -216,7 +205,7 @@ fi
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
@@ -224,7 +213,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        org.gradle.wrapper.GradleWrapperMain \
+        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 
 # Stop when "xargs" is not available.
@@ -258,5 +247,18 @@ eval "set -- $(
         sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
         tr '\n' ' '
     )" '"$@"'
+
+
+# Loop in case we encounter an error.
+for attempt in 1 2 3; do
+  if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.14.0/gradle/wrapper/gradle-wrapper.jar"; then
+      rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
+      # Pause for a bit before looping in case the server throttled us.
+      sleep 5
+      continue
+    fi
+  fi
+done
 
 exec "$JAVACMD" "$@"

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -65,8 +65,8 @@ task bootstrapWrapper() {
         wrapperScript.withPrintWriter { out ->
             def bootstrapWritten = false
             wrapperLines.each { line ->
-                // Print the wrapper bootstrap before the first usage of the wrapper jar.
-                if (!bootstrapWritten && line.contains("gradle-wrapper.jar")) {
+                // Print the wrapper bootstrap before the script execs the wrapper jar.
+                if (!bootstrapWritten && line.startsWith("exec ")) {
                     out.println(bootstrapString)
                     bootstrapWritten = true
                 }


### PR DESCRIPTION
WIP: This PR still uses a Gradle 8.14 RC, and Spotbugs 4.9.4 has not
released yet, so testing it requires a local build.

Upgrade Scala to 2.13.16, in order to get a Java 24-compatible ASM
version.

Upgrade Gradle to 8.14, which is the first Java 24 compatible version.

Upgrade spotbugs to 4.9.4. This is the minimum version that's both  Java
24 compatible, and not affected by
https://github.com/spotbugs/spotbugs/issues/3320

Since the new spotbugs version introduces some extra checks, this commit
excludes those warnings, without looking at whether they are real issues
or false positives.

Addressing those warnings is left as future work, since the code is no
worse now than before the issues were highlighted.
