### PR TITLE
KAFKA-19168: MirrorMaker kafka_metrics_count metric is always incorrect

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
@@ -38,7 +39,7 @@ class MirrorCheckpointMetrics implements AutoCloseable {
 
     private static final String CHECKPOINT_CONNECTOR_GROUP = MirrorCheckpointConnector.class.getSimpleName();
 
-    private static final Set<String> GROUP_TAGS = new HashSet<>(Arrays.asList("source", "target", "group", "topic", "partition", "connector", "task_index"));
+    private static final Set<String> GROUP_TAGS = new HashSet<>(Arrays.asList("source", "target", "group", "topic", "partition", "connector", "task"));
 
     private static final MetricNameTemplate CHECKPOINT_LATENCY = new MetricNameTemplate(
             "checkpoint-latency-ms", CHECKPOINT_CONNECTOR_GROUP,
@@ -64,9 +65,13 @@ class MirrorCheckpointMetrics implements AutoCloseable {
     MirrorCheckpointMetrics(MirrorCheckpointTaskConfig taskConfig) {
         this.target = taskConfig.targetClusterAlias();
         this.source = taskConfig.sourceClusterAlias();
-        this.metrics = new Metrics();
         this.connectorName = taskConfig.connectorName();
         this.taskIndex = taskConfig.getInt(MirrorConnectorConfig.TASK_INDEX);
+        Map<String, String> metricsTags = new LinkedHashMap<>();
+        metricsTags.put("connector", connectorName);
+        metricsTags.put("task", String.valueOf(taskIndex));
+        MetricConfig metricConfig = new MetricConfig().tags(metricsTags);
+        this.metrics = new Metrics(metricConfig);
 
         // for side-effect
         metrics.sensor("record-count");
@@ -104,7 +109,7 @@ class MirrorCheckpointMetrics implements AutoCloseable {
             tags.put("topic", topicPartition.topic());
             tags.put("partition", Integer.toString(topicPartition.partition()));
             tags.put("connector", connectorName);
-            tags.put("task_index", String.valueOf(taskIndex));
+            tags.put("task", String.valueOf(taskIndex));
 
             checkpointLatencySensor = metrics.sensor("checkpoint-latency");
             checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY, tags), new Value());

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetrics.java
@@ -38,7 +38,7 @@ class MirrorCheckpointMetrics implements AutoCloseable {
 
     private static final String CHECKPOINT_CONNECTOR_GROUP = MirrorCheckpointConnector.class.getSimpleName();
 
-    private static final Set<String> GROUP_TAGS = new HashSet<>(Arrays.asList("source", "target", "group", "topic", "partition"));
+    private static final Set<String> GROUP_TAGS = new HashSet<>(Arrays.asList("source", "target", "group", "topic", "partition", "connector", "task_index"));
 
     private static final MetricNameTemplate CHECKPOINT_LATENCY = new MetricNameTemplate(
             "checkpoint-latency-ms", CHECKPOINT_CONNECTOR_GROUP,
@@ -58,11 +58,15 @@ class MirrorCheckpointMetrics implements AutoCloseable {
     private final Map<String, GroupMetrics> groupMetrics = new HashMap<>();
     private final String source;
     private final String target;
+    private final String connectorName;
+    private final int taskIndex;
 
     MirrorCheckpointMetrics(MirrorCheckpointTaskConfig taskConfig) {
         this.target = taskConfig.targetClusterAlias();
         this.source = taskConfig.sourceClusterAlias();
         this.metrics = new Metrics();
+        this.connectorName = taskConfig.connectorName();
+        this.taskIndex = taskConfig.getInt(MirrorConnectorConfig.TASK_INDEX);
 
         // for side-effect
         metrics.sensor("record-count");
@@ -99,7 +103,9 @@ class MirrorCheckpointMetrics implements AutoCloseable {
             tags.put("group", group);
             tags.put("topic", topicPartition.topic());
             tags.put("partition", Integer.toString(topicPartition.partition()));
- 
+            tags.put("connector", connectorName);
+            tags.put("task_index", String.valueOf(taskIndex));
+
             checkpointLatencySensor = metrics.sensor("checkpoint-latency");
             checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY, tags), new Value());
             checkpointLatencySensor.add(metrics.metricInstance(CHECKPOINT_LATENCY_MAX, tags), new Max());

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
@@ -39,6 +39,8 @@ class MirrorSourceMetrics implements AutoCloseable {
 
     private static final String SOURCE_CONNECTOR_GROUP = MirrorSourceConnector.class.getSimpleName();
 
+    private static final Set<String> PARTITION_TAGS = new HashSet<>(Arrays.asList("source", "target", "topic", "partition", "connector", "task_index"));
+
     private final MetricNameTemplate recordCount;
     private final MetricNameTemplate recordRate;
     private final MetricNameTemplate recordAge;
@@ -56,50 +58,52 @@ class MirrorSourceMetrics implements AutoCloseable {
     private final Map<TopicPartition, PartitionMetrics> partitionMetrics;
     private final String source;
     private final String target;
+    private final String connectorName;
+    private final int taskIndex;
 
     MirrorSourceMetrics(MirrorSourceTaskConfig taskConfig) {
         this.target = taskConfig.targetClusterAlias();
         this.source = taskConfig.sourceClusterAlias();
+        this.connectorName = taskConfig.connectorName();
+        this.taskIndex = taskConfig.getInt(MirrorConnectorConfig.TASK_INDEX);
         this.metrics = new Metrics();
-
-        Set<String> partitionTags = new HashSet<>(Arrays.asList("source", "target", "topic", "partition"));
 
         recordCount = new MetricNameTemplate(
                 "record-count", SOURCE_CONNECTOR_GROUP,
-                "Number of source records replicated to the target cluster.", partitionTags);
+                "Number of source records replicated to the target cluster.", PARTITION_TAGS);
         recordRate = new MetricNameTemplate(
                 "record-rate", SOURCE_CONNECTOR_GROUP,
-                "Average number of source records replicated to the target cluster per second.", partitionTags);
+                "Average number of source records replicated to the target cluster per second.", PARTITION_TAGS);
         recordAge = new MetricNameTemplate(
                 "record-age-ms", SOURCE_CONNECTOR_GROUP,
-                "The age of incoming source records when replicated to the target cluster.", partitionTags);
+                "The age of incoming source records when replicated to the target cluster.", PARTITION_TAGS);
         recordAgeMax = new MetricNameTemplate(
                 "record-age-ms-max", SOURCE_CONNECTOR_GROUP,
-                "The max age of incoming source records when replicated to the target cluster.", partitionTags);
+                "The max age of incoming source records when replicated to the target cluster.", PARTITION_TAGS);
         recordAgeMin = new MetricNameTemplate(
                 "record-age-ms-min", SOURCE_CONNECTOR_GROUP,
-                "The min age of incoming source records when replicated to the target cluster.", partitionTags);
+                "The min age of incoming source records when replicated to the target cluster.", PARTITION_TAGS);
         recordAgeAvg = new MetricNameTemplate(
                 "record-age-ms-avg", SOURCE_CONNECTOR_GROUP,
-                "The average age of incoming source records when replicated to the target cluster.", partitionTags);
+                "The average age of incoming source records when replicated to the target cluster.", PARTITION_TAGS);
         byteCount = new MetricNameTemplate(
                 "byte-count", SOURCE_CONNECTOR_GROUP,
-                "Number of bytes replicated to the target cluster.", partitionTags);
+                "Number of bytes replicated to the target cluster.", PARTITION_TAGS);
         byteRate = new MetricNameTemplate(
                 "byte-rate", SOURCE_CONNECTOR_GROUP,
-                "Average number of bytes replicated per second.", partitionTags);
+                "Average number of bytes replicated per second.", PARTITION_TAGS);
         replicationLatency = new MetricNameTemplate(
                 "replication-latency-ms", SOURCE_CONNECTOR_GROUP,
-                "Time it takes records to replicate from source to target cluster.", partitionTags);
+                "Time it takes records to replicate from source to target cluster.", PARTITION_TAGS);
         replicationLatencyMax = new MetricNameTemplate(
                 "replication-latency-ms-max", SOURCE_CONNECTOR_GROUP,
-                "Max time it takes records to replicate from source to target cluster.", partitionTags);
+                "Max time it takes records to replicate from source to target cluster.", PARTITION_TAGS);
         replicationLatencyMin = new MetricNameTemplate(
                 "replication-latency-ms-min", SOURCE_CONNECTOR_GROUP,
-                "Min time it takes records to replicate from source to target cluster.", partitionTags);
+                "Min time it takes records to replicate from source to target cluster.", PARTITION_TAGS);
         replicationLatencyAvg = new MetricNameTemplate(
                 "replication-latency-ms-avg", SOURCE_CONNECTOR_GROUP,
-                "Average time it takes records to replicate from source to target cluster.", partitionTags);
+                "Average time it takes records to replicate from source to target cluster.", PARTITION_TAGS);
 
         // for side-effect
         metrics.sensor("record-count");
@@ -153,6 +157,8 @@ class MirrorSourceMetrics implements AutoCloseable {
             tags.put("target", target); 
             tags.put("topic", topicPartition.topic());
             tags.put("partition", Integer.toString(topicPartition.partition()));
+            tags.put("connector", connectorName);
+            tags.put("task_index", String.valueOf(taskIndex));
 
             recordSensor = metrics.sensor(prefix + "records-sent");
             recordSensor.add(new Meter(metrics.metricInstance(recordRate, tags), metrics.metricInstance(recordCount, tags)));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceMetrics.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
@@ -39,7 +40,7 @@ class MirrorSourceMetrics implements AutoCloseable {
 
     private static final String SOURCE_CONNECTOR_GROUP = MirrorSourceConnector.class.getSimpleName();
 
-    private static final Set<String> PARTITION_TAGS = new HashSet<>(Arrays.asList("source", "target", "topic", "partition", "connector", "task_index"));
+    private static final Set<String> PARTITION_TAGS = new HashSet<>(Arrays.asList("source", "target", "topic", "partition", "connector", "task"));
 
     private final MetricNameTemplate recordCount;
     private final MetricNameTemplate recordRate;
@@ -66,7 +67,11 @@ class MirrorSourceMetrics implements AutoCloseable {
         this.source = taskConfig.sourceClusterAlias();
         this.connectorName = taskConfig.connectorName();
         this.taskIndex = taskConfig.getInt(MirrorConnectorConfig.TASK_INDEX);
-        this.metrics = new Metrics();
+        Map<String, String> metricsTags = new LinkedHashMap<>();
+        metricsTags.put("connector", connectorName);
+        metricsTags.put("task", String.valueOf(taskIndex));
+        MetricConfig metricConfig = new MetricConfig().tags(metricsTags);
+        this.metrics = new Metrics(metricConfig);
 
         recordCount = new MetricNameTemplate(
                 "record-count", SOURCE_CONNECTOR_GROUP,
@@ -158,7 +163,7 @@ class MirrorSourceMetrics implements AutoCloseable {
             tags.put("topic", topicPartition.topic());
             tags.put("partition", Integer.toString(topicPartition.partition()));
             tags.put("connector", connectorName);
-            tags.put("task_index", String.valueOf(taskIndex));
+            tags.put("task", String.valueOf(taskIndex));
 
             recordSensor = metrics.sensor(prefix + "records-sent");
             recordSensor.add(new Meter(metrics.metricInstance(recordRate, tags), metrics.metricInstance(recordCount, tags)));

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetricsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetricsTest.java
@@ -16,25 +16,27 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MirrorSourceMetricsTest {
-
+public class MirrorCheckpointMetricsTest {
     private static final String SOURCE = "source";
     private static final String TARGET = "target";
+    private static final String GROUP = "group";
     private static final TopicPartition TP = new TopicPartition("topic", 0);
     private static final TopicPartition SOURCE_TP = new TopicPartition(SOURCE + "." + TP.topic(), TP.partition());
     private static final String CONNECTOR_NAME = "name";
@@ -55,15 +57,21 @@ public class MirrorSourceMetricsTest {
 
     @Test
     public void testTags() {
-        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(configs);
-        MirrorSourceMetrics metrics = new MirrorSourceMetrics(taskConfig);
+        MirrorCheckpointTaskConfig taskConfig = new MirrorCheckpointTaskConfig(configs);
+        MirrorCheckpointMetrics metrics = new MirrorCheckpointMetrics(taskConfig);
         metrics.addReporter(reporter);
 
-        metrics.countRecord(SOURCE_TP);
-        assertEquals(13, reporter.metrics.size());
-        Map<String, String> tags = reporter.metrics.get(0).metricName().tags();
+        metrics.checkpointLatency(SOURCE_TP, GROUP, 0);
+
+        assertEquals(5, reporter.metrics.size());
+        MetricName metric = reporter.metrics.get(0).metricName();
+        if (Objects.equals(metric.group(), "kafka-metrics-count")) {
+            metric = reporter.metrics.get(1).metricName();
+        }
+        Map<String, String> tags = metric.tags();
         assertEquals(SOURCE, tags.get("source"));
         assertEquals(TARGET, tags.get("target"));
+        assertEquals(GROUP, tags.get("group"));
         assertEquals(SOURCE_TP.topic(), tags.get("topic"));
         assertEquals(String.valueOf(SOURCE_TP.partition()), tags.get("partition"));
         assertEquals(CONNECTOR_NAME, tags.get("connector"));

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetricsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetricsTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MirrorCheckpointMetricsTest {
     private static final String SOURCE = "source";
@@ -75,7 +76,27 @@ public class MirrorCheckpointMetricsTest {
         assertEquals(SOURCE_TP.topic(), tags.get("topic"));
         assertEquals(String.valueOf(SOURCE_TP.partition()), tags.get("partition"));
         assertEquals(CONNECTOR_NAME, tags.get("connector"));
-        assertEquals(String.valueOf(TASK_INDEX), tags.get("task_index"));
+        assertEquals(String.valueOf(TASK_INDEX), tags.get("task"));
+    }
+
+    @Test
+    public void testTagsForKafkaMetricsCount() {
+        MirrorCheckpointTaskConfig taskConfig = new MirrorCheckpointTaskConfig(configs);
+        MirrorCheckpointMetrics metrics = new MirrorCheckpointMetrics(taskConfig);
+        metrics.addReporter(reporter);
+
+        MetricName targetMetric = null;
+        for (KafkaMetric m : reporter.metrics) {
+            MetricName metricName = m.metricName();
+            if (metricName.group().equals("kafka-metrics-count")) {
+                targetMetric = metricName;
+                break;
+            }
+        }
+        assertNotNull(targetMetric);
+        Map<String, String> tags = targetMetric.tags();
+        assertEquals(CONNECTOR_NAME, tags.get("connector"));
+        assertEquals(String.valueOf(TASK_INDEX), tags.get("task"));
     }
 
     static class TestReporter implements MetricsReporter {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetricsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointMetricsTest.java
@@ -21,9 +21,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceMetricsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceMetricsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MirrorSourceMetricsTest {
 
@@ -67,7 +69,27 @@ public class MirrorSourceMetricsTest {
         assertEquals(SOURCE_TP.topic(), tags.get("topic"));
         assertEquals(String.valueOf(SOURCE_TP.partition()), tags.get("partition"));
         assertEquals(CONNECTOR_NAME, tags.get("connector"));
-        assertEquals(String.valueOf(TASK_INDEX), tags.get("task_index"));
+        assertEquals(String.valueOf(TASK_INDEX), tags.get("task"));
+    }
+
+    @Test
+    public void testTagsForKafkaMetricsCount() {
+        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(configs);
+        MirrorSourceMetrics metrics = new MirrorSourceMetrics(taskConfig);
+        metrics.addReporter(reporter);
+
+        MetricName targetMetric = null;
+        for (KafkaMetric m : reporter.metrics) {
+            MetricName metricName = m.metricName();
+            if (metricName.group().equals("kafka-metrics-count")) {
+                targetMetric = metricName;
+                break;
+            }
+        }
+        assertNotNull(targetMetric);
+        Map<String, String> tags = targetMetric.tags();
+        assertEquals(CONNECTOR_NAME, tags.get("connector"));
+        assertEquals(String.valueOf(TASK_INDEX), tags.get("task"));
     }
 
     static class TestReporter implements MetricsReporter {


### PR DESCRIPTION
Provide tags (connector name and task index) so that we get a
kafka.connect.mirror:type=kafka-metrics-count metric per task.

- Set the connector name and task index in the metrics for
MirrorSourceConnector and MirrorCheckpointConnector, and add
corresponding tests.
- Add the MirrorCheckpointMetricsTest.java unit test file.

Jira: [KAFKA-19168](https://issues.apache.org/jira/browse/KAFKA-19168)
