### PR TITLE
MINOR: printing share group describe result in sorted order

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
@@ -41,6 +41,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -344,7 +345,12 @@ public class ShareGroupCommand {
 
         private void printOffsets(TreeMap<String, Entry<ShareGroupDescription, Collection<SharePartitionOffsetInformation>>> offsets, boolean verbose) {
             offsets.forEach((groupId, tuple) -> {
-                Collection<SharePartitionOffsetInformation> offsetsInfo = tuple.getValue();
+                Collection<SharePartitionOffsetInformation> offsetsInfo = tuple.getValue().stream()
+                    .sorted(Comparator
+                        .comparing((SharePartitionOffsetInformation info) -> info.topic)
+                        .thenComparingInt(info -> info.partition))
+                    .toList();
+
                 String fmt = printOffsetFormat(groupId, offsetsInfo, verbose);
 
                 if (verbose) {
@@ -414,7 +420,10 @@ public class ShareGroupCommand {
             descriptions.forEach((groupId, description) -> {
                 int groupLen = Math.max(15, groupId.length());
                 int maxConsumerIdLen = 15, maxHostLen = 15, maxClientIdLen = 15;
-                Collection<ShareMemberDescription> members = description.members();
+                Collection<ShareMemberDescription> members = description.members()
+                    .stream()
+                    .sorted(Comparator.comparing(ShareMemberDescription::consumerId))
+                    .toList();
                 if (maybePrintEmptyGroupState(groupId, description.groupState(), description.members().size())) {
                     for (ShareMemberDescription member : members) {
                         maxConsumerIdLen = Math.max(maxConsumerIdLen, member.consumerId().length());


### PR DESCRIPTION
This PR sorts the information that is printed when kafka-share-groups.sh
--describe is used
