### PR TITLE
KAFKA-19253: Improve metadata handling for share version using feature listeners (1/N)

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.requests.ShareRequestMetadata;
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.GroupConfigManager;
+import org.apache.kafka.server.common.ShareVersion;
 import org.apache.kafka.server.share.CachedSharePartition;
 import org.apache.kafka.server.share.SharePartitionKey;
 import org.apache.kafka.server.share.acknowledge.ShareAcknowledgementBatch;
@@ -744,6 +745,29 @@ public class SharePartitionManager implements AutoCloseable {
                 brokerTopicStats.topicStats(topic).failedShareAcknowledgementRequestRate().mark();
             });
         };
+    }
+
+    /**
+     * The handler for share version feature metadata changes.
+     * @param shareVersion the new share version feature
+     */
+    public void onShareVersionToggle(ShareVersion shareVersion) {
+        if (!shareVersion.supportsShareGroups()) {
+            // Remove all share sessions from share session cache.
+            synchronized (cache) {
+                cache.removeAllSessions();
+            }
+            Set<SharePartitionKey> sharePartitionKeys = new HashSet<>(partitionCacheMap.keySet());
+            // Remove all share partitions from partition cache.
+            sharePartitionKeys.forEach(sharePartitionKey ->
+                removeSharePartitionFromCache(sharePartitionKey, partitionCacheMap, replicaManager)
+            );
+        }
+    }
+
+    // Visible for testing.
+    protected Map<SharePartitionKey, SharePartition> partitionCacheMap() {
+        return new ConcurrentHashMap<>(partitionCacheMap);
     }
 
     /**

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -145,6 +146,11 @@ public class SharePartitionManager implements AutoCloseable {
      */
     private final BrokerTopicStats brokerTopicStats;
 
+    /**
+     * Flag indicating if share groups have been turned on.
+     */
+    private final AtomicBoolean isShareGroupsSupported;
+
     public SharePartitionManager(
         ReplicaManager replicaManager,
         Time time,
@@ -154,7 +160,8 @@ public class SharePartitionManager implements AutoCloseable {
         int maxInFlightMessages,
         Persister persister,
         GroupConfigManager groupConfigManager,
-        BrokerTopicStats brokerTopicStats
+        BrokerTopicStats brokerTopicStats,
+        boolean isShareGroupsSupported
     ) {
         this(replicaManager,
             time,
@@ -166,7 +173,8 @@ public class SharePartitionManager implements AutoCloseable {
             persister,
             groupConfigManager,
             new ShareGroupMetrics(time),
-            brokerTopicStats
+            brokerTopicStats,
+            isShareGroupsSupported
         );
     }
 
@@ -181,7 +189,8 @@ public class SharePartitionManager implements AutoCloseable {
         Persister persister,
         GroupConfigManager groupConfigManager,
         ShareGroupMetrics shareGroupMetrics,
-        BrokerTopicStats brokerTopicStats
+        BrokerTopicStats brokerTopicStats,
+        boolean isShareGroupsSupported
     ) {
         this(replicaManager,
             time,
@@ -195,7 +204,8 @@ public class SharePartitionManager implements AutoCloseable {
             persister,
             groupConfigManager,
             shareGroupMetrics,
-            brokerTopicStats
+            brokerTopicStats,
+            isShareGroupsSupported
         );
     }
 
@@ -212,7 +222,8 @@ public class SharePartitionManager implements AutoCloseable {
             Persister persister,
             GroupConfigManager groupConfigManager,
             ShareGroupMetrics shareGroupMetrics,
-            BrokerTopicStats brokerTopicStats
+            BrokerTopicStats brokerTopicStats,
+            boolean isShareGroupsSupported
     ) {
         this.replicaManager = replicaManager;
         this.time = time;
@@ -226,6 +237,7 @@ public class SharePartitionManager implements AutoCloseable {
         this.groupConfigManager = groupConfigManager;
         this.shareGroupMetrics = shareGroupMetrics;
         this.brokerTopicStats = brokerTopicStats;
+        this.isShareGroupsSupported = new AtomicBoolean(isShareGroupsSupported);
     }
 
     /**
@@ -456,9 +468,12 @@ public class SharePartitionManager implements AutoCloseable {
                         ImplicitLinkedHashCollection<>(shareFetchData.size());
                 shareFetchData.forEach(topicIdPartition ->
                     cachedSharePartitions.mustAdd(new CachedSharePartition(topicIdPartition, false)));
-                ShareSessionKey responseShareSessionKey = cache.maybeCreateSession(groupId, reqMetadata.memberId(),
-                    cachedSharePartitions, clientConnectionId);
-                if (responseShareSessionKey == null) {
+                ShareSessionKey responseShareSessionKey = null;
+                if (isShareGroupsSupported.get()) {
+                    responseShareSessionKey = cache.maybeCreateSession(groupId, reqMetadata.memberId(),
+                        cachedSharePartitions, clientConnectionId);
+                }
+                if (responseShareSessionKey == null && isShareGroupsSupported.get()) {
                     log.error("Could not create a share session for group {} member {}", groupId, reqMetadata.memberId());
                     throw Errors.SHARE_SESSION_NOT_FOUND.exception();
                 }
@@ -484,7 +499,9 @@ public class SharePartitionManager implements AutoCloseable {
                 }
                 Map<ShareSession.ModifiedTopicIdPartitionType, List<TopicIdPartition>> modifiedTopicIdPartitions = shareSession.update(
                     shareFetchData, toForget);
-                cache.updateNumPartitions(shareSession);
+                if (isShareGroupsSupported.get()) {
+                    cache.updateNumPartitions(shareSession);
+                }
                 shareSession.epoch = ShareRequestMetadata.nextEpoch(shareSession.epoch);
                 log.debug("Created a new ShareSessionContext for session key {}, epoch {}: " +
                                 "added {}, updated {}, removed {}", shareSession.key(), shareSession.epoch,
@@ -525,7 +542,9 @@ public class SharePartitionManager implements AutoCloseable {
                             shareSession.epoch, reqMetadata.epoch());
                     throw Errors.INVALID_SHARE_SESSION_EPOCH.exception();
                 }
-                cache.updateNumPartitions(shareSession);
+                if (isShareGroupsSupported.get()) {
+                    cache.updateNumPartitions(shareSession);
+                }
                 shareSession.epoch = ShareRequestMetadata.nextEpoch(shareSession.epoch);
             }
         }
@@ -753,6 +772,7 @@ public class SharePartitionManager implements AutoCloseable {
      */
     public void onShareVersionToggle(ShareVersion shareVersion) {
         if (!shareVersion.supportsShareGroups()) {
+            isShareGroupsSupported.set(false);
             // Remove all share sessions from share session cache.
             synchronized (cache) {
                 cache.removeAllSessions();
@@ -762,12 +782,19 @@ public class SharePartitionManager implements AutoCloseable {
             sharePartitionKeys.forEach(sharePartitionKey ->
                 removeSharePartitionFromCache(sharePartitionKey, partitionCacheMap, replicaManager)
             );
+        } else {
+            isShareGroupsSupported.set(true);
         }
     }
 
     // Visible for testing.
     protected Map<SharePartitionKey, SharePartition> partitionCacheMap() {
         return new ConcurrentHashMap<>(partitionCacheMap);
+    }
+
+    // Visible for testing.
+    boolean isShareGroupsSupported() {
+        return isShareGroupsSupported.get();
     }
 
     /**

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -457,7 +457,7 @@ public class SharePartitionManager implements AutoCloseable {
                 shareFetchData.forEach(topicIdPartition ->
                     cachedSharePartitions.mustAdd(new CachedSharePartition(topicIdPartition, false)));
                 ShareSessionKey responseShareSessionKey = cache.maybeCreateSession(groupId, reqMetadata.memberId(),
-                        cachedSharePartitions, clientConnectionId);
+                    cachedSharePartitions, clientConnectionId);
                 if (responseShareSessionKey == null) {
                     log.error("Could not create a share session for group {} member {}", groupId, reqMetadata.memberId());
                     throw Errors.SHARE_SESSION_NOT_FOUND.exception();

--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -73,7 +73,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -146,11 +145,6 @@ public class SharePartitionManager implements AutoCloseable {
      */
     private final BrokerTopicStats brokerTopicStats;
 
-    /**
-     * Flag indicating if share groups have been turned on.
-     */
-    private final AtomicBoolean isShareGroupsSupported;
-
     public SharePartitionManager(
         ReplicaManager replicaManager,
         Time time,
@@ -160,8 +154,7 @@ public class SharePartitionManager implements AutoCloseable {
         int maxInFlightMessages,
         Persister persister,
         GroupConfigManager groupConfigManager,
-        BrokerTopicStats brokerTopicStats,
-        boolean isShareGroupsSupported
+        BrokerTopicStats brokerTopicStats
     ) {
         this(replicaManager,
             time,
@@ -173,8 +166,7 @@ public class SharePartitionManager implements AutoCloseable {
             persister,
             groupConfigManager,
             new ShareGroupMetrics(time),
-            brokerTopicStats,
-            isShareGroupsSupported
+            brokerTopicStats
         );
     }
 
@@ -189,8 +181,7 @@ public class SharePartitionManager implements AutoCloseable {
         Persister persister,
         GroupConfigManager groupConfigManager,
         ShareGroupMetrics shareGroupMetrics,
-        BrokerTopicStats brokerTopicStats,
-        boolean isShareGroupsSupported
+        BrokerTopicStats brokerTopicStats
     ) {
         this(replicaManager,
             time,
@@ -204,8 +195,7 @@ public class SharePartitionManager implements AutoCloseable {
             persister,
             groupConfigManager,
             shareGroupMetrics,
-            brokerTopicStats,
-            isShareGroupsSupported
+            brokerTopicStats
         );
     }
 
@@ -222,8 +212,7 @@ public class SharePartitionManager implements AutoCloseable {
             Persister persister,
             GroupConfigManager groupConfigManager,
             ShareGroupMetrics shareGroupMetrics,
-            BrokerTopicStats brokerTopicStats,
-            boolean isShareGroupsSupported
+            BrokerTopicStats brokerTopicStats
     ) {
         this.replicaManager = replicaManager;
         this.time = time;
@@ -237,7 +226,6 @@ public class SharePartitionManager implements AutoCloseable {
         this.groupConfigManager = groupConfigManager;
         this.shareGroupMetrics = shareGroupMetrics;
         this.brokerTopicStats = brokerTopicStats;
-        this.isShareGroupsSupported = new AtomicBoolean(isShareGroupsSupported);
     }
 
     /**
@@ -468,12 +456,9 @@ public class SharePartitionManager implements AutoCloseable {
                         ImplicitLinkedHashCollection<>(shareFetchData.size());
                 shareFetchData.forEach(topicIdPartition ->
                     cachedSharePartitions.mustAdd(new CachedSharePartition(topicIdPartition, false)));
-                ShareSessionKey responseShareSessionKey = null;
-                if (isShareGroupsSupported.get()) {
-                    responseShareSessionKey = cache.maybeCreateSession(groupId, reqMetadata.memberId(),
+                ShareSessionKey responseShareSessionKey = cache.maybeCreateSession(groupId, reqMetadata.memberId(),
                         cachedSharePartitions, clientConnectionId);
-                }
-                if (responseShareSessionKey == null && isShareGroupsSupported.get()) {
+                if (responseShareSessionKey == null) {
                     log.error("Could not create a share session for group {} member {}", groupId, reqMetadata.memberId());
                     throw Errors.SHARE_SESSION_NOT_FOUND.exception();
                 }
@@ -499,9 +484,7 @@ public class SharePartitionManager implements AutoCloseable {
                 }
                 Map<ShareSession.ModifiedTopicIdPartitionType, List<TopicIdPartition>> modifiedTopicIdPartitions = shareSession.update(
                     shareFetchData, toForget);
-                if (isShareGroupsSupported.get()) {
-                    cache.updateNumPartitions(shareSession);
-                }
+                cache.updateNumPartitions(shareSession);
                 shareSession.epoch = ShareRequestMetadata.nextEpoch(shareSession.epoch);
                 log.debug("Created a new ShareSessionContext for session key {}, epoch {}: " +
                                 "added {}, updated {}, removed {}", shareSession.key(), shareSession.epoch,
@@ -542,9 +525,7 @@ public class SharePartitionManager implements AutoCloseable {
                             shareSession.epoch, reqMetadata.epoch());
                     throw Errors.INVALID_SHARE_SESSION_EPOCH.exception();
                 }
-                if (isShareGroupsSupported.get()) {
-                    cache.updateNumPartitions(shareSession);
-                }
+                cache.updateNumPartitions(shareSession);
                 shareSession.epoch = ShareRequestMetadata.nextEpoch(shareSession.epoch);
             }
         }
@@ -772,7 +753,7 @@ public class SharePartitionManager implements AutoCloseable {
      */
     public void onShareVersionToggle(ShareVersion shareVersion) {
         if (!shareVersion.supportsShareGroups()) {
-            isShareGroupsSupported.set(false);
+            cache.updateSupportsShareGroups(false);
             // Remove all share sessions from share session cache.
             synchronized (cache) {
                 cache.removeAllSessions();
@@ -783,18 +764,13 @@ public class SharePartitionManager implements AutoCloseable {
                 removeSharePartitionFromCache(sharePartitionKey, partitionCacheMap, replicaManager)
             );
         } else {
-            isShareGroupsSupported.set(true);
+            cache.updateSupportsShareGroups(true);
         }
     }
 
     // Visible for testing.
-    protected Map<SharePartitionKey, SharePartition> partitionCacheMap() {
-        return new ConcurrentHashMap<>(partitionCacheMap);
-    }
-
-    // Visible for testing.
-    boolean isShareGroupsSupported() {
-        return isShareGroupsSupported.get();
+    protected int partitionCacheSize() {
+        return partitionCacheMap.size();
     }
 
     /**

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -45,7 +45,8 @@ import org.apache.kafka.metadata.{BrokerState, ListenerInfo}
 import org.apache.kafka.metadata.publisher.AclPublisher
 import org.apache.kafka.security.CredentialProvider
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.{ApiMessageAndVersion, DirectoryEventHandler, NodeToControllerChannelManager, TopicIdPartition}
+import org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION
+import org.apache.kafka.server.common.{ApiMessageAndVersion, DirectoryEventHandler, FinalizedFeatures, NodeToControllerChannelManager, ShareVersion, TopicIdPartition}
 import org.apache.kafka.server.config.{ConfigType, DelegationTokenManagerConfigs}
 import org.apache.kafka.server.log.remote.storage.{RemoteLogManager, RemoteLogManagerConfig}
 import org.apache.kafka.server.metrics.{ClientMetricsReceiverPlugin, KafkaYammerMetrics}
@@ -441,7 +442,10 @@ class BrokerServer(
         config.shareGroupConfig.shareGroupPartitionMaxRecordLocks,
         persister,
         groupConfigManager,
-        brokerTopicStats
+        brokerTopicStats,
+        ShareVersion.fromFeatureLevel(
+          FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
+        ).supportsShareGroups()
       )
 
       dataPlaneRequestProcessor = new KafkaApis(

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -516,7 +516,8 @@ class BrokerServer(
           authorizerPlugin.toJava
         ),
         sharedServer.initialBrokerMetadataLoadFaultHandler,
-        sharedServer.metadataPublishingFaultHandler
+        sharedServer.metadataPublishingFaultHandler,
+        sharePartitionManager
       )
       // If the BrokerLifecycleManager's initial catch-up future fails, it means we timed out
       // or are shutting down before we could catch up. Therefore, also fail the firstPublishFuture.

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -260,7 +260,12 @@ class BrokerServer(
         Optional.of(clientMetricsManager)
       )
 
-      val shareFetchSessionCache : ShareSessionCache = new ShareSessionCache(config.shareGroupConfig.shareGroupMaxShareSessions())
+      val shareFetchSessionCache : ShareSessionCache = new ShareSessionCache(
+        config.shareGroupConfig.shareGroupMaxShareSessions(),
+        ShareVersion.fromFeatureLevel(
+          FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
+        ).supportsShareGroups()
+      )
 
       val connectionDisconnectListeners = Seq(
         clientMetricsManager.connectionDisconnectListener(),
@@ -442,10 +447,7 @@ class BrokerServer(
         config.shareGroupConfig.shareGroupPartitionMaxRecordLocks,
         persister,
         groupConfigManager,
-        brokerTopicStats,
-        ShareVersion.fromFeatureLevel(
-          FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
-        ).supportsShareGroups()
+        brokerTopicStats
       )
 
       dataPlaneRequestProcessor = new KafkaApis(

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -104,11 +104,9 @@ class BrokerMetadataPublisher(
   val firstPublishFuture = new CompletableFuture[Void]
 
   /**
-   * The share version being used in the current metadata.
+   * The share version being used in the broker metadata.
    */
   private var finalizedShareVersion: Short = FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
-
-    ShareVersion.LATEST_PRODUCTION.featureLevel()
 
   override def name(): String = "BrokerMetadataPublisher"
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -245,7 +245,7 @@ class BrokerMetadataPublisher(
         try {
           val newFinalizedFeatures = new FinalizedFeatures(newImage.features.metadataVersionOrThrow, newImage.features.finalizedVersions, newImage.provenance.lastContainedOffset)
           // Share version feature has been toggled.
-          if (!(newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort) == finalizedShareVersion)) {
+          if (newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort) != finalizedShareVersion) {
             finalizedShareVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
             val shareVersion: ShareVersion = ShareVersion.fromFeatureLevel(finalizedShareVersion)
             info(s"Feature share.version has been updated to version $finalizedShareVersion")

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -248,7 +248,7 @@ class BrokerMetadataPublisher(
           if (!(newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort) == finalizedShareVersion)) {
             finalizedShareVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
             val shareVersion: ShareVersion = ShareVersion.fromFeatureLevel(finalizedShareVersion)
-            info(s"Share version has been toggled to $shareVersion")
+            info(s"Feature share.version has been updated to version $finalizedShareVersion")
             sharePartitionManager.onShareVersionToggle(shareVersion)
           }
         } catch {

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -20,6 +20,7 @@ package kafka.server.metadata
 import java.util.OptionalInt
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.LogManager
+import kafka.server.share.SharePartitionManager
 import kafka.server.{KafkaConfig, ReplicaManager}
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
@@ -32,7 +33,8 @@ import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.publisher.MetadataPublisher
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, TopicDelta}
 import org.apache.kafka.metadata.publisher.AclPublisher
-import org.apache.kafka.server.common.RequestLocal
+import org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION
+import org.apache.kafka.server.common.{FinalizedFeatures, RequestLocal, ShareVersion}
 import org.apache.kafka.server.fault.FaultHandler
 import org.apache.kafka.storage.internals.log.{LogManager => JLogManager}
 
@@ -80,6 +82,7 @@ class BrokerMetadataPublisher(
   aclPublisher: AclPublisher,
   fatalFaultHandler: FaultHandler,
   metadataPublishingFaultHandler: FaultHandler,
+  sharePartitionManager: SharePartitionManager
 ) extends MetadataPublisher with Logging {
   logIdent = s"[BrokerMetadataPublisher id=${config.nodeId}] "
 
@@ -99,6 +102,13 @@ class BrokerMetadataPublisher(
    * A future that is completed when we first publish.
    */
   val firstPublishFuture = new CompletableFuture[Void]
+
+  /**
+   * The share version being used in the current metadata.
+   */
+  private var finalizedShareVersion: Short = FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION).finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
+
+    ShareVersion.LATEST_PRODUCTION.featureLevel()
 
   override def name(): String = "BrokerMetadataPublisher"
 
@@ -232,6 +242,19 @@ class BrokerMetadataPublisher(
       if (_firstPublish) {
         finishInitializingReplicaManager()
       }
+
+      if (delta.featuresDelta != null) {
+        val newFinalizedFeatures = new FinalizedFeatures(newImage.features.metadataVersionOrThrow, newImage.features.finalizedVersions, newImage.provenance.lastContainedOffset)
+        // Share version feature has been toggled.
+        if (!(newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort) == finalizedShareVersion)) {
+          finalizedShareVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
+          val shareVersion: ShareVersion = ShareVersion.fromFeatureLevel(finalizedShareVersion)
+          info(s"Share version has been toggled to $shareVersion")
+          sharePartitionManager.onShareVersionToggle(shareVersion)
+        }
+      }
+
+
     } catch {
       case t: Throwable => metadataPublishingFaultHandler.handleFault("Uncaught exception while " +
         s"publishing broker metadata from $deltaName", t)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -242,16 +242,20 @@ class BrokerMetadataPublisher(
       }
 
       if (delta.featuresDelta != null) {
-        val newFinalizedFeatures = new FinalizedFeatures(newImage.features.metadataVersionOrThrow, newImage.features.finalizedVersions, newImage.provenance.lastContainedOffset)
-        // Share version feature has been toggled.
-        if (!(newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort) == finalizedShareVersion)) {
-          finalizedShareVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
-          val shareVersion: ShareVersion = ShareVersion.fromFeatureLevel(finalizedShareVersion)
-          info(s"Share version has been toggled to $shareVersion")
-          sharePartitionManager.onShareVersionToggle(shareVersion)
+        try {
+          val newFinalizedFeatures = new FinalizedFeatures(newImage.features.metadataVersionOrThrow, newImage.features.finalizedVersions, newImage.provenance.lastContainedOffset)
+          // Share version feature has been toggled.
+          if (!(newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort) == finalizedShareVersion)) {
+            finalizedShareVersion = newFinalizedFeatures.finalizedFeatures().getOrDefault(ShareVersion.FEATURE_NAME, 0.toShort)
+            val shareVersion: ShareVersion = ShareVersion.fromFeatureLevel(finalizedShareVersion)
+            info(s"Share version has been toggled to $shareVersion")
+            sharePartitionManager.onShareVersionToggle(shareVersion)
+          }
+        } catch {
+          case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating share partition manager " +
+            s" with share version feature change in $delta", t)
         }
       }
-
 
     } catch {
       case t: Throwable => metadataPublishingFaultHandler.handleFault("Uncaught exception while " +

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.GroupConfigManager;
+import org.apache.kafka.server.common.ShareVersion;
 import org.apache.kafka.server.purgatory.DelayedOperationKey;
 import org.apache.kafka.server.purgatory.DelayedOperationPurgatory;
 import org.apache.kafka.server.share.CachedSharePartition;
@@ -2801,6 +2802,42 @@ public class SharePartitionManagerTest {
         // Verify the partitions rotation, rotate by 1 (2147483647 % 7).
         resultShareFetch = captor.getValue();
         validateRotatedListEquals(topicIdPartitions, resultShareFetch.topicIdPartitions(), 1);
+    }
+
+    @Test
+    public void testOnShareVersionToggle() {
+        String groupId = "grp";
+        SharePartition sp0 = mock(SharePartition.class);
+        SharePartition sp1 = mock(SharePartition.class);
+        SharePartition sp2 = mock(SharePartition.class);
+        SharePartition sp3 = mock(SharePartition.class);
+
+        // Mock the share partitions corresponding to the topic partitions.
+        Map<SharePartitionKey, SharePartition> partitionCacheMap = new HashMap<>();
+        partitionCacheMap.put(
+            new SharePartitionKey(groupId, new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo1", 0))), sp0
+        );
+        partitionCacheMap.put(
+            new SharePartitionKey(groupId, new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo2", 0))), sp1
+        );
+        partitionCacheMap.put(
+            new SharePartitionKey(groupId, new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo3", 0))), sp2
+        );
+        partitionCacheMap.put(
+            new SharePartitionKey(groupId, new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo4", 0))), sp3
+        );
+        sharePartitionManager = SharePartitionManagerBuilder.builder()
+            .withPartitionCacheMap(partitionCacheMap)
+            .build();
+        assertEquals(4, sharePartitionManager.partitionCacheMap().size());
+        sharePartitionManager.onShareVersionToggle(ShareVersion.SV_0);
+        // Because we are toggling to a share version which does not support share groups, the cache inside share partitions must be cleared.
+        assertTrue(sharePartitionManager.partitionCacheMap().isEmpty());
+        //Check if all share partitions have been fenced.
+        Mockito.verify(sp0).markFenced();
+        Mockito.verify(sp1).markFenced();
+        Mockito.verify(sp2).markFenced();
+        Mockito.verify(sp3).markFenced();
     }
 
     private Timer systemTimerReaper() {

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -2805,7 +2805,7 @@ public class SharePartitionManagerTest {
     }
 
     @Test
-    public void testIsShareGroupEnabled() {
+    public void testShareSessionCacheSupportsShareGroups() {
         ShareSessionCache cache1 = new ShareSessionCache(10, false);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache1)

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -186,7 +186,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testNewContextReturnsFinalContextWithoutRequestData() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -213,7 +213,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testNewContextReturnsFinalContextWithRequestData() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -243,7 +243,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testNewContextReturnsFinalContextWhenTopicPartitionsArePresentInRequestData() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -274,7 +274,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testNewContext() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -435,7 +435,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testZeroSizeShareSession() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -481,7 +481,7 @@ public class SharePartitionManagerTest {
     @Test
     public void testToForgetPartitions() {
         String groupId = "grp";
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -519,7 +519,7 @@ public class SharePartitionManagerTest {
     @Test
     public void testShareSessionUpdateTopicIdsBrokerSide() {
         String groupId = "grp";
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -570,7 +570,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testGetErroneousAndValidTopicIdPartitions() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -663,7 +663,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testShareFetchContextResponseSize() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -764,7 +764,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testCachedTopicPartitionsWithNoTopicPartitions() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -775,7 +775,7 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testCachedTopicPartitionsForValidShareSessions() {
-        ShareSessionCache cache = new ShareSessionCache(10);
+        ShareSessionCache cache = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
             .build();
@@ -2806,19 +2806,21 @@ public class SharePartitionManagerTest {
 
     @Test
     public void testIsShareGroupEnabled() {
+        ShareSessionCache cache1 = new ShareSessionCache(10, false);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
-            .withIsShareGroupsSupported(false)
+            .withCache(cache1)
             .build();
-        // Toggle of isShareGroupEnabled from false to true.
+        // Toggle of supportsShareGroups from false to true.
         sharePartitionManager.onShareVersionToggle(ShareVersion.SV_1);
-        assertTrue(sharePartitionManager.isShareGroupsSupported());
+        assertTrue(cache1.supportsShareGroups());
 
+        ShareSessionCache cache2 = new ShareSessionCache(10, true);
         sharePartitionManager = SharePartitionManagerBuilder.builder()
-            .withIsShareGroupsSupported(true)
+            .withCache(cache2)
             .build();
-        // Toggle of isShareGroupEnabled from true to false.
+        // Toggle of supportsShareGroups from true to false.
         sharePartitionManager.onShareVersionToggle(ShareVersion.SV_0);
-        assertFalse(sharePartitionManager.isShareGroupsSupported());
+        assertFalse(cache2.supportsShareGroups());
     }
 
     @Test
@@ -2846,10 +2848,10 @@ public class SharePartitionManagerTest {
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withPartitionCacheMap(partitionCacheMap)
             .build();
-        assertEquals(4, sharePartitionManager.partitionCacheMap().size());
+        assertEquals(4, sharePartitionManager.partitionCacheSize());
         sharePartitionManager.onShareVersionToggle(ShareVersion.SV_0);
         // Because we are toggling to a share version which does not support share groups, the cache inside share partitions must be cleared.
-        assertTrue(sharePartitionManager.partitionCacheMap().isEmpty());
+        assertEquals(0, sharePartitionManager.partitionCacheSize());
         //Check if all share partitions have been fenced.
         Mockito.verify(sp0).markFenced();
         Mockito.verify(sp1).markFenced();
@@ -3066,12 +3068,11 @@ public class SharePartitionManagerTest {
         private final Persister persister = new NoOpStatePersister();
         private ReplicaManager replicaManager = mock(ReplicaManager.class);
         private Time time = new MockTime();
-        private ShareSessionCache cache = new ShareSessionCache(10);
+        private ShareSessionCache cache = new ShareSessionCache(10, true);
         private Map<SharePartitionKey, SharePartition> partitionCacheMap = new HashMap<>();
         private Timer timer = new MockTimer();
         private ShareGroupMetrics shareGroupMetrics = new ShareGroupMetrics(time);
         private BrokerTopicStats brokerTopicStats;
-        private boolean isShareGroupsSupported = true;
 
         private SharePartitionManagerBuilder withReplicaManager(ReplicaManager replicaManager) {
             this.replicaManager = replicaManager;
@@ -3108,11 +3109,6 @@ public class SharePartitionManagerTest {
             return this;
         }
 
-        private SharePartitionManagerBuilder withIsShareGroupsSupported(boolean isShareGroupsSupported) {
-            this.isShareGroupsSupported = isShareGroupsSupported;
-            return this;
-        }
-
         public static SharePartitionManagerBuilder builder() {
             return new SharePartitionManagerBuilder();
         }
@@ -3129,8 +3125,7 @@ public class SharePartitionManagerTest {
                 persister,
                 mock(GroupConfigManager.class),
                 shareGroupMetrics,
-                brokerTopicStats,
-                isShareGroupsSupported
+                brokerTopicStats
             );
         }
     }

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -2805,6 +2805,23 @@ public class SharePartitionManagerTest {
     }
 
     @Test
+    public void testIsShareGroupEnabled() {
+        sharePartitionManager = SharePartitionManagerBuilder.builder()
+            .withIsShareGroupsSupported(false)
+            .build();
+        // Toggle of isShareGroupEnabled from false to true.
+        sharePartitionManager.onShareVersionToggle(ShareVersion.SV_1);
+        assertTrue(sharePartitionManager.isShareGroupsSupported());
+
+        sharePartitionManager = SharePartitionManagerBuilder.builder()
+            .withIsShareGroupsSupported(true)
+            .build();
+        // Toggle of isShareGroupEnabled from true to false.
+        sharePartitionManager.onShareVersionToggle(ShareVersion.SV_0);
+        assertFalse(sharePartitionManager.isShareGroupsSupported());
+    }
+
+    @Test
     public void testOnShareVersionToggle() {
         String groupId = "grp";
         SharePartition sp0 = mock(SharePartition.class);
@@ -3054,6 +3071,7 @@ public class SharePartitionManagerTest {
         private Timer timer = new MockTimer();
         private ShareGroupMetrics shareGroupMetrics = new ShareGroupMetrics(time);
         private BrokerTopicStats brokerTopicStats;
+        private boolean isShareGroupsSupported = true;
 
         private SharePartitionManagerBuilder withReplicaManager(ReplicaManager replicaManager) {
             this.replicaManager = replicaManager;
@@ -3090,6 +3108,11 @@ public class SharePartitionManagerTest {
             return this;
         }
 
+        private SharePartitionManagerBuilder withIsShareGroupsSupported(boolean isShareGroupsSupported) {
+            this.isShareGroupsSupported = isShareGroupsSupported;
+            return this;
+        }
+
         public static SharePartitionManagerBuilder builder() {
             return new SharePartitionManagerBuilder();
         }
@@ -3106,7 +3129,8 @@ public class SharePartitionManagerTest {
                 persister,
                 mock(GroupConfigManager.class),
                 shareGroupMetrics,
-                brokerTopicStats
+                brokerTopicStats,
+                isShareGroupsSupported
             );
         }
     }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -23,6 +23,7 @@ import java.util.Collections.{singleton, singletonList, singletonMap}
 import java.util.Properties
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import kafka.log.LogManager
+import kafka.server.share.SharePartitionManager
 import kafka.server.{BrokerServer, KafkaConfig, ReplicaManager}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
@@ -204,7 +205,8 @@ class BrokerMetadataPublisherTest {
       mock(classOf[DelegationTokenPublisher]),
       mock(classOf[AclPublisher]),
       faultHandler,
-      faultHandler
+      faultHandler,
+      mock(classOf[SharePartitionManager])
     )
 
     val image = MetadataImage.EMPTY

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -20,7 +20,7 @@ package kafka.server.metadata
 import kafka.coordinator.transaction.TransactionCoordinator
 
 import java.util.Collections.{singleton, singletonList, singletonMap}
-import java.util.Properties
+import java.util.{OptionalInt, Properties}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import kafka.log.LogManager
 import kafka.server.share.SharePartitionManager
@@ -30,16 +30,17 @@ import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, ConfigEntry, NewTopic}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.BROKER
+import org.apache.kafka.common.metadata.FeatureLevelRecord
 import org.apache.kafka.common.test.{KafkaClusterTestKit, TestKitNodes}
 import org.apache.kafka.common.utils.Exit
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.coordinator.share.ShareCoordinator
-import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataImageTest, MetadataProvenance}
+import org.apache.kafka.image.{AclsImage, ClientQuotasImage, ClusterImageTest, ConfigurationsImage, DelegationTokenImage, FeaturesImage, MetadataDelta, MetadataImage, MetadataImageTest, MetadataProvenance, ProducerIdsImage, ScramImage, TopicsImage}
 import org.apache.kafka.image.loader.LogDeltaManifest
 import org.apache.kafka.metadata.publisher.AclPublisher
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.LeaderAndEpoch
-import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion}
+import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion, ShareVersion}
 import org.apache.kafka.server.fault.FaultHandler
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
@@ -49,6 +50,7 @@ import org.mockito.Mockito.{doThrow, mock, verify}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
+import java.util
 import java.util.concurrent.TimeUnit
 import scala.jdk.CollectionConverters._
 
@@ -224,5 +226,69 @@ class BrokerMetadataPublisherTest {
         .build())
 
     verify(groupCoordinator).onNewMetadataImage(image, delta)
+  }
+
+  @Test
+  def testNewShareVersionPushedToSharePartitionManager(): Unit = {
+    val sharePartitionManager = mock(classOf[SharePartitionManager])
+    val faultHandler = mock(classOf[FaultHandler])
+
+    val metadataPublisher = new BrokerMetadataPublisher(
+      KafkaConfig.fromProps(TestUtils.createBrokerConfig(0)),
+      new KRaftMetadataCache(0, () => KRaftVersion.KRAFT_VERSION_1),
+      mock(classOf[LogManager]),
+      mock(classOf[ReplicaManager]),
+      mock(classOf[GroupCoordinator]),
+      mock(classOf[TransactionCoordinator]),
+      mock(classOf[ShareCoordinator]),
+      mock(classOf[DynamicConfigPublisher]),
+      mock(classOf[DynamicClientQuotaPublisher]),
+      mock(classOf[DynamicTopicClusterQuotaPublisher]),
+      mock(classOf[ScramPublisher]),
+      mock(classOf[DelegationTokenPublisher]),
+      mock(classOf[AclPublisher]),
+      faultHandler,
+      faultHandler,
+      sharePartitionManager
+    )
+
+    val featuresImage = new FeaturesImage(
+      util.Map.of(
+        MetadataVersion.FEATURE_NAME, MetadataVersion.latestTesting().featureLevel(),
+        ShareVersion.FEATURE_NAME, ShareVersion.SV_1.featureLevel()
+      ),
+      MetadataVersion.latestTesting())
+
+    val image = new MetadataImage(
+      MetadataProvenance.EMPTY,
+      featuresImage,
+      ClusterImageTest.IMAGE1,
+      TopicsImage.EMPTY,
+      ConfigurationsImage.EMPTY,
+      ClientQuotasImage.EMPTY,
+      ProducerIdsImage.EMPTY,
+      AclsImage.EMPTY,
+      ScramImage.EMPTY,
+      DelegationTokenImage.EMPTY
+    )
+
+    // Share version 1 is getting passed to features delta.
+    val delta = new MetadataDelta(image)
+    delta.replay(new FeatureLevelRecord().setName(ShareVersion.FEATURE_NAME).setFeatureLevel(1))
+
+    metadataPublisher.onMetadataUpdate(
+      delta,
+      image,
+      LogDeltaManifest.newBuilder().
+        provenance(MetadataProvenance.EMPTY).
+        leaderAndEpoch(new LeaderAndEpoch(OptionalInt.of(1), 1)).
+        numBatches(1).
+        elapsedNs(1L).
+        numBytes(1).
+        build()
+    )
+
+    // SharePartitionManager is receiving the latest changes.
+    verify(sharePartitionManager).onShareVersionToggle(any())
   }
 }

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -90,6 +90,14 @@ public class ShareSessionCache {
         return sessions.size();
     }
 
+    /**
+     * Remove all the share sessions from cache.
+     */
+    public synchronized void removeAllSessions() {
+        sessions.clear();
+        numPartitions = 0;
+    }
+
     public synchronized long totalPartitions() {
         return numPartitions;
     }

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -29,6 +29,7 @@ import com.yammer.metrics.core.Meter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Caches share sessions.
@@ -60,10 +61,15 @@ public class ShareSessionCache {
     private final Map<ShareSessionKey, ShareSession> sessions = new HashMap<>();
 
     private final Map<String, ShareSessionKey> connectionIdToSessionMap;
+    /**
+     * Flag indicating if share groups have been turned on.
+     */
+    private final AtomicBoolean supportsShareGroups;
 
     @SuppressWarnings("this-escape")
-    public ShareSessionCache(int maxEntries) {
+    public ShareSessionCache(int maxEntries, boolean supportsShareGroups) {
         this.maxEntries = maxEntries;
+        this.supportsShareGroups = new AtomicBoolean(supportsShareGroups);
         // Register metrics for ShareSessionCache.
         KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup("kafka.server", "ShareSessionCache");
         metricsGroup.newGauge(SHARE_SESSIONS_COUNT, this::size);
@@ -129,7 +135,9 @@ public class ShareSessionCache {
      * @param session  The session.
      */
     public synchronized void updateNumPartitions(ShareSession session) {
-        numPartitions += session.updateCachedSize();
+        if (supportsShareGroups.get()) {
+            numPartitions += session.updateCachedSize();
+        }
     }
 
     /**
@@ -146,7 +154,7 @@ public class ShareSessionCache {
         ImplicitLinkedHashCollection<CachedSharePartition> partitionMap,
         String clientConnectionId
     ) {
-        if (sessions.size() < maxEntries) {
+        if (sessions.size() < maxEntries && supportsShareGroups.get()) {
             ShareSession session = new ShareSession(new ShareSessionKey(groupId, memberId), partitionMap,
                 ShareRequestMetadata.nextEpoch(ShareRequestMetadata.INITIAL_EPOCH));
             sessions.put(session.key(), session);
@@ -180,5 +188,18 @@ public class ShareSessionCache {
                 }
             }
         }
+    }
+
+    /**
+     * Update the value of supportsShareGroups to reflect if share groups are turned on.
+     * @param supportsShareGroups - Boolean indicating if share groups are turned on.
+     */
+    public void updateSupportsShareGroups(boolean supportsShareGroups) {
+        this.supportsShareGroups.set(supportsShareGroups);
+    }
+
+    // Visible for testing.
+    public boolean supportsShareGroups() {
+        return supportsShareGroups.get();
     }
 }

--- a/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
@@ -43,7 +43,7 @@ public class ShareSessionCacheTest {
 
     @Test
     public void testShareSessionCache() throws InterruptedException {
-        ShareSessionCache cache = new ShareSessionCache(3);
+        ShareSessionCache cache = new ShareSessionCache(3, true);
         assertEquals(0, cache.size());
         ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(10), "conn-1");
         ShareSessionKey key2 = cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(20), "conn-2");
@@ -57,7 +57,7 @@ public class ShareSessionCacheTest {
 
     @Test
     public void testResizeCachedSessions() throws InterruptedException {
-        ShareSessionCache cache = new ShareSessionCache(2);
+        ShareSessionCache cache = new ShareSessionCache(2, true);
         assertEquals(0, cache.size());
         assertEquals(0, cache.totalPartitions());
         ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(2), "conn-1");
@@ -111,7 +111,7 @@ public class ShareSessionCacheTest {
 
     @Test
     public void testRemoveConnection() throws InterruptedException {
-        ShareSessionCache cache = new ShareSessionCache(3);
+        ShareSessionCache cache = new ShareSessionCache(3, true);
         assertEquals(0, cache.size());
         ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(1), "conn-1");
         ShareSessionKey key2 = cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(2), "conn-2");
@@ -141,7 +141,7 @@ public class ShareSessionCacheTest {
 
     @Test
     public void testRemoveAllSessions() {
-        ShareSessionCache cache = new ShareSessionCache(3);
+        ShareSessionCache cache = new ShareSessionCache(3, true);
         assertEquals(0, cache.size());
         assertEquals(0, cache.totalPartitions());
         cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(10), "conn-1");

--- a/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
@@ -139,6 +139,21 @@ public class ShareSessionCacheTest {
         assertMetricsValues(3, 9, 1, cache);
     }
 
+    @Test
+    public void testRemoveAllSessions() {
+        ShareSessionCache cache = new ShareSessionCache(3);
+        assertEquals(0, cache.size());
+        assertEquals(0, cache.totalPartitions());
+        cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(10), "conn-1");
+        cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(20), "conn-2");
+        cache.maybeCreateSession("grp", Uuid.randomUuid(), mockedSharePartitionMap(30), "conn-3");
+        assertEquals(3, cache.size());
+        assertEquals(60, cache.totalPartitions());
+        cache.removeAllSessions();
+        assertEquals(0, cache.size());
+        assertEquals(0, cache.totalPartitions());
+    }
+
     private ImplicitLinkedHashCollection<CachedSharePartition> mockedSharePartitionMap(int size) {
         ImplicitLinkedHashCollection<CachedSharePartition> cacheMap = new
                 ImplicitLinkedHashCollection<>(size);


### PR DESCRIPTION
### About
This PR creates a listener for `SharePartitionManager` to listen to any
changes in `ShareVersion` feature. In case, there is a toggle, we need
to change the attributes in `SharePartitionManager` accordingly.

### Testing
Code testing has been done with the help of new unit tests.

Reviewers: Andrew Schofield <aschofield@confluent.io>
