### PR TITLE
KAFKA-19268 Missing mocks for SharePartitionManagerTest tests

### DIFF
--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -1884,6 +1884,7 @@ public class SharePartitionManagerTest {
 
         SharePartition sp1 = mock(SharePartition.class);
         SharePartition sp2 = mock(SharePartition.class);
+        SharePartition sp3 = mock(SharePartition.class);
 
         ShareSessionCache cache = mock(ShareSessionCache.class);
         ShareSession shareSession = mock(ShareSession.class);
@@ -1898,10 +1899,12 @@ public class SharePartitionManagerTest {
             when(sp2.canAcquireRecords()).thenReturn(true);
             return CompletableFuture.completedFuture(Optional.empty());
         }).when(sp2).releaseAcquiredRecords(ArgumentMatchers.eq(memberId));
+        when(sp3.releaseAcquiredRecords(ArgumentMatchers.eq(memberId))).thenReturn(CompletableFuture.completedFuture(null));
 
         SharePartitionCache partitionCache = new SharePartitionCache();
         partitionCache.put(new SharePartitionKey(groupId, tp1), sp1);
         partitionCache.put(new SharePartitionKey(groupId, tp2), sp2);
+        partitionCache.put(new SharePartitionKey(groupId, tp3), sp3);
 
         ShareFetch shareFetch = new ShareFetch(
             FETCH_PARAMS,

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -3179,6 +3179,7 @@ public class SharePartitionManagerTest {
         ))));
         return CollectionConverters.asScala(logReadResults).toSeq();
     }
+
     static void mockReplicaManagerDelayedShareFetch(ReplicaManager replicaManager,
                                                     DelayedOperationPurgatory<DelayedShareFetch> delayedShareFetchPurgatory) {
         doAnswer(invocationOnMock -> {

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.FencedStateEpochException;
 import org.apache.kafka.common.errors.InvalidRecordStateException;
@@ -43,6 +44,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.ShareFetchResponse;
 import org.apache.kafka.common.requests.ShareRequestMetadata;
@@ -777,9 +779,6 @@ public class SharePartitionManagerTest {
     @Test
     public void testCachedTopicPartitionsForValidShareSessions() {
         ShareSessionCache cache = new ShareSessionCache(10);
-        sharePartitionManager = SharePartitionManagerBuilder.builder()
-            .withCache(cache)
-            .build();
 
         Uuid tpId0 = Uuid.randomUuid();
         Uuid tpId1 = Uuid.randomUuid();
@@ -790,6 +789,27 @@ public class SharePartitionManagerTest {
         String groupId = "grp";
         Uuid memberId1 = Uuid.randomUuid();
         Uuid memberId2 = Uuid.randomUuid();
+        SharePartition sp0 = mock(SharePartition.class);
+        SharePartition sp1 = mock(SharePartition.class);
+        SharePartition sp2 = mock(SharePartition.class);
+        SharePartition sp3 = mock(SharePartition.class);
+
+        when(sp0.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
+        when(sp1.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
+        when(sp2.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
+        when(sp3.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
+
+        SharePartitionCache partitionCache = new SharePartitionCache();
+        partitionCache.put(new SharePartitionKey(groupId, tp0), sp0);
+        partitionCache.put(new SharePartitionKey(groupId, tp1), sp1);
+        partitionCache.put(new SharePartitionKey(groupId, tp2), sp2);
+        partitionCache.put(new SharePartitionKey(groupId, tp3), sp3);
+
+        sharePartitionManager = SharePartitionManagerBuilder.builder()
+                .withCache(cache)
+                .withPartitionCache(partitionCache)
+                .build();
+
 
         // Create a new share session with an initial share fetch request.
         List<TopicIdPartition> reqData1 = List.of(tp0, tp1);
@@ -1057,31 +1077,31 @@ public class SharePartitionManagerTest {
             assertEquals(4, sp1.nextFetchOffset());
             assertEquals(10, sp2.nextFetchOffset());
             assertEquals(20, sp3.nextFetchOffset());
-            return buildLogReadResult(topicIdPartitions);
+            return buildLogReadResultWithFakeRecords(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(15, sp0.nextFetchOffset());
             assertEquals(1, sp1.nextFetchOffset());
             assertEquals(25, sp2.nextFetchOffset());
             assertEquals(15, sp3.nextFetchOffset());
-            return buildLogReadResult(topicIdPartitions);
+            return buildLogReadResultWithFakeRecords(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(6, sp0.nextFetchOffset());
             assertEquals(18, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(23, sp3.nextFetchOffset());
-            return buildLogReadResult(topicIdPartitions);
+            return buildLogReadResultWithFakeRecords(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(30, sp0.nextFetchOffset());
             assertEquals(5, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(16, sp3.nextFetchOffset());
-            return buildLogReadResult(topicIdPartitions);
+            return buildLogReadResultWithFakeRecords(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(25, sp0.nextFetchOffset());
             assertEquals(5, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(16, sp3.nextFetchOffset());
-            return buildLogReadResult(topicIdPartitions);
+            return buildLogReadResultWithFakeRecords(topicIdPartitions);
         }).when(mockReplicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
         int threadCount = 100;
@@ -1723,7 +1743,9 @@ public class SharePartitionManagerTest {
         // Since acquisition lock for sp1 and sp2 cannot be acquired, we should have 2 watched keys.
         assertEquals(2, delayedShareFetchPurgatory.watched());
 
-        doAnswer(invocation -> buildLogReadResult(topicIdPartitions)).when(mockReplicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
+        doAnswer(invocation -> buildLogReadResult(List.of(tp1)))
+                .when(mockReplicaManager)
+                .readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
         acknowledgeTopics.put(tp1, List.of(
@@ -3156,6 +3178,26 @@ public class SharePartitionManagerTest {
             Option.empty(),
             Option.empty()
         ))));
+        return CollectionConverters.asScala(logReadResults).toSeq();
+    }
+    static Seq<Tuple2<TopicIdPartition, LogReadResult>> buildLogReadResultWithFakeRecords(List<TopicIdPartition> topicIdPartitions) {
+        List<Tuple2<TopicIdPartition, LogReadResult>> logReadResults = new ArrayList<>();
+        for (TopicIdPartition topicIdPartition : topicIdPartitions) {
+            MemoryRecords records = MemoryRecords.withRecords(
+                    Compression.NONE,
+                    new SimpleRecord("test-key".getBytes(), "test-value".getBytes())
+            );
+
+            LogReadResult logReadResult = new LogReadResult(
+                    new FetchDataInfo(new LogOffsetMetadata(0, 0, 0), records),
+                    Option.empty(),
+                    -1L, -1L, -1L, -1L, -1L,
+                    Option.empty(), Option.empty(), Option.empty()
+            );
+
+            logReadResults.add(new Tuple2<>(topicIdPartition, logReadResult));
+        }
+
         return CollectionConverters.asScala(logReadResults).toSeq();
     }
 

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -3162,7 +3162,8 @@ public class SharePartitionManagerTest {
     static Seq<Tuple2<TopicIdPartition, LogReadResult>> buildLogReadResult(List<TopicIdPartition> topicIdPartitions) {
         List<Tuple2<TopicIdPartition, LogReadResult>> logReadResults = new ArrayList<>();
         topicIdPartitions.forEach(topicIdPartition -> logReadResults.add(new Tuple2<>(topicIdPartition, new LogReadResult(
-            new FetchDataInfo(new LogOffsetMetadata(0, 0, 0), MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("test-key".getBytes(), "test-value".getBytes()))),
+            new FetchDataInfo(new LogOffsetMetadata(0, 0, 0), MemoryRecords.withRecords(
+                    Compression.NONE, new SimpleRecord("test-key".getBytes(), "test-value".getBytes()))),
             Option.empty(),
             -1L,
             -1L,

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -792,18 +792,15 @@ public class SharePartitionManagerTest {
         SharePartition sp0 = mock(SharePartition.class);
         SharePartition sp1 = mock(SharePartition.class);
         SharePartition sp2 = mock(SharePartition.class);
-        SharePartition sp3 = mock(SharePartition.class);
 
         when(sp0.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
         when(sp1.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
         when(sp2.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
-        when(sp3.releaseAcquiredRecords(ArgumentMatchers.eq(String.valueOf(memberId1)))).thenReturn(CompletableFuture.completedFuture(null));
 
         SharePartitionCache partitionCache = new SharePartitionCache();
         partitionCache.put(new SharePartitionKey(groupId, tp0), sp0);
         partitionCache.put(new SharePartitionKey(groupId, tp1), sp1);
         partitionCache.put(new SharePartitionKey(groupId, tp2), sp2);
-        partitionCache.put(new SharePartitionKey(groupId, tp3), sp3);
 
         sharePartitionManager = SharePartitionManagerBuilder.builder()
                 .withCache(cache)
@@ -1077,31 +1074,31 @@ public class SharePartitionManagerTest {
             assertEquals(4, sp1.nextFetchOffset());
             assertEquals(10, sp2.nextFetchOffset());
             assertEquals(20, sp3.nextFetchOffset());
-            return buildLogReadResultWithFakeRecords(topicIdPartitions);
+            return buildLogReadResult(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(15, sp0.nextFetchOffset());
             assertEquals(1, sp1.nextFetchOffset());
             assertEquals(25, sp2.nextFetchOffset());
             assertEquals(15, sp3.nextFetchOffset());
-            return buildLogReadResultWithFakeRecords(topicIdPartitions);
+            return buildLogReadResult(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(6, sp0.nextFetchOffset());
             assertEquals(18, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(23, sp3.nextFetchOffset());
-            return buildLogReadResultWithFakeRecords(topicIdPartitions);
+            return buildLogReadResult(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(30, sp0.nextFetchOffset());
             assertEquals(5, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(16, sp3.nextFetchOffset());
-            return buildLogReadResultWithFakeRecords(topicIdPartitions);
+            return buildLogReadResult(topicIdPartitions);
         }).doAnswer(invocation -> {
             assertEquals(25, sp0.nextFetchOffset());
             assertEquals(5, sp1.nextFetchOffset());
             assertEquals(26, sp2.nextFetchOffset());
             assertEquals(16, sp3.nextFetchOffset());
-            return buildLogReadResultWithFakeRecords(topicIdPartitions);
+            return buildLogReadResult(topicIdPartitions);
         }).when(mockReplicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
         int threadCount = 100;
@@ -1743,9 +1740,7 @@ public class SharePartitionManagerTest {
         // Since acquisition lock for sp1 and sp2 cannot be acquired, we should have 2 watched keys.
         assertEquals(2, delayedShareFetchPurgatory.watched());
 
-        doAnswer(invocation -> buildLogReadResult(List.of(tp1)))
-                .when(mockReplicaManager)
-                .readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
+        doAnswer(invocation -> buildLogReadResult(List.of(tp1))).when(mockReplicaManager).readFromLog(any(), any(), any(ReplicaQuota.class), anyBoolean());
 
         Map<TopicIdPartition, List<ShareAcknowledgementBatch>> acknowledgeTopics = new HashMap<>();
         acknowledgeTopics.put(tp1, List.of(
@@ -3167,7 +3162,7 @@ public class SharePartitionManagerTest {
     static Seq<Tuple2<TopicIdPartition, LogReadResult>> buildLogReadResult(List<TopicIdPartition> topicIdPartitions) {
         List<Tuple2<TopicIdPartition, LogReadResult>> logReadResults = new ArrayList<>();
         topicIdPartitions.forEach(topicIdPartition -> logReadResults.add(new Tuple2<>(topicIdPartition, new LogReadResult(
-            new FetchDataInfo(new LogOffsetMetadata(0, 0, 0), MemoryRecords.EMPTY),
+            new FetchDataInfo(new LogOffsetMetadata(0, 0, 0), MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("test-key".getBytes(), "test-value".getBytes()))),
             Option.empty(),
             -1L,
             -1L,
@@ -3180,27 +3175,6 @@ public class SharePartitionManagerTest {
         ))));
         return CollectionConverters.asScala(logReadResults).toSeq();
     }
-    static Seq<Tuple2<TopicIdPartition, LogReadResult>> buildLogReadResultWithFakeRecords(List<TopicIdPartition> topicIdPartitions) {
-        List<Tuple2<TopicIdPartition, LogReadResult>> logReadResults = new ArrayList<>();
-        for (TopicIdPartition topicIdPartition : topicIdPartitions) {
-            MemoryRecords records = MemoryRecords.withRecords(
-                    Compression.NONE,
-                    new SimpleRecord("test-key".getBytes(), "test-value".getBytes())
-            );
-
-            LogReadResult logReadResult = new LogReadResult(
-                    new FetchDataInfo(new LogOffsetMetadata(0, 0, 0), records),
-                    Option.empty(),
-                    -1L, -1L, -1L, -1L, -1L,
-                    Option.empty(), Option.empty(), Option.empty()
-            );
-
-            logReadResults.add(new Tuple2<>(topicIdPartition, logReadResult));
-        }
-
-        return CollectionConverters.asScala(logReadResults).toSeq();
-    }
-
     static void mockReplicaManagerDelayedShareFetch(ReplicaManager replicaManager,
                                                     DelayedOperationPurgatory<DelayedShareFetch> delayedShareFetchPurgatory) {
         doAnswer(invocationOnMock -> {


### PR DESCRIPTION
jira:
[https://issues.apache.org/jira/browse/KAFKA-19268](https://issues.apache.org/jira/browse/KAFKA-19268)

In jira, there are 5 unit
tests(testAcknowledgeCompletesDelayedShareFetchRequest,
testMultipleConcurrentShareFetches
testCachedTopicPartitionsForValidShareSessions,
testReleaseSessionCompletesDelayedShareFetchRequest,
testReleaseSessionSuccess) that print exceptions.

**testAcknowledgeCompletesDelayedShareFetchRequest**

[problem]

- buildLogReadResult was programmed to return list of tp1, tp2 .
- readFromLog should return only list of topic partitions that will be
acknowleged, otherwise error occurs.

[solution]
- Make buildLogReadResult return list of tp1 which will be acknowleged.

**testMultipleConcurrentShareFetches**

[problem]
- buildlogReadResult had no records which leads to error in
maybeSliceFetchRecords.
- java.util.NoSuchElementException: null
        at
org.apache.kafka.common.utils.AbstractIterator.next(AbstractIterator.java:52)
~[kafka-clients-4.1.0-SNAPSHOT.jar:?]
        at
kafka.server.share.ShareFetchUtils.maybeSliceFetchRecords(ShareFetchUtils.java:219)
[main/:?]
        at
kafka.server.share.ShareFetchUtils.processFetchResponse(ShareFetchUtils.java:132)
[main/:?]

[solution]
- I add buildLogReadResultWithFakeRecords which has records.
- Though above addition makes the test pass well, still not sure
doAnswer chaning (line 1075 ~ 1105) works well in multi threading test.
Even though I changed values of assertEquals in doAnswer chaining to
random value, test passed as well. It needs to be checked that chaining
works well even in multi thread test.

**testCachedTopicPartitionsForValidShareSessions**

[problem]
- ReleaseAcquiredRecords mocks missed.
- SharePartitionManager didn't have right partitionCache.

[solution]
- Above two things are added.

**testReleaseSessionCompletesDelayedShareFetchRequest**

[problem]
- tp3 is not in sharePartitionManager's partition cache.
- In test code, it tries to release tp3 by
'sharePartitionManager.releaseSession(groupId, memberId);' which leads
to exception.

[solution]
- I haven't added nothing since this exception was intended.
- Printing exeption looks bad though.

**testReleaseSessionSuccess**

[problem]
- tp3 is not in sharePartitionManager's partition cache.
- In test code, it tries to release tp3 by
'sharePartitionManager.releaseSession(groupId, memberId.toString());'
which leads to exception.

[solution]
- I haven't added nothing since this exception was intended.
- Printing exeption looks bad though.

Reviewers: Abhinav Dixit <adixit@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
