### PR TITLE
KAFKA-19619: Refactore DescribeTopicPartitionsRequestHandler: Improve readability and add code documentation

### DIFF
--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -80,7 +80,7 @@ public class DescribeTopicPartitionsRequestHandler {
         final Set<String> topicsToDescribe = getTopicsToDescribe(requestData, cursorTopicName);
 
         // Validate cursor if provided in the request
-        validateCursor(requestData.cursor(), topicsToDescribe);
+        validateCursor(requestData.cursor());
 
         // Handle topics that are unauthorized for the Describe operation
         final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
@@ -149,26 +149,18 @@ public class DescribeTopicPartitionsRequestHandler {
     }
 
     /**
-     * Validates the cursor from the request. If the cursor is provided, it checks that the partition index is valid
-     * and that the topic in the cursor is included in the list of topics.
+     * Validates the pagination cursor for a describe-topics request.
+     * <p>
+     * If the cursor is provided, ensures the partition index is non-negative.
      *
-     * @param cursor           The cursor for pagination, if provided in the request.
-     * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
+     * @param cursor the pagination cursor, if present in the request
+     * @throws InvalidRequestException if the partition index is negative
      */
-    private void validateCursor(
-            final DescribeTopicPartitionsRequestData.Cursor cursor,
-            final Set<String> topicsToDescribe
-    ) {
-        if (cursor != null) {
-            // Validate that the partition index in the cursor is valid
-            if (cursor.partitionIndex() < 0) {
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
-            }
-
-            // Ensure the cursor topic is included in the list of topics
-            if (!topicsToDescribe.contains(cursor.topicName())) {
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
-            }
+    private void validateCursor(final DescribeTopicPartitionsRequestData.Cursor cursor) {
+        if (cursor != null && cursor.partitionIndex() < 0) {
+            throw new InvalidRequestException(
+                    "Invalid cursor: partition index must be non-negative. Received: " + cursor
+            );
         }
     }
 

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -41,9 +41,8 @@ import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
 
 /**
- * Handles the DescribeTopicPartitionsRequest, which provides metadata about topic partitions in a Kafka cluster.
- * This handler is responsible for managing authorization checks, cursor validation, and constructing the response data
- * for topics that are authorized for the requestor.
+ * Handles DescribeTopicPartitions requests by performing cursor validation, authorization checks,
+ * topic filtering, and constructing the response with partition metadata.
  */
 public class DescribeTopicPartitionsRequestHandler {
     private final MetadataCache metadataCache;
@@ -51,11 +50,11 @@ public class DescribeTopicPartitionsRequestHandler {
     private final KafkaConfig config;
 
     /**
-     * Constructs a new DescribeTopicPartitionsRequestHandler.
+     * Creates a new request handler for DescribeTopicPartitions.
      *
-     * @param metadataCache The metadata cache used to retrieve topic information.
-     * @param authHelper    The authentication helper used to check the authorization for topics.
-     * @param config        The Kafka configuration.
+     * @param metadataCache metadata lookup for topics
+     * @param authHelper    authorization utility
+     * @param config        broker configuration
      */
     public DescribeTopicPartitionsRequestHandler(
             final MetadataCache metadataCache,
@@ -67,60 +66,55 @@ public class DescribeTopicPartitionsRequestHandler {
     }
 
     /**
-     * Handles the DescribeTopicPartitionsRequest and constructs a response containing metadata about topic partitions.
+     * Main entry point for processing DescribeTopicPartitions requests.
      *
-     * @param abstractRequest The request containing the metadata request for topic partitions.
-     * @return A DescribeTopicPartitionsResponseData containing metadata for the requested topic partitions.
+     * @param abstractRequest the incoming request
+     * @return response data containing metadata for authorized topics
      */
     public DescribeTopicPartitionsResponseData handleDescribeTopicPartitionsRequest(
             final RequestChannel.Request abstractRequest) {
-        final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
 
-        // Get topics to describe based on request data (all topics or specific ones)
+        final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
         final String cursorTopicName = requestData.cursor() != null ? requestData.cursor().topicName() : "";
         final Set<String> topicsToDescribe = getTopicsToDescribe(requestData, cursorTopicName);
 
-        // Validate cursor if provided in the request
         validateCursor(requestData.cursor());
 
-        // Handle topics that are unauthorized for the Describe operation
-        final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
-        final Stream<String> authorizedTopicsStream = filterAuthorizedTopics(
+        final Set<DescribeTopicPartitionsResponseTopic> unauthorizedTopics = new HashSet<>();
+        final Stream<String> authorizedTopics = filterAuthorizedTopics(
                 abstractRequest,
                 topicsToDescribe,
-                unauthorizedForDescribeTopicMetadata,
+                unauthorizedTopics,
                 requestData.topics().isEmpty()
         );
 
-        // Construct the response for authorized topics
         final DescribeTopicPartitionsResponseData response =
-                buildResponse(authorizedTopicsStream, abstractRequest, requestData, cursorTopicName);
+                buildResponse(authorizedTopics, abstractRequest, requestData, cursorTopicName);
 
-        // get topic authorized operations
+        // Include authorized operations
         response.topics().forEach(topicData ->
-                topicData.setTopicAuthorizedOperations(authHelper.authorizedOperations(abstractRequest, new Resource(TOPIC, topicData.name()))));
+                topicData.setTopicAuthorizedOperations(
+                        authHelper.authorizedOperations(abstractRequest, new Resource(TOPIC, topicData.name()))
+                )
+        );
 
-        // Add unauthorized topics to the response to avoid disclosing their existence
-        response.topics().addAll(unauthorizedForDescribeTopicMetadata);
+        // Include unauthorized topic metadata
+        response.topics().addAll(unauthorizedTopics);
         return response;
     }
 
     /**
-     * Extracts the request data from the abstract request.
-     *
-     * @param abstractRequest The incoming request.
-     * @return The request data for the DescribeTopicPartitionsRequest.
+     * Parses the typed request data from the raw abstract request.
      */
     private DescribeTopicPartitionsRequestData getRequestData(final RequestChannel.Request abstractRequest) {
         return ((DescribeTopicPartitionsRequest) abstractRequest.loggableRequest()).data();
     }
 
     /**
-     * Determines the list of topics to describe based on the provided request data.
-     * It can either fetch all topics or only the ones specified in the request.
+     * Computes the set of topics to describe based on the request and cursor.
+     * Filters out topics before the cursor topic (if present).
      *
-     * @param requestData The request data containing the list of topics.
-     * @return A set of topics to describe.
+     * @throws InvalidRequestException if the cursor references a topic not in the requested list
      */
     private Set<String> getTopicsToDescribe(
             final DescribeTopicPartitionsRequestData requestData,
@@ -130,7 +124,6 @@ public class DescribeTopicPartitionsRequestHandler {
         final boolean fetchAllTopics = requestData.topics().isEmpty();
         final DescribeTopicPartitionsRequestData.Cursor cursor = requestData.cursor();
 
-        // If no topics are specified, fetch all topics that come after the cursor topic
         if (fetchAllTopics) {
             metadataCache.getAllTopics().forEach(topicName -> {
                 if (topicName.compareTo(cursorTopicName) >= 0) {
@@ -146,21 +139,17 @@ public class DescribeTopicPartitionsRequestHandler {
             });
 
             if (cursor != null && !topics.contains(cursor.topicName())) {
-                // The topic in cursor must be included in the topic list if provided.
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
+                throw new InvalidRequestException(
+                        "DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
             }
         }
         return topics;
     }
 
-
     /**
-     * Validates the cursor provided in the request.
-     * <p>
-     * If the cursor is not null, this method checks that the partition index is non-negative.
+     * Validates the cursor's partition index, if a cursor is provided.
      *
-     * @param cursor the cursor to validate; may be null
-     * @throws InvalidRequestException if the partition index in the cursor is negative
+     * @throws InvalidRequestException if the partition index is negative
      */
     private void validateCursor(final DescribeTopicPartitionsRequestData.Cursor cursor) {
         if (cursor != null && cursor.partitionIndex() < 0) {
@@ -171,69 +160,60 @@ public class DescribeTopicPartitionsRequestHandler {
     }
 
     /**
-     * Filters the topics based on authorization. It ensures that only topics the requestor is authorized to describe are included.
-     * Unauthorized topics are added to the unauthorized topics list.
+     * Filters the input topics based on authorization.
+     * Adds unauthorized topics to the result with masked metadata.
      *
-     * @param abstractRequest                      The incoming request.
-     * @param topicsToDescribe                     The list of topics to filter.
-     * @param unauthorizedForDescribeTopicMetadata A set to store topics that the requestor is unauthorized to describe.
-     * @param fetchAllTopics                       A flag indicating whether to fetch all topics or only specified ones.
-     * @return A stream of authorized topic names.
+     * @param abstractRequest     the request context
+     * @param topicsToDescribe    candidate topics to filter
+     * @param unauthorizedTopics  output container for unauthorized topics
+     * @param fetchAllTopics      true if request was for all topics
+     * @return a stream of authorized topic names
      */
     private Stream<String> filterAuthorizedTopics(
             final RequestChannel.Request abstractRequest,
             final Set<String> topicsToDescribe,
-            final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata,
+            final Set<DescribeTopicPartitionsResponseTopic> unauthorizedTopics,
             final boolean fetchAllTopics
     ) {
         return topicsToDescribe.stream().sorted().filter(topicName -> {
-            // Check authorization for each topic
-            final boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
-                    DESCRIBE, TOPIC, topicName, true, true, 1
+            final boolean isAuthorized = authHelper.authorize(
+                    abstractRequest.context(), DESCRIBE, TOPIC, topicName, true, true, 1
             );
+
             if (!fetchAllTopics && !isAuthorized) {
-                // We should not return topicId when on unauthorized error, so we return zero uuid.
-                unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
-                        Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
-                );
+                unauthorizedTopics.add(describeTopicPartitionsResponseTopic(
+                        Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of()
+                ));
             }
             return isAuthorized;
         });
     }
 
     /**
-     * Constructs the response data based on authorized topics.
+     * Builds the response containing partition metadata for authorized topics.
      *
-     * @param authorizedTopicsStream A stream of authorized topic names.
-     * @param abstractRequest        The incoming request.
-     * @param requestData            The request data containing the cursor and partition limits.
-     * @return The constructed response data with metadata for the authorized topics.
+     * @param authorizedTopics    stream of authorized topic names
+     * @param abstractRequest     the original request
+     * @param requestData         the parsed request data
+     * @param cursorTopicName     the topic referenced in the cursor (if any)
      */
     private DescribeTopicPartitionsResponseData buildResponse(
-            final Stream<String> authorizedTopicsStream,
+            final Stream<String> authorizedTopics,
             final RequestChannel.Request abstractRequest,
             final DescribeTopicPartitionsRequestData requestData,
             final String cursorTopicName
     ) {
         return metadataCache.describeTopicResponse(
-                authorizedTopicsStream.iterator(),
+                authorizedTopics.iterator(),
                 abstractRequest.context().listenerName,
-                (String topicName) -> topicName.equals(cursorTopicName) ? requestData.cursor().partitionIndex() : 0,
+                topicName -> topicName.equals(cursorTopicName) ? requestData.cursor().partitionIndex() : 0,
                 Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
                 requestData.topics().isEmpty()
         );
     }
 
     /**
-     * Constructs a DescribeTopicPartitionsResponseTopic object, which contains metadata about a single topic,
-     * including error codes, topic ID, partition data, and whether the topic is internal.
-     *
-     * @param error         The error that occurred while accessing the topic.
-     * @param topic         The name of the topic.
-     * @param topicId       The unique identifier for the topic.
-     * @param isInternal    Whether the topic is internal or not.
-     * @param partitionData The partition data associated with the topic.
-     * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
+     * Creates a response topic object, typically used to report errors like unauthorized access.
      */
     private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic(
             final Errors error,
@@ -250,3 +230,4 @@ public class DescribeTopicPartitionsRequestHandler {
                 .setPartitions(partitionData);
     }
 }
+

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -20,6 +20,7 @@ package kafka.server.handlers;
 import kafka.network.RequestChannel;
 import kafka.server.AuthHelper;
 import kafka.server.KafkaConfig;
+
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -230,4 +230,3 @@ public class DescribeTopicPartitionsRequestHandler {
                 .setPartitions(partitionData);
     }
 }
-

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.Descr
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.DescribeTopicPartitionsRequest;
+import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.metadata.MetadataCache;
 
 import java.util.HashSet;
@@ -95,6 +96,10 @@ public class DescribeTopicPartitionsRequestHandler {
         final DescribeTopicPartitionsResponseData response =
                 buildResponse(authorizedTopicsStream, abstractRequest, requestData, cursorTopicName);
 
+        // get topic authorized operations
+        response.topics().forEach(topicData ->
+                topicData.setTopicAuthorizedOperations(authHelper.authorizedOperations(abstractRequest, new Resource(TOPIC, topicData.name()))));
+
         // Add unauthorized topics to the response to avoid disclosing their existence
         response.topics().addAll(unauthorizedForDescribeTopicMetadata);
         return response;
@@ -148,13 +153,14 @@ public class DescribeTopicPartitionsRequestHandler {
         return topics;
     }
 
+
     /**
-     * Validates the pagination cursor for a describe-topics request.
+     * Validates the cursor provided in the request.
      * <p>
-     * If the cursor is provided, ensures the partition index is non-negative.
+     * If the cursor is not null, this method checks that the partition index is non-negative.
      *
-     * @param cursor the pagination cursor, if present in the request
-     * @throws InvalidRequestException if the partition index is negative
+     * @param cursor the cursor to validate; may be null
+     * @throws InvalidRequestException if the partition index in the cursor is negative
      */
     private void validateCursor(final DescribeTopicPartitionsRequestData.Cursor cursor) {
         if (cursor != null && cursor.partitionIndex() < 0) {

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -75,7 +75,7 @@ public class DescribeTopicPartitionsRequestHandler {
         final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
 
         // Get topics to describe based on request data (all topics or specific ones)
-        final String cursorTopicName = requestData.cursor() != null ? cursor.topicName() : "";
+        final String cursorTopicName = requestData.cursor() != null ? requestData.cursor().topicName() : "";
         final Set<String> topicsToDescribe = getTopicsToDescribe(requestData, cursorTopicName);
 
         // Validate cursor if provided in the request
@@ -92,7 +92,7 @@ public class DescribeTopicPartitionsRequestHandler {
 
         // Construct the response for authorized topics
         final DescribeTopicPartitionsResponseData response =
-                buildResponse(authorizedTopicsStream, abstractRequest, requestData);
+                buildResponse(authorizedTopicsStream, abstractRequest, requestData, cursorTopicName);
 
         // Add unauthorized topics to the response to avoid disclosing their existence
         response.topics().addAll(unauthorizedForDescribeTopicMetadata);
@@ -122,7 +122,7 @@ public class DescribeTopicPartitionsRequestHandler {
     ) {
         final Set<String> topics = new HashSet<>();
         final boolean fetchAllTopics = requestData.topics().isEmpty();
-        final DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
+        final DescribeTopicPartitionsRequestData.Cursor cursor = requestData.cursor();
 
         // If no topics are specified, fetch all topics that come after the cursor topic
         if (fetchAllTopics) {
@@ -213,13 +213,14 @@ public class DescribeTopicPartitionsRequestHandler {
     private DescribeTopicPartitionsResponseData buildResponse(
             final Stream<String> authorizedTopicsStream,
             final RequestChannel.Request abstractRequest,
-            final DescribeTopicPartitionsRequestData requestData
+            final DescribeTopicPartitionsRequestData requestData,
+            final String cursorTopicName
     ) {
         return metadataCache.describeTopicResponse(
                 authorizedTopicsStream.iterator(),
                 abstractRequest.context().listenerName,
-                (String topicName) -> topicName.equals(cursorTopicName) ? cursor.partitionIndex() : 0,
-                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), request.responsePartitionLimit()), 1),
+                (String topicName) -> topicName.equals(cursorTopicName) ? requestData.cursor().partitionIndex() : 0,
+                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
                 requestData.topics().isEmpty()
         );
     }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -194,7 +194,7 @@ public class DescribeTopicPartitionsRequestHandler {
                     DESCRIBE, TOPIC, topicName, true, true, 1
             );
             if (!fetchAllTopics && !isAuthorized) {
-                // If unauthorized, add the topic to the unauthorized list with an empty UUID
+                // We should not return topicId when on unauthorized error, so we return zero uuid.
                 unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
                         Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
                 );

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -69,20 +69,20 @@ public class DescribeTopicPartitionsRequestHandler {
      * @return A DescribeTopicPartitionsResponseData containing metadata for the requested topic partitions.
      */
     public DescribeTopicPartitionsResponseData handleDescribeTopicPartitionsRequest(RequestChannel.Request abstractRequest) {
-        DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
+        final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
 
         // Get topics to describe based on request data (all topics or specific ones)
-        Set<String> topicsToDescribe = getTopicsToDescribe(requestData);
+        final Set<String> topicsToDescribe = getTopicsToDescribe(requestData);
 
         // Validate cursor if provided in the request
         validateCursor(requestData.cursor(), topicsToDescribe);
 
         // Handle topics that are unauthorized for the Describe operation
-        Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
-        Stream<String> authorizedTopicsStream = filterAuthorizedTopics(abstractRequest, topicsToDescribe, unauthorizedForDescribeTopicMetadata, requestData.topics().isEmpty());
+        final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
+        final Stream<String> authorizedTopicsStream = filterAuthorizedTopics(abstractRequest, topicsToDescribe, unauthorizedForDescribeTopicMetadata, requestData.topics().isEmpty());
 
         // Construct the response for authorized topics
-        DescribeTopicPartitionsResponseData response = buildResponse(authorizedTopicsStream, abstractRequest, requestData);
+        final DescribeTopicPartitionsResponseData response = buildResponse(authorizedTopicsStream, abstractRequest, requestData);
 
         // Add unauthorized topics to the response to avoid disclosing their existence
         response.topics().addAll(unauthorizedForDescribeTopicMetadata);

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -53,10 +53,13 @@ public class DescribeTopicPartitionsRequestHandler {
      * Constructs a new DescribeTopicPartitionsRequestHandler.
      *
      * @param metadataCache The metadata cache used to retrieve topic information.
-     * @param authHelper The authentication helper used to check the authorization for topics.
-     * @param config The Kafka configuration.
+     * @param authHelper    The authentication helper used to check the authorization for topics.
+     * @param config        The Kafka configuration.
      */
-    public DescribeTopicPartitionsRequestHandler(MetadataCache metadataCache, AuthHelper authHelper, KafkaConfig config) {
+    public DescribeTopicPartitionsRequestHandler(
+            MetadataCache metadataCache,
+            AuthHelper authHelper,
+            KafkaConfig config) {
         this.metadataCache = metadataCache;
         this.authHelper = authHelper;
         this.config = config;
@@ -68,7 +71,8 @@ public class DescribeTopicPartitionsRequestHandler {
      * @param abstractRequest The request containing the metadata request for topic partitions.
      * @return A DescribeTopicPartitionsResponseData containing metadata for the requested topic partitions.
      */
-    public DescribeTopicPartitionsResponseData handleDescribeTopicPartitionsRequest(RequestChannel.Request abstractRequest) {
+    public DescribeTopicPartitionsResponseData handleDescribeTopicPartitionsRequest(
+            RequestChannel.Request abstractRequest) {
         final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
 
         // Get topics to describe based on request data (all topics or specific ones)
@@ -79,10 +83,16 @@ public class DescribeTopicPartitionsRequestHandler {
 
         // Handle topics that are unauthorized for the Describe operation
         final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
-        final Stream<String> authorizedTopicsStream = filterAuthorizedTopics(abstractRequest, topicsToDescribe, unauthorizedForDescribeTopicMetadata, requestData.topics().isEmpty());
+        final Stream<String> authorizedTopicsStream = filterAuthorizedTopics(
+                abstractRequest,
+                topicsToDescribe,
+                unauthorizedForDescribeTopicMetadata,
+                requestData.topics().isEmpty()
+        );
 
         // Construct the response for authorized topics
-        final DescribeTopicPartitionsResponseData response = buildResponse(authorizedTopicsStream, abstractRequest, requestData);
+        final DescribeTopicPartitionsResponseData response =
+                buildResponse(authorizedTopicsStream, abstractRequest, requestData);
 
         // Add unauthorized topics to the response to avoid disclosing their existence
         response.topics().addAll(unauthorizedForDescribeTopicMetadata);
@@ -129,98 +139,110 @@ public class DescribeTopicPartitionsRequestHandler {
 
             if (requestData.cursor() != null && !topics.contains(requestData.cursor().topicName())) {
                 // The topic in cursor must be included in the topic list if provided.
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
-        }
-        return topics;
-    }
-
-    /**
-     * Validates the cursor from the request. If the cursor is provided, it checks that the partition index is valid
-     * and that the topic in the cursor is included in the list of topics.
-     *
-     * @param cursor The cursor for pagination, if provided in the request.
-     * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
-     */
-    private void validateCursor(DescribeTopicPartitionsRequestData.Cursor cursor, Set<String> topicsToDescribe) {
-        if (cursor != null) {
-            // Validate that the partition index in the cursor is valid
-            if (cursor.partitionIndex() < 0) {
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain " +
+                        "the cursor topic: " + cursor.topicName());
             }
+            return topics;
+        }
 
-            // Ensure the cursor topic is included in the list of topics
-            if (!topicsToDescribe.contains(cursor.topicName())) {
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
+        /**
+         * Validates the cursor from the request. If the cursor is provided, it checks that the partition index is valid
+         * and that the topic in the cursor is included in the list of topics.
+         *
+         * @param cursor The cursor for pagination, if provided in the request.
+         * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
+         */
+        private void validateCursor (DescribeTopicPartitionsRequestData.Cursor cursor, Set < String > topicsToDescribe){
+            if (cursor != null) {
+                // Validate that the partition index in the cursor is valid
+                if (cursor.partitionIndex() < 0) {
+                    throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition " +
+                            "must be valid: " + cursor);
+                }
+
+                // Ensure the cursor topic is included in the list of topics
+                if (!topicsToDescribe.contains(cursor.topicName())) {
+                    throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the " +
+                            "cursor topic: " + cursor.topicName());
+                }
             }
         }
-    }
 
-    /**
-     * Filters the topics based on authorization. It ensures that only topics the requestor is authorized to describe are included.
-     * Unauthorized topics are added to the unauthorized topics list.
-     *
-     * @param abstractRequest The incoming request.
-     * @param topicsToDescribe The list of topics to filter.
-     * @param unauthorizedForDescribeTopicMetadata A set to store topics that the requestor is unauthorized to describe.
-     * @param fetchAllTopics A flag indicating whether to fetch all topics or only specified ones.
-     * @return A stream of authorized topic names.
-     */
-    private Stream<String> filterAuthorizedTopics(RequestChannel.Request abstractRequest, Set<String> topicsToDescribe,
-                                                  Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata, boolean fetchAllTopics) {
-        return topicsToDescribe.stream().sorted().filter(topicName -> {
-            // Check authorization for each topic
-            boolean isAuthorized = authHelper.authorize(abstractRequest.context(), DESCRIBE, TOPIC, topicName, true, true, 1);
-            if (!fetchAllTopics && !isAuthorized) {
-                // If unauthorized, add the topic to the unauthorized list with an empty UUID
-                unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
-                        Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
+        /**
+         * Filters the topics based on authorization. It ensures that only topics the requestor is authorized to describe are included.
+         * Unauthorized topics are added to the unauthorized topics list.
+         *
+         * @param abstractRequest The incoming request.
+         * @param topicsToDescribe The list of topics to filter.
+         * @param unauthorizedForDescribeTopicMetadata A set to store topics that the requestor is unauthorized to describe.
+         * @param fetchAllTopics A flag indicating whether to fetch all topics or only specified ones.
+         * @return A stream of authorized topic names.
+         */
+        private Stream<String> filterAuthorizedTopics (
+                RequestChannel.Request abstractRequest,
+                Set < String > topicsToDescribe,
+                Set < DescribeTopicPartitionsResponseTopic > unauthorizedForDescribeTopicMetadata,
+        boolean fetchAllTopics)
+        {
+            return topicsToDescribe.stream().sorted().filter(topicName -> {
+                // Check authorization for each topic
+                boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
+                        DESCRIBE, TOPIC, topicName, true, true, 1
                 );
-            }
-            return isAuthorized;
-        });
-    }
+                if (!fetchAllTopics && !isAuthorized) {
+                    // If unauthorized, add the topic to the unauthorized list with an empty UUID
+                    unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
+                            Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
+                    );
+                }
+                return isAuthorized;
+            });
+        }
 
-    /**
-     * Constructs the response data based on authorized topics.
-     *
-     * @param authorizedTopicsStream A stream of authorized topic names.
-     * @param abstractRequest The incoming request.
-     * @param requestData The request data containing the cursor and partition limits.
-     * @return The constructed response data with metadata for the authorized topics.
-     */
-    private DescribeTopicPartitionsResponseData buildResponse(Stream<String> authorizedTopicsStream, RequestChannel.Request abstractRequest, DescribeTopicPartitionsRequestData requestData) {
-        return metadataCache.describeTopicResponse(
-                authorizedTopicsStream.iterator(),
-                abstractRequest.context().listenerName,
-                topicName -> topicName.equals(requestData.cursor() != null ? requestData.cursor().topicName() : "") ? requestData.cursor().partitionIndex() : 0,
-                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
-                requestData.topics().isEmpty()
-        );
-    }
+        /**
+         * Constructs the response data based on authorized topics.
+         *
+         * @param authorizedTopicsStream A stream of authorized topic names.
+         * @param abstractRequest The incoming request.
+         * @param requestData The request data containing the cursor and partition limits.
+         * @return The constructed response data with metadata for the authorized topics.
+         */
+        private DescribeTopicPartitionsResponseData buildResponse
+        (Stream < String > authorizedTopicsStream, RequestChannel.Request
+        abstractRequest, DescribeTopicPartitionsRequestData requestData){
+            return metadataCache.describeTopicResponse(
+                    authorizedTopicsStream.iterator(),
+                    abstractRequest.context().listenerName,
+                    topicName -> topicName.equals(requestData.cursor() != null
+                            ? requestData.cursor().topicName() : "") ? requestData.cursor().partitionIndex() : 0,
+                    Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
+                    requestData.topics().isEmpty()
+            );
+        }
 
-    /**
-     * Constructs a DescribeTopicPartitionsResponseTopic object, which contains metadata about a single topic,
-     * including error codes, topic ID, partition data, and whether the topic is internal.
-     *
-     * @param error The error that occurred while accessing the topic.
-     * @param topic The name of the topic.
-     * @param topicId The unique identifier for the topic.
-     * @param isInternal Whether the topic is internal or not.
-     * @param partitionData The partition data associated with the topic.
-     * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
-     */
-    private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic(
-            Errors error,
-            String topic,
-            Uuid topicId,
-            Boolean isInternal,
-            List<DescribeTopicPartitionsResponsePartition> partitionData
-    ) {
-        return new DescribeTopicPartitionsResponseTopic()
-                .setErrorCode(error.code())
-                .setName(topic)
-                .setTopicId(topicId)
-                .setIsInternal(isInternal)
-                .setPartitions(partitionData);
+        /**
+         * Constructs a DescribeTopicPartitionsResponseTopic object, which contains metadata about a single topic,
+         * including error codes, topic ID, partition data, and whether the topic is internal.
+         *
+         * @param error The error that occurred while accessing the topic.
+         * @param topic The name of the topic.
+         * @param topicId The unique identifier for the topic.
+         * @param isInternal Whether the topic is internal or not.
+         * @param partitionData The partition data associated with the topic.
+         * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
+         */
+        private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic (
+                Errors error,
+                String topic,
+                Uuid topicId,
+                Boolean isInternal,
+                List < DescribeTopicPartitionsResponsePartition > partitionData
+    ){
+            return new DescribeTopicPartitionsResponseTopic()
+                    .setErrorCode(error.code())
+                    .setName(topic)
+                    .setTopicId(topicId)
+                    .setIsInternal(isInternal)
+                    .setPartitions(partitionData);
+        }
     }
-}

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -156,8 +156,7 @@ public class DescribeTopicPartitionsRequestHandler {
             if (cursor != null) {
                 // Validate that the partition index in the cursor is valid
                 if (cursor.partitionIndex() < 0) {
-                    throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition " +
-                            "must be valid: " + cursor);
+                    throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
                 }
 
                 // Ensure the cursor topic is included in the list of topics

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -127,10 +127,9 @@ public class DescribeTopicPartitionsRequestHandler {
                 }
             });
 
-            // Ensure the cursor topic is included in the list of topics
-            if (requestData.cursor() != null && !topics.contains(requestData.cursor().topicName())) {
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + requestData.cursor().topicName());
-            }
+            if (cursor != null && !topics.contains(cursor.topicName())) {
+                // The topic in cursor must be included in the topic list if provided.
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
         }
         return topics;
     }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -57,9 +57,9 @@ public class DescribeTopicPartitionsRequestHandler {
      * @param config        The Kafka configuration.
      */
     public DescribeTopicPartitionsRequestHandler(
-            MetadataCache metadataCache,
-            AuthHelper authHelper,
-            KafkaConfig config) {
+            final MetadataCache metadataCache,
+            final AuthHelper authHelper,
+            final KafkaConfig config) {
         this.metadataCache = metadataCache;
         this.authHelper = authHelper;
         this.config = config;
@@ -130,7 +130,6 @@ public class DescribeTopicPartitionsRequestHandler {
                 }
             });
         } else {
-            // Add the requested topics to the set, ensuring they come after the cursor topic
             requestData.topics().forEach(topic -> {
                 String topicName = topic.name();
                 if (topicName.compareTo(cursorTopicName) >= 0) {
@@ -180,10 +179,10 @@ public class DescribeTopicPartitionsRequestHandler {
                 RequestChannel.Request abstractRequest,
                 Set < String > topicsToDescribe,
                 Set < DescribeTopicPartitionsResponseTopic > unauthorizedForDescribeTopicMetadata,
-                boolean fetchAllTopics){
+        boolean fetchAllTopics){
             return topicsToDescribe.stream().sorted().filter(topicName -> {
                 // Check authorization for each topic
-                boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
+                final boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
                         DESCRIBE, TOPIC, topicName, true, true, 1
                 );
                 if (!fetchAllTopics && !isAuthorized) {
@@ -205,9 +204,9 @@ public class DescribeTopicPartitionsRequestHandler {
          * @return The constructed response data with metadata for the authorized topics.
          */
         private DescribeTopicPartitionsResponseData buildResponse (
-                Stream < String > authorizedTopicsStream,
-                RequestChannel.Request abstractRequest,
-                DescribeTopicPartitionsRequestData requestData){
+        final Stream<String> authorizedTopicsStream,
+        final RequestChannel.Request abstractRequest,
+        final DescribeTopicPartitionsRequestData requestData){
             return metadataCache.describeTopicResponse(
                     authorizedTopicsStream.iterator(),
                     abstractRequest.context().listenerName,
@@ -230,12 +229,11 @@ public class DescribeTopicPartitionsRequestHandler {
          * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
          */
         private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic (
-                Errors error,
-                String topic,
-                Uuid topicId,
-                Boolean isInternal,
-                List < DescribeTopicPartitionsResponsePartition > partitionData
-    ){
+        final Errors error,
+        final String topic,
+        final Uuid topicId,
+        final Boolean isInternal,
+        final List<DescribeTopicPartitionsResponsePartition> partitionData){
             return new DescribeTopicPartitionsResponseTopic()
                     .setErrorCode(error.code())
                     .setName(topic)

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -72,7 +72,7 @@ public class DescribeTopicPartitionsRequestHandler {
      * @return A DescribeTopicPartitionsResponseData containing metadata for the requested topic partitions.
      */
     public DescribeTopicPartitionsResponseData handleDescribeTopicPartitionsRequest(
-            RequestChannel.Request abstractRequest) {
+            final RequestChannel.Request abstractRequest) {
         final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
 
         // Get topics to describe based on request data (all topics or specific ones)
@@ -105,7 +105,7 @@ public class DescribeTopicPartitionsRequestHandler {
      * @param abstractRequest The incoming request.
      * @return The request data for the DescribeTopicPartitionsRequest.
      */
-    private DescribeTopicPartitionsRequestData getRequestData(RequestChannel.Request abstractRequest) {
+    private DescribeTopicPartitionsRequestData getRequestData(final RequestChannel.Request abstractRequest) {
         return ((DescribeTopicPartitionsRequest) abstractRequest.loggableRequest()).data();
     }
 
@@ -116,7 +116,7 @@ public class DescribeTopicPartitionsRequestHandler {
      * @param requestData The request data containing the list of topics.
      * @return A set of topics to describe.
      */
-    private Set<String> getTopicsToDescribe(DescribeTopicPartitionsRequestData requestData) {
+    private Set<String> getTopicsToDescribe(final DescribeTopicPartitionsRequestData requestData) {
         Set<String> topics = new HashSet<>();
         boolean fetchAllTopics = requestData.topics().isEmpty();
         DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
@@ -151,7 +151,10 @@ public class DescribeTopicPartitionsRequestHandler {
          * @param cursor The cursor for pagination, if provided in the request.
          * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
          */
-        private void validateCursor (DescribeTopicPartitionsRequestData.Cursor cursor, Set < String > topicsToDescribe){
+        private void validateCursor (
+                final DescribeTopicPartitionsRequestData.Cursor cursor,
+                final Set<String> topicsToDescribe
+        ){
             if (cursor != null) {
                 // Validate that the partition index in the cursor is valid
                 if (cursor.partitionIndex() < 0) {
@@ -176,10 +179,11 @@ public class DescribeTopicPartitionsRequestHandler {
          * @return A stream of authorized topic names.
          */
         private Stream<String> filterAuthorizedTopics (
-                RequestChannel.Request abstractRequest,
-                Set < String > topicsToDescribe,
-                Set < DescribeTopicPartitionsResponseTopic > unauthorizedForDescribeTopicMetadata,
-        boolean fetchAllTopics){
+        final RequestChannel.Request abstractRequest,
+        final Set<String> topicsToDescribe,
+        final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata,
+        final boolean fetchAllTopics
+        ){
             return topicsToDescribe.stream().sorted().filter(topicName -> {
                 // Check authorization for each topic
                 final boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
@@ -206,7 +210,8 @@ public class DescribeTopicPartitionsRequestHandler {
         private DescribeTopicPartitionsResponseData buildResponse (
         final Stream<String> authorizedTopicsStream,
         final RequestChannel.Request abstractRequest,
-        final DescribeTopicPartitionsRequestData requestData){
+        final DescribeTopicPartitionsRequestData requestData
+        ){
             return metadataCache.describeTopicResponse(
                     authorizedTopicsStream.iterator(),
                     abstractRequest.context().listenerName,
@@ -233,7 +238,8 @@ public class DescribeTopicPartitionsRequestHandler {
         final String topic,
         final Uuid topicId,
         final Boolean isInternal,
-        final List<DescribeTopicPartitionsResponsePartition> partitionData){
+        final List<DescribeTopicPartitionsResponsePartition> partitionData
+        ){
             return new DescribeTopicPartitionsResponseTopic()
                     .setErrorCode(error.code())
                     .setName(topic)

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -206,9 +206,10 @@ public class DescribeTopicPartitionsRequestHandler {
          * @param requestData The request data containing the cursor and partition limits.
          * @return The constructed response data with metadata for the authorized topics.
          */
-        private DescribeTopicPartitionsResponseData buildResponse
-        (Stream < String > authorizedTopicsStream, RequestChannel.Request
-        abstractRequest, DescribeTopicPartitionsRequestData requestData){
+        private DescribeTopicPartitionsResponseData buildResponse (
+                Stream < String > authorizedTopicsStream,
+                RequestChannel.Request abstractRequest,
+                DescribeTopicPartitionsRequestData requestData){
             return metadataCache.describeTopicResponse(
                     authorizedTopicsStream.iterator(),
                     abstractRequest.context().listenerName,

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -215,9 +215,8 @@ public class DescribeTopicPartitionsRequestHandler {
         return metadataCache.describeTopicResponse(
                 authorizedTopicsStream.iterator(),
                 abstractRequest.context().listenerName,
-                topicName -> topicName.equals(requestData.cursor() != null
-                        ? requestData.cursor().topicName() : "") ? requestData.cursor().partitionIndex() : 0,
-                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
+                (String topicName) -> topicName.equals(cursorTopicName) ? cursor.partitionIndex() : 0,
+                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), request.responsePartitionLimit()), 1),
                 requestData.topics().isEmpty()
         );
     }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -213,7 +213,8 @@ public class DescribeTopicPartitionsRequestHandler {
     private DescribeTopicPartitionsResponseData buildResponse(
             final Stream<String> authorizedTopicsStream,
             final RequestChannel.Request abstractRequest,
-            final DescribeTopicPartitionsRequestData requestData
+            final DescribeTopicPartitionsRequestData requestData,
+            final String cursorTopicName
     ) {
         return metadataCache.describeTopicResponse(
                 authorizedTopicsStream.iterator(),

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -163,8 +163,7 @@ public class DescribeTopicPartitionsRequestHandler {
 
                 // Ensure the cursor topic is included in the list of topics
                 if (!topicsToDescribe.contains(cursor.topicName())) {
-                    throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the " +
-                            "cursor topic: " + cursor.topicName());
+                    throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
                 }
             }
         }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -75,7 +75,8 @@ public class DescribeTopicPartitionsRequestHandler {
         final DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
 
         // Get topics to describe based on request data (all topics or specific ones)
-        final Set<String> topicsToDescribe = getTopicsToDescribe(requestData);
+        final String cursorTopicName = requestData.cursor() != null ? cursor.topicName() : "";
+        final Set<String> topicsToDescribe = getTopicsToDescribe(requestData, cursorTopicName);
 
         // Validate cursor if provided in the request
         validateCursor(requestData.cursor(), topicsToDescribe);
@@ -115,11 +116,13 @@ public class DescribeTopicPartitionsRequestHandler {
      * @param requestData The request data containing the list of topics.
      * @return A set of topics to describe.
      */
-    private Set<String> getTopicsToDescribe(final DescribeTopicPartitionsRequestData requestData) {
+    private Set<String> getTopicsToDescribe(
+            final DescribeTopicPartitionsRequestData requestData,
+            final String cursorTopicName
+    ) {
         final Set<String> topics = new HashSet<>();
         final boolean fetchAllTopics = requestData.topics().isEmpty();
         final DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
-        final String cursorTopicName = requestData.cursor() != null ? cursor.topicName() : "";
 
         // If no topics are specified, fetch all topics that come after the cursor topic
         if (fetchAllTopics) {

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -211,7 +211,12 @@ public class DescribeTopicPartitionsRequestHandler {
      * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
      */
     private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic(
-            Errors error, String topic, Uuid topicId, Boolean isInternal, List<DescribeTopicPartitionsResponsePartition> partitionData) {
+            Errors error,
+            String topic,
+            Uuid topicId,
+            Boolean isInternal,
+            List<DescribeTopicPartitionsResponsePartition> partitionData
+    ) {
         return new DescribeTopicPartitionsResponseTopic()
                 .setErrorCode(error.code())
                 .setName(topic)

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -127,7 +127,7 @@ public class DescribeTopicPartitionsRequestHandler {
                 }
             });
 
-            if (cursor != null && !topics.contains(cursor.topicName())) {
+            if (requestData.cursor() != null && !topics.contains(requestData.cursor().topicName())) {
                 // The topic in cursor must be included in the topic list if provided.
                 throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
         }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -180,8 +180,7 @@ public class DescribeTopicPartitionsRequestHandler {
                 RequestChannel.Request abstractRequest,
                 Set < String > topicsToDescribe,
                 Set < DescribeTopicPartitionsResponseTopic > unauthorizedForDescribeTopicMetadata,
-        boolean fetchAllTopics)
-        {
+                boolean fetchAllTopics){
             return topicsToDescribe.stream().sorted().filter(topicName -> {
                 // Check authorization for each topic
                 boolean isAuthorized = authHelper.authorize(abstractRequest.context(),

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -119,7 +119,8 @@ public class DescribeTopicPartitionsRequestHandler {
     private Set<String> getTopicsToDescribe(DescribeTopicPartitionsRequestData requestData) {
         Set<String> topics = new HashSet<>();
         boolean fetchAllTopics = requestData.topics().isEmpty();
-        String cursorTopicName = requestData.cursor() != null ? requestData.cursor().topicName() : "";
+        DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
+        String cursorTopicName = requestData.cursor() != null ? cursor.topicName() : "";
 
         // If no topics are specified, fetch all topics that come after the cursor topic
         if (fetchAllTopics) {
@@ -137,7 +138,7 @@ public class DescribeTopicPartitionsRequestHandler {
                 }
             });
 
-            if (requestData.cursor() != null && !topics.contains(requestData.cursor().topicName())) {
+            if (cursor != null && !topics.contains(cursor.topicName())) {
                 // The topic in cursor must be included in the topic list if provided.
                 throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain " +
                         "the cursor topic: " + cursor.topicName());

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -20,7 +20,6 @@ package kafka.server.handlers;
 import kafka.network.RequestChannel;
 import kafka.server.AuthHelper;
 import kafka.server.KafkaConfig;
-
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;
@@ -40,27 +39,79 @@ import java.util.stream.Stream;
 import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
 
+/**
+ * Handles the DescribeTopicPartitionsRequest, which provides metadata about topic partitions in a Kafka cluster.
+ * This handler is responsible for managing authorization checks, cursor validation, and constructing the response data
+ * for topics that are authorized for the requestor.
+ */
 public class DescribeTopicPartitionsRequestHandler {
-    MetadataCache metadataCache;
-    AuthHelper authHelper;
-    KafkaConfig config;
+    private final MetadataCache metadataCache;
+    private final AuthHelper authHelper;
+    private final KafkaConfig config;
 
-    public DescribeTopicPartitionsRequestHandler(
-        MetadataCache metadataCache,
-        AuthHelper authHelper,
-        KafkaConfig config
-    ) {
+    /**
+     * Constructs a new DescribeTopicPartitionsRequestHandler.
+     *
+     * @param metadataCache The metadata cache used to retrieve topic information.
+     * @param authHelper The authentication helper used to check the authorization for topics.
+     * @param config The Kafka configuration.
+     */
+    public DescribeTopicPartitionsRequestHandler(MetadataCache metadataCache, AuthHelper authHelper, KafkaConfig config) {
         this.metadataCache = metadataCache;
         this.authHelper = authHelper;
         this.config = config;
     }
 
+    /**
+     * Handles the DescribeTopicPartitionsRequest and constructs a response containing metadata about topic partitions.
+     *
+     * @param abstractRequest The request containing the metadata request for topic partitions.
+     * @return A DescribeTopicPartitionsResponseData containing metadata for the requested topic partitions.
+     */
     public DescribeTopicPartitionsResponseData handleDescribeTopicPartitionsRequest(RequestChannel.Request abstractRequest) {
-        DescribeTopicPartitionsRequestData request = ((DescribeTopicPartitionsRequest) abstractRequest.loggableRequest()).data();
+        DescribeTopicPartitionsRequestData requestData = getRequestData(abstractRequest);
+
+        // Get topics to describe based on request data (all topics or specific ones)
+        Set<String> topicsToDescribe = getTopicsToDescribe(requestData);
+
+        // Validate cursor if provided in the request
+        validateCursor(requestData.cursor(), topicsToDescribe);
+
+        // Handle topics that are unauthorized for the Describe operation
+        Set<DescribeTopicPartitionsResponseTopic> unauthorizedTopics = new HashSet<>();
+        Stream<String> authorizedTopicsStream = filterAuthorizedTopics(abstractRequest, topicsToDescribe, unauthorizedTopics, requestData.topics().isEmpty());
+
+        // Construct the response for authorized topics
+        DescribeTopicPartitionsResponseData response = buildResponse(authorizedTopicsStream, abstractRequest, requestData);
+
+        // Add unauthorized topics to the response to avoid disclosing their existence
+        response.topics().addAll(unauthorizedTopics);
+        return response;
+    }
+
+    /**
+     * Extracts the request data from the abstract request.
+     *
+     * @param abstractRequest The incoming request.
+     * @return The request data for the DescribeTopicPartitionsRequest.
+     */
+    private DescribeTopicPartitionsRequestData getRequestData(RequestChannel.Request abstractRequest) {
+        return ((DescribeTopicPartitionsRequest) abstractRequest.loggableRequest()).data();
+    }
+
+    /**
+     * Determines the list of topics to describe based on the provided request data.
+     * It can either fetch all topics or only the ones specified in the request.
+     *
+     * @param requestData The request data containing the list of topics.
+     * @return A set of topics to describe.
+     */
+    private Set<String> getTopicsToDescribe(DescribeTopicPartitionsRequestData requestData) {
         Set<String> topics = new HashSet<>();
-        boolean fetchAllTopics = request.topics().isEmpty();
-        DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
-        String cursorTopicName = cursor != null ? cursor.topicName() : "";
+        boolean fetchAllTopics = requestData.topics().isEmpty();
+        String cursorTopicName = requestData.cursor() != null ? requestData.cursor().topicName() : "";
+
+        // If no topics are specified, fetch all topics that come after the cursor topic
         if (fetchAllTopics) {
             metadataCache.getAllTopics().forEach(topicName -> {
                 if (topicName.compareTo(cursorTopicName) >= 0) {
@@ -68,67 +119,104 @@ public class DescribeTopicPartitionsRequestHandler {
                 }
             });
         } else {
-            request.topics().forEach(topic -> {
+            // Add the requested topics to the set, ensuring they come after the cursor topic
+            requestData.topics().forEach(topic -> {
                 String topicName = topic.name();
                 if (topicName.compareTo(cursorTopicName) >= 0) {
                     topics.add(topicName);
                 }
             });
 
-            if (cursor != null && !topics.contains(cursor.topicName())) {
-                // The topic in cursor must be included in the topic list if provided.
+            // Ensure the cursor topic is included in the list of topics
+            if (requestData.cursor() != null && !topics.contains(requestData.cursor().topicName())) {
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + requestData.cursor().topicName());
+            }
+        }
+        return topics;
+    }
+
+    /**
+     * Validates the cursor from the request. If the cursor is provided, it checks that the partition index is valid
+     * and that the topic in the cursor is included in the list of topics.
+     *
+     * @param cursor The cursor for pagination, if provided in the request.
+     * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
+     */
+    private void validateCursor(DescribeTopicPartitionsRequestData.Cursor cursor, Set<String> topicsToDescribe) {
+        if (cursor != null) {
+            // Validate that the partition index in the cursor is valid
+            if (cursor.partitionIndex() < 0) {
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
+            }
+
+            // Ensure the cursor topic is included in the list of topics
+            if (!topicsToDescribe.contains(cursor.topicName())) {
                 throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
             }
         }
+    }
 
-        if (cursor != null && cursor.partitionIndex() < 0) {
-            // The partition id in cursor must be valid.
-            throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
-        }
-
-        // Do not disclose the existence of topics unauthorized for Describe, so we've not even checked if they exist or not
-        Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
-
-        Stream<String> authorizedTopicsStream = topics.stream().sorted().filter(topicName -> {
-            boolean isAuthorized = authHelper.authorize(
-                abstractRequest.context(), DESCRIBE, TOPIC, topicName, true, true, 1);
+    /**
+     * Filters the topics based on authorization. It ensures that only topics the requestor is authorized to describe are included.
+     * Unauthorized topics are added to the unauthorized topics list.
+     *
+     * @param abstractRequest The incoming request.
+     * @param topicsToDescribe The list of topics to filter.
+     * @param unauthorizedTopics A set to store topics that the requestor is unauthorized to describe.
+     * @param fetchAllTopics A flag indicating whether to fetch all topics or only specified ones.
+     * @return A stream of authorized topic names.
+     */
+    private Stream<String> filterAuthorizedTopics(RequestChannel.Request abstractRequest, Set<String> topicsToDescribe,
+                                                  Set<DescribeTopicPartitionsResponseTopic> unauthorizedTopics, boolean fetchAllTopics) {
+        return topicsToDescribe.stream().sorted().filter(topicName -> {
+            // Check authorization for each topic
+            boolean isAuthorized = authHelper.authorize(abstractRequest.context(), DESCRIBE, TOPIC, topicName, true, true, 1);
             if (!fetchAllTopics && !isAuthorized) {
-                // We should not return topicId when on unauthorized error, so we return zero uuid.
-                unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
-                    Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
+                // If unauthorized, add the topic to the unauthorized list with an empty UUID
+                unauthorizedTopics.add(describeTopicPartitionsResponseTopic(
+                        Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
                 );
             }
             return isAuthorized;
         });
-
-        DescribeTopicPartitionsResponseData response = metadataCache.describeTopicResponse(
-            authorizedTopicsStream.iterator(),
-            abstractRequest.context().listenerName,
-            (String topicName) -> topicName.equals(cursorTopicName) ? cursor.partitionIndex() : 0,
-            Math.max(Math.min(config.maxRequestPartitionSizeLimit(), request.responsePartitionLimit()), 1),
-            fetchAllTopics
-        );
-
-        // get topic authorized operations
-        response.topics().forEach(topicData ->
-            topicData.setTopicAuthorizedOperations(authHelper.authorizedOperations(abstractRequest, new Resource(TOPIC, topicData.name()))));
-
-        response.topics().addAll(unauthorizedForDescribeTopicMetadata);
-        return response;
     }
 
+    /**
+     * Constructs the response data based on authorized topics.
+     *
+     * @param authorizedTopicsStream A stream of authorized topic names.
+     * @param abstractRequest The incoming request.
+     * @param requestData The request data containing the cursor and partition limits.
+     * @return The constructed response data with metadata for the authorized topics.
+     */
+    private DescribeTopicPartitionsResponseData buildResponse(Stream<String> authorizedTopicsStream, RequestChannel.Request abstractRequest, DescribeTopicPartitionsRequestData requestData) {
+        return metadataCache.describeTopicResponse(
+                authorizedTopicsStream.iterator(),
+                abstractRequest.context().listenerName,
+                topicName -> topicName.equals(requestData.cursor() != null ? requestData.cursor().topicName() : "") ? requestData.cursor().partitionIndex() : 0,
+                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
+                requestData.topics().isEmpty()
+        );
+    }
+
+    /**
+     * Constructs a DescribeTopicPartitionsResponseTopic object, which contains metadata about a single topic,
+     * including error codes, topic ID, partition data, and whether the topic is internal.
+     *
+     * @param error The error that occurred while accessing the topic.
+     * @param topic The name of the topic.
+     * @param topicId The unique identifier for the topic.
+     * @param isInternal Whether the topic is internal or not.
+     * @param partitionData The partition data associated with the topic.
+     * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
+     */
     private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic(
-        Errors error,
-        String topic,
-        Uuid topicId,
-        Boolean isInternal,
-        List<DescribeTopicPartitionsResponsePartition> partitionData
-    ) {
+            Errors error, String topic, Uuid topicId, Boolean isInternal, List<DescribeTopicPartitionsResponsePartition> partitionData) {
         return new DescribeTopicPartitionsResponseTopic()
-            .setErrorCode(error.code())
-            .setName(topic)
-            .setTopicId(topicId)
-            .setIsInternal(isInternal)
-            .setPartitions(partitionData);
+                .setErrorCode(error.code())
+                .setName(topic)
+                .setTopicId(topicId)
+                .setIsInternal(isInternal)
+                .setPartitions(partitionData);
     }
 }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.Descr
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.DescribeTopicPartitionsRequest;
-import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.metadata.MetadataCache;
 
 import java.util.HashSet;
@@ -117,10 +116,10 @@ public class DescribeTopicPartitionsRequestHandler {
      * @return A set of topics to describe.
      */
     private Set<String> getTopicsToDescribe(final DescribeTopicPartitionsRequestData requestData) {
-        Set<String> topics = new HashSet<>();
-        boolean fetchAllTopics = requestData.topics().isEmpty();
-        DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
-        String cursorTopicName = requestData.cursor() != null ? cursor.topicName() : "";
+        final Set<String> topics = new HashSet<>();
+        final boolean fetchAllTopics = requestData.topics().isEmpty();
+        final DescribeTopicPartitionsRequestData.Cursor cursor = request.cursor();
+        final String cursorTopicName = requestData.cursor() != null ? cursor.topicName() : "";
 
         // If no topics are specified, fetch all topics that come after the cursor topic
         if (fetchAllTopics) {
@@ -141,110 +140,111 @@ public class DescribeTopicPartitionsRequestHandler {
                 // The topic in cursor must be included in the topic list if provided.
                 throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
             }
-            return topics;
         }
+        return topics;
+    }
 
-        /**
-         * Validates the cursor from the request. If the cursor is provided, it checks that the partition index is valid
-         * and that the topic in the cursor is included in the list of topics.
-         *
-         * @param cursor The cursor for pagination, if provided in the request.
-         * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
-         */
-        private void validateCursor (
-                final DescribeTopicPartitionsRequestData.Cursor cursor,
-                final Set<String> topicsToDescribe
-        ){
-            if (cursor != null) {
-                // Validate that the partition index in the cursor is valid
-                if (cursor.partitionIndex() < 0) {
-                    throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
-                }
+    /**
+     * Validates the cursor from the request. If the cursor is provided, it checks that the partition index is valid
+     * and that the topic in the cursor is included in the list of topics.
+     *
+     * @param cursor           The cursor for pagination, if provided in the request.
+     * @param topicsToDescribe The list of topics that the requestor is authorized to describe.
+     */
+    private void validateCursor(
+            final DescribeTopicPartitionsRequestData.Cursor cursor,
+            final Set<String> topicsToDescribe
+    ) {
+        if (cursor != null) {
+            // Validate that the partition index in the cursor is valid
+            if (cursor.partitionIndex() < 0) {
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest cursor partition must be valid: " + cursor);
+            }
 
-                // Ensure the cursor topic is included in the list of topics
-                if (!topicsToDescribe.contains(cursor.topicName())) {
-                    throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
-                }
+            // Ensure the cursor topic is included in the list of topics
+            if (!topicsToDescribe.contains(cursor.topicName())) {
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
             }
         }
-
-        /**
-         * Filters the topics based on authorization. It ensures that only topics the requestor is authorized to describe are included.
-         * Unauthorized topics are added to the unauthorized topics list.
-         *
-         * @param abstractRequest The incoming request.
-         * @param topicsToDescribe The list of topics to filter.
-         * @param unauthorizedForDescribeTopicMetadata A set to store topics that the requestor is unauthorized to describe.
-         * @param fetchAllTopics A flag indicating whether to fetch all topics or only specified ones.
-         * @return A stream of authorized topic names.
-         */
-        private Stream<String> filterAuthorizedTopics (
-        final RequestChannel.Request abstractRequest,
-        final Set<String> topicsToDescribe,
-        final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata,
-        final boolean fetchAllTopics
-        ){
-            return topicsToDescribe.stream().sorted().filter(topicName -> {
-                // Check authorization for each topic
-                final boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
-                        DESCRIBE, TOPIC, topicName, true, true, 1
-                );
-                if (!fetchAllTopics && !isAuthorized) {
-                    // If unauthorized, add the topic to the unauthorized list with an empty UUID
-                    unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
-                            Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
-                    );
-                }
-                return isAuthorized;
-            });
-        }
-
-        /**
-         * Constructs the response data based on authorized topics.
-         *
-         * @param authorizedTopicsStream A stream of authorized topic names.
-         * @param abstractRequest The incoming request.
-         * @param requestData The request data containing the cursor and partition limits.
-         * @return The constructed response data with metadata for the authorized topics.
-         */
-        private DescribeTopicPartitionsResponseData buildResponse (
-        final Stream<String> authorizedTopicsStream,
-        final RequestChannel.Request abstractRequest,
-        final DescribeTopicPartitionsRequestData requestData
-        ){
-            return metadataCache.describeTopicResponse(
-                    authorizedTopicsStream.iterator(),
-                    abstractRequest.context().listenerName,
-                    topicName -> topicName.equals(requestData.cursor() != null
-                            ? requestData.cursor().topicName() : "") ? requestData.cursor().partitionIndex() : 0,
-                    Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
-                    requestData.topics().isEmpty()
-            );
-        }
-
-        /**
-         * Constructs a DescribeTopicPartitionsResponseTopic object, which contains metadata about a single topic,
-         * including error codes, topic ID, partition data, and whether the topic is internal.
-         *
-         * @param error The error that occurred while accessing the topic.
-         * @param topic The name of the topic.
-         * @param topicId The unique identifier for the topic.
-         * @param isInternal Whether the topic is internal or not.
-         * @param partitionData The partition data associated with the topic.
-         * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
-         */
-        private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic (
-        final Errors error,
-        final String topic,
-        final Uuid topicId,
-        final Boolean isInternal,
-        final List<DescribeTopicPartitionsResponsePartition> partitionData
-        ){
-            return new DescribeTopicPartitionsResponseTopic()
-                    .setErrorCode(error.code())
-                    .setName(topic)
-                    .setTopicId(topicId)
-                    .setIsInternal(isInternal)
-                    .setPartitions(partitionData);
-        }
     }
+
+    /**
+     * Filters the topics based on authorization. It ensures that only topics the requestor is authorized to describe are included.
+     * Unauthorized topics are added to the unauthorized topics list.
+     *
+     * @param abstractRequest                      The incoming request.
+     * @param topicsToDescribe                     The list of topics to filter.
+     * @param unauthorizedForDescribeTopicMetadata A set to store topics that the requestor is unauthorized to describe.
+     * @param fetchAllTopics                       A flag indicating whether to fetch all topics or only specified ones.
+     * @return A stream of authorized topic names.
+     */
+    private Stream<String> filterAuthorizedTopics(
+            final RequestChannel.Request abstractRequest,
+            final Set<String> topicsToDescribe,
+            final Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata,
+            final boolean fetchAllTopics
+    ) {
+        return topicsToDescribe.stream().sorted().filter(topicName -> {
+            // Check authorization for each topic
+            final boolean isAuthorized = authHelper.authorize(abstractRequest.context(),
+                    DESCRIBE, TOPIC, topicName, true, true, 1
+            );
+            if (!fetchAllTopics && !isAuthorized) {
+                // If unauthorized, add the topic to the unauthorized list with an empty UUID
+                unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
+                        Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
+                );
+            }
+            return isAuthorized;
+        });
+    }
+
+    /**
+     * Constructs the response data based on authorized topics.
+     *
+     * @param authorizedTopicsStream A stream of authorized topic names.
+     * @param abstractRequest        The incoming request.
+     * @param requestData            The request data containing the cursor and partition limits.
+     * @return The constructed response data with metadata for the authorized topics.
+     */
+    private DescribeTopicPartitionsResponseData buildResponse(
+            final Stream<String> authorizedTopicsStream,
+            final RequestChannel.Request abstractRequest,
+            final DescribeTopicPartitionsRequestData requestData
+    ) {
+        return metadataCache.describeTopicResponse(
+                authorizedTopicsStream.iterator(),
+                abstractRequest.context().listenerName,
+                topicName -> topicName.equals(requestData.cursor() != null
+                        ? requestData.cursor().topicName() : "") ? requestData.cursor().partitionIndex() : 0,
+                Math.max(Math.min(config.maxRequestPartitionSizeLimit(), requestData.responsePartitionLimit()), 1),
+                requestData.topics().isEmpty()
+        );
+    }
+
+    /**
+     * Constructs a DescribeTopicPartitionsResponseTopic object, which contains metadata about a single topic,
+     * including error codes, topic ID, partition data, and whether the topic is internal.
+     *
+     * @param error         The error that occurred while accessing the topic.
+     * @param topic         The name of the topic.
+     * @param topicId       The unique identifier for the topic.
+     * @param isInternal    Whether the topic is internal or not.
+     * @param partitionData The partition data associated with the topic.
+     * @return A DescribeTopicPartitionsResponseTopic object with the specified metadata.
+     */
+    private DescribeTopicPartitionsResponseTopic describeTopicPartitionsResponseTopic(
+            final Errors error,
+            final String topic,
+            final Uuid topicId,
+            final Boolean isInternal,
+            final List<DescribeTopicPartitionsResponsePartition> partitionData
+    ) {
+        return new DescribeTopicPartitionsResponseTopic()
+                .setErrorCode(error.code())
+                .setName(topic)
+                .setTopicId(topicId)
+                .setIsInternal(isInternal)
+                .setPartitions(partitionData);
+    }
+}

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -78,14 +78,14 @@ public class DescribeTopicPartitionsRequestHandler {
         validateCursor(requestData.cursor(), topicsToDescribe);
 
         // Handle topics that are unauthorized for the Describe operation
-        Set<DescribeTopicPartitionsResponseTopic> unauthorizedTopics = new HashSet<>();
-        Stream<String> authorizedTopicsStream = filterAuthorizedTopics(abstractRequest, topicsToDescribe, unauthorizedTopics, requestData.topics().isEmpty());
+        Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata = new HashSet<>();
+        Stream<String> authorizedTopicsStream = filterAuthorizedTopics(abstractRequest, topicsToDescribe, unauthorizedForDescribeTopicMetadata, requestData.topics().isEmpty());
 
         // Construct the response for authorized topics
         DescribeTopicPartitionsResponseData response = buildResponse(authorizedTopicsStream, abstractRequest, requestData);
 
         // Add unauthorized topics to the response to avoid disclosing their existence
-        response.topics().addAll(unauthorizedTopics);
+        response.topics().addAll(unauthorizedForDescribeTopicMetadata);
         return response;
     }
 
@@ -161,18 +161,18 @@ public class DescribeTopicPartitionsRequestHandler {
      *
      * @param abstractRequest The incoming request.
      * @param topicsToDescribe The list of topics to filter.
-     * @param unauthorizedTopics A set to store topics that the requestor is unauthorized to describe.
+     * @param unauthorizedForDescribeTopicMetadata A set to store topics that the requestor is unauthorized to describe.
      * @param fetchAllTopics A flag indicating whether to fetch all topics or only specified ones.
      * @return A stream of authorized topic names.
      */
     private Stream<String> filterAuthorizedTopics(RequestChannel.Request abstractRequest, Set<String> topicsToDescribe,
-                                                  Set<DescribeTopicPartitionsResponseTopic> unauthorizedTopics, boolean fetchAllTopics) {
+                                                  Set<DescribeTopicPartitionsResponseTopic> unauthorizedForDescribeTopicMetadata, boolean fetchAllTopics) {
         return topicsToDescribe.stream().sorted().filter(topicName -> {
             // Check authorization for each topic
             boolean isAuthorized = authHelper.authorize(abstractRequest.context(), DESCRIBE, TOPIC, topicName, true, true, 1);
             if (!fetchAllTopics && !isAuthorized) {
                 // If unauthorized, add the topic to the unauthorized list with an empty UUID
-                unauthorizedTopics.add(describeTopicPartitionsResponseTopic(
+                unauthorizedForDescribeTopicMetadata.add(describeTopicPartitionsResponseTopic(
                         Errors.TOPIC_AUTHORIZATION_FAILED, topicName, Uuid.ZERO_UUID, false, List.of())
                 );
             }

--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -140,8 +140,7 @@ public class DescribeTopicPartitionsRequestHandler {
 
             if (cursor != null && !topics.contains(cursor.topicName())) {
                 // The topic in cursor must be included in the topic list if provided.
-                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain " +
-                        "the cursor topic: " + cursor.topicName());
+                throw new InvalidRequestException("DescribeTopicPartitionsRequest topic list should contain the cursor topic: " + cursor.topicName());
             }
             return topics;
         }


### PR DESCRIPTION
Refactor DescribeTopicPartitionsRequestHandler: Improve readability and add code documentation

### Changes:
* Improved variable naming for better clarity.
* Added detailed inline comments
* Refactored some sections of the code for improved readability (e.g., combining logical blocks).
* Added JavaDoc-style documentation to key methods explaining parameters, return values, and functionality.


Reviewers: TengYao Chi [kitingiao@gmail.com](mailto:kitingiao@gmail.com), Sanskar Jhajharia
[sjhajharia@confluent.io](mailto:sjhajharia@confluent.io), Chia-Ping Tsai [chia7712@gmail.com](mailto:chia7712@gmail.com)