### PR TITLE
MINOR: Fix version in 4.0 branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=4.1.0-SNAPSHOT
+version=4.0.1-SNAPSHOT
 scalaVersion=2.13.15
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.25


### PR DESCRIPTION
This patch fixes the version used in the `4.0` branch. It should be `4.0.1` instead of `4.1.0`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
