### PR TITLE
KAFKA-19255: KRaft request manager should support one in-flight request per request type

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3296,17 +3296,13 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         // voter in order to discover if there has been a leader change.
         final long backoffMs;
         Node leaderNode = state.leaderNode(channel.listenerName());
-        if (requestManager.hasRequestTimedOut(leaderNode, currentTimeMs, ApiKeys.FETCH) ||
-            requestManager.hasRequestTimedOut(leaderNode, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
+        if (requestManager.hasRequestTimedOut(leaderNode, currentTimeMs, ApiKeys.FETCH)) {
             // Once the request has timed out backoff the connection
             requestManager.reset(leaderNode, ApiKeys.FETCH);
-            requestManager.reset(leaderNode, ApiKeys.FETCH_SNAPSHOT);
             backoffMs = maybeSendFetchToAnyBootstrap(currentTimeMs);
-        } else if (requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH) ||
-            requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
+        } else if (requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH)) {
             backoffMs = maybeSendFetchToAnyBootstrap(currentTimeMs);
-        } else if (!requestManager.hasAnyInflightRequest(currentTimeMs,
-            Set.of(ApiKeys.FETCH, ApiKeys.FETCH_SNAPSHOT))) {
+        } else if (!requestManager.hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH)) {
             backoffMs = maybeSendFetchOrFetchSnapshot(state, currentTimeMs);
         } else {
             backoffMs = requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs);

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2766,28 +2766,27 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      *
      * @param currentTimeMs the current time
      * @param destination the node receiving the request
-     * @param requestSupplier the function that creates the request
-     * @param api the type of request to maybe send
+     * @param requestSupplier the function supplier that creates the request
      * @return the first element in the pair indicates if the request was sent; the second element
      *         in the pair indicates the time to wait before retrying.
      */
     private RequestSendResult maybeSendRequest(
         long currentTimeMs,
         Node destination,
-        Supplier<ApiMessage> requestSupplier,
-        ApiKeys api
+        RequestSupplier requestSupplier
     )  {
         var requestSent = false;
+        final var apiKey = requestSupplier.apiKey();
 
-        if (requestManager.isBackingOff(destination, currentTimeMs, api)) {
-            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs, api);
+        if (requestManager.isBackingOff(destination, currentTimeMs, apiKey)) {
+            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs, apiKey);
             logger.debug("Connection for {} is backing off for {} ms", destination, remainingBackoffMs);
             return RequestSendResult.of(requestSent, remainingBackoffMs);
         }
 
-        if (requestManager.isReady(destination, currentTimeMs, api)) {
+        if (requestManager.isReady(destination, currentTimeMs, apiKey)) {
             int correlationId = channel.newCorrelationId();
-            final var request = requestSupplier.get();
+            final var request = requestSupplier.request();
 
             RaftRequest.Outbound requestMessage = new RaftRequest.Outbound(
                 correlationId,
@@ -2799,7 +2798,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             requestMessage.completion.whenComplete((response, exception) -> {
                 if (exception != null) {
                     Errors error = Errors.forException(exception);
-                    ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
+                    ApiMessage errorResponse = RaftUtil.errorResponse(apiKey, error);
 
                     response = new RaftResponse.Inbound(
                         correlationId,
@@ -2811,7 +2810,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 messageQueue.add(response);
             });
 
-            requestManager.onRequestSent(destination, correlationId, currentTimeMs, api);
+            requestManager.onRequestSent(destination, correlationId, currentTimeMs, apiKey);
             channel.send(requestMessage);
             requestSent = true;
             logger.trace("Sent outbound request: {}", requestMessage);
@@ -2819,7 +2818,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         return RequestSendResult.of(
             requestSent,
-            requestManager.remainingRequestTimeMs(destination, currentTimeMs, api)
+            requestManager.remainingRequestTimeMs(destination, currentTimeMs, apiKey)
         );
     }
 
@@ -2838,16 +2837,14 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private long maybeSendRequests(
         long currentTimeMs,
         Set<Node> destinations,
-        Supplier<ApiMessage> requestSupplier,
-        ApiKeys requestType
+        RequestSupplier requestSupplier
     ) {
         long minBackoffMs = Long.MAX_VALUE;
         for (Node destination : destinations) {
             long backoffMs = maybeSendRequest(
                 currentTimeMs,
                 destination,
-                requestSupplier,
-                requestType
+                requestSupplier
             ).timeToWaitMs();
             if (backoffMs < minBackoffMs) {
                 minBackoffMs = backoffMs;
@@ -2868,8 +2865,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             long backoffMs = maybeSendRequest(
                 currentTimeMs,
                 destinationSupplier.apply(voter.id()),
-                () -> requestSupplier.apply(voter),
-                requestType
+                RequestSupplier.of(() -> requestSupplier.apply(voter), requestType)
             ).timeToWaitMs();
             minBackoffMs = Math.min(minBackoffMs, backoffMs);
         }
@@ -2925,8 +2921,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             node -> maybeSendRequest(
                 currentTimeMs,
                 node,
-                this::buildFetchRequest,
-                ApiKeys.FETCH
+                RequestSupplier.of(this::buildFetchRequest, ApiKeys.FETCH)
             ).timeToWaitMs()
         ).orElseGet(() -> requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs));
     }
@@ -3068,8 +3063,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             partitionState
                 .lastVoterSet()
                 .voterNodes(state.unackedVoters().stream(), channel.listenerName()),
-            () -> buildEndQuorumEpochRequest(state),
-            ApiKeys.END_QUORUM_EPOCH
+            RequestSupplier.of(() -> buildEndQuorumEpochRequest(state), ApiKeys.END_QUORUM_EPOCH)
         );
 
         GracefulShutdown shutdown = this.shutdown.get();
@@ -3311,8 +3305,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         } else if (requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH) ||
             requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
             backoffMs = maybeSendFetchToAnyBootstrap(currentTimeMs);
-        } else if (!(requestManager.hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH) ||
-            requestManager.hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH_SNAPSHOT))) {
+        } else if (!requestManager.hasAnyInflightRequest(currentTimeMs,
+            Set.of(ApiKeys.FETCH, ApiKeys.FETCH_SNAPSHOT))) {
             backoffMs = maybeSendFetchOrFetchSnapshot(state, currentTimeMs);
         } else {
             backoffMs = requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs);
@@ -3338,8 +3332,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            requestSupplier,
-            requestType
+            RequestSupplier.of(requestSupplier, requestType)
         ).timeToWaitMs();
     }
 
@@ -3357,8 +3350,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            this::buildUpdateVoterRequest,
-            ApiKeys.UPDATE_RAFT_VOTER
+            RequestSupplier.of(this::buildUpdateVoterRequest, ApiKeys.UPDATE_RAFT_VOTER)
         );
     }
 
@@ -3769,6 +3761,24 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
     private boolean isInitialized() {
         return partitionState != null && quorum != null && requestManager != null && kafkaRaftMetrics != null;
+    }
+
+    private record RequestSupplier(Supplier<ApiMessage> supplier, ApiKeys apiKey) {
+        private static RequestSupplier of(
+            Supplier<ApiMessage> supplier,
+            ApiKeys apiKey
+        ) {
+            return new RequestSupplier(supplier, apiKey);
+        }
+
+        private ApiMessage request() {
+            ApiMessage request = supplier.get();
+            if (request.apiKey() != apiKey.id) {
+                throw new IllegalStateException("Request type mismatch: expected " + apiKey +
+                    " but got " + request.apiKey());
+            }
+            return request;
+        }
     }
 
     private class GracefulShutdown {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2626,7 +2626,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             response.source(),
             response.correlationId(),
             handledSuccessfully,
-            currentTimeMs
+            currentTimeMs,
+            apiKey
         );
     }
 
@@ -2744,7 +2745,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         if (message instanceof RaftRequest.Inbound request) {
             handleRequest(request, currentTimeMs);
         } else if (message instanceof RaftResponse.Inbound response) {
-            if (requestManager.isResponseExpected(response.source(), response.correlationId())) {
+            if (requestManager.isResponseExpected(
+                response.source(),
+                response.correlationId(),
+                ApiKeys.forId(message.data().apiKey()))
+            ) {
                 handleResponse(response, currentTimeMs);
             } else {
                 logger.debug("Ignoring response {} since it is no longer needed", response);
@@ -2771,16 +2776,17 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         Supplier<ApiMessage> requestSupplier
     )  {
         var requestSent = false;
+        final var request = requestSupplier.get();
+        final var api = ApiKeys.forId(request.apiKey());
 
-        if (requestManager.isBackingOff(destination, currentTimeMs)) {
-            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs);
+        if (requestManager.isBackingOff(destination, currentTimeMs, api)) {
+            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs, api);
             logger.debug("Connection for {} is backing off for {} ms", destination, remainingBackoffMs);
             return RequestSendResult.of(requestSent, remainingBackoffMs);
         }
 
-        if (requestManager.isReady(destination, currentTimeMs)) {
+        if (requestManager.isReady(destination, currentTimeMs, api)) {
             int correlationId = channel.newCorrelationId();
-            ApiMessage request = requestSupplier.get();
 
             RaftRequest.Outbound requestMessage = new RaftRequest.Outbound(
                 correlationId,
@@ -2791,7 +2797,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
             requestMessage.completion.whenComplete((response, exception) -> {
                 if (exception != null) {
-                    ApiKeys api = ApiKeys.forId(request.apiKey());
                     Errors error = Errors.forException(exception);
                     ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
 
@@ -2805,7 +2810,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 messageQueue.add(response);
             });
 
-            requestManager.onRequestSent(destination, correlationId, currentTimeMs);
+            requestManager.onRequestSent(destination, correlationId, currentTimeMs, api);
             channel.send(requestMessage);
             requestSent = true;
             logger.trace("Sent outbound request: {}", requestMessage);
@@ -2813,7 +2818,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         return RequestSendResult.of(
             requestSent,
-            requestManager.remainingRequestTimeMs(destination, currentTimeMs)
+            requestManager.remainingRequestTimeMs(destination, currentTimeMs, api)
         );
     }
 
@@ -3285,13 +3290,17 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         // voter in order to discover if there has been a leader change.
         final long backoffMs;
         Node leaderNode = state.leaderNode(channel.listenerName());
-        if (requestManager.hasRequestTimedOut(leaderNode, currentTimeMs)) {
+        if (requestManager.hasRequestTimedOut(leaderNode, currentTimeMs, ApiKeys.FETCH) ||
+            requestManager.hasRequestTimedOut(leaderNode, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
             // Once the request has timed out backoff the connection
-            requestManager.reset(leaderNode);
+            requestManager.reset(leaderNode, ApiKeys.FETCH);
+            requestManager.reset(leaderNode, ApiKeys.FETCH_SNAPSHOT);
             backoffMs = maybeSendFetchToAnyBootstrap(currentTimeMs);
-        } else if (requestManager.isBackingOff(leaderNode, currentTimeMs)) {
+        } else if (requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH) ||
+            requestManager.isBackingOff(leaderNode, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
             backoffMs = maybeSendFetchToAnyBootstrap(currentTimeMs);
-        } else if (!requestManager.hasAnyInflightRequest(currentTimeMs)) {
+        } else if (!(requestManager.hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH) ||
+            requestManager.hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH_SNAPSHOT))) {
             backoffMs = maybeSendFetchOrFetchSnapshot(state, currentTimeMs);
         } else {
             backoffMs = requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs);

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2823,7 +2823,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private RequestSupplier buildEndQuorumEpochRequest(
+    private RequestSupplier endQuorumEpochRequestSupplier(
         ResignedState state
     ) {
         return RequestSupplier.of(
@@ -2875,7 +2875,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return minBackoffMs;
     }
 
-    private RequestSupplier buildBeginQuorumEpochRequest(ReplicaKey remoteVoter) {
+    private RequestSupplier beginQuorumEpochRequestSupplier(ReplicaKey remoteVoter) {
         return RequestSupplier.of(
             () -> RaftUtil.singletonBeginQuorumEpochRequest(
                 log.topicPartition(),
@@ -2889,7 +2889,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private RequestSupplier buildVoteRequest(ReplicaKey remoteVoter, boolean preVote) {
+    private RequestSupplier voteRequestSupplier(ReplicaKey remoteVoter, boolean preVote) {
         return RequestSupplier.of(
             () -> {
                 OffsetAndEpoch endOffset = endOffset();
@@ -2908,7 +2908,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private RequestSupplier buildFetchRequest() {
+    private RequestSupplier fetchRequestSupplier() {
         return RequestSupplier.of(
             () -> {
                 FetchRequestData request = RaftUtil.singletonFetchRequest(
@@ -2939,12 +2939,15 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             node -> maybeSendRequest(
                 currentTimeMs,
                 node,
-                buildFetchRequest()
+                fetchRequestSupplier()
             ).timeToWaitMs()
         ).orElseGet(() -> requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs));
     }
 
-    private RequestSupplier buildFetchSnapshotRequest(OffsetAndEpoch snapshotId, long snapshotSize) {
+    private RequestSupplier fetchSnapshotRequestSupplier(
+        OffsetAndEpoch snapshotId,
+        long snapshotSize
+    ) {
         return RequestSupplier.of(
             () -> RaftUtil.singletonFetchSnapshotRequest(
                 clusterId,
@@ -3069,7 +3072,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                     .filter(key -> key.id() != quorum.localIdOrThrow())
                     .collect(Collectors.toSet()),
                 nodeSupplier,
-                this::buildBeginQuorumEpochRequest
+                this::beginQuorumEpochRequestSupplier
             );
             state.resetBeginQuorumEpochTimer(currentTimeMs);
         }
@@ -3083,7 +3086,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             partitionState
                 .lastVoterSet()
                 .voterNodes(state.unackedVoters().stream(), channel.listenerName()),
-            buildEndQuorumEpochRequest(state)
+            endQuorumEpochRequestSupplier(state)
         );
 
         GracefulShutdown shutdown = this.shutdown.get();
@@ -3163,7 +3166,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                             )
                         )
                     ),
-                voterId -> buildVoteRequest(voterId, preVote)
+                voterId -> voteRequestSupplier(voterId, preVote)
             );
         }
         return Long.MAX_VALUE;
@@ -3336,9 +3339,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             RawSnapshotWriter snapshot = state.fetchingSnapshot().get();
             long snapshotSize = snapshot.sizeInBytes();
 
-            requestSupplier = buildFetchSnapshotRequest(snapshot.snapshotId(), snapshotSize);
+            requestSupplier = fetchSnapshotRequestSupplier(snapshot.snapshotId(), snapshotSize);
         } else {
-            requestSupplier = buildFetchRequest();
+            requestSupplier = fetchRequestSupplier();
         }
 
         return maybeSendRequest(
@@ -3348,7 +3351,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         ).timeToWaitMs();
     }
 
-    private RequestSupplier buildUpdateVoterRequest() {
+    private RequestSupplier updateVoterRequestSupplier() {
         return RequestSupplier.of(
             () -> RaftUtil.updateVoterRequest(
                 clusterId,
@@ -3365,7 +3368,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            buildUpdateVoterRequest()
+            updateVoterRequestSupplier()
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -83,6 +83,7 @@ import org.apache.kafka.raft.internals.MemoryBatchReader;
 import org.apache.kafka.raft.internals.RecordsBatchReader;
 import org.apache.kafka.raft.internals.RemoveVoterHandler;
 import org.apache.kafka.raft.internals.RequestSendResult;
+import org.apache.kafka.raft.internals.RequestSupplier;
 import org.apache.kafka.raft.internals.ThresholdPurgatory;
 import org.apache.kafka.raft.internals.UpdateVoterHandler;
 import org.apache.kafka.server.common.KRaftVersion;
@@ -3757,24 +3758,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
     private boolean isInitialized() {
         return partitionState != null && quorum != null && requestManager != null && kafkaRaftMetrics != null;
-    }
-
-    private record RequestSupplier(Supplier<ApiMessage> supplier, ApiKeys apiKey) {
-        private static RequestSupplier of(
-            Supplier<ApiMessage> supplier,
-            ApiKeys apiKey
-        ) {
-            return new RequestSupplier(supplier, apiKey);
-        }
-
-        private ApiMessage request() {
-            ApiMessage request = supplier.get();
-            if (request.apiKey() != apiKey.id) {
-                throw new IllegalStateException("Request type mismatch: expected " + apiKey +
-                    " but got " + request.apiKey());
-            }
-            return request;
-        }
     }
 
     private class GracefulShutdown {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2747,9 +2747,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             handleRequest(request, currentTimeMs);
         } else if (message instanceof RaftResponse.Inbound response) {
             if (requestManager.isResponseExpected(
-                response.source(),
-                response.correlationId(),
-                ApiKeys.forId(message.data().apiKey()))
+                    response.source(),
+                    response.correlationId(),
+                    ApiKeys.forId(message.data().apiKey())
+                )
             ) {
                 handleResponse(response, currentTimeMs);
             } else {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2767,17 +2767,17 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * @param currentTimeMs the current time
      * @param destination the node receiving the request
      * @param requestSupplier the function that creates the request
+     * @param api the type of request to maybe send
      * @return the first element in the pair indicates if the request was sent; the second element
      *         in the pair indicates the time to wait before retrying.
      */
     private RequestSendResult maybeSendRequest(
         long currentTimeMs,
         Node destination,
-        Supplier<ApiMessage> requestSupplier
+        Supplier<ApiMessage> requestSupplier,
+        ApiKeys api
     )  {
         var requestSent = false;
-        final var request = requestSupplier.get();
-        final var api = ApiKeys.forId(request.apiKey());
 
         if (requestManager.isBackingOff(destination, currentTimeMs, api)) {
             long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs, api);
@@ -2787,6 +2787,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         if (requestManager.isReady(destination, currentTimeMs, api)) {
             int correlationId = channel.newCorrelationId();
+            final var request = requestSupplier.get();
 
             RaftRequest.Outbound requestMessage = new RaftRequest.Outbound(
                 correlationId,
@@ -2837,12 +2838,17 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private long maybeSendRequests(
         long currentTimeMs,
         Set<Node> destinations,
-        Supplier<ApiMessage> requestSupplier
+        Supplier<ApiMessage> requestSupplier,
+        ApiKeys requestType
     ) {
         long minBackoffMs = Long.MAX_VALUE;
         for (Node destination : destinations) {
-            long backoffMs = maybeSendRequest(currentTimeMs, destination, requestSupplier)
-                .timeToWaitMs();
+            long backoffMs = maybeSendRequest(
+                currentTimeMs,
+                destination,
+                requestSupplier,
+                requestType
+            ).timeToWaitMs();
             if (backoffMs < minBackoffMs) {
                 minBackoffMs = backoffMs;
             }
@@ -2854,14 +2860,16 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         long currentTimeMs,
         Set<ReplicaKey> remoteVoters,
         Function<Integer, Node> destinationSupplier,
-        Function<ReplicaKey, ApiMessage> requestSupplier
+        Function<ReplicaKey, ApiMessage> requestSupplier,
+        ApiKeys requestType
     ) {
         long minBackoffMs = Long.MAX_VALUE;
         for (ReplicaKey voter: remoteVoters) {
             long backoffMs = maybeSendRequest(
                 currentTimeMs,
                 destinationSupplier.apply(voter.id()),
-                () -> requestSupplier.apply(voter)
+                () -> requestSupplier.apply(voter),
+                requestType
             ).timeToWaitMs();
             minBackoffMs = Math.min(minBackoffMs, backoffMs);
         }
@@ -2917,7 +2925,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             node -> maybeSendRequest(
                 currentTimeMs,
                 node,
-                this::buildFetchRequest
+                this::buildFetchRequest,
+                ApiKeys.FETCH
             ).timeToWaitMs()
         ).orElseGet(() -> requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs));
     }
@@ -3044,7 +3053,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                     .filter(key -> key.id() != quorum.localIdOrThrow())
                     .collect(Collectors.toSet()),
                 nodeSupplier,
-                this::buildBeginQuorumEpochRequest
+                this::buildBeginQuorumEpochRequest,
+                ApiKeys.BEGIN_QUORUM_EPOCH
             );
             state.resetBeginQuorumEpochTimer(currentTimeMs);
         }
@@ -3058,7 +3068,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             partitionState
                 .lastVoterSet()
                 .voterNodes(state.unackedVoters().stream(), channel.listenerName()),
-            () -> buildEndQuorumEpochRequest(state)
+            () -> buildEndQuorumEpochRequest(state),
+            ApiKeys.END_QUORUM_EPOCH
         );
 
         GracefulShutdown shutdown = this.shutdown.get();
@@ -3138,7 +3149,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                             )
                         )
                     ),
-                voterId -> buildVoteRequest(voterId, preVote)
+                voterId -> buildVoteRequest(voterId, preVote),
+                ApiKeys.VOTE
             );
         }
         return Long.MAX_VALUE;
@@ -3310,20 +3322,24 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
     private long maybeSendFetchOrFetchSnapshot(FollowerState state, long currentTimeMs) {
         final Supplier<ApiMessage> requestSupplier;
+        final ApiKeys requestType;
 
         if (state.fetchingSnapshot().isPresent()) {
             RawSnapshotWriter snapshot = state.fetchingSnapshot().get();
             long snapshotSize = snapshot.sizeInBytes();
 
             requestSupplier = () -> buildFetchSnapshotRequest(snapshot.snapshotId(), snapshotSize);
+            requestType = ApiKeys.FETCH_SNAPSHOT;
         } else {
             requestSupplier = this::buildFetchRequest;
+            requestType = ApiKeys.FETCH;
         }
 
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            requestSupplier
+            requestSupplier,
+            requestType
         ).timeToWaitMs();
     }
 
@@ -3341,7 +3357,8 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            this::buildUpdateVoterRequest
+            this::buildUpdateVoterRequest,
+            ApiKeys.UPDATE_RAFT_VOTER
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -119,7 +119,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -2824,15 +2823,18 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private EndQuorumEpochRequestData buildEndQuorumEpochRequest(
+    private RequestSupplier buildEndQuorumEpochRequest(
         ResignedState state
     ) {
-        return RaftUtil.singletonEndQuorumEpochRequest(
-            log.topicPartition(),
-            clusterId,
-            quorum.epoch(),
-            quorum.localIdOrThrow(),
-            state.preferredSuccessors()
+        return RequestSupplier.of(
+            () -> RaftUtil.singletonEndQuorumEpochRequest(
+                log.topicPartition(),
+                clusterId,
+                quorum.epoch(),
+                quorum.localIdOrThrow(),
+                state.preferredSuccessors()
+            ),
+            ApiKeys.END_QUORUM_EPOCH
         );
     }
 
@@ -2859,62 +2861,76 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         long currentTimeMs,
         Set<ReplicaKey> remoteVoters,
         Function<Integer, Node> destinationSupplier,
-        Function<ReplicaKey, ApiMessage> requestSupplier,
-        ApiKeys requestType
+        Function<ReplicaKey, RequestSupplier> requestSupplier
     ) {
         long minBackoffMs = Long.MAX_VALUE;
         for (ReplicaKey voter: remoteVoters) {
             long backoffMs = maybeSendRequest(
                 currentTimeMs,
                 destinationSupplier.apply(voter.id()),
-                RequestSupplier.of(() -> requestSupplier.apply(voter), requestType)
+                requestSupplier.apply(voter)
             ).timeToWaitMs();
             minBackoffMs = Math.min(minBackoffMs, backoffMs);
         }
         return minBackoffMs;
     }
 
-    private BeginQuorumEpochRequestData buildBeginQuorumEpochRequest(ReplicaKey remoteVoter) {
-        return RaftUtil.singletonBeginQuorumEpochRequest(
-            log.topicPartition(),
-            clusterId,
-            quorum.epoch(),
-            quorum.localIdOrThrow(),
-            quorum.leaderEndpoints(),
-            remoteVoter
+    private RequestSupplier buildBeginQuorumEpochRequest(ReplicaKey remoteVoter) {
+        return RequestSupplier.of(
+            () -> RaftUtil.singletonBeginQuorumEpochRequest(
+                log.topicPartition(),
+                clusterId,
+                quorum.epoch(),
+                quorum.localIdOrThrow(),
+                quorum.leaderEndpoints(),
+                remoteVoter
+            ),
+            ApiKeys.BEGIN_QUORUM_EPOCH
         );
     }
 
-    private VoteRequestData buildVoteRequest(ReplicaKey remoteVoter, boolean preVote) {
-        OffsetAndEpoch endOffset = endOffset();
-        return RaftUtil.singletonVoteRequest(
-            log.topicPartition(),
-            clusterId,
-            quorum.epoch(),
-            quorum.localReplicaKeyOrThrow(),
-            remoteVoter,
-            endOffset.epoch(),
-            endOffset.offset(),
-            preVote
+    private RequestSupplier buildVoteRequest(ReplicaKey remoteVoter, boolean preVote) {
+        return RequestSupplier.of(
+            () -> {
+                OffsetAndEpoch endOffset = endOffset();
+                return RaftUtil.singletonVoteRequest(
+                    log.topicPartition(),
+                    clusterId,
+                    quorum.epoch(),
+                    quorum.localReplicaKeyOrThrow(),
+                    remoteVoter,
+                    endOffset.epoch(),
+                    endOffset.offset(),
+                    preVote
+                );
+            },
+            ApiKeys.VOTE
         );
     }
 
-    private FetchRequestData buildFetchRequest() {
-        FetchRequestData request = RaftUtil.singletonFetchRequest(
-            log.topicPartition(),
-            log.topicId(),
-            fetchPartition -> fetchPartition
-                .setCurrentLeaderEpoch(quorum.epoch())
-                .setLastFetchedEpoch(log.lastFetchedEpoch())
-                .setFetchOffset(log.endOffset().offset())
-                .setReplicaDirectoryId(quorum.localDirectoryId())
-        );
+    private RequestSupplier buildFetchRequest() {
+        return RequestSupplier.of(
+            () -> {
+                FetchRequestData request = RaftUtil.singletonFetchRequest(
+                    log.topicPartition(),
+                    log.topicId(),
+                    fetchPartition -> fetchPartition
+                        .setCurrentLeaderEpoch(quorum.epoch())
+                        .setLastFetchedEpoch(log.lastFetchedEpoch())
+                        .setFetchOffset(log.endOffset().offset())
+                        .setReplicaDirectoryId(quorum.localDirectoryId())
+                );
 
-        return request
-            .setMaxBytes(MAX_FETCH_SIZE_BYTES)
-            .setMaxWaitMs(fetchMaxWaitMs)
-            .setClusterId(clusterId)
-            .setReplicaState(new FetchRequestData.ReplicaState().setReplicaId(quorum.localIdOrSentinel()));
+                return request
+                    .setMaxBytes(MAX_FETCH_SIZE_BYTES)
+                    .setMaxWaitMs(fetchMaxWaitMs)
+                    .setClusterId(clusterId)
+                    .setReplicaState(
+                        new FetchRequestData.ReplicaState().setReplicaId(quorum.localIdOrSentinel())
+                    );
+            },
+            ApiKeys.FETCH
+        );
     }
 
     private long maybeSendFetchToAnyBootstrap(long currentTimeMs) {
@@ -2923,20 +2939,23 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             node -> maybeSendRequest(
                 currentTimeMs,
                 node,
-                RequestSupplier.of(this::buildFetchRequest, ApiKeys.FETCH)
+                buildFetchRequest()
             ).timeToWaitMs()
         ).orElseGet(() -> requestManager.backoffBeforeAvailableBootstrapServer(currentTimeMs));
     }
 
-    private FetchSnapshotRequestData buildFetchSnapshotRequest(OffsetAndEpoch snapshotId, long snapshotSize) {
-        return RaftUtil.singletonFetchSnapshotRequest(
-            clusterId,
-            ReplicaKey.of(quorum().localIdOrSentinel(), quorum.localDirectoryId()),
-            log.topicPartition(),
-            quorum.epoch(),
-            snapshotId,
-            MAX_FETCH_SIZE_BYTES,
-            snapshotSize
+    private RequestSupplier buildFetchSnapshotRequest(OffsetAndEpoch snapshotId, long snapshotSize) {
+        return RequestSupplier.of(
+            () -> RaftUtil.singletonFetchSnapshotRequest(
+                clusterId,
+                ReplicaKey.of(quorum().localIdOrSentinel(), quorum.localDirectoryId()),
+                log.topicPartition(),
+                quorum.epoch(),
+                snapshotId,
+                MAX_FETCH_SIZE_BYTES,
+                snapshotSize
+            ),
+            ApiKeys.FETCH_SNAPSHOT
         );
     }
 
@@ -3050,8 +3069,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                     .filter(key -> key.id() != quorum.localIdOrThrow())
                     .collect(Collectors.toSet()),
                 nodeSupplier,
-                this::buildBeginQuorumEpochRequest,
-                ApiKeys.BEGIN_QUORUM_EPOCH
+                this::buildBeginQuorumEpochRequest
             );
             state.resetBeginQuorumEpochTimer(currentTimeMs);
         }
@@ -3065,7 +3083,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             partitionState
                 .lastVoterSet()
                 .voterNodes(state.unackedVoters().stream(), channel.listenerName()),
-            RequestSupplier.of(() -> buildEndQuorumEpochRequest(state), ApiKeys.END_QUORUM_EPOCH)
+            buildEndQuorumEpochRequest(state)
         );
 
         GracefulShutdown shutdown = this.shutdown.get();
@@ -3145,8 +3163,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                             )
                         )
                     ),
-                voterId -> buildVoteRequest(voterId, preVote),
-                ApiKeys.VOTE
+                voterId -> buildVoteRequest(voterId, preVote)
             );
         }
         return Long.MAX_VALUE;
@@ -3313,34 +3330,34 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private long maybeSendFetchOrFetchSnapshot(FollowerState state, long currentTimeMs) {
-        final Supplier<ApiMessage> requestSupplier;
-        final ApiKeys requestType;
+        final RequestSupplier requestSupplier;
 
         if (state.fetchingSnapshot().isPresent()) {
             RawSnapshotWriter snapshot = state.fetchingSnapshot().get();
             long snapshotSize = snapshot.sizeInBytes();
 
-            requestSupplier = () -> buildFetchSnapshotRequest(snapshot.snapshotId(), snapshotSize);
-            requestType = ApiKeys.FETCH_SNAPSHOT;
+            requestSupplier = buildFetchSnapshotRequest(snapshot.snapshotId(), snapshotSize);
         } else {
-            requestSupplier = this::buildFetchRequest;
-            requestType = ApiKeys.FETCH;
+            requestSupplier = buildFetchRequest();
         }
 
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            RequestSupplier.of(requestSupplier, requestType)
+            requestSupplier
         ).timeToWaitMs();
     }
 
-    private UpdateRaftVoterRequestData buildUpdateVoterRequest() {
-        return RaftUtil.updateVoterRequest(
-            clusterId,
-            quorum.localReplicaKeyOrThrow(),
-            quorum.epoch(),
-            localSupportedKRaftVersion,
-            localListeners
+    private RequestSupplier buildUpdateVoterRequest() {
+        return RequestSupplier.of(
+            () -> RaftUtil.updateVoterRequest(
+                clusterId,
+                quorum.localReplicaKeyOrThrow(),
+                quorum.epoch(),
+                localSupportedKRaftVersion,
+                localListeners
+            ),
+            ApiKeys.UPDATE_RAFT_VOTER
         );
     }
 
@@ -3348,7 +3365,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return maybeSendRequest(
             currentTimeMs,
             state.leaderNode(channel.listenerName()),
-            RequestSupplier.of(this::buildUpdateVoterRequest, ApiKeys.UPDATE_RAFT_VOTER)
+            buildUpdateVoterRequest()
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * The request manager keeps tracks of the connection with remote replicas.
@@ -47,7 +48,7 @@ public class RequestManager {
             return new NodeAndRequestKey(node.idString(), requestKey);
         }
     }
-    private final Map<NodeAndRequestKey, ConnectionState> connections = new HashMap<>();
+    private final Map<NodeAndRequestKey, RequestState> inflightRequests = new HashMap<>();
     private final ArrayList<Node> bootstrapServers;
 
     private final int retryBackoffMs;
@@ -67,7 +68,7 @@ public class RequestManager {
     }
 
     /**
-     * Returns true if there are any connections with pending requests for a request type.
+     * Returns true if there are any in-flight requests for a set of request types.
      *
      * This is useful for satisfying the invariant that there is only one pending Fetch
      * and FetchSnapshot request.
@@ -75,29 +76,27 @@ public class RequestManager {
      * the same offset twice.
      *
      * @param currentTimeMs the current time
-     * @param requestKey the api key for the request
-     * @return true if the request manager is tracking at least one request
+     * @param requestKeys the set request types check for pending requests
+     * @return true if the request manager is tracking at least one request of the given types
      */
-    public boolean hasAnyInflightRequest(long currentTimeMs, ApiKeys requestKey) {
+    public boolean hasAnyInflightRequest(long currentTimeMs, Set<ApiKeys> requestKeys) {
         boolean result = false;
 
-        final var iterator = connections.entrySet().iterator();
+        final var iterator = inflightRequests.entrySet().iterator();
         while (iterator.hasNext()) {
             final var entry = iterator.next();
             final var nodeAndRequestKey = entry.getKey();
-            final var connection = entry.getValue();
-            if (!nodeAndRequestKey.requestKey.equals(requestKey)) {
-                continue;
-            }
-            if (connection.hasRequestTimedOut(currentTimeMs)) {
+            final var requestState = entry.getValue();
+            if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
                 iterator.remove();
-            } else if (connection.isBackoffComplete(currentTimeMs)) {
+            } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (connection.hasInflightRequest(currentTimeMs)) {
+            } else if (requestKeys.contains(nodeAndRequestKey.requestKey) &&
+                requestState.hasInflightRequest(currentTimeMs)) {
                 // If there is at least one inflight request, it is enough
-                // to stop checking the rest of the connections
+                // to stop checking the rest of the inflightRequests
                 result = true;
                 break;
             }
@@ -119,8 +118,7 @@ public class RequestManager {
     public Optional<Node> findReadyBootstrapServer(long currentTimeMs) {
         // Check that there are no inflight fetch or fetch snapshot requests
         // across any of the known nodes not just the bootstrap servers
-        if (hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH) ||
-            hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
+        if (hasAnyInflightRequest(currentTimeMs, Set.of(ApiKeys.FETCH, ApiKeys.FETCH_SNAPSHOT))) {
             return Optional.empty();
         }
 
@@ -159,26 +157,24 @@ public class RequestManager {
     public long backoffBeforeAvailableBootstrapServer(long currentTimeMs) {
         long minBackoffMs = retryBackoffMs;
 
-        final var iterator = connections.entrySet().iterator();
+        final var iterator = inflightRequests.entrySet().iterator();
         while (iterator.hasNext()) {
             final var entry = iterator.next();
-            final var nodeAndRequestKey = entry.getKey();
-            final var connection = entry.getValue();
-            if (!(nodeAndRequestKey.requestKey.equals(ApiKeys.FETCH) ||
-                nodeAndRequestKey.requestKey.equals(ApiKeys.FETCH_SNAPSHOT))) {
-                continue;
-            }
-            if (connection.hasRequestTimedOut(currentTimeMs)) {
+            final var requestType = entry.getKey().requestKey;
+            final var requestState = entry.getValue();
+            if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
                 iterator.remove();
-            } else if (connection.isBackoffComplete(currentTimeMs)) {
+            } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (connection.hasInflightRequest(currentTimeMs)) {
+            } else if ((requestType == ApiKeys.FETCH || requestType == ApiKeys.FETCH_SNAPSHOT) &&
+                requestState.hasInflightRequest(currentTimeMs)) {
                 // There can be at most one inflight fetch or fetch snapshot request
-                return connection.remainingRequestTimeMs(currentTimeMs);
-            } else if (connection.isBackingOff(currentTimeMs)) {
-                minBackoffMs = Math.min(minBackoffMs, connection.remainingBackoffMs(currentTimeMs));
+                return requestState.remainingRequestTimeMs(currentTimeMs);
+            } else if ((requestType == ApiKeys.FETCH || requestType == ApiKeys.FETCH_SNAPSHOT) &&
+                requestState.isBackingOff(currentTimeMs)) {
+                minBackoffMs = Math.min(minBackoffMs, requestState.remainingBackoffMs(currentTimeMs));
             }
         }
 
@@ -194,8 +190,16 @@ public class RequestManager {
         return minBackoffMs;
     }
 
+    /**
+     * Returns true if a request to the given node with the given request type has timed out.
+     *
+     * @param node the destination of the request
+     * @param timeMs the current time
+     * @param requestKey the type of request to check
+     * @return true if the request has timed out, false otherwise
+     */
     public boolean hasRequestTimedOut(Node node, long timeMs, ApiKeys requestKey) {
-        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
+        RequestState state = inflightRequests.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return false;
         }
@@ -203,8 +207,16 @@ public class RequestManager {
         return state.hasRequestTimedOut(timeMs);
     }
 
+    /**
+     * Returns true if a request to the given node with the given request type is ready to be sent.
+     *
+     * @param node the destination of the request
+     * @param timeMs the current time
+     * @param requestKey the type of request to check
+     * @return true if the request is ready to be sent, false otherwise
+     */
     public boolean isReady(Node node, long timeMs, ApiKeys requestKey) {
-        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
+        RequestState state = inflightRequests.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return true;
         }
@@ -217,8 +229,16 @@ public class RequestManager {
         return ready;
     }
 
+    /**
+     * Returns true if a request to the given node with the given request type is backing off.
+     *
+     * @param node the destination of the request
+     * @param timeMs the current time
+     * @param requestKey the type of request to check
+     * @return true if the request is backing off, false otherwise
+     */
     public boolean isBackingOff(Node node, long timeMs, ApiKeys requestKey) {
-        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
+        RequestState state = inflightRequests.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return false;
         }
@@ -226,8 +246,17 @@ public class RequestManager {
         return state.isBackingOff(timeMs);
     }
 
+    /**
+     * Returns the amount of time to wait in milliseconds before a request to the given
+     * node with the given request type is considered timed out.
+     *
+     * @param node the destination of the request
+     * @param timeMs the current time
+     * @param requestKey the type of request to check
+     * @return 0 if there is no in-flight request, or the amount of time left
+     */
     public long remainingRequestTimeMs(Node node, long timeMs, ApiKeys requestKey) {
-        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
+        RequestState state = inflightRequests.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return 0;
         }
@@ -235,8 +264,17 @@ public class RequestManager {
         return state.remainingRequestTimeMs(timeMs);
     }
 
+    /**
+     * Returns the amount of time to wait in milliseconds before a request to the given
+     * node with the given request type can be retried.
+     *
+     * @param node the destination of the request
+     * @param timeMs the current time
+     * @param requestKey the type of request to check
+     * @return 0 if the request is not backing off, or the amount of time left in the backoff
+     */
     public long remainingBackoffMs(Node node, long timeMs, ApiKeys requestKey) {
-        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
+        RequestState state = inflightRequests.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return 0;
         }
@@ -244,8 +282,17 @@ public class RequestManager {
         return state.remainingBackoffMs(timeMs);
     }
 
+    /**
+     * Returns whether the manager expects a response for the given request key and correlation id
+     * from the given node.
+     *
+     * @param node the node to check
+     * @param correlationId the correlation id of the request
+     * @param requestKey the type of request to check
+     * @return true if a response is expected, false otherwise
+     */
     public boolean isResponseExpected(Node node, long correlationId, ApiKeys requestKey) {
-        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
+        RequestState state = inflightRequests.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return false;
         }
@@ -275,7 +322,7 @@ public class RequestManager {
                 reset(node, requestKey);
             } else {
                 // Backoff the connection
-                connections.get(NodeAndRequestKey.of(node, requestKey))
+                inflightRequests.get(NodeAndRequestKey.of(node, requestKey))
                     .onResponseError(correlationId, timeMs);
             }
         }
@@ -290,20 +337,26 @@ public class RequestManager {
      * @param requestKey the api key for the request
      */
     public void onRequestSent(Node node, long correlationId, long timeMs, ApiKeys requestKey) {
-        ConnectionState state = connections.computeIfAbsent(
+        RequestState state = inflightRequests.computeIfAbsent(
             NodeAndRequestKey.of(node, requestKey),
-            key -> new ConnectionState(node, retryBackoffMs, requestTimeoutMs)
+            key -> new RequestState(node, retryBackoffMs, requestTimeoutMs)
         );
 
         state.onRequestSent(correlationId, timeMs);
     }
 
+    /**
+     * Updates the manager when a request is completed or times out.
+     *
+     * @param node the destination of the request
+     * @param requestKey the api key for the request
+     */
     public void reset(Node node, ApiKeys requestKey) {
-        connections.remove(NodeAndRequestKey.of(node, requestKey));
+        inflightRequests.remove(NodeAndRequestKey.of(node, requestKey));
     }
 
     public void resetAll() {
-        connections.clear();
+        inflightRequests.clear();
     }
 
     private enum State {
@@ -312,7 +365,7 @@ public class RequestManager {
         READY
     }
 
-    private static final class ConnectionState {
+    private static final class RequestState {
         private final Node node;
         private final int retryBackoffMs;
         private final int requestTimeoutMs;
@@ -322,7 +375,7 @@ public class RequestManager {
         private long lastFailTimeMs = 0L;
         private OptionalLong inFlightCorrelationId = OptionalLong.empty();
 
-        private ConnectionState(
+        private RequestState(
             Node node,
             int retryBackoffMs,
             int requestTimeoutMs
@@ -402,7 +455,7 @@ public class RequestManager {
         @Override
         public String toString() {
             return String.format(
-                "ConnectionState(node=%s, state=%s, lastSendTimeMs=%d, lastFailTimeMs=%d, inFlightCorrelationId=%s)",
+                "RequestState(node=%s, state=%s, lastSendTimeMs=%d, lastFailTimeMs=%d, inFlightCorrelationId=%s)",
                 node,
                 state,
                 lastSendTimeMs,

--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -18,6 +18,7 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.raft.internals.RequestType;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,15 +27,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Random;
-import java.util.Set;
 
 /**
- * The request manager keeps tracks of the connection with remote replicas.
+ * The request manager keeps track of the pending requests with remote replicas. The manager supports
+ * one pending request per type per node, except for FETCH and FETCH_SNAPSHOT requests. For those,
+ * the manager allows at most one pending request across all nodes to prevent writing the same offset twice.
  *
- * When sending a request update this type by calling {@code onRequestSent(Node, long, long)}. When
- * the RPC returns a response, update this manager with {@code onResponseResult(Node, long, boolean, long)}.
+ * When sending a request update this type by calling {@code onRequestSent(Node, long, long, ApiKeys)}.
+ * When the RPC returns a response, update this manager with {@code onResponseResult(Node, long, boolean, long, ApiKeys)}.
  *
- * Connections start in the ready state ({@code isReady(Node, long)} returns true).
+ * Requests start in the ready state ({@code isReady(Node, long, ApiKeys)} returns true).
  *
  * When a request times out or completes successfully the collection will transition back to the
  * ready state.
@@ -43,9 +45,9 @@ import java.util.Set;
  * {@code retryBackoffMs}.
  */
 public class RequestManager {
-    private record NodeAndRequestKey(String nodeId, ApiKeys requestKey) {
-        private static NodeAndRequestKey of(Node node, ApiKeys requestKey) {
-            return new NodeAndRequestKey(node.idString(), requestKey);
+    private record NodeAndRequestKey(String nodeId, RequestType requestType) {
+        private static NodeAndRequestKey of(Node node, ApiKeys requestType) {
+            return new NodeAndRequestKey(node.idString(), RequestType.of(requestType));
         }
     }
     private final Map<NodeAndRequestKey, RequestState> inflightRequests = new HashMap<>();
@@ -68,7 +70,7 @@ public class RequestManager {
     }
 
     /**
-     * Returns true if there are any in-flight requests for a set of request types.
+     * Returns true if there are any in-flight requests for a request type.
      *
      * This is useful for satisfying the invariant that there is only one pending Fetch
      * and FetchSnapshot request.
@@ -76,10 +78,10 @@ public class RequestManager {
      * the same offset twice.
      *
      * @param currentTimeMs the current time
-     * @param requestKeys the set request types check for pending requests
-     * @return true if the request manager is tracking at least one request of the given types
+     * @param requestKey the request type to check for pending requests
+     * @return true if the request manager is tracking at least one request of the given type
      */
-    public boolean hasAnyInflightRequest(long currentTimeMs, Set<ApiKeys> requestKeys) {
+    public boolean hasAnyInflightRequest(long currentTimeMs, ApiKeys requestKey) {
         boolean result = false;
 
         final var iterator = inflightRequests.entrySet().iterator();
@@ -93,7 +95,7 @@ public class RequestManager {
             } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (requestKeys.contains(nodeAndRequestKey.requestKey) &&
+            } else if (nodeAndRequestKey.requestType().apiKey() == requestKey &&
                 requestState.hasInflightRequest(currentTimeMs)) {
                 // If there is at least one inflight request, it is enough
                 // to stop checking the rest of the inflightRequests
@@ -118,7 +120,7 @@ public class RequestManager {
     public Optional<Node> findReadyBootstrapServer(long currentTimeMs) {
         // Check that there are no inflight fetch or fetch snapshot requests
         // across any of the known nodes not just the bootstrap servers
-        if (hasAnyInflightRequest(currentTimeMs, Set.of(ApiKeys.FETCH, ApiKeys.FETCH_SNAPSHOT))) {
+        if (hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH)) {
             return Optional.empty();
         }
 
@@ -128,8 +130,7 @@ public class RequestManager {
             int index = (startIndex + i) % bootstrapServers.size();
             Node node = bootstrapServers.get(index);
 
-            if (isReady(node, currentTimeMs, ApiKeys.FETCH) &&
-                isReady(node, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
+            if (isReady(node, currentTimeMs, ApiKeys.FETCH)) {
                 result = Optional.of(node);
                 break;
             }
@@ -160,7 +161,7 @@ public class RequestManager {
         final var iterator = inflightRequests.entrySet().iterator();
         while (iterator.hasNext()) {
             final var entry = iterator.next();
-            final var requestType = entry.getKey().requestKey;
+            final var requestType = entry.getKey().requestType().apiKey();
             final var requestState = entry.getValue();
             if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
@@ -168,11 +169,11 @@ public class RequestManager {
             } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if ((requestType == ApiKeys.FETCH || requestType == ApiKeys.FETCH_SNAPSHOT) &&
+            } else if (requestType == ApiKeys.FETCH &&
                 requestState.hasInflightRequest(currentTimeMs)) {
                 // There can be at most one inflight fetch or fetch snapshot request
                 return requestState.remainingRequestTimeMs(currentTimeMs);
-            } else if ((requestType == ApiKeys.FETCH || requestType == ApiKeys.FETCH_SNAPSHOT) &&
+            } else if (requestType == ApiKeys.FETCH &&
                 requestState.isBackingOff(currentTimeMs)) {
                 minBackoffMs = Math.min(minBackoffMs, requestState.remainingBackoffMs(currentTimeMs));
             }
@@ -180,8 +181,7 @@ public class RequestManager {
 
         // There are no inflight fetch requests so check if there is a ready bootstrap server
         for (Node node : bootstrapServers) {
-            if (isReady(node, currentTimeMs, ApiKeys.FETCH) &&
-                isReady(node, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
+            if (isReady(node, currentTimeMs, ApiKeys.FETCH)) {
                 return 0L;
             }
         }

--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -17,11 +17,11 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.protocol.ApiKeys;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -42,7 +42,12 @@ import java.util.Random;
  * {@code retryBackoffMs}.
  */
 public class RequestManager {
-    private final Map<String, ConnectionState> connections = new HashMap<>();
+    private record NodeAndRequestKey(String nodeId, ApiKeys requestKey) {
+        private static NodeAndRequestKey of(Node node, ApiKeys requestKey) {
+            return new NodeAndRequestKey(node.idString(), requestKey);
+        }
+    }
+    private final Map<NodeAndRequestKey, ConnectionState> connections = new HashMap<>();
     private final ArrayList<Node> bootstrapServers;
 
     private final int retryBackoffMs;
@@ -62,21 +67,28 @@ public class RequestManager {
     }
 
     /**
-     * Returns true if there are any connections with pending requests.
+     * Returns true if there are any connections with pending requests for a request type.
      *
-     * This is useful for satisfying the invariant that there is only one pending Fetch request.
+     * This is useful for satisfying the invariant that there is only one pending Fetch
+     * and FetchSnapshot request.
      * If there are more than one pending fetch request, it is possible for the follower to write
      * the same offset twice.
      *
      * @param currentTimeMs the current time
+     * @param requestKey the api key for the request
      * @return true if the request manager is tracking at least one request
      */
-    public boolean hasAnyInflightRequest(long currentTimeMs) {
+    public boolean hasAnyInflightRequest(long currentTimeMs, ApiKeys requestKey) {
         boolean result = false;
 
-        Iterator<ConnectionState> iterator = connections.values().iterator();
+        final var iterator = connections.entrySet().iterator();
         while (iterator.hasNext()) {
-            ConnectionState connection = iterator.next();
+            final var entry = iterator.next();
+            final var nodeAndRequestKey = entry.getKey();
+            final var connection = entry.getValue();
+            if (!nodeAndRequestKey.requestKey.equals(requestKey)) {
+                continue;
+            }
             if (connection.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
                 iterator.remove();
@@ -99,15 +111,18 @@ public class RequestManager {
      *
      * This method doesn't return a node if there is at least one request pending. In general this
      * method is used to send Fetch requests. Fetch requests have the invariant that there can
-     * only be one pending Fetch request for the LEO.
+     * only be one pending Fetch or FetchSnapshot request for the LEO.
      *
      * @param currentTimeMs the current time
      * @return a random ready bootstrap node
      */
     public Optional<Node> findReadyBootstrapServer(long currentTimeMs) {
-        // Check that there are no inflight requests across any of the known nodes not just
-        // the bootstrap servers
-        if (hasAnyInflightRequest(currentTimeMs)) {
+        // Check that there are no inflight fetch or fetch snapshot requests
+        // across any of the known nodes not just the bootstrap servers
+        System.out.println(connections);
+        System.out.println("requestTImeoutMs: " + requestTimeoutMs);
+        if (hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH) ||
+            hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
             return Optional.empty();
         }
 
@@ -117,7 +132,8 @@ public class RequestManager {
             int index = (startIndex + i) % bootstrapServers.size();
             Node node = bootstrapServers.get(index);
 
-            if (isReady(node, currentTimeMs)) {
+            if (isReady(node, currentTimeMs, ApiKeys.FETCH) &&
+                isReady(node, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
                 result = Optional.of(node);
                 break;
             }
@@ -145,9 +161,15 @@ public class RequestManager {
     public long backoffBeforeAvailableBootstrapServer(long currentTimeMs) {
         long minBackoffMs = retryBackoffMs;
 
-        Iterator<ConnectionState> iterator = connections.values().iterator();
+        final var iterator = connections.entrySet().iterator();
         while (iterator.hasNext()) {
-            ConnectionState connection = iterator.next();
+            final var entry = iterator.next();
+            final var nodeAndRequestKey = entry.getKey();
+            final var connection = entry.getValue();
+            if (!(nodeAndRequestKey.requestKey.equals(ApiKeys.FETCH) ||
+                nodeAndRequestKey.requestKey.equals(ApiKeys.FETCH_SNAPSHOT))) {
+                continue;
+            }
             if (connection.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
                 iterator.remove();
@@ -155,7 +177,7 @@ public class RequestManager {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
             } else if (connection.hasInflightRequest(currentTimeMs)) {
-                // There can be at most one inflight fetch request
+                // There can be at most one inflight fetch or fetch snapshot request
                 return connection.remainingRequestTimeMs(currentTimeMs);
             } else if (connection.isBackingOff(currentTimeMs)) {
                 minBackoffMs = Math.min(minBackoffMs, connection.remainingBackoffMs(currentTimeMs));
@@ -164,7 +186,8 @@ public class RequestManager {
 
         // There are no inflight fetch requests so check if there is a ready bootstrap server
         for (Node node : bootstrapServers) {
-            if (isReady(node, currentTimeMs)) {
+            if (isReady(node, currentTimeMs, ApiKeys.FETCH) &&
+                isReady(node, currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
                 return 0L;
             }
         }
@@ -173,8 +196,8 @@ public class RequestManager {
         return minBackoffMs;
     }
 
-    public boolean hasRequestTimedOut(Node node, long timeMs) {
-        ConnectionState state = connections.get(node.idString());
+    public boolean hasRequestTimedOut(Node node, long timeMs, ApiKeys requestKey) {
+        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return false;
         }
@@ -182,22 +205,22 @@ public class RequestManager {
         return state.hasRequestTimedOut(timeMs);
     }
 
-    public boolean isReady(Node node, long timeMs) {
-        ConnectionState state = connections.get(node.idString());
+    public boolean isReady(Node node, long timeMs, ApiKeys requestKey) {
+        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return true;
         }
 
         boolean ready = state.isReady(timeMs);
         if (ready) {
-            reset(node);
+            reset(node, requestKey);
         }
 
         return ready;
     }
 
-    public boolean isBackingOff(Node node, long timeMs) {
-        ConnectionState state = connections.get(node.idString());
+    public boolean isBackingOff(Node node, long timeMs, ApiKeys requestKey) {
+        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return false;
         }
@@ -205,8 +228,8 @@ public class RequestManager {
         return state.isBackingOff(timeMs);
     }
 
-    public long remainingRequestTimeMs(Node node, long timeMs) {
-        ConnectionState state = connections.get(node.idString());
+    public long remainingRequestTimeMs(Node node, long timeMs, ApiKeys requestKey) {
+        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return 0;
         }
@@ -214,8 +237,8 @@ public class RequestManager {
         return state.remainingRequestTimeMs(timeMs);
     }
 
-    public long remainingBackoffMs(Node node, long timeMs) {
-        ConnectionState state = connections.get(node.idString());
+    public long remainingBackoffMs(Node node, long timeMs, ApiKeys requestKey) {
+        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return 0;
         }
@@ -223,8 +246,8 @@ public class RequestManager {
         return state.remainingBackoffMs(timeMs);
     }
 
-    public boolean isResponseExpected(Node node, long correlationId) {
-        ConnectionState state = connections.get(node.idString());
+    public boolean isResponseExpected(Node node, long correlationId, ApiKeys requestKey) {
+        ConnectionState state = connections.get(NodeAndRequestKey.of(node, requestKey));
         if (state == null) {
             return false;
         }
@@ -239,15 +262,23 @@ public class RequestManager {
      * @param correlationId the correlation id of the response
      * @param success true if the request was successful, false otherwise
      * @param timeMs the current time
+     * @param requestKey the api key for the request
      */
-    public void onResponseResult(Node node, long correlationId, boolean success, long timeMs) {
-        if (isResponseExpected(node, correlationId)) {
+    public void onResponseResult(
+        Node node,
+        long correlationId,
+        boolean success,
+        long timeMs,
+        ApiKeys requestKey
+    ) {
+        if (isResponseExpected(node, correlationId, requestKey)) {
             if (success) {
                 // Mark the connection as ready by resetting it
-                reset(node);
+                reset(node, requestKey);
             } else {
                 // Backoff the connection
-                connections.get(node.idString()).onResponseError(correlationId, timeMs);
+                connections.get(NodeAndRequestKey.of(node, requestKey))
+                    .onResponseError(correlationId, timeMs);
             }
         }
     }
@@ -258,18 +289,19 @@ public class RequestManager {
      * @param node the destination of the request
      * @param correlationId the correlation id of the request
      * @param timeMs the current time
+     * @param requestKey the api key for the request
      */
-    public void onRequestSent(Node node, long correlationId, long timeMs) {
+    public void onRequestSent(Node node, long correlationId, long timeMs, ApiKeys requestKey) {
         ConnectionState state = connections.computeIfAbsent(
-            node.idString(),
+            NodeAndRequestKey.of(node, requestKey),
             key -> new ConnectionState(node, retryBackoffMs, requestTimeoutMs)
         );
 
         state.onRequestSent(correlationId, timeMs);
     }
 
-    public void reset(Node node) {
-        connections.remove(node.idString());
+    public void reset(Node node, ApiKeys requestKey) {
+        connections.remove(NodeAndRequestKey.of(node, requestKey));
     }
 
     public void resetAll() {

--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -119,8 +119,6 @@ public class RequestManager {
     public Optional<Node> findReadyBootstrapServer(long currentTimeMs) {
         // Check that there are no inflight fetch or fetch snapshot requests
         // across any of the known nodes not just the bootstrap servers
-        System.out.println(connections);
-        System.out.println("requestTImeoutMs: " + requestTimeoutMs);
         if (hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH) ||
             hasAnyInflightRequest(currentTimeMs, ApiKeys.FETCH_SNAPSHOT)) {
             return Optional.empty();

--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -38,7 +38,7 @@ import java.util.Random;
  *
  * Requests start in the ready state ({@code isReady(Node, long, ApiKeys)} returns true).
  *
- * When a request times out or completes successfully the collection will transition back to the
+ * When a request times out or completes successfully the request state will transition back to the
  * ready state.
  *
  * When a request completes with an error it still transitions to the backoff state until
@@ -85,9 +85,10 @@ public class RequestManager {
         boolean result = false;
 
         final var iterator = inflightRequests.entrySet().iterator();
+        final var wantRequestType = RequestType.of(wantRequestKey);
         while (iterator.hasNext()) {
             final var entry = iterator.next();
-            final var requestKey = entry.getKey().requestType().apiKey();
+            final var requestType = entry.getKey().requestType();
             final var requestState = entry.getValue();
             if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
@@ -95,7 +96,7 @@ public class RequestManager {
             } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (requestKey == wantRequestKey &&
+            } else if (requestType.equals(wantRequestType) &&
                 requestState.hasInflightRequest(currentTimeMs)) {
                 // If there is at least one inflight request, it is enough
                 // to stop checking the rest of the inflightRequests
@@ -161,7 +162,7 @@ public class RequestManager {
         final var iterator = inflightRequests.entrySet().iterator();
         while (iterator.hasNext()) {
             final var entry = iterator.next();
-            final var requestKey = entry.getKey().requestType().apiKey();
+            final var requestType = entry.getKey().requestType();
             final var requestState = entry.getValue();
             if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
@@ -169,11 +170,11 @@ public class RequestManager {
             } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (requestKey == ApiKeys.FETCH &&
+            } else if (requestType.equals(RequestType.FETCH_AND_FETCH_SNAPSHOT) &&
                 requestState.hasInflightRequest(currentTimeMs)) {
                 // There can be at most one inflight fetch or fetch snapshot request
                 return requestState.remainingRequestTimeMs(currentTimeMs);
-            } else if (requestKey == ApiKeys.FETCH &&
+            } else if (requestType.equals(RequestType.FETCH_AND_FETCH_SNAPSHOT) &&
                 requestState.isBackingOff(currentTimeMs)) {
                 minBackoffMs = Math.min(minBackoffMs, requestState.remainingBackoffMs(currentTimeMs));
             }

--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -78,16 +78,16 @@ public class RequestManager {
      * the same offset twice.
      *
      * @param currentTimeMs the current time
-     * @param requestKey the request type to check for pending requests
+     * @param wantRequestKey the request type to check for in-flight requests
      * @return true if the request manager is tracking at least one request of the given type
      */
-    public boolean hasAnyInflightRequest(long currentTimeMs, ApiKeys requestKey) {
+    public boolean hasAnyInflightRequest(long currentTimeMs, ApiKeys wantRequestKey) {
         boolean result = false;
 
         final var iterator = inflightRequests.entrySet().iterator();
         while (iterator.hasNext()) {
             final var entry = iterator.next();
-            final var nodeAndRequestKey = entry.getKey();
+            final var requestKey = entry.getKey().requestType().apiKey();
             final var requestState = entry.getValue();
             if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
@@ -95,7 +95,7 @@ public class RequestManager {
             } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (nodeAndRequestKey.requestType().apiKey() == requestKey &&
+            } else if (requestKey == wantRequestKey &&
                 requestState.hasInflightRequest(currentTimeMs)) {
                 // If there is at least one inflight request, it is enough
                 // to stop checking the rest of the inflightRequests
@@ -161,7 +161,7 @@ public class RequestManager {
         final var iterator = inflightRequests.entrySet().iterator();
         while (iterator.hasNext()) {
             final var entry = iterator.next();
-            final var requestType = entry.getKey().requestType().apiKey();
+            final var requestKey = entry.getKey().requestType().apiKey();
             final var requestState = entry.getValue();
             if (requestState.hasRequestTimedOut(currentTimeMs)) {
                 // Mark the node as ready after request timeout
@@ -169,11 +169,11 @@ public class RequestManager {
             } else if (requestState.isBackoffComplete(currentTimeMs)) {
                 // Mark the node as ready after completed backoff
                 iterator.remove();
-            } else if (requestType == ApiKeys.FETCH &&
+            } else if (requestKey == ApiKeys.FETCH &&
                 requestState.hasInflightRequest(currentTimeMs)) {
                 // There can be at most one inflight fetch or fetch snapshot request
                 return requestState.remainingRequestTimeMs(currentTimeMs);
-            } else if (requestType == ApiKeys.FETCH &&
+            } else if (requestKey == ApiKeys.FETCH &&
                 requestState.isBackingOff(currentTimeMs)) {
                 minBackoffMs = Math.min(minBackoffMs, requestState.remainingBackoffMs(currentTimeMs));
             }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
@@ -63,20 +63,21 @@ public final class DefaultRequestSender  implements RequestSender {
         Supplier<ApiMessage> requestSupplier,
         long currentTimeMs
     ) {
-        if (requestManager.isBackingOff(destination, currentTimeMs)) {
-            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs);
+        final var request = requestSupplier.get();
+        final var api = ApiKeys.forId(request.apiKey());
+        if (requestManager.isBackingOff(destination, currentTimeMs, api)) {
+            long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs, api);
             logger.debug("Connection for {} is backing off for {} ms", destination, remainingBackoffMs);
             return OptionalLong.empty();
         }
 
-        if (!requestManager.isReady(destination, currentTimeMs)) {
-            long remainingMs = requestManager.remainingRequestTimeMs(destination, currentTimeMs);
+        if (!requestManager.isReady(destination, currentTimeMs, api)) {
+            long remainingMs = requestManager.remainingRequestTimeMs(destination, currentTimeMs, api);
             logger.debug("Connection for {} has a pending request for {} ms", destination, remainingMs);
             return OptionalLong.empty();
         }
 
         int correlationId = channel.newCorrelationId();
-        ApiMessage request = requestSupplier.get();
 
         RaftRequest.Outbound requestMessage = new RaftRequest.Outbound(
             correlationId,
@@ -87,7 +88,6 @@ public final class DefaultRequestSender  implements RequestSender {
 
         requestMessage.completion.whenComplete((response, exception) -> {
             if (exception != null) {
-                ApiKeys api = ApiKeys.forId(request.apiKey());
                 Errors error = Errors.forException(exception);
                 ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
 
@@ -101,10 +101,10 @@ public final class DefaultRequestSender  implements RequestSender {
             messageQueue.add(response);
         });
 
-        requestManager.onRequestSent(destination, correlationId, currentTimeMs);
+        requestManager.onRequestSent(destination, correlationId, currentTimeMs, api);
         channel.send(requestMessage);
         logger.trace("Sent outbound request: {}", requestMessage);
 
-        return OptionalLong.of(requestManager.remainingRequestTimeMs(destination, currentTimeMs));
+        return OptionalLong.of(requestManager.remainingRequestTimeMs(destination, currentTimeMs, api));
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RequestSupplier.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RequestSupplier.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import java.util.function.Supplier;
+
+/**
+ * This class is used to generate requests from a supplier for KRaft RPCs. If the
+ * api key of the supplier's generated request does not match the expected api key,
+ * an IllegalStateException is thrown.
+ */
+public class RequestSupplier {
+    private final Supplier<ApiMessage> supplier;
+    private final ApiKeys apiKey;
+
+    private RequestSupplier(Supplier<ApiMessage> supplier, ApiKeys apiKey) {
+        this.supplier = supplier;
+        this.apiKey = apiKey;
+    }
+
+    public static RequestSupplier of(
+        Supplier<ApiMessage> supplier,
+        ApiKeys apiKey
+    ) {
+        return new RequestSupplier(supplier, apiKey);
+    }
+
+    public ApiMessage request() {
+        ApiMessage request = supplier.get();
+        if (request.apiKey() != apiKey.id) {
+            throw new IllegalStateException("Request type mismatch: expected " + apiKey +
+                " but got " + request.apiKey());
+        }
+        return request;
+    }
+
+    public ApiKeys apiKey() {
+        return apiKey;
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RequestType.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RequestType.java
@@ -59,4 +59,9 @@ public class RequestType {
     public int hashCode() {
         return apiKey.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return String.format("RequestType(apiKey=%s)", apiKey.name());
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RequestType.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RequestType.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+/**
+ * This class is used to wrap the ApiKeys enum for KRaft RPCs so the KRaft request
+ * manager can treat the FETCH and FETCH_SNAPSHOT requests as the same type when
+ * managing in-flight requests. This is useful for satisfying the invariant
+ * that at most one FETCH or FETCH_SNAPSHOT request is pending at any time.
+ */
+public class RequestType {
+    private final ApiKeys apiKey;
+
+    private RequestType(ApiKeys apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public static RequestType of(ApiKeys apiKey) {
+        if (apiKey == ApiKeys.FETCH_SNAPSHOT) {
+            return new RequestType(ApiKeys.FETCH);
+        }
+        return new RequestType(apiKey);
+    }
+
+    public ApiKeys apiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RequestType)) {
+            return false;
+        }
+        RequestType other = (RequestType) obj;
+        return apiKey == other.apiKey;
+    }
+
+    @Override
+    public int hashCode() {
+        return apiKey.hashCode();
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RequestType.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RequestType.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
  * that at most one FETCH or FETCH_SNAPSHOT request is pending at any time.
  */
 public class RequestType {
+    public static final RequestType FETCH_AND_FETCH_SNAPSHOT = new RequestType(ApiKeys.FETCH);
     private final ApiKeys apiKey;
 
     private RequestType(ApiKeys apiKey) {
@@ -33,7 +34,7 @@ public class RequestType {
 
     public static RequestType of(ApiKeys apiKey) {
         if (apiKey == ApiKeys.FETCH_SNAPSHOT) {
-            return new RequestType(ApiKeys.FETCH);
+            return FETCH_AND_FETCH_SNAPSHOT;
         }
         return new RequestType(apiKey);
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2730,9 +2730,22 @@ public class KafkaRaftClientReconfigTest {
 
         // don't send a response but increase the time
         context.time.sleep(context.requestTimeoutMs() - 1);
+        // this poll will result in sending an update voter request because there is not one
+        // in flight and its timer has expired
         context.client.poll();
+        context.assertSentUpdateVoterRequest(
+            local,
+            epoch,
+            Feature.KRAFT_VERSION.supportedVersionRange(),
+            localListeners
+        );
 
-        // expect an update voter request after the FETCH rpc completes
+        // polling again should not send any request because there are pending fetch and
+        // update voter requests
+        context.client.poll();
+        assertFalse(context.channel.hasSentRequests());
+
+        // deliver the fetch response
         context.deliverResponse(
             fetchRequest.correlationId(),
             fetchRequest.destination(),
@@ -2744,13 +2757,11 @@ public class KafkaRaftClientReconfigTest {
                 Errors.NONE
             )
         );
+
+        // The next request should be a fetch
         context.pollUntilRequest();
-        context.assertSentUpdateVoterRequest(
-            local,
-            epoch,
-            Feature.KRAFT_VERSION.supportedVersionRange(),
-            localListeners
-        );
+        fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2250,13 +2250,16 @@ public class KafkaRaftClientReconfigTest {
                 new LeaderAndEpoch(OptionalInt.of(voter1.id()), epoch)
             )
         );
+        // polling sends a fetch because no fetches are in flight, only the update voter
         context.client.poll();
+        RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
 
         // after sending an update voter the next requests should be fetch and no update voter
         for (int i = 0; i < 10; i++) {
             context.time.sleep(context.fetchTimeoutMs - 1);
             context.pollUntilRequest();
-            RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
+            fetchRequest = context.assertSentFetchRequest();
             context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
 
             context.deliverResponse(
@@ -2728,7 +2731,6 @@ public class KafkaRaftClientReconfigTest {
         // don't send a response but increase the time
         context.time.sleep(context.requestTimeoutMs() - 1);
         context.client.poll();
-        assertFalse(context.channel.hasSentRequests());
 
         // expect an update voter request after the FETCH rpc completes
         context.deliverResponse(
@@ -2817,9 +2819,16 @@ public class KafkaRaftClientReconfigTest {
             )
         );
 
-        // check that there is a fetch to the new leader
+        // the first poll can still send a fetch request to the old leader, because there is not one in flight
+        // but will handle the update voter response afterwards to update state
         context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
+        assertEquals(voter1.id(), fetchRequest.destination().id());
+
+        // the next poll should send a fetch request to the new leader
+        context.pollUntilRequest();
+        fetchRequest = context.assertSentFetchRequest();
         context.assertFetchRequestData(fetchRequest, epoch + 1, 0L, 0);
         assertEquals(voter2.id(), fetchRequest.destination().id());
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2251,6 +2251,7 @@ public class KafkaRaftClientReconfigTest {
             )
         );
         // polling sends a fetch because no fetches are in flight, only the update voter
+        // it will also handle the incoming update voter response, which will reset the fetch timer
         context.client.poll();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
@@ -2830,12 +2831,27 @@ public class KafkaRaftClientReconfigTest {
             )
         );
 
-        // the first poll can still send a fetch request to the old leader, because there is not one in flight
-        // but will handle the update voter response afterwards to update state
+        // this poll will send a fetch request to the old leader, because there is not one in flight
+        // after sending the request, the local replica will handle the update voter response to update
+        // its state to a higher epoch
         context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
         assertEquals(voter1.id(), fetchRequest.destination().id());
+
+        // deliver the old fetch response with some records, which should be
+        // ignored on the next poll since the local replica is now in a higher epoch
+        context.deliverResponse(
+            fetchRequest.correlationId(),
+            fetchRequest.destination(),
+            context.fetchResponse(
+                epoch,
+                voter1.id(),
+                context.buildBatch(0L, epoch, List.of("a", "b", "c")),
+                3L,
+                Errors.NONE
+            )
+        );
 
         // the next poll should send a fetch request to the new leader
         context.pollUntilRequest();

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -363,22 +362,23 @@ public class RequestManagerTest {
             random
         );
 
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot, updateVoter)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send a request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetchSnapshot, updateVoter)));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send the other request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), updateVoter);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(updateVoter)));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetchSnapshot)));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot, updateVoter)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Results should not affect the connection state of other request types
         cache.onRequestSent(otherNode, 12, time.milliseconds(), updateVoter);
@@ -386,14 +386,15 @@ public class RequestManagerTest {
         // Send another request and fail it
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot)));
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(updateVoter)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
-        // Send another request and mark it successful
+        // Send fetch snapshot request, it should be treated the same as fetch
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetchSnapshot);
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetchSnapshot);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot)));
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(updateVoter)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
     }
 
     @Test
@@ -407,25 +408,25 @@ public class RequestManagerTest {
             random
         );
 
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Send a request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Send another request and fail it
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Send another request and mark it successful
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
     }
 
     private List<Node> makeBootstrapList(int numberOfNodes) {

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -353,21 +353,25 @@ public class RequestManagerTest {
         );
 
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send a request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send the other request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), updateVoter);
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Results should not affect the connection state of other request types
@@ -377,13 +381,18 @@ public class RequestManagerTest {
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send fetch snapshot request, it should be treated the same as fetch
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetchSnapshot);
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetchSnapshot);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.utils.MockTime;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ public class RequestManagerTest {
     private final int requestTimeoutMs = 30000;
     private final int retryBackoffMs = 100;
     private final Random random = new Random(1);
+    private final ApiKeys fetch = ApiKeys.FETCH;
 
     @Test
     public void testResetAllConnections() {
@@ -51,19 +53,19 @@ public class RequestManagerTest {
         );
 
         // One host has an inflight request
-        cache.onRequestSent(node1, 1, time.milliseconds());
-        assertFalse(cache.isReady(node1, time.milliseconds()));
+        cache.onRequestSent(node1, 1, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node1, time.milliseconds(), fetch));
 
         // Another is backing off
-        cache.onRequestSent(node2, 2, time.milliseconds());
-        cache.onResponseResult(node2, 2, false, time.milliseconds());
-        assertFalse(cache.isReady(node2, time.milliseconds()));
+        cache.onRequestSent(node2, 2, time.milliseconds(), fetch);
+        cache.onResponseResult(node2, 2, false, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node2, time.milliseconds(), fetch));
 
         cache.resetAll();
 
         // Now both should be ready
-        assertTrue(cache.isReady(node1, time.milliseconds()));
-        assertTrue(cache.isReady(node2, time.milliseconds()));
+        assertTrue(cache.isReady(node1, time.milliseconds(), fetch));
+        assertTrue(cache.isReady(node2, time.milliseconds(), fetch));
     }
 
     @Test
@@ -77,17 +79,17 @@ public class RequestManagerTest {
             random
         );
 
-        assertTrue(cache.isReady(node, time.milliseconds()));
+        assertTrue(cache.isReady(node, time.milliseconds(), fetch));
 
         long correlationId = 1;
-        cache.onRequestSent(node, correlationId, time.milliseconds());
-        assertFalse(cache.isReady(node, time.milliseconds()));
+        cache.onRequestSent(node, correlationId, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
 
-        cache.onResponseResult(node, correlationId, false, time.milliseconds());
-        assertFalse(cache.isReady(node, time.milliseconds()));
+        cache.onResponseResult(node, correlationId, false, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
 
         time.sleep(retryBackoffMs);
-        assertTrue(cache.isReady(node, time.milliseconds()));
+        assertTrue(cache.isReady(node, time.milliseconds(), fetch));
     }
 
     @Test
@@ -102,10 +104,10 @@ public class RequestManagerTest {
         );
 
         long correlationId = 1;
-        cache.onRequestSent(node, correlationId, time.milliseconds());
-        assertFalse(cache.isReady(node, time.milliseconds()));
-        cache.onResponseResult(node, correlationId, true, time.milliseconds());
-        assertTrue(cache.isReady(node, time.milliseconds()));
+        cache.onRequestSent(node, correlationId, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+        cache.onResponseResult(node, correlationId, true, time.milliseconds(), fetch);
+        assertTrue(cache.isReady(node, time.milliseconds(), fetch));
     }
 
     @Test
@@ -120,10 +122,10 @@ public class RequestManagerTest {
         );
 
         long correlationId = 1;
-        cache.onRequestSent(node, correlationId, time.milliseconds());
-        assertFalse(cache.isReady(node, time.milliseconds()));
-        cache.onResponseResult(node, correlationId + 1, true, time.milliseconds());
-        assertFalse(cache.isReady(node, time.milliseconds()));
+        cache.onRequestSent(node, correlationId, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+        cache.onResponseResult(node, correlationId + 1, true, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
     }
 
     @Test
@@ -138,14 +140,14 @@ public class RequestManagerTest {
         );
 
         long correlationId = 1;
-        cache.onRequestSent(node, correlationId, time.milliseconds());
-        assertFalse(cache.isReady(node, time.milliseconds()));
+        cache.onRequestSent(node, correlationId, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
 
         time.sleep(requestTimeoutMs - 1);
-        assertFalse(cache.isReady(node, time.milliseconds()));
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
 
         time.sleep(1);
-        assertTrue(cache.isReady(node, time.milliseconds()));
+        assertTrue(cache.isReady(node, time.milliseconds(), fetch));
     }
 
     @Test
@@ -167,7 +169,7 @@ public class RequestManagerTest {
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
 
         // Send a request and check the cache state
-        cache.onRequestSent(bootstrapNode1, 1, time.milliseconds());
+        cache.onRequestSent(bootstrapNode1, 1, time.milliseconds(), fetch);
         assertEquals(
             Optional.empty(),
             cache.findReadyBootstrapServer(time.milliseconds())
@@ -176,13 +178,13 @@ public class RequestManagerTest {
 
         // Fail the request
         time.sleep(100);
-        cache.onResponseResult(bootstrapNode1, 1, false, time.milliseconds());
+        cache.onResponseResult(bootstrapNode1, 1, false, time.milliseconds(), fetch);
         Node bootstrapNode2 = cache.findReadyBootstrapServer(time.milliseconds()).get();
         assertNotEquals(bootstrapNode1, bootstrapNode2);
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
 
         // Send a request to the second node and check the state
-        cache.onRequestSent(bootstrapNode2, 2, time.milliseconds());
+        cache.onRequestSent(bootstrapNode2, 2, time.milliseconds(), fetch);
         assertEquals(
             Optional.empty(),
             cache.findReadyBootstrapServer(time.milliseconds())
@@ -192,7 +194,7 @@ public class RequestManagerTest {
 
         // Fail the second request before the request timeout
         time.sleep(retryBackoffMs - 1);
-        cache.onResponseResult(bootstrapNode2, 2, false, time.milliseconds());
+        cache.onResponseResult(bootstrapNode2, 2, false, time.milliseconds(), fetch);
         assertEquals(
             Optional.empty(),
             cache.findReadyBootstrapServer(time.milliseconds())
@@ -218,7 +220,7 @@ public class RequestManagerTest {
         );
 
         // Send request to a node that is not in the bootstrap list
-        cache.onRequestSent(otherNode, 1, time.milliseconds());
+        cache.onRequestSent(otherNode, 1, time.milliseconds(), fetch);
         assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
     }
 
@@ -234,15 +236,15 @@ public class RequestManagerTest {
         );
 
         // Send request to a node that is not in the bootstrap list
-        cache.onRequestSent(otherNode, 1, time.milliseconds());
-        assertTrue(cache.isResponseExpected(otherNode, 1));
+        cache.onRequestSent(otherNode, 1, time.milliseconds(), fetch);
+        assertTrue(cache.isResponseExpected(otherNode, 1, fetch));
         assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
 
         // Timeout the request
         time.sleep(requestTimeoutMs);
         Node bootstrapNode = cache.findReadyBootstrapServer(time.milliseconds()).get();
         assertTrue(bootstrapList.contains(bootstrapNode));
-        assertFalse(cache.isResponseExpected(otherNode, 1));
+        assertFalse(cache.isResponseExpected(otherNode, 1, fetch));
     }
 
     @Test
@@ -256,25 +258,25 @@ public class RequestManagerTest {
             random
         );
 
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds()));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Send a request and check state
-        cache.onRequestSent(otherNode, 11, time.milliseconds());
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds()));
+        cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds()));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Send another request and fail it
-        cache.onRequestSent(otherNode, 12, time.milliseconds());
-        cache.onResponseResult(otherNode, 12, false, time.milliseconds());
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds()));
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
+        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
 
         // Send another request and mark it successful
-        cache.onRequestSent(otherNode, 12, time.milliseconds());
-        cache.onResponseResult(otherNode, 12, true, time.milliseconds());
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds()));
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
+        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
     }
 
     private List<Node> makeBootstrapList(int numberOfNodes) {

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -135,13 +135,39 @@ public class RequestManagerTest {
         assertFalse(cache.isReady(node, time.milliseconds(), fetch));
         cache.onResponseResult(node, correlationId + 1, true, time.milliseconds(), fetch);
         assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+    }
+
+    @Test
+    public void testIgnoreOtherRequestTypeResponses() {
+        Node node = new Node(1, "mock-host-1", 4321);
+
+        RequestManager cache = new RequestManager(
+            makeBootstrapList(3),
+            retryBackoffMs,
+            requestTimeoutMs,
+            random
+        );
+        long correlationId = 1;
 
         // completing a request of a different type should not affect the state of other requests
+        assertTrue(cache.isReady(node, time.milliseconds(), updateVoter));
+        assertTrue(cache.isReady(node, time.milliseconds(), fetch));
+
+        cache.onRequestSent(node, correlationId, time.milliseconds(), fetch);
+        assertTrue(cache.isReady(node, time.milliseconds(), updateVoter));
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+
         cache.onRequestSent(node, correlationId, time.milliseconds(), updateVoter);
         assertFalse(cache.isReady(node, time.milliseconds(), updateVoter));
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+
         cache.onResponseResult(node, correlationId, true, time.milliseconds(), updateVoter);
         assertTrue(cache.isReady(node, time.milliseconds(), updateVoter));
         assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+
+        cache.onResponseResult(node, correlationId, true, time.milliseconds(), fetch);
+        assertTrue(cache.isReady(node, time.milliseconds(), updateVoter));
+        assertTrue(cache.isReady(node, time.milliseconds(), fetch));
     }
 
     @Test
@@ -208,20 +234,31 @@ public class RequestManagerTest {
         Node bootstrapNode3 = cache.findReadyBootstrapServer(time.milliseconds()).get();
         assertEquals(bootstrapNode1, bootstrapNode3);
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+    }
+
+    @Test
+    public void testRequestToBootstrapListMultipleRequests() {
+        List<Node> bootstrapList = makeBootstrapList(2);
+        RequestManager cache = new RequestManager(
+            bootstrapList,
+            retryBackoffMs,
+            requestTimeoutMs,
+            random
+        );
 
         // Pending fetch snapshot requests should also result in a returned backoff
-        Node bootstrapNode4 = assertReadyBootstrapServer(cache, bootstrapList);
+        Node bootstrapNode = assertReadyBootstrapServer(cache, bootstrapList);
 
         // Send a request and check the cache state
-        cache.onRequestSent(bootstrapNode4, 1, time.milliseconds(), fetchSnapshot);
+        cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), fetchSnapshot);
         assertNotReadyBootstrapServer(cache);
 
         // Other pending requests should not affect readiness of bootstrap servers
-        cache.onRequestSent(bootstrapNode4, 1, time.milliseconds(), updateVoter);
+        cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), updateVoter);
         assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
 
         // Complete the fetch snapshot request and show that node is ready
-        cache.onResponseResult(bootstrapNode4, 1, true, time.milliseconds(), fetchSnapshot);
+        cache.onResponseResult(bootstrapNode, 1, true, time.milliseconds(), fetchSnapshot);
         assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
     }
@@ -245,7 +282,7 @@ public class RequestManagerTest {
     }
 
     @Test
-    public void testFindReadyWithInflightRequest() {
+    public void testFindReadyWithInflightFetchRequest() {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -256,18 +293,35 @@ public class RequestManagerTest {
         );
 
         // Send request to a node that is not in the bootstrap list
-        cache.onRequestSent(otherNode, 1, time.milliseconds(), fetch);
-        assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
-        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), fetch);
-        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+        completeFetchAndCheckReadiness(cache, otherNode, fetch);
 
         // A pending fetch snapshot request does not return a ready node
-        cache.onRequestSent(otherNode, 1, time.milliseconds(), fetchSnapshot);
-        assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
-        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), fetchSnapshot);
-        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+        completeFetchAndCheckReadiness(cache, otherNode, fetchSnapshot);
+    }
 
-        // Other pending requests do return a ready node
+    private void completeFetchAndCheckReadiness(
+        RequestManager cache,
+        Node destination,
+        ApiKeys apiKey
+    ) {
+        cache.onRequestSent(destination, 1, time.milliseconds(), apiKey);
+        assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
+        cache.onResponseResult(destination, 1, true, time.milliseconds(), apiKey);
+        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+    }
+
+    @Test
+    public void testFindReadyWithOtherInflightRequest() {
+        Node otherNode = new Node(1, "other-node", 1234);
+        List<Node> bootstrapList = makeBootstrapList(3);
+        RequestManager cache = new RequestManager(
+            bootstrapList,
+            retryBackoffMs,
+            requestTimeoutMs,
+            random
+        );
+
+        // Other pending request types do not affect readiness of bootstrap servers
         cache.onRequestSent(otherNode, 1, time.milliseconds(), updateVoter);
         assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
     }
@@ -296,7 +350,39 @@ public class RequestManagerTest {
     }
 
     @Test
-    public void testAnyInflightRequestWithAnyRequest() {
+    public void testAnyInflightRequestOneRequest() {
+        Node otherNode = new Node(1, "other-node", 1234);
+        List<Node> bootstrapList = makeBootstrapList(3);
+        RequestManager cache = new RequestManager(
+            bootstrapList,
+            retryBackoffMs,
+            requestTimeoutMs,
+            random
+        );
+
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Send a request and check state
+        cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Wait until the request times out
+        time.sleep(requestTimeoutMs);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Send another request and fail it
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
+        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Send another request and mark it successful
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
+        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+    }
+
+    @Test
+    public void testAnyInflightRequestMultipleRequests() {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -326,6 +412,7 @@ public class RequestManagerTest {
         time.sleep(requestTimeoutMs);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Results should not affect the connection state of other request types
         cache.onRequestSent(otherNode, 12, time.milliseconds(), updateVoter);
@@ -337,9 +424,9 @@ public class RequestManagerTest {
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send another request and mark it successful
-        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
-        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetchSnapshot);
+        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetchSnapshot);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -352,7 +352,7 @@ public class RequestManagerTest {
     }
 
     @Test
-    public void testAnyInflightRequest() {
+    public void testAnyInflightRequestWithMultipleRequestTypes() {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -401,7 +401,7 @@ public class RequestManagerTest {
     }
 
     @Test
-    public void testAnyInflightRequestWithMultipleRequestTypes() {
+    public void testAnyInflightRequestWithAnyRequest() {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -207,37 +207,36 @@ public class RequestManagerTest {
 
         // Send a request and check the cache state
         cache.onRequestSent(bootstrapNode1, 1, time.milliseconds(), fetch);
-        assertNotReadyBootstrapServer(cache);
+        assertNotReadyBootstrapServerOnSend(cache);
 
-        // Fail the request
-        time.sleep(100);
+        // Fail the request. BootstrapNode1 begins backing off, meaning the other bootstrap
+        // node is ready to serve a fetch request
         cache.onResponseResult(bootstrapNode1, 1, false, time.milliseconds(), fetch);
-        Node bootstrapNode2 = cache.findReadyBootstrapServer(time.milliseconds()).get();
+        Node bootstrapNode2 = assertReadyBootstrapServer(cache, bootstrapList);
         assertNotEquals(bootstrapNode1, bootstrapNode2);
-        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
 
         // Send a request to the second node and check the state
         cache.onRequestSent(bootstrapNode2, 2, time.milliseconds(), fetch);
-        assertNotReadyBootstrapServer(cache);
+        assertNotReadyBootstrapServerOnSend(cache);
 
-        // Fail the second request before the request timeout
+        // Fail the second request before the bootstrapNode1's backoff is complete
         time.sleep(retryBackoffMs - 1);
         cache.onResponseResult(bootstrapNode2, 2, false, time.milliseconds(), fetch);
         assertEquals(
             Optional.empty(),
             cache.findReadyBootstrapServer(time.milliseconds())
         );
+        // This is the remaining backoff time for bootstrapNode1 to become available
         assertEquals(1, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
 
         // Timeout the first backoff and show that that node is ready
         time.sleep(1);
-        Node bootstrapNode3 = cache.findReadyBootstrapServer(time.milliseconds()).get();
+        Node bootstrapNode3 = assertReadyBootstrapServer(cache, bootstrapList);
         assertEquals(bootstrapNode1, bootstrapNode3);
-        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
     }
 
     @Test
-    public void testRequestToBootstrapListMultipleRequests() {
+    public void testRequestToBootstrapListMultipleRequestTypes() {
         List<Node> bootstrapList = makeBootstrapList(2);
         RequestManager cache = new RequestManager(
             bootstrapList,
@@ -245,22 +244,30 @@ public class RequestManagerTest {
             requestTimeoutMs,
             random
         );
-
-        // Pending fetch snapshot requests should also result in a returned backoff
+        // Pending fetch snapshot requests should also result in no ready bootstrap server
         Node bootstrapNode = assertReadyBootstrapServer(cache, bootstrapList);
+
+        // Other requests should not affect readiness of bootstrap servers
+        cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), updateVoter);
+        assertReadyBootstrapServer(cache, bootstrapList);
 
         // Send a request and check the cache state
         cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), fetchSnapshot);
-        assertNotReadyBootstrapServer(cache);
+        assertNotReadyBootstrapServerOnSend(cache);
 
-        // Other pending requests should not affect readiness of bootstrap servers
-        cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), updateVoter);
-        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        // Other requests should not affect readiness of bootstrap servers
+        cache.onResponseResult(bootstrapNode, 1, true, time.milliseconds(), updateVoter);
+        assertNotReadyBootstrapServerOnSend(cache);
+        cache.onRequestSent(bootstrapNode, 2, time.milliseconds(), updateVoter);
+        assertNotReadyBootstrapServerOnSend(cache);
 
         // Complete the fetch snapshot request and show that node is ready
         cache.onResponseResult(bootstrapNode, 1, true, time.milliseconds(), fetchSnapshot);
-        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
-        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        assertReadyBootstrapServer(cache, bootstrapList);
+
+        // Other requests should not affect readiness of bootstrap servers
+        cache.onResponseResult(bootstrapNode, 2, false, time.milliseconds(), updateVoter);
+        assertReadyBootstrapServer(cache, bootstrapList);
     }
 
     private Node assertReadyBootstrapServer(RequestManager cache, List<Node> bootstrapList) {
@@ -273,7 +280,7 @@ public class RequestManagerTest {
         return bootstrapNode;
     }
 
-    private void assertNotReadyBootstrapServer(RequestManager cache) {
+    private void assertNotReadyBootstrapServerOnSend(RequestManager cache) {
         assertEquals(
             Optional.empty(),
             cache.findReadyBootstrapServer(time.milliseconds())
@@ -282,7 +289,7 @@ public class RequestManagerTest {
     }
 
     @Test
-    public void testFindReadyWithInflightFetchRequest() {
+    public void testFindReadyWithInflightFetchToNonBootstrapNode() {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -293,39 +300,22 @@ public class RequestManagerTest {
         );
 
         // Send request to a node that is not in the bootstrap list
-        completeFetchAndCheckReadiness(cache, otherNode, fetch);
+        completeFetchAndCheckReadiness(cache, otherNode, bootstrapList, fetch);
 
-        // A pending fetch snapshot request does not return a ready node
-        completeFetchAndCheckReadiness(cache, otherNode, fetchSnapshot);
+        // A pending fetch snapshot request also does not return a ready node
+        completeFetchAndCheckReadiness(cache, otherNode, bootstrapList, fetchSnapshot);
     }
 
     private void completeFetchAndCheckReadiness(
         RequestManager cache,
         Node destination,
+        List<Node> bootstrapList,
         ApiKeys apiKey
     ) {
         cache.onRequestSent(destination, 1, time.milliseconds(), apiKey);
-        assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
+        assertNotReadyBootstrapServerOnSend(cache);
         cache.onResponseResult(destination, 1, true, time.milliseconds(), apiKey);
-        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
-    }
-
-    @Test
-    public void testFindReadyWithOtherInflightRequest() {
-        Node otherNode = new Node(1, "other-node", 1234);
-        List<Node> bootstrapList = makeBootstrapList(3);
-        RequestManager cache = new RequestManager(
-            bootstrapList,
-            retryBackoffMs,
-            requestTimeoutMs,
-            random
-        );
-
-        // Other pending request types do not affect readiness of bootstrap servers
-        cache.onRequestSent(otherNode, 1, time.milliseconds(), updateVoter);
-        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
-        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), updateVoter);
-        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+        assertReadyBootstrapServer(cache, bootstrapList);
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -39,6 +39,8 @@ public class RequestManagerTest {
     private final int retryBackoffMs = 100;
     private final Random random = new Random(1);
     private final ApiKeys fetch = ApiKeys.FETCH;
+    private final ApiKeys fetchSnapshot = ApiKeys.FETCH_SNAPSHOT;
+    private final ApiKeys updateVoter = ApiKeys.UPDATE_RAFT_VOTER;
 
     @Test
     public void testResetAllConnections() {
@@ -52,20 +54,27 @@ public class RequestManagerTest {
             random
         );
 
-        // One host has an inflight request
+        // One host has inflight requests
         cache.onRequestSent(node1, 1, time.milliseconds(), fetch);
         assertFalse(cache.isReady(node1, time.milliseconds(), fetch));
+        cache.onRequestSent(node1, 1, time.milliseconds(), updateVoter);
+        assertFalse(cache.isReady(node1, time.milliseconds(), updateVoter));
 
         // Another is backing off
         cache.onRequestSent(node2, 2, time.milliseconds(), fetch);
         cache.onResponseResult(node2, 2, false, time.milliseconds(), fetch);
         assertFalse(cache.isReady(node2, time.milliseconds(), fetch));
+        cache.onRequestSent(node2, 2, time.milliseconds(), updateVoter);
+        cache.onResponseResult(node2, 2, false, time.milliseconds(), updateVoter);
+        assertFalse(cache.isReady(node2, time.milliseconds(), updateVoter));
 
         cache.resetAll();
 
         // Now both should be ready
         assertTrue(cache.isReady(node1, time.milliseconds(), fetch));
+        assertTrue(cache.isReady(node1, time.milliseconds(), updateVoter));
         assertTrue(cache.isReady(node2, time.milliseconds(), fetch));
+        assertTrue(cache.isReady(node2, time.milliseconds(), updateVoter));
     }
 
     @Test
@@ -125,6 +134,13 @@ public class RequestManagerTest {
         cache.onRequestSent(node, correlationId, time.milliseconds(), fetch);
         assertFalse(cache.isReady(node, time.milliseconds(), fetch));
         cache.onResponseResult(node, correlationId + 1, true, time.milliseconds(), fetch);
+        assertFalse(cache.isReady(node, time.milliseconds(), fetch));
+
+        // completing a request of a different type should not affect the state of other requests
+        cache.onRequestSent(node, correlationId, time.milliseconds(), updateVoter);
+        assertFalse(cache.isReady(node, time.milliseconds(), updateVoter));
+        cache.onResponseResult(node, correlationId, true, time.milliseconds(), updateVoter);
+        assertTrue(cache.isReady(node, time.milliseconds(), updateVoter));
         assertFalse(cache.isReady(node, time.milliseconds(), fetch));
     }
 
@@ -206,6 +222,31 @@ public class RequestManagerTest {
         Node bootstrapNode3 = cache.findReadyBootstrapServer(time.milliseconds()).get();
         assertEquals(bootstrapNode1, bootstrapNode3);
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+
+        // Pending fetch snapshot requests should also result in a returned backoff
+        Node bootstrapNode4 = cache.findReadyBootstrapServer(time.milliseconds()).get();
+        assertTrue(
+            bootstrapList.contains(bootstrapNode4),
+            String.format("%s is not in %s", bootstrapNode4, bootstrapList)
+        );
+        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+
+        // Send a request and check the cache state
+        cache.onRequestSent(bootstrapNode4, 1, time.milliseconds(), fetchSnapshot);
+        assertEquals(
+            Optional.empty(),
+            cache.findReadyBootstrapServer(time.milliseconds())
+        );
+        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+
+        // Other pending requests should not affect readiness of bootstrap servers
+        cache.onRequestSent(bootstrapNode4, 1, time.milliseconds(), updateVoter);
+        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+
+        // Complete the fetch snapshot request and show that node is ready
+        cache.onResponseResult(bootstrapNode4, 1, true, time.milliseconds(), fetchSnapshot);
+        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
     }
 
     @Test
@@ -222,6 +263,18 @@ public class RequestManagerTest {
         // Send request to a node that is not in the bootstrap list
         cache.onRequestSent(otherNode, 1, time.milliseconds(), fetch);
         assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
+        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), fetch);
+        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+
+        // A pending fetch snapshot request does not return a ready node
+        cache.onRequestSent(otherNode, 1, time.milliseconds(), fetchSnapshot);
+        assertEquals(Optional.empty(), cache.findReadyBootstrapServer(time.milliseconds()));
+        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), fetchSnapshot);
+        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+
+        // Other pending requests do return a ready node
+        cache.onRequestSent(otherNode, 1, time.milliseconds(), updateVoter);
+        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
     }
 
     @Test
@@ -259,24 +312,40 @@ public class RequestManagerTest {
         );
 
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Send a request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+
+        // Send the other request and check state
+        cache.onRequestSent(otherNode, 11, time.milliseconds(), updateVoter);
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+
+        // Results should not affect the connection state of other request types
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), updateVoter);
 
         // Send another request and fail it
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
 
         // Send another request and mark it successful
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
     }
 
     private List<Node> makeBootstrapList(int numberOfNodes) {

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -324,6 +324,8 @@ public class RequestManagerTest {
         // Other pending request types do not affect readiness of bootstrap servers
         cache.onRequestSent(otherNode, 1, time.milliseconds(), updateVoter);
         assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
+        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), updateVoter);
+        assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
     }
 
     @Test
@@ -350,39 +352,7 @@ public class RequestManagerTest {
     }
 
     @Test
-    public void testAnyInflightRequestOneRequest() {
-        Node otherNode = new Node(1, "other-node", 1234);
-        List<Node> bootstrapList = makeBootstrapList(3);
-        RequestManager cache = new RequestManager(
-            bootstrapList,
-            retryBackoffMs,
-            requestTimeoutMs,
-            random
-        );
-
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-
-        // Send a request and check state
-        cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-
-        // Wait until the request times out
-        time.sleep(requestTimeoutMs);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-
-        // Send another request and fail it
-        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
-        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-
-        // Send another request and mark it successful
-        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
-        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-    }
-
-    @Test
-    public void testAnyInflightRequestMultipleRequests() {
+    public void testAnyInflightRequest() {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -428,6 +398,38 @@ public class RequestManagerTest {
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetchSnapshot);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+    }
+
+    @Test
+    public void testAnyInflightRequestWithMultipleRequestTypes() {
+        Node otherNode = new Node(1, "other-node", 1234);
+        List<Node> bootstrapList = makeBootstrapList(3);
+        RequestManager cache = new RequestManager(
+            bootstrapList,
+            retryBackoffMs,
+            requestTimeoutMs,
+            random
+        );
+
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Send a request and check state
+        cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Wait until the request times out
+        time.sleep(requestTimeoutMs);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Send another request and fail it
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
+        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+
+        // Send another request and mark it successful
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
+        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
     }
 
     private List<Node> makeBootstrapList(int numberOfNodes) {

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -177,20 +177,11 @@ public class RequestManagerTest {
         );
 
         // Find a ready node with the starting state
-        Node bootstrapNode1 = cache.findReadyBootstrapServer(time.milliseconds()).get();
-        assertTrue(
-            bootstrapList.contains(bootstrapNode1),
-            String.format("%s is not in %s", bootstrapNode1, bootstrapList)
-        );
-        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        Node bootstrapNode1 = assertReadyBootstrapServer(cache, bootstrapList);
 
         // Send a request and check the cache state
         cache.onRequestSent(bootstrapNode1, 1, time.milliseconds(), fetch);
-        assertEquals(
-            Optional.empty(),
-            cache.findReadyBootstrapServer(time.milliseconds())
-        );
-        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        assertNotReadyBootstrapServer(cache);
 
         // Fail the request
         time.sleep(100);
@@ -201,12 +192,7 @@ public class RequestManagerTest {
 
         // Send a request to the second node and check the state
         cache.onRequestSent(bootstrapNode2, 2, time.milliseconds(), fetch);
-        assertEquals(
-            Optional.empty(),
-            cache.findReadyBootstrapServer(time.milliseconds())
-        );
-        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
-
+        assertNotReadyBootstrapServer(cache);
 
         // Fail the second request before the request timeout
         time.sleep(retryBackoffMs - 1);
@@ -224,20 +210,11 @@ public class RequestManagerTest {
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
 
         // Pending fetch snapshot requests should also result in a returned backoff
-        Node bootstrapNode4 = cache.findReadyBootstrapServer(time.milliseconds()).get();
-        assertTrue(
-            bootstrapList.contains(bootstrapNode4),
-            String.format("%s is not in %s", bootstrapNode4, bootstrapList)
-        );
-        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        Node bootstrapNode4 = assertReadyBootstrapServer(cache, bootstrapList);
 
         // Send a request and check the cache state
         cache.onRequestSent(bootstrapNode4, 1, time.milliseconds(), fetchSnapshot);
-        assertEquals(
-            Optional.empty(),
-            cache.findReadyBootstrapServer(time.milliseconds())
-        );
-        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        assertNotReadyBootstrapServer(cache);
 
         // Other pending requests should not affect readiness of bootstrap servers
         cache.onRequestSent(bootstrapNode4, 1, time.milliseconds(), updateVoter);
@@ -247,6 +224,24 @@ public class RequestManagerTest {
         cache.onResponseResult(bootstrapNode4, 1, true, time.milliseconds(), fetchSnapshot);
         assertTrue(cache.findReadyBootstrapServer(time.milliseconds()).isPresent());
         assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+    }
+
+    private Node assertReadyBootstrapServer(RequestManager cache, List<Node> bootstrapList) {
+        Node bootstrapNode = cache.findReadyBootstrapServer(time.milliseconds()).get();
+        assertTrue(
+            bootstrapList.contains(bootstrapNode),
+            String.format("%s is not in %s", bootstrapNode, bootstrapList)
+        );
+        assertEquals(0, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
+        return bootstrapNode;
+    }
+
+    private void assertNotReadyBootstrapServer(RequestManager cache) {
+        assertEquals(
+            Optional.empty(),
+            cache.findReadyBootstrapServer(time.milliseconds())
+        );
+        assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -362,27 +363,22 @@ public class RequestManagerTest {
             random
         );
 
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot, updateVoter)));
 
         // Send a request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetchSnapshot, updateVoter)));
 
         // Send the other request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), updateVoter);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(updateVoter)));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetchSnapshot)));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot, updateVoter)));
 
         // Results should not affect the connection state of other request types
         cache.onRequestSent(otherNode, 12, time.milliseconds(), updateVoter);
@@ -390,14 +386,14 @@ public class RequestManagerTest {
         // Send another request and fail it
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot)));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(updateVoter)));
 
         // Send another request and mark it successful
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetchSnapshot);
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetchSnapshot);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch, fetchSnapshot)));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(updateVoter)));
     }
 
     @Test
@@ -411,25 +407,25 @@ public class RequestManagerTest {
             random
         );
 
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
 
         // Send a request and check state
         cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
-        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
 
         // Send another request and fail it
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
 
         // Send another request and mark it successful
         cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
         cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
-        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), Set.of(fetch)));
     }
 
     private List<Node> makeBootstrapList(int numberOfNodes) {

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.utils.MockTime;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.List;
 import java.util.Optional;
@@ -192,8 +194,9 @@ public class RequestManagerTest {
         assertTrue(cache.isReady(node, time.milliseconds(), fetch));
     }
 
-    @Test
-    public void testRequestToBootstrapList() {
+    @ParameterizedTest
+    @EnumSource(value = ApiKeys.class, names = {"FETCH", "FETCH_SNAPSHOT"})
+    public void testRequestToBootstrapList(ApiKeys apiKey) {
         List<Node> bootstrapList = makeBootstrapList(2);
         RequestManager cache = new RequestManager(
             bootstrapList,
@@ -206,22 +209,22 @@ public class RequestManagerTest {
         Node bootstrapNode1 = assertReadyBootstrapServer(cache, bootstrapList);
 
         // Send a request and check the cache state
-        cache.onRequestSent(bootstrapNode1, 1, time.milliseconds(), fetch);
+        cache.onRequestSent(bootstrapNode1, 1, time.milliseconds(), apiKey);
         assertNotReadyBootstrapServerOnSend(cache);
 
         // Fail the request. BootstrapNode1 begins backing off, meaning the other bootstrap
         // node is ready to serve a fetch request
-        cache.onResponseResult(bootstrapNode1, 1, false, time.milliseconds(), fetch);
+        cache.onResponseResult(bootstrapNode1, 1, false, time.milliseconds(), apiKey);
         Node bootstrapNode2 = assertReadyBootstrapServer(cache, bootstrapList);
         assertNotEquals(bootstrapNode1, bootstrapNode2);
 
         // Send a request to the second node and check the state
-        cache.onRequestSent(bootstrapNode2, 2, time.milliseconds(), fetch);
+        cache.onRequestSent(bootstrapNode2, 2, time.milliseconds(), apiKey);
         assertNotReadyBootstrapServerOnSend(cache);
 
         // Fail the second request before the bootstrapNode1's backoff is complete
         time.sleep(retryBackoffMs - 1);
-        cache.onResponseResult(bootstrapNode2, 2, false, time.milliseconds(), fetch);
+        cache.onResponseResult(bootstrapNode2, 2, false, time.milliseconds(), apiKey);
         assertEquals(
             Optional.empty(),
             cache.findReadyBootstrapServer(time.milliseconds())
@@ -235,8 +238,9 @@ public class RequestManagerTest {
         assertEquals(bootstrapNode1, bootstrapNode3);
     }
 
-    @Test
-    public void testRequestToBootstrapListMultipleRequestTypes() {
+    @ParameterizedTest
+    @EnumSource(value = ApiKeys.class, names = {"FETCH", "FETCH_SNAPSHOT"})
+    public void testRequestToBootstrapListMultipleRequestTypes(ApiKeys apiKey) {
         List<Node> bootstrapList = makeBootstrapList(2);
         RequestManager cache = new RequestManager(
             bootstrapList,
@@ -244,15 +248,14 @@ public class RequestManagerTest {
             requestTimeoutMs,
             random
         );
-        // Pending fetch snapshot requests should also result in no ready bootstrap server
-        Node bootstrapNode = assertReadyBootstrapServer(cache, bootstrapList);
 
-        // Other requests should not affect readiness of bootstrap servers
+        // Other requests should not affect readiness of bootstrap servers for fetching
+        Node bootstrapNode = assertReadyBootstrapServer(cache, bootstrapList);
         cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), updateVoter);
         assertReadyBootstrapServer(cache, bootstrapList);
 
         // Send a request and check the cache state
-        cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), fetchSnapshot);
+        cache.onRequestSent(bootstrapNode, 1, time.milliseconds(), apiKey);
         assertNotReadyBootstrapServerOnSend(cache);
 
         // Other requests should not affect readiness of bootstrap servers
@@ -261,8 +264,8 @@ public class RequestManagerTest {
         cache.onRequestSent(bootstrapNode, 2, time.milliseconds(), updateVoter);
         assertNotReadyBootstrapServerOnSend(cache);
 
-        // Complete the fetch snapshot request and show that node is ready
-        cache.onResponseResult(bootstrapNode, 1, true, time.milliseconds(), fetchSnapshot);
+        // Complete the fetch or fetch snapshot request and show that node is ready
+        cache.onResponseResult(bootstrapNode, 1, true, time.milliseconds(), apiKey);
         assertReadyBootstrapServer(cache, bootstrapList);
 
         // Other requests should not affect readiness of bootstrap servers
@@ -288,8 +291,9 @@ public class RequestManagerTest {
         assertEquals(requestTimeoutMs, cache.backoffBeforeAvailableBootstrapServer(time.milliseconds()));
     }
 
-    @Test
-    public void testFindReadyWithInflightFetchToNonBootstrapNode() {
+    @ParameterizedTest
+    @EnumSource(value = ApiKeys.class, names = {"FETCH", "FETCH_SNAPSHOT"})
+    public void testFindReadyWithInflightFetchToNonBootstrapNode(ApiKeys apiKey) {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -299,22 +303,9 @@ public class RequestManagerTest {
             random
         );
 
-        // Send request to a node that is not in the bootstrap list
-        completeFetchAndCheckReadiness(cache, otherNode, bootstrapList, fetch);
-
-        // A pending fetch snapshot request also does not return a ready node
-        completeFetchAndCheckReadiness(cache, otherNode, bootstrapList, fetchSnapshot);
-    }
-
-    private void completeFetchAndCheckReadiness(
-        RequestManager cache,
-        Node destination,
-        List<Node> bootstrapList,
-        ApiKeys apiKey
-    ) {
-        cache.onRequestSent(destination, 1, time.milliseconds(), apiKey);
+        cache.onRequestSent(otherNode, 1, time.milliseconds(), apiKey);
         assertNotReadyBootstrapServerOnSend(cache);
-        cache.onResponseResult(destination, 1, true, time.milliseconds(), apiKey);
+        cache.onResponseResult(otherNode, 1, true, time.milliseconds(), apiKey);
         assertReadyBootstrapServer(cache, bootstrapList);
     }
 
@@ -396,8 +387,9 @@ public class RequestManagerTest {
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), updateVoter));
     }
 
-    @Test
-    public void testAnyInflightRequestWithAnyRequest() {
+    @ParameterizedTest
+    @EnumSource(value = ApiKeys.class, names = {"FETCH", "FETCH_SNAPSHOT"})
+    public void testAnyInflightRequestWithFetchOrFetchSnapshot(ApiKeys apiKey) {
         Node otherNode = new Node(1, "other-node", 1234);
         List<Node> bootstrapList = makeBootstrapList(3);
         RequestManager cache = new RequestManager(
@@ -408,24 +400,70 @@ public class RequestManagerTest {
         );
 
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Send a request and check state
-        cache.onRequestSent(otherNode, 11, time.milliseconds(), fetch);
+        cache.onRequestSent(otherNode, 11, time.milliseconds(), apiKey);
         assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Wait until the request times out
         time.sleep(requestTimeoutMs);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Send another request and fail it
-        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
-        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), fetch);
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), apiKey);
+        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), apiKey);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
 
         // Send another request and mark it successful
-        cache.onRequestSent(otherNode, 12, time.milliseconds(), fetch);
-        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), fetch);
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), apiKey);
+        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), apiKey);
         assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetch));
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), fetchSnapshot));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ApiKeys.class,
+        names = {
+            "VOTE",
+            "BEGIN_QUORUM_EPOCH",
+            "END_QUORUM_EPOCH",
+            "API_VERSIONS",
+            "UPDATE_RAFT_VOTER"
+        })
+    public void testAnyInflightRequestWithOtherKRaftRequests(ApiKeys apiKey) {
+        Node otherNode = new Node(1, "other-node", 1234);
+        List<Node> bootstrapList = makeBootstrapList(3);
+        RequestManager cache = new RequestManager(
+            bootstrapList,
+            retryBackoffMs,
+            requestTimeoutMs,
+            random
+        );
+
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), apiKey));
+
+        // Send a request and check state
+        cache.onRequestSent(otherNode, 11, time.milliseconds(), apiKey);
+        assertTrue(cache.hasAnyInflightRequest(time.milliseconds(), apiKey));
+
+        // Wait until the request times out
+        time.sleep(requestTimeoutMs);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), apiKey));
+
+        // Send another request and fail it
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), apiKey);
+        cache.onResponseResult(otherNode, 12, false, time.milliseconds(), apiKey);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), apiKey));
+
+        // Send another request and mark it successful
+        cache.onRequestSent(otherNode, 12, time.milliseconds(), apiKey);
+        cache.onResponseResult(otherNode, 12, true, time.milliseconds(), apiKey);
+        assertFalse(cache.hasAnyInflightRequest(time.milliseconds(), apiKey));
     }
 
     private List<Node> makeBootstrapList(int numberOfNodes) {


### PR DESCRIPTION
Previously, `RequestManager` only allowed for one "in-flight" request at a time across all KRaft RPC types. This PR allows `RequestManager` to handle one "in-flight" request per type. 

We maintain the invariant of only 1 pending fetch request by treating `FETCH` and `FETCH_SNAPSHOT` as the same request type.