### PR TITLE
MINOR: Update the supported tags in docker_scan.yml

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # This is an array of supported tags. Make sure this array only contains the supported tags
-        supported_image_tag: ['latest', '3.7.2', '3.8.1', '3.9.0', '4.0.0']
+        supported_image_tag: ['latest', '3.7.2', '3.8.1', '3.9.1', '4.0.0']
     steps:
       - name: Run CVE scan
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0


### PR DESCRIPTION
The 3.9.1-rc2 has been accepted as the new release. Hence, we should
update the supported tags.

Reviewers: Luke Chen <showuon@gmail.com>
