### PR TITLE
KAFKA-19267: the min version used by ListOffsetsRequest should be 1 rather than 0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -66,7 +66,7 @@ public class ListOffsetsRequest extends AbstractRequest {
                                           boolean requireMaxTimestamp,
                                           boolean requireEarliestLocalTimestamp,
                                           boolean requireTieredStorageTimestamp) {
-            short minVersion = 0;
+            short minVersion = ApiKeys.LIST_OFFSETS.oldestVersion();
             if (requireTieredStorageTimestamp)
                 minVersion = 9;
             else if (requireEarliestLocalTimestamp)
@@ -81,7 +81,7 @@ public class ListOffsetsRequest extends AbstractRequest {
         }
 
         public static Builder forReplica(short allowedVersion, int replicaId) {
-            return new Builder((short) 0, allowedVersion, replicaId, IsolationLevel.READ_UNCOMMITTED);
+            return new Builder(ApiKeys.LIST_OFFSETS.oldestVersion(), allowedVersion, replicaId, IsolationLevel.READ_UNCOMMITTED);
         }
 
         private Builder(short oldestAllowedVersion,

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -135,7 +135,7 @@ public class ListOffsetsRequestTest {
         ListOffsetsRequest.Builder requireTieredStorageTimestampRequestBuilder = ListOffsetsRequest.Builder
             .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false, false, true);
 
-        assertEquals((short) 0, consumerRequestBuilder.oldestAllowedVersion());
+        assertEquals((short) 1, consumerRequestBuilder.oldestAllowedVersion());
         assertEquals((short) 1, requireTimestampRequestBuilder.oldestAllowedVersion());
         assertEquals((short) 2, requestCommittedRequestBuilder.oldestAllowedVersion());
         assertEquals((short) 7, maxTimestampRequestBuilder.oldestAllowedVersion());


### PR DESCRIPTION
jira: [KAFKA-19267](https://issues.apache.org/jira/browse/KAFKA-19267)

Updates the min version used by `ListOffsetsRequest` to
`ApiKeys.LIST_OFFSETS.oldestVersion()` rather than hardcoding `1`.

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, TengYao Chi <frankvicky@apache.org>, Chia-Ping
 Tsai <chia7712@gmail.com>
