### PR TITLE
MINOR; Log message for unexpected buffer allocation

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.common.errors.CorruptRecordException
 import org.apache.kafka.common.record.{MemoryRecords, Records}
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.raft.{Isolation, KafkaRaftClient, LogAppendInfo, LogFetchInfo, LogOffsetMetadata, MetadataLogConfig, OffsetAndEpoch, OffsetMetadata, ReplicatedLog, SegmentPosition, ValidOffsetAndEpoch}
@@ -417,7 +418,7 @@ final class KafkaMetadataLog private (
    */
   private def readSnapshotTimestamp(snapshotId: OffsetAndEpoch): Option[Long] = {
     readSnapshot(snapshotId).toScala.map { reader =>
-      Snapshots.lastContainedLogTimestamp(reader)
+      Snapshots.lastContainedLogTimestamp(reader, new LogContext(logIdent))
     }
   }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -197,7 +197,7 @@ class BrokerServer(
 
       config.dynamicConfig.initialize(Some(clientMetricsReceiverPlugin))
       quotaManagers = QuotaFactory.instantiate(config, metrics, time, s"broker-${config.nodeId}-", ProcessRole.BrokerRole.toString)
-      DynamicBrokerConfig.readDynamicBrokerConfigsFromSnapshot(raftManager, config, quotaManagers)
+      DynamicBrokerConfig.readDynamicBrokerConfigsFromSnapshot(raftManager, config, quotaManagers, logContext)
 
       /* start scheduler */
       kafkaScheduler = new KafkaScheduler(config.backgroundThreads)

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.metadata.{ConfigRecord, MetadataRecordType}
 import org.apache.kafka.common.metrics.{Metrics, MetricsReporter}
 import org.apache.kafka.common.network.{ListenerName, ListenerReconfigurable}
 import org.apache.kafka.common.security.authenticator.LoginManager
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.common.utils.{BufferSupplier, ConfigUtils, Utils}
 import org.apache.kafka.config
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
@@ -48,15 +49,16 @@ import org.apache.kafka.server.telemetry.ClientTelemetry
 import org.apache.kafka.snapshot.RecordsSnapshotReader
 import org.apache.kafka.storage.internals.log.{LogCleaner, LogConfig}
 
+import scala.util.Using
 import scala.collection._
 import scala.jdk.CollectionConverters._
 
 /**
   * Dynamic broker configurations may be defined at two levels:
   * <ul>
-  *   <li>Per-broker configurations are persisted at the controller and can be described 
+  *   <li>Per-broker configurations are persisted at the controller and can be described
   *         or altered using AdminClient with the resource name brokerId.</li>
-  *   <li>Cluster-wide default configurations are persisted at the cluster level and can be 
+  *   <li>Cluster-wide default configurations are persisted at the cluster level and can be
   *         described or altered using AdminClient with an empty resource name.</li>
   * </ul>
   * The order of precedence for broker configs is:
@@ -195,7 +197,8 @@ object DynamicBrokerConfig {
   private[server] def readDynamicBrokerConfigsFromSnapshot(
     raftManager: KafkaRaftManager[ApiMessageAndVersion],
     config: KafkaConfig,
-    quotaManagers: QuotaFactory.QuotaManagers
+    quotaManagers: QuotaFactory.QuotaManagers,
+    logContext: LogContext
   ): Unit = {
     def putOrRemoveIfNull(props: Properties, key: String, value: String): Unit = {
       if (value == null) {
@@ -204,38 +207,42 @@ object DynamicBrokerConfig {
         props.put(key, value)
       }
     }
-    raftManager.replicatedLog.latestSnapshotId().ifPresent(latestSnapshotId => {
-      raftManager.replicatedLog.readSnapshot(latestSnapshotId).ifPresent(rawSnapshotReader => {
-        val reader = RecordsSnapshotReader.of(
-          rawSnapshotReader,
-          raftManager.recordSerde,
-          BufferSupplier.create(),
-          KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
-          true
-        )
-        val dynamicPerBrokerConfigs = new Properties()
-        val dynamicDefaultConfigs = new Properties()
-        while (reader.hasNext) {
-          val batch = reader.next()
-          batch.forEach(record => {
-            if (record.message().apiKey() == MetadataRecordType.CONFIG_RECORD.id) {
-              val configRecord = record.message().asInstanceOf[ConfigRecord]
-              if (DynamicBrokerConfig.AllDynamicConfigs.contains(configRecord.name()) &&
-                configRecord.resourceType() == ConfigResource.Type.BROKER.id()) {
-                if (configRecord.resourceName().isEmpty) {
-                  putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
-                } else if (configRecord.resourceName() == config.brokerId.toString) {
-                  putOrRemoveIfNull(dynamicPerBrokerConfigs, configRecord.name(), configRecord.value())
-                }
+    raftManager.replicatedLog.latestSnapshotId().ifPresent { latestSnapshotId =>
+      raftManager.replicatedLog.readSnapshot(latestSnapshotId).ifPresent { rawSnapshotReader =>
+        Using.resource(
+          RecordsSnapshotReader.of(
+            rawSnapshotReader,
+            raftManager.recordSerde,
+            BufferSupplier.create(),
+            KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+            true,
+            logContext
+          )
+        ) { reader =>
+          val dynamicPerBrokerConfigs = new Properties()
+          val dynamicDefaultConfigs = new Properties()
+          while (reader.hasNext) {
+            val batch = reader.next()
+            batch.forEach { record =>
+              if (record.message().apiKey() == MetadataRecordType.CONFIG_RECORD.id) {
+                val configRecord = record.message().asInstanceOf[ConfigRecord]
+                if (DynamicBrokerConfig.AllDynamicConfigs.contains(configRecord.name()) &&
+                  configRecord.resourceType() == ConfigResource.Type.BROKER.id()) {
+                    if (configRecord.resourceName().isEmpty) {
+                      putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
+                    } else if (configRecord.resourceName() == config.brokerId.toString) {
+                      putOrRemoveIfNull(dynamicPerBrokerConfigs, configRecord.name(), configRecord.value())
+                    }
+                  }
               }
             }
-          })
+          }
+          val configHandler = new BrokerConfigHandler(config, quotaManagers)
+          configHandler.processConfigChanges("", dynamicPerBrokerConfigs)
+          configHandler.processConfigChanges(config.brokerId.toString, dynamicPerBrokerConfigs)
         }
-        val configHandler = new BrokerConfigHandler(config, quotaManagers)
-        configHandler.processConfigChanges("", dynamicPerBrokerConfigs)
-        configHandler.processConfigChanges(config.brokerId.toString, dynamicPerBrokerConfigs)
-      })
-    })
+      }
+    }
   }
 }
 

--- a/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
@@ -20,6 +20,7 @@ package kafka.server
 import kafka.utils.TestUtils
 import org.apache.kafka.common.test.{KafkaClusterTestKit, TestKitNodes}
 import org.apache.kafka.common.utils.BufferSupplier
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.metadata.MetadataRecordSerde
 import org.apache.kafka.raft.MetadataLogConfig
 import org.apache.kafka.snapshot.RecordsSnapshotReader
@@ -79,7 +80,8 @@ class RaftClusterSnapshotTest {
             new MetadataRecordSerde(),
             BufferSupplier.create(),
             1,
-            true
+            true,
+            new LogContext()
           )
         ) { snapshot =>
           // Check that the snapshot is non-empty

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -395,6 +395,8 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
         }
     }
 
+    private final LogContext logContext;
+
     private final Logger log;
 
     /**
@@ -448,6 +450,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                            SharedLogData shared,
                            String threadNamePrefix,
                            KRaftVersion lastKRaftVersion) {
+        this.logContext = logContext;
         this.log = logContext.logger(LocalLogManager.class);
         this.nodeId = nodeId;
         this.shared = shared;
@@ -477,7 +480,8 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                                         new  MetadataRecordSerde(),
                                         BufferSupplier.create(),
                                         Integer.MAX_VALUE,
-                                        true
+                                        true,
+                                        logContext
                                     )
                                 );
                             }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -443,7 +443,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 serde,
                 BufferSupplier.create(),
                 MAX_BATCH_SIZE_BYTES,
-                true /* Validate batch CRC*/
+                true, /* Validate batch CRC*/
+                logContext
             )
         );
     }
@@ -3896,7 +3897,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                     BufferSupplier.create(),
                     MAX_BATCH_SIZE_BYTES,
                     this,
-                    true /* Validate batch CRC*/
+                    true, /* Validate batch CRC*/
+                    logContext
                 )
             );
         }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/KRaftControlRecordStateMachine.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/KRaftControlRecordStateMachine.java
@@ -52,6 +52,7 @@ public final class KRaftControlRecordStateMachine {
     private static final long STARTING_NEXT_OFFSET = -1;
     private static final long SMALLEST_LOG_OFFSET = 0;
 
+    private final LogContext logContext;
     private final ReplicatedLog log;
     private final RecordSerde<?> serde;
     private final BufferSupplier bufferSupplier;
@@ -95,12 +96,13 @@ public final class KRaftControlRecordStateMachine {
         KafkaRaftMetrics kafkaRaftMetrics,
         ExternalKRaftMetrics externalKRaftMetrics
     ) {
+        this.logContext = logContext;
         this.log = log;
         this.voterSetHistory = new VoterSetHistory(staticVoterSet, logContext);
         this.serde = serde;
         this.bufferSupplier = bufferSupplier;
         this.maxBatchSizeBytes = maxBatchSizeBytes;
-        this.logger = logContext.logger(this.getClass());
+        this.logger = logContext.logger(getClass());
         this.kafkaRaftMetrics = kafkaRaftMetrics;
         this.externalKRaftMetrics = externalKRaftMetrics;
         this.staticVoterSet = staticVoterSet;
@@ -237,7 +239,8 @@ public final class KRaftControlRecordStateMachine {
                     serde,
                     bufferSupplier,
                     maxBatchSizeBytes,
-                    true // Validate batch CRC
+                    true, // Validate batch CRC
+                    logContext
                 )
             ) {
                 while (iterator.hasNext()) {
@@ -266,7 +269,8 @@ public final class KRaftControlRecordStateMachine {
                     serde,
                     bufferSupplier,
                     maxBatchSizeBytes,
-                    true // Validate batch CRC
+                    true, // Validate batch CRC
+                    logContext
                 )
             ) {
                 logger.info(

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RecordsBatchReader.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RecordsBatchReader.java
@@ -18,6 +18,7 @@ package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.BatchReader;
 import org.apache.kafka.server.common.serialization.RecordSerde;
@@ -102,11 +103,12 @@ public final class RecordsBatchReader<T> implements BatchReader<T> {
         BufferSupplier bufferSupplier,
         int maxBatchSize,
         CloseListener<BatchReader<T>> closeListener,
-        boolean doCrcValidation
+        boolean doCrcValidation,
+        LogContext logContext
     ) {
         return new RecordsBatchReader<>(
             baseOffset,
-            new RecordsIterator<>(records, serde, bufferSupplier, maxBatchSize, doCrcValidation),
+            new RecordsIterator<>(records, serde, bufferSupplier, maxBatchSize, doCrcValidation, logContext),
             closeListener
         );
     }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
@@ -27,10 +27,13 @@ import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteUtils;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.ControlRecord;
 import org.apache.kafka.server.common.serialization.RecordSerde;
+
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,6 +48,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseable {
+    private final Logger logger;
     private final Records records;
     private final RecordSerde<T> serde;
     private final BufferSupplier bufferSupplier;
@@ -73,13 +77,15 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
         RecordSerde<T> serde,
         BufferSupplier bufferSupplier,
         int batchSize,
-        boolean doCrcValidation
+        boolean doCrcValidation,
+        LogContext logContext
     ) {
         this.records = records;
         this.serde = serde;
         this.bufferSupplier = bufferSupplier;
         this.batchSize = Math.max(batchSize, Records.HEADER_SIZE_UP_TO_MAGIC);
         this.doCrcValidation = doCrcValidation;
+        this.logger = logContext.logger(getClass());
     }
 
     @Override
@@ -143,9 +149,15 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
         MemoryRecords memoryRecords = readFileRecords(fileRecords, buffer);
 
         // firstBatchSize() is always non-null because the minimum buffer is HEADER_SIZE_UP_TO_MAGIC.
-        if (memoryRecords.firstBatchSize() <= buffer.remaining()) {
+        int firstBatchSize = memoryRecords.firstBatchSize();
+        if (firstBatchSize <= buffer.remaining()) {
             return memoryRecords;
         } else {
+            logger.info(
+                "Creating a new buffer; previous buffer {} cannot fit at least {} bytes",
+                buffer,
+                firstBatchSize
+            );
             // Not enough bytes read; create a bigger buffer
             ByteBuffer newBuffer = bufferSupplier.get(memoryRecords.firstBatchSize());
             allocatedBuffer = Optional.of(newBuffer);

--- a/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotReader.java
@@ -20,6 +20,7 @@ package org.apache.kafka.snapshot;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.raft.internals.RecordsIterator;
@@ -112,11 +113,12 @@ public final class RecordsSnapshotReader<T> implements SnapshotReader<T> {
         RecordSerde<T> serde,
         BufferSupplier bufferSupplier,
         int maxBatchSize,
-        boolean doCrcValidation
+        boolean doCrcValidation,
+        LogContext logContext
     ) {
         return new RecordsSnapshotReader<>(
             snapshot.snapshotId(),
-            new RecordsIterator<>(snapshot.records(), serde, bufferSupplier, maxBatchSize, doCrcValidation)
+            new RecordsIterator<>(snapshot.records(), serde, bufferSupplier, maxBatchSize, doCrcValidation, logContext)
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.snapshot;
 
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.KafkaRaftClient;
 import org.apache.kafka.raft.OffsetAndEpoch;
@@ -159,23 +160,26 @@ public final class Snapshots {
         }
     }
 
-    public static long lastContainedLogTimestamp(RawSnapshotReader reader) {
-        try (RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
-             RecordsSnapshotReader.of(
-                 reader,
-                 IdentitySerde.INSTANCE,
-                 new BufferSupplier.GrowableBufferSupplier(),
-                 KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
-                 true
-             )
-        ) {
-            return recordsSnapshotReader.lastContainedLogTimestamp();
+    public static long lastContainedLogTimestamp(RawSnapshotReader reader, LogContext logContext) {
+        try (var bufferSupplier = new BufferSupplier.GrowableBufferSupplier()) {
+            try (RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
+                RecordsSnapshotReader.of(
+                    reader,
+                    IdentitySerde.INSTANCE,
+                    bufferSupplier,
+                    KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+                    true,
+                    logContext
+                )
+            ) {
+                return recordsSnapshotReader.lastContainedLogTimestamp();
+            }
         }
     }
 
-    public static long lastContainedLogTimestamp(Path logDir, OffsetAndEpoch snapshotId) {
+    public static long lastContainedLogTimestamp(Path logDir, OffsetAndEpoch snapshotId, LogContext logContext) {
         try (FileRawSnapshotReader reader = FileRawSnapshotReader.open(logDir, snapshotId)) {
-            return lastContainedLogTimestamp(reader);
+            return lastContainedLogTimestamp(reader, logContext);
         }
     }
 }

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -161,8 +161,8 @@ public final class Snapshots {
     }
 
     public static long lastContainedLogTimestamp(RawSnapshotReader reader, LogContext logContext) {
-        try (var bufferSupplier = new BufferSupplier.GrowableBufferSupplier()) {
-            try (RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
+        try (var bufferSupplier = new BufferSupplier.GrowableBufferSupplier();
+             RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
                 RecordsSnapshotReader.of(
                     reader,
                     IdentitySerde.INSTANCE,
@@ -171,9 +171,8 @@ public final class Snapshots {
                     true,
                     logContext
                 )
-            ) {
-                return recordsSnapshotReader.lastContainedLogTimestamp();
-            }
+        ) {
+            return recordsSnapshotReader.lastContainedLogTimestamp();
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.server.common.Feature;
 import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.snapshot.RecordsSnapshotReader;
@@ -127,7 +128,8 @@ public class KafkaRaftClientReconfigTest {
                 context.serde,
                 BufferSupplier.NO_CACHING,
                 KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
-                false
+                false,
+                new LogContext()
             )
         ) {
             SnapshotWriterReaderTest.assertControlSnapshot(expectedBootstrapRecords, reader);

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -927,6 +927,7 @@ public class RaftEventSimulationTest {
     }
 
     private static class RaftNode {
+        final LogContext logContext;
         final int nodeId;
         final KafkaRaftClient<Integer> client;
         final MockLog log;
@@ -948,6 +949,7 @@ public class RaftEventSimulationTest {
             Random random,
             RecordSerde<Integer> intSerde
         ) {
+            this.logContext = logContext;
             this.nodeId = nodeId;
             this.client = client;
             this.log = log;
@@ -996,6 +998,10 @@ public class RaftEventSimulationTest {
                 highWatermark(),
                 logEndOffset()
             );
+        }
+
+        LogContext logContext() {
+            return logContext;
         }
     }
 
@@ -1335,7 +1341,8 @@ public class RaftEventSimulationTest {
                         node.intSerde,
                         BufferSupplier.create(),
                         Integer.MAX_VALUE,
-                        true
+                        true,
+                        node.logContext()
                     )
                 ) {
                     // Since the state machine is only on e value we only expect one data record in the snapshot

--- a/raft/src/test/java/org/apache/kafka/raft/internals/RecordsBatchReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/RecordsBatchReaderTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.raft.BatchReader;
 import org.apache.kafka.raft.ControlRecord;
 import org.apache.kafka.raft.internals.RecordsIteratorTest.TestBatch;
@@ -88,7 +89,8 @@ class RecordsBatchReaderTest {
                 BufferSupplier.NO_CACHING,
                 MAX_BATCH_BYTES,
                 ignore -> { },
-                true
+                true,
+                new LogContext()
             )
         ) {
             assertTrue(reader.hasNext());
@@ -128,7 +130,8 @@ class RecordsBatchReaderTest {
             bufferSupplier,
             MAX_BATCH_BYTES,
             closeListener,
-            true
+            true,
+            new LogContext()
         );
         try {
             for (TestBatch<String> batch : expectedBatches) {

--- a/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.ControlRecord;
@@ -322,7 +323,14 @@ public final class RecordsIteratorTest {
         BufferSupplier bufferSupplier,
         boolean validateCrc
     ) {
-        return new RecordsIterator<>(records, STRING_SERDE, bufferSupplier, Records.HEADER_SIZE_UP_TO_MAGIC, validateCrc);
+        return new RecordsIterator<>(
+            records,
+            STRING_SERDE,
+            bufferSupplier,
+            Records.HEADER_SIZE_UP_TO_MAGIC,
+            validateCrc,
+            new LogContext()
+        );
     }
 
     static BufferSupplier mockBufferSupplier(Set<ByteBuffer> buffers) {

--- a/raft/src/test/java/org/apache/kafka/snapshot/RecordsSnapshotWriterTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/RecordsSnapshotWriterTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.OffsetAndEpoch;
@@ -68,7 +69,8 @@ final class RecordsSnapshotWriterTest {
                 STRING_SERDE,
                 BufferSupplier.NO_CACHING,
                 maxBatchSize,
-                true
+                true,
+                new LogContext()
             )
         ) {
             // Consume the control record batch
@@ -140,7 +142,8 @@ final class RecordsSnapshotWriterTest {
                 STRING_SERDE,
                 BufferSupplier.NO_CACHING,
                 maxBatchSize,
-                true
+                true,
+                new LogContext()
             )
         ) {
             // Consume the control record batch
@@ -197,7 +200,8 @@ final class RecordsSnapshotWriterTest {
                 STRING_SERDE,
                 BufferSupplier.NO_CACHING,
                 maxBatchSize,
-                true
+                true,
+                new LogContext()
             )
         ) {
             // Consume the control record batch

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.BufferSupplier.GrowableBufferSupplier;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.ControlRecord;
 import org.apache.kafka.raft.OffsetAndEpoch;
@@ -111,7 +112,7 @@ public final class SnapshotWriterReaderTest {
             assertEquals((recordsPerBatch * batches) + delimiterCount, recordCount);
             assertDataSnapshot(expected, reader);
 
-            assertEquals(magicTimestamp, Snapshots.lastContainedLogTimestamp(snapshot));
+            assertEquals(magicTimestamp, Snapshots.lastContainedLogTimestamp(snapshot, new LogContext()));
         }
     }
 
@@ -195,7 +196,8 @@ public final class SnapshotWriterReaderTest {
             context.serde,
             BufferSupplier.create(),
             maxBatchSize,
-            true
+            true,
+            new LogContext()
         );
     }
 
@@ -249,7 +251,14 @@ public final class SnapshotWriterReaderTest {
     public static void assertDataSnapshot(List<List<String>> batches, RawSnapshotReader reader) {
         assertDataSnapshot(
             batches,
-            RecordsSnapshotReader.of(reader, new StringSerde(), BufferSupplier.create(), Integer.MAX_VALUE, true)
+            RecordsSnapshotReader.of(
+                reader,
+                new StringSerde(),
+                BufferSupplier.create(),
+                Integer.MAX_VALUE,
+                true,
+                new LogContext()
+            )
         );
     }
 


### PR DESCRIPTION
Log a message when reading a batch that is larger than the currently
allocated batch.

Reviewers: Colin Patrick McCabe <cmccabe@apache.org>, PoAn Yang
 <payang@apache.org>
