### PR TITLE
HOTFIX: Fix build issue due to alter offsets.

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8163,7 +8163,7 @@ public class GroupMetadataManager {
             }
         });
 
-        addInitializingTopicsRecords(groupId, records, initializingTopics);
+        addInitializingTopicsRecords(groupId, records, attachInitValue(initializingTopics));
         return Map.entry(
             new AlterShareGroupOffsetsResponseData()
                 .setResponses(alterShareGroupOffsetsResponseTopics),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -21714,7 +21714,8 @@ public class GroupMetadataManagerTest {
         CoordinatorRecord record = newShareGroupStatePartitionMetadataRecord(groupId, Map.of(), snapshotMetadataInitializeRecordMap, Map.of());
 
         assertNull(result.response());
-        assertEquals(List.of(record), result.records());
+        assertEquals(1, result.records().size());
+        assertRecordEquals(record, result.records().get(0));
         // Make sure the timeline map is not modified yet.
         assertEquals(snapshotMetadataInitializeRecordMap, context.groupMetadataManager.shareGroupStatePartitionMetadata().get(groupId).initializingTopics());
     }


### PR DESCRIPTION
Build failing due to incompatible map type passed to
`GroupMetadataManager.addInitializingTopicsRecords`. Used util method to
wrap it.

Reviewers: wilmerdooley <wilmer@snovon.com>
