### PR TITLE
MINOR: Fix unchecked type warnings in several test classes

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -158,7 +158,7 @@ public class ListConsumerGroupOffsetsHandlerTest {
                             .setPartitionIndexes(List.of(t2p0.partition(), t2p1.partition(), t2p2.partition()))
                     ))
             ),
-            new HashSet(request1.data().groups())
+            new HashSet<>(request1.data().groups())
         );
 
         var request2 = handler.buildBatchedRequest(coordinatorKeys(group3)).build();
@@ -173,7 +173,7 @@ public class ListConsumerGroupOffsetsHandlerTest {
                             .setPartitionIndexes(List.of(t3p0.partition(), t3p1.partition()))
                     ))
             ),
-            new HashSet(request2.data().groups())
+            new HashSet<>(request2.data().groups())
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -158,7 +158,7 @@ public class ListConsumerGroupOffsetsHandlerTest {
                             .setPartitionIndexes(List.of(t2p0.partition(), t2p1.partition(), t2p2.partition()))
                     ))
             ),
-            new HashSet<>(request1.data().groups())
+            Set.copyOf(request1.data().groups())
         );
 
         var request2 = handler.buildBatchedRequest(coordinatorKeys(group3)).build();
@@ -173,7 +173,7 @@ public class ListConsumerGroupOffsetsHandlerTest {
                             .setPartitionIndexes(List.of(t3p0.partition(), t3p1.partition()))
                     ))
             ),
-            new HashSet<>(request2.data().groups())
+            Set.copyOf(request2.data().groups())
         );
     }
 

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -446,7 +446,7 @@ public class TopicsImageTest {
 
     @Test
     public void testTopicDeltaElectionStatsWithEmptyImage() {
-        TopicImage image = new TopicImage("topic", Uuid.randomUuid(), Collections.<Integer, PartitionRegistration>emptyMap());
+        TopicImage image = new TopicImage("topic", Uuid.randomUuid(), Map.of());
         TopicDelta delta = new TopicDelta(image);
         delta.replay(new PartitionRecord().setPartitionId(0).setLeader(0).setIsr(List.of(0, 1)).setReplicas(List.of(0, 1, 2)));
         delta.replay(new PartitionChangeRecord().setPartitionId(0).setLeader(2).setIsr(List.of(2)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -446,7 +446,7 @@ public class TopicsImageTest {
 
     @Test
     public void testTopicDeltaElectionStatsWithEmptyImage() {
-        TopicImage image = new TopicImage("topic", Uuid.randomUuid(), Collections.EMPTY_MAP);
+        TopicImage image = new TopicImage("topic", Uuid.randomUuid(), Collections.<Integer, PartitionRegistration>emptyMap());
         TopicDelta delta = new TopicDelta(image);
         delta.replay(new PartitionRecord().setPartitionId(0).setLeader(0).setIsr(List.of(0, 1)).setReplicas(List.of(0, 1, 2)));
         delta.replay(new PartitionChangeRecord().setPartitionId(0).setLeader(2).setIsr(List.of(2)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
@@ -138,6 +138,7 @@ public class ConsoleShareConsumerTest {
         consumer.cleanup();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void shouldUpgradeDeliveryCount() {
         // Mock dependencies


### PR DESCRIPTION
* In ConsoleShareConsumerTest, add `@SuppressWarnings("unchecked")`
annotation in method shouldUpgradeDeliveryCount
* In ListConsumerGroupOffsetsHandlerTest, add generic parameters to
HashSet constructors
* In TopicsImageTest, add explicit generic type to Collections.EMPTY_MAP
to fix raw type usage

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
