### PR TITLE
KAFKA-19273:Ensure the delete policy is configured when the tiered storage is enabled

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -297,25 +297,23 @@ class LogConfigTest {
   }
 
   @Test
-  def testEnableRemoteLogStorageOnCompactedTopic(): Unit = {
+  def testEnableRemoteLogStorageCleanupPolicy(): Unit = {
     val kafkaProps = TestUtils.createDummyBrokerConfig()
     kafkaProps.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
     val kafkaConfig = KafkaConfig.fromProps(kafkaProps)
-
     val logProps = new Properties()
+    def validateCleanupPolicy(): Unit = {
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+    }
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
-    LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
-
+    validateCleanupPolicy()
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
-    assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+    assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "delete,compact")
-    assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+    assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "compact,delete")
-    assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+    assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
   }
 
   @ParameterizedTest(name = "testEnableRemoteLogStorage with sysRemoteStorageEnabled: {0}")

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -316,6 +316,8 @@ class LogConfigTest {
     assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "delete,delete,delete")
     validateCleanupPolicy()
+    logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "")
+    assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
   }
 
   @ParameterizedTest(name = "testEnableRemoteLogStorage with sysRemoteStorageEnabled: {0}")

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -314,6 +314,8 @@ class LogConfigTest {
     assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "compact,delete")
     assertThrows(classOf[ConfigException], () => validateCleanupPolicy())
+    logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "delete,delete,delete")
+    validateCleanupPolicy()
   }
 
   @ParameterizedTest(name = "testEnableRemoteLogStorage with sysRemoteStorageEnabled: {0}")

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -563,8 +563,8 @@ public class LogConfig extends AbstractConfig {
 
     @SuppressWarnings("unchecked")
     private static void validateRemoteStorageRequiresDeleteCleanupPolicy(Map<?, ?> props) {
-        List<Object> cleanupPolicy = (List) props.get(TopicConfig.CLEANUP_POLICY_CONFIG);
-        if (cleanupPolicy.size() != 1 || !cleanupPolicy.get(0).toString().toLowerCase(Locale.getDefault()).equals(TopicConfig.CLEANUP_POLICY_DELETE)) {
+        List<String> cleanupPolicy = (List<String>) props.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+        if (cleanupPolicy.size() != 1 || !cleanupPolicy.get(0).toLowerCase(Locale.getDefault()).equals(TopicConfig.CLEANUP_POLICY_DELETE)) {
             throw new ConfigException("Remote log storage only supports topics with cleanup.policy=delete");
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -564,7 +564,8 @@ public class LogConfig extends AbstractConfig {
     @SuppressWarnings("unchecked")
     private static void validateRemoteStorageRequiresDeleteCleanupPolicy(Map<?, ?> props) {
         List<String> cleanupPolicy = (List<String>) props.get(TopicConfig.CLEANUP_POLICY_CONFIG);
-        if (cleanupPolicy.size() != 1 || !cleanupPolicy.get(0).toLowerCase(Locale.getDefault()).equals(TopicConfig.CLEANUP_POLICY_DELETE)) {
+        Set<String> policySet = cleanupPolicy.stream().map(policy -> policy.toLowerCase(Locale.getDefault())).collect(Collectors.toSet());
+        if (!Set.of(TopicConfig.CLEANUP_POLICY_DELETE).equals(policySet)) {
             throw new ConfigException("Remote log storage only supports topics with cleanup.policy=delete");
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -511,7 +511,7 @@ public class LogConfig extends AbstractConfig {
         boolean isRemoteLogStorageEnabled = (Boolean) newConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG);
         if (isRemoteLogStorageEnabled) {
             validateRemoteStorageOnlyIfSystemEnabled(newConfigs, isRemoteLogStorageSystemEnabled, false);
-            validateNoRemoteStorageForCompactedTopic(newConfigs);
+            validateRemoteStorageRequiresDeleteCleanupPolicy(newConfigs);
             validateRemoteStorageRetentionSize(newConfigs);
             validateRemoteStorageRetentionTime(newConfigs);
             validateRetentionConfigsWhenRemoteCopyDisabled(newConfigs, isRemoteLogStorageEnabled);
@@ -561,10 +561,11 @@ public class LogConfig extends AbstractConfig {
         }
     }
 
-    private static void validateNoRemoteStorageForCompactedTopic(Map<?, ?> props) {
-        String cleanupPolicy = props.get(TopicConfig.CLEANUP_POLICY_CONFIG).toString().toLowerCase(Locale.getDefault());
-        if (cleanupPolicy.contains(TopicConfig.CLEANUP_POLICY_COMPACT)) {
-            throw new ConfigException("Remote log storage is unsupported for the compacted topics");
+    @SuppressWarnings("unchecked")
+    private static void validateRemoteStorageRequiresDeleteCleanupPolicy(Map<?, ?> props) {
+        List<Object> cleanupPolicy = (List) props.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+        if (cleanupPolicy.size() != 1 || !cleanupPolicy.get(0).toString().toLowerCase(Locale.getDefault()).equals(TopicConfig.CLEANUP_POLICY_DELETE)) {
+            throw new ConfigException("Remote log storage only supports topics with cleanup.policy=delete");
         }
     }
 


### PR DESCRIPTION
We updated the validation rule for cleanup.policy in remote storage
mode.

If remote log storage is enabled, only cleanup.policy=delete is allowed.
Any other value (e.g. compact, compact,delete) will now result in a
config validation error.

Reviewers: Luke Chen <showuon@gmail.com>, Ken Huang
 <s7133700@gmail.com>, PoAn Yang <payang@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>
