### PR TITLE
MINOR: Upgrade to Gradle 8.14.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -59,7 +59,7 @@ versions += [
   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "10.20.2",
   commonsValidator: "1.9.0",
   classgraph: "4.8.173",
-  gradle: "8.14",
+  gradle: "8.14.1",
   grgit: "4.1.1",
   httpclient: "4.5.14",
   jackson: "2.16.2",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=efe9a3d147d948d7528a9887fa35abcf24ca1a43ad06439996490f77569b02d1
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionSha256Sum=845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -116,7 +116,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.14.0/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.14.1/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -24,7 +24,6 @@
 // Read more about the wrapper here: https://docs.gradle.org/current/userguide/gradle_wrapper.html
 wrapper {
     gradleVersion = project.gradleVersion
-    distributionType = Wrapper.DistributionType.ALL
 }
 
 // Custom task to inject support for downloading the gradle wrapper jar if it doesn't exist.


### PR DESCRIPTION
This patch upgrades to Gradle 8.14.1.  Note that we are switching to
using the recommended "-bin" package.


