### PR TITLE
MINOR: Update spotbugs to v4.9.0 to support Java 24

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -121,7 +121,7 @@ versions += [
   scoverage: "2.0.11",
   slf4j: "1.7.36",
   snappy: "1.1.10.5",
-  spotbugs: "4.8.6",
+  spotbugs: "4.9.0",
   zinc: "1.9.2",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid


### PR DESCRIPTION
Spotbugs 4.9.0 brings in ASM v9.7.1 [[0]] which supports Java 24 [[1]].

[0]: https://github.com/spotbugs/spotbugs/commit/2d48463113f9073369eb01757bc069d107757a9c
[1]: https://gitlab.ow2.org/asm/asm/-/commit/e6fe58350624ba7fcd7ea0a0c4a94ba857866837