### PR TITLE
KAFKA-19330: Change MockSerializer/Deserializer to use String serializer instead of byte[]

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -603,12 +603,11 @@ public class KafkaProducerTest {
         final int oldInitCount = MockSerializer.INIT_COUNT.get();
         final int oldCloseCount = MockSerializer.CLOSE_COUNT.get();
 
-        KafkaProducer<String, String> producer = new KafkaProducer<>(
-                configs, new MockSerializer(), new MockSerializer());
-        assertEquals(oldInitCount + 2, MockSerializer.INIT_COUNT.get());
-        assertEquals(oldCloseCount, MockSerializer.CLOSE_COUNT.get());
+        try (var ignored = new KafkaProducer<>(configs, new MockSerializer(), new MockSerializer())) {
+            assertEquals(oldInitCount + 2, MockSerializer.INIT_COUNT.get());
+            assertEquals(oldCloseCount, MockSerializer.CLOSE_COUNT.get());
+        }
 
-        producer.close();
         assertEquals(oldInitCount + 2, MockSerializer.INIT_COUNT.get());
         assertEquals(oldCloseCount + 2, MockSerializer.CLOSE_COUNT.get());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -603,7 +603,7 @@ public class KafkaProducerTest {
         final int oldInitCount = MockSerializer.INIT_COUNT.get();
         final int oldCloseCount = MockSerializer.CLOSE_COUNT.get();
 
-        KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(
+        KafkaProducer<String, String> producer = new KafkaProducer<>(
                 configs, new MockSerializer(), new MockSerializer());
         assertEquals(oldInitCount + 2, MockSerializer.INIT_COUNT.get());
         assertEquals(oldCloseCount, MockSerializer.CLOSE_COUNT.get());

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -53,9 +53,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class MockProducerTest {
 
     private final String topic = "topic";
-    private MockProducer<byte[], byte[]> producer;
-    private final ProducerRecord<byte[], byte[]> record1 = new ProducerRecord<>(topic, "key1".getBytes(), "value1".getBytes());
-    private final ProducerRecord<byte[], byte[]> record2 = new ProducerRecord<>(topic, "key2".getBytes(), "value2".getBytes());
+    private MockProducer<String, String> producer;
+    private final ProducerRecord<String, String> record1 = new ProducerRecord<>(topic, "key1", "value1");
+    private final ProducerRecord<String, String> record2 = new ProducerRecord<>(topic, "key2", "value2");
     private final String groupId = "group";
 
     private void buildMockProducer(boolean autoComplete) {
@@ -318,7 +318,7 @@ public class MockProducerTest {
 
         producer.commitTransaction();
 
-        List<ProducerRecord<byte[], byte[]>> expectedResult = new ArrayList<>();
+        List<ProducerRecord<String, String>> expectedResult = new ArrayList<>();
         expectedResult.add(record1);
         expectedResult.add(record2);
 
@@ -385,7 +385,7 @@ public class MockProducerTest {
         producer.beginTransaction();
         producer.abortTransaction();
 
-        List<ProducerRecord<byte[], byte[]>> expectedResult = new ArrayList<>();
+        List<ProducerRecord<String, String>> expectedResult = new ArrayList<>();
         expectedResult.add(record1);
         expectedResult.add(record2);
 

--- a/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
@@ -57,10 +57,8 @@ public class MockDeserializer implements ClusterResourceListener, Deserializer<S
         // This will ensure that we get the cluster metadata when deserialize is called for the first time
         // as subsequent compareAndSet operations will fail.
         clusterIdBeforeDeserialize.compareAndSet(noClusterId, clusterMeta.get());
-        if (data == null)
-            return null;
-        else
-            return new String(data, StandardCharsets.UTF_8);
+        if (data == null) return null;
+        return new String(data, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
@@ -20,11 +20,12 @@ import org.apache.kafka.common.ClusterResource;
 import org.apache.kafka.common.ClusterResourceListener;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class MockDeserializer implements ClusterResourceListener, Deserializer<byte[]> {
+public class MockDeserializer implements ClusterResourceListener, Deserializer<String> {
     public static AtomicInteger initCount = new AtomicInteger(0);
     public static AtomicInteger closeCount = new AtomicInteger(0);
     public static AtomicReference<ClusterResource> clusterMeta = new AtomicReference<>();
@@ -52,11 +53,14 @@ public class MockDeserializer implements ClusterResourceListener, Deserializer<b
     }
 
     @Override
-    public byte[] deserialize(String topic, byte[] data) {
+    public String deserialize(String topic, byte[] data) {
         // This will ensure that we get the cluster metadata when deserialize is called for the first time
         // as subsequent compareAndSet operations will fail.
         clusterIdBeforeDeserialize.compareAndSet(noClusterId, clusterMeta.get());
-        return data;
+        if (data == null)
+            return null;
+        else
+            return new String(data, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockSerializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSerializer.java
@@ -20,10 +20,11 @@ import org.apache.kafka.common.ClusterResource;
 import org.apache.kafka.common.ClusterResourceListener;
 import org.apache.kafka.common.serialization.Serializer;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class MockSerializer implements ClusterResourceListener, Serializer<byte[]> {
+public class MockSerializer implements ClusterResourceListener, Serializer<String> {
     public static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
     public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
     public static final AtomicReference<ClusterResource> CLUSTER_META = new AtomicReference<>();
@@ -35,11 +36,14 @@ public class MockSerializer implements ClusterResourceListener, Serializer<byte[
     }
 
     @Override
-    public byte[] serialize(String topic, byte[] data) {
+    public byte[] serialize(String topic, String data) {
         // This will ensure that we get the cluster metadata when serialize is called for the first time
         // as subsequent compareAndSet operations will fail.
         CLUSTER_ID_BEFORE_SERIALIZE.compareAndSet(NO_CLUSTER_ID, CLUSTER_META.get());
-        return data;
+        if (data == null)
+            return null;
+        else
+            return data.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockSerializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSerializer.java
@@ -40,10 +40,8 @@ public class MockSerializer implements ClusterResourceListener, Serializer<Strin
         // This will ensure that we get the cluster metadata when serialize is called for the first time
         // as subsequent compareAndSet operations will fail.
         CLUSTER_ID_BEFORE_SERIALIZE.compareAndSet(NO_CLUSTER_ID, CLUSTER_META.get());
-        if (data == null)
-            return null;
-        else
-            return data.getBytes(StandardCharsets.UTF_8);
+        if (data == null) return null;
+        return data.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/core/src/test/scala/integration/kafka/api/EndToEndClusterIdTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndClusterIdTest.scala
@@ -186,9 +186,9 @@ class EndToEndClusterIdTest extends KafkaServerTestHarness {
     MockProducerInterceptor.resetCounters()
   }
 
-  private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int, tp: TopicPartition): Unit = {
+  private def sendRecords(producer: KafkaProducer[String, String], numRecords: Int, tp: TopicPartition): Unit = {
     val futures = (0 until numRecords).map { i =>
-      val record = new ProducerRecord(tp.topic(), tp.partition(), s"$i".getBytes, s"$i".getBytes)
+      val record = new ProducerRecord(tp.topic(), tp.partition(), s"$i", s"$i")
       debug(s"Sending this record: $record")
       producer.send(record)
     }
@@ -199,7 +199,7 @@ class EndToEndClusterIdTest extends KafkaServerTestHarness {
     }
   }
 
-  private def consumeRecords(consumer: Consumer[Array[Byte], Array[Byte]],
+  private def consumeRecords(consumer: Consumer[String, String],
                              numRecords: Int,
                              startingOffset: Int = 0,
                              topic: String = topic,


### PR DESCRIPTION
While rewriting `EndToEndClusterIdTest` in Java (#19741 ), I found that
the test uses `MockInterceptor` and `MockSerializer` together. However,
`MockSerializer` was using a `byte[]` serializer, while
`MockInterceptor` expected a `String` serializer, leading to a
`ClassCastException`.

I chose to update `MockSerializer` to use `String`, as it is used less
frequently than the `MockInterceptor`. Using `String` also simplifies
the code  by avoiding the need to write expressions like
`"value".getBytes`.

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <frankvicky@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
