### PR TITLE
MINOR: Fix backticks in PR body

### DIFF
--- a/.github/scripts/pr-format.py
+++ b/.github/scripts/pr-format.py
@@ -97,6 +97,8 @@ def split_paragraphs(text: str):
         else:
             if line[0] in ("#", "*", "-", "=") or line[0].isdigit():
                 markdown = True
+            if "```" in line:
+                markdown = True
             paragraph.append(line)
     yield paragraph, markdown
 


### PR DESCRIPTION
This fixes the paragraph splitting done in the pr-format.py script. If a
line contains a triple-backtick, the script will consider it markdown
and adjust the formatting accordingly.

Reviewers: TengYao Chi <frankvicky@apache.org>, Ken Huang
 <s7133700@gmail.com>, Jhen-Yung Hsu <jhenyunghsu@gmail.com>
