### PR TITLE
MINOR: add xijiu from asf.yaml in order to resend invitation

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,7 @@ github:
     - ShivsundarR
     - smjn
     - TaiJuWu
+    - xijiu
     - Yunyung
   enabled_merge_buttons:
     squash: true


### PR DESCRIPTION
@xijiu's invitation is timeout, so we have to remove the name, then
re-add it in a new commit.

see https://issues.apache.org/jira/browse/INFRA-26796

Reviewers: PoAn Yang <payang@apache.org>, xijiu <422766572@qq.com>,
 Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Ken Huang <s7133700@gmail.com>,
 TengYao Chi <frankvicky@apache.org>
