### PR TITLE
KAFKA-18345; Wait the entire election timeout on election loss

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -34,10 +34,8 @@ public class CandidateState implements NomineeState {
     private final Optional<LogOffsetMetadata> highWatermark;
     private final int electionTimeoutMs;
     private final Timer electionTimer;
-    private final Timer backoffTimer;
     private final Logger log;
 
-    private boolean isBackingOff;
     /**
      * The lifetime of a candidate state is the following.
      *
@@ -73,18 +71,10 @@ public class CandidateState implements NomineeState {
         this.highWatermark = highWatermark;
         this.electionTimeoutMs = electionTimeoutMs;
         this.electionTimer = time.timer(electionTimeoutMs);
-        this.backoffTimer = time.timer(0);
         this.log = logContext.logger(CandidateState.class);
 
         this.epochElection = new EpochElection(voters.voterKeys());
         epochElection.recordVote(localId, true);
-    }
-
-    /**
-     * Check if the candidate is backing off before transitioning back to prospective state
-     */
-    public boolean isBackingOff() {
-        return isBackingOff;
     }
 
     @Override
@@ -108,13 +98,6 @@ public class CandidateState implements NomineeState {
                 " which previously granted our request");
         }
         return epochElection().recordVote(remoteNodeId, false);
-    }
-
-    /**
-     * Record the current election has failed since we've received sufficient rejecting voters
-     */
-    public void startBackingOff() {
-        this.isBackingOff = true;
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -30,7 +30,6 @@ public class CandidateState implements NomineeState {
     private final int localId;
     private final Uuid localDirectoryId;
     private final int epoch;
-    private final int retries;
     private final EpochElection epochElection;
     private final Optional<LogOffsetMetadata> highWatermark;
     private final int electionTimeoutMs;
@@ -54,7 +53,6 @@ public class CandidateState implements NomineeState {
         int epoch,
         VoterSet voters,
         Optional<LogOffsetMetadata> highWatermark,
-        int retries,
         int electionTimeoutMs,
         LogContext logContext
     ) {
@@ -73,8 +71,6 @@ public class CandidateState implements NomineeState {
         this.localDirectoryId = localDirectoryId;
         this.epoch = epoch;
         this.highWatermark = highWatermark;
-        this.retries = retries;
-        this.isBackingOff = false;
         this.electionTimeoutMs = electionTimeoutMs;
         this.electionTimer = time.timer(electionTimeoutMs);
         this.backoffTimer = time.timer(0);
@@ -85,14 +81,10 @@ public class CandidateState implements NomineeState {
     }
 
     /**
-     * Check if the candidate is backing off for the next election
+     * Check if the candidate is backing off before transitionint back to prospective state
      */
     public boolean isBackingOff() {
         return isBackingOff;
-    }
-
-    public int retries() {
-        return retries;
     }
 
     @Override
@@ -119,11 +111,9 @@ public class CandidateState implements NomineeState {
     }
 
     /**
-     * Record the current election has failed since we've either received sufficient rejecting voters or election timed out
+     * Record the current election has failed since we've received sufficient rejecting voters
      */
-    public void startBackingOff(long currentTimeMs, long backoffDurationMs) {
-        this.backoffTimer.update(currentTimeMs);
-        this.backoffTimer.reset(backoffDurationMs);
+    public void startBackingOff() {
         this.isBackingOff = true;
     }
 
@@ -131,19 +121,6 @@ public class CandidateState implements NomineeState {
     public boolean hasElectionTimeoutExpired(long currentTimeMs) {
         electionTimer.update(currentTimeMs);
         return electionTimer.isExpired();
-    }
-
-    public boolean isBackoffComplete(long currentTimeMs) {
-        backoffTimer.update(currentTimeMs);
-        return backoffTimer.isExpired();
-    }
-
-    public long remainingBackoffMs(long currentTimeMs) {
-        if (!isBackingOff) {
-            throw new IllegalStateException("Candidate is not currently backing off");
-        }
-        backoffTimer.update(currentTimeMs);
-        return backoffTimer.remainingMs();
     }
 
     @Override
@@ -201,12 +178,11 @@ public class CandidateState implements NomineeState {
     @Override
     public String toString() {
         return String.format(
-            "CandidateState(localId=%d, localDirectoryId=%s, epoch=%d, retries=%d, epochElection=%s, " +
+            "CandidateState(localId=%d, localDirectoryId=%s, epoch=%d, epochElection=%s, " +
             "highWatermark=%s, electionTimeoutMs=%d)",
             localId,
             localDirectoryId,
             epoch,
-            retries,
             epochElection(),
             highWatermark,
             electionTimeoutMs

--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -81,7 +81,7 @@ public class CandidateState implements NomineeState {
     }
 
     /**
-     * Check if the candidate is backing off before transitionint back to prospective state
+     * Check if the candidate is backing off before transitioning back to prospective state
      */
     public boolean isBackingOff() {
         return isBackingOff;

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1020,24 +1020,14 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         if (state instanceof CandidateState candidate) {
             if (candidate.epochElection().isVoteRejected() && !candidate.isBackingOff()) {
                 logger.info(
-                    "Insufficient remaining votes to become leader. We will backoff before retrying election again. " +
-                    "Current epoch election state is {}.",
+                    "Insufficient remaining votes to become leader. Candidate will wait the remaining election " +
+                        "timeout ({}) before transitioning back to Prospective. Current epoch election state is {}.",
+                    candidate.remainingElectionTimeMs(currentTimeMs),
                     candidate.epochElection()
                 );
-                // Go immediately to a random, exponential backoff. The backoff starts low to prevent
-                // needing to wait the entire election timeout when the vote result has already been
-                // determined. The randomness prevents the next election from being gridlocked with
-                // another nominee due to timing. The exponential aspect limits epoch churn when the
-                // replica has failed multiple elections in succession.
-                candidate.startBackingOff(
-                    currentTimeMs,
-                    RaftUtil.binaryExponentialElectionBackoffMs(
-                        quorumConfig.electionBackoffMaxMs(),
-                        RETRY_BACKOFF_BASE_MS,
-                        candidate.retries(),
-                        random
-                    )
-                );
+                // Mark that the candidate is now backing off. After election timeout expires the candidate will
+                // transition back to prospective
+                candidate.startBackingOff();
             }
         } else if (state instanceof ProspectiveState prospective) {
             if (prospective.epochElection().isVoteRejected()) {
@@ -3149,17 +3139,12 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             //  3) the shutdown timer expires
             long minRequestBackoffMs = maybeSendVoteRequests(state, currentTimeMs);
             return Math.min(shutdown.remainingTimeMs(), minRequestBackoffMs);
-        } else if (state.isBackingOff()) {
-            if (state.isBackoffComplete(currentTimeMs)) {
-                logger.info("Transition to prospective after election backoff has completed");
-                transitionToProspective(currentTimeMs);
-                return 0L;
-            }
-            return state.remainingBackoffMs(currentTimeMs);
         } else if (state.hasElectionTimeoutExpired(currentTimeMs)) {
             logger.info("Election was not granted, transitioning to prospective");
             transitionToProspective(currentTimeMs);
             return 0L;
+        } else if (state.isBackingOff()) {
+            return state.remainingElectionTimeMs(currentTimeMs);
         } else {
             long minVoteRequestBackoffMs = maybeSendVoteRequests(state, currentTimeMs);
             return Math.min(minVoteRequestBackoffMs, state.remainingElectionTimeMs(currentTimeMs));

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1017,18 +1017,13 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * If replica is candidate, it will start backing off.
      */
     private void maybeHandleElectionLoss(NomineeState state, long currentTimeMs) {
-        if (state instanceof CandidateState candidate) {
-            if (candidate.epochElection().isVoteRejected() && !candidate.isBackingOff()) {
-                logger.info(
-                    "Insufficient remaining votes to become leader. Candidate will wait the remaining election " +
-                        "timeout ({}) before transitioning back to Prospective. Current epoch election state is {}.",
-                    candidate.remainingElectionTimeMs(currentTimeMs),
-                    candidate.epochElection()
-                );
-                // Mark that the candidate is now backing off. After election timeout expires the candidate will
-                // transition back to prospective
-                candidate.startBackingOff();
-            }
+        if (state instanceof CandidateState candidate && candidate.epochElection().isVoteRejected()) {
+            logger.info(
+                "Insufficient remaining votes to become leader. Candidate will wait the remaining election " +
+                    "timeout ({}) before transitioning back to Prospective. Current epoch election state is {}.",
+                candidate.remainingElectionTimeMs(currentTimeMs),
+                candidate.epochElection()
+            );
         } else if (state instanceof ProspectiveState prospective) {
             if (prospective.epochElection().isVoteRejected()) {
                 logger.info(
@@ -3143,7 +3138,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             logger.info("Election was not granted, transitioning to prospective");
             transitionToProspective(currentTimeMs);
             return 0L;
-        } else if (state.isBackingOff()) {
+        } else if (state.epochElection().isVoteRejected()) {
             return state.remainingElectionTimeMs(currentTimeMs);
         } else {
             long minVoteRequestBackoffMs = maybeSendVoteRequests(state, currentTimeMs);

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1018,7 +1018,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      */
     private void maybeHandleElectionLoss(NomineeState state, long currentTimeMs) {
         if (state instanceof CandidateState candidate) {
-            if (candidate.epochElection().isVoteRejected()){
+            if (candidate.epochElection().isVoteRejected()) {
                 logger.info(
                     "Insufficient remaining votes to become leader. Candidate will wait the remaining election " +
                         "timeout ({}) before transitioning back to Prospective. Current epoch election state is {}.",
@@ -3140,8 +3140,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             logger.info("Election was not granted, transitioning to prospective");
             transitionToProspective(currentTimeMs);
             return 0L;
-        } else if (state.epochElection().isVoteRejected()) {
-            return state.remainingElectionTimeMs(currentTimeMs);
         } else {
             long minVoteRequestBackoffMs = maybeSendVoteRequests(state, currentTimeMs);
             return Math.min(minVoteRequestBackoffMs, state.remainingElectionTimeMs(currentTimeMs));

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1017,13 +1017,15 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * If replica is candidate, it will start backing off.
      */
     private void maybeHandleElectionLoss(NomineeState state, long currentTimeMs) {
-        if (state instanceof CandidateState candidate && candidate.epochElection().isVoteRejected()) {
-            logger.info(
-                "Insufficient remaining votes to become leader. Candidate will wait the remaining election " +
-                    "timeout ({}) before transitioning back to Prospective. Current epoch election state is {}.",
-                candidate.remainingElectionTimeMs(currentTimeMs),
-                candidate.epochElection()
-            );
+        if (state instanceof CandidateState candidate) {
+            if (candidate.epochElection().isVoteRejected()){
+                logger.info(
+                    "Insufficient remaining votes to become leader. Candidate will wait the remaining election " +
+                        "timeout ({}) before transitioning back to Prospective. Current epoch election state is {}.",
+                    candidate.remainingElectionTimeMs(currentTimeMs),
+                    candidate.epochElection()
+                );
+            }
         } else if (state instanceof ProspectiveState prospective) {
             if (prospective.epochElection().isVoteRejected()) {
                 logger.info(

--- a/raft/src/main/java/org/apache/kafka/raft/ProspectiveState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ProspectiveState.java
@@ -37,7 +37,6 @@ public class ProspectiveState implements NomineeState {
     private final VoterSet voters;
     private final EpochElection epochElection;
     private final Optional<LogOffsetMetadata> highWatermark;
-    private final int retries;
     private final long electionTimeoutMs;
     private final Timer electionTimer;
     private final Logger log;
@@ -60,7 +59,6 @@ public class ProspectiveState implements NomineeState {
         Optional<ReplicaKey> votedKey,
         VoterSet voters,
         Optional<LogOffsetMetadata> highWatermark,
-        int retries,
         int electionTimeoutMs,
         LogContext logContext
     ) {
@@ -71,7 +69,6 @@ public class ProspectiveState implements NomineeState {
         this.votedKey = votedKey;
         this.voters = voters;
         this.highWatermark = highWatermark;
-        this.retries = retries;
         this.electionTimeoutMs = electionTimeoutMs;
         this.electionTimer = time.timer(electionTimeoutMs);
         this.log = logContext.logger(ProspectiveState.class);
@@ -87,10 +84,6 @@ public class ProspectiveState implements NomineeState {
     @Override
     public EpochElection epochElection() {
         return epochElection;
-    }
-
-    public int retries() {
-        return retries;
     }
 
     @Override
@@ -160,11 +153,10 @@ public class ProspectiveState implements NomineeState {
     @Override
     public String toString() {
         return String.format(
-            "ProspectiveState(epoch=%d, leaderId=%s, retries=%d, votedKey=%s, epochElection=%s, " +
+            "ProspectiveState(epoch=%d, leaderId=%s, votedKey=%s, epochElection=%s, " +
             "electionTimeoutMs=%s, highWatermark=%s)",
             epoch,
             leaderId,
-            retries,
             votedKey,
             epochElection,
             electionTimeoutMs,

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -200,7 +200,6 @@ public class QuorumState {
                 election.epoch(),
                 partitionState.lastVoterSet(),
                 Optional.empty(),
-                1,
                 randomElectionTimeoutMs(),
                 logContext
             );
@@ -481,6 +480,7 @@ public class QuorumState {
         int epoch,
         ReplicaKey candidateKey
     ) {
+        prospectiveStateOrThrow();
         int currentEpoch = state.epoch();
         if (localId.isPresent() && candidateKey.id() == localId.getAsInt()) {
             throw new IllegalStateException(
@@ -505,7 +505,6 @@ public class QuorumState {
             );
         }
 
-        ProspectiveState prospectiveState = prospectiveStateOrThrow();
         // Note that we reset the election timeout after voting for a candidate because we
         // know that the candidate has at least as good of a chance of getting elected as us
         durableTransitionTo(
@@ -518,7 +517,6 @@ public class QuorumState {
                 Optional.of(candidateKey),
                 partitionState.lastVoterSet(),
                 state.highWatermark(),
-                prospectiveState.retries(),
                 randomElectionTimeoutMs(),
                 logContext
             )
@@ -620,8 +618,6 @@ public class QuorumState {
                 " is state " + state);
         }
 
-        int retries = isCandidate() ? candidateStateOrThrow().retries() + 1 : 1;
-
         // Durable transition is not necessary since there is no change to the persisted electionState
         memoryTransitionTo(
             new ProspectiveState(
@@ -633,7 +629,6 @@ public class QuorumState {
                 votedKey(),
                 partitionState.lastVoterSet(),
                 state.highWatermark(),
-                retries,
                 randomElectionTimeoutMs(),
                 logContext
             )
@@ -646,8 +641,6 @@ public class QuorumState {
         int newEpoch = epoch() + 1;
         int electionTimeoutMs = randomElectionTimeoutMs();
 
-        int retries = isProspective() ? prospectiveStateOrThrow().retries() : 1;
-
         durableTransitionTo(new CandidateState(
             time,
             localIdOrThrow(),
@@ -655,7 +648,6 @@ public class QuorumState {
             newEpoch,
             partitionState.lastVoterSet(),
             state.highWatermark(),
-            retries,
             electionTimeoutMs,
             logContext
         ));

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -480,6 +480,8 @@ public class QuorumState {
         int epoch,
         ReplicaKey candidateKey
     ) {
+        // Verify the current state is prospective, this method should only be used to add voted state to
+        // prospective state. Transitions from other states to prospective use transitionToProspective instead.
         prospectiveStateOrThrow();
         int currentEpoch = state.epoch();
         if (localId.isPresent() && candidateKey.id() == localId.getAsInt()) {

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -48,7 +48,6 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -755,19 +754,5 @@ public class RaftUtil {
                    data.topics().get(0).topicName().equals(topicPartition.topic()) &&
                    data.topics().get(0).partitions().size() == 1 &&
                    data.topics().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
-    }
-
-    static int binaryExponentialElectionBackoffMs(int backoffMaxMs, int backoffBaseMs, int retries, Random random) {
-        if (retries <= 0) {
-            throw new IllegalArgumentException("Retries " + retries + " should be larger than zero");
-        }
-        // Takes minimum of the following:
-        // 1. exponential backoff calculation (maxes out at 102.4 seconds)
-        // 2. configurable electionBackoffMaxMs + jitter
-        // The jitter is added to prevent livelock of elections.
-        return Math.min(
-            backoffBaseMs * random.nextInt(1, 2 << Math.min(10, retries - 1)),
-            backoffMaxMs + random.nextInt(backoffBaseMs)
-        );
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/CandidateStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/CandidateStateTest.java
@@ -50,7 +50,6 @@ public class CandidateStateTest {
             epoch,
             voters,
             Optional.empty(),
-            1,
             electionTimeoutMs,
             logContext
         );

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1774,7 +1774,7 @@ class KafkaRaftClientTest {
         int localId = randomReplicaId();
         int otherNodeId = localId + 1;
         int epoch = 1;
-        int jitter = 85;  // set it large enough so that replica will bound on jitter
+        int jitter = 85;
         Set<Integer> voters = Set.of(localId, otherNodeId);
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1132,13 +1132,8 @@ class KafkaRaftClientTest {
         context.client.poll();
         context.assertVotedCandidate(epoch, localId);
 
-        // Enter the backoff period
+        // After election timeout, replica will become prospective again
         context.time.sleep(1);
-        context.client.poll();
-        context.assertVotedCandidate(epoch, localId);
-
-        // After backoff, replica will become prospective again
-        context.time.sleep(context.electionBackoffMaxMs);
         context.client.poll();
         assertTrue(context.client.quorum().isProspective());
     }
@@ -1775,15 +1770,15 @@ class KafkaRaftClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void testCandidateBackoffElection(boolean withKip853Rpc) throws Exception {
+    public void testCandidateWaitsRestOfElectionTimeoutAfterElectionLoss(boolean withKip853Rpc) throws Exception {
         int localId = randomReplicaId();
         int otherNodeId = localId + 1;
         int epoch = 1;
-        int exponentialFactor = 85;  // set it large enough so that replica will bound on jitter
+        int jitter = 85;  // set it large enough so that replica will bound on jitter
         Set<Integer> voters = Set.of(localId, otherNodeId);
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
-            .updateRandom(r -> r.mockNextInt(exponentialFactor))
+            .updateRandom(r -> r.mockNextInt(jitter))
             .withKip853Rpc(withKip853Rpc)
             .build();
 
@@ -1793,9 +1788,8 @@ class KafkaRaftClientTest {
         context.pollUntilRequest();
         context.assertVotedCandidate(epoch, localId);
         CandidateState candidate = context.client.quorum().candidateStateOrThrow();
-        assertEquals(1, candidate.retries());
         assertEquals(
-            context.electionTimeoutMs() + exponentialFactor,
+            context.electionTimeoutMs() + jitter,
             candidate.remainingElectionTimeMs(context.time.milliseconds())
         );
         assertFalse(candidate.isBackingOff());
@@ -1810,43 +1804,27 @@ class KafkaRaftClientTest {
 
         context.client.poll();
         assertTrue(candidate.isBackingOff());
-        assertEquals(
-            context.electionBackoffMaxMs + exponentialFactor,
-            candidate.remainingBackoffMs(context.time.milliseconds())
-        );
 
         // Election is lost, but local replica should still remember that it has voted
         context.assertVotedCandidate(epoch, localId);
 
-        // Even though candidacy was rejected, local replica will backoff for jitter period
+        // Even though candidacy was rejected, local replica will backoff for remaining election timeout
         // before transitioning to prospective and starting a new election.
-        context.time.sleep(context.electionBackoffMaxMs + exponentialFactor - 1);
+        context.time.sleep(context.electionTimeoutMs() + jitter - 1);
         context.client.poll();
         context.assertVotedCandidate(epoch, localId);
 
-        // After jitter expires, become a prospective again
+        // After election timeout expires, become a prospective again
         context.time.sleep(1);
         context.client.poll();
         assertTrue(context.client.quorum().isProspective());
         ProspectiveState prospective = context.client.quorum().prospectiveStateOrThrow();
-        assertEquals(2, prospective.retries());
         context.pollUntilRequest();
         request = context.assertSentPreVoteRequest(epoch, 0, 0L, 1);
         assertEquals(
-            context.electionTimeoutMs() + exponentialFactor,
+            context.electionTimeoutMs() + jitter,
             prospective.remainingElectionTimeMs(context.time.milliseconds())
         );
-
-        // After becoming candidate again, retries should be 2
-        context.deliverResponse(
-            request.correlationId(),
-            request.destination(),
-            context.voteResponse(true, OptionalInt.empty(), 1)
-        );
-        context.client.poll();
-        context.assertVotedCandidate(epoch + 1, localId);
-        candidate = context.client.quorum().candidateStateOrThrow();
-        assertEquals(2, candidate.retries());
     }
 
     @ParameterizedTest
@@ -1870,7 +1848,6 @@ class KafkaRaftClientTest {
         context.assertVotedCandidate(epoch, localId);
         context.assertSentVoteRequest(epoch, 0, 0L, 1);
         CandidateState candidate = context.client.quorum().candidateStateOrThrow();
-        assertEquals(1, candidate.retries());
         assertEquals(
             context.electionTimeoutMs() + jitter,
             candidate.remainingElectionTimeMs(context.time.milliseconds())
@@ -1883,7 +1860,6 @@ class KafkaRaftClientTest {
         assertTrue(context.client.quorum().isProspective());
 
         ProspectiveState prospective = context.client.quorum().prospectiveStateOrThrow();
-        assertEquals(2, prospective.retries());
         context.pollUntilRequest();
         context.assertSentPreVoteRequest(epoch, 0, 0L, 1);
         assertEquals(

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1792,7 +1792,7 @@ class KafkaRaftClientTest {
             context.electionTimeoutMs() + jitter,
             candidate.remainingElectionTimeMs(context.time.milliseconds())
         );
-        assertFalse(candidate.isBackingOff());
+        assertFalse(candidate.epochElection().isVoteRejected());
 
         // Quorum size is two. If the other member rejects, then the local replica will lose the election.
         RaftRequest.Outbound request = context.assertSentVoteRequest(epoch, 0, 0L, 1);
@@ -1803,7 +1803,7 @@ class KafkaRaftClientTest {
         );
 
         context.client.poll();
-        assertTrue(candidate.isBackingOff());
+        assertTrue(candidate.epochElection().isVoteRejected());
 
         // Election is lost, but local replica should still remember that it has voted
         context.assertVotedCandidate(epoch, localId);
@@ -1820,7 +1820,7 @@ class KafkaRaftClientTest {
         assertTrue(context.client.quorum().isProspective());
         ProspectiveState prospective = context.client.quorum().prospectiveStateOrThrow();
         context.pollUntilRequest();
-        request = context.assertSentPreVoteRequest(epoch, 0, 0L, 1);
+        context.assertSentPreVoteRequest(epoch, 0, 0L, 1);
         assertEquals(
             context.electionTimeoutMs() + jitter,
             prospective.remainingElectionTimeMs(context.time.milliseconds())
@@ -1852,7 +1852,7 @@ class KafkaRaftClientTest {
             context.electionTimeoutMs() + jitter,
             candidate.remainingElectionTimeMs(context.time.milliseconds())
         );
-        assertFalse(candidate.isBackingOff());
+        assertFalse(candidate.epochElection().isVoteRejected());
 
         // If election times out, replica transition to prospective without any additional backoff
         context.time.sleep(candidate.remainingElectionTimeMs(context.time.milliseconds()));

--- a/raft/src/test/java/org/apache/kafka/raft/MockableRandom.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockableRandom.java
@@ -48,9 +48,4 @@ class MockableRandom extends Random {
     public int nextInt(int bound) {
         return nextIntFunction.apply(bound).orElse(super.nextInt(bound));
     }
-
-    @Override
-    public int nextInt(int origin, int bound) {
-        return nextIntFunction.apply(bound).orElse(super.nextInt(bound));
-    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/ProspectiveStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/ProspectiveStateTest.java
@@ -71,7 +71,6 @@ public class ProspectiveStateTest {
             votedKey,
             voters,
             Optional.empty(),
-            1,
             electionTimeoutMs,
             logContext
         );
@@ -87,7 +86,6 @@ public class ProspectiveStateTest {
             Optional.empty(),
             voters,
             Optional.empty(),
-            1,
             electionTimeoutMs,
             logContext
         );


### PR DESCRIPTION
Replaces exponential backoff for candidate state after losing election
with waiting rest of election timeout. There is no need to have an
exponential backoff when the election timeout already provides a natural
throttle and it is randomized.

Reviewers: José Armando García Sancio <jsancio@apache.org>, TaiJuWu
 <tjwu1217@gmail.com>
