### PR TITLE
KAFKA-19281: Add share enable flag to periodic jobs.

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -664,6 +664,7 @@ class BrokerServer(
       .withWriter(writer)
       .withCoordinatorRuntimeMetrics(new ShareCoordinatorRuntimeMetrics(metrics))
       .withCoordinatorMetrics(new ShareCoordinatorMetrics(metrics))
+      .withShareGroupEnabled(() => config.shareGroupConfig.isShareGroupEnabled)
       .build()
   }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -664,7 +664,7 @@ class BrokerServer(
       .withWriter(writer)
       .withCoordinatorRuntimeMetrics(new ShareCoordinatorRuntimeMetrics(metrics))
       .withCoordinatorMetrics(new ShareCoordinatorMetrics(metrics))
-      .withShareGroupEnabled(() => config.shareGroupConfig.isShareGroupEnabled)
+      .withShareGroupEnabledConfigSupplier(() => config.shareGroupConfig.isShareGroupEnabled)
       .build()
   }
 

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -142,8 +142,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
             return this;
         }
 
-        public Builder withShareGroupEnabledConfigSupplier(Supplier<Boolean> isEnabled) {
-            this.shareGroupConfigEnabledSupplier = isEnabled;
+        public Builder withShareGroupEnabledConfigSupplier(Supplier<Boolean> shareGroupConfigEnabledSupplier) {
+            this.shareGroupConfigEnabledSupplier = shareGroupConfigEnabledSupplier;
             return this;
         }
 
@@ -170,7 +170,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                 throw new IllegalArgumentException("Coordinator runtime metrics must be set.");
             }
             if (shareGroupConfigEnabledSupplier == null) {
-                throw new IllegalArgumentException("Share group enabled config supplier must be set.");
+                throw new IllegalArgumentException("Share group enabled config enabled supplier must be set.");
             }
 
             String logPrefix = String.format("ShareCoordinator id=%d", nodeId);

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -54,6 +54,7 @@ import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
 import org.apache.kafka.coordinator.share.metrics.ShareCoordinatorMetrics;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.server.common.ShareVersion;
 import org.apache.kafka.server.record.BrokerCompressionType;
 import org.apache.kafka.server.share.SharePartitionKey;
 import org.apache.kafka.server.util.FutureUtils;
@@ -91,6 +92,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     private final Timer timer;
     private final PartitionWriter writer;
     private final Map<TopicPartition, Long> lastPrunedOffsets;
+    private final AtomicBoolean shouldRunPeriodJob = new AtomicBoolean(true);
 
     public static class Builder {
         private final int nodeId;
@@ -276,6 +278,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
     private void setupRecordPruning() {
         log.debug("Scheduling share-group state topic prune job.");
+        if (!shouldRunPeriodJob.get()) {
+            return;
+        }
         timer.add(new TimerTask(config.shareCoordinatorTopicPruneIntervalMs()) {
             @Override
             public void run() {
@@ -287,7 +292,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                         if (exp != null) {
                             log.error("Received error in share-group state topic prune.", exp);
                         }
-                        // Perpetual recursion, failure or not.
+                        // Perpetual recursion if share groups enabled, failure or not.
                         setupRecordPruning();
                     });
             }
@@ -350,6 +355,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private void setupSnapshotColdPartitions() {
+        if (!shouldRunPeriodJob.get()) {
+            return;
+        }
         log.debug("Scheduling cold share-partition snapshotting.");
         timer.add(new TimerTask(config.shareCoordinatorColdPartitionSnapshotIntervalMs()) {
             @Override
@@ -1075,6 +1083,19 @@ public class ShareCoordinatorService implements ShareCoordinator {
     public void onNewMetadataImage(MetadataImage newImage, MetadataDelta delta) {
         throwIfNotActive();
         this.runtime.onNewMetadataImage(newImage, delta);
+        boolean enabled = isShareGroupsEnabled(newImage);
+        // enabled    shouldRunFlag         result (XOR)
+        // 0            0               no op on flag, do not call jobs
+        // 0            1               disable flag, do not call jobs                      => action
+        // 1            0               enable flag, call jobs as they are not recursing    => action
+        // 1            1               no op on flag, do not call jobs
+
+        if (enabled ^ shouldRunPeriodJob.get()) {
+            shouldRunPeriodJob.set(enabled);
+            if (enabled) {
+                setupPeriodicJobs();
+            }
+        }
     }
 
     TopicPartition topicPartitionFor(SharePartitionKey key) {
@@ -1089,5 +1110,11 @@ public class ShareCoordinatorService implements ShareCoordinator {
         if (!isActive.get()) {
             throw Errors.COORDINATOR_NOT_AVAILABLE.exception();
         }
+    }
+
+    private boolean isShareGroupsEnabled(MetadataImage image) {
+        return ShareVersion.fromFeatureLevel(
+            image.features().finalizedVersions().getOrDefault(ShareVersion.FEATURE_NAME, (short) 0)
+        ).supportsShareGroups();
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -77,6 +77,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
+import java.util.function.Supplier;
 
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorOperationExceptionHelper.handleOperationException;
 
@@ -92,6 +93,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     private final Timer timer;
     private final PartitionWriter writer;
     private final Map<TopicPartition, Long> lastPrunedOffsets;
+    private Supplier<Boolean> isShareGroupConfigEnabled = () -> true;
     private final AtomicBoolean shouldRunPeriodJob = new AtomicBoolean(true);
 
     public static class Builder {
@@ -101,7 +103,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         private CoordinatorLoader<CoordinatorRecord> loader;
         private Time time;
         private Timer timer;
-
+        private Supplier<Boolean> isShareGroupConfigEnabled;
         private ShareCoordinatorMetrics coordinatorMetrics;
         private CoordinatorRuntimeMetrics coordinatorRuntimeMetrics;
 
@@ -140,6 +142,11 @@ public class ShareCoordinatorService implements ShareCoordinator {
             return this;
         }
 
+        public Builder withShareGroupEnabled(Supplier<Boolean> isEnabled) {
+            this.isShareGroupConfigEnabled = isEnabled;
+            return this;
+        }
+
         public ShareCoordinatorService build() {
             if (config == null) {
                 throw new IllegalArgumentException("Config must be set.");
@@ -161,6 +168,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
             }
             if (coordinatorRuntimeMetrics == null) {
                 throw new IllegalArgumentException("Coordinator runtime metrics must be set.");
+            }
+            if (isShareGroupConfigEnabled == null) {
+                throw new IllegalArgumentException("Share group enabled config supplier must be set.");
             }
 
             String logPrefix = String.format("ShareCoordinator id=%d", nodeId);
@@ -204,7 +214,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
                 coordinatorMetrics,
                 time,
                 timer,
-                writer
+                writer,
+                isShareGroupConfigEnabled
             );
         }
     }
@@ -216,7 +227,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
         ShareCoordinatorMetrics shareCoordinatorMetrics,
         Time time,
         Timer timer,
-        PartitionWriter writer
+        PartitionWriter writer,
+        Supplier<Boolean> isShareGroupConfigEnabled
     ) {
         this.log = logContext.logger(ShareCoordinatorService.class);
         this.config = config;
@@ -226,6 +238,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         this.timer = timer;
         this.writer = writer;
         this.lastPrunedOffsets = new ConcurrentHashMap<>();
+        this.isShareGroupConfigEnabled = isShareGroupConfigEnabled;
     }
 
     @Override
@@ -1091,7 +1104,6 @@ public class ShareCoordinatorService implements ShareCoordinator {
         // 0            1               disable flag, do not call jobs                      => action
         // 1            0               enable flag, call jobs as they are not recursing    => action
         // 1            1               no op on flag, do not call jobs
-
         if (enabled ^ shouldRunPeriodJob.get()) {
             shouldRunPeriodJob.set(enabled);
             if (enabled) {
@@ -1115,7 +1127,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private boolean isShareGroupsEnabled(MetadataImage image) {
-        return ShareVersion.fromFeatureLevel(
+        return isShareGroupConfigEnabled.get() || ShareVersion.fromFeatureLevel(
             image.features().finalizedVersions().getOrDefault(ShareVersion.FEATURE_NAME, (short) 0)
         ).supportsShareGroups();
     }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -276,11 +276,12 @@ public class ShareCoordinatorService implements ShareCoordinator {
         setupSnapshotColdPartitions();
     }
 
-    private void setupRecordPruning() {
-        log.debug("Scheduling share-group state topic prune job.");
+    // Visibility for tests
+    void setupRecordPruning() {
         if (!shouldRunPeriodJob.get()) {
             return;
         }
+        log.debug("Scheduling share-group state topic prune job.");
         timer.add(new TimerTask(config.shareCoordinatorTopicPruneIntervalMs()) {
             @Override
             public void run() {
@@ -354,7 +355,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
         return fut;
     }
 
-    private void setupSnapshotColdPartitions() {
+    // Visibility for tests
+    void setupSnapshotColdPartitions() {
         if (!shouldRunPeriodJob.get()) {
             return;
         }
@@ -1116,5 +1118,10 @@ public class ShareCoordinatorService implements ShareCoordinator {
         return ShareVersion.fromFeatureLevel(
             image.features().finalizedVersions().getOrDefault(ShareVersion.FEATURE_NAME, (short) 0)
         ).supportsShareGroups();
+    }
+
+    // Visibility for tests
+    boolean shouldRunPruneJob() {
+        return shouldRunPeriodJob.get();
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -93,8 +93,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
     private final Timer timer;
     private final PartitionWriter writer;
     private final Map<TopicPartition, Long> lastPrunedOffsets;
-    private Supplier<Boolean> isShareGroupConfigEnabled = () -> true;
-    private final AtomicBoolean shouldRunPeriodJob = new AtomicBoolean(true);
+    private final Supplier<Boolean> shareGroupConfigEnabledSupplier;
+    private volatile boolean shouldRunPeriodicJob;
 
     public static class Builder {
         private final int nodeId;
@@ -103,7 +103,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         private CoordinatorLoader<CoordinatorRecord> loader;
         private Time time;
         private Timer timer;
-        private Supplier<Boolean> isShareGroupConfigEnabled;
+        private Supplier<Boolean> shareGroupConfigEnabledSupplier;
         private ShareCoordinatorMetrics coordinatorMetrics;
         private CoordinatorRuntimeMetrics coordinatorRuntimeMetrics;
 
@@ -142,8 +142,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
             return this;
         }
 
-        public Builder withShareGroupEnabled(Supplier<Boolean> isEnabled) {
-            this.isShareGroupConfigEnabled = isEnabled;
+        public Builder withShareGroupEnabledConfigSupplier(Supplier<Boolean> isEnabled) {
+            this.shareGroupConfigEnabledSupplier = isEnabled;
             return this;
         }
 
@@ -169,7 +169,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
             if (coordinatorRuntimeMetrics == null) {
                 throw new IllegalArgumentException("Coordinator runtime metrics must be set.");
             }
-            if (isShareGroupConfigEnabled == null) {
+            if (shareGroupConfigEnabledSupplier == null) {
                 throw new IllegalArgumentException("Share group enabled config supplier must be set.");
             }
 
@@ -215,7 +215,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                 time,
                 timer,
                 writer,
-                isShareGroupConfigEnabled
+                shareGroupConfigEnabledSupplier
             );
         }
     }
@@ -228,7 +228,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         Time time,
         Timer timer,
         PartitionWriter writer,
-        Supplier<Boolean> isShareGroupConfigEnabled
+        Supplier<Boolean> shareGroupConfigEnabledSupplier
     ) {
         this.log = logContext.logger(ShareCoordinatorService.class);
         this.config = config;
@@ -238,7 +238,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         this.timer = timer;
         this.writer = writer;
         this.lastPrunedOffsets = new ConcurrentHashMap<>();
-        this.isShareGroupConfigEnabled = isShareGroupConfigEnabled;
+        this.shareGroupConfigEnabledSupplier = shareGroupConfigEnabledSupplier;
     }
 
     @Override
@@ -280,7 +280,6 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
         log.info("Starting up.");
         numPartitions = shareGroupTopicPartitionCount.getAsInt();
-        setupPeriodicJobs();
         log.info("Startup complete.");
     }
 
@@ -291,13 +290,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
     // Visibility for tests
     void setupRecordPruning() {
-        if (!shouldRunPeriodJob.get()) {
-            return;
-        }
         log.debug("Scheduling share-group state topic prune job.");
         timer.add(new TimerTask(config.shareCoordinatorTopicPruneIntervalMs()) {
             @Override
             public void run() {
+                if (!shouldRunPeriodicJob) {
+                    return;
+                }
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
                 runtime.activeTopicPartitions().forEach(tp -> futures.add(performRecordPruning(tp)));
 
@@ -306,7 +305,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                         if (exp != null) {
                             log.error("Received error in share-group state topic prune.", exp);
                         }
-                        // Perpetual recursion if share groups enabled, failure or not.
+                        // Perpetual recursion, failure or not.
                         setupRecordPruning();
                     });
             }
@@ -370,13 +369,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
 
     // Visibility for tests
     void setupSnapshotColdPartitions() {
-        if (!shouldRunPeriodJob.get()) {
-            return;
-        }
         log.debug("Scheduling cold share-partition snapshotting.");
         timer.add(new TimerTask(config.shareCoordinatorColdPartitionSnapshotIntervalMs()) {
             @Override
             public void run() {
+                if (!shouldRunPeriodicJob) {
+                    return;
+                }
                 List<CompletableFuture<Void>> futures = runtime.scheduleWriteAllOperation(
                     "snapshot-cold-partitions",
                     Duration.ofMillis(config.shareCoordinatorWriteTimeoutMs()),
@@ -1099,13 +1098,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
         throwIfNotActive();
         this.runtime.onNewMetadataImage(newImage, delta);
         boolean enabled = isShareGroupsEnabled(newImage);
-        // enabled    shouldRunFlag         result (XOR)
+        // enabled    shouldRunJob         result (XOR)
         // 0            0               no op on flag, do not call jobs
         // 0            1               disable flag, do not call jobs                      => action
         // 1            0               enable flag, call jobs as they are not recursing    => action
         // 1            1               no op on flag, do not call jobs
-        if (enabled ^ shouldRunPeriodJob.get()) {
-            shouldRunPeriodJob.set(enabled);
+        if (enabled ^ shouldRunPeriodicJob) {
+            shouldRunPeriodicJob = enabled;
             if (enabled) {
                 setupPeriodicJobs();
             }
@@ -1127,13 +1126,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
     }
 
     private boolean isShareGroupsEnabled(MetadataImage image) {
-        return isShareGroupConfigEnabled.get() || ShareVersion.fromFeatureLevel(
+        return shareGroupConfigEnabledSupplier.get() || ShareVersion.fromFeatureLevel(
             image.features().finalizedVersions().getOrDefault(ShareVersion.FEATURE_NAME, (short) 0)
         ).supportsShareGroups();
     }
 
     // Visibility for tests
-    boolean shouldRunPruneJob() {
-        return shouldRunPeriodJob.get();
+    boolean shouldRunPeriodicJob() {
+        return shouldRunPeriodicJob;
     }
 }

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -2073,7 +2073,7 @@ class ShareCoordinatorServiceTest {
 
         // Feature disabled on start.
         when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
-        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will not execute as feature is off in image.
+        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will not execute as feature is OFF in image.
 
         verify(timer, times(0)).add(any()); // Timer task not added.
         verify(runtime, times(0)).scheduleWriteOperation(
@@ -2092,7 +2092,7 @@ class ShareCoordinatorServiceTest {
         // Enable feature.
         Mockito.reset(mockedImage);
         when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 1);
-        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will execute as feature is on in image.
+        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will execute as feature is ON in image.
 
         verify(timer, times(2)).add(any()); // Timer task added twice (prune, snapshot).
         timer.advanceClock(30001L);
@@ -2130,7 +2130,7 @@ class ShareCoordinatorServiceTest {
         assertFalse(service.shouldRunPeriodicJob());
 
         timer.advanceClock(30001L);
-        verify(timer, times(4)).add(any()); // Not new additions.
+        verify(timer, times(4)).add(any()); // No new additions.
 
         service.shutdown();
     }

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -45,6 +45,9 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
 import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
 import org.apache.kafka.coordinator.share.metrics.ShareCoordinatorMetrics;
+import org.apache.kafka.image.MetadataDelta;
+import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.server.common.ShareVersion;
 import org.apache.kafka.server.share.SharePartitionKey;
 import org.apache.kafka.server.util.FutureUtils;
 import org.apache.kafka.server.util.MockTime;
@@ -52,6 +55,7 @@ import org.apache.kafka.server.util.timer.MockTimer;
 import org.apache.kafka.server.util.timer.Timer;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.util.HashSet;
@@ -68,17 +72,21 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.kafka.coordinator.common.runtime.TestUtil.requestContext;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("ClassFanOutComplexity")
 class ShareCoordinatorServiceTest {
 
     @SuppressWarnings("unchecked")
@@ -1976,6 +1984,120 @@ class ShareCoordinatorServiceTest {
                 any());
 
         checkMetrics(metrics);
+
+        service.shutdown();
+    }
+
+    @Test
+    public void testPeriodicJobDoNotRunWhenShareGroupsDisabled() throws InterruptedException {
+        CoordinatorRuntime<ShareCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        PartitionWriter writer = mock(PartitionWriter.class);
+        MockTime time = new MockTime();
+        MockTimer timer = spy(new MockTimer(time));
+
+        Metrics metrics = new Metrics();
+
+        ShareCoordinatorService service = spy(new ShareCoordinatorService(
+            new LogContext(),
+            ShareCoordinatorTestConfig.testConfig(),
+            runtime,
+            new ShareCoordinatorMetrics(metrics),
+            time,
+            timer,
+            writer
+        ));
+
+        MetadataImage mockedImage = mock(MetadataImage.class, RETURNS_DEEP_STUBS);
+        MetadataDelta delta = mock(MetadataDelta.class);
+        ShareVersion shareVersion = mock(ShareVersion.class);
+        when(shareVersion.supportsShareGroups()).thenReturn(false);
+        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
+
+        // Prune job.
+        when(runtime.scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any(),
+            any()
+        )).thenAnswer(inv -> {
+            service.onNewMetadataImage(mockedImage, delta);
+            return CompletableFuture.completedFuture(Optional.empty());
+        });
+
+        // Snapshot job.
+        when(runtime.scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any(),
+            any()
+        )).thenAnswer(inv -> {
+            service.onNewMetadataImage(mockedImage, delta);
+            return List.of();
+        });
+
+        assertTrue(service.shouldRunPruneJob());
+
+        service.startup(() -> 1);
+        verify(timer, times(2)).add(any()); // Timer task added twice (prune, snapshot).
+        timer.advanceClock(30001L); // Will cause task execution.
+
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any(),
+            any()
+        );
+
+        verify(runtime, times(1)).scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any(),
+            any()
+        );
+
+        // New metadata image will have been served.
+        assertFalse(service.shouldRunPruneJob());
+        verify(timer, times(2)).add(any()); // Timer tasks no longer added.
+
+        // Explicit invocations
+        service.setupRecordPruning();
+        service.setupSnapshotColdPartitions();
+        timer.advanceClock(30001L);
+
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any(),
+            any()
+        );
+
+        verify(runtime, times(1)).scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any(),
+            any()
+        );
+
+        assertFalse(service.shouldRunPruneJob());
+        verify(timer, times(2)).add(any()); // Timer tasks no longer added.
+
+        // Re-enable
+        Mockito.reset(shareVersion, mockedImage);
+        when(shareVersion.supportsShareGroups()).thenReturn(true);
+        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 1);
+
+        service.onNewMetadataImage(mockedImage, delta);
+        assertTrue(service.shouldRunPruneJob());
+        timer.advanceClock(30001);
+        verify(runtime, times(2)).scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any(),
+            any()
+        );
+
+        verify(runtime, times(2)).scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any(),
+            any()
+        );
 
         service.shutdown();
     }

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -107,7 +107,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             new MockTimer(),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -130,7 +131,8 @@ class ShareCoordinatorServiceTest {
             coordinatorMetrics,
             time,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -240,7 +242,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -342,7 +345,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -426,7 +430,8 @@ class ShareCoordinatorServiceTest {
             coordinatorMetrics,
             time,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -508,7 +513,8 @@ class ShareCoordinatorServiceTest {
             coordinatorMetrics,
             time,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -590,7 +596,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -637,7 +644,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -684,7 +692,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -731,7 +740,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -778,7 +788,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -825,7 +836,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         String groupId = "group1";
@@ -904,7 +916,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         String groupId = "group1";
@@ -967,7 +980,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         String groupId = "group1";
@@ -1030,7 +1044,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         String groupId = "group1";
@@ -1091,7 +1106,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         String groupId = "group1";
@@ -1151,7 +1167,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -1201,7 +1218,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -1244,7 +1262,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -1287,7 +1306,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -1329,7 +1349,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -1370,7 +1391,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         service.startup(() -> 1);
@@ -1399,7 +1421,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(),
             Time.SYSTEM,
             mock(Timer.class),
-            mock(PartitionWriter.class)
+            mock(PartitionWriter.class),
+            () -> true
         );
 
         String groupId = "group1";
@@ -1457,7 +1480,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 1);
@@ -1550,7 +1574,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 2);
@@ -1610,7 +1635,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 1);
@@ -1661,7 +1687,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 1);
@@ -1710,7 +1737,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 1);
@@ -1771,7 +1799,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 1);
@@ -1845,7 +1874,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 1);
@@ -1897,7 +1927,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         when(runtime.scheduleWriteAllOperation(
@@ -1959,7 +1990,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 2);
@@ -2004,7 +2036,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> false // So that the feature config is used.
         ));
 
         MetadataImage mockedImage = mock(MetadataImage.class, RETURNS_DEEP_STUBS);
@@ -2117,7 +2150,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         List<String> propNames = List.of(
@@ -2147,7 +2181,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 3);
@@ -2187,7 +2222,8 @@ class ShareCoordinatorServiceTest {
             new ShareCoordinatorMetrics(metrics),
             time,
             timer,
-            writer
+            writer,
+            () -> true
         ));
 
         service.startup(() -> 3);

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -1485,6 +1485,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1579,6 +1580,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 2);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1640,6 +1642,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1692,6 +1695,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1742,6 +1746,8 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
+
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1804,6 +1810,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1879,6 +1886,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
@@ -1938,6 +1946,7 @@ class ShareCoordinatorServiceTest {
         )).thenReturn(List.of(CompletableFuture.completedFuture(null)));
 
         service.startup(() -> 1);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteOperation(
                 eq("snapshot-cold-partitions"),
@@ -1995,6 +2004,7 @@ class ShareCoordinatorServiceTest {
         ));
 
         service.startup(() -> 2);
+        service.onNewMetadataImage(mock(MetadataImage.class), mock(MetadataDelta.class));
         verify(runtime, times(0))
             .scheduleWriteAllOperation(
                 eq("snapshot-cold-partitions"),
@@ -2040,97 +2050,87 @@ class ShareCoordinatorServiceTest {
             () -> false // So that the feature config is used.
         ));
 
-        MetadataImage mockedImage = mock(MetadataImage.class, RETURNS_DEEP_STUBS);
-        MetadataDelta delta = mock(MetadataDelta.class);
-        ShareVersion shareVersion = mock(ShareVersion.class);
-        when(shareVersion.supportsShareGroups()).thenReturn(false);
-        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
-
         // Prune job.
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
             any(),
             any()
-        )).thenAnswer(inv -> {
-            service.onNewMetadataImage(mockedImage, delta);
-            return CompletableFuture.completedFuture(Optional.empty());
-        });
+        )).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         // Snapshot job.
         when(runtime.scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
             any(),
             any()
-        )).thenAnswer(inv -> {
-            service.onNewMetadataImage(mockedImage, delta);
-            return List.of();
-        });
+        )).thenReturn(List.of());
 
-        assertTrue(service.shouldRunPruneJob());
+        assertFalse(service.shouldRunPeriodicJob());
 
         service.startup(() -> 1);
-        verify(timer, times(2)).add(any()); // Timer task added twice (prune, snapshot).
-        timer.advanceClock(30001L); // Will cause task execution.
 
+        MetadataImage mockedImage = mock(MetadataImage.class, RETURNS_DEEP_STUBS);
+
+        // Feature disabled on start.
+        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
+        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will not execute as feature is off in image.
+
+        verify(timer, times(0)).add(any()); // Timer task not added.
+        verify(runtime, times(0)).scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any(),
+            any()
+        );
+        verify(runtime, times(0)).scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any(),
+            any()
+        );
+        assertFalse(service.shouldRunPeriodicJob());
+
+        // Enable feature.
+        Mockito.reset(mockedImage);
+        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 1);
+        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will execute as feature is on in image.
+
+        verify(timer, times(2)).add(any()); // Timer task added twice (prune, snapshot).
+        timer.advanceClock(30001L);
         verify(runtime, times(1)).scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
             any(),
             any()
         );
-
         verify(runtime, times(1)).scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
             any(),
             any()
         );
+        assertTrue(service.shouldRunPeriodicJob());
 
-        // New metadata image will have been served.
-        assertFalse(service.shouldRunPruneJob());
-        verify(timer, times(2)).add(any()); // Timer tasks no longer added.
-
-        // Explicit invocations
-        service.setupRecordPruning();
-        service.setupSnapshotColdPartitions();
+        // Disable feature
+        Mockito.reset(mockedImage);
+        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
+        service.onNewMetadataImage(mockedImage, mock(MetadataDelta.class));   // Jobs will not execute as feature is on in image.
         timer.advanceClock(30001L);
 
+        verify(timer, times(4)).add(any()); // Tasks added but will return immediately.
         verify(runtime, times(1)).scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
             any(),
             any()
         );
-
         verify(runtime, times(1)).scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
             any(),
             any()
         );
+        assertFalse(service.shouldRunPeriodicJob());
 
-        assertFalse(service.shouldRunPruneJob());
-        verify(timer, times(2)).add(any()); // Timer tasks no longer added.
-
-        // Re-enable
-        Mockito.reset(shareVersion, mockedImage);
-        when(shareVersion.supportsShareGroups()).thenReturn(true);
-        when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 1);
-
-        service.onNewMetadataImage(mockedImage, delta);
-        assertTrue(service.shouldRunPruneJob());
-        timer.advanceClock(30001);
-        verify(runtime, times(2)).scheduleWriteOperation(
-            eq("write-state-record-prune"),
-            any(),
-            any(),
-            any()
-        );
-
-        verify(runtime, times(2)).scheduleWriteAllOperation(
-            eq("snapshot-cold-partitions"),
-            any(),
-            any()
-        );
+        timer.advanceClock(30001L);
+        verify(timer, times(4)).add(any()); // Not new additions.
 
         service.shutdown();
     }

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -2031,7 +2031,7 @@ class ShareCoordinatorServiceTest {
     }
 
     @Test
-    public void testPeriodicJobDoNotRunWhenShareGroupsDisabled() throws InterruptedException {
+    public void testPeriodicJobsDoNotRunWhenShareGroupsDisabled() throws InterruptedException {
         CoordinatorRuntime<ShareCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
         PartitionWriter writer = mock(PartitionWriter.class);
         MockTime time = new MockTime();


### PR DESCRIPTION
* We have a few periodic timer tasks in `ShareCoordinatorService` which
run continuously.
* With the recent introduction of share group enabled config at feature
level, we would like these jobs to stop when the aforementioned feature
is disabled.
* In this PR, we have added the functionality to make that possible.
* Additionally the service has been supplemented with addition of a
static share group config supplier.
* New test has been added.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Apoorv Mittal
 <apoorvmittal10@gmail.com>
