### PR TITLE
KAFKA-19180: Fix the hanging testPendingTaskSize

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
@@ -220,7 +220,9 @@ class SchedulerTest {
     scheduler.scheduleOnce("task1", task1, 0)
     scheduler.scheduleOnce("task2", () => latch2.countDown(), 5)
     scheduler.scheduleOnce("task3", () => latch2.countDown(), 5)
-    assertEquals(2, scheduler.pendingTaskSize())
+    retry(30000) {
+      assertEquals(2, scheduler.pendingTaskSize())
+    }
     latch1.countDown()
     latch2.await()
     assertEquals(0, scheduler.pendingTaskSize())

--- a/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/SchedulerTest.scala
@@ -225,7 +225,9 @@ class SchedulerTest {
     }
     latch1.countDown()
     latch2.await()
-    assertEquals(0, scheduler.pendingTaskSize())
+    retry(30000) {
+      assertEquals(0, scheduler.pendingTaskSize())
+    }
     scheduler.shutdown()
     assertEquals(0, scheduler.pendingTaskSize())
   }


### PR DESCRIPTION
The check for `scheduler.pendingTaskSize()` may fail if the thread pool
is too slow to consume the runnable objects.  Jira:
https://issues.apache.org/jira/browse/KAFKA-19180

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
