### PR TITLE
HOTFIX: Fix GroupMetadataManager#completeAlterShareGroupOffsets to use InitMapValue in addInitializingTopicsRecords

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8108,6 +8108,7 @@ public class GroupMetadataManager {
         AlterShareGroupOffsetsRequestData alterShareGroupOffsetsRequest,
         List<CoordinatorRecord> records
     ) {
+        final long currentTimeMs = time.milliseconds();
         Group group = groups.get(groupId);
         List<AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic> alterShareGroupOffsetsResponseTopics = new ArrayList<>();
 
@@ -8136,7 +8137,6 @@ public class GroupMetadataManager {
                     }
                 });
 
-                long currentTimeMs = time.milliseconds();
                 initializingTopics.put(topicId, new InitMapValue(
                     topic.topicName(),
                     topic.partitions().stream()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8111,7 +8111,7 @@ public class GroupMetadataManager {
         Group group = groups.get(groupId);
         List<AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic> alterShareGroupOffsetsResponseTopics = new ArrayList<>();
 
-        Map<Uuid, Set<Integer>> initializingTopics = new HashMap<>();
+        Map<Uuid, InitMapValue> initializingTopics = new HashMap<>();
         Map<Uuid, Map<Integer, Long>> offsetByTopicPartitions = new HashMap<>();
 
         alterShareGroupOffsetsRequest.topics().forEach(topic -> {
@@ -8136,10 +8136,14 @@ public class GroupMetadataManager {
                     }
                 });
 
-                initializingTopics.put(topicId, topic.partitions().stream()
-                    .map(AlterShareGroupOffsetsRequestData.AlterShareGroupOffsetsRequestPartition::partitionIndex)
-                    .filter(existingPartitions::contains)
-                    .collect(Collectors.toSet()));
+                initializingTopics.put(topicId, new InitMapValue(
+                    topic.topicName(),
+                    topic.partitions().stream()
+                        .map(AlterShareGroupOffsetsRequestData.AlterShareGroupOffsetsRequestPartition::partitionIndex)
+                        .filter(existingPartitions::contains)
+                        .collect(Collectors.toSet()),
+                    time.milliseconds()
+                ));
 
                 alterShareGroupOffsetsResponseTopics.add(
                     new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8136,14 +8136,14 @@ public class GroupMetadataManager {
                     }
                 });
 
-                long curTimestamp = time.milliseconds();
+                long currentTimeMs = time.milliseconds();
                 initializingTopics.put(topicId, new InitMapValue(
                     topic.topicName(),
                     topic.partitions().stream()
                         .map(AlterShareGroupOffsetsRequestData.AlterShareGroupOffsetsRequestPartition::partitionIndex)
                         .filter(existingPartitions::contains)
                         .collect(Collectors.toSet()),
-                    curTimestamp
+                    currentTimeMs
                 ));
 
                 alterShareGroupOffsetsResponseTopics.add(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8136,13 +8136,14 @@ public class GroupMetadataManager {
                     }
                 });
 
+                long curTimestamp = time.milliseconds();
                 initializingTopics.put(topicId, new InitMapValue(
                     topic.topicName(),
                     topic.partitions().stream()
                         .map(AlterShareGroupOffsetsRequestData.AlterShareGroupOffsetsRequestPartition::partitionIndex)
                         .filter(existingPartitions::contains)
                         .collect(Collectors.toSet()),
-                    time.milliseconds()
+                    curTimestamp
                 ));
 
                 alterShareGroupOffsetsResponseTopics.add(


### PR DESCRIPTION
https://github.com/apache/kafka/pull/19781/files#diff-00f0f81cf13e66781777d94f7d2e68a581663385c37e98792507f2294c91bb09L2746-R2745
changes the `addInitializingTopicsRecords` signature while
https://github.com/apache/kafka/pull/18929/files#r2104172356 didn't make
adjustment accordingly.

Fix GroupMetadataManager#completeAlterShareGroupOffsets to use
`InitMapValue` in `initializingTopics` so  that
`addInitializingTopicsRecords` can accept it.
