### PR TITLE
KAFKA-18537: Fix flaky RemoteIndexCacheTest#testCleanerThreadShutdown

### DIFF
--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -376,6 +376,8 @@ public class RemoteIndexCacheTest {
         // close the cache properly
         cache.close();
         // verify that the thread is closed properly
+        TestUtils.waitForCondition(() -> getRunningCleanerThread().isEmpty(),
+                "Failed while waiting for cleaner thread to shutdown");
         threads = getRunningCleanerThread();
         assertTrue(threads.isEmpty(), "Found unexpected " + threads.size() + " threads=" + threads.stream().map(Thread::getName).collect(Collectors.joining(", ")));
         // if the thread is correctly being shutdown it will not be running

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -376,10 +376,13 @@ public class RemoteIndexCacheTest {
         // close the cache properly
         cache.close();
         // verify that the thread is closed properly
-        TestUtils.waitForCondition(() -> getRunningCleanerThread().isEmpty(),
-                "Failed while waiting for cleaner threads to shutdown");
-        threads = getRunningCleanerThread();
-        assertTrue(threads.isEmpty(), "Found unexpected " + threads.size() + " threads=" + threads.stream().map(Thread::getName).collect(Collectors.joining(", ")));
+        TestUtils.waitForCondition(
+                () -> getRunningCleanerThread().isEmpty(),
+                () -> {
+                    Set<Thread> remaining = getRunningCleanerThread();
+                    return "Failed while waiting for cleaner threads to shutdown. Remaining threads: " +
+                            remaining.stream().map(Thread::getName).collect(Collectors.joining(", "));
+                });
         // if the thread is correctly being shutdown it will not be running
         assertFalse(cache.cleanerScheduler().isStarted(), "Unexpected thread state=running. Check error logs.");
     }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -377,7 +377,7 @@ public class RemoteIndexCacheTest {
         cache.close();
         // verify that the thread is closed properly
         TestUtils.waitForCondition(() -> getRunningCleanerThread().isEmpty(),
-                "Failed while waiting for cleaner thread to shutdown");
+                "Failed while waiting for cleaner threads to shutdown");
         threads = getRunningCleanerThread();
         assertTrue(threads.isEmpty(), "Found unexpected " + threads.size() + " threads=" + threads.stream().map(Thread::getName).collect(Collectors.joining(", ")));
         // if the thread is correctly being shutdown it will not be running

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -378,11 +378,8 @@ public class RemoteIndexCacheTest {
         // verify that the thread is closed properly
         TestUtils.waitForCondition(
                 () -> getRunningCleanerThread().isEmpty(),
-                () -> {
-                    Set<Thread> remaining = getRunningCleanerThread();
-                    return "Failed while waiting for cleaner threads to shutdown. Remaining threads: " +
-                            remaining.stream().map(Thread::getName).collect(Collectors.joining(", "));
-                });
+                () -> "Failed while waiting for cleaner threads to shutdown. Remaining threads: " +
+                        getRunningCleanerThread().stream().map(Thread::getName).collect(Collectors.joining(", ")));
         // if the thread is correctly being shutdown it will not be running
         assertFalse(cache.cleanerScheduler().isStarted(), "Unexpected thread state=running. Check error logs.");
     }


### PR DESCRIPTION
[Jira: KAFKA-18537](https://issues.apache.org/jira/browse/KAFKA-18537)
Add a wait for cleaner thread shutdown in `testCleanerThreadShutdown` to
eliminate flakiness. After calling `cache.close()`, the test now uses
`TestUtils.waitForCondition` to poll until the background
“remote-log-index-cleaner” thread has fully exited before asserting that
no cleaner threads remain. This ensures the asynchronous shutdown always
completes before the final assertions.

Reviewers: TengYao Chi <kitingiao@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
