### PR TITLE
MINOR: Fix unchecked warnings in gradle build

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -109,6 +109,7 @@ public class ListConsumerGroupOffsetsHandlerTest {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testBuildRequestWithMultipleGroups() {
         var groupSpecs = new HashMap<>(multiGroupSpecs);

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -444,6 +444,7 @@ public class TopicsImageTest {
         assertThrows(RuntimeException.class, () -> RecordTestUtils.replayAll(delta, topicRecords));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testTopicDeltaElectionStatsWithEmptyImage() {
         TopicImage image = new TopicImage("topic", Uuid.randomUuid(), Collections.EMPTY_MAP);

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
@@ -138,6 +138,7 @@ public class ConsoleShareConsumerTest {
         consumer.cleanup();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void shouldUpgradeDeliveryCount() {
         // Mock dependencies


### PR DESCRIPTION
### About
`./gradlew clean build -x test` throws warnings around unchecked or
unsafe operations. This PR eliminates those warnings.

### Testing
**Before changes**
```
➜  apache-kafka-fork-copy git:(trunk) ✗ ./gradlew clean build -x test

> Configure project : Starting build with version 4.1.0-SNAPSHOT (commit
id eb3714f0) using Gradle 8.10.2, Java 21 and Scala 2.13.15 Build
properties: ignoreFailures=false, maxParallelForks=12,
maxScalacThreads=8, maxTestRetries=0

> Task :transaction-coordinator:processMessages MessageGenerator:
processed 2 Kafka message JSON files(s).

> Task :share-coordinator:processMessages MessageGenerator: processed 4
Kafka message JSON files(s).

> Task :raft:processMessages MessageGenerator: processed 1 Kafka message
JSON files(s).

> Task :metadata:processMessages MessageGenerator: processed 26 Kafka
message JSON files(s).

> Task :group-coordinator:processMessages MessageGenerator: processed 48
Kafka message JSON files(s).

> Task :storage:processMessages MessageGenerator: processed 5 Kafka
message JSON files(s).

> Task :clients:processMessages MessageGenerator: processed 197 Kafka
message JSON files(s).

> Task :streams:processMessages MessageGenerator: processed 1 Kafka
message JSON files(s).

> Task :clients:processTestMessages MessageGenerator: processed 4 Kafka
message JSON files(s).

> Task :clients:compileTestJava Note: Some input files use or override a
deprecated API. Note: Recompile with -Xlint:deprecation for details.
Note:
/Users/abhinavdixit/IdeaProjects/apache-kafka-fork-copy/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
uses unchecked or unsafe operations. Note: Recompile with
-Xlint:unchecked for details.

> Task :metadata:compileTestJava Note:
/Users/abhinavdixit/IdeaProjects/apache-kafka-fork-copy/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
uses unchecked or unsafe operations. Note: Recompile with
-Xlint:unchecked for details.

> Task :streams:compileTestJava Note: Some input files use or override a
deprecated API. Note: Recompile with -Xlint:deprecation for details.

> Task :connect:runtime:compileTestJava Note: Some input files use
unchecked or unsafe operations. Note: Recompile with -Xlint:unchecked
for details.

> Task :clients:clients-integration-tests:compileTestJava Note: Some
input files use unchecked or unsafe operations. Note: Recompile with
-Xlint:unchecked for details.

> Task :storage:compileTestJava Note: Some input files use unchecked or
unsafe operations. Note: Recompile with -Xlint:unchecked for details.

> Task :tools:compileTestJava Note:
/Users/abhinavdixit/IdeaProjects/apache-kafka-fork-copy/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerTest.java
uses unchecked or unsafe operations. Note: Recompile with
-Xlint:unchecked for details. ```

**After changes**
```
apache-kafka-fork-copy git:(trunk) ✗ ./gradlew clean build -x test

> Configure project : Starting build with version 4.1.0-SNAPSHOT (commit
id eb3714f0) using Gradle 8.10.2, Java 21 and Scala 2.13.15 Build
properties: ignoreFailures=false, maxParallelForks=12,
maxScalacThreads=8, maxTestRetries=0

> Task :transaction-coordinator:processMessages MessageGenerator:
processed 2 Kafka message JSON files(s).

> Task :raft:processMessages MessageGenerator: processed 1 Kafka message
JSON files(s).

> Task :share-coordinator:processMessages MessageGenerator: processed 4
Kafka message JSON files(s).

> Task :storage:processMessages MessageGenerator: processed 5 Kafka
message JSON files(s).

> Task :group-coordinator:processMessages MessageGenerator: processed 48
Kafka message JSON files(s).

> Task :metadata:processMessages MessageGenerator: processed 26 Kafka
message JSON files(s).

> Task :clients:processMessages MessageGenerator: processed 197 Kafka
message JSON files(s).

> Task :clients:processTestMessages MessageGenerator: processed 4 Kafka
message JSON files(s).

> Task :streams:processMessages MessageGenerator: processed 1 Kafka
message JSON files(s).

> Task :clients:compileTestJava Note: Some input files use or override a
deprecated API. Note: Recompile with -Xlint:deprecation for details.

> Task :connect:runtime:compileTestJava Note: Some input files use
unchecked or unsafe operations. Note: Recompile with -Xlint:unchecked
for details.

> Task :streams:compileTestJava Note: Some input files use or override a
deprecated API. Note: Recompile with -Xlint:deprecation for details.

> Task :clients:clients-integration-tests:compileTestJava Note: Some
input files use unchecked or unsafe operations. Note: Recompile with
-Xlint:unchecked for details.

> Task :storage:compileTestJava Note: Some input files use unchecked or
unsafe operations. Note: Recompile with -Xlint:unchecked for details.
```

Reviewers: Andrew Schofield <aschofield@confluent.io>
