### PR TITLE
KAFKA-19284: Add documentation to clarify the behavior of null values for all partitionsToOffsetAndMetadata methods.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
@@ -45,6 +45,8 @@ public class ListConsumerGroupOffsetsResult {
     /**
      * Return a future which yields a map of topic partitions to OffsetAndMetadata objects.
      * If the group does not have a committed offset for this partition, the corresponding value in the returned map will be null.
+     *
+     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata() {
         if (futures.size() != 1) {
@@ -58,6 +60,9 @@ public class ListConsumerGroupOffsetsResult {
      * Return a future which yields a map of topic partitions to OffsetAndMetadata objects for
      * the specified group. If the group doesn't have a committed offset for a specific
      * partition, the corresponding value in the returned map will be null.
+     *
+     * @param groupId The group ID.
+     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata(String groupId) {
         if (!futures.containsKey(groupId))

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
@@ -45,8 +45,6 @@ public class ListConsumerGroupOffsetsResult {
     /**
      * Return a future which yields a map of topic partitions to OffsetAndMetadata objects.
      * If the group does not have a committed offset for this partition, the corresponding value in the returned map will be null.
-     *
-     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata() {
         if (futures.size() != 1) {
@@ -60,9 +58,6 @@ public class ListConsumerGroupOffsetsResult {
      * Return a future which yields a map of topic partitions to OffsetAndMetadata objects for
      * the specified group. If the group doesn't have a committed offset for a specific
      * partition, the corresponding value in the returned map will be null.
-     *
-     * @param groupId The group ID.
-     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata(String groupId) {
         if (!futures.containsKey(groupId))

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
@@ -68,9 +68,6 @@ public class ListShareGroupOffsetsResult {
     /**
      * Return a future which yields a map of topic partitions to offsets for the specified group. If the group doesn't
      * have a committed offset for a specific partition, the corresponding value in the returned map will be null.
-     *
-     * @param groupId The group ID.
-     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata(String groupId) {
         if (!futures.containsKey(groupId)) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
@@ -66,7 +66,8 @@ public class ListShareGroupOffsetsResult {
     }
 
     /**
-     * Return a future which yields a map of topic partitions to offsets for the specified group.
+     * Return a future which yields a map of topic partitions to offsets for the specified group. If the group doesn't
+     * have a committed offset for a specific partition, the corresponding value in the returned map will be null.
      *
      * @param groupId The group ID.
      * @return Future which yields a map of topic partitions to offsets for the specified group.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListStreamsGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListStreamsGroupOffsetsResult.java
@@ -52,9 +52,6 @@ public class ListStreamsGroupOffsetsResult {
     /**
      * Return a future which yields a map of topic partitions to offsets for the specified group. If the group doesn't
      * have a committed offset for a specific partition, the corresponding value in the returned map will be null.
-     *
-     * @param groupId The group ID.
-     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata(String groupId) {
         return delegate.partitionsToOffsetAndMetadata(groupId);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListStreamsGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListStreamsGroupOffsetsResult.java
@@ -50,7 +50,11 @@ public class ListStreamsGroupOffsetsResult {
     }
 
     /**
-     * Return a future which yields a map of topic partitions to offsets for the specified group.
+     * Return a future which yields a map of topic partitions to offsets for the specified group. If the group doesn't
+     * have a committed offset for a specific partition, the corresponding value in the returned map will be null.
+     *
+     * @param groupId The group ID.
+     * @return Future which yields a map of topic partitions to offsets for the specified group.
      */
     public KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> partitionsToOffsetAndMetadata(String groupId) {
         return delegate.partitionsToOffsetAndMetadata(groupId);


### PR DESCRIPTION
Adds missing documentation to the `partitionsToOffsetAndMetadata`
methods in both `ListStreamsGroupOffsetsResult` and
`ListShareGroupOffsetsResult` classes to clarify the behavior when a
group does not have a committed offset for a specific partition.

As document in ListConsumerGroupOffsetsResult: > If the group doesn’t
have a committed offset for a specific partition, the corresponding
value in the returned map will be null.

This important detail was previously missing in the JavaDoc of the
stream and share group variants.

Reviewers: Nick Guo <lansg0504@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
