### PR TITLE
KAFKA-19154; Offset Fetch API should return INVALID_OFFSET if requested topic id does not match persisted one

### DIFF
--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -100,6 +100,20 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     }
   }
 
+  protected def deleteTopic(
+    topic: String
+  ): Unit = {
+    val admin = cluster.admin()
+    try {
+      admin
+        .deleteTopics(TopicCollection.ofTopicNames(List(topic).asJava))
+        .all()
+        .get()
+    } finally {
+      admin.close()
+    }
+  }
+
   protected def createTopicAndReturnLeaders(
     topic: String,
     numPartitions: Int = 1,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -859,6 +859,7 @@ public class OffsetMetadataManager {
      *
      * @return A List of OffsetFetchResponseTopics response.
      */
+    @SuppressWarnings("NPathComplexity")
     public OffsetFetchResponseData.OffsetFetchResponseGroup fetchOffsets(
         OffsetFetchRequestData.OffsetFetchRequestGroup request,
         long lastCommittedOffset
@@ -906,7 +907,7 @@ public class OffsetMetadataManager {
                         .setCommittedOffset(INVALID_OFFSET)
                         .setCommittedLeaderEpoch(-1)
                         .setMetadata(""));
-                } else if (offsetAndMetadata == null) {
+                } else if (offsetAndMetadata == null || isMismatchedTopicId(offsetAndMetadata.topicId, topic.topicId())) {
                     topicResponse.partitions().add(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
                         .setPartitionIndex(partitionIndex)
                         .setCommittedOffset(INVALID_OFFSET)
@@ -925,6 +926,10 @@ public class OffsetMetadataManager {
         return new OffsetFetchResponseData.OffsetFetchResponseGroup()
             .setGroupId(request.groupId())
             .setTopics(topicResponses);
+    }
+
+    private boolean isMismatchedTopicId(Uuid actual, Uuid expected) {
+        return !actual.equals(Uuid.ZERO_UUID) && !actual.equals(expected);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -929,7 +929,7 @@ public class OffsetMetadataManager {
     }
 
     private boolean isMismatchedTopicId(Uuid actual, Uuid expected) {
-        return !actual.equals(Uuid.ZERO_UUID) && !actual.equals(expected);
+        return !actual.equals(Uuid.ZERO_UUID) && !expected.equals(Uuid.ZERO_UUID) && !actual.equals(expected);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -859,7 +859,6 @@ public class OffsetMetadataManager {
      *
      * @return A List of OffsetFetchResponseTopics response.
      */
-    @SuppressWarnings("NPathComplexity")
     public OffsetFetchResponseData.OffsetFetchResponseGroup fetchOffsets(
         OffsetFetchRequestData.OffsetFetchRequestGroup request,
         long lastCommittedOffset
@@ -907,7 +906,7 @@ public class OffsetMetadataManager {
                         .setCommittedOffset(INVALID_OFFSET)
                         .setCommittedLeaderEpoch(-1)
                         .setMetadata(""));
-                } else if (offsetAndMetadata == null || isMismatchedTopicId(offsetAndMetadata.topicId, topic.topicId())) {
+                } else if (isOffsetInvalid(offsetAndMetadata, topic.topicId())) {
                     topicResponse.partitions().add(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
                         .setPartitionIndex(partitionIndex)
                         .setCommittedOffset(INVALID_OFFSET)
@@ -928,7 +927,11 @@ public class OffsetMetadataManager {
             .setTopics(topicResponses);
     }
 
-    private boolean isMismatchedTopicId(Uuid actual, Uuid expected) {
+    private static boolean isOffsetInvalid(OffsetAndMetadata offsetAndMetadata, Uuid expectedTopicId) {
+        return offsetAndMetadata == null || isMismatchedTopicId(offsetAndMetadata.topicId, expectedTopicId);
+    }
+
+    private static boolean isMismatchedTopicId(Uuid actual, Uuid expected) {
         return !actual.equals(Uuid.ZERO_UUID) && !expected.equals(Uuid.ZERO_UUID) && !actual.equals(expected);
     }
 


### PR DESCRIPTION
This patch updates the OffsetFetch API to ensure that a committed offset
is returned iff the requested topic id matches the persisted one; the
invalid offset is returned otherwise.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
