### PR TITLE
MINOR: Improve the `KAFKA_HEAP_OPTS` definition while run `kafka-server-start.bat` Batch

### DIFF
--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -25,8 +25,7 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
     rem detect OS architecture
-    wmic os get osarchitecture | find /i "32-bit" >nul 2>&1
-    IF NOT ERRORLEVEL 1 (
+    IF ["%PROCESSOR_ARCHITECTURE%"] EQU ["x86"] (
         rem 32-bit OS
         set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
     ) ELSE (


### PR DESCRIPTION
## Info

- Remove the `wmic` dependency while run `kafka-server-start.bat` script in order to defined the `KAFKA_HEAP_OPTS` if is not previously defined.

## Why

- If the host machine do not have the `wmic` dependency, the execution will gonna fail;
- If the host machine contains restrictions about the way of:
    - install dependencies;
    - environment variables; 
    - `PATH` modifications the Kafka service won't start.

## Evidence

```bash
# powershell
systeminfo

Host Name: ...
OS Name: ... Microsoft Windows 11 Enterprise
OS Version: ... 10.0.26100 ...

...

System Type: ... x64-based PC

...
```

A way of execute Kafka (one of the possible many ways) and the error expected:

```bash
# powershell
cd C:\directory\kafka; .\bin\windows\kafka-server-start.bat .\config\server.properties
'wmic' is not recognized as an internal or external command,
operable program or batch file.
```

After apply the contribution we have Kafka working as expected.

## Disclaimer

UNIX user here, I do not invest to much time about the collateral damage and/or why the `wmic` is required.

Reviewers: vbakke (github:vbakke)
