### PR TITLE
KAFKA-7516: Attempt to dynamically load ManagementFactory

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.Properties;
 
+import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -81,7 +82,7 @@ public class AppInfoParser {
             server.registerMBean(mBean, name);
 
             registerMetrics(metrics, mBean); // prefix will be added later by JmxReporter
-        } catch (Throwable e) {
+        } catch (JMException | ReflectiveOperationException e) {
             log.warn("Error registering AppInfo mbean", e);
         }
     }
@@ -96,7 +97,7 @@ public class AppInfoParser {
                 server.unregisterMBean(name);
 
             unregisterMetrics(metrics);
-        } catch (Throwable e) {
+        } catch (JMException | ReflectiveOperationException e) {
             log.warn("Error unregistering AppInfo mbean", e);
         } finally {
             log.info("App info {} for {} unregistered", prefix, id);

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -25,10 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
-import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
 import java.util.Properties;
 
-import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -36,6 +35,7 @@ public class AppInfoParser {
     private static final Logger log = LoggerFactory.getLogger(AppInfoParser.class);
     private static final String VERSION;
     private static final String COMMIT_ID;
+    private static final Method GET_MBEAN_SERVER;
 
     protected static final String DEFAULT_VALUE = "unknown";
 
@@ -48,6 +48,15 @@ public class AppInfoParser {
         }
         VERSION = props.getProperty("version", DEFAULT_VALUE).trim();
         COMMIT_ID = props.getProperty("commitId", DEFAULT_VALUE).trim();
+
+        Method getMBeanServer;
+        try {
+            Class<?> managementFactory = Class.forName("java.lang.management.ManagementFactory");
+            getMBeanServer = managementFactory.getMethod("getPlatformMBeanServer");
+        } catch (ReflectiveOperationException e) {
+            getMBeanServer = null;
+        }
+        GET_MBEAN_SERVER = getMBeanServer;
     }
 
     public static String getVersion() {
@@ -59,9 +68,11 @@ public class AppInfoParser {
     }
 
     public static synchronized void registerAppInfo(String prefix, String id, Metrics metrics, long nowMs) {
+        if (GET_MBEAN_SERVER == null)
+            return;
         try {
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
-            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            MBeanServer server = (MBeanServer) GET_MBEAN_SERVER.invoke(null);
             if (server.isRegistered(name)) {
                 log.info("The mbean of App info: [{}], id: [{}] already exists, so skipping a new mbean creation.", prefix, id);
                 return;
@@ -70,20 +81,22 @@ public class AppInfoParser {
             server.registerMBean(mBean, name);
 
             registerMetrics(metrics, mBean); // prefix will be added later by JmxReporter
-        } catch (JMException e) {
+        } catch (Throwable e) {
             log.warn("Error registering AppInfo mbean", e);
         }
     }
 
     public static synchronized void unregisterAppInfo(String prefix, String id, Metrics metrics) {
-        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        if (GET_MBEAN_SERVER == null)
+            return;
         try {
+            MBeanServer server = (MBeanServer) GET_MBEAN_SERVER.invoke(null);
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
             if (server.isRegistered(name))
                 server.unregisterMBean(name);
 
             unregisterMetrics(metrics);
-        } catch (JMException e) {
+        } catch (Throwable e) {
             log.warn("Error unregistering AppInfo mbean", e);
         } finally {
             log.info("App info {} for {} unregistered", prefix, id);

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.util.Properties;
 
 import javax.management.JMException;
@@ -36,7 +35,6 @@ public class AppInfoParser {
     private static final Logger log = LoggerFactory.getLogger(AppInfoParser.class);
     private static final String VERSION;
     private static final String COMMIT_ID;
-    private static final Method GET_MBEAN_SERVER;
 
     protected static final String DEFAULT_VALUE = "unknown";
 
@@ -49,15 +47,20 @@ public class AppInfoParser {
         }
         VERSION = props.getProperty("version", DEFAULT_VALUE).trim();
         COMMIT_ID = props.getProperty("commitId", DEFAULT_VALUE).trim();
+    }
 
-        Method getMBeanServer;
+    static MBeanServer getPlatformMBeanServer(ClassLoader loader) {
         try {
-            Class<?> managementFactory = Class.forName("java.lang.management.ManagementFactory");
-            getMBeanServer = managementFactory.getMethod("getPlatformMBeanServer");
+            // Not all platforms (*cough*Android*cough*) have MBeans, query using reflection
+            Class<?> managementFactory = Class.forName("java.lang.management.ManagementFactory", true, loader);
+            return (MBeanServer) managementFactory.getMethod("getPlatformMBeanServer").invoke(null);
         } catch (ReflectiveOperationException e) {
-            getMBeanServer = null;
+            return null;
         }
-        GET_MBEAN_SERVER = getMBeanServer;
+    }
+
+    static MBeanServer getPlatformMBeanServer() {
+        return getPlatformMBeanServer(AppInfoParser.class.getClassLoader());
     }
 
     public static String getVersion() {
@@ -69,11 +72,12 @@ public class AppInfoParser {
     }
 
     public static synchronized void registerAppInfo(String prefix, String id, Metrics metrics, long nowMs) {
-        if (GET_MBEAN_SERVER == null)
+        MBeanServer server = getPlatformMBeanServer();
+        if (server == null) {
             return;
+        }
         try {
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
-            MBeanServer server = (MBeanServer) GET_MBEAN_SERVER.invoke(null);
             if (server.isRegistered(name)) {
                 log.info("The mbean of App info: [{}], id: [{}] already exists, so skipping a new mbean creation.", prefix, id);
                 return;
@@ -82,22 +86,23 @@ public class AppInfoParser {
             server.registerMBean(mBean, name);
 
             registerMetrics(metrics, mBean); // prefix will be added later by JmxReporter
-        } catch (JMException | ReflectiveOperationException e) {
+        } catch (JMException e) {
             log.warn("Error registering AppInfo mbean", e);
         }
     }
 
     public static synchronized void unregisterAppInfo(String prefix, String id, Metrics metrics) {
-        if (GET_MBEAN_SERVER == null)
+        MBeanServer server = getPlatformMBeanServer();
+        if (server == null) {
             return;
+        }
         try {
-            MBeanServer server = (MBeanServer) GET_MBEAN_SERVER.invoke(null);
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
             if (server.isRegistered(name))
                 server.unregisterMBean(name);
 
             unregisterMetrics(metrics);
-        } catch (JMException | ReflectiveOperationException e) {
+        } catch (JMException e) {
             log.warn("Error unregistering AppInfo mbean", e);
         } finally {
             log.info("App info {} for {} unregistered", prefix, id);

--- a/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
@@ -31,6 +31,7 @@ import javax.management.ObjectName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,6 +54,23 @@ public class AppInfoParserTest {
     @AfterEach
     public void tearDown() {
         metrics.close();
+    }
+
+    @Test
+    public void testGetPlatformMBeanServer() {
+        assertNotNull(AppInfoParser.getPlatformMBeanServer(AppInfoParser.class.getClassLoader()));
+    }
+
+    @Test
+    public void testFailGetPlatformMBeanServer() {
+        ClassLoader nullLoader = new ClassLoader(null) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                throw new ClassNotFoundException(name);
+            }
+        };
+
+        assertNull(AppInfoParser.getPlatformMBeanServer(nullLoader));
     }
 
     @Test


### PR DESCRIPTION
Fail gracefully if not found. This can be the case on Dalvik/Android.

With this change, it's no longer necessary to stub out JMX classes on Android. The "metric.reporters" configuration should be set to an empty string as well, since the default implementation also relies on nonexistent classes.

Also added test cases for getting the MBeanServer instance.
