### PR TITLE
MINOR Fix: API Responses missing latest version in Kafka protocol guide

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -208,7 +208,7 @@ public class Protocol {
             // Responses
             b.append("<b>Responses:</b><br>\n");
             Schema[] responses = key.messageType.responseSchemas();
-            for (int version = key.oldestVersion(); version < key.latestVersion(); version++) {
+            for (int version = key.oldestVersion(); version <= key.latestVersion(); version++) {
                 Schema schema = responses[version];
                 if (schema == null)
                     throw new IllegalStateException("Unexpected null schema for " + key + " with version " + version);


### PR DESCRIPTION
### Issue:

API Responses missing latest version in [Kafka protocol guide](https://kafka.apache.org/protocol.html)

#### For example:

These are missing:

- ApiVersions Response (Version: 4) — Only versions 0–3 are documented,
though version 4 of the request is included.

- DescribeTopicPartitions Response — Not listed at all.

- Fetch Response (Version: 17) — Only versions 4–16 are documented,
though version 17 of the request is included.

#### After the fix:

docs/generated/protocol_messages.html

<img width="1045" alt="image"
src="https://github.com/user-attachments/assets/5ea79ced-aab5-4c47-8e09-9956047c9bf1"
/>

Reviewers: dengziming <dengziming1993@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
