### PR TITLE
KAFKA-19202: Enable KIP-1071 in streams_relational_smoke_test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -635,6 +635,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                                            final String application,
                                            final String id,
                                            final String processingGuarantee,
+                                           final String groupProtocol,
                                            final String stateDir) {
             final Properties properties =
                 mkProperties(
@@ -644,7 +645,8 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                         mkEntry(StreamsConfig.CLIENT_ID_CONFIG, id),
                         mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee),
                         mkEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
-                        mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir)
+                        mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir),
+                        mkEntry(StreamsConfig.GROUP_PROTOCOL_CONFIG, groupProtocol)
                     )
                 );
             properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
@@ -656,9 +658,10 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                                              final String application,
                                              final String id,
                                              final String processingGuarantee,
+                                             final String groupProtocol,
                                              final String stateDir) throws InterruptedException {
             final KafkaStreams kafkaStreams =
-                new KafkaStreams(getTopology(), getConfig(broker, application, id, processingGuarantee, stateDir));
+                new KafkaStreams(getTopology(), getConfig(broker, application, id, processingGuarantee, groupProtocol, stateDir));
             final CountDownLatch startUpLatch = new CountDownLatch(1);
             kafkaStreams.setStateListener((newState, oldState) -> {
                 if (oldState == KafkaStreams.State.REBALANCING && newState == KafkaStreams.State.RUNNING) {
@@ -989,8 +992,9 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                 case "application": {
                     final String nodeId = args[2];
                     final String processingGuarantee = args[3];
-                    final String stateDir = args[4];
-                    App.startSync(kafka, UUID.randomUUID().toString(), nodeId, processingGuarantee, stateDir);
+                    final String groupProtocol = args[4];
+                    final String stateDir = args[5];
+                    App.startSync(kafka, UUID.randomUUID().toString(), nodeId, processingGuarantee, groupProtocol, stateDir);
                     break;
                 }
                 default:

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTestTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTestTest.java
@@ -45,6 +45,7 @@ public class RelationalSmokeTestTest extends SmokeTestUtil {
                                             "test",
                                             "test",
                                             StreamsConfig.AT_LEAST_ONCE,
+                                            "classic",
                                             TestUtils.tempDirectory().getAbsolutePath()
                                         ))) {
 

--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -74,7 +74,6 @@ DELEGATION_TOKEN_EXPIRY_TIME_MS="delegation.token.expiry.time.ms"
 DELEGATION_TOKEN_SECRET_KEY="delegation.token.secret.key"
 SASL_ENABLED_MECHANISMS="sasl.enabled.mechanisms"
 
-GROUP_COORDINATOR_REBALANCE_PROTOCOLS="group.coordinator.rebalance.protocols"
 CONSUMER_GROUP_MIGRATION_POLICY = "group.consumer.migration.policy"
 
 SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR ="share.coordinator.state.topic.replication.factor"
@@ -82,6 +81,7 @@ SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR = "share.coordinator.state.topic.min.isr"
 SHARE_GROUP_ENABLE = "group.share.enable"
 
 UNSTABLE_API_VERSIONS_ENABLE = "unstable.api.versions.enable"
+UNSTABLE_FEATURE_VERSIONS_ENABLE = "unstable.feature.versions.enable"
 
 """
 From KafkaConfig.scala

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -784,17 +784,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         for prop in self.per_node_server_prop_overrides.get(self.idx(node), []):
             override_configs[prop[0]] = prop[1]
 
-        enabledProtocols = 'classic,consumer'
-
         if self.use_share_groups is not None and self.use_share_groups is True:
             override_configs[config_property.SHARE_GROUP_ENABLE] = str(self.use_share_groups)
-            enabledProtocols += ',share'
 
         if self.use_streams_groups is True:
             override_configs[config_property.UNSTABLE_API_VERSIONS_ENABLE] = str(True)
-            enabledProtocols += ',streams'
-
-        override_configs[config_property.GROUP_COORDINATOR_REBALANCE_PROTOCOLS] = enabledProtocols
+            override_configs[config_property.UNSTABLE_FEATURE_VERSIONS_ENABLE] = str(True)
 
         #update template configs with test override configs
         configs.update(override_configs)

--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -47,6 +47,7 @@ class BaseStreamsTest(Test):
 
     def setUp(self):
         self.kafka.start()
+        self.kafka.run_features_command("upgrade", "streams.version", 1)
 
     def get_consumer(self, client_id, topic, num_messages):
         return VerifiableConsumer(self.test_context,


### PR DESCRIPTION
Enable next system test with KIP-1071.

Also fixes the other KIP-1071 system tests, which now require enabling
the unstable `streams.version` feature.

Reviewers: Bill Bejeck <bbejeck@apache.org>
