### PR TITLE
MINOR: use `isEmpty()` to avoid compiler warning

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerInterceptorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerInterceptorsTest.java
@@ -71,7 +71,7 @@ public class ProducerInterceptorsTest {
                 onErrorAckCount++;
                 // the length check is just to call topic() method and let it throw an exception
                 // if RecordMetadata.TopicPartition is null
-                if (metadata != null && metadata.topic().length() >= 0) {
+                if (metadata != null && !metadata.topic().isEmpty()) {
                     onErrorAckWithTopicSetCount++;
                     if (metadata.partition() >= 0)
                         onErrorAckWithTopicPartitionSetCount++;
@@ -126,7 +126,7 @@ public class ProducerInterceptorsTest {
                 onErrorAckCount++;
                 // the length check is just to call topic() method and let it throw an exception
                 // if RecordMetadata.TopicPartition is null
-                if (metadata != null && metadata.topic().length() >= 0) {
+                if (metadata != null && !metadata.topic().isEmpty()) {
                     onErrorAckWithTopicSetCount++;
                     if (metadata.partition() >= 0)
                         onErrorAckWithTopicPartitionSetCount++;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerInterceptorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerInterceptorsTest.java
@@ -69,9 +69,10 @@ public class ProducerInterceptorsTest {
             onAckCount++;
             if (exception != null) {
                 onErrorAckCount++;
-                // the length check is just to call topic() method and let it throw an exception
-                // if RecordMetadata.TopicPartition is null
-                if (metadata != null && !metadata.topic().isEmpty()) {
+                if (metadata != null) {
+                    if (metadata.topic() == null) {
+                        throw new NullPointerException("Topic is null");
+                    }
                     onErrorAckWithTopicSetCount++;
                     if (metadata.partition() >= 0)
                         onErrorAckWithTopicPartitionSetCount++;
@@ -124,9 +125,10 @@ public class ProducerInterceptorsTest {
             onAckCount++;
             if (exception != null) {
                 onErrorAckCount++;
-                // the length check is just to call topic() method and let it throw an exception
-                // if RecordMetadata.TopicPartition is null
-                if (metadata != null && !metadata.topic().isEmpty()) {
+                if (metadata != null) {
+                    if (metadata.topic() == null) {
+                        throw new NullPointerException("Topic is null");
+                    }
                     onErrorAckWithTopicSetCount++;
                     if (metadata.partition() >= 0)
                         onErrorAckWithTopicPartitionSetCount++;


### PR DESCRIPTION
Reviewers: Anna Sophie Blee-Goldman <ableegoldman@apache.org>
