### PR TITLE
MINOR: Minor updates to RangeSet

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
@@ -40,12 +40,19 @@ class RangeSet implements Set<Integer> {
     public RangeSet(int from, int to) {
         this.from = from;
         this.to = to;
+
+        if ((long) to - (long) from > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Range exceeds the maximum size of Integer.MAX_VALUE");
+        }
     }
 
     @Override
     public int size() {
-        if (to < from) return 0;
-        return to - from;
+        // We could end up with a negative size in two cases:
+        //  * The range is empty and to < from
+        //  * The range is larger than Integer.MAX_VALUE
+        // We return 0 in the first case and forbid the second case in the constructor.
+        return Math.max(0, to - from);
     }
 
     @Override
@@ -184,7 +191,7 @@ class RangeSet implements Set<Integer> {
         // The sum of the integers from 1 to n is n * (n + 1) / 2.
         // To get the sum of the integers from 1 + k to n + k, we can add n * k.
         // So our hash code comes out to n * (from + to - 1) / 2.
-        long size = (long) to - (long) from;
+        long size = size();
         if (size <= 0) return 0;
 
         // The arithmetic has to be done using longs, since the division by 2 is equivalent to

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
@@ -191,12 +191,10 @@ class RangeSet implements Set<Integer> {
         // The sum of the integers from 1 to n is n * (n + 1) / 2.
         // To get the sum of the integers from 1 + k to n + k, we can add n * k.
         // So our hash code comes out to n * (from + to - 1) / 2.
-        long size = size();
-        if (size <= 0) return 0;
 
         // The arithmetic has to be done using longs, since the division by 2 is equivalent to
         // shifting the 33rd bit right.
-        long sum = size * (from + to - 1) / 2;
+        long sum = size() * ((long) from + (long) to - 1) / 2;
         return (int) sum;
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
@@ -41,6 +41,10 @@ class RangeSet implements Set<Integer> {
         this.from = from;
         this.to = to;
 
+        if (to < from) {
+            throw new IllegalArgumentException("Invalid range: to must be greater than or equal to from");
+        }
+
         if ((long) to - (long) from > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Range exceeds the maximum size of Integer.MAX_VALUE");
         }
@@ -48,11 +52,7 @@ class RangeSet implements Set<Integer> {
 
     @Override
     public int size() {
-        // We could end up with a negative size in two cases:
-        //  * The range is empty and to < from
-        //  * The range is larger than Integer.MAX_VALUE
-        // We return 0 in the first case and forbid the second case in the constructor.
-        return Math.max(0, to - from);
+        return to - from;
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/RangeSet.java
@@ -44,6 +44,7 @@ class RangeSet implements Set<Integer> {
 
     @Override
     public int size() {
+        if (to < from) return 0;
         return to - from;
     }
 
@@ -163,6 +164,7 @@ class RangeSet implements Set<Integer> {
         if (!(o instanceof Set<?> otherSet)) return false;
 
         if (o instanceof RangeSet other) {
+            if (this.size() == 0 && other.size() == 0) return true;
             return this.from == other.from && this.to == other.to;
         }
 
@@ -176,8 +178,18 @@ class RangeSet implements Set<Integer> {
 
     @Override
     public int hashCode() {
-        int result = from;
-        result = 31 * result + to;
-        return result;
+        // The hash code of a Set is defined as the sum of the hash codes of its elements.
+        // The hash code of an integer is the integer itself.
+
+        // The sum of the integers from 1 to n is n * (n + 1) / 2.
+        // To get the sum of the integers from 1 + k to n + k, we can add n * k.
+        // So our hash code comes out to n * (from + to - 1) / 2.
+        long size = (long) to - (long) from;
+        if (size <= 0) return 0;
+
+        // The arithmetic has to be done using longs, since the division by 2 is equivalent to
+        // shifting the 33rd bit right.
+        long sum = size * (from + to - 1) / 2;
+        return (int) sum;
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
@@ -150,7 +150,7 @@ public class RangeSetTest {
         assertEquals(Set.of(5, 6, 7, 8, 9).hashCode(), rangeSet1.hashCode());
         assertEquals(Set.of(6, 7, 8, 9).hashCode(), rangeSet2.hashCode());
 
-        RangeSet emptySet = new RangeSet(5, -2);
+        RangeSet emptySet = new RangeSet(5, 5);
         assertEquals(Set.of().hashCode(), emptySet.hashCode());
 
         // Both these cases overflow the range of an int when calculating the hash code. They're

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
@@ -36,12 +36,26 @@ public class RangeSetTest {
     void testSize() {
         RangeSet rangeSet = new RangeSet(5, 10);
         assertEquals(5, rangeSet.size());
+
+        RangeSet emptyRangeSet = new RangeSet(5, -2);
+        assertEquals(0, emptyRangeSet.size());
+
+        // We don't really support ranges this large, but their size shouldn't be 0.
+        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
+        assertEquals(-0x80000000, overflowRangeSet.size());
     }
 
     @Test
     void testIsEmpty() {
         RangeSet rangeSet = new RangeSet(5, 5);
         assertTrue(rangeSet.isEmpty());
+
+        RangeSet emptyRangeSet = new RangeSet(5, -2);
+        assertTrue(emptyRangeSet.isEmpty());
+
+        // We don't really support ranges this large, but they aren't empty.
+        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
+        assertFalse(overflowRangeSet.isEmpty());
     }
 
     @Test
@@ -81,6 +95,9 @@ public class RangeSetTest {
         RangeSet rangeSet = new RangeSet(5, 10);
         Object[] expectedArray = {5, 6, 7, 8, 9};
         assertArrayEquals(expectedArray, rangeSet.toArray());
+
+        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
+        assertThrows(NegativeArraySizeException.class, () -> overflowRangeSet.toArray());
     }
 
     @Test
@@ -89,6 +106,9 @@ public class RangeSetTest {
         Integer[] inputArray = new Integer[5];
         Integer[] expectedArray = {5, 6, 7, 8, 9};
         assertArrayEquals(expectedArray, rangeSet.toArray(inputArray));
+
+        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> overflowRangeSet.toArray(inputArray));
     }
 
     @Test
@@ -117,15 +137,49 @@ public class RangeSetTest {
         assertEquals(rangeSet1, set);
         assertEquals(rangeSet3, hashSet);
         assertNotEquals(rangeSet1, new Object());
+
+        // Empty sets are equal.
+        RangeSet emptyRangeSet1 = new RangeSet(0, 0);
+        RangeSet emptyRangeSet2 = new RangeSet(2, -5);
+        Set<Integer> emptySet = Set.of();
+
+        assertEquals(emptySet, emptyRangeSet1);
+        assertEquals(emptySet, emptyRangeSet2);
+        assertEquals(emptyRangeSet1, emptyRangeSet2);
+
+        // We don't really support ranges this large, but equality shouldn't treat them as 0-size
+        // ranges.
+        RangeSet overflowRangeSet1 = new RangeSet(-1, 0x7FFFFFFF);
+        RangeSet overflowRangeSet2 = new RangeSet(-2, 0x7FFFFFFE);
+        assertNotEquals(overflowRangeSet1, overflowRangeSet2);
     }
 
     @Test
     void testHashCode() {
         RangeSet rangeSet1 = new RangeSet(5, 10);
-        RangeSet rangeSet2 = new RangeSet(5, 10);
-        RangeSet rangeSet3 = new RangeSet(6, 10);
+        RangeSet rangeSet2 = new RangeSet(6, 10);
 
-        assertEquals(rangeSet1.hashCode(), rangeSet2.hashCode());
-        assertNotEquals(rangeSet1.hashCode(), rangeSet3.hashCode());
+        assertEquals(Set.of(5, 6, 7, 8, 9).hashCode(), rangeSet1.hashCode());
+        assertEquals(Set.of(6, 7, 8, 9).hashCode(), rangeSet2.hashCode());
+
+        RangeSet emptySet = new RangeSet(5, -2);
+        assertEquals(Set.of().hashCode(), emptySet.hashCode());
+
+        // Both these cases overflow the range of an int when calculating the hash code. They're
+        // chosen so that their hash codes are almost the same except for the most significant bit.
+        RangeSet overflowRangeSet1 = new RangeSet(0x3FFFFFFD, 0x3FFFFFFF);
+        RangeSet overflowRangeSet2 = new RangeSet(0x7FFFFFFD, 0x7FFFFFFF);
+        assertEquals(
+            Set.of(0x3FFFFFFD, 0x3FFFFFFE).hashCode(),
+            overflowRangeSet1.hashCode() // == 0x0_FFFFFFF6 / 2
+        );
+        assertEquals(
+            Set.of(0x7FFFFFFD, 0x7FFFFFFE).hashCode(),
+            overflowRangeSet2.hashCode() // == 0x1_FFFFFFF6 / 2
+        );
+
+        // Negative and positive elements cancel out.
+        RangeSet overflowRangeSet3 = new RangeSet(-0x80000000, 0x7FFFFFFF);
+        assertEquals(Set.of(-0x80000000, -0x7FFFFFFF).hashCode(), overflowRangeSet3.hashCode());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
@@ -33,16 +33,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RangeSetTest {
     @Test
+    void testOverflow() {
+        // This range is the maximum size we allow.
+        new RangeSet(0, Integer.MAX_VALUE);
+
+        assertThrows(IllegalArgumentException.class, () -> new RangeSet(-1, Integer.MAX_VALUE));
+    }
+
+    @Test
     void testSize() {
         RangeSet rangeSet = new RangeSet(5, 10);
         assertEquals(5, rangeSet.size());
 
         RangeSet emptyRangeSet = new RangeSet(5, -2);
         assertEquals(0, emptyRangeSet.size());
-
-        // We don't really support ranges this large, but their size shouldn't be 0.
-        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
-        assertEquals(-0x80000000, overflowRangeSet.size());
     }
 
     @Test
@@ -52,10 +56,6 @@ public class RangeSetTest {
 
         RangeSet emptyRangeSet = new RangeSet(5, -2);
         assertTrue(emptyRangeSet.isEmpty());
-
-        // We don't really support ranges this large, but they aren't empty.
-        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
-        assertFalse(overflowRangeSet.isEmpty());
     }
 
     @Test
@@ -95,9 +95,6 @@ public class RangeSetTest {
         RangeSet rangeSet = new RangeSet(5, 10);
         Object[] expectedArray = {5, 6, 7, 8, 9};
         assertArrayEquals(expectedArray, rangeSet.toArray());
-
-        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
-        assertThrows(NegativeArraySizeException.class, () -> overflowRangeSet.toArray());
     }
 
     @Test
@@ -106,9 +103,6 @@ public class RangeSetTest {
         Integer[] inputArray = new Integer[5];
         Integer[] expectedArray = {5, 6, 7, 8, 9};
         assertArrayEquals(expectedArray, rangeSet.toArray(inputArray));
-
-        RangeSet overflowRangeSet = new RangeSet(-1, 0x7FFFFFFF);
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> overflowRangeSet.toArray(inputArray));
     }
 
     @Test
@@ -146,12 +140,6 @@ public class RangeSetTest {
         assertEquals(emptySet, emptyRangeSet1);
         assertEquals(emptySet, emptyRangeSet2);
         assertEquals(emptyRangeSet1, emptyRangeSet2);
-
-        // We don't really support ranges this large, but equality shouldn't treat them as 0-size
-        // ranges.
-        RangeSet overflowRangeSet1 = new RangeSet(-1, 0x7FFFFFFF);
-        RangeSet overflowRangeSet2 = new RangeSet(-2, 0x7FFFFFFE);
-        assertNotEquals(overflowRangeSet1, overflowRangeSet2);
     }
 
     @Test
@@ -177,9 +165,5 @@ public class RangeSetTest {
             Set.of(0x7FFFFFFD, 0x7FFFFFFE).hashCode(),
             overflowRangeSet2.hashCode() // == 0x1_FFFFFFF6 / 2
         );
-
-        // Negative and positive elements cancel out.
-        RangeSet overflowRangeSet3 = new RangeSet(-0x80000000, 0x7FFFFFFF);
-        assertEquals(Set.of(-0x80000000, -0x7FFFFFFF).hashCode(), overflowRangeSet3.hashCode());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
@@ -34,6 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RangeSetTest {
     @Test
+    void testNegativeSize() {
+        assertThrows(IllegalArgumentException.class, () -> new RangeSet(0, -1));
+    }
+
+    @Test
     void testOverflow() {
         // This range is the maximum size we allow.
         assertDoesNotThrow(() -> new RangeSet(0, Integer.MAX_VALUE));
@@ -45,18 +50,12 @@ public class RangeSetTest {
     void testSize() {
         RangeSet rangeSet = new RangeSet(5, 10);
         assertEquals(5, rangeSet.size());
-
-        RangeSet emptyRangeSet = new RangeSet(5, -2);
-        assertEquals(0, emptyRangeSet.size());
     }
 
     @Test
     void testIsEmpty() {
         RangeSet rangeSet = new RangeSet(5, 5);
         assertTrue(rangeSet.isEmpty());
-
-        RangeSet emptyRangeSet = new RangeSet(5, -2);
-        assertTrue(emptyRangeSet.isEmpty());
     }
 
     @Test
@@ -135,7 +134,7 @@ public class RangeSetTest {
 
         // Empty sets are equal.
         RangeSet emptyRangeSet1 = new RangeSet(0, 0);
-        RangeSet emptyRangeSet2 = new RangeSet(2, -5);
+        RangeSet emptyRangeSet2 = new RangeSet(5, 5);
         Set<Integer> emptySet = Set.of();
 
         assertEquals(emptySet, emptyRangeSet1);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/RangeSetTest.java
@@ -24,6 +24,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -35,7 +36,7 @@ public class RangeSetTest {
     @Test
     void testOverflow() {
         // This range is the maximum size we allow.
-        new RangeSet(0, Integer.MAX_VALUE);
+        assertDoesNotThrow(() -> new RangeSet(0, Integer.MAX_VALUE));
 
         assertThrows(IllegalArgumentException.class, () -> new RangeSet(-1, Integer.MAX_VALUE));
     }


### PR DESCRIPTION
Minor updates to RangeSet:   * Disallow ranges with negative size   *
Disallow ranges with more than Integer.MAX_VALUE elements   * Fix
equals() so that all empty RangeSets are equal, to follow the Set
interface definition better.   * Reimplement hashCode() to follow the
Set interface definition.

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
