### PR TITLE
MINOR: Change info log to debug for scheduled timer tasks.

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -291,7 +291,6 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private CompletableFuture<Void> performRecordPruning(TopicPartition tp) {
-        // This future will always be completed normally, exception or not.
         CompletableFuture<Void> fut = new CompletableFuture<>();
 
         runtime.scheduleWriteOperation(
@@ -326,7 +325,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                 writer.deleteRecords(tp, off)
                     .whenComplete((res, exp) -> {
                         if (exp != null) {
-                            log.debug("Exception while deleting records in {} till offset {}.", tp, off, exp);
+                            log.error("Exception while deleting records in {} till offset {}.", tp, off, exp);
                             fut.completeExceptionally(exp);
                             return;
                         }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -271,7 +271,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private void setupRecordPruning() {
-        log.info("Scheduling share-group state topic prune job.");
+        log.debug("Scheduling share-group state topic prune job.");
         timer.add(new TimerTask(config.shareCoordinatorTopicPruneIntervalMs()) {
             @Override
             public void run() {
@@ -322,7 +322,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                     return;
                 }
 
-                log.info("Pruning records in {} till offset {}.", tp, off);
+                log.debug("Pruning records in {} till offset {}.", tp, off);
                 writer.deleteRecords(tp, off)
                     .whenComplete((res, exp) -> {
                         if (exp != null) {
@@ -347,7 +347,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private void setupSnapshotColdPartitions() {
-        log.info("Scheduling cold share-partition snapshotting.");
+        log.debug("Scheduling cold share-partition snapshotting.");
         timer.add(new TimerTask(config.shareCoordinatorColdPartitionSnapshotIntervalMs()) {
             @Override
             public void run() {


### PR DESCRIPTION
* We have a 2 perpetual timer tasks in ShareCoordinatorService to do
internal topic cleanup and snapshot cold partitions respectively.
* There are a few info level logs being printed as part of the
procedures. These are introducing noise and are not absolutely
necessary.
* We also move a debug log to error for the prune job.
* To remedy the situation, this PR changes the log level from info to
debug.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
