### PR TITLE
KAFKA-18903: update-cache.sh use curl + jq to get sha contains gradle cache instead of gh cli

### DIFF
--- a/committer-tools/README.md
+++ b/committer-tools/README.md
@@ -103,14 +103,3 @@ Found tests that were started, but not finished:
 
 2024-09-10T20:31:26.6830206Z Gradle Test Run :streams:test > Gradle Test Executor 47 > StreamThreadTest > shouldReturnErrorIfProducerInstanceIdNotInitialized(boolean, boolean) > "shouldReturnErrorIfProducerInstanceIdNotInitialized(boolean, boolean).stateUpdaterEnabled=true, processingThreadsEnabled=true" STARTED
 ```
-
-
-## Speed up the CI
-`update-cache.sh` allows developers to retrieve the latest commit SHA that contains the Gradle build cache and create a local branch called `trunk-cached`. 
-Developers can then checkout a new branch based on `trunk-cached` to speed up CI.
-
-```bash
-./update-cache.sh
-
-Local branch 'trunk-cached' successfully updated to f26974b16d (from 19 hours ago).
-```

--- a/committer-tools/README.md
+++ b/committer-tools/README.md
@@ -103,3 +103,14 @@ Found tests that were started, but not finished:
 
 2024-09-10T20:31:26.6830206Z Gradle Test Run :streams:test > Gradle Test Executor 47 > StreamThreadTest > shouldReturnErrorIfProducerInstanceIdNotInitialized(boolean, boolean) > "shouldReturnErrorIfProducerInstanceIdNotInitialized(boolean, boolean).stateUpdaterEnabled=true, processingThreadsEnabled=true" STARTED
 ```
+
+
+## Speed up the CI
+`update-cache.sh` allows developers to retrieve the latest commit SHA that contains the Gradle build cache and create a local branch called `trunk-cached`. 
+Developers can then checkout a new branch based on `trunk-cached` to speed up CI.
+
+```bash
+./update-cache.sh
+
+Local branch 'trunk-cached' successfully updated to f26974b16d (from 19 hours ago).
+```

--- a/committer-tools/update-cache.sh
+++ b/committer-tools/update-cache.sh
@@ -16,22 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if ! git config --get alias.update-cache > /dev/null; then
-  printf '\e[36m%s\n\n  %s\n\e[0m\n' \
-    'Hint: you can create a Git alias to execute this script. Example:' \
-    "git config alias.update-cache '!bash $(realpath "$0")'"
-fi
-
-key="$(
-  gh cache list \
-    --key 'gradle-home-v1|Linux-X64|test' \
-    --sort 'created_at' \
-    --limit 1 \
-    --json 'key' \
-    --jq '.[].key'
-)"
-
-sha="$(cut -d '-' -f 5 <<< "$key")"
+# Get the latest commit SHA that contains the Gradle build cache.
+sha=$(curl -s "https://api.github.com/repos/apache/kafka/actions/caches?key=gradle-home-v1&ref=refs/heads/trunk" \
+  | jq -r '.actions_caches | max_by(.created_at) | .key | split("-")[4]')
 
 if ! git show "$sha" &> /dev/null; then
   printf '\e[33m%s\n%s\e[0m\n' \


### PR DESCRIPTION
Instead of using the GH CLI (which requires some local setup), we can
just use cURL and JQ. Additionally, the original logic required setting
up alias.update-cache. After the change, this configuration is no longer
necessary.

validation on mac:

```
❯ ./update-cache.sh
Local branch 'trunk-cached' successfully updated to f26974b16d (from 19
hours ago).
```

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
