### PR TITLE
MINOR: changed the default value of metadata_quorum in test methods to quorum.isolated_kraft where quorum.zk was used

### DIFF
--- a/tests/kafkatest/tests/client/share_consumer_test.py
+++ b/tests/kafkatest/tests/client/share_consumer_test.py
@@ -248,7 +248,7 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         metadata_quorum=[quorum.isolated_kraft, quorum.combined_kraft],
         use_share_groups=[True]
     )
-    def test_share_consumer_bounce(self, clean_shutdown, bounce_mode, metadata_quorum=quorum.zk, use_share_groups=True):
+    def test_share_consumer_bounce(self, clean_shutdown, bounce_mode, metadata_quorum=quorum.isolated_kraft, use_share_groups=True):
         """
         Verify correct share consumer behavior when the share consumers in the group are consecutively restarted.
 
@@ -290,7 +290,7 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         metadata_quorum=[quorum.isolated_kraft, quorum.combined_kraft],
         use_share_groups=[True]
     )
-    def test_share_consumer_failure(self, clean_shutdown, metadata_quorum=quorum.zk, num_failed_consumers=1, use_share_groups=True):
+    def test_share_consumer_failure(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, num_failed_consumers=1, use_share_groups=True):
 
         producer = self.setup_producer(self.TOPIC2["name"])
         consumer = self.setup_share_group(self.TOPIC2["name"], offset_reset_strategy="earliest")


### PR DESCRIPTION
There were some tests in share_consumer_test, where the default value of
metadata_quorum was quorum.zk. That is change to quorum.isolted_kraft in
this PR

Reviewers: Andrew Schofield <aschofield@confluent.io>
