### PR TITLE
MINOR: Cleanup Share Coordinator 

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareGroupOffset.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareGroupOffset.java
@@ -190,7 +190,7 @@ public class ShareGroupOffset {
         }
 
         public Builder setStateBatches(List<PersisterStateBatch> stateBatches) {
-            this.stateBatches = stateBatches == null ? Collections.emptyList() : stateBatches.stream().toList();
+            this.stateBatches = stateBatches == null ? List.of() : stateBatches.stream().toList();
             return this;
         }
 

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -31,8 +31,8 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 
 import com.yammer.metrics.core.MetricsRegistry;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -91,7 +91,7 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
     @Override
     public void close() throws Exception {
-        Arrays.asList(
+        List.of(
             SHARE_COORDINATOR_WRITE_SENSOR_NAME,
             SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME
         ).forEach(metrics::removeSensor);

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -59,8 +59,6 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -760,7 +758,7 @@ class ShareCoordinatorShardTest {
         //        -Share coordinator writes the snapshot with startOffset 110 and batch 3.
         //        -batch2 should NOT be lost
         ShareCoordinatorShard shard = new ShareCoordinatorShardBuilder()
-            .setConfigOverrides(Collections.singletonMap(ShareCoordinatorConfig.SNAPSHOT_UPDATE_RECORDS_PER_SNAPSHOT_CONFIG, "0"))
+            .setConfigOverrides(Map.of(ShareCoordinatorConfig.SNAPSHOT_UPDATE_RECORDS_PER_SNAPSHOT_CONFIG, "0"))
             .build();
 
         SharePartitionKey shareCoordinatorKey = SharePartitionKey.getInstance(GROUP_ID, TOPIC_ID, PARTITION);
@@ -775,7 +773,7 @@ class ShareCoordinatorShardTest {
                     .setStartOffset(100)
                     .setStateEpoch(0)
                     .setLeaderEpoch(0)
-                    .setStateBatches(Arrays.asList(
+                    .setStateBatches(List.of(
                         new WriteShareGroupStateRequestData.StateBatch()    //b1
                             .setFirstOffset(100)
                             .setLastOffset(109)
@@ -862,7 +860,7 @@ class ShareCoordinatorShardTest {
             .setLeaderEpoch(0)
             .setStateEpoch(0)
             .setSnapshotEpoch(2)    // since 2nd share snapshot
-            .setStateBatches(Arrays.asList(
+            .setStateBatches(List.of(
                 new PersisterStateBatch(110, 119, (byte) 1, (short) 2),  // b2 not lost
                 new PersisterStateBatch(120, 129, (byte) 2, (short) 1)
             ))

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetricsTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetricsTest.java
@@ -26,8 +26,8 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.coordinator.share.metrics.ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME;
@@ -42,7 +42,7 @@ public class ShareCoordinatorMetricsTest {
     public void testMetricNames() {
         Metrics metrics = new Metrics();
 
-        HashSet<MetricName> expectedMetrics = new HashSet<>(Arrays.asList(
+        HashSet<MetricName> expectedMetrics = new HashSet<>(List.of(
             metrics.metricName("write-rate", ShareCoordinatorMetrics.METRICS_GROUP),
             metrics.metricName("write-total", ShareCoordinatorMetrics.METRICS_GROUP),
             metrics.metricName("write-latency-avg", ShareCoordinatorMetrics.METRICS_GROUP),


### PR DESCRIPTION
Now that Kafka Brokers support Java 17, this PR updates the share
coordinator module to get rid of older code. The changes mostly include:
- Collections.emptyList(), Collections.singletonList() and
- Arrays.asList() are replaced with List.of()
- Collections.emptyMap() and Collections.singletonMap() are replaced
with Map.of()
- Collections.singleton() is replaced with Set.of()

Reviewers: Andrew Schofield <aschofield@confluent.io>
