### PR TITLE
MINOR: Add deprecation warning for `log.cleaner.enable` and `log.cleaner.threads`

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -629,6 +629,9 @@ class LogManager(logDirs: Seq[File],
     if (cleanerConfig.enableCleaner) {
       _cleaner = new LogCleaner(cleanerConfig, liveLogDirs.asJava, currentLogs, logDirFailureChannel, time)
       _cleaner.startup()
+    } else {
+      warn("The config `log.cleaner.enable` is deprecated and will be removed in Kafka 5.0. Starting from Kafka 5.0, the log cleaner will always be enabled, and this config will be ignored.")
+
     }
   }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
@@ -198,6 +198,11 @@ public class LogCleaner implements BrokerReconfigurable {
      * Start the background cleaner threads.
      */
     public void startup() {
+        if (config.numThreads < 1) {
+            LOG.warn("Invalid value for `log.cleaner.threads`: must be >= 1 starting from Kafka 5.0 since log cleaner" +
+                    " is always enabled.");
+        }
+
         LOG.info("Starting the log cleaner");
         IntStream.range(0, config.numThreads).forEach(i -> {
             try {


### PR DESCRIPTION
Add a warning message when using log.cleaner.enable to remind users that this configuration is deprecated. Also, add a warning message for log.cleaner.threads=0 because in version 5.0, the value must be greater than zero.


Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang <payang@apache.org>, TengYao Chi <frankvicky@apache.org>, TaiJuWu <tjwu1217@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
