### PR TITLE
MINOR: Add more description to KIP-1148

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -36,6 +36,7 @@
                 <ul>
                     <li>
                         The configuration <code>log.cleaner.enable</code> is deprecated. Users should no longer set it to <code>false</code> to prepare for future removal.
+                        After the removal, <code>log.cleaner.threads</code> will also have a lower bound of 1.
                         For further details, please refer to <a href="https://cwiki.apache.org/confluence/x/XAyWF">KIP-1148</a>.
                     </li>
                 </ul>


### PR DESCRIPTION
Given that we will remove the `log.cleaner.enable`, the related config
`log.cleaner.threads` will also have the respective adjustment.  This
patch will add a description to it.

For more details:
https://issues.apache.org/jira/browse/KAFKA-13610?focusedCommentId=17950756&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17950756

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
