### PR TITLE
MINOR; Remove cast for Records' slice

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -64,7 +64,6 @@ public class FileRecords extends AbstractRecords implements Closeable {
         this.start = 0;
         this.end = end;
         this.isSlice = false;
-        this.size = new AtomicInteger();
 
         if (channel.size() > Integer.MAX_VALUE) {
             throw new KafkaException(
@@ -74,10 +73,9 @@ public class FileRecords extends AbstractRecords implements Closeable {
         }
 
         int limit = Math.min((int) channel.size(), end);
-        size.set(limit - start);
+        this.size = new AtomicInteger(limit - start);
 
-        // if this is not a slice, update the file pointer to the end of the file
-        // set the file position to the last byte in the file
+        // update the file position to the end of the file
         channel.position(limit);
 
         batches = batchesFrom(start);
@@ -99,10 +97,9 @@ public class FileRecords extends AbstractRecords implements Closeable {
         this.start = start;
         this.end = end;
         this.isSlice = true;
-        this.size = new AtomicInteger();
 
         // don't check the file size if this is just a slice view
-        size.set(end - start);
+        this.size = new AtomicInteger(end - start);
 
         batches = batchesFrom(start);
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -87,7 +87,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
     /**
      * The {@code FileRecords.open} methods should be used instead of this constructor whenever possible.
      *
-     * isSlice must be true. This overloaded constructor avoids having the declared a checked IO exception.
+     * isSlice must be true. This overloaded constructor avoids having to declare a checked IO exception.
      */
     private FileRecords(
         File file,

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -57,12 +57,11 @@ public class FileRecords extends AbstractRecords implements Closeable {
     FileRecords(
         File file,
         FileChannel channel,
-        int start,
         int end
     ) throws IOException {
         this.file = file;
         this.channel = channel;
-        this.start = start;
+        this.start = 0;
         this.end = end;
         this.isSlice = false;
         this.size = new AtomicInteger();
@@ -93,13 +92,8 @@ public class FileRecords extends AbstractRecords implements Closeable {
         File file,
         FileChannel channel,
         int start,
-        int end,
-        boolean isSlice
+        int end
     ) {
-        if (!isSlice) {
-            throw new IllegalArgumentException("Slice constructor must be called with isSlice set to true");
-        }
-
         this.file = file;
         this.channel = channel;
         this.start = start;
@@ -153,7 +147,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
         int availableBytes = availableBytes(position, size);
         int startPosition = this.start + position;
 
-        return new FileRecords(file, channel, startPosition, startPosition + availableBytes, true);
+        return new FileRecords(file, channel, startPosition, startPosition + availableBytes);
     }
 
     /**
@@ -453,7 +447,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
                                    boolean preallocate) throws IOException {
         FileChannel channel = openChannel(file, mutable, fileAlreadyExists, initFileSize, preallocate);
         int end = (!fileAlreadyExists && preallocate) ? 0 : Integer.MAX_VALUE;
-        return new FileRecords(file, channel, 0, end, false);
+        return new FileRecords(file, channel, end);
     }
 
     public static FileRecords open(File file,

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -121,10 +122,14 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     @Override
-    public FileRecords slice(int position, int size) throws IOException {
+    public FileRecords slice(int position, int size) {
         int availableBytes = availableBytes(position, size);
         int startPosition = this.start + position;
-        return new FileRecords(file, channel, startPosition, startPosition + availableBytes, true);
+        try {
+            return new FileRecords(file, channel, startPosition, startPosition + availableBytes, true);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -84,9 +84,9 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     /**
-     * The {@code FileRecords.open} methods should be used instead of this constructor whenever possible.
+     * Constructor for creating a slice.
      *
-     * isSlice must be true. This overloaded constructor avoids having to declare a checked IO exception.
+     * This overloaded constructor avoids having to declare a checked IO exception.
      */
     private FileRecords(
         File file,

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -98,7 +98,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
         this.end = end;
         this.isSlice = true;
 
-        // don't check the file size if this is just a slice view
+        // don't check the file size since this is just a slice view
         this.size = new AtomicInteger(end - start);
 
         batches = batchesFrom(start);

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -121,7 +121,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     @Override
-    public Records slice(int position, int size) throws IOException {
+    public FileRecords slice(int position, int size) throws IOException {
         int availableBytes = availableBytes(position, size);
         int startPosition = this.start + position;
         return new FileRecords(file, channel, startPosition, startPosition + availableBytes, true);
@@ -288,7 +288,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
      */
     public LogOffsetPosition searchForOffsetFromPosition(long targetOffset, int startingPosition) {
         FileChannelRecordBatch prevBatch = null;
-        // The following logic is intentionally designed to minimize memory usage by avoiding 
+        // The following logic is intentionally designed to minimize memory usage by avoiding
         // unnecessary calls to lastOffset() for every batch.
         // Instead, we use baseOffset() comparisons when possible, and only check lastOffset() when absolutely necessary.
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
@@ -296,14 +296,14 @@ public class FileRecords extends AbstractRecords implements Closeable {
             if (batch.baseOffset() == targetOffset) {
                 return LogOffsetPosition.fromBatch(batch);
             }
-            
+
             // If we find the first batch with baseOffset greater than targetOffset
             if (batch.baseOffset() > targetOffset) {
                 // If the previous batch contains the target
                 if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
                     return LogOffsetPosition.fromBatch(prevBatch);
                 else {
-                    // If there's no previous batch or the previous batch doesn't contain the 
+                    // If there's no previous batch or the previous batch doesn't contain the
                     // target, return the current batch
                     return LogOffsetPosition.fromBatch(batch);
                 }
@@ -312,7 +312,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
         }
         // Only one case would reach here: all batches have baseOffset less than targetOffset
         // Check if the last batch contains the target
-        if (prevBatch != null && prevBatch.lastOffset() >= targetOffset) 
+        if (prevBatch != null && prevBatch.lastOffset() >= targetOffset)
             return LogOffsetPosition.fromBatch(prevBatch);
 
         return null;
@@ -475,7 +475,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
         public final long offset;
         public final int position;
         public final int size;
-        
+
         public static LogOffsetPosition fromBatch(FileChannelRecordBatch batch) {
             return new LogOffsetPosition(batch.baseOffset(), batch.position(), batch.sizeInBytes());
         }

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -26,7 +26,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -55,33 +54,61 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * The {@code FileRecords.open} methods should be used instead of this constructor whenever possible.
      * The constructor is visible for tests.
      */
-    FileRecords(File file,
-                FileChannel channel,
-                int start,
-                int end,
-                boolean isSlice) throws IOException {
+    FileRecords(
+        File file,
+        FileChannel channel,
+        int start,
+        int end
+    ) throws IOException {
         this.file = file;
         this.channel = channel;
         this.start = start;
         this.end = end;
-        this.isSlice = isSlice;
+        this.isSlice = false;
         this.size = new AtomicInteger();
 
-        if (isSlice) {
-            // don't check the file size if this is just a slice view
-            size.set(end - start);
-        } else {
-            if (channel.size() > Integer.MAX_VALUE)
-                throw new KafkaException("The size of segment " + file + " (" + channel.size() +
-                        ") is larger than the maximum allowed segment size of " + Integer.MAX_VALUE);
-
-            int limit = Math.min((int) channel.size(), end);
-            size.set(limit - start);
-
-            // if this is not a slice, update the file pointer to the end of the file
-            // set the file position to the last byte in the file
-            channel.position(limit);
+        if (channel.size() > Integer.MAX_VALUE) {
+            throw new KafkaException(
+                "The size of segment " + file + " (" + channel.size() +
+                ") is larger than the maximum allowed segment size of " + Integer.MAX_VALUE
+            );
         }
+
+        int limit = Math.min((int) channel.size(), end);
+        size.set(limit - start);
+
+        // if this is not a slice, update the file pointer to the end of the file
+        // set the file position to the last byte in the file
+        channel.position(limit);
+
+        batches = batchesFrom(start);
+    }
+
+    /**
+     * The {@code FileRecords.open} methods should be used instead of this constructor whenever possible.
+     *
+     * isSlice must be true. This overloaded constructor avoids having the declared a checked IO exception.
+     */
+    private FileRecords(
+        File file,
+        FileChannel channel,
+        int start,
+        int end,
+        boolean isSlice
+    ) {
+        if (!isSlice) {
+            throw new IllegalArgumentException("Slice constructor must be called with isSlice set to true");
+        }
+
+        this.file = file;
+        this.channel = channel;
+        this.start = start;
+        this.end = end;
+        this.isSlice = true;
+        this.size = new AtomicInteger();
+
+        // don't check the file size if this is just a slice view
+        size.set(end - start);
 
         batches = batchesFrom(start);
     }
@@ -125,11 +152,8 @@ public class FileRecords extends AbstractRecords implements Closeable {
     public FileRecords slice(int position, int size) {
         int availableBytes = availableBytes(position, size);
         int startPosition = this.start + position;
-        try {
-            return new FileRecords(file, channel, startPosition, startPosition + availableBytes, true);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+
+        return new FileRecords(file, channel, startPosition, startPosition + availableBytes, true);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -301,7 +301,7 @@ public class MemoryRecords extends AbstractRecords {
     }
 
     @Override
-    public Records slice(int position, int size) {
+    public MemoryRecords slice(int position, int size) {
         if (position < 0)
             throw new IllegalArgumentException("Invalid position: " + position + " in read from " + this);
         if (position > buffer.limit())

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordBatchIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordBatchIterator.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.common.record;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.utils.AbstractIterator;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 
 class RecordBatchIterator<T extends RecordBatch> extends AbstractIterator<T> {
 
@@ -41,7 +41,7 @@ class RecordBatchIterator<T extends RecordBatch> extends AbstractIterator<T> {
         } catch (EOFException e) {
             throw new CorruptRecordException("Unexpected EOF while attempting to read the next batch", e);
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new KafkaException(e);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordBatchIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordBatchIterator.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.common.record;
 
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.utils.AbstractIterator;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 class RecordBatchIterator<T extends RecordBatch> extends AbstractIterator<T> {
 
@@ -41,7 +41,7 @@ class RecordBatchIterator<T extends RecordBatch> extends AbstractIterator<T> {
         } catch (EOFException e) {
             throw new CorruptRecordException("Unexpected EOF while attempting to read the next batch", e);
         } catch (IOException e) {
-            throw new KafkaException(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/Records.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/Records.java
@@ -18,7 +18,6 @@ package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.utils.AbstractIterator;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -105,5 +104,5 @@ public interface Records extends TransferableRecords {
      * @param size The number of bytes after the start position to include
      * @return A sliced wrapper on this message set limited based on the given position and size
      */
-    Records slice(int position, int size) throws IOException;
+    Records slice(int position, int size);
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -198,9 +198,9 @@ public class FileRecordsTest {
      */
     @Test
     public void testRead() throws IOException {
-        Records read = fileRecords.slice(0, fileRecords.sizeInBytes());
+        FileRecords read = fileRecords.slice(0, fileRecords.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes(), read.sizeInBytes());
-        TestUtils.checkEquals(fileRecords.batches(), ((FileRecords) read).batches());
+        TestUtils.checkEquals(fileRecords.batches(), read.batches());
 
         List<RecordBatch> items = batches(read);
         RecordBatch first = items.get(0);

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -89,7 +89,7 @@ public class FileRecordsTest {
         FileChannel fileChannelMock = mock(FileChannel.class);
         when(fileChannelMock.size()).thenReturn((long) Integer.MAX_VALUE);
 
-        FileRecords records = new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE, false);
+        FileRecords records = new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE);
         assertThrows(IllegalArgumentException.class, () -> append(records, values));
     }
 
@@ -99,7 +99,7 @@ public class FileRecordsTest {
         FileChannel fileChannelMock = mock(FileChannel.class);
         when(fileChannelMock.size()).thenReturn(Integer.MAX_VALUE + 5L);
 
-        assertThrows(KafkaException.class, () -> new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE, false));
+        assertThrows(KafkaException.class, () -> new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE));
     }
 
     @Test
@@ -313,7 +313,7 @@ public class FileRecordsTest {
         when(channelMock.size()).thenReturn(42L);
         when(channelMock.position(42L)).thenReturn(null);
 
-        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE, false);
+        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE);
         fileRecords.truncateTo(42);
 
         verify(channelMock, atLeastOnce()).size();
@@ -330,7 +330,7 @@ public class FileRecordsTest {
 
         when(channelMock.size()).thenReturn(42L);
 
-        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE, false);
+        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE);
 
         try {
             fileRecords.truncateTo(43);
@@ -352,7 +352,7 @@ public class FileRecordsTest {
         when(channelMock.size()).thenReturn(42L);
         when(channelMock.truncate(anyLong())).thenReturn(channelMock);
 
-        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE, false);
+        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE);
         fileRecords.truncateTo(23);
 
         verify(channelMock, atLeastOnce()).size();
@@ -526,7 +526,7 @@ public class FileRecordsTest {
      * 1. If the target offset equals the base offset of the first batch
      * 2. If the target offset is less than the base offset of the first batch
      * <p>
-     * If the base offset of the first batch is equal to or greater than the target offset, it should return the 
+     * If the base offset of the first batch is equal to or greater than the target offset, it should return the
      * position of the first batch and the lastOffset method should not be called.
      */
     @ParameterizedTest
@@ -537,7 +537,7 @@ public class FileRecordsTest {
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
         when(batch.baseOffset()).thenReturn(baseOffset);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, batch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(5L, 0);
@@ -557,7 +557,7 @@ public class FileRecordsTest {
         when(batch.baseOffset()).thenReturn(3L);
         when(batch.lastOffset()).thenReturn(5L);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, batch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(5L, 0);
@@ -581,7 +581,7 @@ public class FileRecordsTest {
         when(currentBatch.baseOffset()).thenReturn(15L);
         when(currentBatch.lastOffset()).thenReturn(20L);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(20L, 0);
@@ -605,13 +605,13 @@ public class FileRecordsTest {
         FileLogInputStream.FileChannelRecordBatch currentBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
         when(currentBatch.baseOffset()).thenReturn(15L); // >= targetOffset
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(10L, 0);
 
         assertEquals(FileRecords.LogOffsetPosition.fromBatch(prevBatch), result);
-        // Because the target offset is in the current batch, we should call lastOffset 
+        // Because the target offset is in the current batch, we should call lastOffset
         // on the previous batch
         verify(prevBatch, times(1)).lastOffset();
     }
@@ -629,13 +629,13 @@ public class FileRecordsTest {
         when(batch2.baseOffset()).thenReturn(8L);  // < targetOffset
         when(batch2.lastOffset()).thenReturn(9L);  // < targetOffset
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(10L, 0);
 
         assertNull(result);
-        // Because the target offset is exceeded by the last offset of the batch2, 
+        // Because the target offset is exceeded by the last offset of the batch2,
         // we should call lastOffset on the batch2
         verify(batch1, never()).lastOffset();
         verify(batch2, times(1)).lastOffset();
@@ -657,7 +657,7 @@ public class FileRecordsTest {
         when(batch2.baseOffset()).thenReturn(baseOffset);  // < targetOffset or == targetOffset
         when(batch2.lastOffset()).thenReturn(12L); // >= targetOffset
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         long targetOffset = 10L;
@@ -670,7 +670,7 @@ public class FileRecordsTest {
             verify(batch1, never()).lastOffset();
             verify(batch2, never()).lastOffset();
         } else {
-            // Because the target offset is in the batch2, we should not call 
+            // Because the target offset is in the batch2, we should not call
             // lastOffset on batch1
             verify(batch1, never()).lastOffset();
             verify(batch2, times(1)).lastOffset();
@@ -685,13 +685,13 @@ public class FileRecordsTest {
         File mockFile = mock(File.class);
         FileChannel mockChannel = mock(FileChannel.class);
         FileLogInputStream.FileChannelRecordBatch batch1 = mock(FileLogInputStream.FileChannelRecordBatch.class);
-        when(batch1.baseOffset()).thenReturn(5L);  
-        when(batch1.lastOffset()).thenReturn(10L); 
+        when(batch1.baseOffset()).thenReturn(5L);
+        when(batch1.lastOffset()).thenReturn(10L);
         FileLogInputStream.FileChannelRecordBatch batch2 = mock(FileLogInputStream.FileChannelRecordBatch.class);
-        when(batch2.baseOffset()).thenReturn(15L);  
-        when(batch2.lastOffset()).thenReturn(20L);  
+        when(batch2.baseOffset()).thenReturn(15L);
+        when(batch2.lastOffset()).thenReturn(20L);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100, false));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(13L, 0);

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -89,7 +89,7 @@ public class FileRecordsTest {
         FileChannel fileChannelMock = mock(FileChannel.class);
         when(fileChannelMock.size()).thenReturn((long) Integer.MAX_VALUE);
 
-        FileRecords records = new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE);
+        FileRecords records = new FileRecords(fileMock, fileChannelMock, Integer.MAX_VALUE);
         assertThrows(IllegalArgumentException.class, () -> append(records, values));
     }
 
@@ -99,7 +99,7 @@ public class FileRecordsTest {
         FileChannel fileChannelMock = mock(FileChannel.class);
         when(fileChannelMock.size()).thenReturn(Integer.MAX_VALUE + 5L);
 
-        assertThrows(KafkaException.class, () -> new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE));
+        assertThrows(KafkaException.class, () -> new FileRecords(fileMock, fileChannelMock, Integer.MAX_VALUE));
     }
 
     @Test
@@ -313,7 +313,7 @@ public class FileRecordsTest {
         when(channelMock.size()).thenReturn(42L);
         when(channelMock.position(42L)).thenReturn(null);
 
-        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE);
+        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, Integer.MAX_VALUE);
         fileRecords.truncateTo(42);
 
         verify(channelMock, atLeastOnce()).size();
@@ -330,7 +330,7 @@ public class FileRecordsTest {
 
         when(channelMock.size()).thenReturn(42L);
 
-        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE);
+        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, Integer.MAX_VALUE);
 
         try {
             fileRecords.truncateTo(43);
@@ -352,7 +352,7 @@ public class FileRecordsTest {
         when(channelMock.size()).thenReturn(42L);
         when(channelMock.truncate(anyLong())).thenReturn(channelMock);
 
-        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, 0, Integer.MAX_VALUE);
+        FileRecords fileRecords = new FileRecords(tempFile(), channelMock, Integer.MAX_VALUE);
         fileRecords.truncateTo(23);
 
         verify(channelMock, atLeastOnce()).size();
@@ -537,7 +537,7 @@ public class FileRecordsTest {
         FileLogInputStream.FileChannelRecordBatch batch = mock(FileLogInputStream.FileChannelRecordBatch.class);
         when(batch.baseOffset()).thenReturn(baseOffset);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, batch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(5L, 0);
@@ -557,7 +557,7 @@ public class FileRecordsTest {
         when(batch.baseOffset()).thenReturn(3L);
         when(batch.lastOffset()).thenReturn(5L);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, batch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(5L, 0);
@@ -581,7 +581,7 @@ public class FileRecordsTest {
         when(currentBatch.baseOffset()).thenReturn(15L);
         when(currentBatch.lastOffset()).thenReturn(20L);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(20L, 0);
@@ -605,7 +605,7 @@ public class FileRecordsTest {
         FileLogInputStream.FileChannelRecordBatch currentBatch = mock(FileLogInputStream.FileChannelRecordBatch.class);
         when(currentBatch.baseOffset()).thenReturn(15L); // >= targetOffset
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, prevBatch, currentBatch);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(10L, 0);
@@ -629,7 +629,7 @@ public class FileRecordsTest {
         when(batch2.baseOffset()).thenReturn(8L);  // < targetOffset
         when(batch2.lastOffset()).thenReturn(9L);  // < targetOffset
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(10L, 0);
@@ -657,7 +657,7 @@ public class FileRecordsTest {
         when(batch2.baseOffset()).thenReturn(baseOffset);  // < targetOffset or == targetOffset
         when(batch2.lastOffset()).thenReturn(12L); // >= targetOffset
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         long targetOffset = 10L;
@@ -691,7 +691,7 @@ public class FileRecordsTest {
         when(batch2.baseOffset()).thenReturn(15L);
         when(batch2.lastOffset()).thenReturn(20L);
 
-        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 0, 100));
+        FileRecords fileRecords = Mockito.spy(new FileRecords(mockFile, mockChannel, 100));
         mockFileRecordBatches(fileRecords, batch1, batch2);
 
         FileRecords.LogOffsetPosition result = fileRecords.searchForOffsetFromPosition(13L, 0);

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1075,7 +1074,7 @@ public class MemoryRecordsTest {
 
     @ParameterizedTest
     @ArgumentsSource(MemoryRecordsArgumentsProvider.class)
-    public void testSlice(Args args) throws IOException {
+    public void testSlice(Args args) {
         // Create a MemoryRecords instance with multiple batches. Prior RecordBatch.MAGIC_VALUE_V2,
         // every append in a batch is a new batch. After RecordBatch.MAGIC_VALUE_V2, we can have multiple
         // batches in a single MemoryRecords instance. Though with compression, we can have multiple
@@ -1170,7 +1169,7 @@ public class MemoryRecordsTest {
      */
     @ParameterizedTest
     @ArgumentsSource(MemoryRecordsArgumentsProvider.class)
-    public void testSliceForAlreadySlicedMemoryRecords(Args args) throws IOException {
+    public void testSliceForAlreadySlicedMemoryRecords(Args args) {
         LinkedHashMap<Long, Integer> recordsPerOffset = new LinkedHashMap<>();
         recordsPerOffset.put(args.firstOffset, 5);
         recordsPerOffset.put(args.firstOffset + 5L, 10);

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
@@ -135,10 +135,6 @@ public class MemoryRecordsTest {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
 
         int partitionLeaderEpoch = 998;
-        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, magic, compression,
-                TimestampType.CREATE_TIME, firstOffset, logAppendTime, pid, epoch, firstSequence, false, false,
-                partitionLeaderEpoch, buffer.limit());
-
         SimpleRecord[] records = new SimpleRecord[] {
             new SimpleRecord(1L, "a".getBytes(), "1".getBytes()),
             new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
@@ -148,10 +144,29 @@ public class MemoryRecordsTest {
             new SimpleRecord(6L, (byte[]) null, null)
         };
 
-        for (SimpleRecord record : records)
-            builder.append(record);
+        final MemoryRecords memoryRecords;
+        try (var builder = new MemoryRecordsBuilder(
+                buffer,
+                magic,
+                compression,
+                TimestampType.CREATE_TIME,
+                firstOffset,
+                logAppendTime,
+                pid,
+                epoch,
+                firstSequence,
+                false,
+                false,
+                partitionLeaderEpoch, buffer.limit()
+            )
+        ) {
+            for (SimpleRecord record : records) {
+                builder.append(record);
+            }
 
-        MemoryRecords memoryRecords = builder.build();
+            memoryRecords = builder.build();
+        }
+
         for (int iteration = 0; iteration < 2; iteration++) {
             int total = 0;
             for (RecordBatch batch : memoryRecords.batches()) {
@@ -1086,10 +1101,10 @@ public class MemoryRecordsTest {
         MemoryRecords records = createMemoryRecords(args, recordsPerOffset);
 
         // Test slicing from start
-        Records sliced = records.slice(0, records.sizeInBytes());
+        MemoryRecords sliced = records.slice(0, records.sizeInBytes());
         assertEquals(records.sizeInBytes(), sliced.sizeInBytes());
-        assertEquals(records.validBytes(), ((MemoryRecords) sliced).validBytes());
-        TestUtils.checkEquals(records.batches(), ((MemoryRecords) sliced).batches());
+        assertEquals(records.validBytes(), sliced.validBytes());
+        TestUtils.checkEquals(records.batches(), sliced.batches());
 
         List<RecordBatch> items = batches(records);
         // Test slicing first message.
@@ -1097,19 +1112,19 @@ public class MemoryRecordsTest {
         sliced = records.slice(first.sizeInBytes(), records.sizeInBytes() - first.sizeInBytes());
         assertEquals(records.sizeInBytes() - first.sizeInBytes(), sliced.sizeInBytes());
         assertEquals(items.subList(1, items.size()), batches(sliced), "Read starting from the second message");
-        assertTrue(((MemoryRecords) sliced).validBytes() <= sliced.sizeInBytes());
+        assertTrue(sliced.validBytes() <= sliced.sizeInBytes());
 
         // Read from second message and size is past the end of the file.
         sliced = records.slice(first.sizeInBytes(), records.sizeInBytes());
         assertEquals(records.sizeInBytes() - first.sizeInBytes(), sliced.sizeInBytes());
         assertEquals(items.subList(1, items.size()), batches(sliced), "Read starting from the second message");
-        assertTrue(((MemoryRecords) sliced).validBytes() <= sliced.sizeInBytes());
+        assertTrue(sliced.validBytes() <= sliced.sizeInBytes());
 
         // Read from second message and position + size overflows.
         sliced = records.slice(first.sizeInBytes(), Integer.MAX_VALUE);
         assertEquals(records.sizeInBytes() - first.sizeInBytes(), sliced.sizeInBytes());
         assertEquals(items.subList(1, items.size()), batches(sliced), "Read starting from the second message");
-        assertTrue(((MemoryRecords) sliced).validBytes() <= sliced.sizeInBytes());
+        assertTrue(sliced.validBytes() <= sliced.sizeInBytes());
 
         // Read a single message starting from second message.
         RecordBatch second = items.get(1);
@@ -1130,14 +1145,14 @@ public class MemoryRecordsTest {
             .slice(first.sizeInBytes() - 1, records.sizeInBytes());
         assertEquals(records.sizeInBytes() - first.sizeInBytes(), sliced.sizeInBytes());
         assertEquals(items.subList(1, items.size()), batches(sliced), "Read starting from the second message");
-        assertTrue(((MemoryRecords) sliced).validBytes() <= sliced.sizeInBytes());
+        assertTrue(sliced.validBytes() <= sliced.sizeInBytes());
 
         // Read from second message and position + size overflows on the already sliced view.
         sliced = records.slice(1, records.sizeInBytes() - 1)
             .slice(first.sizeInBytes() - 1, Integer.MAX_VALUE);
         assertEquals(records.sizeInBytes() - first.sizeInBytes(), sliced.sizeInBytes());
         assertEquals(items.subList(1, items.size()), batches(sliced), "Read starting from the second message");
-        assertTrue(((MemoryRecords) sliced).validBytes() <= sliced.sizeInBytes());
+        assertTrue(sliced.validBytes() <= sliced.sizeInBytes());
     }
 
     @ParameterizedTest

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
@@ -157,7 +157,8 @@ public class MemoryRecordsTest {
                 firstSequence,
                 false,
                 false,
-                partitionLeaderEpoch, buffer.limit()
+                partitionLeaderEpoch,
+                buffer.limit()
             )
         ) {
             for (SimpleRecord record : records) {

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -277,7 +277,7 @@ object DumpLogSegments {
         println(s"Snapshot end offset: ${path.snapshotId.offset}, epoch: ${path.snapshotId.epoch}")
       }
     }
-    val fileRecords = FileRecords.open(file, false).slice(0, maxBytes).asInstanceOf[FileRecords]
+    val fileRecords = FileRecords.open(file, false).slice(0, maxBytes)
     try {
       var validBytes = 0L
       var lastOffset = -1L
@@ -567,7 +567,7 @@ object DumpLogSegments {
 
   private class RemoteMetadataLogMessageParser extends MessageParser[String, String] {
     private val metadataRecordSerde = new RemoteLogMetadataSerde
-    
+
     override def parse(record: Record): (Option[String], Option[String]) = {
       val output = try {
         val data = new Array[Byte](record.value.remaining)
@@ -626,7 +626,7 @@ object DumpLogSegments {
     private val transactionLogOpt = parser.accepts("transaction-log-decoder", "If set, log data will be parsed as " +
       "transaction metadata from the __transaction_state topic.")
     private val clusterMetadataOpt = parser.accepts("cluster-metadata-decoder", "If set, log data will be parsed as cluster metadata records.")
-    private val remoteMetadataOpt = parser.accepts("remote-log-metadata-decoder", "If set, log data will be parsed as TopicBasedRemoteLogMetadataManager (RLMM) metadata records." + 
+    private val remoteMetadataOpt = parser.accepts("remote-log-metadata-decoder", "If set, log data will be parsed as TopicBasedRemoteLogMetadataManager (RLMM) metadata records." +
       " Instead, the value-decoder-class option can be used if a custom RLMM implementation is configured.")
     private val shareStateOpt = parser.accepts("share-group-state-decoder", "If set, log data will be parsed as share group state data from the " +
       "__share_group_state topic.")


### PR DESCRIPTION
In Java return types are covariant. This means that method override can
override the return type with a subclass.

Reviewers: Jun Rao <junrao@apache.org>, Chia-Ping Tsai
 <chia7712@apache.org>, Apoorv Mittal <apoorvmittal10@gmail.com>
