### PR TITLE
MINOR Fix: fix line separator for different systems

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -602,7 +602,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
         throw new ConfigException(
           s"""If using ${KRaftConfigs.PROCESS_ROLES_CONFIG}, either ${QuorumConfig.QUORUM_BOOTSTRAP_SERVERS_CONFIG} must
           |contain the set of bootstrap controllers or ${QuorumConfig.QUORUM_VOTERS_CONFIG} must contain a parseable
-          |set of controllers.""".stripMargin.replace("\n", " ")
+          |set of controllers.""".stripMargin.replace(System.lineSeparator(), " ")
         )
       }
     }

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -213,7 +213,7 @@ class KafkaConfigTest {
       propertiesFile,
       """If using process.roles, either controller.quorum.bootstrap.servers
       |must contain the set of bootstrap controllers or controller.quorum.voters must contain a
-      |parseable set of controllers.""".stripMargin.replace("\n", " ")
+      |parseable set of controllers.""".stripMargin.replace(System.lineSeparator(), " ")
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1350,14 +1350,14 @@ class KafkaConfigTest {
     props.remove(SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG)
     props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, incorrectListeners)
     var expectedExceptionContainsText = """The listeners config must only contain KRaft controller listeners from
-    |controller.listener.names when process.roles=controller""".stripMargin.replaceAll("\n", " ")
+    |controller.listener.names when process.roles=controller""".stripMargin.replaceAll(System.lineSeparator(), " ")
     assertBadConfigContainingMessage(props, expectedExceptionContainsText)
 
     // Invalid if listeners doesn't contain every name in controller.listener.names
     props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, correctListeners)
     props.setProperty(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, correctControllerListenerNames + ",SASL_SSL")
     expectedExceptionContainsText = """controller.listener.names must only contain values appearing in the 'listeners'
-    |configuration when running the KRaft controller role""".stripMargin.replaceAll("\n", " ")
+    |configuration when running the KRaft controller role""".stripMargin.replaceAll(System.lineSeparator(), " ")
     assertBadConfigContainingMessage(props, expectedExceptionContainsText)
 
     // Valid now
@@ -1378,7 +1378,7 @@ class KafkaConfigTest {
 
     val expectedExceptionContainsText =
       """controller.listener.names must not contain an explicitly set inter.broker.listener.name configuration value
-        |when process.roles=controller""".stripMargin.replaceAll("\n", " ")
+        |when process.roles=controller""".stripMargin.replaceAll(System.lineSeparator(), " ")
     assertBadConfigContainingMessage(props, expectedExceptionContainsText)
   }
 


### PR DESCRIPTION
fix separator for different systems

line separator  ， for windows use  "\r\n",    for Linux/macOS use "\n" ；  just use   System.lineSeparator()  instead . is ok  

**issue**
UT case  in  core , failed on windows .  
1、 kafka.server.testAdvertisedListenersAllowedForKRaftControllerOnlyRole
2、 kafka.testMustContainQuorumVotersIfUsingProcessRoles



