### PR TITLE
KAFKA-19185: add logs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -131,6 +131,7 @@ public class ConsumerNetworkClient implements Closeable {
         ClientRequest clientRequest = client.newClientRequest(node.idString(), requestBuilder, now, true,
             requestTimeoutMs, completionHandler);
         unsent.put(node, clientRequest);
+        log.info("Generated FETCH with correlation id {}.", clientRequest.correlationId());
 
         // wakeup the client in case it is blocking in poll so that we can send the queued request
         client.wakeup();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -195,6 +195,7 @@ public class Fetcher<K, V> extends AbstractFetch {
             responseFuture.addListener(new RequestFutureListener<>() {
                 @Override
                 public void onSuccess(ClientResponse resp) {
+                    log.info("The client got FETCH response with correlation  id {}.", resp.requestHeader().correlationId());
                     successHandler.handle(fetchTarget, data, resp);
                 }
 


### PR DESCRIPTION
This PR aims at enhancing logging in `Consumer` request/response as follows:
- Logging when a FETCH request is generated, including the correlation ID. 
- Logging the response received before any processing 