### PR TITLE
KAFKA-19205: inconsistent result of beginningOffsets/endoffset between classic and async consumer with 0 timeout

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1613,7 +1613,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @see #seekToBeginning(Collection)
      *
      * @param partitions the partitions to get the earliest offsets.
-     * @return The earliest available offsets for the given partitions
+     * @return The earliest available offsets for the given partitions, and it will return empty map if the offsets
+     *         cannot be retrieved within the timeout
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offset metadata could not be fetched before
@@ -1634,7 +1635,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param partitions the partitions to get the earliest offsets
      * @param timeout The maximum amount of time to await retrieval of the beginning offsets
      *
-     * @return The earliest available offsets for the given partitions
+     * @return The earliest available offsets for the given partitions, and it will return empty map if the offsets
+     *         cannot be retrieved within the timeout
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offset metadata could not be fetched before
@@ -1658,7 +1660,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @see #seekToEnd(Collection)
      *
      * @param partitions the partitions to get the end offsets.
-     * @return The end offsets for the given partitions.
+     * @return The end offsets for the given partitions, and it will return empty map if the offsets cannot be retrieved within the timeout
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offset metadata could not be fetched before
@@ -1684,7 +1686,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param partitions the partitions to get the end offsets.
      * @param timeout The maximum amount of time to await retrieval of the end offsets
      *
-     * @return The end offsets for the given partitions.
+     * @return The end offsets for the given partitions, and it will return empty map if the offsets cannot be retrieved within the timeout
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offsets could not be fetched before

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1613,8 +1613,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @see #seekToBeginning(Collection)
      *
      * @param partitions the partitions to get the earliest offsets.
-     * @return The earliest available offsets for the given partitions, and it will return empty map if the offsets
-     *         cannot be retrieved within the timeout
+     * @return The earliest available offsets for the given partitions
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offset metadata could not be fetched before
@@ -1635,8 +1634,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param partitions the partitions to get the earliest offsets
      * @param timeout The maximum amount of time to await retrieval of the beginning offsets
      *
-     * @return The earliest available offsets for the given partitions, and it will return empty map if the offsets
-     *         cannot be retrieved within the timeout
+     * @return The earliest available offsets for the given partitions, and it will return empty map if zero timeout is provided
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offset metadata could not be fetched before
@@ -1660,7 +1658,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @see #seekToEnd(Collection)
      *
      * @param partitions the partitions to get the end offsets.
-     * @return The end offsets for the given partitions, and it will return empty map if the offsets cannot be retrieved within the timeout
+     * @return The end offsets for the given partitions.
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offset metadata could not be fetched before
@@ -1686,7 +1684,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param partitions the partitions to get the end offsets.
      * @param timeout The maximum amount of time to await retrieval of the end offsets
      *
-     * @return The end offsets for the given partitions, and it will return empty map if the offsets cannot be retrieved within the timeout
+     * @return The end offsets for the given partitions, and it will return empty map if zero timeout is provided
      * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic(s). See the exception for more details
      * @throws org.apache.kafka.common.errors.TimeoutException if the offsets could not be fetched before

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1306,7 +1306,10 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             // and throw timeout exception if it cannot complete in time.
             if (timeout.isZero()) {
                 applicationEventHandler.add(listOffsetsEvent);
-                return listOffsetsEvent.emptyResults();
+                // It is used to align with classic consumer.
+                // When the "timeout == 0", the classic consumer will return an empty map.
+                // Therefore, the AsyncKafkaConsumer needs to be consistent with it.
+                return new HashMap<>();
             }
 
             Map<TopicPartition, OffsetAndTimestampInternal> offsetAndTimestampMap;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
@@ -21,7 +21,6 @@ import org.apache.kafka.clients.consumer.internals.OffsetAndTimestampInternal;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
@@ -49,6 +49,8 @@ public class ListOffsetsEvent extends CompletableApplicationEvent<Map<TopicParti
      * @return empty map
      */
     public <T> Map<TopicPartition, T> emptyResults() {
+        // It is used to align with classic consumer. When the timeout == 0, the classic consumer will return an empty map.
+        // Therefore, the AsyncKafkaConsumer needs to be consistent with it.
         return Map.of();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
@@ -50,7 +50,7 @@ public class ListOffsetsEvent extends CompletableApplicationEvent<Map<TopicParti
      * @return empty map
      */
     public <T> Map<TopicPartition, T> emptyResults() {
-        return new HashMap<>();
+        return Map.of();
     }
 
     public Map<TopicPartition, Long> timestampsToSearch() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.internals.OffsetAndTimestampInternal;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -46,12 +47,13 @@ public class ListOffsetsEvent extends CompletableApplicationEvent<Map<TopicParti
     /**
      * Build result representing that no offsets were found as part of the current event.
      *
-     * @return empty map
+     * @return Map containing all the partitions the event was trying to get offsets for, and
+     * null {@link OffsetAndTimestamp} as value
      */
     public <T> Map<TopicPartition, T> emptyResults() {
-        // It is used to align with classic consumer. When the timeout == 0, the classic consumer will return an empty map.
-        // Therefore, the AsyncKafkaConsumer needs to be consistent with it.
-        return Map.of();
+        Map<TopicPartition, T> result = new HashMap<>();
+        timestampsToSearch.keySet().forEach(tp -> result.put(tp, null));
+        return result;
     }
 
     public Map<TopicPartition, Long> timestampsToSearch() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsEvent.java
@@ -47,13 +47,10 @@ public class ListOffsetsEvent extends CompletableApplicationEvent<Map<TopicParti
     /**
      * Build result representing that no offsets were found as part of the current event.
      *
-     * @return Map containing all the partitions the event was trying to get offsets for, and
-     * null {@link OffsetAndTimestamp} as value
+     * @return empty map
      */
     public <T> Map<TopicPartition, T> emptyResults() {
-        Map<TopicPartition, T> result = new HashMap<>();
-        timestampsToSearch.keySet().forEach(tp -> result.put(tp, null));
-        return result;
+        return new HashMap<>();
     }
 
     public Map<TopicPartition, Long> timestampsToSearch() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -994,8 +994,8 @@ public class AsyncKafkaConsumerTest {
         Map<TopicPartition, Long> result =
                 assertDoesNotThrow(() -> consumer.beginningOffsets(Collections.singletonList(tp), Duration.ZERO));
         // The result should be {tp=null}
-        assertTrue(result.containsKey(tp));
-        assertNull(result.get(tp));
+        assertNotNull(result);
+        assertEquals(0, result.size());
         verify(applicationEventHandler).add(ArgumentMatchers.isA(ListOffsetsEvent.class));
     }
 
@@ -1003,11 +1003,11 @@ public class AsyncKafkaConsumerTest {
     public void testOffsetsForTimesWithZeroTimeout() {
         consumer = newConsumer();
         TopicPartition tp = new TopicPartition("topic1", 0);
-        Map<TopicPartition, OffsetAndTimestamp> expectedResult = Collections.singletonMap(tp, null);
         Map<TopicPartition, Long> timestampToSearch = Collections.singletonMap(tp, 5L);
         Map<TopicPartition, OffsetAndTimestamp> result =
             assertDoesNotThrow(() -> consumer.offsetsForTimes(timestampToSearch, Duration.ZERO));
-        assertEquals(expectedResult, result);
+        assertNotNull(result);
+        assertEquals(0, result.size());
         verify(applicationEventHandler, never()).addAndGet(ArgumentMatchers.isA(ListOffsetsEvent.class));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -993,7 +993,6 @@ public class AsyncKafkaConsumerTest {
         TopicPartition tp = new TopicPartition("topic1", 0);
         Map<TopicPartition, Long> result =
                 assertDoesNotThrow(() -> consumer.beginningOffsets(Collections.singletonList(tp), Duration.ZERO));
-        // The result should be {tp=null}
         assertNotNull(result);
         assertEquals(0, result.size());
         verify(applicationEventHandler).add(ArgumentMatchers.isA(ListOffsetsEvent.class));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -1003,11 +1003,11 @@ public class AsyncKafkaConsumerTest {
     public void testOffsetsForTimesWithZeroTimeout() {
         consumer = newConsumer();
         TopicPartition tp = new TopicPartition("topic1", 0);
+        Map<TopicPartition, OffsetAndTimestamp> expectedResult = Collections.singletonMap(tp, null);
         Map<TopicPartition, Long> timestampToSearch = Collections.singletonMap(tp, 5L);
         Map<TopicPartition, OffsetAndTimestamp> result =
             assertDoesNotThrow(() -> consumer.offsetsForTimes(timestampToSearch, Duration.ZERO));
-        assertNotNull(result);
-        assertEquals(0, result.size());
+        assertEquals(expectedResult, result);
         verify(applicationEventHandler, never()).addAndGet(ArgumentMatchers.isA(ListOffsetsEvent.class));
     }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -876,7 +876,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
-  def test(groupProtocol: String): Unit = {
+  def testBeginningAndEndOffsetsWhenTimeoutZero(groupProtocol: String): Unit = {
     val consumer = createConsumer()
     val result1 = consumer.beginningOffsets(util.List.of(tp), Duration.ZERO)
     assertNotNull(result1)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -14,6 +14,7 @@ package kafka.api
 
 import kafka.api.BaseConsumerTest.{DeserializerImpl, SerializerImpl}
 
+import java.lang.{Long => JLong}
 import java.time.Duration
 import java.util
 import java.util.Arrays.asList
@@ -876,7 +877,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
-  def testBeginningAndEndOffsetsWhenTimeoutZero(groupProtocol: String): Unit = {
+  def testOffsetRelatedWhenTimeoutZero(groupProtocol: String): Unit = {
     val consumer = createConsumer()
     val result1 = consumer.beginningOffsets(util.List.of(tp), Duration.ZERO)
     assertNotNull(result1)
@@ -885,5 +886,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val result2 = consumer.endOffsets(util.List.of(tp), Duration.ZERO)
     assertNotNull(result2)
     assertEquals(0, result2.size())
+
+    val result3 = consumer.offsetsForTimes(Map[TopicPartition, JLong]((tp, 0)).asJava, Duration.ZERO)
+    assertNotNull(result3)
+    assertEquals(1, result3.size())
+    assertNull(result3.get(tp))
   }
 }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -878,11 +878,11 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def test(groupProtocol: String): Unit = {
     val consumer = createConsumer()
-    val result1 = consumer.beginningOffsets(Collections.singleton(tp), Duration.ZERO)
+    val result1 = consumer.beginningOffsets(util.List.of(tp), Duration.ZERO)
     assertNotNull(result1)
     assertEquals(0, result1.size())
 
-    val result2 = consumer.endOffsets(Collections.singleton(tp), Duration.ZERO)
+    val result2 = consumer.endOffsets(util.List.of(tp), Duration.ZERO)
     assertNotNull(result2)
     assertEquals(0, result2.size())
   }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -873,4 +873,17 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       waitTimeMs=leaveGroupTimeoutMs
     )
   }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
+  @MethodSource(Array("getTestGroupProtocolParametersAll"))
+  def test(groupProtocol: String): Unit = {
+    val consumer = createConsumer()
+    val result1 = consumer.beginningOffsets(Collections.singleton(tp), Duration.ZERO)
+    assertNotNull(result1)
+    assertEquals(0, result1.size())
+
+    val result2 = consumer.endOffsets(Collections.singleton(tp), Duration.ZERO)
+    assertNotNull(result2)
+    assertEquals(0, result2.size())
+  }
 }


### PR DESCRIPTION
In the return results of the methods beginningOffsets and endOffset, if
timeout == 0, then an empty Map should be returned uniformly instead of
in the form of <TopicPartition, null>

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>, Lianet
 Magrans <lmagrans@confluent.io>
