### PR TITLE
KAFKA-18345; Prevent livelocked elections

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -168,7 +168,8 @@ import static org.apache.kafka.snapshot.Snapshots.BOOTSTRAP_SNAPSHOT_ID;
  */
 @SuppressWarnings({ "ClassDataAbstractionCoupling", "ClassFanOutComplexity", "ParameterNumber", "NPathComplexity", "JavaNCSS" })
 public final class KafkaRaftClient<T> implements RaftClient<T> {
-    private static final int RETRY_BACKOFF_BASE_MS = 50;
+    // visible for testing
+    static final int RETRY_BACKOFF_BASE_MS = 50;
     private static final int MAX_NUMBER_OF_BATCHES = 10;
     public static final int MAX_FETCH_WAIT_MS = 500;
     public static final int MAX_BATCH_SIZE_BYTES = 8 * 1024 * 1024;
@@ -1030,7 +1031,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 // replica has failed multiple elections in succession.
                 candidate.startBackingOff(
                     currentTimeMs,
-                    binaryExponentialElectionBackoffMs(candidate.retries())
+                    binaryExponentialElectionBackoffMs(
+                        quorumConfig.electionBackoffMaxMs(),
+                        candidate.retries(),
+                        random
+                    )
                 );
             }
         } else if (state instanceof ProspectiveState prospective) {
@@ -1048,15 +1053,16 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         }
     }
 
-    private int binaryExponentialElectionBackoffMs(int retries) {
+    // visible for testing
+    static int binaryExponentialElectionBackoffMs(int backoffMaxMs, int retries, Random random) {
         if (retries <= 0) {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
         // take minimum of exponential backoff calculation (maxes out to ~1.7 minutes)
         // and configurable electionBackoffMaxMs + jitter. jitter is added to prevent deadlock of elections
         return Math.min(
-            RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(10, retries - 1)),
-            quorumConfig.electionBackoffMaxMs() + random.nextInt(RETRY_BACKOFF_BASE_MS)
+            RETRY_BACKOFF_BASE_MS * random.nextInt(1, 2 << Math.min(10, retries - 1)),
+            backoffMaxMs + random.nextInt(RETRY_BACKOFF_BASE_MS)
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1031,8 +1031,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 // replica has failed multiple elections in succession.
                 candidate.startBackingOff(
                     currentTimeMs,
-                    binaryExponentialElectionBackoffMs(
+                    RaftUtil.binaryExponentialElectionBackoffMs(
                         quorumConfig.electionBackoffMaxMs(),
+                        RETRY_BACKOFF_BASE_MS,
                         candidate.retries(),
                         random
                     )
@@ -1051,21 +1052,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 "Expected to be a NomineeState (Prospective or Candidate), but current state is " + state
             );
         }
-    }
-
-    // visible for testing
-    static int binaryExponentialElectionBackoffMs(int backoffMaxMs, int retries, Random random) {
-        if (retries <= 0) {
-            throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
-        }
-        // Takes minimum of the following:
-        // 1. exponential backoff calculation (maxes out at 102.4 seconds)
-        // 2. configurable electionBackoffMaxMs + jitter
-        // The jitter is added to prevent deadlock of elections.
-        return Math.min(
-            RETRY_BACKOFF_BASE_MS * random.nextInt(1, 2 << Math.min(10, retries - 1)),
-            backoffMaxMs + random.nextInt(RETRY_BACKOFF_BASE_MS)
-        );
     }
 
     private int strictExponentialElectionBackoffMs(int positionInSuccessors, int totalNumSuccessors) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -168,7 +168,7 @@ import static org.apache.kafka.snapshot.Snapshots.BOOTSTRAP_SNAPSHOT_ID;
  */
 @SuppressWarnings({ "ClassDataAbstractionCoupling", "ClassFanOutComplexity", "ParameterNumber", "NPathComplexity", "JavaNCSS" })
 public final class KafkaRaftClient<T> implements RaftClient<T> {
-    private static final int RETRY_BACKOFF_BASE_MS = 100;
+    private static final int RETRY_BACKOFF_BASE_MS = 50;
     private static final int MAX_NUMBER_OF_BATCHES = 10;
     public static final int MAX_FETCH_WAIT_MS = 500;
     public static final int MAX_BATCH_SIZE_BYTES = 8 * 1024 * 1024;
@@ -1052,10 +1052,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         if (retries <= 0) {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
-        // upper limit exponential co-efficients at 20 to avoid overflow
+        // take minimum of exponential backoff calculation (maxes out to ~1.7 minutes)
+        // and configurable electionBackoffMaxMs + jitter. jitter is added to prevent deadlock of elections
         return Math.min(
-            RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(20, retries - 1)),
-            quorumConfig.electionBackoffMaxMs()
+            RETRY_BACKOFF_BASE_MS * random.nextInt(2 << Math.min(10, retries - 1)),
+            quorumConfig.electionBackoffMaxMs() + random.nextInt(RETRY_BACKOFF_BASE_MS)
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1058,8 +1058,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         if (retries <= 0) {
             throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
         }
-        // take minimum of exponential backoff calculation (maxes out to ~1.7 minutes)
-        // and configurable electionBackoffMaxMs + jitter. jitter is added to prevent deadlock of elections
+        // Takes minimum of the following:
+        // 1. exponential backoff calculation (maxes out at 102.4 seconds)
+        // 2. configurable electionBackoffMaxMs + jitter
+        // The jitter is added to prevent deadlock of elections.
         return Math.min(
             RETRY_BACKOFF_BASE_MS * random.nextInt(1, 2 << Math.min(10, retries - 1)),
             backoffMaxMs + random.nextInt(RETRY_BACKOFF_BASE_MS)

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -48,6 +48,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -754,5 +755,19 @@ public class RaftUtil {
                    data.topics().get(0).topicName().equals(topicPartition.topic()) &&
                    data.topics().get(0).partitions().size() == 1 &&
                    data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
+    }
+
+    static int binaryExponentialElectionBackoffMs(int backoffMaxMs, int backoffBaseMs, int retries, Random random) {
+        if (retries <= 0) {
+            throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
+        }
+        // Takes minimum of the following:
+        // 1. exponential backoff calculation (maxes out at 102.4 seconds)
+        // 2. configurable electionBackoffMaxMs + jitter
+        // The jitter is added to prevent deadlock of elections.
+        return Math.min(
+            backoffBaseMs * random.nextInt(1, 2 << Math.min(10, retries - 1)),
+            backoffMaxMs + random.nextInt(backoffBaseMs)
+        );
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -764,7 +764,7 @@ public class RaftUtil {
         // Takes minimum of the following:
         // 1. exponential backoff calculation (maxes out at 102.4 seconds)
         // 2. configurable electionBackoffMaxMs + jitter
-        // The jitter is added to prevent deadlock of elections.
+        // The jitter is added to prevent livelock of elections.
         return Math.min(
             backoffBaseMs * random.nextInt(1, 2 << Math.min(10, retries - 1)),
             backoffMaxMs + random.nextInt(backoffBaseMs)

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1811,7 +1811,7 @@ class KafkaRaftClientTest {
         context.client.poll();
         assertTrue(candidate.isBackingOff());
         assertEquals(
-            context.electionBackoffMaxMs,
+            context.electionBackoffMaxMs + exponentialFactor,
             candidate.remainingBackoffMs(context.time.milliseconds())
         );
 
@@ -1820,7 +1820,7 @@ class KafkaRaftClientTest {
 
         // Even though candidacy was rejected, local replica will backoff for jitter period
         // before transitioning to prospective and starting a new election.
-        context.time.sleep(context.electionBackoffMaxMs - 1);
+        context.time.sleep(context.electionBackoffMaxMs + exponentialFactor - 1);
         context.client.poll();
         context.assertVotedCandidate(epoch, localId);
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -46,28 +46,23 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
-import static org.apache.kafka.raft.KafkaRaftClient.RETRY_BACKOFF_BASE_MS;
-import static org.apache.kafka.raft.KafkaRaftClient.binaryExponentialElectionBackoffMs;
 import static org.apache.kafka.raft.RaftClientTestContext.Builder.DEFAULT_ELECTION_TIMEOUT_MS;
 import static org.apache.kafka.raft.RaftClientTestContext.RaftProtocol.KIP_853_PROTOCOL;
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
@@ -4572,55 +4567,6 @@ class KafkaRaftClientTest {
         context.client.poll();
         assertEquals(3L, context.log.endOffset().offset());
         assertEquals(3, context.log.lastFetchedEpoch());
-    }
-
-    @Test
-    public void testExponentialElectionBackoffMs() {
-        Random mockedRandom = Mockito.mock(Random.class);
-        int electionBackoffMaxMs = 1000;
-
-        // test the bound of the first call to random.nextInt
-        for (int retries = 1; retries < 11; retries++) {
-            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, retries, mockedRandom);
-            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-            int actualBound = nextIntCaptor.getValue();
-            int expectedBound = (int) (2 * Math.pow(2, retries - 1));
-            assertEquals(expectedBound, actualBound, "Incorrect bound for retries=" + retries);
-            Mockito.clearInvocations(mockedRandom);
-        }
-        // after the 10th retry, the bound of the first call to random.nextInt will remain capped to
-        // (RETRY_BACKOFF_BASE_MS * 2 << 10)=2048 to prevent overflow
-        int firstNextIntMaxBound = 2048;
-        for (int retries = 11; retries < 13; retries++) {
-            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, retries, mockedRandom);
-            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-            int actualBound = nextIntCaptor.getValue();
-            assertEquals(firstNextIntMaxBound, actualBound);
-            Mockito.clearInvocations(mockedRandom);
-        }
-
-        // test that the return value of the method is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
-        int jitterMs = 50;
-        // any bound >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 will result in returning this cap
-        for (int firstNextInt : Arrays.asList(21, 1000, firstNextIntMaxBound)) {
-            Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
-            Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
-
-            int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, 11, mockedRandom);
-
-            // verify nextInt was called on both expected bounds
-            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-            Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
-            List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
-            assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
-            assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
-
-            // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
-            assertEquals(electionBackoffMaxMs + jitterMs, returnedBackoffMs);
-        }
     }
 
     private static KafkaMetric getMetric(final Metrics metrics, final String name) {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -4603,22 +4604,23 @@ class KafkaRaftClientTest {
         // test that the return value of the method is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
         int jitterMs = 50;
         // any bound >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 will result in returning this cap
-        int firstNextInt = new Random().nextInt(21, firstNextIntMaxBound);
-        Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
-        Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
+        for (int firstNextInt : Arrays.asList(21, 1000, firstNextIntMaxBound)) {
+            Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
+            Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
 
-        int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, 11, mockedRandom);
+            int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, 11, mockedRandom);
 
-        // verify nextInt was called on both expected bounds
-        ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-        Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-        Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
-        List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
-        assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
-        assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
+            // verify nextInt was called on both expected bounds
+            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+            Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
+            List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
+            assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
+            assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
 
-        // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
-        assertEquals(electionBackoffMaxMs + jitterMs, returnedBackoffMs);
+            // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
+            assertEquals(electionBackoffMaxMs + jitterMs, returnedBackoffMs);
+        }
     }
 
     private static KafkaMetric getMetric(final Metrics metrics, final String name) {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -4577,7 +4577,8 @@ class KafkaRaftClientTest {
     public void testExponentialElectionBackoffMs() {
         Random mockedRandom = Mockito.mock(Random.class);
         int electionBackoffMaxMs = 1000;
-        // retries start at 1
+
+        // test the bound of the first call to random.nextInt
         for (int retries = 1; retries < 11; retries++) {
             binaryExponentialElectionBackoffMs(electionBackoffMaxMs, retries, mockedRandom);
             ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
@@ -4587,7 +4588,8 @@ class KafkaRaftClientTest {
             assertEquals(expectedBound, actualBound, "Incorrect bound for retries=" + retries);
             Mockito.clearInvocations(mockedRandom);
         }
-        // after the 10th retry, the bound of the first call to nextInt is capped to (RETRY_BACKOFF_BASE_MS * 2 << 10)=2048 to prevent overflow
+        // after the 10th retry, the bound of the first call to random.nextInt will remain capped to
+        // (RETRY_BACKOFF_BASE_MS * 2 << 10)=2048 to prevent overflow
         int firstNextIntMaxBound = 2048;
         for (int retries = 11; retries < 13; retries++) {
             binaryExponentialElectionBackoffMs(electionBackoffMaxMs, retries, mockedRandom);
@@ -4598,13 +4600,11 @@ class KafkaRaftClientTest {
             Mockito.clearInvocations(mockedRandom);
         }
 
-        // test that the exponential backoff is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
+        // test that the return value of the method is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
         int jitterMs = 50;
-        // any value >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 returned by the first call to nextInt will result in the cap
+        // any bound >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 will result in returning this cap
         int firstNextInt = new Random().nextInt(21, firstNextIntMaxBound);
-        // with retries=11, first call to nextInt expected on max bound (RETRY_BACKOFF_BASE_MS * 2 << 10)
         Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
-        // second call to nextInt always on (RETRY_BACKOFF_BASE_MS)
         Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
 
         int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, 11, mockedRandom);

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -57,12 +58,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.raft.KafkaRaftClient.RETRY_BACKOFF_BASE_MS;
+import static org.apache.kafka.raft.KafkaRaftClient.binaryExponentialElectionBackoffMs;
 import static org.apache.kafka.raft.RaftClientTestContext.Builder.DEFAULT_ELECTION_TIMEOUT_MS;
 import static org.apache.kafka.raft.RaftClientTestContext.RaftProtocol.KIP_853_PROTOCOL;
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
@@ -4567,6 +4571,54 @@ class KafkaRaftClientTest {
         context.client.poll();
         assertEquals(3L, context.log.endOffset().offset());
         assertEquals(3, context.log.lastFetchedEpoch());
+    }
+
+    @Test
+    public void testExponentialElectionBackoffMs() {
+        Random mockedRandom = Mockito.mock(Random.class);
+        int electionBackoffMaxMs = 1000;
+        // retries start at 1
+        for (int retries = 1; retries < 11; retries++) {
+            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, retries, mockedRandom);
+            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+            int actualBound = nextIntCaptor.getValue();
+            int expectedBound = (int) (2 * Math.pow(2, retries - 1));
+            assertEquals(expectedBound, actualBound, "Incorrect bound for retries=" + retries);
+            Mockito.clearInvocations(mockedRandom);
+        }
+        // after the 10th retry, the bound of the first call to nextInt is capped to (RETRY_BACKOFF_BASE_MS * 2 << 10)=2048 to prevent overflow
+        int firstNextIntMaxBound = 2048;
+        for (int retries = 11; retries < 13; retries++) {
+            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, retries, mockedRandom);
+            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+            int actualBound = nextIntCaptor.getValue();
+            assertEquals(firstNextIntMaxBound, actualBound);
+            Mockito.clearInvocations(mockedRandom);
+        }
+
+        // test that the exponential backoff is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
+        int jitterMs = 50;
+        // any value >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 returned by the first call to nextInt will result in the cap
+        int firstNextInt = new Random().nextInt(21, firstNextIntMaxBound);
+        // with retries=11, first call to nextInt expected on max bound (RETRY_BACKOFF_BASE_MS * 2 << 10)
+        Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
+        // second call to nextInt always on (RETRY_BACKOFF_BASE_MS)
+        Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
+
+        int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, 11, mockedRandom);
+
+        // verify nextInt was called on both expected bounds
+        ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+        Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+        Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
+        List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
+        assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
+        assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
+
+        // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
+        assertEquals(electionBackoffMaxMs + jitterMs, returnedBackoffMs);
     }
 
     private static KafkaMetric getMetric(final Metrics metrics, final String name) {

--- a/raft/src/test/java/org/apache/kafka/raft/MockableRandom.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockableRandom.java
@@ -48,4 +48,9 @@ class MockableRandom extends Random {
     public int nextInt(int bound) {
         return nextIntFunction.apply(bound).orElse(super.nextInt(bound));
     }
+
+    @Override
+    public int nextInt(int origin, int bound) {
+        return nextIntFunction.apply(bound).orElse(super.nextInt(bound));
+    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
@@ -59,13 +59,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.raft.KafkaRaftClient.RETRY_BACKOFF_BASE_MS;
+import static org.apache.kafka.raft.RaftUtil.binaryExponentialElectionBackoffMs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -619,6 +625,57 @@ public class RaftUtilTest {
         );
         JsonNode json = DescribeQuorumResponseDataJsonConverter.write(describeQuorumResponseData, version);
         assertEquals(expectedJson, json.toString());
+    }
+
+
+    @Test
+    public void testExponentialElectionBackoffMs() {
+        Random mockedRandom = Mockito.mock(Random.class);
+        int electionBackoffMaxMs = 1000;
+
+        // test the bound of the first call to random.nextInt
+        for (int retries = 1; retries < 11; retries++) {
+            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, retries, mockedRandom);
+            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+            int actualBound = nextIntCaptor.getValue();
+            int expectedBound = (int) (2 * Math.pow(2, retries - 1));
+            assertEquals(expectedBound, actualBound, "Incorrect bound for retries=" + retries);
+            Mockito.clearInvocations(mockedRandom);
+        }
+        // after the 10th retry, the bound of the first call to random.nextInt will remain capped to
+        // (RETRY_BACKOFF_BASE_MS * 2 << 10)=2048 to prevent overflow
+        int firstNextIntMaxBound = 2048;
+        for (int retries = 11; retries < 13; retries++) {
+            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, retries, mockedRandom);
+            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+            int actualBound = nextIntCaptor.getValue();
+            assertEquals(firstNextIntMaxBound, actualBound);
+            Mockito.clearInvocations(mockedRandom);
+        }
+
+        // test that the return value of the method is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
+        int jitterMs = 50;
+        // any bound >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 will result in returning this cap
+        for (int firstNextInt : Arrays.asList(21, 1000, firstNextIntMaxBound)) {
+            Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
+            Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
+
+            int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, 11, mockedRandom);
+
+            // verify nextInt was called on both expected bounds
+            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+            Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
+            List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
+            assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
+            assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
+
+            // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
+            assertEquals(electionBackoffMaxMs + jitterMs, returnedBackoffMs);
+            Mockito.clearInvocations(mockedRandom);
+        }
     }
 
     private Records createRecords() {

--- a/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
@@ -59,12 +59,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -74,6 +74,7 @@ import static org.apache.kafka.raft.KafkaRaftClient.RETRY_BACKOFF_BASE_MS;
 import static org.apache.kafka.raft.RaftUtil.binaryExponentialElectionBackoffMs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RaftUtilTest {
 
@@ -627,54 +628,57 @@ public class RaftUtilTest {
         assertEquals(expectedJson, json.toString());
     }
 
-
-    @Test
-    public void testExponentialElectionBackoffMs() {
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13})
+    public void testExponentialBoundOfExponentialElectionBackoffMs(int retries) {
         Random mockedRandom = Mockito.mock(Random.class);
         int electionBackoffMaxMs = 1000;
 
-        // test the bound of the first call to random.nextInt
-        for (int retries = 1; retries < 11; retries++) {
-            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, retries, mockedRandom);
-            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-            int actualBound = nextIntCaptor.getValue();
-            int expectedBound = (int) (2 * Math.pow(2, retries - 1));
-            assertEquals(expectedBound, actualBound, "Incorrect bound for retries=" + retries);
-            Mockito.clearInvocations(mockedRandom);
-        }
+        // test the bound of the method's first call to random.nextInt
+        binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, retries, mockedRandom);
+        ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+        Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+        int actualBound = nextIntCaptor.getValue();
+        int expectedBound = (int) (2 * Math.pow(2, retries - 1));
         // after the 10th retry, the bound of the first call to random.nextInt will remain capped to
         // (RETRY_BACKOFF_BASE_MS * 2 << 10)=2048 to prevent overflow
-        int firstNextIntMaxBound = 2048;
-        for (int retries = 11; retries < 13; retries++) {
-            binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, retries, mockedRandom);
-            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-            int actualBound = nextIntCaptor.getValue();
-            assertEquals(firstNextIntMaxBound, actualBound);
-            Mockito.clearInvocations(mockedRandom);
+        if (retries > 10) {
+            expectedBound = 2048;
         }
+        assertEquals(expectedBound, actualBound, "Incorrect bound for retries=" + retries);
+    }
 
-        // test that the return value of the method is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
+    // test that the return value of the method is capped to QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG + jitter
+    // any exponential >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 will result in this cap
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 20, 21, 22, 2048})
+    public void testExponentialElectionBackoffMsIsCapped(int exponential) {
+        Random mockedRandom = Mockito.mock(Random.class);
+        int electionBackoffMaxMs = 1000;
+        // this is the max bound of the method's first call to random.nextInt
+        int firstNextIntMaxBound = 2048;
+
         int jitterMs = 50;
-        // any bound >= (1000 + jitter)/(RETRY_BACKOFF_BASE_MS)=21 will result in returning this cap
-        for (int firstNextInt : Arrays.asList(21, 1000, firstNextIntMaxBound)) {
-            Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(firstNextInt);
-            Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
+        Mockito.when(mockedRandom.nextInt(1, firstNextIntMaxBound)).thenReturn(exponential);
+        Mockito.when(mockedRandom.nextInt(RETRY_BACKOFF_BASE_MS)).thenReturn(jitterMs);
 
-            int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, 11, mockedRandom);
+        int returnedBackoffMs = binaryExponentialElectionBackoffMs(electionBackoffMaxMs, RETRY_BACKOFF_BASE_MS, 11, mockedRandom);
 
-            // verify nextInt was called on both expected bounds
-            ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
-            Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
-            List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
-            assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
-            assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
+        // verify nextInt was called on both expected bounds
+        ArgumentCaptor<Integer> nextIntCaptor = ArgumentCaptor.forClass(Integer.class);
+        Mockito.verify(mockedRandom).nextInt(Mockito.eq(1), nextIntCaptor.capture());
+        Mockito.verify(mockedRandom).nextInt(nextIntCaptor.capture());
+        List<Integer> allCapturedBounds = nextIntCaptor.getAllValues();
+        assertEquals(firstNextIntMaxBound, allCapturedBounds.get(0));
+        assertEquals(RETRY_BACKOFF_BASE_MS, allCapturedBounds.get(1));
 
-            // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
-            assertEquals(electionBackoffMaxMs + jitterMs, returnedBackoffMs);
-            Mockito.clearInvocations(mockedRandom);
+        // finally verify the backoff returned is capped to electionBackoffMaxMs + jitterMs
+        int backoffValueCap = electionBackoffMaxMs + jitterMs;
+        if (exponential < 21) {
+            assertEquals(RETRY_BACKOFF_BASE_MS * exponential, returnedBackoffMs);
+            assertTrue(returnedBackoffMs < backoffValueCap);
+        } else {
+            assertEquals(backoffValueCap, returnedBackoffMs);
         }
     }
 


### PR DESCRIPTION
At the retry limit binaryExponentialElectionBackoffMs it becomes
statistically likely that the exponential backoff returned
electionBackoffMaxMs. This is an issue as multiple replicas can get
stuck starting elections at the same cadence.

This change fixes that by added a random jitter to the max election
backoff.

Reviewers: José Armando García Sancio <jsancio@apache.org>, TaiJuWu
 <tjwu1217@gmail.com>, Yung <yungyung7654321@gmail.com>
