### PR TITLE
KAFKA-19269: `Unexpected error ..` should not happen when the delete.topic.enable is false

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -147,7 +147,6 @@ class ControllerApis(
       }
     } catch {
       case e: FatalExitError => throw e
-      case e: TopicDeletionDisabledException => requestHelper.handleError(request, e)
       case t: Throwable =>
         // This catches exceptions in the blocking parts of the request handlers
         error(s"Unexpected error handling request ${request.requestDesc(true)} " +
@@ -230,9 +229,9 @@ class ControllerApis(
     // Check if topic deletion is enabled at all.
     if (!config.deleteTopicEnable) {
       if (apiVersion < 3) {
-        throw new InvalidRequestException("Topic deletion is disabled.")
+        return CompletableFuture.failedFuture(new InvalidRequestException("Topic deletion is disabled."))
       } else {
-        throw new TopicDeletionDisabledException()
+        return CompletableFuture.failedFuture(new TopicDeletionDisabledException("Topic deletion is disabled"))
       }
     }
     // The first step is to load up the names and IDs that have been provided by the

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -147,6 +147,7 @@ class ControllerApis(
       }
     } catch {
       case e: FatalExitError => throw e
+      case e: TopicDeletionDisabledException => requestHelper.handleError(request, e)
       case t: Throwable =>
         // This catches exceptions in the blocking parts of the request handlers
         error(s"Unexpected error handling request ${request.requestDesc(true)} " +

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -229,9 +229,9 @@ class ControllerApis(
     // Check if topic deletion is enabled at all.
     if (!config.deleteTopicEnable) {
       if (apiVersion < 3) {
-        return CompletableFuture.failedFuture(new InvalidRequestException("Topic deletion is disabled."))
+        return CompletableFuture.failedFuture(new InvalidRequestException("This version does not support topic deletion."))
       } else {
-        return CompletableFuture.failedFuture(new TopicDeletionDisabledException("Topic deletion is disabled"))
+        return CompletableFuture.failedFuture(new TopicDeletionDisabledException())
       }
     }
     // The first step is to load up the names and IDs that have been provided by the

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -74,7 +74,7 @@ import java.net.InetAddress
 import java.util
 import java.util.Collections.{singleton, singletonList, singletonMap}
 import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.{Collections, Optional, Properties}
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -154,7 +154,8 @@ class ControllerApisTest {
   private def createControllerApis(authorizer: Option[Plugin[Authorizer]],
                                    controller: Controller,
                                    props: Properties = new Properties(),
-                                   throttle: Boolean = false): ControllerApis = {
+                                   throttle: Boolean = false,
+                                   errorLogCallback: Option[String => Unit] = None): ControllerApis = {
     props.put(KRaftConfigs.NODE_ID_CONFIG, nodeId: java.lang.Integer)
     props.put(KRaftConfigs.PROCESS_ROLES_CONFIG, "controller")
     props.put(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER")
@@ -175,7 +176,12 @@ class ControllerApisTest {
         true,
         () => FinalizedFeatures.fromKRaftVersion(MetadataVersion.latestTesting())),
       metadataCache
-    )
+    ) {
+      override def error(msg: => String, e: => Throwable): Unit = {
+        errorLogCallback.foreach(_(msg))
+        super.error(msg, e)
+      }
+    }
   }
 
   /**
@@ -963,6 +969,28 @@ class ControllerApisTest {
         hasClusterAuth = false,
         _ => Set("foo", "bar"),
         _ => Set("foo", "bar")))
+  }
+
+  @Test
+  def testDeleteTopicsWhenDeleteConfigDisable(): Unit = {
+    val deleteTopicData = new DeleteTopicsRequestData()
+    deleteTopicData.setTopicNames(Collections.singletonList("topicA"))
+    val deleteTopicsRequest = new DeleteTopicsRequest.Builder(deleteTopicData).build(ApiKeys.DELETE_TOPICS.latestVersion)
+    // boolean flag, it will set to true if error log triggered
+    val printUnexpectedLog = new AtomicBoolean(false)
+
+    // set 'delete.topic.enable' to false
+    val props = new Properties()
+    props.put(ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG, "false")
+    controllerApis = createControllerApis(None, new MockController.Builder().build(), props = props, errorLogCallback = Some(msg => {
+      // set flag to true
+      if (msg != null && msg.startsWith("Unexpected error")) {
+        printUnexpectedLog.set(true)
+      }
+    }))
+
+    controllerApis.handle(buildRequest(deleteTopicsRequest), RequestLocal.noCaching)
+    assertFalse(printUnexpectedLog.get())
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -957,18 +957,24 @@ class ControllerApisTest {
     controllerApis = createControllerApis(None, controller, props)
     val request = new DeleteTopicsRequestData()
     request.topics().add(new DeleteTopicState().setName("foo").setTopicId(ZERO_UUID))
-    assertThrows(classOf[TopicDeletionDisabledException],
-      () => controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
-        ApiKeys.DELETE_TOPICS.latestVersion().toInt,
-        hasClusterAuth = false,
-        _ => Set("foo", "bar"),
-        _ => Set("foo", "bar")))
-    assertThrows(classOf[InvalidRequestException],
-      () => controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
-        1,
-        hasClusterAuth = false,
-        _ => Set("foo", "bar"),
-        _ => Set("foo", "bar")))
+
+    controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
+      ApiKeys.DELETE_TOPICS.latestVersion().toInt,
+      hasClusterAuth = false,
+      _ => Set("foo", "bar"),
+      _ => Set("foo", "bar")).exceptionally(e => {
+      assertTrue(e.isInstanceOf[TopicDeletionDisabledException])
+      return
+    })
+
+    controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
+      1,
+      hasClusterAuth = false,
+      _ => Set("foo", "bar"),
+      _ => Set("foo", "bar")).exceptionally(e => {
+      assertTrue(e.isInstanceOf[InvalidRequestException])
+      return
+    })
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -61,6 +61,7 @@ import org.apache.kafka.server.common.{ApiMessageAndVersion, FinalizedFeatures, 
 import org.apache.kafka.server.config.{KRaftConfigs, ServerConfigs}
 import org.apache.kafka.server.util.FutureUtils
 import org.apache.kafka.storage.internals.log.CleanerConfig
+import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -74,7 +75,7 @@ import java.net.InetAddress
 import java.util
 import java.util.Collections.{singleton, singletonList, singletonMap}
 import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.atomic.AtomicReference
 import java.util.{Collections, Optional, Properties}
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -154,8 +155,7 @@ class ControllerApisTest {
   private def createControllerApis(authorizer: Option[Plugin[Authorizer]],
                                    controller: Controller,
                                    props: Properties = new Properties(),
-                                   throttle: Boolean = false,
-                                   errorLogCallback: Option[String => Unit] = None): ControllerApis = {
+                                   throttle: Boolean = false): ControllerApis = {
     props.put(KRaftConfigs.NODE_ID_CONFIG, nodeId: java.lang.Integer)
     props.put(KRaftConfigs.PROCESS_ROLES_CONFIG, "controller")
     props.put(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER")
@@ -176,12 +176,7 @@ class ControllerApisTest {
         true,
         () => FinalizedFeatures.fromKRaftVersion(MetadataVersion.latestTesting())),
       metadataCache
-    ) {
-      override def error(msg: => String, e: => Throwable): Unit = {
-        errorLogCallback.foreach(_(msg))
-        super.error(msg, e)
-      }
-    }
+    )
   }
 
   /**
@@ -958,45 +953,17 @@ class ControllerApisTest {
     val request = new DeleteTopicsRequestData()
     request.topics().add(new DeleteTopicState().setName("foo").setTopicId(ZERO_UUID))
 
-    controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
+    TestUtils.assertFutureThrows(classOf[TopicDeletionDisabledException], controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
       ApiKeys.DELETE_TOPICS.latestVersion().toInt,
       hasClusterAuth = false,
       _ => Set("foo", "bar"),
-      _ => Set("foo", "bar")).exceptionally(e => {
-      assertTrue(e.isInstanceOf[TopicDeletionDisabledException])
-      return
-    })
+      _ => Set("foo", "bar")))
 
-    controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
+    TestUtils.assertFutureThrows(classOf[InvalidRequestException], controllerApis.deleteTopics(ANONYMOUS_CONTEXT, request,
       1,
       hasClusterAuth = false,
       _ => Set("foo", "bar"),
-      _ => Set("foo", "bar")).exceptionally(e => {
-      assertTrue(e.isInstanceOf[InvalidRequestException])
-      return
-    })
-  }
-
-  @Test
-  def testDeleteTopicsWhenDeleteConfigDisable(): Unit = {
-    val deleteTopicData = new DeleteTopicsRequestData()
-    deleteTopicData.setTopicNames(Collections.singletonList("topicA"))
-    val deleteTopicsRequest = new DeleteTopicsRequest.Builder(deleteTopicData).build(ApiKeys.DELETE_TOPICS.latestVersion)
-    // boolean flag, it will set to true if error log triggered
-    val printUnexpectedLog = new AtomicBoolean(false)
-
-    // set 'delete.topic.enable' to false
-    val props = new Properties()
-    props.put(ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG, "false")
-    controllerApis = createControllerApis(None, new MockController.Builder().build(), props = props, errorLogCallback = Some(msg => {
-      // set flag to true
-      if (msg != null && msg.startsWith("Unexpected error")) {
-        printUnexpectedLog.set(true)
-      }
-    }))
-
-    controllerApis.handle(buildRequest(deleteTopicsRequest), RequestLocal.noCaching)
-    assertFalse(printUnexpectedLog.get())
+      _ => Set("foo", "bar")))
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Do not print the `"Unexpected error .."` log when the config
`delete.topic.enable` is false

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, TengYao Chi <frankvicky@apache.org>, Chia-Ping
 Tsai <chia7712@gmail.com>
