### PR TITLE
MINOR: Improve client error messages for share groups not enabled

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -54,6 +54,9 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
     public static final String SHARE_PROTOCOL_NOT_SUPPORTED_MSG = "The cluster does not support the share group protocol. " +
         "To use share groups, the cluster must have the share group protocol enabled.";
 
+    public static final String SHARE_PROTOCOL_VERSION_NOT_SUPPORTED_MSG = "The cluster does not support the share group protocol " +
+        "using ShareGroupHeartbeat API version 1 or later. This version of the API was introduced in Apache Kafka v4.1.";
+
     public ShareHeartbeatRequestManager(
             final LogContext logContext,
             final Time time,
@@ -93,8 +96,8 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
     public boolean handleSpecificFailure(Throwable exception) {
         boolean errorHandled = false;
         if (exception instanceof UnsupportedVersionException) {
-            logger.error("{} failed due to {}: {}", heartbeatRequestName(), exception.getMessage(), SHARE_PROTOCOL_NOT_SUPPORTED_MSG);
-            handleFatalFailure(new UnsupportedVersionException(SHARE_PROTOCOL_NOT_SUPPORTED_MSG, exception));
+            logger.error("{} failed due to {}: {}", heartbeatRequestName(), exception.getMessage(), SHARE_PROTOCOL_VERSION_NOT_SUPPORTED_MSG);
+            handleFatalFailure(new UnsupportedVersionException(SHARE_PROTOCOL_VERSION_NOT_SUPPORTED_MSG, exception));
             errorHandled = true;
         }
         return errorHandled;


### PR DESCRIPTION
As mentioned in
https://github.com/apache/kafka/pull/19378#pullrequestreview-2775598123,
the error messages for a 4.1 share consumer could be clearer for the
different cases for when it cannot successfully join a share group.

Now, for a 4.1 consumer connecting to a 4.0 broker with share groups
disabled:     ```
org.apache.kafka.common.errors.UnsupportedVersionException: The cluster
does not support the share group protocol using ShareGroupHeartbeat API
version 1 or later. This version of the API was introduced in Apache
Kafka v4.1.  Caused by:
org.apache.kafka.common.errors.UnsupportedVersionException: The node
does not support SHARE_GROUP_HEARTBEAT    ```

And a 4.1 consumer connecting to a 4.0 broker with share groups enabled:
```  org.apache.kafka.common.errors.UnsupportedVersionException: The
cluster does not support the share group protocol using
ShareGroupHeartbeat API version 1 or later. This version of the API was
introduced in Apache Kafka v4.1.  Caused by:
org.apache.kafka.common.errors.UnsupportedVersionException: The node
does not support SHARE_GROUP_HEARTBEAT with version in range [1,1]. The
supported range is [0,0].    ```

And a 4.1 consumer connecting to a 4.1 broker with share groups
disabled:     ```
org.apache.kafka.common.errors.UnsupportedVersionException: The cluster
does not support the share group protocol. To use share groups, the
cluster must have the share group protocol enabled.     ```

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
