### PR TITLE
KAFKA-19234: broker should return UNAUTHORIZATION error for non-exist…

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -413,8 +413,6 @@ class KafkaApis(val requestChannel: RequestChannel,
         val topicPartition = new TopicPartition(topicName, partition.index())
         if (topicName.isEmpty)
           nonExistingTopicResponses += new TopicIdPartition(topicId, topicPartition) -> new PartitionResponse(Errors.UNKNOWN_TOPIC_ID)
-        else if (!metadataCache.contains(topicPartition))
-          nonExistingTopicResponses += new TopicIdPartition(topicId, topicPartition) -> new PartitionResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION)
         else
           topicIdToPartitionData += new TopicIdPartition(topicId, topicPartition) -> partition
       }
@@ -429,6 +427,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       val memoryRecords = partition.records.asInstanceOf[MemoryRecords]
       if (!authorizedTopics.contains(topicIdPartition.topic))
         unauthorizedTopicResponses += topicIdPartition -> new PartitionResponse(Errors.TOPIC_AUTHORIZATION_FAILED)
+      else if (!metadataCache.contains(topicIdPartition.topicPartition))
+        nonExistingTopicResponses += topicIdPartition -> new PartitionResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION)
       else
         try {
           ProduceRequest.validateRecords(request.header.apiVersion, memoryRecords)


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/15968/files, we changed the authorization logic slightly. If a produce request includes a topic name that doesn't exist and is not authorized, it now returns an UNKNOWN_TOPIC_OR_PARTITION error. Since topic name is sensitive information, it should return a TOPIC_AUTHORIZATION_FAILED error as before that PR.

        else if (!metadataCache.contains(topicPartition))
          nonExistingTopicResponses += new TopicIdPartition(topicId, topicPartition) -> new PartitionResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION)
