### PR TITLE
HOTFIX: Fix IQv2EndpointToPartitionsIntegrationTest

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2EndpointToPartitionsIntegrationTest.java
@@ -72,7 +72,7 @@ public class IQv2EndpointToPartitionsIntegrationTest {
     public void startCluster(final int standbyConfig) throws IOException {
         final Properties properties = new Properties();
         properties.put(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_CONFIG, standbyConfig);
-        cluster = EmbeddedKafkaCluster.withStreamsRebalanceProtocol(NUM_BROKERS, properties);
+        cluster = new EmbeddedKafkaCluster(NUM_BROKERS, properties);
         cluster.start();
     }
 


### PR DESCRIPTION
It seems that IQv2EndpointToPartitionsIntegrationTest uses a
non-existent method to create `EmbeddedKafkaCluster`

Reviewers: Luke Chen <showuon@gmail.com>, PoAn Yang <payang@apache.org>,
 Ken Huang <s7133700@gmail.com>
