### PR TITLE
KAFKA-19131: Adjust remote storage reader thread maximum pool size to avoid illegal argument

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -303,14 +303,26 @@ public class RemoteLogManager implements Closeable {
 
     public void resizeReaderThreadPool(int newSize) {
         int currentSize = remoteStorageReaderThreadPool.getCorePoolSize();
+        int currentMaximumSize = remoteStorageReaderThreadPool.getMaximumPoolSize();
         LOGGER.info("Updating remote reader thread pool size from {} to {}", currentSize, newSize);
-        remoteStorageReaderThreadPool.setCorePoolSize(newSize);
+        if (newSize > currentMaximumSize) {
+            remoteStorageReaderThreadPool.setMaximumPoolSize(newSize);
+            remoteStorageReaderThreadPool.setCorePoolSize(newSize);
+        } else {
+            remoteStorageReaderThreadPool.setCorePoolSize(newSize);
+            remoteStorageReaderThreadPool.setMaximumPoolSize(newSize);
+        }
     }
 
     private void removeMetrics() {
         metricsGroup.removeMetric(REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC);
         metricsGroup.removeMetric(REMOTE_LOG_READER_FETCH_RATE_AND_TIME_METRIC);
         remoteStorageReaderThreadPool.removeMetrics();
+    }
+
+    // Visible for testing
+    int readerThreadPoolSize() {
+        return remoteStorageReaderThreadPool.getCorePoolSize();
     }
 
     /**

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1156,7 +1156,7 @@ public class RemoteLogManagerTest {
                         safeLongYammerMetricValue("RemoteLogSizeComputationTime,topic=" + leaderTopic),
                         safeLongYammerMetricValue("RemoteLogSizeComputationTime")));
         remoteLogSizeComputationTimeLatch.countDown();
-        
+
         TestUtils.waitForCondition(
                 () -> 0 == safeLongYammerMetricValue("RemoteCopyLagBytes") && 0 == safeLongYammerMetricValue("RemoteCopyLagBytes,topic=" + leaderTopic),
                 String.format("Expected to find 0 for RemoteCopyLagBytes metric value, but found %d for topic 'Leader' and %d for all topics.",
@@ -3711,6 +3711,15 @@ public class RemoteLogManagerTest {
         verifyNoMoreInteractions(remoteLogMetadataManager);
         verify(remoteStorageManager).configure(anyMap());
         verifyNoMoreInteractions(remoteStorageManager);
+    }
+
+    @Test
+    void testUpdateRemoteStorageReaderThreads() {
+        assertEquals(10, remoteLogManager.readerThreadPoolSize());
+        remoteLogManager.resizeReaderThreadPool(6);
+        assertEquals(6, remoteLogManager.readerThreadPoolSize());
+        remoteLogManager.resizeReaderThreadPool(12);
+        assertEquals(12, remoteLogManager.readerThreadPoolSize());
     }
 
     private void appendRecordsToFile(File file, int nRecords, int nRecordsPerBatch) throws IOException {


### PR DESCRIPTION
The remote storage reader thread pool use same count for both maximum and core size. If users adjust the pool size larger than original value, it throws `IllegalArgumentException`. Updated both value to fix the issue.

cherry-pick PR: #19532
cherry-pick commit: https://github.com/apache/kafka/commit/965743c35bdf2d009456676e50024b767b2a9318

---------

Signed-off-by: PoAn Yang <payang@apache.org>

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, PoAn Yang <payang@apache.org>