### PR TITLE
MINOR:- Edit test in transaction command

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/TransactionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TransactionsCommandTest.java
@@ -265,7 +265,7 @@ public class TransactionsCommandTest {
         assertCommandFailure(new String[]{
             "--bootstrap-server",
             "localhost:9092",
-            "force-terminate"
+            "forceTerminateTransaction"
         });
     }
 


### PR DESCRIPTION
The test incorrectly used force-terminate instead of
forceTerminateTransaction

Reviewers: Justine Olshan <jolshan@confuent.io>, Kuan-Po Tseng
 <brandboat@gmail.com>, Ken Huang <s7133700@gmail.com>
