### PR TITLE
KAFKA-19166 Fix RC tag in release script

### DIFF
--- a/release/git.py
+++ b/release/git.py
@@ -128,8 +128,12 @@ def create_tag(tag, **kwargs):
     cmd(f"Creating git tag {tag}", ["git", "tag", "-a", tag, "-m", tag], **kwargs)
 
 
-def push_tag(tag, remote=push_remote_name, **kwargs):
+def push_ref(ref, remote=push_remote_name, **kwargs):
     __defaults(kwargs)
-    cmd("Pushing tag {tag} to {remote}", f"git push {remote} {tag}")
+    cmd(f"Pushing ref {ref} to {remote}", f"git push {remote} {ref}")
 
+
+def merge_ref(ref, **kwargs): 
+    __defaults(kwargs)
+    cmd(f"Merging ref {ref}", f"git merge {ref}")
 

--- a/release/release.py
+++ b/release/release.py
@@ -297,6 +297,7 @@ textfiles.replace(f"{repo_dir}/docs/js/templateData.js", "-SNAPSHOT", "", regex=
 git.commit(f"Bump version to {release_version}")
 git.create_tag(rc_tag)
 git.switch_branch(starting_branch)
+git.merge_ref(rc_tag)
 
 # Note that we don't use tempfile here because mkdtemp causes problems with being able to determine the absolute path to a file.
 # Instead we rely on a fixed path
@@ -367,7 +368,8 @@ confirm_or_fail("Have you sufficiently verified the release artifacts?")
 print(templates.deploy_instructions())
 confirm_or_fail("Have you successfully deployed the artifacts?")
 confirm_or_fail(f"Ok to push RC tag {rc_tag}?")
-git.push_tag(rc_tag)
+git.push_ref(rc_tag)
+git.push_ref(starting_branch)
 
 # Move back to starting branch and clean out the temporary release branch (e.g. 1.0.0) we used to generate everything
 git.reset_hard_head()


### PR DESCRIPTION
The release script was pushing the RC tag off of a temporary branch that
was never merged back into the release branch. This meant that our RC
and release tags were detached from the rest of the repository.

This patch changes the release script to merge the RC tag back into the
release branch and pushes both the tag and the branch.
