### PR TITLE
MINOR: Update system test dev version to 3.9.1

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -122,7 +122,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("3.9.1-SNAPSHOT")
+DEV_VERSION = KafkaVersion("3.9.1")
 
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
 LATEST_STABLE_METADATA_VERSION = "3.9-IV0"


### PR DESCRIPTION
Ran system test based on 3.9 branch, but got the error: 
`Did expect to read 'Kafka version.*3.9.1.*SNAPSHOT' from ducker@ducker04`. It's because the version should be `3.9.1` without snapshot. Update the version.

Reviewers: TengYao Chi <frankvicky@apache.org>
