### PR TITLE
KAFKA-19133: Support fetching for multiple remote fetch topic partitions in a single share fetch request

### DIFF
--- a/core/src/main/java/kafka/server/share/DelayedShareFetch.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetch.java
@@ -250,16 +250,18 @@ public class DelayedShareFetch extends DelayedOperation {
                 // updated in a different tryComplete thread.
                 responseData = combineLogReadResponse(topicPartitionData, localPartitionsAlreadyFetched);
 
-            updateFetchOffsetMetadataForRemoteFetchPartitions(topicPartitionData, responseData);
+            resetFetchOffsetMetadataForRemoteFetchPartitions(topicPartitionData, responseData);
 
             List<ShareFetchPartitionData> shareFetchPartitionDataList = new ArrayList<>();
-            responseData.forEach((topicIdPartition, logReadResult) ->
-                shareFetchPartitionDataList.add(new ShareFetchPartitionData(
-                    topicIdPartition,
-                    topicPartitionData.get(topicIdPartition),
-                    logReadResult.toFetchPartitionData(false)
-                ))
-            );
+            responseData.forEach((topicIdPartition, logReadResult) -> {
+                if (logReadResult.info().delayedRemoteStorageFetch.isEmpty()) {
+                    shareFetchPartitionDataList.add(new ShareFetchPartitionData(
+                        topicIdPartition,
+                        topicPartitionData.get(topicIdPartition),
+                        logReadResult.toFetchPartitionData(false)
+                    ));
+                }
+            });
 
             shareFetch.maybeComplete(ShareFetchUtils.processFetchResponse(
                 shareFetch,
@@ -278,7 +280,7 @@ public class DelayedShareFetch extends DelayedOperation {
 
     /**
      * This function updates the cached fetch offset metadata to null corresponding to the share partition's fetch offset.
-     * This is required in the case when a topic partition that has local log fetch during tryComplete changes to remote
+     * This is required in the case when a topic partition that has local log fetch during tryComplete, but changes to remote
      * storage fetch in onComplete. In this situation, if the cached fetchOffsetMetadata got updated in tryComplete, then
      * we will enter a state where each share fetch request for this topic partition from client will use the cached
      * fetchOffsetMetadata in tryComplete and return an empty response to the client from onComplete.
@@ -287,7 +289,7 @@ public class DelayedShareFetch extends DelayedOperation {
      * @param topicPartitionData - Map containing the fetch offset for the topic partitions.
      * @param replicaManagerReadResponse - Map containing the readFromLog response from replicaManager for the topic partitions.
      */
-    private void updateFetchOffsetMetadataForRemoteFetchPartitions(
+    private void resetFetchOffsetMetadataForRemoteFetchPartitions(
         LinkedHashMap<TopicIdPartition, Long> topicPartitionData,
         LinkedHashMap<TopicIdPartition, LogReadResult> replicaManagerReadResponse
     ) {
@@ -823,6 +825,7 @@ public class DelayedShareFetch extends DelayedOperation {
                     LinkedHashMap<TopicIdPartition, LogReadResult> responseData = readFromLog(
                         acquiredNonRemoteFetchTopicPartitionData,
                         partitionMaxBytesStrategy.maxBytes(shareFetch.fetchParams().maxBytes - readableBytes, acquiredNonRemoteFetchTopicPartitionData.keySet(), acquiredNonRemoteFetchTopicPartitionData.size()));
+                    resetFetchOffsetMetadataForRemoteFetchPartitions(acquiredNonRemoteFetchTopicPartitionData, responseData);
                     for (Map.Entry<TopicIdPartition, LogReadResult> entry : responseData.entrySet()) {
                         if (entry.getValue().info().delayedRemoteStorageFetch.isEmpty()) {
                             shareFetchPartitionData.add(

--- a/core/src/main/java/kafka/server/share/DelayedShareFetch.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetch.java
@@ -250,6 +250,8 @@ public class DelayedShareFetch extends DelayedOperation {
                 // updated in a different tryComplete thread.
                 responseData = combineLogReadResponse(topicPartitionData, localPartitionsAlreadyFetched);
 
+            updateFetchOffsetMetadataForRemoteFetchPartitions(topicPartitionData, responseData);
+
             List<ShareFetchPartitionData> shareFetchPartitionDataList = new ArrayList<>();
             responseData.forEach((topicIdPartition, logReadResult) ->
                 shareFetchPartitionDataList.add(new ShareFetchPartitionData(
@@ -272,6 +274,32 @@ public class DelayedShareFetch extends DelayedOperation {
         } finally {
             releasePartitionLocksAndAddToActionQueue(topicPartitionData.keySet());
         }
+    }
+
+    /**
+     * This function updates the cached fetch offset metadata to null corresponding to the share partition's fetch offset.
+     * This is required in the case when a topic partition that has local log fetch during tryComplete changes to remote
+     * storage fetch in onComplete. In this situation, if the cached fetchOffsetMetadata got updated in tryComplete, then
+     * we will enter a state where each share fetch request for this topic partition from client will use the cached
+     * fetchOffsetMetadata in tryComplete and return an empty response to the client from onComplete.
+     * Hence, we require to set offsetMetadata to null for this fetch offset, which would cause tryComplete to update
+     * fetchOffsetMetadata and thereby we will identify this partition for remote storage fetch.
+     * @param topicPartitionData - Map containing the fetch offset for the topic partitions.
+     * @param replicaManagerReadResponse - Map containing the readFromLog response from replicaManager for the topic partitions.
+     */
+    private void updateFetchOffsetMetadataForRemoteFetchPartitions(
+        LinkedHashMap<TopicIdPartition, Long> topicPartitionData,
+        LinkedHashMap<TopicIdPartition, LogReadResult> replicaManagerReadResponse
+    ) {
+        replicaManagerReadResponse.forEach((topicIdPartition, logReadResult) -> {
+            if (logReadResult.info().delayedRemoteStorageFetch.isPresent()) {
+                SharePartition sharePartition = sharePartitions.get(topicIdPartition);
+                sharePartition.updateFetchOffsetMetadata(
+                    topicPartitionData.get(topicIdPartition),
+                    null
+                );
+            }
+        });
     }
 
     /**
@@ -671,7 +699,7 @@ public class DelayedShareFetch extends DelayedOperation {
      * Case a: The partition is in an offline log directory on this broker
      * Case b: This broker does not know the partition it tries to fetch
      * Case c: This broker is no longer the leader of the partition it tries to fetch
-     * Case d: The remote storage read request completed (succeeded or failed)
+     * Case d: All remote storage read requests completed
      * @return boolean representing whether the remote fetch is completed or not.
      */
     private boolean maybeCompletePendingRemoteFetch() {

--- a/core/src/main/java/kafka/server/share/DelayedShareFetch.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetch.java
@@ -72,6 +72,8 @@ import scala.collection.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 import scala.runtime.BoxedUnit;
 
+import static kafka.server.share.PendingRemoteFetches.RemoteFetch;
+
 /**
  * A delayed share fetch operation has been introduced in case there is a share fetch request which cannot be completed instantaneously.
  */
@@ -98,7 +100,7 @@ public class DelayedShareFetch extends DelayedOperation {
     private long acquireStartTimeMs;
     private LinkedHashMap<TopicIdPartition, Long> partitionsAcquired;
     private LinkedHashMap<TopicIdPartition, LogReadResult> localPartitionsAlreadyFetched;
-    private Optional<RemoteFetch> remoteFetchOpt;
+    private Optional<PendingRemoteFetches> pendingRemoteFetchesOpt;
     private Optional<Exception> remoteStorageFetchException;
 
     /**
@@ -142,7 +144,7 @@ public class DelayedShareFetch extends DelayedOperation {
      * @param partitionMaxBytesStrategy The strategy to identify the max bytes for topic partitions in the share fetch request.
      * @param shareGroupMetrics The share group metrics to record the metrics.
      * @param time The system time.
-     * @param remoteFetchOpt Optional containing an in-flight remote fetch object or an empty optional.
+     * @param pendingRemoteFetchesOpt Optional containing an in-flight remote fetch object or an empty optional.
      */
     DelayedShareFetch(
         ShareFetch shareFetch,
@@ -152,7 +154,7 @@ public class DelayedShareFetch extends DelayedOperation {
         PartitionMaxBytesStrategy partitionMaxBytesStrategy,
         ShareGroupMetrics shareGroupMetrics,
         Time time,
-        Optional<RemoteFetch> remoteFetchOpt
+        Optional<PendingRemoteFetches> pendingRemoteFetchesOpt
     ) {
         super(shareFetch.fetchParams().maxWaitMs, Optional.empty());
         this.shareFetch = shareFetch;
@@ -165,7 +167,7 @@ public class DelayedShareFetch extends DelayedOperation {
         this.shareGroupMetrics = shareGroupMetrics;
         this.time = time;
         this.acquireStartTimeMs = time.hiResClockMs();
-        this.remoteFetchOpt = remoteFetchOpt;
+        this.pendingRemoteFetchesOpt = pendingRemoteFetchesOpt;
         this.remoteStorageFetchException = Optional.empty();
         // Register metrics for DelayedShareFetch.
         KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup("kafka.server", "DelayedShareFetchMetrics");
@@ -194,7 +196,7 @@ public class DelayedShareFetch extends DelayedOperation {
         try {
             if (remoteStorageFetchException.isPresent()) {
                 completeErroneousRemoteShareFetchRequest();
-            } else if (remoteFetchOpt.isPresent()) {
+            } else if (pendingRemoteFetchesOpt.isPresent()) {
                 completeRemoteStorageShareFetchRequest();
             } else {
                 completeLocalLogShareFetchRequest();
@@ -278,7 +280,7 @@ public class DelayedShareFetch extends DelayedOperation {
     @Override
     public boolean tryComplete() {
         // Check to see if the remote fetch is in flight. If there is an in flight remote fetch we want to resolve it first.
-        if (remoteFetchOpt.isPresent()) {
+        if (pendingRemoteFetchesOpt.isPresent()) {
             return maybeCompletePendingRemoteFetch();
         }
 
@@ -291,11 +293,11 @@ public class DelayedShareFetch extends DelayedOperation {
                 // replicaManager.readFromLog to populate the offset metadata and update the fetch offset metadata for
                 // those topic partitions.
                 LinkedHashMap<TopicIdPartition, LogReadResult> replicaManagerReadResponse = maybeReadFromLog(topicPartitionData);
-                // Store the remote fetch info and the topic partition for which we need to perform remote fetch.
-                Optional<TopicPartitionRemoteFetchInfo> topicPartitionRemoteFetchInfoOpt = maybePrepareRemoteStorageFetchInfo(topicPartitionData, replicaManagerReadResponse);
+                // Store the remote fetch info for the topic partitions for which we need to perform remote fetch.
+                LinkedHashMap<TopicIdPartition, LogReadResult> remoteStorageFetchInfoMap = maybePrepareRemoteStorageFetchInfo(topicPartitionData, replicaManagerReadResponse);
 
-                if (topicPartitionRemoteFetchInfoOpt.isPresent()) {
-                    return maybeProcessRemoteFetch(topicPartitionData, topicPartitionRemoteFetchInfoOpt.get());
+                if (!remoteStorageFetchInfoMap.isEmpty()) {
+                    return maybeProcessRemoteFetch(topicPartitionData, remoteStorageFetchInfoMap);
                 }
                 maybeUpdateFetchOffsetMetadata(topicPartitionData, replicaManagerReadResponse);
                 if (anyPartitionHasLogReadError(replicaManagerReadResponse) || isMinBytesSatisfied(topicPartitionData, partitionMaxBytesStrategy.maxBytes(shareFetch.fetchParams().maxBytes, topicPartitionData.keySet(), topicPartitionData.size()))) {
@@ -579,8 +581,8 @@ public class DelayedShareFetch extends DelayedOperation {
     }
 
     // Visible for testing.
-    RemoteFetch remoteFetch() {
-        return remoteFetchOpt.orElse(null);
+    PendingRemoteFetches pendingRemoteFetches() {
+        return pendingRemoteFetchesOpt.orElse(null);
     }
 
     // Visible for testing.
@@ -588,76 +590,83 @@ public class DelayedShareFetch extends DelayedOperation {
         return expiredRequestMeter;
     }
 
-    private Optional<TopicPartitionRemoteFetchInfo> maybePrepareRemoteStorageFetchInfo(
+    private LinkedHashMap<TopicIdPartition, LogReadResult> maybePrepareRemoteStorageFetchInfo(
         LinkedHashMap<TopicIdPartition, Long> topicPartitionData,
         LinkedHashMap<TopicIdPartition, LogReadResult> replicaManagerReadResponse
     ) {
-        Optional<TopicPartitionRemoteFetchInfo> topicPartitionRemoteFetchInfoOpt = Optional.empty();
+        LinkedHashMap<TopicIdPartition, LogReadResult> remoteStorageFetchInfoMap = new LinkedHashMap<>();
         for (Map.Entry<TopicIdPartition, LogReadResult> entry : replicaManagerReadResponse.entrySet()) {
             TopicIdPartition topicIdPartition = entry.getKey();
             LogReadResult logReadResult = entry.getValue();
             if (logReadResult.info().delayedRemoteStorageFetch.isPresent()) {
-                // TODO: There is a limitation in remote storage fetch for consumer groups that we can only perform remote fetch for
-                //  a single topic partition in a fetch request. Since, the logic of fetch is largely based on how consumer groups work,
-                //  we are following the same logic. However, this problem should be addressed as part of KAFKA-19133 which should help us perform
-                //  fetch for multiple remote fetch topic partition in a single share fetch request
-                topicPartitionRemoteFetchInfoOpt = Optional.of(new TopicPartitionRemoteFetchInfo(topicIdPartition, logReadResult));
+                remoteStorageFetchInfoMap.put(topicIdPartition, logReadResult);
                 partitionsAcquired.put(topicIdPartition, topicPartitionData.get(topicIdPartition));
-                break;
             }
         }
-        return topicPartitionRemoteFetchInfoOpt;
+        return remoteStorageFetchInfoMap;
     }
 
     private boolean maybeProcessRemoteFetch(
         LinkedHashMap<TopicIdPartition, Long> topicPartitionData,
-        TopicPartitionRemoteFetchInfo topicPartitionRemoteFetchInfo
+        LinkedHashMap<TopicIdPartition, LogReadResult> remoteStorageFetchInfoMap
     ) {
         Set<TopicIdPartition> nonRemoteFetchTopicPartitions = new LinkedHashSet<>();
         topicPartitionData.keySet().forEach(topicIdPartition -> {
-            // topic partitions for which fetch would not be happening in this share fetch request.
-            if (!topicPartitionRemoteFetchInfo.topicIdPartition().equals(topicIdPartition)) {
+            // non-remote storage fetch topic partitions for which fetch would not be happening in this share fetch request.
+            if (!remoteStorageFetchInfoMap.containsKey(topicIdPartition)) {
                 nonRemoteFetchTopicPartitions.add(topicIdPartition);
             }
         });
         // Release fetch lock for the topic partitions that were acquired but were not a part of remote fetch and add
         // them to the delayed actions queue.
         releasePartitionLocksAndAddToActionQueue(nonRemoteFetchTopicPartitions);
-        processRemoteFetchOrException(topicPartitionRemoteFetchInfo);
+        processRemoteFetchOrException(remoteStorageFetchInfoMap);
         // Check if remote fetch can be completed.
         return maybeCompletePendingRemoteFetch();
     }
 
     /**
-     * Throws an exception if a task for remote storage fetch could not be scheduled successfully else updates remoteFetchOpt.
-     * @param topicPartitionRemoteFetchInfo - The remote storage fetch information.
+     * Throws an exception if a task for remote storage fetch could not be scheduled successfully else updates pendingRemoteFetchesOpt.
+     * @param remoteStorageFetchInfoMap - The remote storage fetch information.
      */
     private void processRemoteFetchOrException(
-        TopicPartitionRemoteFetchInfo topicPartitionRemoteFetchInfo
+        LinkedHashMap<TopicIdPartition, LogReadResult> remoteStorageFetchInfoMap
     ) {
-        TopicIdPartition remoteFetchTopicIdPartition = topicPartitionRemoteFetchInfo.topicIdPartition();
-        RemoteStorageFetchInfo remoteStorageFetchInfo = topicPartitionRemoteFetchInfo.logReadResult().info().delayedRemoteStorageFetch.get();
+        LinkedHashMap<TopicIdPartition, LogOffsetMetadata> fetchOffsetMetadataMap = new LinkedHashMap<>();
+        remoteStorageFetchInfoMap.forEach((topicIdPartition, logReadResult) -> fetchOffsetMetadataMap.put(
+            topicIdPartition,
+            logReadResult.info().fetchOffsetMetadata
+        ));
 
-        Future<Void> remoteFetchTask;
-        CompletableFuture<RemoteLogReadResult> remoteFetchResult = new CompletableFuture<>();
-        try {
-            remoteFetchTask = replicaManager.remoteLogManager().get().asyncRead(
-                remoteStorageFetchInfo,
-                result -> {
-                    remoteFetchResult.complete(result);
-                    replicaManager.completeDelayedShareFetchRequest(new DelayedShareFetchGroupKey(shareFetch.groupId(), remoteFetchTopicIdPartition.topicId(), remoteFetchTopicIdPartition.partition()));
-                }
-            );
-        } catch (Exception e) {
-            // Throw the error if any in scheduling the remote fetch task.
-            remoteStorageFetchException = Optional.of(e);
-            throw e;
+        List<RemoteFetch> remoteFetches = new ArrayList<>();
+        for (Map.Entry<TopicIdPartition, LogReadResult> entry : remoteStorageFetchInfoMap.entrySet()) {
+            TopicIdPartition remoteFetchTopicIdPartition = entry.getKey();
+            RemoteStorageFetchInfo remoteStorageFetchInfo = entry.getValue().info().delayedRemoteStorageFetch.get();
+
+            Future<Void> remoteFetchTask;
+            CompletableFuture<RemoteLogReadResult> remoteFetchResult = new CompletableFuture<>();
+            try {
+                remoteFetchTask = replicaManager.remoteLogManager().get().asyncRead(
+                    remoteStorageFetchInfo,
+                    result -> {
+                        remoteFetchResult.complete(result);
+                        replicaManager.completeDelayedShareFetchRequest(new DelayedShareFetchGroupKey(shareFetch.groupId(), remoteFetchTopicIdPartition.topicId(), remoteFetchTopicIdPartition.partition()));
+                    }
+                );
+            } catch (Exception e) {
+                // Cancel the already created remote fetch tasks in case an exception occurs.
+                remoteFetches.forEach(this::cancelRemoteFetchTask);
+                // Throw the error if any in scheduling the remote fetch task.
+                remoteStorageFetchException = Optional.of(e);
+                throw e;
+            }
+            remoteFetches.add(new RemoteFetch(remoteFetchTopicIdPartition, entry.getValue(), remoteFetchTask, remoteFetchResult, remoteStorageFetchInfo));
         }
-        remoteFetchOpt = Optional.of(new RemoteFetch(remoteFetchTopicIdPartition, topicPartitionRemoteFetchInfo.logReadResult(), remoteFetchTask, remoteFetchResult, remoteStorageFetchInfo));
+        pendingRemoteFetchesOpt = Optional.of(new PendingRemoteFetches(remoteFetches, fetchOffsetMetadataMap));
     }
 
     /**
-     * This function checks if the remote fetch can be completed or not. It should always be called once you confirm remoteFetchOpt.isPresent().
+     * This function checks if the remote fetch can be completed or not. It should always be called once you confirm pendingRemoteFetchesOpt.isPresent().
      * The operation can be completed if:
      * Case a: The partition is in an offline log directory on this broker
      * Case b: This broker does not know the partition it tries to fetch
@@ -668,21 +677,24 @@ public class DelayedShareFetch extends DelayedOperation {
     private boolean maybeCompletePendingRemoteFetch() {
         boolean canComplete = false;
 
-        TopicIdPartition topicIdPartition = remoteFetchOpt.get().topicIdPartition();
-        try {
-            replicaManager.getPartitionOrException(topicIdPartition.topicPartition());
-        } catch (KafkaStorageException e) { // Case a
-            log.debug("TopicPartition {} is in an offline log directory, satisfy {} immediately", topicIdPartition, shareFetch.fetchParams());
-            canComplete = true;
-        } catch (UnknownTopicOrPartitionException e) { // Case b
-            log.debug("Broker no longer knows of topicPartition {}, satisfy {} immediately", topicIdPartition, shareFetch.fetchParams());
-            canComplete = true;
-        } catch (NotLeaderOrFollowerException e) { // Case c
-            log.debug("Broker is no longer the leader or follower of topicPartition {}, satisfy {} immediately", topicIdPartition, shareFetch.fetchParams());
-            canComplete = true;
+        for (TopicIdPartition topicIdPartition : pendingRemoteFetchesOpt.get().fetchOffsetMetadataMap().keySet()) {
+            try {
+                replicaManager.getPartitionOrException(topicIdPartition.topicPartition());
+            } catch (KafkaStorageException e) { // Case a
+                log.debug("TopicPartition {} is in an offline log directory, satisfy {} immediately", topicIdPartition, shareFetch.fetchParams());
+                canComplete = true;
+            } catch (UnknownTopicOrPartitionException e) { // Case b
+                log.debug("Broker no longer knows of topicPartition {}, satisfy {} immediately", topicIdPartition, shareFetch.fetchParams());
+                canComplete = true;
+            } catch (NotLeaderOrFollowerException e) { // Case c
+                log.debug("Broker is no longer the leader or follower of topicPartition {}, satisfy {} immediately", topicIdPartition, shareFetch.fetchParams());
+                canComplete = true;
+            }
+            if (canComplete)
+                break;
         }
 
-        if (canComplete || remoteFetchOpt.get().remoteFetchResult().isDone()) { // Case d
+        if (canComplete || pendingRemoteFetchesOpt.get().isDone()) { // Case d
             return forceCompleteRequest();
         } else
             return false;
@@ -725,44 +737,45 @@ public class DelayedShareFetch extends DelayedOperation {
         try {
             List<ShareFetchPartitionData> shareFetchPartitionData = new ArrayList<>();
             int readableBytes = 0;
-            if (remoteFetchOpt.get().remoteFetchResult().isDone()) {
-                RemoteFetch remoteFetch = remoteFetchOpt.get();
-                RemoteLogReadResult remoteLogReadResult = remoteFetch.remoteFetchResult().get();
-                if (remoteLogReadResult.error.isPresent()) {
-                    Throwable error = remoteLogReadResult.error.get();
-                    // If there is any error for the remote fetch topic partition, we populate the error accordingly.
-                    shareFetchPartitionData.add(
-                        new ShareFetchPartitionData(
-                            remoteFetch.topicIdPartition(),
-                            partitionsAcquired.get(remoteFetch.topicIdPartition()),
-                            ReplicaManager.createLogReadResult(error).toFetchPartitionData(false)
-                        )
-                    );
-                } else {
-                    FetchDataInfo info = remoteLogReadResult.fetchDataInfo.get();
-                    TopicIdPartition topicIdPartition = remoteFetch.topicIdPartition();
-                    LogReadResult logReadResult = remoteFetch.logReadResult();
-                    shareFetchPartitionData.add(
-                        new ShareFetchPartitionData(
-                            topicIdPartition,
-                            partitionsAcquired.get(remoteFetch.topicIdPartition()),
-                            new FetchPartitionData(
-                                logReadResult.error(),
-                                logReadResult.highWatermark(),
-                                logReadResult.leaderLogStartOffset(),
-                                info.records,
-                                Optional.empty(),
-                                logReadResult.lastStableOffset().isDefined() ? OptionalLong.of((Long) logReadResult.lastStableOffset().get()) : OptionalLong.empty(),
-                                info.abortedTransactions,
-                                logReadResult.preferredReadReplica().isDefined() ? OptionalInt.of((Integer) logReadResult.preferredReadReplica().get()) : OptionalInt.empty(),
-                                false
+            for (RemoteFetch remoteFetch : pendingRemoteFetchesOpt.get().remoteFetches()) {
+                if (remoteFetch.remoteFetchResult().isDone()) {
+                    RemoteLogReadResult remoteLogReadResult = remoteFetch.remoteFetchResult().get();
+                    if (remoteLogReadResult.error.isPresent()) {
+                        Throwable error = remoteLogReadResult.error.get();
+                        // If there is any error for the remote fetch topic partition, we populate the error accordingly.
+                        shareFetchPartitionData.add(
+                            new ShareFetchPartitionData(
+                                remoteFetch.topicIdPartition(),
+                                partitionsAcquired.get(remoteFetch.topicIdPartition()),
+                                ReplicaManager.createLogReadResult(error).toFetchPartitionData(false)
                             )
-                        )
-                    );
-                    readableBytes += info.records.sizeInBytes();
+                        );
+                    } else {
+                        FetchDataInfo info = remoteLogReadResult.fetchDataInfo.get();
+                        TopicIdPartition topicIdPartition = remoteFetch.topicIdPartition();
+                        LogReadResult logReadResult = remoteFetch.logReadResult();
+                        shareFetchPartitionData.add(
+                            new ShareFetchPartitionData(
+                                topicIdPartition,
+                                partitionsAcquired.get(remoteFetch.topicIdPartition()),
+                                new FetchPartitionData(
+                                    logReadResult.error(),
+                                    logReadResult.highWatermark(),
+                                    logReadResult.leaderLogStartOffset(),
+                                    info.records,
+                                    Optional.empty(),
+                                    logReadResult.lastStableOffset().isDefined() ? OptionalLong.of((Long) logReadResult.lastStableOffset().get()) : OptionalLong.empty(),
+                                    info.abortedTransactions,
+                                    logReadResult.preferredReadReplica().isDefined() ? OptionalInt.of((Integer) logReadResult.preferredReadReplica().get()) : OptionalInt.empty(),
+                                    false
+                                )
+                            )
+                        );
+                        readableBytes += info.records.sizeInBytes();
+                    }
+                } else {
+                    cancelRemoteFetchTask(remoteFetch);
                 }
-            } else {
-                cancelRemoteFetchTask();
             }
 
             // If remote fetch bytes  < shareFetch.fetchParams().maxBytes, then we will try for a local read.
@@ -806,7 +819,7 @@ public class DelayedShareFetch extends DelayedOperation {
             shareFetch.maybeComplete(remoteFetchResponse);
             log.trace("Remote share fetch request completed successfully, response: {}", remoteFetchResponse);
         } catch (InterruptedException | ExecutionException e) {
-            log.error("Exception occurred in completing remote fetch {} for delayed share fetch request {}", remoteFetchOpt.get(), e);
+            log.error("Exception occurred in completing remote fetch {} for delayed share fetch request {}", pendingRemoteFetchesOpt.get(), e);
             handleExceptionInCompletingRemoteStorageShareFetchRequest(acquiredNonRemoteFetchTopicPartitionData.keySet(), e);
         } catch (Exception e) {
             log.error("Unexpected error in processing delayed share fetch request", e);
@@ -832,11 +845,11 @@ public class DelayedShareFetch extends DelayedOperation {
      * already running as it may force closing opened/cached resources as transaction index.
      * Note - This function should only be called when we know that there is remote fetch.
      */
-    private void cancelRemoteFetchTask() {
-        boolean cancelled = remoteFetchOpt.get().remoteFetchTask().cancel(false);
+    private void cancelRemoteFetchTask(RemoteFetch remoteFetch) {
+        boolean cancelled = remoteFetch.remoteFetchTask().cancel(false);
         if (!cancelled) {
             log.debug("Remote fetch task for RemoteStorageFetchInfo: {} could not be cancelled and its isDone value is {}",
-                remoteFetchOpt.get().remoteFetchInfo(), remoteFetchOpt.get().remoteFetchTask().isDone());
+                remoteFetch.remoteFetchInfo(), remoteFetch.remoteFetchTask().isDone());
         }
     }
 
@@ -848,37 +861,5 @@ public class DelayedShareFetch extends DelayedOperation {
             releasePartitionLocksAndAddToActionQueue(partitionsAcquired.keySet());
         }
         return completedByMe;
-    }
-
-    public record RemoteFetch(
-        TopicIdPartition topicIdPartition,
-        LogReadResult logReadResult,
-        Future<Void> remoteFetchTask,
-        CompletableFuture<RemoteLogReadResult> remoteFetchResult,
-        RemoteStorageFetchInfo remoteFetchInfo
-    ) {
-        @Override
-        public String toString() {
-            return "RemoteFetch(" +
-                "topicIdPartition=" + topicIdPartition +
-                ", logReadResult=" + logReadResult +
-                ", remoteFetchTask=" + remoteFetchTask +
-                ", remoteFetchResult=" + remoteFetchResult +
-                ", remoteFetchInfo=" + remoteFetchInfo +
-                ")";
-        }
-    }
-
-    public record TopicPartitionRemoteFetchInfo(
-        TopicIdPartition topicIdPartition,
-        LogReadResult logReadResult
-    ) {
-        @Override
-        public String toString() {
-            return "TopicPartitionRemoteFetchInfo(" +
-                "topicIdPartition=" + topicIdPartition +
-                ", logReadResult=" + logReadResult +
-                ")";
-        }
     }
 }

--- a/core/src/main/java/kafka/server/share/PendingRemoteFetches.java
+++ b/core/src/main/java/kafka/server/share/PendingRemoteFetches.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server.share;
+
+import kafka.server.LogReadResult;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
+import org.apache.kafka.storage.internals.log.RemoteLogReadResult;
+import org.apache.kafka.storage.internals.log.RemoteStorageFetchInfo;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+/**
+ * This class is used to store the remote storage fetch information for topic partitions in a share fetch request.
+ */
+public class PendingRemoteFetches {
+    private final List<RemoteFetch> remoteFetches;
+    private final LinkedHashMap<TopicIdPartition, LogOffsetMetadata> fetchOffsetMetadataMap;
+
+    PendingRemoteFetches(List<RemoteFetch> remoteFetches, LinkedHashMap<TopicIdPartition, LogOffsetMetadata> fetchOffsetMetadataMap) {
+        this.remoteFetches = remoteFetches;
+        this.fetchOffsetMetadataMap = fetchOffsetMetadataMap;
+    }
+
+    public boolean isDone() {
+        for (RemoteFetch remoteFetch : remoteFetches) {
+            if (!remoteFetch.remoteFetchResult.isDone())
+                return false;
+        }
+        return true;
+    }
+
+    public List<RemoteFetch> remoteFetches() {
+        return remoteFetches;
+    }
+
+    public LinkedHashMap<TopicIdPartition, LogOffsetMetadata> fetchOffsetMetadataMap() {
+        return fetchOffsetMetadataMap;
+    }
+
+    @Override
+    public String toString() {
+        return "PendingRemoteFetches(" +
+            "remoteFetches=" + remoteFetches +
+            ", fetchOffsetMetadataMap=" + fetchOffsetMetadataMap +
+            ")";
+    }
+
+    public record RemoteFetch(
+        TopicIdPartition topicIdPartition,
+        LogReadResult logReadResult,
+        Future<Void> remoteFetchTask,
+        CompletableFuture<RemoteLogReadResult> remoteFetchResult,
+        RemoteStorageFetchInfo remoteFetchInfo
+    ) {
+        @Override
+        public String toString() {
+            return "RemoteFetch(" +
+                "topicIdPartition=" + topicIdPartition +
+                ", logReadResult=" + logReadResult +
+                ", remoteFetchTask=" + remoteFetchTask +
+                ", remoteFetchResult=" + remoteFetchResult +
+                ", remoteFetchInfo=" + remoteFetchInfo +
+                ")";
+        }
+    }
+}

--- a/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
+++ b/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
@@ -79,6 +79,7 @@ import scala.Tuple2;
 import scala.collection.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 
+import static kafka.server.share.PendingRemoteFetches.RemoteFetch;
 import static kafka.server.share.SharePartitionManagerTest.DELAYED_SHARE_FETCH_PURGATORY_PURGE_INTERVAL;
 import static kafka.server.share.SharePartitionManagerTest.buildLogReadResult;
 import static kafka.server.share.SharePartitionManagerTest.mockReplicaManagerDelayedShareFetch;
@@ -1226,7 +1227,7 @@ public class DelayedShareFetchTest {
         assertFalse(delayedShareFetch.tryComplete());
         assertFalse(delayedShareFetch.isCompleted());
         // Remote fetch object gets created for delayed share fetch object.
-        assertNotNull(delayedShareFetch.remoteFetch());
+        assertNotNull(delayedShareFetch.pendingRemoteFetches());
         // Verify the locks are released for local log read topic partitions tp0 and tp1.
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0, tp1));
         assertTrue(delayedShareFetch.lock().tryLock());
@@ -1238,38 +1239,53 @@ public class DelayedShareFetchTest {
         ReplicaManager replicaManager = mock(ReplicaManager.class);
         TopicIdPartition tp0 = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
         TopicIdPartition tp1 = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 1));
+        TopicIdPartition tp2 = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 2));
 
         SharePartition sp0 = mock(SharePartition.class);
         SharePartition sp1 = mock(SharePartition.class);
+        SharePartition sp2 = mock(SharePartition.class);
 
         // All the topic partitions are acquirable.
         when(sp0.maybeAcquireFetchLock()).thenReturn(true);
         when(sp1.maybeAcquireFetchLock()).thenReturn(true);
+        when(sp2.maybeAcquireFetchLock()).thenReturn(true);
         when(sp0.canAcquireRecords()).thenReturn(true);
         when(sp1.canAcquireRecords()).thenReturn(true);
+        when(sp2.canAcquireRecords()).thenReturn(true);
 
         LinkedHashMap<TopicIdPartition, SharePartition> sharePartitions = new LinkedHashMap<>();
         sharePartitions.put(tp0, sp0);
         sharePartitions.put(tp1, sp1);
+        sharePartitions.put(tp2, sp2);
 
         CompletableFuture<Map<TopicIdPartition, ShareFetchResponseData.PartitionData>> future = new CompletableFuture<>();
         ShareFetch shareFetch = new ShareFetch(FETCH_PARAMS, "grp", Uuid.randomUuid().toString(),
-            future, List.of(tp0, tp1), BATCH_SIZE, MAX_FETCH_RECORDS,
+            future, List.of(tp0, tp1, tp2), BATCH_SIZE, MAX_FETCH_RECORDS,
             BROKER_TOPIC_STATS);
 
         when(sp0.nextFetchOffset()).thenReturn(10L);
         when(sp1.nextFetchOffset()).thenReturn(20L);
+        when(sp2.nextFetchOffset()).thenReturn(25L);
 
-        // Fetch offset does not match with the cached entry for sp0 and sp1. Hence, a replica manager fetch will happen for sp0 and sp1.
+        // Fetch offset does not match with the cached entry for sp0, sp1 and sp2. Hence, a replica manager fetch will happen for all.
         when(sp0.fetchOffsetMetadata(anyLong())).thenReturn(Optional.empty());
         when(sp1.fetchOffsetMetadata(anyLong())).thenReturn(Optional.empty());
+        when(sp2.fetchOffsetMetadata(anyLong())).thenReturn(Optional.empty());
 
-        // Mocking local log read result for tp0 and remote storage read result for tp1.
-        doAnswer(invocation -> buildLocalAndRemoteFetchResult(Set.of(tp0), Set.of(tp1))).when(replicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
+        // Mocking local log read result for tp0 and remote storage read result for tp1 and tp2.
+        doAnswer(invocation -> buildLocalAndRemoteFetchResult(Set.of(tp0), Set.of(tp1, tp2))).when(replicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
-        // Remote fetch related mocks. Exception will be thrown during the creation of remoteFetch object.
+        // Remote fetch related mocks. Exception will be thrown during the creation of remoteFetch object for tp2.
+        // remoteFetchTask gets created for tp1 successfully.
+        Future<Void> remoteFetchTask = mock(Future.class);
+        doAnswer(invocation -> {
+            when(remoteFetchTask.isCancelled()).thenReturn(true);
+            return false;
+        }).when(remoteFetchTask).cancel(false);
         RemoteLogManager remoteLogManager = mock(RemoteLogManager.class);
-        when(remoteLogManager.asyncRead(any(), any())).thenThrow(new RejectedExecutionException("Exception thrown"));
+        when(remoteLogManager.asyncRead(any(), any()))
+            .thenReturn(remoteFetchTask) // for tp1
+            .thenThrow(new RejectedExecutionException("Exception thrown"));  // for tp2
         when(replicaManager.remoteLogManager()).thenReturn(Option.apply(remoteLogManager));
 
         BiConsumer<SharePartitionKey, Throwable> exceptionHandler = mockExceptionHandler();
@@ -1278,7 +1294,7 @@ public class DelayedShareFetchTest {
             .withSharePartitions(sharePartitions)
             .withReplicaManager(replicaManager)
             .withExceptionHandler(exceptionHandler)
-            .withPartitionMaxBytesStrategy(mockPartitionMaxBytes(Set.of(tp0, tp1)))
+            .withPartitionMaxBytesStrategy(mockPartitionMaxBytes(Set.of(tp0, tp1, tp2)))
             .build());
 
         assertFalse(delayedShareFetch.isCompleted());
@@ -1287,13 +1303,15 @@ public class DelayedShareFetchTest {
         assertTrue(delayedShareFetch.isCompleted());
         // The future of shareFetch completes.
         assertTrue(shareFetch.isCompleted());
+        // The remoteFetchTask created for tp1 is cancelled successfully.
+        assertTrue(remoteFetchTask.isCancelled());
         assertFalse(future.isCompletedExceptionally());
-        assertEquals(Set.of(tp1), future.join().keySet());
+        assertEquals(Set.of(tp1, tp2), future.join().keySet());
         // Exception occurred and was handled.
-        Mockito.verify(exceptionHandler, times(1)).accept(any(), any());
-        // Verify the locks are released for both local and remote read topic partitions tp0 and tp1 because of exception occurrence.
+        Mockito.verify(exceptionHandler, times(2)).accept(any(), any());
+        // Verify the locks are released for both local and remote read topic partitions tp0, tp1 and tp2 because of exception occurrence.
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0));
-        Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp1));
+        Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp1, tp2));
         Mockito.verify(delayedShareFetch, times(1)).onComplete();
         assertTrue(delayedShareFetch.lock().tryLock());
         delayedShareFetch.lock().unlock();
@@ -1373,8 +1391,10 @@ public class DelayedShareFetchTest {
 
         assertTrue(delayedShareFetch.isCompleted());
         // Pending remote fetch object gets created for delayed share fetch.
-        assertNotNull(delayedShareFetch.remoteFetch());
-        assertTrue(delayedShareFetch.remoteFetch().remoteFetchTask().isCancelled());
+        assertNotNull(delayedShareFetch.pendingRemoteFetches());
+        List<RemoteFetch> remoteFetches = delayedShareFetch.pendingRemoteFetches().remoteFetches();
+        assertEquals(1, remoteFetches.size());
+        assertTrue(remoteFetches.get(0).remoteFetchTask().isCancelled());
         // Partition locks should be released for all 3 topic partitions
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0, tp1, tp2));
         assertTrue(shareFetch.isCompleted());
@@ -1444,7 +1464,7 @@ public class DelayedShareFetchTest {
 
         assertTrue(delayedShareFetch.isCompleted());
         // Pending remote fetch object gets created for delayed share fetch.
-        assertNotNull(delayedShareFetch.remoteFetch());
+        assertNotNull(delayedShareFetch.pendingRemoteFetches());
         // Verify the locks are released for tp0.
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0));
         assertTrue(shareFetch.isCompleted());
@@ -1509,7 +1529,7 @@ public class DelayedShareFetchTest {
 
         assertTrue(delayedShareFetch.isCompleted());
         // Pending remote fetch object gets created for delayed share fetch.
-        assertNotNull(delayedShareFetch.remoteFetch());
+        assertNotNull(delayedShareFetch.pendingRemoteFetches());
         // Verify the locks are released for tp0.
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0));
         assertTrue(shareFetch.isCompleted());
@@ -1596,7 +1616,7 @@ public class DelayedShareFetchTest {
 
         assertTrue(delayedShareFetch.isCompleted());
         // Pending remote fetch object gets created for delayed share fetch.
-        assertNotNull(delayedShareFetch.remoteFetch());
+        assertNotNull(delayedShareFetch.pendingRemoteFetches());
         // the future of shareFetch completes.
         assertTrue(shareFetch.isCompleted());
         assertEquals(Set.of(tp0, tp1, tp2), future.join().keySet());
@@ -1610,7 +1630,7 @@ public class DelayedShareFetchTest {
     }
 
     @Test
-    public void testRemoteStorageFetchOnlyHappensForFirstTopicPartition() {
+    public void testRemoteStorageFetchHappensForAllTopicPartitions() {
         ReplicaManager replicaManager = mock(ReplicaManager.class);
         TopicIdPartition tp0 = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
         TopicIdPartition tp1 = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 1));
@@ -1669,22 +1689,22 @@ public class DelayedShareFetchTest {
 
         when(sp0.acquire(any(), anyInt(), anyInt(), anyLong(), any(), any())).thenReturn(
             createShareAcquiredRecords(new ShareFetchResponseData.AcquiredRecords().setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1)));
+        when(sp1.acquire(any(), anyInt(), anyInt(), anyLong(), any(), any())).thenReturn(
+            createShareAcquiredRecords(new ShareFetchResponseData.AcquiredRecords().setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1)));
 
         assertFalse(delayedShareFetch.isCompleted());
         assertTrue(delayedShareFetch.tryComplete());
 
         assertTrue(delayedShareFetch.isCompleted());
         // Pending remote fetch object gets created for delayed share fetch.
-        assertNotNull(delayedShareFetch.remoteFetch());
-        // Verify the locks are released separately for tp1 (from tryComplete).
-        Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp1));
-        // From onComplete, the locks will be released for both tp0 and tp1. tp0 because it was acquired from
-        // tryComplete and has remote fetch processed. tp1 will be reacquired in onComplete when we check for local log read.
+        assertNotNull(delayedShareFetch.pendingRemoteFetches());
+        // Verify the locks are released for both tp0 and tp1.
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0, tp1));
         assertTrue(shareFetch.isCompleted());
-        // Share fetch response only contains the first remote storage fetch topic partition - tp0.
-        assertEquals(Set.of(tp0), future.join().keySet());
+        // Share fetch response contains both remote storage fetch topic partitions.
+        assertEquals(Set.of(tp0, tp1), future.join().keySet());
         assertEquals(Errors.NONE.code(), future.join().get(tp0).errorCode());
+        assertEquals(Errors.NONE.code(), future.join().get(tp1).errorCode());
         assertTrue(delayedShareFetch.lock().tryLock());
         delayedShareFetch.lock().unlock();
     }
@@ -1759,7 +1779,7 @@ public class DelayedShareFetchTest {
         private LinkedHashMap<TopicIdPartition, SharePartition> sharePartitions = mock(LinkedHashMap.class);
         private PartitionMaxBytesStrategy partitionMaxBytesStrategy = mock(PartitionMaxBytesStrategy.class);
         private Time time = new MockTime();
-        private final Optional<DelayedShareFetch.RemoteFetch> remoteFetch = Optional.empty();
+        private final Optional<PendingRemoteFetches> pendingRemoteFetches = Optional.empty();
         private ShareGroupMetrics shareGroupMetrics = mock(ShareGroupMetrics.class);
 
         DelayedShareFetchBuilder withShareFetchData(ShareFetch shareFetch) {
@@ -1810,7 +1830,7 @@ public class DelayedShareFetchTest {
                 partitionMaxBytesStrategy,
                 shareGroupMetrics,
                 time,
-                remoteFetch);
+                pendingRemoteFetches);
         }
     }
 }

--- a/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
+++ b/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
@@ -1309,7 +1309,7 @@ public class DelayedShareFetchTest {
         assertEquals(Set.of(tp1, tp2), future.join().keySet());
         // Exception occurred and was handled.
         Mockito.verify(exceptionHandler, times(2)).accept(any(), any());
-        // Verify the locks are released for both local and remote read topic partitions tp0, tp1 and tp2 because of exception occurrence.
+        // Verify the locks are released for all local and remote read topic partitions tp0, tp1 and tp2 because of exception occurrence.
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp0));
         Mockito.verify(delayedShareFetch, times(1)).releasePartitionLocks(Set.of(tp1, tp2));
         Mockito.verify(delayedShareFetch, times(1)).onComplete();


### PR DESCRIPTION
### About
This PR removes the limitation in remote storage fetch for share groups
of only performing remote fetch for a single topic partition in a share
fetch request. With this PR, share groups can now fetch multiple remote
storage topic partitions in a single share fetch request.

### Testing
I have followed the [AK
documentation](https://kafka.apache.org/documentation/#tiered_storage_config_ex)
to test my code locally (by adopting `LocalTieredStorage.java`) and
verify with the help of logs that remote storage is happening for
multiple topic partitions in a single share fetch request. Also,
verified it with the help of unit tests.
