### PR TITLE
KAFKA-19181: removed assertions in test_share_multiple_partitions as a result of change in assignor algorithm

### DIFF
--- a/tests/kafkatest/tests/client/share_consumer_test.py
+++ b/tests/kafkatest/tests/client/share_consumer_test.py
@@ -168,11 +168,6 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         for event_handler in consumer.event_handlers.values():
             assert event_handler.total_consumed > 0
             assert event_handler.total_acknowledged_successfully > 0
-            for topic_partition in self.get_topic_partitions(self.TOPIC2):
-                assert topic_partition in event_handler.consumed_per_partition
-                assert event_handler.consumed_per_partition[topic_partition] > 0
-                assert topic_partition in event_handler.acknowledged_per_partition
-                assert event_handler.acknowledged_per_partition[topic_partition] > 0
 
         producer.stop()
         consumer.stop_all()


### PR DESCRIPTION
The system test `ShareConsumerTest.test_share_multiple_partitions`
started failing because of the recent change in the SimpleAssignor
algorithm. The tests assumed that if a share group is subscribed to a
topic, then every share consumers part of the group will be assigned all
partitions of the topic. But that does not happen now, and partitions
are split between the share consumers in certain cases, in which some
partitions are only assigned to a subset of share consumers. This change
removes that assumption

Refer: [KAFKA-19181](https://issues.apache.org/jira/browse/KAFKA-19181)
