### PR TITLE
[WIP] KAFKA-19167: Move RemoteLogManagerConfig out of KafkaConfig

### DIFF
--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -40,6 +40,7 @@ import org.apache.kafka.server.ApiVersionManager;
 import org.apache.kafka.server.ClientMetricsManager;
 import org.apache.kafka.server.DelegationTokenManager;
 import org.apache.kafka.server.authorizer.Authorizer;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
 import java.util.Map;
@@ -204,7 +205,7 @@ public class KafkaApisBuilder {
         if (fetchManager == null) throw new RuntimeException("You must set fetchManager");
         if (sharePartitionManager == null) throw new RuntimeException("You must set sharePartitionManager");
         if (clientMetricsManager == null) throw new RuntimeException("You must set clientMetricsManager");
-        if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig().isRemoteStorageSystemEnabled());
+        if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(new RemoteLogManagerConfig(config).isRemoteStorageSystemEnabled());
         if (apiVersionManager == null) throw new RuntimeException("You must set apiVersionManager");
         if (groupConfigManager == null) throw new RuntimeException("You must set groupConfigManager");
 

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.server.DelayedActionQueue;
 import org.apache.kafka.server.common.DirectoryEventHandler;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
@@ -105,7 +106,7 @@ public class ReplicaManagerBuilder {
         if (metadataCache == null) throw new RuntimeException("You must set metadataCache");
         if (logDirFailureChannel == null) throw new RuntimeException("You must set logDirFailureChannel");
         if (alterPartitionManager == null) throw new RuntimeException("You must set alterIsrManager");
-        if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig().isRemoteStorageSystemEnabled());
+        if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(new RemoteLogManagerConfig(config).isRemoteStorageSystemEnabled());
         // Initialize metrics in the end just before passing it to ReplicaManager to ensure ReplicaManager closes the
         // metrics correctly. There might be a resource leak if it is initialized and an exception occurs between
         // its initialization and creation of ReplicaManager.

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -37,6 +37,7 @@ import scala.util.{Failure, Success, Try}
 import org.apache.kafka.image.TopicsImage
 import org.apache.kafka.metadata.ConfigRepository
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, PropertiesUtils}
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 
 import java.util.{Collections, Optional, OptionalLong, Properties}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
@@ -1530,7 +1531,8 @@ object LogManager {
             logDirFailureChannel: LogDirFailureChannel): LogManager = {
     val defaultProps = config.extractLogConfigMap
 
-    LogConfig.validateBrokerLogConfigValues(defaultProps, config.remoteLogManagerConfig.isRemoteStorageSystemEnabled)
+    val remoteStorageSystemEnabled = new RemoteLogManagerConfig(config).isRemoteStorageSystemEnabled
+    LogConfig.validateBrokerLogConfigValues(defaultProps, remoteStorageSystemEnabled)
     val defaultLogConfig = new LogConfig(defaultProps)
 
     val cleanerConfig = new CleanerConfig(config)
@@ -1553,7 +1555,7 @@ object LogManager {
       brokerTopicStats = brokerTopicStats,
       logDirFailureChannel = logDirFailureChannel,
       time = time,
-      remoteStorageSystemEnable = config.remoteLogManagerConfig.isRemoteStorageSystemEnabled,
+      remoteStorageSystemEnable = remoteStorageSystemEnabled,
       initialTaskDelayMs = config.logInitialTaskDelayMs)
   }
 }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -204,7 +204,7 @@ class BrokerServer(
       kafkaScheduler.startup()
 
       /* register broker metrics */
-      brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      brokerTopicStats = new BrokerTopicStats(new RemoteLogManagerConfig(config).isRemoteStorageSystemEnabled)
 
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
 
@@ -441,7 +441,7 @@ class BrokerServer(
         config.shareGroupConfig.shareGroupRecordLockDurationMs,
         config.shareGroupConfig.shareGroupDeliveryCountLimit,
         config.shareGroupConfig.shareGroupPartitionMaxRecordLocks,
-        config.remoteLogManagerConfig.remoteFetchMaxWaitMs().toLong,
+        new RemoteLogManagerConfig(config).remoteFetchMaxWaitMs().toLong,
         persister,
         groupConfigManager,
         brokerTopicStats
@@ -697,8 +697,9 @@ class BrokerServer(
   }
 
   protected def createRemoteLogManager(listenerInfo: ListenerInfo): Option[RemoteLogManager] = {
-    if (config.remoteLogManagerConfig.isRemoteStorageSystemEnabled) {
-      val listenerName = config.remoteLogManagerConfig.remoteLogMetadataManagerListenerName()
+    val remoteLogManagerConfig = new RemoteLogManagerConfig(config)
+    if (remoteLogManagerConfig.isRemoteStorageSystemEnabled) {
+      val listenerName = remoteLogManagerConfig.remoteLogMetadataManagerListenerName()
       val endpoint = if (listenerName != null) {
         Some(listenerInfo.listeners().values().stream
           .filter(e =>
@@ -712,7 +713,7 @@ class BrokerServer(
         None
       }
 
-      val rlm = new RemoteLogManager(config.remoteLogManagerConfig, config.brokerId, config.logDirs.get(0), clusterId, time,
+      val rlm = new RemoteLogManager(remoteLogManagerConfig, config.brokerId, config.logDirs.get(0), clusterId, time,
         (tp: TopicPartition) => logManager.getLog(tp).toJava,
         (tp: TopicPartition, remoteLogStartOffset: java.lang.Long) => {
           logManager.getLog(tp).foreach { log =>

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.server.ClientMetricsManager
 import org.apache.kafka.server.common.StopPartition
 import org.apache.kafka.server.log.remote.TopicPartitionLog
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.storage.internals.log.{LogStartOffsetIncrementReason, ThrottledReplicaListValidator, UnifiedLog}
 
 import scala.jdk.CollectionConverters._
@@ -54,7 +55,7 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
     val wasRemoteLogEnabled = logs.exists(_.remoteLogEnabled())
     val wasCopyDisabled = logs.exists(_.config.remoteLogCopyDisable())
 
-    logManager.updateTopicConfig(topic, topicConfig, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled,
+    logManager.updateTopicConfig(topic, topicConfig, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled,
       wasRemoteLogEnabled)
     maybeUpdateRemoteLogComponents(topic, logs, wasRemoteLogEnabled, wasCopyDisabled)
   }

--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.controller.ConfigurationValidator
 import org.apache.kafka.common.errors.{InvalidConfigurationException, InvalidRequestException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.coordinator.group.GroupConfigManager
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.ClientMetricsConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
 
@@ -118,7 +119,7 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
             nullTopicConfigs.mkString(","))
         }
         LogConfig.validate(oldConfigs, properties, kafkaConfig.extractLogConfigMap,
-          kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+          new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
       case BROKER => validateBrokerName(resource.name())
       case CLIENT_METRICS =>
         val properties = new Properties()

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -663,7 +663,7 @@ class DynamicLogConfig(logManager: LogManager) extends BrokerReconfigurable with
 
     def validateLogLocalRetentionMs(): Unit = {
       val logRetentionMs = newConfig.logRetentionTimeMillis
-      val logLocalRetentionMs: java.lang.Long = newConfig.remoteLogManagerConfig.logLocalRetentionMs
+      val logLocalRetentionMs: java.lang.Long = new RemoteLogManagerConfig(newConfig).logLocalRetentionMs
       if (logRetentionMs != -1L && logLocalRetentionMs != -2L) {
         if (logLocalRetentionMs == -1L) {
           throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
@@ -678,7 +678,7 @@ class DynamicLogConfig(logManager: LogManager) extends BrokerReconfigurable with
 
     def validateLogLocalRetentionBytes(): Unit = {
       val logRetentionBytes = newConfig.logRetentionBytes
-      val logLocalRetentionBytes: java.lang.Long = newConfig.remoteLogManagerConfig.logLocalRetentionBytes
+      val logLocalRetentionBytes: java.lang.Long = new RemoteLogManagerConfig(newConfig).logLocalRetentionBytes
       if (logRetentionBytes > -1 && logLocalRetentionBytes != -2) {
         if (logLocalRetentionBytes == -1) {
           throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
@@ -1075,8 +1075,8 @@ class DynamicRemoteLogConfig(server: KafkaBroker) extends BrokerReconfigurable w
           s"old value: $oldValue, new value: $newValue")
       }
 
-      val newRLMConfig = newConfig.remoteLogManagerConfig
-      val oldRLMConfig = oldConfig.remoteLogManagerConfig
+      val newRLMConfig = new RemoteLogManagerConfig(newConfig)
+      val oldRLMConfig = new RemoteLogManagerConfig(oldConfig)
       if (newRLMConfig.remoteLogManagerCopierThreadPoolSize() != oldRLMConfig.remoteLogManagerCopierThreadPoolSize())
         remoteLogManager.resizeCopierThreadPool(newRLMConfig.remoteLogManagerCopierThreadPoolSize())
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -196,9 +196,6 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   def valuesFromThisConfigWithPrefixOverride(prefix: String): util.Map[String, AnyRef] =
     super.valuesWithPrefixOverride(prefix)
 
-  private val _remoteLogManagerConfig = new RemoteLogManagerConfig(this)
-  def remoteLogManagerConfig = _remoteLogManagerConfig
-
   private val _quorumConfig = new QuorumConfig(this)
   def quorumConfig: QuorumConfig = _quorumConfig
 
@@ -774,8 +771,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     logProps.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, logMessageTimestampType.name)
     logProps.put(TopicConfig.MESSAGE_TIMESTAMP_BEFORE_MAX_MS_CONFIG, logMessageTimestampBeforeMaxMs: java.lang.Long)
     logProps.put(TopicConfig.MESSAGE_TIMESTAMP_AFTER_MAX_MS_CONFIG, logMessageTimestampAfterMaxMs: java.lang.Long)
-    logProps.put(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, remoteLogManagerConfig.logLocalRetentionMs: java.lang.Long)
-    logProps.put(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG, remoteLogManagerConfig.logLocalRetentionBytes: java.lang.Long)
+    logProps.put(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, new RemoteLogManagerConfig(this).logLocalRetentionMs(): java.lang.Long)
+    logProps.put(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG,  new RemoteLogManagerConfig(this).logLocalRetentionBytes(): java.lang.Long)
     logProps
   }
 }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -53,7 +53,7 @@ import org.apache.kafka.metadata.MetadataCache
 import org.apache.kafka.server.common.{DirectoryEventHandler, RequestLocal, StopPartition}
 import org.apache.kafka.server.log.remote.TopicPartitionLog
 import org.apache.kafka.server.config.ReplicationConfigs
-import org.apache.kafka.server.log.remote.storage.RemoteLogManager
+import org.apache.kafka.server.log.remote.storage.{RemoteLogManager, RemoteLogManagerConfig}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.purgatory.{DelayedDeleteRecords, DelayedOperationPurgatory, DelayedRemoteListOffsets, DeleteRecordsPartitionStatus, ListOffsetsPartitionStatus, TopicPartitionOperationKey}
@@ -1612,7 +1612,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     if (delayedRemoteListOffsetsRequired(statusByPartition)) {
-      val delayMs: Long = if (timeoutMs > 0) timeoutMs else config.remoteLogManagerConfig.remoteListOffsetsRequestTimeoutMs()
+      val delayMs: Long = if (timeoutMs > 0) timeoutMs else  new RemoteLogManagerConfig(config).remoteListOffsetsRequestTimeoutMs()
       // create delayed remote list offsets operation
       val delayedRemoteListOffsets = new DelayedRemoteListOffsets(delayMs, version, statusByPartition.asJava, tp => getPartitionOrException(tp), responseCallback)
       // create a list of (topic, partition) pairs to use as keys for this delayed remote list offsets operation
@@ -1666,7 +1666,7 @@ class ReplicaManager(val config: KafkaConfig,
         return Some(createLogReadResult(e))
     }
 
-    val remoteFetchMaxWaitMs = config.remoteLogManagerConfig.remoteFetchMaxWaitMs().toLong
+    val remoteFetchMaxWaitMs = new RemoteLogManagerConfig(config).remoteFetchMaxWaitMs().toLong
     val remoteFetch = new DelayedRemoteFetch(remoteFetchTask, remoteFetchResult, remoteFetchInfo, remoteFetchMaxWaitMs,
       fetchPartitionStatus, params, logReadResults, this, responseCallback)
     delayedRemoteFetchPurgatory.tryCompleteElseWatch(remoteFetch, util.Collections.singletonList(key))

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -293,7 +293,7 @@ class LogConfigTest {
     props.put(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, localRetentionMs.toString)
     props.put(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG, localRetentionBytes.toString)
     assertThrows(classOf[ConfigException],
-      () => LogConfig.validate(Collections.emptyMap(), props, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+      () => LogConfig.validate(Collections.emptyMap(), props, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled))
   }
 
   @Test
@@ -303,7 +303,7 @@ class LogConfigTest {
     val kafkaConfig = KafkaConfig.fromProps(kafkaProps)
     val logProps = new Properties()
     def validateCleanupPolicy(): Unit = {
-      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     }
     logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
@@ -330,10 +330,10 @@ class LogConfigTest {
     val logProps = new Properties()
     logProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
     if (sysRemoteStorageEnabled) {
-      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     } else {
       val message = assertThrows(classOf[ConfigException],
-        () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+        () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled))
       assertTrue(message.getMessage.contains("Tiered Storage functionality is disabled in the broker"))
     }
   }
@@ -350,7 +350,7 @@ class LogConfigTest {
     if (wasRemoteStorageEnabled) {
       val message = assertThrows(classOf[InvalidConfigurationException],
         () => LogConfig.validate(Collections.singletonMap(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true"),
-          logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+          logProps, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled))
       assertTrue(message.getMessage.contains("It is invalid to disable remote storage without deleting remote data. " +
         "If you want to keep the remote data and turn to read only, please set `remote.storage.enable=true,remote.log.copy.disable=true`. " +
         "If you want to disable remote storage and delete all remote data, please set `remote.storage.enable=false,remote.log.delete.on.disable=true`."))
@@ -359,11 +359,11 @@ class LogConfigTest {
       // It should be able to disable the remote log storage when delete on disable is set to true
       logProps.put(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, "true")
       LogConfig.validate(Collections.singletonMap(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true"),
-        logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+        logProps, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     } else {
-      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
       LogConfig.validate(Collections.singletonMap(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"), logProps,
-        kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+        kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     }
   }
 
@@ -383,11 +383,11 @@ class LogConfigTest {
     if (sysRemoteStorageEnabled) {
       val message = assertThrows(classOf[ConfigException],
         () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap,
-          kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+          new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled))
       assertTrue(message.getMessage.contains(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG))
     } else {
       LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap,
-        kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+        new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     }
   }
 
@@ -407,11 +407,11 @@ class LogConfigTest {
     if (sysRemoteStorageEnabled) {
       val message = assertThrows(classOf[ConfigException],
         () => LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap,
-          kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+          new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled))
       assertTrue(message.getMessage.contains(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG))
     } else {
       LogConfig.validate(Collections.emptyMap(), logProps, kafkaConfig.extractLogConfigMap,
-        kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+        new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     }
   }
 
@@ -426,10 +426,10 @@ class LogConfigTest {
 
     if (sysRemoteStorageEnabled) {
       val message = assertThrows(classOf[ConfigException],
-        () => LogConfig.validateBrokerLogConfigValues(kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled()))
+        () => LogConfig.validateBrokerLogConfigValues(kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled))
       assertTrue(message.getMessage.contains(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG))
     } else {
-      LogConfig.validateBrokerLogConfigValues(kafkaConfig.extractLogConfigMap, kafkaConfig.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+      LogConfig.validateBrokerLogConfigValues(kafkaConfig.extractLogConfigMap, new RemoteLogManagerConfig(kafkaConfig).isRemoteStorageSystemEnabled)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.record.{ControlRecordType, DefaultRecordBatch, Me
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.metadata.MockConfigRepository
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.util.{MockTime, Scheduler}
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
 import org.apache.kafka.storage.internals.log.{AbortedTxn, CleanerConfig, EpochEntry, LocalLog, LogConfig, LogDirFailureChannel, LogFileUtils, LogLoader, LogOffsetMetadata, LogOffsetsListener, LogSegment, LogSegments, LogStartOffsetIncrementReason, OffsetIndex, ProducerStateManager, ProducerStateManagerConfig, SnapshotFile, UnifiedLog}
@@ -126,7 +127,7 @@ class LogLoaderTest {
         brokerTopicStats = new BrokerTopicStats(),
         logDirFailureChannel = logDirFailureChannel,
         time = time,
-        remoteStorageSystemEnable = config.remoteLogManagerConfig.isRemoteStorageSystemEnabled,
+        remoteStorageSystemEnable = new RemoteLogManagerConfig(config).isRemoteStorageSystemEnabled,
         initialTaskDelayMs = config.logInitialTaskDelayMs) {
 
         override def loadLog(logDir: File, hadCleanShutdown: Boolean, recoveryPoints: util.Map[TopicPartition, JLong],

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -2228,7 +2228,7 @@ class UnifiedLogTest {
   def testFetchOffsetByTimestampFromRemoteStorage(): Unit = {
     val config: KafkaConfig = createKafkaConfigWithRLM
     val purgatory = new DelayedOperationPurgatory[DelayedRemoteListOffsets]("RemoteListOffsets", config.brokerId)
-    val remoteLogManager = spy(new RemoteLogManager(config.remoteLogManagerConfig,
+    val remoteLogManager = spy(new RemoteLogManager(new RemoteLogManagerConfig(config),
       0,
       logDir.getAbsolutePath,
       "clusterId",
@@ -2326,7 +2326,7 @@ class UnifiedLogTest {
   def testFetchLatestTieredTimestampWithRemoteStorage(): Unit = {
     val config: KafkaConfig = createKafkaConfigWithRLM
     val purgatory = new DelayedOperationPurgatory[DelayedRemoteListOffsets]("RemoteListOffsets", config.brokerId)
-    val remoteLogManager = spy(new RemoteLogManager(config.remoteLogManagerConfig,
+    val remoteLogManager = spy(new RemoteLogManager(new RemoteLogManagerConfig(config),
       0,
       logDir.getAbsolutePath,
       "clusterId",

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -172,9 +172,9 @@ class DynamicBrokerConfigTest {
   def testUpdateRemoteLogManagerDynamicThreadPool(): Unit = {
     val origProps = TestUtils.createBrokerConfig(0, port = 8181)
     val config = KafkaConfig(origProps)
-    assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE, config.remoteLogManagerConfig.remoteLogManagerCopierThreadPoolSize())
-    assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE, config.remoteLogManagerConfig.remoteLogManagerExpirationThreadPoolSize())
-    assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_READER_THREADS, config.remoteLogManagerConfig.remoteLogReaderThreads())
+    assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE, new RemoteLogManagerConfig(config).remoteLogManagerCopierThreadPoolSize())
+    assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE, new RemoteLogManagerConfig(config).remoteLogManagerExpirationThreadPoolSize())
+    assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_READER_THREADS, new RemoteLogManagerConfig(config).remoteLogReaderThreads())
 
     val serverMock = mock(classOf[KafkaBroker])
     val remoteLogManager = mock(classOf[RemoteLogManager])
@@ -189,19 +189,19 @@ class DynamicBrokerConfigTest {
     props.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE_PROP, "8")
     config.dynamicConfig.validate(props, perBrokerConfig = true)
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(8, config.remoteLogManagerConfig.remoteLogManagerCopierThreadPoolSize())
+    assertEquals(8, new RemoteLogManagerConfig(config).remoteLogManagerCopierThreadPoolSize())
     verify(remoteLogManager).resizeCopierThreadPool(8)
 
     props.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE_PROP, "7")
     config.dynamicConfig.validate(props, perBrokerConfig = false)
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(7, config.remoteLogManagerConfig.remoteLogManagerExpirationThreadPoolSize())
+    assertEquals(7, new RemoteLogManagerConfig(config).remoteLogManagerExpirationThreadPoolSize())
     verify(remoteLogManager).resizeExpirationThreadPool(7)
 
     props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, "6")
     config.dynamicConfig.validate(props, perBrokerConfig = true)
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(6, config.remoteLogManagerConfig.remoteLogReaderThreads())
+    assertEquals(6, new RemoteLogManagerConfig(config).remoteLogReaderThreads())
     verify(remoteLogManager).resizeReaderThreadPool(6)
     props.clear()
     verifyNoMoreInteractions(remoteLogManager)
@@ -694,13 +694,13 @@ class DynamicBrokerConfigTest {
     // update default config
     config.dynamicConfig.validate(newProps, perBrokerConfig = false)
     config.dynamicConfig.updateDefaultConfig(newProps)
-    assertEquals(2160000000L, config.remoteLogManagerConfig.logLocalRetentionMs)
+    assertEquals(2160000000L, new RemoteLogManagerConfig(config).logLocalRetentionMs)
 
     // update per broker config
     config.dynamicConfig.validate(newProps, perBrokerConfig = true)
     newProps.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, "2150000000")
     config.dynamicConfig.updateBrokerConfig(0, newProps)
-    assertEquals(2150000000L, config.remoteLogManagerConfig.logLocalRetentionMs)
+    assertEquals(2150000000L, new RemoteLogManagerConfig(config).logLocalRetentionMs)
   }
 
   @Test
@@ -717,13 +717,13 @@ class DynamicBrokerConfigTest {
     // update default config
     config.dynamicConfig.validate(newProps, perBrokerConfig = false)
     config.dynamicConfig.updateDefaultConfig(newProps)
-    assertEquals(4294967295L, config.remoteLogManagerConfig.logLocalRetentionBytes)
+    assertEquals(4294967295L, new RemoteLogManagerConfig(config).logLocalRetentionBytes)
 
     // update per broker config
     config.dynamicConfig.validate(newProps, perBrokerConfig = true)
     newProps.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "4294967294")
     config.dynamicConfig.updateBrokerConfig(0, newProps)
-    assertEquals(4294967294L, config.remoteLogManagerConfig.logLocalRetentionBytes)
+    assertEquals(4294967294L, new RemoteLogManagerConfig(config).logLocalRetentionBytes)
   }
 
   @Test
@@ -759,7 +759,7 @@ class DynamicBrokerConfigTest {
     val kafkaBroker = mock(classOf[KafkaBroker])
     when(kafkaBroker.config).thenReturn(config)
     when(kafkaBroker.remoteLogManagerOpt).thenReturn(None)
-    assertEquals(500, config.remoteLogManagerConfig.remoteFetchMaxWaitMs)
+    assertEquals(500, new RemoteLogManagerConfig(config).remoteFetchMaxWaitMs)
 
     val dynamicRemoteLogConfig = new DynamicRemoteLogConfig(kafkaBroker)
     config.dynamicConfig.initialize(None)
@@ -770,13 +770,13 @@ class DynamicBrokerConfigTest {
     // update default config
     config.dynamicConfig.validate(newProps, perBrokerConfig = false)
     config.dynamicConfig.updateDefaultConfig(newProps)
-    assertEquals(30000, config.remoteLogManagerConfig.remoteFetchMaxWaitMs)
+    assertEquals(30000, new RemoteLogManagerConfig(config).remoteFetchMaxWaitMs)
 
     // update per broker config
     newProps.put(RemoteLogManagerConfig.REMOTE_FETCH_MAX_WAIT_MS_PROP, "10000")
     config.dynamicConfig.validate(newProps, perBrokerConfig = true)
     config.dynamicConfig.updateBrokerConfig(0, newProps)
-    assertEquals(10000, config.remoteLogManagerConfig.remoteFetchMaxWaitMs)
+    assertEquals(10000, new RemoteLogManagerConfig(config).remoteFetchMaxWaitMs)
 
     // invalid values
     for (maxWaitMs <- Seq(-1, 0)) {
@@ -794,7 +794,7 @@ class DynamicBrokerConfigTest {
     when(kafkaBroker.config).thenReturn(config)
     when(kafkaBroker.remoteLogManagerOpt).thenReturn(None)
     assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS,
-      config.remoteLogManagerConfig.remoteListOffsetsRequestTimeoutMs)
+      new RemoteLogManagerConfig(config).remoteListOffsetsRequestTimeoutMs)
 
     val dynamicRemoteLogConfig = new DynamicRemoteLogConfig(kafkaBroker)
     config.dynamicConfig.initialize(None)
@@ -805,13 +805,13 @@ class DynamicBrokerConfigTest {
     // update default config
     config.dynamicConfig.validate(newProps, perBrokerConfig = false)
     config.dynamicConfig.updateDefaultConfig(newProps)
-    assertEquals(60000L, config.remoteLogManagerConfig.remoteListOffsetsRequestTimeoutMs)
+    assertEquals(60000L, new RemoteLogManagerConfig(config).remoteListOffsetsRequestTimeoutMs)
 
     // update per broker config
     newProps.put(RemoteLogManagerConfig.REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_PROP, "10000")
     config.dynamicConfig.validate(newProps, perBrokerConfig = true)
     config.dynamicConfig.updateBrokerConfig(0, newProps)
-    assertEquals(10000L, config.remoteLogManagerConfig.remoteListOffsetsRequestTimeoutMs)
+    assertEquals(10000L, new RemoteLogManagerConfig(config).remoteListOffsetsRequestTimeoutMs)
 
     // invalid values
     for (timeoutMs <- Seq(-1, 0)) {
@@ -840,7 +840,7 @@ class DynamicBrokerConfigTest {
 
     props.put(RemoteLogManagerConfig.REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP, "4")
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(4L, config.remoteLogManagerConfig.remoteLogIndexFileCacheTotalSizeBytes())
+    assertEquals(4L, new RemoteLogManagerConfig(config).remoteLogIndexFileCacheTotalSizeBytes())
     Mockito.verify(remoteLogManager).resizeCacheSize(4)
 
     Mockito.verifyNoMoreInteractions(remoteLogManager)
@@ -860,18 +860,18 @@ class DynamicBrokerConfigTest {
     config.dynamicConfig.addBrokerReconfigurable(new DynamicRemoteLogConfig(serverMock))
 
     assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND,
-      config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond())
+      new RemoteLogManagerConfig(config).remoteLogManagerCopyMaxBytesPerSecond())
 
     // Update default config
     props.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND_PROP, "100")
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(100, config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond())
+    assertEquals(100, new RemoteLogManagerConfig(config).remoteLogManagerCopyMaxBytesPerSecond())
     verify(remoteLogManager).updateCopyQuota(100)
 
     // Update per broker config
     props.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND_PROP, "200")
     config.dynamicConfig.updateBrokerConfig(0, props)
-    assertEquals(200, config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond())
+    assertEquals(200, new RemoteLogManagerConfig(config).remoteLogManagerCopyMaxBytesPerSecond())
     verify(remoteLogManager).updateCopyQuota(200)
 
     verifyNoMoreInteractions(remoteLogManager)
@@ -891,18 +891,18 @@ class DynamicBrokerConfigTest {
     config.dynamicConfig.addBrokerReconfigurable(new DynamicRemoteLogConfig(serverMock))
 
     assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND,
-      config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond())
+      new RemoteLogManagerConfig(config).remoteLogManagerFetchMaxBytesPerSecond())
 
     // Update default config
     props.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND_PROP, "100")
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(100, config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond())
+    assertEquals(100, new RemoteLogManagerConfig(config).remoteLogManagerFetchMaxBytesPerSecond())
     verify(remoteLogManager).updateFetchQuota(100)
 
     // Update per broker config
     props.put(RemoteLogManagerConfig.REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND_PROP, "200")
     config.dynamicConfig.updateBrokerConfig(0, props)
-    assertEquals(200, config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond())
+    assertEquals(200, new RemoteLogManagerConfig(config).remoteLogManagerFetchMaxBytesPerSecond())
     verify(remoteLogManager).updateFetchQuota(200)
 
     verifyNoMoreInteractions(remoteLogManager)
@@ -927,20 +927,20 @@ class DynamicBrokerConfigTest {
 
     // Default values
     assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES,
-      config.remoteLogManagerConfig.remoteLogIndexFileCacheTotalSizeBytes())
+      new RemoteLogManagerConfig(config).remoteLogIndexFileCacheTotalSizeBytes())
     assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND,
-      config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond())
+      new RemoteLogManagerConfig(config).remoteLogManagerCopyMaxBytesPerSecond())
     assertEquals(RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND,
-      config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond())
+      new RemoteLogManagerConfig(config).remoteLogManagerFetchMaxBytesPerSecond())
 
     // Update default config
     props.put(indexFileCacheSizeProp, "4")
     props.put(copyQuotaProp, "100")
     props.put(fetchQuotaProp, "200")
     config.dynamicConfig.updateDefaultConfig(props)
-    assertEquals(4, config.remoteLogManagerConfig.remoteLogIndexFileCacheTotalSizeBytes())
-    assertEquals(100, config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond())
-    assertEquals(200, config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond())
+    assertEquals(4, new RemoteLogManagerConfig(config).remoteLogIndexFileCacheTotalSizeBytes())
+    assertEquals(100, new RemoteLogManagerConfig(config).remoteLogManagerCopyMaxBytesPerSecond())
+    assertEquals(200, new RemoteLogManagerConfig(config).remoteLogManagerFetchMaxBytesPerSecond())
     verify(remoteLogManager).resizeCacheSize(4)
     verify(remoteLogManager).updateCopyQuota(100)
     verify(remoteLogManager).updateFetchQuota(200)
@@ -950,9 +950,9 @@ class DynamicBrokerConfigTest {
     props.put(copyQuotaProp, "200")
     props.put(fetchQuotaProp, "400")
     config.dynamicConfig.updateBrokerConfig(0, props)
-    assertEquals(8, config.remoteLogManagerConfig.remoteLogIndexFileCacheTotalSizeBytes())
-    assertEquals(200, config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond())
-    assertEquals(400, config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond())
+    assertEquals(8, new RemoteLogManagerConfig(config).remoteLogIndexFileCacheTotalSizeBytes())
+    assertEquals(200, new RemoteLogManagerConfig(config).remoteLogManagerCopyMaxBytesPerSecond())
+    assertEquals(400, new RemoteLogManagerConfig(config).remoteLogManagerFetchMaxBytesPerSecond())
     verify(remoteLogManager).resizeCacheSize(8)
     verify(remoteLogManager).updateCopyQuota(200)
     verify(remoteLogManager).updateFetchQuota(400)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1060,7 +1060,8 @@ class KafkaConfigTest {
     val props = baseProperties
     props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
     val config = KafkaConfig.fromProps(props)
-
+    val remoteLogManagerConfig = new RemoteLogManagerConfig(config)
+    
     def assertDynamic(property: String, value: Any, accessor: () => Any): Unit = {
       val initial = accessor()
       props.setProperty(property, value.toString)
@@ -1127,9 +1128,9 @@ class KafkaConfigTest {
         case TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG =>
           assertDynamic(kafkaConfigProp, true, () => config.uncleanLeaderElectionEnable)
         case TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG =>
-          assertDynamic(kafkaConfigProp, 10015L, () => config.remoteLogManagerConfig.logLocalRetentionMs)
+          assertDynamic(kafkaConfigProp, 10015L, () => remoteLogManagerConfig.logLocalRetentionMs)
         case TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG =>
-          assertDynamic(kafkaConfigProp, 10016L, () => config.remoteLogManagerConfig.logLocalRetentionBytes)
+          assertDynamic(kafkaConfigProp, 10016L, () => remoteLogManagerConfig.logLocalRetentionBytes)
         // not dynamically updatable
         case QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG =>
         // topic only config

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -3285,7 +3285,7 @@ class ReplicaManagerTest {
     when(mockLog.config).thenReturn(logConfig)
     when(mockLog.remoteLogEnabled()).thenReturn(enableRemoteStorage)
     val aliveBrokers = aliveBrokerIds.map(brokerId => new Node(brokerId, s"host$brokerId", brokerId))
-    brokerTopicStats = new BrokerTopicStats(KafkaConfig.fromProps(props).remoteLogManagerConfig.isRemoteStorageSystemEnabled)
+    brokerTopicStats = new BrokerTopicStats(new RemoteLogManagerConfig(KafkaConfig.fromProps(props)).isRemoteStorageSystemEnabled)
 
     val metadataCache: MetadataCache = mock(classOf[MetadataCache])
     when(metadataCache.topicIdsToNames()).thenReturn(topicNames.asJava)
@@ -3794,10 +3794,11 @@ class ReplicaManagerTest {
     // set log reader threads number to 2
     props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, 2.toString)
     val config = KafkaConfig.fromProps(props)
+    val remoteLogManagerConfig = new RemoteLogManagerConfig(config)
     val mockLog = mock(classOf[UnifiedLog])
-    val brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig.isRemoteStorageSystemEnabled)
+    val brokerTopicStats = new BrokerTopicStats(remoteLogManagerConfig.isRemoteStorageSystemEnabled)
     val remoteLogManager = new RemoteLogManager(
-      config.remoteLogManagerConfig,
+      remoteLogManagerConfig, 
       0,
       TestUtils.tempRelativeDir("data").getAbsolutePath,
       "clusterId",
@@ -3905,10 +3906,11 @@ class ReplicaManagerTest {
     props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, classOf[NoOpRemoteStorageManager].getName)
     props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, classOf[NoOpRemoteLogMetadataManager].getName)
     val config = KafkaConfig.fromProps(props)
+    val remoteLogManagerConfig = new RemoteLogManagerConfig(config)
     val dummyLog = mock(classOf[UnifiedLog])
-    val brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig.isRemoteStorageSystemEnabled)
+    val brokerTopicStats = new BrokerTopicStats(remoteLogManagerConfig.isRemoteStorageSystemEnabled)
     val remoteLogManager = new RemoteLogManager(
-      config.remoteLogManagerConfig,
+      remoteLogManagerConfig,
       0,
       TestUtils.tempRelativeDir("data").getAbsolutePath,
       "clusterId",

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
 import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
@@ -192,6 +194,8 @@ public final class RemoteLogManagerConfig {
     public static final long DEFAULT_REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS = 30000L;
 
     private final AbstractConfig config;
+
+    private final ConcurrentMap<String, Object> usedConfig = new ConcurrentHashMap<>();
 
     public static ConfigDef configDef() {
         return new ConfigDef()
@@ -372,51 +376,51 @@ public final class RemoteLogManagerConfig {
     }
 
     public boolean isRemoteStorageSystemEnabled() {
-        return config.getBoolean(REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP);
+        return (Boolean) usedConfig.computeIfAbsent(REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, config::getBoolean);
     }
 
     public String remoteStorageManagerClassName() {
-        return config.getString(REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, config::getString);
     }
 
     public String remoteStorageManagerClassPath() {
-        return config.getString(REMOTE_STORAGE_MANAGER_CLASS_PATH_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_STORAGE_MANAGER_CLASS_PATH_PROP, config::getString);
     }
 
     public String remoteLogMetadataManagerClassName() {
-        return config.getString(REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, config::getString);
     }
 
     public String remoteLogMetadataManagerClassPath() {
-        return config.getString(REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_PROP, config::getString);
     }
 
     public int remoteLogManagerThreadPoolSize() {
-        return config.getInt(REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_PROP, config::getInt);
     }
 
     public int remoteLogManagerCopierThreadPoolSize() {
-        return config.getInt(REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE_PROP, config::getInt);
     }
 
     public int remoteLogManagerExpirationThreadPoolSize() {
-        return config.getInt(REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_EXPIRATION_THREAD_POOL_SIZE_PROP, config::getInt);
     }
 
     public long remoteLogManagerTaskIntervalMs() {
-        return config.getLong(REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_PROP, config::getLong);
     }
 
     public long remoteLogManagerTaskRetryBackoffMs() {
-        return config.getLong(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_PROP, config::getLong);
     }
 
     public long remoteLogManagerTaskRetryBackoffMaxMs() {
-        return config.getLong(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_PROP, config::getLong);
     }
 
     public double remoteLogManagerTaskRetryJitter() {
-        return config.getDouble(REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_PROP);
+        return (Double) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_PROP, config::getDouble);
     }
 
     public int remoteLogReaderThreads() {
@@ -424,80 +428,77 @@ public final class RemoteLogManagerConfig {
     }
 
     public int remoteLogReaderMaxPendingTasks() {
-        return config.getInt(REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, config::getInt);
     }
 
     public String remoteLogMetadataManagerListenerName() {
-        return config.getString(REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP, config::getString);
     }
 
     public int remoteLogMetadataCustomMetadataMaxBytes() {
-        return config.getInt(REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES_PROP, config::getInt);
     }
 
     public String remoteStorageManagerPrefix() {
-        return config.getString(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, config::getString);
     }
 
     public String remoteLogMetadataManagerPrefix() {
-        return config.getString(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP);
+        return (String) usedConfig.computeIfAbsent(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, config::getString);
     }
 
     public Map<String, Object> remoteStorageManagerProps() {
-        return getConfigProps(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP);
+        String prefix = (String) usedConfig.computeIfAbsent(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, config::getString);
+        return prefix == null ? Map.of() : Collections.unmodifiableMap(config.originalsWithPrefix(prefix));
     }
 
     public Map<String, Object> remoteLogMetadataManagerProps() {
-        return getConfigProps(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP);
-    }
-
-    public Map<String, Object> getConfigProps(String configPrefixProp) {
-        String prefixProp = config.getString(configPrefixProp);
-        return prefixProp == null ? Map.of() : Collections.unmodifiableMap(config.originalsWithPrefix(prefixProp));
+        String prefix = (String) usedConfig.computeIfAbsent(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, config::getString);
+        return prefix == null ? Map.of() : Collections.unmodifiableMap(config.originalsWithPrefix(prefix));
     }
 
     public int remoteLogManagerCopyNumQuotaSamples() {
-        return config.getInt(REMOTE_LOG_MANAGER_COPY_QUOTA_WINDOW_NUM_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_COPY_QUOTA_WINDOW_NUM_PROP, config::getInt);
     }
 
     public int remoteLogManagerCopyQuotaWindowSizeSeconds() {
-        return config.getInt(REMOTE_LOG_MANAGER_COPY_QUOTA_WINDOW_SIZE_SECONDS_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_COPY_QUOTA_WINDOW_SIZE_SECONDS_PROP, config::getInt);
     }
 
     public int remoteLogManagerFetchNumQuotaSamples() {
-        return config.getInt(REMOTE_LOG_MANAGER_FETCH_QUOTA_WINDOW_NUM_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_FETCH_QUOTA_WINDOW_NUM_PROP, config::getInt);
     }
 
     public int remoteLogManagerFetchQuotaWindowSizeSeconds() {
-        return config.getInt(REMOTE_LOG_MANAGER_FETCH_QUOTA_WINDOW_SIZE_SECONDS_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_FETCH_QUOTA_WINDOW_SIZE_SECONDS_PROP, config::getInt);
     }
 
     public long remoteLogIndexFileCacheTotalSizeBytes() {
-        return config.getLong(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP, config::getLong);
     }
 
     public long remoteLogManagerCopyMaxBytesPerSecond() {
-        return config.getLong(REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND_PROP, config::getLong);
     }
 
     public long remoteLogManagerFetchMaxBytesPerSecond() {
-        return config.getLong(REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND_PROP, config::getLong);
     }
 
     public int remoteFetchMaxWaitMs() {
-        return config.getInt(REMOTE_FETCH_MAX_WAIT_MS_PROP);
+        return (Integer) usedConfig.computeIfAbsent(REMOTE_FETCH_MAX_WAIT_MS_PROP, config::getInt);
     }
 
     public long logLocalRetentionBytes() {
-        return config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
+        return (Long) usedConfig.computeIfAbsent(LOG_LOCAL_RETENTION_BYTES_PROP, config::getLong);
     }
 
     public long logLocalRetentionMs() {
-        return config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
+        return (Long) usedConfig.computeIfAbsent(LOG_LOCAL_RETENTION_MS_PROP, config::getLong);
     }
 
     public long remoteListOffsetsRequestTimeoutMs() {
-        return config.getLong(REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_PROP);
+        return (Long) usedConfig.computeIfAbsent(REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_PROP, config::getLong);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
[JIRA: KAFKA-19167](https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-19167?filter=allissues)

As part of refactoring `KafkaConfig` to reduce its responsibilities, this PR removes the `remoteLogManagerConfig`  from `KafkaConfig`, which was still exposed externally.

