### PR TITLE
MINOR: Move TxnTransitMetadata to transaction-coordinator

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.{AddPartitionsToTxnResponse, TransactionResult}
 import org.apache.kafka.common.utils.{LogContext, ProducerIdAndEpoch, Time}
-import org.apache.kafka.coordinator.transaction.{ProducerIdManager, TransactionLogConfig, TransactionState, TransactionStateManagerConfig}
+import org.apache.kafka.coordinator.transaction.{ProducerIdManager, TransactionLogConfig, TransactionState, TransactionStateManagerConfig, TxnTransitMetadata}
 import org.apache.kafka.metadata.MetadataCache
 import org.apache.kafka.server.common.{RequestLocal, TransactionVersion}
 import org.apache.kafka.server.util.Scheduler
@@ -76,7 +76,7 @@ object TransactionCoordinator {
   }
 
   private def initTransactionMetadata(txnMetadata: TxnTransitMetadata): InitProducerIdResult = {
-    InitProducerIdResult(txnMetadata.producerId, txnMetadata.producerEpoch, Errors.NONE)
+    InitProducerIdResult(txnMetadata.producerId(), txnMetadata.producerEpoch(), Errors.NONE)
   }
 }
 
@@ -182,7 +182,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
           responseCallback(initTransactionError(error))
 
         case Right((coordinatorEpoch, newMetadata)) =>
-          if (newMetadata.txnState == TransactionState.PREPARE_EPOCH_FENCE) {
+          if (newMetadata.txnState() == TransactionState.PREPARE_EPOCH_FENCE) {
             // abort the ongoing transaction and then return CONCURRENT_TRANSACTIONS to let client wait and retry
             def sendRetriableErrorCallback(error: Errors, newProducerId: Long, newProducerEpoch: Short): Unit = {
               if (error != Errors.NONE) {
@@ -193,8 +193,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
             }
 
             endTransaction(transactionalId,
-              newMetadata.producerId,
-              newMetadata.producerEpoch,
+              newMetadata.producerId(),
+              newMetadata.producerEpoch(),
               TransactionResult.ABORT,
               isFromClient = false,
               clientTransactionVersion = txnManager.transactionVersionLevel(), // Since this is not from client, use server TV
@@ -203,8 +203,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
           } else {
             def sendPidResponseCallback(error: Errors): Unit = {
               if (error == Errors.NONE) {
-                info(s"Initialized transactionalId $transactionalId with producerId ${newMetadata.producerId} and producer " +
-                  s"epoch ${newMetadata.producerEpoch} on partition " +
+                info(s"Initialized transactionalId $transactionalId with producerId ${newMetadata.producerId()} and producer " +
+                  s"epoch ${newMetadata.producerEpoch()} on partition " +
                   s"${Topic.TRANSACTION_STATE_TOPIC_NAME}-${txnManager.partitionFor(transactionalId)}")
                 responseCallback(initTransactionMetadata(newMetadata))
               } else {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -76,7 +76,7 @@ object TransactionCoordinator {
   }
 
   private def initTransactionMetadata(txnMetadata: TxnTransitMetadata): InitProducerIdResult = {
-    InitProducerIdResult(txnMetadata.producerId(), txnMetadata.producerEpoch(), Errors.NONE)
+    InitProducerIdResult(txnMetadata.producerId, txnMetadata.producerEpoch, Errors.NONE)
   }
 }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -182,7 +182,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
           responseCallback(initTransactionError(error))
 
         case Right((coordinatorEpoch, newMetadata)) =>
-          if (newMetadata.txnState() == TransactionState.PREPARE_EPOCH_FENCE) {
+          if (newMetadata.txnState == TransactionState.PREPARE_EPOCH_FENCE) {
             // abort the ongoing transaction and then return CONCURRENT_TRANSACTIONS to let client wait and retry
             def sendRetriableErrorCallback(error: Errors, newProducerId: Long, newProducerEpoch: Short): Unit = {
               if (error != Errors.NONE) {
@@ -193,8 +193,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
             }
 
             endTransaction(transactionalId,
-              newMetadata.producerId(),
-              newMetadata.producerEpoch(),
+              newMetadata.producerId,
+              newMetadata.producerEpoch,
               TransactionResult.ABORT,
               isFromClient = false,
               clientTransactionVersion = txnManager.transactionVersionLevel(), // Since this is not from client, use server TV
@@ -203,8 +203,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
           } else {
             def sendPidResponseCallback(error: Errors): Unit = {
               if (error == Errors.NONE) {
-                info(s"Initialized transactionalId $transactionalId with producerId ${newMetadata.producerId()} and producer " +
-                  s"epoch ${newMetadata.producerEpoch()} on partition " +
+                info(s"Initialized transactionalId $transactionalId with producerId ${newMetadata.producerId} and producer " +
+                  s"epoch ${newMetadata.producerEpoch} on partition " +
                   s"${Topic.TRANSACTION_STATE_TOPIC_NAME}-${txnManager.partitionFor(transactionalId)}")
                 responseCallback(initTransactionMetadata(newMetadata))
               } else {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
@@ -62,11 +62,11 @@ object TransactionLog {
     */
   private[transaction] def valueToBytes(txnMetadata: TxnTransitMetadata,
                                         transactionVersionLevel: TransactionVersion): Array[Byte] = {
-    if (txnMetadata.txnState() == TransactionState.EMPTY && !txnMetadata.topicPartitions().isEmpty)
-        throw new IllegalStateException(s"Transaction is not expected to have any partitions since its state is ${txnMetadata.txnState()}: $txnMetadata")
+    if (txnMetadata.txnState == TransactionState.EMPTY && !txnMetadata.topicPartitions.isEmpty)
+        throw new IllegalStateException(s"Transaction is not expected to have any partitions since its state is ${txnMetadata.txnState}: $txnMetadata")
 
-      val transactionPartitions = if (txnMetadata.txnState() == TransactionState.EMPTY) null
-      else txnMetadata.topicPartitions().asScala
+      val transactionPartitions = if (txnMetadata.txnState == TransactionState.EMPTY) null
+      else txnMetadata.topicPartitions.asScala
         .groupBy(_.topic)
         .map { case (topic, partitions) =>
           new TransactionLogValue.PartitionsSchema()
@@ -78,14 +78,14 @@ object TransactionLog {
     // which enables flexible fields in records.
     MessageUtil.toVersionPrefixedBytes(transactionVersionLevel.transactionLogValueVersion(),
       new TransactionLogValue()
-        .setProducerId(txnMetadata.producerId())
-        .setProducerEpoch(txnMetadata.producerEpoch())
-        .setTransactionTimeoutMs(txnMetadata.txnTimeoutMs())
-        .setTransactionStatus(txnMetadata.txnState().id)
-        .setTransactionLastUpdateTimestampMs(txnMetadata.txnLastUpdateTimestamp())
-        .setTransactionStartTimestampMs(txnMetadata.txnStartTimestamp())
+        .setProducerId(txnMetadata.producerId)
+        .setProducerEpoch(txnMetadata.producerEpoch)
+        .setTransactionTimeoutMs(txnMetadata.txnTimeoutMs)
+        .setTransactionStatus(txnMetadata.txnState.id)
+        .setTransactionLastUpdateTimestampMs(txnMetadata.txnLastUpdateTimestamp)
+        .setTransactionStartTimestampMs(txnMetadata.txnStartTimestamp)
         .setTransactionPartitions(transactionPartitions)
-        .setClientTransactionVersion(txnMetadata.clientTransactionVersion().featureLevel()))
+        .setClientTransactionVersion(txnMetadata.clientTransactionVersion.featureLevel()))
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
@@ -62,7 +62,7 @@ object TransactionLog {
     */
   private[transaction] def valueToBytes(txnMetadata: TxnTransitMetadata,
                                         transactionVersionLevel: TransactionVersion): Array[Byte] = {
-    if (txnMetadata.txnState() == TransactionState.EMPTY && !txnMetadata.topicPartitions().isEmpty())
+    if (txnMetadata.txnState() == TransactionState.EMPTY && !txnMetadata.topicPartitions().isEmpty)
         throw new IllegalStateException(s"Transaction is not expected to have any partitions since its state is ${txnMetadata.txnState()}: $txnMetadata")
 
       val transactionPartitions = if (txnMetadata.txnState() == TransactionState.EMPTY) null

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
@@ -21,7 +21,7 @@ import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.protocol.{ByteBufferAccessor, MessageUtil}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.coordinator.transaction.TransactionState
+import org.apache.kafka.coordinator.transaction.{TransactionState, TxnTransitMetadata}
 import org.apache.kafka.coordinator.transaction.generated.{CoordinatorRecordType, TransactionLogKey, TransactionLogValue}
 import org.apache.kafka.server.common.TransactionVersion
 
@@ -62,11 +62,11 @@ object TransactionLog {
     */
   private[transaction] def valueToBytes(txnMetadata: TxnTransitMetadata,
                                         transactionVersionLevel: TransactionVersion): Array[Byte] = {
-    if (txnMetadata.txnState == TransactionState.EMPTY && txnMetadata.topicPartitions.nonEmpty)
-        throw new IllegalStateException(s"Transaction is not expected to have any partitions since its state is ${txnMetadata.txnState}: $txnMetadata")
+    if (txnMetadata.txnState() == TransactionState.EMPTY && !txnMetadata.topicPartitions().isEmpty())
+        throw new IllegalStateException(s"Transaction is not expected to have any partitions since its state is ${txnMetadata.txnState()}: $txnMetadata")
 
-      val transactionPartitions = if (txnMetadata.txnState == TransactionState.EMPTY) null
-      else txnMetadata.topicPartitions
+      val transactionPartitions = if (txnMetadata.txnState() == TransactionState.EMPTY) null
+      else txnMetadata.topicPartitions().asScala
         .groupBy(_.topic)
         .map { case (topic, partitions) =>
           new TransactionLogValue.PartitionsSchema()
@@ -78,14 +78,14 @@ object TransactionLog {
     // which enables flexible fields in records.
     MessageUtil.toVersionPrefixedBytes(transactionVersionLevel.transactionLogValueVersion(),
       new TransactionLogValue()
-        .setProducerId(txnMetadata.producerId)
-        .setProducerEpoch(txnMetadata.producerEpoch)
-        .setTransactionTimeoutMs(txnMetadata.txnTimeoutMs)
-        .setTransactionStatus(txnMetadata.txnState.id)
-        .setTransactionLastUpdateTimestampMs(txnMetadata.txnLastUpdateTimestamp)
-        .setTransactionStartTimestampMs(txnMetadata.txnStartTimestamp)
+        .setProducerId(txnMetadata.producerId())
+        .setProducerEpoch(txnMetadata.producerEpoch())
+        .setTransactionTimeoutMs(txnMetadata.txnTimeoutMs())
+        .setTransactionStatus(txnMetadata.txnState().id)
+        .setTransactionLastUpdateTimestampMs(txnMetadata.txnLastUpdateTimestamp())
+        .setTransactionStartTimestampMs(txnMetadata.txnStartTimestamp())
         .setTransactionPartitions(transactionPartitions)
-        .setClientTransactionVersion(txnMetadata.clientTransactionVersion.featureLevel()))
+        .setClientTransactionVersion(txnMetadata.clientTransactionVersion().featureLevel()))
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.common.requests.{TransactionResult, WriteTxnMarkersReque
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{Node, Reconfigurable, TopicPartition}
+import org.apache.kafka.coordinator.transaction.TxnTransitMetadata
 import org.apache.kafka.metadata.MetadataCache
 import org.apache.kafka.server.common.RequestLocal
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
@@ -275,7 +276,7 @@ class TransactionMarkerChannelManager(
     val coordinatorEpoch = pendingCompleteTxn.coordinatorEpoch
 
     trace(s"Completed sending transaction markers for $transactionalId; begin transition " +
-      s"to ${newMetadata.txnState}")
+      s"to ${newMetadata.txnState()}")
 
     txnStateManager.getTransactionState(transactionalId) match {
       case Left(Errors.NOT_COORDINATOR) =>

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -276,7 +276,7 @@ class TransactionMarkerChannelManager(
     val coordinatorEpoch = pendingCompleteTxn.coordinatorEpoch
 
     trace(s"Completed sending transaction markers for $transactionalId; begin transition " +
-      s"to ${newMetadata.txnState()}")
+      s"to ${newMetadata.txnState}")
 
     txnStateManager.getTransactionState(transactionalId) match {
       case Left(Errors.NOT_COORDINATOR) =>

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -21,41 +21,14 @@ import kafka.utils.{CoreUtils, Logging, nonthreadsafe}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
-import org.apache.kafka.coordinator.transaction.TransactionState
+import org.apache.kafka.coordinator.transaction.{TransactionState, TxnTransitMetadata}
 import org.apache.kafka.server.common.TransactionVersion
 
 import scala.collection.{immutable, mutable}
+import scala.jdk.CollectionConverters._
 
 private[transaction] object TransactionMetadata {
   def isEpochExhausted(producerEpoch: Short): Boolean = producerEpoch >= Short.MaxValue - 1
-}
-
-// this is a immutable object representing the target transition of the transaction metadata
-private[transaction] case class TxnTransitMetadata(producerId: Long,
-                                                   prevProducerId: Long,
-                                                   nextProducerId: Long,
-                                                   producerEpoch: Short,
-                                                   lastProducerEpoch: Short,
-                                                   txnTimeoutMs: Int,
-                                                   txnState: TransactionState,
-                                                   topicPartitions: mutable.Set[TopicPartition],
-                                                   txnStartTimestamp: Long,
-                                                   txnLastUpdateTimestamp: Long,
-                                                   clientTransactionVersion: TransactionVersion) {
-  override def toString: String = {
-    "TxnTransitMetadata(" +
-      s"producerId=$producerId, " +
-      s"previousProducerId=$prevProducerId, " +
-      s"nextProducerId=$nextProducerId, " +
-      s"producerEpoch=$producerEpoch, " +
-      s"lastProducerEpoch=$lastProducerEpoch, " +
-      s"txnTimeoutMs=$txnTimeoutMs, " +
-      s"txnState=$txnState, " +
-      s"topicPartitions=$topicPartitions, " +
-      s"txnStartTimestamp=$txnStartTimestamp, " +
-      s"txnLastUpdateTimestamp=$txnLastUpdateTimestamp, " +
-      s"clientTransactionVersion=$clientTransactionVersion)"
-  }
 }
 
 /**
@@ -114,7 +87,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
   // this is visible for test only
   def prepareNoTransit(): TxnTransitMetadata = {
     // do not call transitTo as it will set the pending state, a follow-up call to abort the transaction will set its pending state
-    TxnTransitMetadata(producerId, prevProducerId, nextProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs, state, topicPartitions.clone(),
+    new TxnTransitMetadata(producerId, prevProducerId, nextProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs, state, topicPartitions.clone().asJava,
       txnStartTimestamp, txnLastUpdateTimestamp, clientTransactionVersion)
   }
 
@@ -317,8 +290,8 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
 
     // check that the new state transition is valid and update the pending state if necessary
     if (state.validPreviousStates.contains(this.state)) {
-      val transitMetadata = TxnTransitMetadata(producerId, this.producerId, nextProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs, state,
-        topicPartitions, txnStartTimestamp, txnLastUpdateTimestamp, clientTransactionVersion)
+      val transitMetadata = new TxnTransitMetadata(producerId, this.producerId, nextProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs, state,
+        topicPartitions.asJava, txnStartTimestamp, txnLastUpdateTimestamp, clientTransactionVersion)
       debug(s"TransactionalId ${this.transactionalId} prepare transition from ${this.state} to $transitMetadata")
       pendingState = Some(state)
       transitMetadata
@@ -348,22 +321,22 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
         "completing transaction state transition while it does not have a pending state")
     }
 
-    if (toState != transitMetadata.txnState) {
+    if (toState != transitMetadata.txnState()) {
       throwStateTransitionFailure(transitMetadata)
     } else {
       toState match {
         case TransactionState.EMPTY => // from initPid
-          if ((producerEpoch != transitMetadata.producerEpoch && !validProducerEpochBump(transitMetadata)) ||
-            transitMetadata.topicPartitions.nonEmpty ||
-            transitMetadata.txnStartTimestamp != -1) {
+          if ((producerEpoch != transitMetadata.producerEpoch() && !validProducerEpochBump(transitMetadata)) ||
+            !transitMetadata.topicPartitions().isEmpty ||
+            transitMetadata.txnStartTimestamp() != -1) {
 
             throwStateTransitionFailure(transitMetadata)
           }
 
         case TransactionState.ONGOING => // from addPartitions
           if (!validProducerEpoch(transitMetadata) ||
-            !topicPartitions.subsetOf(transitMetadata.topicPartitions) ||
-            txnTimeoutMs != transitMetadata.txnTimeoutMs) {
+            !topicPartitions.subsetOf(transitMetadata.topicPartitions().asScala) ||
+            txnTimeoutMs != transitMetadata.txnTimeoutMs()) {
 
             throwStateTransitionFailure(transitMetadata)
           }
@@ -371,20 +344,20 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
         case TransactionState.PREPARE_ABORT | TransactionState.PREPARE_COMMIT => // from endTxn
           // In V2, we allow state transits from Empty, CompleteCommit and CompleteAbort to PrepareAbort. It is possible
           // their updated start time is not equal to the current start time.
-          val allowedEmptyAbort = toState == TransactionState.PREPARE_ABORT && transitMetadata.clientTransactionVersion.supportsEpochBump() &&
+          val allowedEmptyAbort = toState == TransactionState.PREPARE_ABORT && transitMetadata.clientTransactionVersion().supportsEpochBump() &&
             (state == TransactionState.EMPTY || state == TransactionState.COMPLETE_COMMIT || state == TransactionState.COMPLETE_ABORT)
-          val validTimestamp = txnStartTimestamp == transitMetadata.txnStartTimestamp || allowedEmptyAbort
+          val validTimestamp = txnStartTimestamp == transitMetadata.txnStartTimestamp() || allowedEmptyAbort
           if (!validProducerEpoch(transitMetadata) ||
-            !topicPartitions.equals(transitMetadata.topicPartitions) ||
-            txnTimeoutMs != transitMetadata.txnTimeoutMs || !validTimestamp) {
+            !topicPartitions.equals(transitMetadata.topicPartitions().asScala) ||
+            txnTimeoutMs != transitMetadata.txnTimeoutMs() || !validTimestamp) {
 
             throwStateTransitionFailure(transitMetadata)
           }
 
         case TransactionState.COMPLETE_ABORT | TransactionState.COMPLETE_COMMIT => // from write markers
           if (!validProducerEpoch(transitMetadata) ||
-            txnTimeoutMs != transitMetadata.txnTimeoutMs ||
-            transitMetadata.txnStartTimestamp == -1) {
+            txnTimeoutMs != transitMetadata.txnTimeoutMs() ||
+            transitMetadata.txnStartTimestamp() == -1) {
             throwStateTransitionFailure(transitMetadata)
           }
 
@@ -405,16 +378,16 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
       }
 
       debug(s"TransactionalId $transactionalId complete transition from $state to $transitMetadata")
-      producerId = transitMetadata.producerId
-      prevProducerId = transitMetadata.prevProducerId
-      nextProducerId = transitMetadata.nextProducerId
-      producerEpoch = transitMetadata.producerEpoch
-      lastProducerEpoch = transitMetadata.lastProducerEpoch
-      txnTimeoutMs = transitMetadata.txnTimeoutMs
-      topicPartitions = transitMetadata.topicPartitions
-      txnStartTimestamp = transitMetadata.txnStartTimestamp
-      txnLastUpdateTimestamp = transitMetadata.txnLastUpdateTimestamp
-      clientTransactionVersion = transitMetadata.clientTransactionVersion
+      producerId = transitMetadata.producerId()
+      prevProducerId = transitMetadata.prevProducerId()
+      nextProducerId = transitMetadata.nextProducerId()
+      producerEpoch = transitMetadata.producerEpoch()
+      lastProducerEpoch = transitMetadata.lastProducerEpoch()
+      txnTimeoutMs = transitMetadata.txnTimeoutMs()
+      topicPartitions = transitMetadata.topicPartitions().asScala
+      txnStartTimestamp = transitMetadata.txnStartTimestamp()
+      txnLastUpdateTimestamp = transitMetadata.txnLastUpdateTimestamp()
+      clientTransactionVersion = transitMetadata.clientTransactionVersion()
 
       pendingState = None
       state = toState
@@ -443,16 +416,16 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
    * @return true if the producer epoch and ID are valid; false otherwise.
    */
   private def validProducerEpoch(transitMetadata: TxnTransitMetadata): Boolean = {
-    val isAtLeastTransactionsV2 = transitMetadata.clientTransactionVersion.supportsEpochBump()
-    val txnState = transitMetadata.txnState
-    val transitProducerEpoch = transitMetadata.producerEpoch
-    val transitProducerId = transitMetadata.producerId
-    val transitLastProducerEpoch = transitMetadata.lastProducerEpoch
+    val isAtLeastTransactionsV2 = transitMetadata.clientTransactionVersion().supportsEpochBump()
+    val txnState = transitMetadata.txnState()
+    val transitProducerEpoch = transitMetadata.producerEpoch()
+    val transitProducerId = transitMetadata.producerId()
+    val transitLastProducerEpoch = transitMetadata.lastProducerEpoch()
 
     (isAtLeastTransactionsV2, txnState, transitProducerEpoch) match {
       case (true, TransactionState.COMPLETE_COMMIT | TransactionState.COMPLETE_ABORT, epoch) if epoch == 0.toShort =>
         transitLastProducerEpoch == lastProducerEpoch &&
-          transitMetadata.prevProducerId == producerId
+          transitMetadata.prevProducerId() == producerId
 
       case (true, TransactionState.PREPARE_COMMIT | TransactionState.PREPARE_ABORT, _) =>
         transitLastProducerEpoch == producerEpoch &&
@@ -465,8 +438,8 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
   }
 
   private def validProducerEpochBump(transitMetadata: TxnTransitMetadata): Boolean = {
-    val transitEpoch = transitMetadata.producerEpoch
-    val transitProducerId = transitMetadata.producerId
+    val transitEpoch = transitMetadata.producerEpoch()
+    val transitProducerId = transitMetadata.producerId()
     transitEpoch == producerEpoch + 1 || (transitEpoch == 0 && transitProducerId != producerId)
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -321,22 +321,22 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
         "completing transaction state transition while it does not have a pending state")
     }
 
-    if (toState != transitMetadata.txnState()) {
+    if (toState != transitMetadata.txnState) {
       throwStateTransitionFailure(transitMetadata)
     } else {
       toState match {
         case TransactionState.EMPTY => // from initPid
-          if ((producerEpoch != transitMetadata.producerEpoch() && !validProducerEpochBump(transitMetadata)) ||
-            !transitMetadata.topicPartitions().isEmpty ||
-            transitMetadata.txnStartTimestamp() != -1) {
+          if ((producerEpoch != transitMetadata.producerEpoch && !validProducerEpochBump(transitMetadata)) ||
+            !transitMetadata.topicPartitions.isEmpty ||
+            transitMetadata.txnStartTimestamp != -1) {
 
             throwStateTransitionFailure(transitMetadata)
           }
 
         case TransactionState.ONGOING => // from addPartitions
           if (!validProducerEpoch(transitMetadata) ||
-            !topicPartitions.subsetOf(transitMetadata.topicPartitions().asScala) ||
-            txnTimeoutMs != transitMetadata.txnTimeoutMs()) {
+            !topicPartitions.subsetOf(transitMetadata.topicPartitions.asScala) ||
+            txnTimeoutMs != transitMetadata.txnTimeoutMs) {
 
             throwStateTransitionFailure(transitMetadata)
           }
@@ -344,20 +344,20 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
         case TransactionState.PREPARE_ABORT | TransactionState.PREPARE_COMMIT => // from endTxn
           // In V2, we allow state transits from Empty, CompleteCommit and CompleteAbort to PrepareAbort. It is possible
           // their updated start time is not equal to the current start time.
-          val allowedEmptyAbort = toState == TransactionState.PREPARE_ABORT && transitMetadata.clientTransactionVersion().supportsEpochBump() &&
+          val allowedEmptyAbort = toState == TransactionState.PREPARE_ABORT && transitMetadata.clientTransactionVersion.supportsEpochBump() &&
             (state == TransactionState.EMPTY || state == TransactionState.COMPLETE_COMMIT || state == TransactionState.COMPLETE_ABORT)
-          val validTimestamp = txnStartTimestamp == transitMetadata.txnStartTimestamp() || allowedEmptyAbort
+          val validTimestamp = txnStartTimestamp == transitMetadata.txnStartTimestamp || allowedEmptyAbort
           if (!validProducerEpoch(transitMetadata) ||
-            !topicPartitions.equals(transitMetadata.topicPartitions().asScala) ||
-            txnTimeoutMs != transitMetadata.txnTimeoutMs() || !validTimestamp) {
+            !topicPartitions.equals(transitMetadata.topicPartitions.asScala) ||
+            txnTimeoutMs != transitMetadata.txnTimeoutMs || !validTimestamp) {
 
             throwStateTransitionFailure(transitMetadata)
           }
 
         case TransactionState.COMPLETE_ABORT | TransactionState.COMPLETE_COMMIT => // from write markers
           if (!validProducerEpoch(transitMetadata) ||
-            txnTimeoutMs != transitMetadata.txnTimeoutMs() ||
-            transitMetadata.txnStartTimestamp() == -1) {
+            txnTimeoutMs != transitMetadata.txnTimeoutMs ||
+            transitMetadata.txnStartTimestamp == -1) {
             throwStateTransitionFailure(transitMetadata)
           }
 
@@ -378,16 +378,16 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
       }
 
       debug(s"TransactionalId $transactionalId complete transition from $state to $transitMetadata")
-      producerId = transitMetadata.producerId()
-      prevProducerId = transitMetadata.prevProducerId()
-      nextProducerId = transitMetadata.nextProducerId()
-      producerEpoch = transitMetadata.producerEpoch()
-      lastProducerEpoch = transitMetadata.lastProducerEpoch()
-      txnTimeoutMs = transitMetadata.txnTimeoutMs()
-      topicPartitions = transitMetadata.topicPartitions().asScala
-      txnStartTimestamp = transitMetadata.txnStartTimestamp()
-      txnLastUpdateTimestamp = transitMetadata.txnLastUpdateTimestamp()
-      clientTransactionVersion = transitMetadata.clientTransactionVersion()
+      producerId = transitMetadata.producerId
+      prevProducerId = transitMetadata.prevProducerId
+      nextProducerId = transitMetadata.nextProducerId
+      producerEpoch = transitMetadata.producerEpoch
+      lastProducerEpoch = transitMetadata.lastProducerEpoch
+      txnTimeoutMs = transitMetadata.txnTimeoutMs
+      topicPartitions = transitMetadata.topicPartitions.asScala
+      txnStartTimestamp = transitMetadata.txnStartTimestamp
+      txnLastUpdateTimestamp = transitMetadata.txnLastUpdateTimestamp
+      clientTransactionVersion = transitMetadata.clientTransactionVersion
 
       pendingState = None
       state = toState
@@ -416,16 +416,16 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
    * @return true if the producer epoch and ID are valid; false otherwise.
    */
   private def validProducerEpoch(transitMetadata: TxnTransitMetadata): Boolean = {
-    val isAtLeastTransactionsV2 = transitMetadata.clientTransactionVersion().supportsEpochBump()
-    val txnState = transitMetadata.txnState()
-    val transitProducerEpoch = transitMetadata.producerEpoch()
-    val transitProducerId = transitMetadata.producerId()
-    val transitLastProducerEpoch = transitMetadata.lastProducerEpoch()
+    val isAtLeastTransactionsV2 = transitMetadata.clientTransactionVersion.supportsEpochBump()
+    val txnState = transitMetadata.txnState
+    val transitProducerEpoch = transitMetadata.producerEpoch
+    val transitProducerId = transitMetadata.producerId
+    val transitLastProducerEpoch = transitMetadata.lastProducerEpoch
 
     (isAtLeastTransactionsV2, txnState, transitProducerEpoch) match {
       case (true, TransactionState.COMPLETE_COMMIT | TransactionState.COMPLETE_ABORT, epoch) if epoch == 0.toShort =>
         transitLastProducerEpoch == lastProducerEpoch &&
-          transitMetadata.prevProducerId() == producerId
+          transitMetadata.prevProducerId == producerId
 
       case (true, TransactionState.PREPARE_COMMIT | TransactionState.PREPARE_ABORT, _) =>
         transitLastProducerEpoch == producerEpoch &&
@@ -438,8 +438,8 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
   }
 
   private def validProducerEpochBump(transitMetadata: TxnTransitMetadata): Boolean = {
-    val transitEpoch = transitMetadata.producerEpoch()
-    val transitProducerId = transitMetadata.producerId()
+    val transitEpoch = transitMetadata.producerEpoch
+    val transitProducerId = transitMetadata.producerId
     transitEpoch == producerEpoch + 1 || (transitEpoch == 0 && transitProducerId != producerId)
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -35,7 +35,7 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicIdPartition, TopicPartition}
-import org.apache.kafka.coordinator.transaction.{TransactionLogConfig, TransactionState, TransactionStateManagerConfig}
+import org.apache.kafka.coordinator.transaction.{TransactionLogConfig, TransactionState, TransactionStateManagerConfig, TxnTransitMetadata}
 import org.apache.kafka.metadata.MetadataCache
 import org.apache.kafka.server.common.{RequestLocal, TransactionVersion}
 import org.apache.kafka.server.config.ServerConfigs

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionLogTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionLogTest.scala
@@ -23,14 +23,15 @@ import org.apache.kafka.common.protocol.{ByteBufferAccessor, MessageUtil}
 import org.apache.kafka.common.protocol.types.Field.TaggedFieldsSection
 import org.apache.kafka.common.protocol.types.{CompactArrayOf, Field, Schema, Struct, Type}
 import org.apache.kafka.common.record.{MemoryRecords, RecordBatch, SimpleRecord}
-import org.apache.kafka.coordinator.transaction.TransactionState
+import org.apache.kafka.coordinator.transaction.{TransactionState, TxnTransitMetadata}
 import org.apache.kafka.coordinator.transaction.generated.{TransactionLogKey, TransactionLogValue}
 import org.apache.kafka.server.common.TransactionVersion.{TV_0, TV_2}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue, fail}
 import org.junit.jupiter.api.Test
 
 import java.nio.ByteBuffer
-import scala.collection.{Seq, mutable}
+import java.util.Collections
+import scala.collection.Seq
 import scala.jdk.CollectionConverters._
 
 class TransactionLogTest {
@@ -114,14 +115,14 @@ class TransactionLogTest {
 
   @Test
   def testSerializeTransactionLogValueToHighestNonFlexibleVersion(): Unit = {
-    val txnTransitMetadata = TxnTransitMetadata(1, 1, 1, 1, 1, 1000, TransactionState.COMPLETE_COMMIT, mutable.Set.empty, 500, 500, TV_0)
+    val txnTransitMetadata = new TxnTransitMetadata(1, 1, 1, 1, 1, 1000, TransactionState.COMPLETE_COMMIT, Collections.emptySet(), 500, 500, TV_0)
     val txnLogValueBuffer = ByteBuffer.wrap(TransactionLog.valueToBytes(txnTransitMetadata, TV_0))
     assertEquals(0, txnLogValueBuffer.getShort)
   }
 
   @Test
   def testSerializeTransactionLogValueToFlexibleVersion(): Unit = {
-    val txnTransitMetadata = TxnTransitMetadata(1, 1, 1, 1, 1, 1000, TransactionState.COMPLETE_COMMIT, mutable.Set.empty, 500, 500, TV_2)
+    val txnTransitMetadata = new TxnTransitMetadata(1, 1, 1, 1, 1, 1000, TransactionState.COMPLETE_COMMIT, Collections.emptySet(), 500, 500, TV_2)
     val txnLogValueBuffer = ByteBuffer.wrap(TransactionLog.valueToBytes(txnTransitMetadata, TV_2))
     assertEquals(TransactionLogValue.HIGHEST_SUPPORTED_VERSION, txnLogValueBuffer.getShort)
   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.Optional
+
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
@@ -19,7 +19,7 @@ package kafka.coordinator.transaction
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
-import org.apache.kafka.coordinator.transaction.TransactionState
+import org.apache.kafka.coordinator.transaction.{TransactionState, TxnTransitMetadata}
 import org.apache.kafka.server.common.TransactionVersion
 import org.apache.kafka.server.common.TransactionVersion.{TV_0, TV_2}
 import org.apache.kafka.server.util.MockTime
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.Optional
-
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.MockTime
-import org.apache.kafka.coordinator.transaction.TransactionState
+import org.apache.kafka.coordinator.transaction.{TransactionState, TxnTransitMetadata}
 import org.apache.kafka.metadata.MetadataCache
 import org.apache.kafka.server.common.{FinalizedFeatures, MetadataVersion, RequestLocal, TransactionVersion}
 import org.apache.kafka.server.common.TransactionVersion.{TV_0, TV_2}

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TxnTransitMetadata.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TxnTransitMetadata.java
@@ -1,20 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.kafka.coordinator.transaction;
 
@@ -26,7 +24,7 @@ import java.util.Set;
 /**
  * Immutable object representing the target transition of the transaction metadata
  */
-public record TxnTransitMetadata (
+public record TxnTransitMetadata(
         long producerId,
         long prevProducerId,
         long nextProducerId,
@@ -38,4 +36,4 @@ public record TxnTransitMetadata (
         long txnStartTimestamp,
         long txnLastUpdateTimestamp,
         TransactionVersion clientTransactionVersion
-) {}
+) { }

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TxnTransitMetadata.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TxnTransitMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.kafka.coordinator.transaction;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.server.common.TransactionVersion;
+
+import java.util.Set;
+
+/**
+ * Immutable object representing the target transition of the transaction metadata
+ */
+public record TxnTransitMetadata (
+        long producerId,
+        long prevProducerId,
+        long nextProducerId,
+        short producerEpoch,
+        short lastProducerEpoch,
+        int txnTimeoutMs,
+        TransactionState txnState,
+        Set<TopicPartition> topicPartitions,
+        long txnStartTimestamp,
+        long txnLastUpdateTimestamp,
+        TransactionVersion clientTransactionVersion
+) {}


### PR DESCRIPTION
Migrates the `TxnTransitMetadata` class from scala to java, moving it
from to the `transaction-coordinator` module.

Reviewers: PoAn Yang <payang@apache.org>, Nick Guo
 <lansg0504@gmail.com>, Ken Huang <s7133700@gmail.com>, Jhen-Yung Hsu
 <jhenyunghsu@gmail.com>, TaiJuWu <tjwu1217@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
