### PR TITLE
MINOR: Improve output for delete-offset of kafka-consumer-groups.sh

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -229,7 +229,7 @@ public enum Errors {
             "The group member's supported protocols are incompatible with those of existing members " +
             "or first group member tried to join with empty protocol type or empty protocol list.",
             InconsistentGroupProtocolException::new),
-    INVALID_GROUP_ID(24, "The configured groupId is invalid.",
+    INVALID_GROUP_ID(24, "The group id is invalid.",
             InvalidGroupIdException::new),
     UNKNOWN_MEMBER_ID(25, "The coordinator is not aware of this member.",
             UnknownMemberIdException::new),

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -708,7 +708,7 @@ public class ConsumerGroupCommand {
             }
         }
 
-        Entry<Throwable, Map<TopicPartition, Throwable>> deleteOffsets(String groupId, List<String> topics) {
+        Entry<Errors, Map<TopicPartition, Throwable>> deleteOffsets(String groupId, List<String> topics) {
             Map<TopicPartition, Throwable> partitionLevelResult = new HashMap<>();
             Set<String> topicWithPartitions = new HashSet<>();
             Set<String> topicWithoutPartitions = new HashSet<>();
@@ -748,12 +748,12 @@ public class ConsumerGroupCommand {
                 withTimeoutMs(new DeleteConsumerGroupOffsetsOptions())
             );
 
-            Throwable topLevelException = null;
+            Errors topLevelException = Errors.NONE;
 
             try {
                 deleteResult.all().get();
             } catch (ExecutionException | InterruptedException e) {
-                topLevelException = e.getCause();
+                topLevelException = Errors.forException(e.getCause());
             }
 
             partitions.forEach(partition -> {
@@ -772,30 +772,28 @@ public class ConsumerGroupCommand {
             String groupId = opts.options.valueOf(opts.groupOpt);
             List<String> topics = opts.options.valuesOf(opts.topicOpt);
 
-            Entry<Throwable, Map<TopicPartition, Throwable>> res = deleteOffsets(groupId, topics);
+            Entry<Errors, Map<TopicPartition, Throwable>> res = deleteOffsets(groupId, topics);
 
-            Throwable topLevelResult = res.getKey();
+            Errors topLevelResult = res.getKey();
             Map<TopicPartition, Throwable> partitionLevelResult = res.getValue();
 
-            if (topLevelResult == null) {
-                System.out.println("Request succeeded for deleting offsets from group " + groupId + ".");
-            } else {
-                Errors topLevelError = Errors.forException(topLevelResult);
-                switch (topLevelError) {
-                    case INVALID_GROUP_ID:
-                    case GROUP_ID_NOT_FOUND:
-                    case GROUP_AUTHORIZATION_FAILED:
-                    case NON_EMPTY_GROUP:
-                        printError(topLevelResult.getMessage(), Optional.empty());
-                        break;
-                    case GROUP_SUBSCRIBED_TO_TOPIC:
-                    case TOPIC_AUTHORIZATION_FAILED:
-                    case UNKNOWN_TOPIC_OR_PARTITION:
-                        printError("Encountered some partition-level error, see the follow-up details:", Optional.empty());
-                        break;
-                    default:
-                        printError("Encountered some unknown error: " + topLevelResult, Optional.empty());
-                }
+            switch (topLevelResult) {
+                case NONE:
+                    System.out.println("Request succeeded for deleting offsets from group " + groupId + ".");
+                    break;
+                case INVALID_GROUP_ID:
+                case GROUP_ID_NOT_FOUND:
+                case GROUP_AUTHORIZATION_FAILED:
+                case NON_EMPTY_GROUP:
+                    printError(topLevelResult.message(), Optional.empty());
+                    break;
+                case GROUP_SUBSCRIBED_TO_TOPIC:
+                case TOPIC_AUTHORIZATION_FAILED:
+                case UNKNOWN_TOPIC_OR_PARTITION:
+                    printError("Encountered some partition-level error, see the follow-up details.", Optional.empty());
+                    break;
+                default:
+                    printError("Encountered some unknown error: " + topLevelResult, Optional.empty());
             }
 
             int maxTopicLen = 15;

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -708,7 +708,7 @@ public class ConsumerGroupCommand {
             }
         }
 
-        Entry<Errors, Map<TopicPartition, Throwable>> deleteOffsets(String groupId, List<String> topics) {
+        Entry<Throwable, Map<TopicPartition, Throwable>> deleteOffsets(String groupId, List<String> topics) {
             Map<TopicPartition, Throwable> partitionLevelResult = new HashMap<>();
             Set<String> topicWithPartitions = new HashSet<>();
             Set<String> topicWithoutPartitions = new HashSet<>();
@@ -748,12 +748,12 @@ public class ConsumerGroupCommand {
                 withTimeoutMs(new DeleteConsumerGroupOffsetsOptions())
             );
 
-            Errors topLevelException = Errors.NONE;
+            Throwable topLevelException = null;
 
             try {
                 deleteResult.all().get();
             } catch (ExecutionException | InterruptedException e) {
-                topLevelException = Errors.forException(e.getCause());
+                topLevelException = e.getCause();
             }
 
             partitions.forEach(partition -> {
@@ -772,37 +772,38 @@ public class ConsumerGroupCommand {
             String groupId = opts.options.valueOf(opts.groupOpt);
             List<String> topics = opts.options.valuesOf(opts.topicOpt);
 
-            Entry<Errors, Map<TopicPartition, Throwable>> res = deleteOffsets(groupId, topics);
+            Entry<Throwable, Map<TopicPartition, Throwable>> res = deleteOffsets(groupId, topics);
 
-            Errors topLevelResult = res.getKey();
+            Throwable topLevelResult = res.getKey();
             Map<TopicPartition, Throwable> partitionLevelResult = res.getValue();
 
-            switch (topLevelResult) {
-                case NONE:
-                    System.out.println("Request succeed for deleting offsets with topic " + String.join(", ", topics) + " group " + groupId);
-                    break;
-                case INVALID_GROUP_ID:
-                    printError("'" + groupId + "' is not valid.", Optional.empty());
-                    break;
-                case GROUP_ID_NOT_FOUND:
-                    printError("'" + groupId + "' does not exist.", Optional.empty());
-                    break;
-                case GROUP_AUTHORIZATION_FAILED:
-                    printError("Access to '" + groupId + "' is not authorized.", Optional.empty());
-                    break;
-                case NON_EMPTY_GROUP:
-                    printError("Deleting offsets of a consumer group '" + groupId + "' is forbidden if the group is not empty.", Optional.empty());
-                    break;
-                case GROUP_SUBSCRIBED_TO_TOPIC:
-                case TOPIC_AUTHORIZATION_FAILED:
-                case UNKNOWN_TOPIC_OR_PARTITION:
-                    printError("Encounter some partition level error, see the follow-up details:", Optional.empty());
-                    break;
-                default:
-                    printError("Encounter some unknown error: " + topLevelResult, Optional.empty());
+            if (topLevelResult == null) {
+                System.out.println("Request succeed for deleting offsets with topic " + String.join(", ", topics) + " group " + groupId);
+            } else {
+                Errors topLevelError = Errors.forException(topLevelResult);
+                switch (topLevelError) {
+                    case INVALID_GROUP_ID:
+                    case GROUP_ID_NOT_FOUND:
+                    case GROUP_AUTHORIZATION_FAILED:
+                    case NON_EMPTY_GROUP:
+                        printError(topLevelResult.getMessage(), Optional.empty());
+                        break;
+                    case GROUP_SUBSCRIBED_TO_TOPIC:
+                    case TOPIC_AUTHORIZATION_FAILED:
+                    case UNKNOWN_TOPIC_OR_PARTITION:
+                        printError("Encountered some partition-level error, see the follow-up details:", Optional.empty());
+                        break;
+                    default:
+                        printError("Encountered some unknown error: " + topLevelResult, Optional.empty());
+                }
             }
 
-            String format = "%n%-30s %-15s %-15s";
+            int maxTopicLen = 15;
+            for (TopicPartition tp : partitionLevelResult.keySet()) {
+                maxTopicLen = Math.max(maxTopicLen, tp.topic().length());
+            }
+
+            String format = "%n%" + (-maxTopicLen) + "s %-10s %-15s";
 
             System.out.printf(format, "TOPIC", "PARTITION", "STATUS");
             partitionLevelResult.entrySet().stream()
@@ -812,7 +813,7 @@ public class ConsumerGroupCommand {
                     Throwable error = e.getValue();
                     System.out.printf(format,
                         tp.topic(),
-                        tp.partition() >= 0 ? tp.partition() : "Not Provided",
+                        tp.partition() >= 0 ? tp.partition() : MISSING_COLUMN_VALUE,
                         error != null ? "Error: " + error.getMessage() : "Successful"
                     );
                 });

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -778,7 +778,7 @@ public class ConsumerGroupCommand {
             Map<TopicPartition, Throwable> partitionLevelResult = res.getValue();
 
             if (topLevelResult == null) {
-                System.out.println("Request succeed for deleting offsets with topic " + String.join(", ", topics) + " group " + groupId);
+                System.out.println("Request succeeded for deleting offsets from group " + groupId + ".");
             } else {
                 Errors topLevelError = Errors.forException(topLevelResult);
                 switch (topLevelError) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteOffsetsConsumerGroupCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteOffsetsConsumerGroupCommandIntegrationTest.java
@@ -80,8 +80,8 @@ public class DeleteOffsetsConsumerGroupCommandIntegrationTest {
         String group = "missing.group";
         String topic = "foo:1";
         try (ConsumerGroupCommand.ConsumerGroupService consumerGroupService = consumerGroupService(getArgs(group, topic))) {
-            Entry<Throwable, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(group, Collections.singletonList(topic));
-            assertEquals(Errors.GROUP_ID_NOT_FOUND, Errors.forException(res.getKey()));
+            Entry<Errors, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(group, Collections.singletonList(topic));
+            assertEquals(Errors.GROUP_ID_NOT_FOUND, res.getKey());
         }
     }
 
@@ -197,17 +197,13 @@ public class DeleteOffsetsConsumerGroupCommandIntegrationTest {
         return () -> {
             String topic = inputPartition >= 0 ? inputTopic + ":" + inputPartition : inputTopic;
             try (ConsumerGroupCommand.ConsumerGroupService consumerGroupService = consumerGroupService(getArgs(inputGroup, topic))) {
-                Entry<Throwable, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(inputGroup, Collections.singletonList(topic));
-                Throwable topLevelError = res.getKey();
+                Entry<Errors, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(inputGroup, Collections.singletonList(topic));
+                Errors topLevelError = res.getKey();
                 Map<TopicPartition, Throwable> partitions = res.getValue();
                 TopicPartition tp = new TopicPartition(inputTopic, expectedPartition);
                 // Partition level error should propagate to top level, unless this is due to a missed partition attempt.
                 if (inputPartition >= 0) {
-                    if (topLevelError == null) {
-                        assertEquals(expectedError, Errors.NONE);
-                    } else {
-                        assertEquals(expectedError, Errors.forException(topLevelError));
-                    }
+                    assertEquals(expectedError, topLevelError);
                 }
                 if (expectedError == Errors.NONE)
                     assertNull(partitions.get(tp));

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteOffsetsConsumerGroupCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteOffsetsConsumerGroupCommandIntegrationTest.java
@@ -80,8 +80,8 @@ public class DeleteOffsetsConsumerGroupCommandIntegrationTest {
         String group = "missing.group";
         String topic = "foo:1";
         try (ConsumerGroupCommand.ConsumerGroupService consumerGroupService = consumerGroupService(getArgs(group, topic))) {
-            Entry<Errors, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(group, Collections.singletonList(topic));
-            assertEquals(Errors.GROUP_ID_NOT_FOUND, res.getKey());
+            Entry<Throwable, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(group, Collections.singletonList(topic));
+            assertEquals(Errors.GROUP_ID_NOT_FOUND, Errors.forException(res.getKey()));
         }
     }
 
@@ -197,13 +197,17 @@ public class DeleteOffsetsConsumerGroupCommandIntegrationTest {
         return () -> {
             String topic = inputPartition >= 0 ? inputTopic + ":" + inputPartition : inputTopic;
             try (ConsumerGroupCommand.ConsumerGroupService consumerGroupService = consumerGroupService(getArgs(inputGroup, topic))) {
-                Entry<Errors, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(inputGroup, Collections.singletonList(topic));
-                Errors topLevelError = res.getKey();
+                Entry<Throwable, Map<TopicPartition, Throwable>> res = consumerGroupService.deleteOffsets(inputGroup, Collections.singletonList(topic));
+                Throwable topLevelError = res.getKey();
                 Map<TopicPartition, Throwable> partitions = res.getValue();
                 TopicPartition tp = new TopicPartition(inputTopic, expectedPartition);
                 // Partition level error should propagate to top level, unless this is due to a missed partition attempt.
                 if (inputPartition >= 0) {
-                    assertEquals(expectedError, topLevelError);
+                    if (topLevelError == null) {
+                        assertEquals(expectedError, Errors.NONE);
+                    } else {
+                        assertEquals(expectedError, Errors.forException(topLevelError));
+                    }
                 }
                 if (expectedError == Errors.NONE)
                     assertNull(partitions.get(tp));


### PR DESCRIPTION
The output from the delete-offsets option of kafka-consumer-groups.sh
can be improved. For example, the column widths are excessive which
looks untidy, and the output messages can be improved.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
