### PR TITLE
KAFKA-19271:  Add internal ConsumerWrapper

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1320,6 +1320,9 @@ public class StreamsConfig extends AbstractConfig {
         // This is settable in the main Streams config, but it's a private API for testing
         public static final String ASSIGNMENT_LISTENER = "__assignment.listener__";
 
+        // This is settable in the main Streams config, but it's a private API for testing
+        public static final String INTERNAL_CONSUMER_WRAPPER = "__internal.consumer.wrapper__";
+
         // Private API used to control the emit latency for left/outer join results (https://issues.apache.org/jira/browse/KAFKA-10847)
         public static final String EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "__emit.interval.ms.kstreams.outer.join.spurious.results.fix__";
 

--- a/streams/src/main/java/org/apache/kafka/streams/internals/ConsumerWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/ConsumerWrapper.java
@@ -16,8 +16,301 @@
  */
 package org.apache.kafka.streams.internals;
 
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.SubscriptionPattern;
+import org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer;
+import org.apache.kafka.clients.consumer.internals.StreamsRebalanceData;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
-public interface ConsumerWrapper extends Consumer<byte[], byte[]> {
-    void wrapConsumer(final Consumer<byte[], byte[]> delegate);
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public abstract class ConsumerWrapper implements Consumer<byte[], byte[]> {
+    protected AsyncKafkaConsumer<byte[], byte[]> delegate;
+
+    public void wrapConsumer(
+        final AsyncKafkaConsumer<byte[], byte[]> delegate,
+        final Map<String, Object> config,
+        final Optional<StreamsRebalanceData> streamsRebalanceData
+    ) {
+        this.delegate = delegate;
+    }
+
+    public AsyncKafkaConsumer<byte[], byte[]> consumer() {
+        return delegate;
+    }
+
+    @Override
+    public Set<TopicPartition> assignment() {
+        return delegate.assignment();
+    }
+
+    @Override
+    public Set<String> subscription() {
+        return delegate.subscription();
+    }
+
+    @Override
+    public void subscribe(final Collection<String> topics) {
+        delegate.subscribe(topics);
+    }
+
+    @Override
+    public void subscribe(final Collection<String> topics, final ConsumerRebalanceListener callback) {
+        delegate.subscribe(topics, callback);
+    }
+
+    @Override
+    public void assign(final Collection<TopicPartition> partitions) {
+        delegate.assign(partitions);
+    }
+
+    @Override
+    public void subscribe(final Pattern pattern, final ConsumerRebalanceListener callback) {
+        delegate.subscribe(pattern, callback);
+    }
+
+    @Override
+    public void subscribe(final Pattern pattern) {
+        delegate.subscribe(pattern);
+    }
+
+    @Override
+    public void subscribe(final SubscriptionPattern pattern, final ConsumerRebalanceListener callback) {
+        delegate.subscribe(pattern, callback);
+    }
+
+    @Override
+    public void subscribe(final SubscriptionPattern pattern) {
+        delegate.subscribe(pattern);
+    }
+
+    @Override
+    public void unsubscribe() {
+        delegate.unsubscribe();
+    }
+
+    @Override
+    public ConsumerRecords<byte[], byte[]> poll(final Duration timeout) {
+        return delegate.poll(timeout);
+    }
+
+    @Override
+    public void commitSync() {
+        delegate.commitSync();
+    }
+
+    @Override
+    public void commitSync(final Duration timeout) {
+        delegate.commitSync(timeout);
+    }
+
+    @Override
+    public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        delegate.commitSync(offsets);
+    }
+
+    @Override
+    public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout) {
+        delegate.commitSync(offsets, timeout);
+    }
+
+    @Override
+    public void commitAsync() {
+        delegate.commitAsync();
+    }
+
+    @Override
+    public void commitAsync(final OffsetCommitCallback callback) {
+        delegate.commitAsync(callback);
+    }
+
+    @Override
+    public void commitAsync(final Map<TopicPartition, OffsetAndMetadata> offsets, final OffsetCommitCallback callback) {
+        delegate.commitAsync(offsets, callback);
+    }
+
+    @Override
+    public void registerMetricForSubscription(final KafkaMetric metric) {
+        delegate.registerMetricForSubscription(metric);
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(final KafkaMetric metric) {
+        delegate.unregisterMetricFromSubscription(metric);
+    }
+
+    @Override
+    public void seek(final TopicPartition partition, final long offset) {
+        delegate.seek(partition, offset);
+    }
+
+    @Override
+    public void seek(final TopicPartition partition, final OffsetAndMetadata offsetAndMetadata) {
+        delegate.seek(partition, offsetAndMetadata);
+    }
+
+    @Override
+    public void seekToBeginning(final Collection<TopicPartition> partitions) {
+        delegate.seekToBeginning(partitions);
+    }
+
+    @Override
+    public void seekToEnd(final Collection<TopicPartition> partitions) {
+        delegate.seekToEnd(partitions);
+    }
+
+    @Override
+    public long position(final TopicPartition partition) {
+        return delegate.position(partition);
+    }
+
+    @Override
+    public long position(final TopicPartition partition, final Duration timeout) {
+        return delegate.position(partition, timeout);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions) {
+        return delegate.committed(partitions);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions, final Duration timeout) {
+        return delegate.committed(partitions, timeout);
+    }
+
+    @Override
+    public Uuid clientInstanceId(final Duration timeout) {
+        return delegate.clientInstanceId(timeout);
+    }
+
+    @Override
+    public Map<MetricName, ? extends Metric> metrics() {
+        return delegate.metrics();
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(final String topic) {
+        return delegate.partitionsFor(topic);
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(final String topic, final Duration timeout) {
+        return delegate.partitionsFor(topic, timeout);
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics() {
+        return delegate.listTopics();
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(final Duration timeout) {
+        return delegate.listTopics(timeout);
+    }
+
+    @Override
+    public Set<TopicPartition> paused() {
+        return delegate.paused();
+    }
+
+    @Override
+    public void pause(final Collection<TopicPartition> partitions) {
+        delegate.pause(partitions);
+    }
+
+    @Override
+    public void resume(final Collection<TopicPartition> partitions) {
+        delegate.resume(partitions);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch) {
+        return delegate.offsetsForTimes(timestampsToSearch);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch, final Duration timeout) {
+        return delegate.offsetsForTimes(timestampsToSearch, timeout);
+    }
+
+    @Override
+    public Map<TopicPartition, Long> beginningOffsets(final Collection<TopicPartition> partitions) {
+        return delegate.beginningOffsets(partitions);
+    }
+
+    @Override
+    public Map<TopicPartition, Long> beginningOffsets(final Collection<TopicPartition> partitions, final Duration timeout) {
+        return delegate.beginningOffsets(partitions, timeout);
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(final Collection<TopicPartition> partitions) {
+        return delegate.endOffsets(partitions);
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(final Collection<TopicPartition> partitions, final Duration timeout) {
+        return delegate.endOffsets(partitions, timeout);
+    }
+
+    @Override
+    public OptionalLong currentLag(final TopicPartition topicPartition) {
+        return delegate.currentLag(topicPartition);
+    }
+
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        return delegate.groupMetadata();
+    }
+
+    @Override
+    public void enforceRebalance() {
+        delegate.enforceRebalance();
+    }
+
+    @Override
+    public void enforceRebalance(final String reason) {
+        delegate.enforceRebalance(reason);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Deprecated
+    @Override
+    public void close(final Duration timeout) {
+        delegate.close(timeout);
+    }
+
+    @Override
+    public void close(final CloseOptions option) {
+        delegate.close(option);
+    }
+
+    @Override
+    public void wakeup() {
+        delegate.wakeup();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/internals/ConsumerWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/ConsumerWrapper.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+public interface ConsumerWrapper extends Consumer<byte[], byte[]> {
+    void wrapConsumer(final Consumer<byte[], byte[]> delegate);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -55,6 +55,7 @@ import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.ConsumerWrapper;
 import org.apache.kafka.streams.internals.metrics.ClientMetrics;
 import org.apache.kafka.streams.internals.metrics.StreamsThreadMetricsDelegatingReporter;
 import org.apache.kafka.streams.processor.StandbyUpdateListener;
@@ -550,12 +551,16 @@ public class StreamThread extends Thread implements ProcessingThread {
             );
             final ByteArrayDeserializer keyDeserializer = new ByteArrayDeserializer();
             final ByteArrayDeserializer valueDeserializer = new ByteArrayDeserializer();
+
             return new MainConsumerSetup(
-                new AsyncKafkaConsumer<>(
-                    new ConsumerConfig(ConsumerConfig.appendDeserializerToConfig(consumerConfigs, keyDeserializer, valueDeserializer)),
-                    keyDeserializer,
-                    valueDeserializer,
-                    streamsRebalanceData
+                maybeWrapConsumer(
+                    config.originals(),
+                    new AsyncKafkaConsumer<>(
+                        new ConsumerConfig(ConsumerConfig.appendDeserializerToConfig(consumerConfigs, keyDeserializer, valueDeserializer)),
+                        keyDeserializer,
+                        valueDeserializer,
+                        streamsRebalanceData
+                    )
                 ),
                 streamsRebalanceData
             );
@@ -565,6 +570,31 @@ public class StreamThread extends Thread implements ProcessingThread {
                 Optional.empty()
             );
         }
+    }
+
+    private static Consumer<byte[], byte[]> maybeWrapConsumer(final Map<String, ?> config,
+                                                              final Consumer<byte[], byte[]> consumer) {
+        final Object o = config.get(InternalConfig.INTERNAL_CONSUMER_WRAPPER);
+        if (o == null) {
+            return consumer;
+        }
+
+        final ConsumerWrapper wrapper;
+        if (o instanceof String) {
+            try {
+                wrapper = Utils.newInstance((String) o, ConsumerWrapper.class);
+            } catch (final ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
+        } else if (o instanceof Class<?>) {
+            wrapper = (ConsumerWrapper) Utils.newInstance((Class<?>) o);
+        } else {
+            throw new IllegalArgumentException("Internal config " + InternalConfig.INTERNAL_CONSUMER_WRAPPER + " must be a class or class name");
+        }
+
+        wrapper.wrapConsumer(consumer);
+
+        return wrapper;
     }
 
     private static class MainConsumerSetup {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -554,13 +554,14 @@ public class StreamThread extends Thread implements ProcessingThread {
 
             return new MainConsumerSetup(
                 maybeWrapConsumer(
-                    config.originals(),
+                    consumerConfigs,
                     new AsyncKafkaConsumer<>(
                         new ConsumerConfig(ConsumerConfig.appendDeserializerToConfig(consumerConfigs, keyDeserializer, valueDeserializer)),
                         keyDeserializer,
                         valueDeserializer,
                         streamsRebalanceData
-                    )
+                    ),
+                    streamsRebalanceData
                 ),
                 streamsRebalanceData
             );
@@ -572,8 +573,9 @@ public class StreamThread extends Thread implements ProcessingThread {
         }
     }
 
-    private static Consumer<byte[], byte[]> maybeWrapConsumer(final Map<String, ?> config,
-                                                              final Consumer<byte[], byte[]> consumer) {
+    private static Consumer<byte[], byte[]> maybeWrapConsumer(final Map<String, Object> config,
+                                                              final AsyncKafkaConsumer<byte[], byte[]> consumer,
+                                                              final Optional<StreamsRebalanceData> streamsRebalanceData) {
         final Object o = config.get(InternalConfig.INTERNAL_CONSUMER_WRAPPER);
         if (o == null) {
             return consumer;
@@ -592,7 +594,7 @@ public class StreamThread extends Thread implements ProcessingThread {
             throw new IllegalArgumentException("Internal config " + InternalConfig.INTERNAL_CONSUMER_WRAPPER + " must be a class or class name");
         }
 
-        wrapper.wrapConsumer(consumer);
+        wrapper.wrapConsumer(consumer, config, streamsRebalanceData);
 
         return wrapper;
     }
@@ -1135,7 +1137,10 @@ public class StreamThread extends Thread implements ProcessingThread {
             mainConsumer.subscribe(topologyMetadata.sourceTopicPattern(), rebalanceListener);
         } else {
             if (streamsRebalanceData.isPresent()) {
-                ((AsyncKafkaConsumer<byte[], byte[]>) mainConsumer).subscribe(
+                final AsyncKafkaConsumer<byte[], byte[]> consumer = mainConsumer instanceof ConsumerWrapper
+                    ? ((ConsumerWrapper) mainConsumer).consumer()
+                    : (AsyncKafkaConsumer<byte[], byte[]>) mainConsumer;
+                consumer.subscribe(
                     topologyMetadata.allFullSourceTopicNames(),
                     new DefaultStreamsRebalanceListener(
                         log,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.admin.MockAdminClient;
-import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -26,9 +25,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.consumer.SubscriptionPattern;
 import org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer;
 import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.MockRebalanceListener;
@@ -135,7 +131,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -144,7 +139,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -3943,7 +3937,7 @@ public class StreamThreadTest {
 
         assertInstanceOf(
             AsyncKafkaConsumer.class,
-            assertInstanceOf(TestWrapper.class, thread.mainConsumer()).delegate
+            assertInstanceOf(TestWrapper.class, thread.mainConsumer()).consumer()
         );
     }
 
@@ -3958,168 +3952,11 @@ public class StreamThreadTest {
 
         assertInstanceOf(
             AsyncKafkaConsumer.class,
-            assertInstanceOf(TestWrapper.class, thread.mainConsumer()).delegate
+            assertInstanceOf(TestWrapper.class, thread.mainConsumer()).consumer()
         );
     }
 
-    public static final class TestWrapper implements ConsumerWrapper {
-        private Consumer<byte[], byte[]> delegate;
-
-        @Override
-        public void wrapConsumer(final Consumer<byte[], byte[]> delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public Set<TopicPartition> assignment() {
-            return Set.of();
-        }
-        @Override
-        public Set<String> subscription() {
-            return Set.of();
-        }
-        @Override
-        public void subscribe(final Collection<String> topics) { }
-        @Override
-        public void subscribe(final Collection<String> topics, final ConsumerRebalanceListener callback) { }
-        @Override
-        public void assign(final Collection<TopicPartition> partitions) { }
-        @Override
-        public void subscribe(final Pattern pattern, final ConsumerRebalanceListener callback) { }
-        @Override
-        public void subscribe(final Pattern pattern) { }
-        @Override
-        public void subscribe(final SubscriptionPattern pattern, final ConsumerRebalanceListener callback) { }
-        @Override
-        public void subscribe(final SubscriptionPattern pattern) { }
-        @Override
-        public void unsubscribe() { }
-        @Override
-        public ConsumerRecords<byte[], byte[]> poll(final Duration timeout) {
-            return null;
-        }
-        @Override
-        public void commitSync() { }
-        @Override
-        public void commitSync(final Duration timeout) { }
-        @Override
-        public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) { }
-        @Override
-        public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout) { }
-        @Override
-        public void commitAsync() { }
-        @Override
-        public void commitAsync(final OffsetCommitCallback callback) { }
-        @Override
-        public void commitAsync(final Map<TopicPartition, OffsetAndMetadata> offsets, final OffsetCommitCallback callback) { }
-        @Override
-        public void registerMetricForSubscription(final KafkaMetric metric) { }
-        @Override
-        public void unregisterMetricFromSubscription(final KafkaMetric metric) { }
-        @Override
-        public void seek(final TopicPartition partition, final long offset) { }
-        @Override
-        public void seek(final TopicPartition partition, final OffsetAndMetadata offsetAndMetadata) { }
-        @Override
-        public void seekToBeginning(final Collection<TopicPartition> partitions) { }
-        @Override
-        public void seekToEnd(final Collection<TopicPartition> partitions) { }
-        @Override
-        public long position(final TopicPartition partition) {
-            return 0;
-        }
-        @Override
-        public long position(final TopicPartition partition, final Duration timeout) {
-            return 0;
-        }
-        @Override
-        public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions) {
-            return Map.of();
-        }
-        @Override
-        public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions, final Duration timeout) {
-            return Map.of();
-        }
-        @Override
-        public Uuid clientInstanceId(final Duration timeout) {
-            return null;
-        }
-        @Override
-        public Map<MetricName, ? extends Metric> metrics() {
-            return Map.of();
-        }
-        @Override
-        public List<PartitionInfo> partitionsFor(final String topic) {
-            return List.of();
-        }
-        @Override
-        public List<PartitionInfo> partitionsFor(final String topic, final Duration timeout) {
-            return List.of();
-        }
-        @Override
-        public Map<String, List<PartitionInfo>> listTopics() {
-            return Map.of();
-        }
-        @Override
-        public Map<String, List<PartitionInfo>> listTopics(final Duration timeout) {
-            return Map.of();
-        }
-        @Override
-        public Set<TopicPartition> paused() {
-            return Set.of();
-        }
-        @Override
-        public void pause(final Collection<TopicPartition> partitions) { }
-        @Override
-        public void resume(final Collection<TopicPartition> partitions) { }
-        @Override
-        public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch) {
-            return Map.of();
-        }
-        @Override
-        public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch, final Duration timeout) {
-            return Map.of();
-        }
-        @Override
-        public Map<TopicPartition, Long> beginningOffsets(final Collection<TopicPartition> partitions) {
-            return Map.of();
-        }
-        @Override
-        public Map<TopicPartition, Long> beginningOffsets(final Collection<TopicPartition> partitions, final Duration timeout) {
-            return Map.of();
-        }
-        @Override
-        public Map<TopicPartition, Long> endOffsets(final Collection<TopicPartition> partitions) {
-            return Map.of();
-        }
-        @Override
-        public Map<TopicPartition, Long> endOffsets(final Collection<TopicPartition> partitions, final Duration timeout) {
-            return Map.of();
-        }
-        @Override
-        public OptionalLong currentLag(final TopicPartition topicPartition) {
-            return OptionalLong.empty();
-        }
-
-        @Override
-        public ConsumerGroupMetadata groupMetadata() {
-            return delegate.groupMetadata();
-        }
-
-        @Override
-        public void enforceRebalance() { }
-        @Override
-        public void enforceRebalance(final String reason) { }
-        @Override
-        public void close() { }
-        @Deprecated
-        @Override
-        public void close(final Duration timeout) { }
-        @Override
-        public void close(final CloseOptions option) { }
-        @Override
-        public void wakeup() { }
-    }
+    public static final class TestWrapper extends ConsumerWrapper { }
 
     private StreamThread setUpThread(final Properties streamsConfigProps) {
         final StreamsConfig config = new StreamsConfig(streamsConfigProps);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -25,6 +26,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.SubscriptionPattern;
 import org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumer;
 import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.MockRebalanceListener;
@@ -69,6 +73,7 @@ import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.ConsumerWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
@@ -130,6 +135,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -138,6 +144,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -3923,6 +3930,195 @@ public class StreamThreadTest {
                 )
             )
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldWrapMainConsumerFromClassConfig(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
+        final Properties streamsConfigProps = configProps(false, stateUpdaterEnabled, processingThreadsEnabled);
+        streamsConfigProps.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
+        streamsConfigProps.put(InternalConfig.INTERNAL_CONSUMER_WRAPPER, TestWrapper.class);
+
+        thread = createStreamThread("clientId", new StreamsConfig(streamsConfigProps));
+
+        assertInstanceOf(
+            AsyncKafkaConsumer.class,
+            assertInstanceOf(TestWrapper.class, thread.mainConsumer()).delegate
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldWrapMainConsumerFromStringConfig(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
+        final Properties streamsConfigProps = configProps(false, stateUpdaterEnabled, processingThreadsEnabled);
+        streamsConfigProps.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
+        streamsConfigProps.put(InternalConfig.INTERNAL_CONSUMER_WRAPPER, TestWrapper.class.getName());
+
+        thread = createStreamThread("clientId", new StreamsConfig(streamsConfigProps));
+
+        assertInstanceOf(
+            AsyncKafkaConsumer.class,
+            assertInstanceOf(TestWrapper.class, thread.mainConsumer()).delegate
+        );
+    }
+
+    public static final class TestWrapper implements ConsumerWrapper {
+        private Consumer<byte[], byte[]> delegate;
+
+        @Override
+        public void wrapConsumer(final Consumer<byte[], byte[]> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Set<TopicPartition> assignment() {
+            return Set.of();
+        }
+        @Override
+        public Set<String> subscription() {
+            return Set.of();
+        }
+        @Override
+        public void subscribe(final Collection<String> topics) { }
+        @Override
+        public void subscribe(final Collection<String> topics, final ConsumerRebalanceListener callback) { }
+        @Override
+        public void assign(final Collection<TopicPartition> partitions) { }
+        @Override
+        public void subscribe(final Pattern pattern, final ConsumerRebalanceListener callback) { }
+        @Override
+        public void subscribe(final Pattern pattern) { }
+        @Override
+        public void subscribe(final SubscriptionPattern pattern, final ConsumerRebalanceListener callback) { }
+        @Override
+        public void subscribe(final SubscriptionPattern pattern) { }
+        @Override
+        public void unsubscribe() { }
+        @Override
+        public ConsumerRecords<byte[], byte[]> poll(final Duration timeout) {
+            return null;
+        }
+        @Override
+        public void commitSync() { }
+        @Override
+        public void commitSync(final Duration timeout) { }
+        @Override
+        public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) { }
+        @Override
+        public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout) { }
+        @Override
+        public void commitAsync() { }
+        @Override
+        public void commitAsync(final OffsetCommitCallback callback) { }
+        @Override
+        public void commitAsync(final Map<TopicPartition, OffsetAndMetadata> offsets, final OffsetCommitCallback callback) { }
+        @Override
+        public void registerMetricForSubscription(final KafkaMetric metric) { }
+        @Override
+        public void unregisterMetricFromSubscription(final KafkaMetric metric) { }
+        @Override
+        public void seek(final TopicPartition partition, final long offset) { }
+        @Override
+        public void seek(final TopicPartition partition, final OffsetAndMetadata offsetAndMetadata) { }
+        @Override
+        public void seekToBeginning(final Collection<TopicPartition> partitions) { }
+        @Override
+        public void seekToEnd(final Collection<TopicPartition> partitions) { }
+        @Override
+        public long position(final TopicPartition partition) {
+            return 0;
+        }
+        @Override
+        public long position(final TopicPartition partition, final Duration timeout) {
+            return 0;
+        }
+        @Override
+        public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions) {
+            return Map.of();
+        }
+        @Override
+        public Map<TopicPartition, OffsetAndMetadata> committed(final Set<TopicPartition> partitions, final Duration timeout) {
+            return Map.of();
+        }
+        @Override
+        public Uuid clientInstanceId(final Duration timeout) {
+            return null;
+        }
+        @Override
+        public Map<MetricName, ? extends Metric> metrics() {
+            return Map.of();
+        }
+        @Override
+        public List<PartitionInfo> partitionsFor(final String topic) {
+            return List.of();
+        }
+        @Override
+        public List<PartitionInfo> partitionsFor(final String topic, final Duration timeout) {
+            return List.of();
+        }
+        @Override
+        public Map<String, List<PartitionInfo>> listTopics() {
+            return Map.of();
+        }
+        @Override
+        public Map<String, List<PartitionInfo>> listTopics(final Duration timeout) {
+            return Map.of();
+        }
+        @Override
+        public Set<TopicPartition> paused() {
+            return Set.of();
+        }
+        @Override
+        public void pause(final Collection<TopicPartition> partitions) { }
+        @Override
+        public void resume(final Collection<TopicPartition> partitions) { }
+        @Override
+        public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch) {
+            return Map.of();
+        }
+        @Override
+        public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch, final Duration timeout) {
+            return Map.of();
+        }
+        @Override
+        public Map<TopicPartition, Long> beginningOffsets(final Collection<TopicPartition> partitions) {
+            return Map.of();
+        }
+        @Override
+        public Map<TopicPartition, Long> beginningOffsets(final Collection<TopicPartition> partitions, final Duration timeout) {
+            return Map.of();
+        }
+        @Override
+        public Map<TopicPartition, Long> endOffsets(final Collection<TopicPartition> partitions) {
+            return Map.of();
+        }
+        @Override
+        public Map<TopicPartition, Long> endOffsets(final Collection<TopicPartition> partitions, final Duration timeout) {
+            return Map.of();
+        }
+        @Override
+        public OptionalLong currentLag(final TopicPartition topicPartition) {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public ConsumerGroupMetadata groupMetadata() {
+            return delegate.groupMetadata();
+        }
+
+        @Override
+        public void enforceRebalance() { }
+        @Override
+        public void enforceRebalance(final String reason) { }
+        @Override
+        public void close() { }
+        @Deprecated
+        @Override
+        public void close(final Duration timeout) { }
+        @Override
+        public void close(final CloseOptions option) { }
+        @Override
+        public void wakeup() { }
     }
 
     private StreamThread setUpThread(final Properties streamsConfigProps) {


### PR DESCRIPTION
With KIP-1071 enabled, the main consumer is created differently,  side
stepping `KafkaClientSupplier`.

To allow injection test wrappers, we add an internal ConsumerWrapper,
until we define a new public interface.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
