### PR TITLE
MINOR: Remove unnecessary Optional from offsetsToSnapshot

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -2416,15 +2416,15 @@ public class UnifiedLog implements AutoCloseable {
                                             Time time,
                                             boolean reloadFromCleanShutdown,
                                             String logPrefix) throws IOException {
-        List<Optional<Long>> offsetsToSnapshot = new ArrayList<>();
+        List<Long> offsetsToSnapshot = new ArrayList<>();
         if (segments.nonEmpty()) {
             long lastSegmentBaseOffset = segments.lastSegment().get().baseOffset();
             Optional<LogSegment> lowerSegment = segments.lowerSegment(lastSegmentBaseOffset);
             Optional<Long> nextLatestSegmentBaseOffset = lowerSegment.map(LogSegment::baseOffset);
-            offsetsToSnapshot.add(nextLatestSegmentBaseOffset);
-            offsetsToSnapshot.add(Optional.of(lastSegmentBaseOffset));
+            nextLatestSegmentBaseOffset.ifPresent(offsetsToSnapshot::add);
+            offsetsToSnapshot.add(lastSegmentBaseOffset);
         }
-        offsetsToSnapshot.add(Optional.of(lastOffset));
+        offsetsToSnapshot.add(lastOffset);
 
         LOG.info("{}Loading producer state till offset {}", logPrefix, lastOffset);
 
@@ -2443,11 +2443,9 @@ public class UnifiedLog implements AutoCloseable {
             // To avoid an expensive scan through all the segments, we take empty snapshots from the start of the
             // last two segments and the last offset. This should avoid the full scan in the case that the log needs
             // truncation.
-            for (Optional<Long> offset : offsetsToSnapshot) {
-                if (offset.isPresent()) {
-                    producerStateManager.updateMapEndOffset(offset.get());
-                    producerStateManager.takeSnapshot();
-                }
+            for (Long offset : offsetsToSnapshot) {
+                producerStateManager.updateMapEndOffset(offset);
+                producerStateManager.takeSnapshot();
             }
         } else {
             LOG.info("{}Reloading from producer snapshot and rebuilding producer state from offset {}", logPrefix, lastOffset);
@@ -2469,7 +2467,7 @@ public class UnifiedLog implements AutoCloseable {
                     long startOffset = Utils.max(segment.baseOffset(), producerStateManager.mapEndOffset(), logStartOffset);
                     producerStateManager.updateMapEndOffset(startOffset);
 
-                    if (offsetsToSnapshot.contains(Optional.of(segment.baseOffset()))) {
+                    if (offsetsToSnapshot.contains(segment.baseOffset())) {
                         producerStateManager.takeSnapshot();
                     }
                     int maxPosition = segment.size();

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -2417,7 +2417,7 @@ public class UnifiedLog implements AutoCloseable {
                                             boolean reloadFromCleanShutdown,
                                             String logPrefix) throws IOException {
         List<Long> offsetsToSnapshot = new ArrayList<>();
-        if (segments.nonEmpty()) {
+        if (segments.lastSegment().isPresent()) {
             long lastSegmentBaseOffset = segments.lastSegment().get().baseOffset();
             Optional<LogSegment> lowerSegment = segments.lowerSegment(lastSegmentBaseOffset);
             Optional<Long> nextLatestSegmentBaseOffset = lowerSegment.map(LogSegment::baseOffset);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -2419,8 +2419,7 @@ public class UnifiedLog implements AutoCloseable {
         List<Long> offsetsToSnapshot = new ArrayList<>();
         segments.lastSegment().ifPresent(lastSegment -> {
             long lastSegmentBaseOffset = lastSegment.baseOffset();
-            Optional<Long> nextLatestSegmentBaseOffset = segments.lowerSegment(lastSegmentBaseOffset).map(LogSegment::baseOffset);
-            nextLatestSegmentBaseOffset.ifPresent(offsetsToSnapshot::add);
+            segments.lowerSegment(lastSegmentBaseOffset).ifPresent(s -> offsetsToSnapshot.add(s.baseOffset()));
             offsetsToSnapshot.add(lastSegmentBaseOffset);
         });
         offsetsToSnapshot.add(lastOffset);
@@ -2442,7 +2441,7 @@ public class UnifiedLog implements AutoCloseable {
             // To avoid an expensive scan through all the segments, we take empty snapshots from the start of the
             // last two segments and the last offset. This should avoid the full scan in the case that the log needs
             // truncation.
-            for (Long offset : offsetsToSnapshot) {
+            for (long offset : offsetsToSnapshot) {
                 producerStateManager.updateMapEndOffset(offset);
                 producerStateManager.takeSnapshot();
             }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -2419,7 +2419,8 @@ public class UnifiedLog implements AutoCloseable {
         List<Long> offsetsToSnapshot = new ArrayList<>();
         segments.lastSegment().ifPresent(lastSegment -> {
             long lastSegmentBaseOffset = lastSegment.baseOffset();
-            segments.lowerSegment(lastSegmentBaseOffset).map(LogSegment::baseOffset).ifPresent(offsetsToSnapshot::add);
+            Optional<Long> nextLatestSegmentBaseOffset = segments.lowerSegment(lastSegmentBaseOffset).map(LogSegment::baseOffset);
+            nextLatestSegmentBaseOffset.ifPresent(offsetsToSnapshot::add);
             offsetsToSnapshot.add(lastSegmentBaseOffset);
         });
         offsetsToSnapshot.add(lastOffset);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -2421,8 +2421,8 @@ public class UnifiedLog implements AutoCloseable {
             long lastSegmentBaseOffset = segments.lastSegment().get().baseOffset();
             Optional<LogSegment> lowerSegment = segments.lowerSegment(lastSegmentBaseOffset);
             Optional<Long> nextLatestSegmentBaseOffset = lowerSegment.map(LogSegment::baseOffset);
-            nextLatestSegmentBaseOffset.ifPresent(offsetsToSnapshot::add);
             offsetsToSnapshot.add(lastSegmentBaseOffset);
+            nextLatestSegmentBaseOffset.ifPresent(offsetsToSnapshot::add);
         }
         offsetsToSnapshot.add(lastOffset);
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -2417,13 +2417,11 @@ public class UnifiedLog implements AutoCloseable {
                                             boolean reloadFromCleanShutdown,
                                             String logPrefix) throws IOException {
         List<Long> offsetsToSnapshot = new ArrayList<>();
-        if (segments.lastSegment().isPresent()) {
-            long lastSegmentBaseOffset = segments.lastSegment().get().baseOffset();
-            Optional<LogSegment> lowerSegment = segments.lowerSegment(lastSegmentBaseOffset);
-            Optional<Long> nextLatestSegmentBaseOffset = lowerSegment.map(LogSegment::baseOffset);
+        segments.lastSegment().ifPresent(lastSegment -> {
+            long lastSegmentBaseOffset = lastSegment.baseOffset();
+            segments.lowerSegment(lastSegmentBaseOffset).map(LogSegment::baseOffset).ifPresent(offsetsToSnapshot::add);
             offsetsToSnapshot.add(lastSegmentBaseOffset);
-            nextLatestSegmentBaseOffset.ifPresent(offsetsToSnapshot::add);
-        }
+        });
         offsetsToSnapshot.add(lastOffset);
 
         LOG.info("{}Loading producer state till offset {}", logPrefix, lastOffset);


### PR DESCRIPTION
Remove unnecessary Optional container from offsetsToSnapshot.

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, TengYao Chi <kitingiao@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
