### PR TITLE
MINOR: remove @FunctionalInterface annotation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/BatchingStateRestoreCallback.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/BatchingStateRestoreCallback.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 public interface BatchingStateRestoreCallback extends StateRestoreCallback {
 
     /**
-     * Called to restore a number of records.  This method is called repeatedly until the {@link StateStore} is fulled
+     * Called to restore a number of records. This method is called repeatedly until the {@link StateStore} is fully
      * restored.
      *
      * @param records the records to restore.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/BatchingStateRestoreCallback.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/BatchingStateRestoreCallback.java
@@ -28,7 +28,6 @@ import java.util.Collection;
  * It is expected that implementations of this class will not call the {@link StateRestoreCallback#restore(byte[],
  * byte[])} method.
  */
-@FunctionalInterface
 public interface BatchingStateRestoreCallback extends StateRestoreCallback {
 
     /**


### PR DESCRIPTION
BatchingStateRestoreCallback's default implemeantion of restore() lead
to waraning `FunctionalInterfaceMethodChanged`.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, PoAn Yang
 <payang@apache.org>, Ken Huang <s7133700@gmail.com>, TengYao Chi
 <frankvicky@apache.org>
