### PR TITLE
MINOR: remove xijiu from asf.yaml in order to resend invitation

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,7 +37,6 @@ github:
     - ShivsundarR
     - smjn
     - TaiJuWu
-    - xijiu
     - Yunyung
   enabled_merge_buttons:
     squash: true


### PR DESCRIPTION
@xijiu's invitation is timeout, so we have to remove the name, then
re-add it in a new commit.

see https://issues.apache.org/jira/browse/INFRA-26796

Reviewers: Chih-Yuan Chien <joshua2519@gmail.com>, Kuan-Po Tseng
 <brandboat@gmail.com>, PoAn Yang <payang@apache.org>, yunchi
 <yunchipang@gmail.com>, TengYao Chi <kitingiao@gmail.com>, Hong-Yi Chen
 <apalan60@gmail.com>, Bolin Lin <linbolin1230@gmail.com>, Shih-Yuan Lin
 <shmily7829@gmail.com>, Mirai1129 <minecraftmiku831@gmail.com>
