### PR TITLE
MINOR: Fix initProducerId throttle time to non-zero

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdRequest.java
@@ -62,7 +62,7 @@ public class InitProducerIdRequest extends AbstractRequest {
                 .setErrorCode(Errors.forException(e).code())
                 .setProducerId(RecordBatch.NO_PRODUCER_ID)
                 .setProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
-                .setThrottleTimeMs(0);
+                .setThrottleTimeMs(throttleTimeMs);
         return new InitProducerIdResponse(response);
     }
 


### PR DESCRIPTION
There was a small error in setting the throttle time in the
InitProducerId response in this PR
[https://github.com/apache/kafka/commit/53e95ffcdb1cecbba67eb726aa2abcab3ae49c66#diff-1f7f71b4fbeaf65123e65cf2e4d9c2ae8153820869eb5e88279df979130929d2R69](url),
which was supposed to be mostly mechanical changes.

Reviewers: Justine Olshan <jolshan@confluent.io>
