### PR TITLE
MINOR: Cleanup Shell Module

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -45,11 +45,9 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
 
 /**
  * The Kafka metadata shell entry point.
@@ -161,7 +159,7 @@ public final class MetadataShell {
 
     public void run(List<String> args) throws Exception {
         initializeWithSnapshotFileReader();
-        loader.installPublishers(Collections.singletonList(publisher)).get(15, TimeUnit.MINUTES);
+        loader.installPublishers(List.of(publisher)).get(15, TimeUnit.MINUTES);
         if (args == null || args.isEmpty()) {
             // Interactive mode.
             System.out.println("Loading...");

--- a/shell/src/main/java/org/apache/kafka/shell/command/Commands.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/Commands.java
@@ -32,7 +32,6 @@ import org.jline.reader.Candidate;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NavigableMap;
@@ -50,7 +49,7 @@ public final class Commands {
 
     static {
         TreeMap<String, Type> typesMap = new TreeMap<>();
-        for (Type type : Arrays.asList(
+        for (Type type : List.of(
             CatCommandHandler.TYPE,
             CdCommandHandler.TYPE,
             ExitCommandHandler.TYPE,

--- a/shell/src/main/java/org/apache/kafka/shell/glob/GlobComponent.java
+++ b/shell/src/main/java/org/apache/kafka/shell/glob/GlobComponent.java
@@ -32,39 +32,20 @@ public final class GlobComponent {
      * Returns true if the character is a special character for regular expressions.
      */
     private static boolean isRegularExpressionSpecialCharacter(char ch) {
-        switch (ch) {
-            case '$':
-            case '(':
-            case ')':
-            case '+':
-            case '.':
-            case '[':
-            case ']':
-            case '^':
-            case '{':
-            case '|':
-                return true;
-            default:
-                break;
-        }
-        return false;
+        return switch (ch) {
+            case '$', '(', ')', '+', '.', '[', ']', '^', '{', '|' -> true;
+            default -> false;
+        };
     }
 
     /**
      * Returns true if the character is a special character for globs.
      */
     private static boolean isGlobSpecialCharacter(char ch) {
-        switch (ch) {
-            case '*':
-            case '?':
-            case '\\':
-            case '{':
-            case '}':
-                return true;
-            default:
-                break;
-        }
-        return false;
+        return switch (ch) {
+            case '*', '?', '\\', '{', '}' -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/shell/src/main/java/org/apache/kafka/shell/node/LocalShellNode.java
+++ b/shell/src/main/java/org/apache/kafka/shell/node/LocalShellNode.java
@@ -21,9 +21,8 @@ import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.image.node.MetadataLeafNode;
 import org.apache.kafka.image.node.MetadataNode;
 
-import java.util.Arrays;
 import java.util.Collection;
-
+import java.util.List;
 
 /**
  * The /local node of the metadata shell, which contains information about the shell itself.
@@ -46,7 +45,7 @@ public class LocalShellNode implements MetadataNode {
 
     @Override
     public Collection<String> childNames() {
-        return Arrays.asList(VERSION, COMMIT_ID);
+        return List.of(VERSION, COMMIT_ID);
     }
 
     @Override

--- a/shell/src/main/java/org/apache/kafka/shell/node/RootShellNode.java
+++ b/shell/src/main/java/org/apache/kafka/shell/node/RootShellNode.java
@@ -21,8 +21,8 @@ import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.node.MetadataImageNode;
 import org.apache.kafka.image.node.MetadataNode;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The root node of the Kafka metadata shell.
@@ -36,7 +36,7 @@ public class RootShellNode implements MetadataNode {
 
     @Override
     public Collection<String> childNames() {
-        return Arrays.asList(LocalShellNode.NAME, MetadataImageNode.NAME);
+        return List.of(LocalShellNode.NAME, MetadataImageNode.NAME);
     }
 
     @Override

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataShellIntegrationTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataShellIntegrationTest.java
@@ -33,7 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -91,7 +91,7 @@ public class MetadataShellIntegrationTest {
             if (canLock) {
                 assertEquals(NoSuchFileException.class,
                     assertThrows(ExecutionException.class,
-                        () -> env.shell.run(Collections.emptyList())).
+                        () -> env.shell.run(List.of())).
                             getCause().getClass());
             } else {
                 FileLock fileLock = new FileLock(new File(env.tempDir, ".lock"));
@@ -101,7 +101,7 @@ public class MetadataShellIntegrationTest {
                         ". Please ensure that no broker or controller process is using this " +
                         "directory before proceeding.",
                         assertThrows(RuntimeException.class,
-                            () -> env.shell.run(Collections.emptyList())).
+                            () -> env.shell.run(List.of())).
                                 getMessage());
                 } finally {
                     fileLock.destroy();

--- a/shell/src/test/java/org/apache/kafka/shell/command/CommandTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/command/CommandTest.java
@@ -20,8 +20,7 @@ package org.apache.kafka.shell.command;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,40 +29,40 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class CommandTest {
     @Test
     public void testParseCommands() {
-        assertEquals(new CatCommandHandler(Collections.singletonList("foo")),
-            new Commands(true).parseCommand(Arrays.asList("cat", "foo")));
+        assertEquals(new CatCommandHandler(List.of("foo")),
+            new Commands(true).parseCommand(List.of("cat", "foo")));
         assertEquals(new CdCommandHandler(Optional.empty()),
-            new Commands(true).parseCommand(Collections.singletonList("cd")));
+            new Commands(true).parseCommand(List.of("cd")));
         assertEquals(new CdCommandHandler(Optional.of("foo")),
-            new Commands(true).parseCommand(Arrays.asList("cd", "foo")));
+            new Commands(true).parseCommand(List.of("cd", "foo")));
         assertEquals(new ExitCommandHandler(),
-            new Commands(true).parseCommand(Collections.singletonList("exit")));
+            new Commands(true).parseCommand(List.of("exit")));
         assertEquals(new HelpCommandHandler(),
-            new Commands(true).parseCommand(Collections.singletonList("help")));
+            new Commands(true).parseCommand(List.of("help")));
         assertEquals(new HistoryCommandHandler(3),
-            new Commands(true).parseCommand(Arrays.asList("history", "3")));
+            new Commands(true).parseCommand(List.of("history", "3")));
         assertEquals(new HistoryCommandHandler(Integer.MAX_VALUE),
-            new Commands(true).parseCommand(Collections.singletonList("history")));
-        assertEquals(new LsCommandHandler(Collections.emptyList()),
-            new Commands(true).parseCommand(Collections.singletonList("ls")));
-        assertEquals(new LsCommandHandler(Arrays.asList("abc", "123")),
-            new Commands(true).parseCommand(Arrays.asList("ls", "abc", "123")));
+            new Commands(true).parseCommand(List.of("history")));
+        assertEquals(new LsCommandHandler(List.of()),
+            new Commands(true).parseCommand(List.of("ls")));
+        assertEquals(new LsCommandHandler(List.of("abc", "123")),
+            new Commands(true).parseCommand(List.of("ls", "abc", "123")));
         assertEquals(new PwdCommandHandler(),
-            new Commands(true).parseCommand(Collections.singletonList("pwd")));
+            new Commands(true).parseCommand(List.of("pwd")));
     }
 
     @Test
     public void testParseInvalidCommand() {
         assertEquals(new ErroneousCommandHandler("invalid choice: 'blah' (choose " +
             "from 'cat', 'cd', 'exit', 'find', 'help', 'history', 'ls', 'man', 'pwd', 'tree')"),
-            new Commands(true).parseCommand(Collections.singletonList("blah")));
+            new Commands(true).parseCommand(List.of("blah")));
     }
 
     @Test
     public void testEmptyCommandLine() {
         assertEquals(new NoOpCommandHandler(),
-            new Commands(true).parseCommand(Collections.singletonList("")));
+            new Commands(true).parseCommand(List.of("")));
         assertEquals(new NoOpCommandHandler(),
-            new Commands(true).parseCommand(Collections.emptyList()));
+            new Commands(true).parseCommand(List.of()));
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/command/CommandUtilsTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/command/CommandUtilsTest.java
@@ -20,7 +20,7 @@ package org.apache.kafka.shell.command;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.Arrays;
+import java.util.List;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,9 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class CommandUtilsTest {
     @Test
     public void testSplitPath() {
-        assertEquals(Arrays.asList("alpha", "beta"),
+        assertEquals(List.of("alpha", "beta"),
             CommandUtils.splitPath("/alpha/beta"));
-        assertEquals(Arrays.asList("alpha", "beta"),
+        assertEquals(List.of("alpha", "beta"),
             CommandUtils.splitPath("//alpha/beta/"));
     }
 
@@ -39,13 +39,13 @@ public class CommandUtilsTest {
     public void testStripDotPathComponents() {
 
         //double dots
-        assertEquals(Arrays.asList("keep", "keep2"), CommandUtils.stripDotPathComponents(Arrays.asList("..", "keep", "keep2")));
+        assertEquals(List.of("keep", "keep2"), CommandUtils.stripDotPathComponents(List.of("..", "keep", "keep2")));
         //single dots
-        assertEquals(Arrays.asList("keep", "keep2"), CommandUtils.stripDotPathComponents(Arrays.asList(".", "keep", "keep2")));
+        assertEquals(List.of("keep", "keep2"), CommandUtils.stripDotPathComponents(List.of(".", "keep", "keep2")));
 
-        assertEquals(Arrays.asList(".keep", "keep2"), CommandUtils.stripDotPathComponents(Arrays.asList(".", ".keep", "keep2")));
+        assertEquals(List.of(".keep", "keep2"), CommandUtils.stripDotPathComponents(List.of(".", ".keep", "keep2")));
 
-        assertEquals(Arrays.asList(".keep", "keep2"), CommandUtils.stripDotPathComponents(Arrays.asList("..", ".keep", "keep2")));
+        assertEquals(List.of(".keep", "keep2"), CommandUtils.stripDotPathComponents(List.of("..", ".keep", "keep2")));
 
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/command/LsCommandHandlerTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/command/LsCommandHandlerTest.java
@@ -27,8 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.OptionalInt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,16 +38,16 @@ public class LsCommandHandlerTest {
     public void testCalculateColumnSchema() {
         assertEquals(new ColumnSchema(1, 3),
             LsCommandHandler.calculateColumnSchema(OptionalInt.empty(),
-                Arrays.asList("abc", "def", "ghi")));
+                List.of("abc", "def", "ghi")));
         assertEquals(new ColumnSchema(1, 2),
             LsCommandHandler.calculateColumnSchema(OptionalInt.of(0),
-                Arrays.asList("abc", "def")));
+                List.of("abc", "def")));
         assertEquals(new ColumnSchema(3, 1).setColumnWidths(3, 8, 6),
             LsCommandHandler.calculateColumnSchema(OptionalInt.of(80),
-                Arrays.asList("a", "abcdef", "beta")));
+                List.of("a", "abcdef", "beta")));
         assertEquals(new ColumnSchema(2, 3).setColumnWidths(10, 7),
             LsCommandHandler.calculateColumnSchema(OptionalInt.of(18),
-                Arrays.asList("alphabet", "beta", "gamma", "theta", "zeta")));
+                List.of("alphabet", "beta", "gamma", "theta", "zeta")));
     }
 
     @Test
@@ -57,9 +56,9 @@ public class LsCommandHandlerTest {
             try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(
                     stream, StandardCharsets.UTF_8))) {
                 LsCommandHandler.printEntries(writer, "", OptionalInt.of(18),
-                    Arrays.asList("alphabet", "beta", "gamma", "theta", "zeta"));
+                    List.of("alphabet", "beta", "gamma", "theta", "zeta"));
             }
-            assertEquals(String.join(String.format("%n"), Arrays.asList(
+            assertEquals(String.join(String.format("%n"), List.of(
                 "alphabet  theta",
                 "beta      zeta",
                 "gamma")), stream.toString().trim());
@@ -72,14 +71,14 @@ public class LsCommandHandlerTest {
             try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(
                     stream, StandardCharsets.UTF_8))) {
                 LsCommandHandler.printTargets(writer, OptionalInt.of(18),
-                    Arrays.asList("foo", "foobarbaz", "quux"), Arrays.asList(
+                    List.of("foo", "foobarbaz", "quux"), List.of(
                         new TargetDirectory("/some/dir",
-                            Collections.singletonList("supercalifragalistic")),
+                            List.of("supercalifragalistic")),
                         new TargetDirectory("/some/other/dir",
-                            Arrays.asList("capability", "delegation", "elephant",
+                            List.of("capability", "delegation", "elephant",
                                 "fungible", "green"))));
             }
-            assertEquals(String.join(String.format("%n"), Arrays.asList(
+            assertEquals(String.join(String.format("%n"), List.of(
                 "foo        quux",
                 "foobarbaz  ",
                 "",

--- a/shell/src/test/java/org/apache/kafka/shell/glob/GlobVisitorTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/glob/GlobVisitorTest.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -127,7 +125,7 @@ public class GlobVisitorTest {
         InfoConsumer consumer = new InfoConsumer();
         GlobVisitor visitor = new GlobVisitor("*", consumer);
         visitor.accept(DATA);
-        assertEquals(Optional.of(Arrays.asList(
+        assertEquals(Optional.of(List.of(
             new MetadataNodeInfo(new String[] {"foo", "a"},
                 DATA.root().child("foo").child("a")),
             new MetadataNodeInfo(new String[] {"foo", "beta"},
@@ -139,7 +137,7 @@ public class GlobVisitorTest {
         InfoConsumer consumer = new InfoConsumer();
         GlobVisitor visitor = new GlobVisitor("..", consumer);
         visitor.accept(DATA);
-        assertEquals(Optional.of(Collections.singletonList(
+        assertEquals(Optional.of(List.of(
             new MetadataNodeInfo(new String[0], DATA.root()))), consumer.infos);
     }
 
@@ -148,7 +146,7 @@ public class GlobVisitorTest {
         InfoConsumer consumer = new InfoConsumer();
         GlobVisitor visitor = new GlobVisitor("../..", consumer);
         visitor.accept(DATA);
-        assertEquals(Optional.of(Collections.singletonList(
+        assertEquals(Optional.of(List.of(
             new MetadataNodeInfo(new String[0], DATA.root()))), consumer.infos);
     }
 
@@ -157,7 +155,7 @@ public class GlobVisitorTest {
         InfoConsumer consumer = new InfoConsumer();
         GlobVisitor visitor = new GlobVisitor("../z*", consumer);
         visitor.accept(DATA);
-        assertEquals(Optional.of(Arrays.asList(
+        assertEquals(Optional.of(List.of(
             new MetadataNodeInfo(new String[] {"zeta"},
                 DATA.root().child("zeta")),
             new MetadataNodeInfo(new String[] {"zzz"},
@@ -169,7 +167,7 @@ public class GlobVisitorTest {
         InfoConsumer consumer = new InfoConsumer();
         GlobVisitor visitor = new GlobVisitor("../*/{beta,theta}", consumer);
         visitor.accept(DATA);
-        assertEquals(Optional.of(Arrays.asList(
+        assertEquals(Optional.of(List.of(
             new MetadataNodeInfo(new String[] {"alpha", "beta"},
                 DATA.root().child("alpha").child("beta")),
             new MetadataNodeInfo(new String[] {"alpha", "theta"},
@@ -191,7 +189,7 @@ public class GlobVisitorTest {
         InfoConsumer consumer = new InfoConsumer();
         GlobVisitor visitor = new GlobVisitor("/a?pha", consumer);
         visitor.accept(DATA);
-        assertEquals(Optional.of(Collections.singletonList(
+        assertEquals(Optional.of(List.of(
             new MetadataNodeInfo(new String[]{"alpha"},
                 DATA.root().child("alpha")))), consumer.infos);
     }


### PR DESCRIPTION
Now that Kafka support Java 17, this PR updates the shell module to get
rid of older code. The changes mostly include:
- Collections.emptyList(), Collections.singletonList() and
- Arrays.asList() are replaced with List.of()

Reviewers: PoAn Yang <payang@apache.org>, Yung
 <yungyung7654321@gmail.com>, Ken Huang <s7133700@gmail.com>, TengYao
 Chi <frankvicky@apache.org>
