### PR TITLE
KAFKA-19229: Ignore background errors while closing share consumers. (Fix flaky test)

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -51,6 +52,8 @@ import org.apache.kafka.test.MockConsumerInterceptor;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -673,8 +676,9 @@ public class ShareConsumerImplTest {
         verify(applicationEventHandler).addAndGet(any(ShareAcknowledgeOnCloseEvent.class));
     }
 
-    @Test
-    public void testCloseWithBackgroundQueueErrorsAfterUnsubscribe() {
+    @ParameterizedTest
+    @EnumSource(value = Errors.class, names = {"TOPIC_AUTHORIZATION_FAILED", "GROUP_AUTHORIZATION_FAILED", "INVALID_TOPIC_EXCEPTION"})
+    public void testCloseWithBackgroundQueueErrorsAfterUnsubscribe(Errors error) {
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(subscriptions);
 
@@ -687,9 +691,7 @@ public class ShareConsumerImplTest {
         // Mock the applicationEventHandler to add errors to the queue after unsubscribe
         doAnswer(invocation -> {
             // Add errors to the queue after unsubscribe event is processed
-            backgroundEventQueue.add(new ErrorEvent(new TopicAuthorizationException("test-topic")));
-            backgroundEventQueue.add(new ErrorEvent(new InvalidTopicException("test-topic")));
-            backgroundEventQueue.add(new ErrorEvent(new GroupAuthorizationException("test-group")));
+            backgroundEventQueue.add(new ErrorEvent(error.exception()));
             return null;
         }).when(applicationEventHandler).add(any(StopFindCoordinatorOnCloseEvent.class));
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.TimeoutException;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -670,6 +671,33 @@ public class ShareConsumerImplTest {
         completeShareUnsubscribeApplicationEventSuccessfully(subscriptions);
         consumer.close();
         verify(applicationEventHandler).addAndGet(any(ShareAcknowledgeOnCloseEvent.class));
+    }
+
+    @Test
+    public void testCloseWithBackgroundQueueErrorsAfterUnsubscribe() {
+        SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
+        consumer = newConsumer(subscriptions);
+
+        // Complete the acknowledge on close event successfully
+        completeShareAcknowledgeOnCloseApplicationEventSuccessfully();
+        
+        // Complete the unsubscribe event successfully
+        completeShareUnsubscribeApplicationEventSuccessfully(subscriptions);
+
+        // Mock the applicationEventHandler to add errors to the queue after unsubscribe
+        doAnswer(invocation -> {
+            // Add errors to the queue after unsubscribe event is processed
+            backgroundEventQueue.add(new ErrorEvent(new TopicAuthorizationException("test-topic")));
+            backgroundEventQueue.add(new ErrorEvent(new InvalidTopicException("test-topic")));
+            backgroundEventQueue.add(new ErrorEvent(new GroupAuthorizationException("test-group")));
+            return null;
+        }).when(applicationEventHandler).add(any(StopFindCoordinatorOnCloseEvent.class));
+
+        // Close should complete successfully despite the errors in the background queue
+        assertDoesNotThrow(() -> consumer.close());
+
+        // Verify that the background queue was processed
+        assertTrue(backgroundEventQueue.isEmpty(), "Background queue should be empty after close");
     }
 
     private Properties requiredConsumerPropertiesAndGroupId(final String groupId) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-19229

*What*

- A couple of newly added tests were found to be flaky in
`AuthorizerIntegrationTest.scala`.
- `testShareGroupDescribeWithGroupDescribeAndTopicDescribeAcl` and
`testShareGroupDescribeWithoutGroupDescribeAcl`. These tests pass
locally, so could not replicate the failure.
- But logs from develocity indicated that the test fails when the
following condition happens :
   When the background error event arrives after the consumer had
unsubscribed, then these events are processed in the
`handleCompletedAcknowledgements` method and the exception from the
event is thrown, preventing `close()` to complete.

https://develocity.apache.org/s/lhcd3jiumrsem/tests/task/:core:test/details/kafka.api.AuthorizerIntegrationTest/testShareGroupDescribeWithGroupDescribeAndTopicDescribeAcl(String)%5B1%5D?top-execution=2
```
  | [2025-05-05 16:34:52,200] WARN [ShareConsumer
clientId=consumer-share-group-2, groupId=share-group] Consumer triggered
an unsubscribe event to leave the group but couldn't complete it within
0 ms. It will proceed to close.
(org.apache.kafka.clients.consumer.internals.ShareConsumerImpl:944) |
  | [2025-05-05 16:34:52,200] ERROR [ShareConsumer
clientId=consumer-share-group-2, groupId=share-group] Failed invoking
acknowledgement commit callback
(org.apache.kafka.clients.consumer.internals.ShareConsumerImpl:1052) |
  | org.apache.kafka.common.errors.GroupAuthorizationException: Not
authorized to access group: share-group |  
  | [2025-05-05 16:34:52,645] WARN [NodeToControllerChannelManager
id=1000 name=registration] Attempting to close NetworkClient that has
already been closed. (org.apache.kafka.clients.NetworkClient:744)
```

This confirms that the test failed at the acknowledgement commit
callback step where the `GroupAuthorizationException` is thrown.

***Fix***

- We need to handle this race condition where we might get the
background event after unsubscribe and before processing the callbacks.
- PR fixes this by ignoring the exceptions in the background queue when
the `handleCompletedAcknowledgements` method is called during `close()`.
This ensures `close()` completes successfully.
- Have added a unit test which mimics the race condition as well.

Reviewers: Andrew Schofield <aschofield@confluent.io>
