### PR TITLE
KAFKA-19314: Remove unnecessary code of closing snapshotWriter

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
@@ -157,8 +157,6 @@ public class SnapshotEmitter implements SnapshotGenerator.Emitter {
             log.error("Encountered error while writing {}", provenance.snapshotName(), e);
             throw e;
         } finally {
-            Utils.closeQuietly(writer, "RaftSnapshotWriter");
-            Utils.closeQuietly(snapshotWriter.get(), "SnapshotWriter");
-        }
+            Utils.closeQuietly(writer, "RaftSnapshotWriter");}
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
@@ -157,6 +157,7 @@ public class SnapshotEmitter implements SnapshotGenerator.Emitter {
             log.error("Encountered error while writing {}", provenance.snapshotName(), e);
             throw e;
         } finally {
-            Utils.closeQuietly(writer, "RaftSnapshotWriter");}
+            Utils.closeQuietly(writer, "RaftSnapshotWriter");
+        }
     }
 }


### PR DESCRIPTION
- Remove redundant close of `snapshotWriter`.
- `snapshotWriter` is already closed by `RaftSnapshotWriter#writer`.

Reviewers: Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
