### PR TITLE
MINOR: add 3.9.1 to system tests

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,7 +101,7 @@ versions += [
   kafka_36: "3.6.2",
   kafka_37: "3.7.2",
   kafka_38: "3.8.1",
-  kafka_39: "3.9.0",
+  kafka_39: "3.9.1",
   kafka_40: "4.0.0",
   log4j2: "2.24.3",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -117,7 +117,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.5.2-test.jar" -o /opt/kafka-3.5.2/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.6.2-test.jar" -o /opt/kafka-3.6.2/libs/kafka-streams-3.6.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.7.2-test.jar" -o /opt/kafka-3.7.2/libs/kafka-streams-3.7.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.8.1-test.jar" -o /opt/kafka-3.8.1/libs/kafka-streams-3.8.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.9.1-test.jar" -o /opt/kafka-3.9.0/libs/kafka-streams-3.9.1-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.9.1-test.jar" -o /opt/kafka-3.9.1/libs/kafka-streams-3.9.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.0.0-test.jar" -o /opt/kafka-4.0.0/libs/kafka-streams-4.0.0-test.jar
 
 # To ensure the Kafka cluster starts successfully under JDK 17, we need to update the Zookeeper 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN mkdir -p "/opt/kafka-3.5.2" && chmod a+rw /opt/kafka-3.5.2 && curl -s "$KAFK
 RUN mkdir -p "/opt/kafka-3.6.2" && chmod a+rw /opt/kafka-3.6.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.6.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.6.2"
 RUN mkdir -p "/opt/kafka-3.7.2" && chmod a+rw /opt/kafka-3.7.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.7.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.7.2"
 RUN mkdir -p "/opt/kafka-3.8.1" && chmod a+rw /opt/kafka-3.8.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.8.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.8.1"
-RUN mkdir -p "/opt/kafka-3.9.0" && chmod a+rw /opt/kafka-3.9.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.9.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.9.0"
+RUN mkdir -p "/opt/kafka-3.9.1" && chmod a+rw /opt/kafka-3.9.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.9.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.9.1"
 RUN mkdir -p "/opt/kafka-4.0.0" && chmod a+rw /opt/kafka-4.0.0 && curl -s "$KAFKA_MIRROR/kafka_2.13-4.0.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-4.0.0"
 
 
@@ -117,7 +117,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.5.2-test.jar" -o /opt/kafka-3.5.2/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.6.2-test.jar" -o /opt/kafka-3.6.2/libs/kafka-streams-3.6.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.7.2-test.jar" -o /opt/kafka-3.7.2/libs/kafka-streams-3.7.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.8.1-test.jar" -o /opt/kafka-3.8.1/libs/kafka-streams-3.8.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.9.0-test.jar" -o /opt/kafka-3.9.0/libs/kafka-streams-3.9.0-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.9.1-test.jar" -o /opt/kafka-3.9.0/libs/kafka-streams-3.9.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.0.0-test.jar" -o /opt/kafka-4.0.0/libs/kafka-streams-4.0.0-test.jar
 
 # To ensure the Kafka cluster starts successfully under JDK 17, we need to update the Zookeeper 

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -216,7 +216,8 @@ LATEST_3_8 = V_3_8_1
 
 # 3.9.x version
 V_3_9_0 = KafkaVersion("3.9.0")
-LATEST_3_9 = V_3_9_0
+V_3_9_1 = KafkaVersion("3.9.1")
+LATEST_3_9 = V_3_9_1
 
 # 4.0.x version
 V_4_0_0 = KafkaVersion("4.0.0")

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -148,8 +148,8 @@ get_kafka 3.7.2 2.12
 chmod a+rw /opt/kafka-3.7.2
 get_kafka 3.8.1 2.12
 chmod a+rw /opt/kafka-3.8.1
-get_kafka 3.9.0 2.12
-chmod a+rw /opt/kafka-3.9.0
+get_kafka 3.9.1 2.12
+chmod a+rw /opt/kafka-3.9.1
 get_kafka 4.0.0 2.13
 chmod a+rw /opt/kafka-4.0.0
 


### PR DESCRIPTION
Add 3.9.1 to system tests following this release guide:
https://cwiki.apache.org/confluence/display/KAFKA/Release+Process#ReleaseProcess-Afterrelease

Reviewers: TengYao Chi <frankvicky@apache.org>
