### PR TITLE
MINOR: Fix typo in ApiKeyVersionsProvider exception message

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/utils/annotation/ApiKeyVersionsProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/annotation/ApiKeyVersionsProvider.java
@@ -52,7 +52,7 @@ public class ApiKeyVersionsProvider implements ArgumentsProvider, AnnotationCons
 
         if (toVersion > latestVersion) {
             throw new IllegalArgumentException(String.format("The toVersion %s is newer than the latest version %s",
-                fromVersion, latestVersion));
+                toVersion, latestVersion));
         }
     }
 


### PR DESCRIPTION
This patch addresses issue #19516 and corrects a typo in
`ApiKeyVersionsProvider`: when `toVersion` exceeds  `latestVersion`, the
`IllegalArgumentException` message was erroneously formatted with
`fromVersion`. The format argument has been updated to use `toVersion`
so that the error message reports the correct value.

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Chia-Ping
 Tsai <chia7712@gmail.com>
