### PR TITLE
KAFKA-19290: Exploit mapKey optimisation in protocol requests and responses

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsResponse.java
@@ -20,13 +20,12 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.AlterShareGroupOffsetsResponseData;
 import org.apache.kafka.common.message.AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic;
+import org.apache.kafka.common.message.AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 
 public class AlterShareGroupOffsetsResponse extends AbstractResponse {
@@ -71,15 +70,15 @@ public class AlterShareGroupOffsetsResponse extends AbstractResponse {
 
     public static class Builder {
         AlterShareGroupOffsetsResponseData data = new AlterShareGroupOffsetsResponseData();
-        HashMap<String, AlterShareGroupOffsetsResponseTopic> topics = new HashMap<>();
+        AlterShareGroupOffsetsResponseTopicCollection topics = new AlterShareGroupOffsetsResponseTopicCollection();
 
         private AlterShareGroupOffsetsResponseTopic getOrCreateTopic(String topic, Uuid topicId) {
-            AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic topicData = topics.get(topic);
+            AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic topicData = topics.find(topic);
             if (topicData == null) {
                 topicData = new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic()
                     .setTopicName(topic)
                     .setTopicId(topicId == null ? Uuid.ZERO_UUID : topicId);
-                topics.put(topic, topicData);
+                topics.add(topicData);
             }
             return topicData;
         }
@@ -94,7 +93,7 @@ public class AlterShareGroupOffsetsResponse extends AbstractResponse {
         }
 
         public AlterShareGroupOffsetsResponse build() {
-            data.setResponses(new ArrayList<>(topics.values()));
+            data.setResponses(topics);
             return new AlterShareGroupOffsetsResponse(data);
         }
 

--- a/clients/src/main/resources/common/message/AlterShareGroupOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/AlterShareGroupOffsetsResponse.json
@@ -25,7 +25,7 @@
       "about": "The top-level error message, or null if there was no error." },
     { "name": "Responses", "type": "[]AlterShareGroupOffsetsResponseTopic", "versions": "0+",
       "about": "The results for each topic.", "fields": [
-      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName", "mapKey": true,
         "about": "The topic name." },
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The unique topic ID." },

--- a/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
+++ b/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
@@ -32,10 +32,10 @@
       "about": "The current share session epoch: 0 to open a share session; -1 to close it; otherwise increments for consecutive requests." },
     { "name": "Topics", "type": "[]AcknowledgeTopic", "versions": "0+",
       "about": "The topics containing records to acknowledge.", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID." },
+      { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID.", "mapKey": true },
       { "name": "Partitions", "type": "[]AcknowledgePartition", "versions": "0+",
         "about": "The partitions containing records to acknowledge.", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+", "mapKey": true,
           "about": "The partition index." },
         { "name": "AcknowledgementBatches", "type": "[]AcknowledgementBatch", "versions": "0+",
           "about": "Record batches to acknowledge.", "fields": [

--- a/clients/src/main/resources/common/message/ShareAcknowledgeResponse.json
+++ b/clients/src/main/resources/common/message/ShareAcknowledgeResponse.json
@@ -43,7 +43,7 @@
       "about": "The top-level error message, or null if there was no error." },
     { "name": "Responses", "type": "[]ShareAcknowledgeTopicResponse", "versions": "0+",
       "about": "The response topics.", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+",
+      { "name": "TopicId", "type": "uuid", "versions": "0+", "mapKey": true,
         "about": "The unique topic ID." },
       { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
         "about": "The topic partitions.", "fields": [

--- a/clients/src/main/resources/common/message/ShareFetchRequest.json
+++ b/clients/src/main/resources/common/message/ShareFetchRequest.json
@@ -42,10 +42,10 @@
       "about": "The optimal number of records for batches of acquired records and acknowledgements." },
     { "name": "Topics", "type": "[]FetchTopic", "versions": "0+",
       "about": "The topics to fetch.", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID."},
+      { "name": "TopicId", "type": "uuid", "versions": "0+", "about": "The unique topic ID.", "mapKey":  true },
       { "name": "Partitions", "type": "[]FetchPartition", "versions": "0+",
         "about": "The partitions to fetch.", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+", "mapKey":  true,
           "about": "The partition index." },
         { "name": "PartitionMaxBytes", "type": "int32", "versions": "0",
           "about": "The maximum bytes to fetch from this partition. 0 when only acknowledgement with no fetching is required. See KIP-74 for cases where this limit may not be honored." },

--- a/clients/src/main/resources/common/message/ShareFetchResponse.json
+++ b/clients/src/main/resources/common/message/ShareFetchResponse.json
@@ -46,7 +46,7 @@
       "about": "The time in milliseconds for which the acquired records are locked." },
     { "name": "Responses", "type": "[]ShareFetchableTopicResponse", "versions": "0+",
       "about": "The response topics.", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "0+",
+      { "name": "TopicId", "type": "uuid", "versions": "0+", "mapKey": true,
         "about": "The unique topic ID." },
       { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
         "about": "The topic partitions.", "fields": [

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -11329,10 +11329,10 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
 
             AlterShareGroupOffsetsResponseData data = new AlterShareGroupOffsetsResponseData().setResponses(
-                List.of(
+                new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection(List.of(
                     new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic().setTopicName("foo").setPartitions(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition().setPartitionIndex(0), new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition().setPartitionIndex(1))),
                     new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic().setTopicName("bar").setPartitions(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition().setPartitionIndex(0)))
-                )
+                ).iterator())
             );
 
             TopicPartition fooTopicPartition0 = new TopicPartition("foo", 0);
@@ -11358,10 +11358,10 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
 
             AlterShareGroupOffsetsResponseData data = new AlterShareGroupOffsetsResponseData().setResponses(
-                List.of(
+                new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection(List.of(
                     new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic().setTopicName("foo").setPartitions(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition().setPartitionIndex(0), new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition().setPartitionIndex(1).setErrorCode(Errors.NON_EMPTY_GROUP.code()).setErrorMessage("The group is not empty"))),
                     new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic().setTopicName("bar").setPartitions(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition().setPartitionIndex(0)))
-                )
+                ).iterator())
             );
 
             TopicPartition fooTopicPartition0 = new TopicPartition("foo", 0);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
@@ -166,9 +166,9 @@ public class KafkaShareConsumerTest {
                 return request.data().groupId().equals(groupId) &&
                     request.data().shareSessionEpoch() == 0 &&
                     request.data().batchSize() == batchSize &&
-                    request.data().topics().get(0).topicId().equals(topicId1) &&
-                    request.data().topics().get(0).partitions().size() == 1 &&
-                    request.data().topics().get(0).partitions().get(0).acknowledgementBatches().isEmpty();
+                    request.data().topics().stream().findFirst().get().topicId().equals(topicId1) &&
+                    request.data().topics().stream().findFirst().get().partitions().size() == 1 &&
+                    request.data().topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().isEmpty();
             } else {
                 return false;
             }
@@ -180,10 +180,10 @@ public class KafkaShareConsumerTest {
                 ShareAcknowledgeRequest request = (ShareAcknowledgeRequest) body;
                 return request.data().groupId().equals(groupId) &&
                     request.data().shareSessionEpoch() == 1 &&
-                    request.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).firstOffset() == 0 &&
-                    request.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).lastOffset() == 1 &&
-                    request.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).acknowledgeTypes().size() == 1 &&
-                    request.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).acknowledgeTypes().get(0) == (byte) 1;
+                    request.data().topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().get(0).firstOffset() == 0 &&
+                    request.data().topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().get(0).lastOffset() == 1 &&
+                    request.data().topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().get(0).acknowledgeTypes().size() == 1 &&
+                    request.data().topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().get(0).acknowledgeTypes().get(0) == (byte) 1;
             } else {
                 return false;
             }
@@ -243,9 +243,9 @@ public class KafkaShareConsumerTest {
                 return request.data().groupId().equals(groupId) &&
                     request.data().shareSessionEpoch() == 0 &&
                     request.data().batchSize() == batchSize &&
-                    request.data().topics().get(0).topicId().equals(topicId1) &&
-                    request.data().topics().get(0).partitions().size() == 1 &&
-                    request.data().topics().get(0).partitions().get(0).acknowledgementBatches().isEmpty();
+                    request.data().topics().stream().findFirst().get().topicId().equals(topicId1) &&
+                    request.data().topics().stream().findFirst().get().partitions().size() == 1 &&
+                    request.data().topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().isEmpty();
             } else {
                 return false;
             }
@@ -411,7 +411,7 @@ public class KafkaShareConsumerTest {
             .setPartitions(List.of(partData));
         return new ShareAcknowledgeResponse(
             new ShareAcknowledgeResponseData()
-                .setResponses(List.of(topicResponse))
+                .setResponses(new ShareAcknowledgeResponseData.ShareAcknowledgeTopicResponseCollection(List.of(topicResponse).iterator()))
         );
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManagerTest.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
+import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -994,12 +995,14 @@ public class ShareConsumeRequestManagerTest {
 
         // Verify the builder data for node0.
         assertEquals(1, builder1.data().topics().size());
-        assertEquals(tip0.topicId(), builder1.data().topics().get(0).topicId());
-        assertEquals(1, builder1.data().topics().get(0).partitions().size());
-        assertEquals(0, builder1.data().topics().get(0).partitions().get(0).partitionIndex());
-        assertEquals(1, builder1.data().topics().get(0).partitions().get(0).acknowledgementBatches().size());
-        assertEquals(0L, builder1.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).firstOffset());
-        assertEquals(2L, builder1.data().topics().get(0).partitions().get(0).acknowledgementBatches().get(0).lastOffset());
+        ShareFetchRequestData.FetchTopic fetchTopic = builder1.data().topics().stream().findFirst().get();
+        assertEquals(tip0.topicId(), fetchTopic.topicId());
+        assertEquals(1, fetchTopic.partitions().size());
+        ShareFetchRequestData.FetchPartition fetchPartition = fetchTopic.partitions().stream().findFirst().get();
+        assertEquals(0, fetchPartition.partitionIndex());
+        assertEquals(1, fetchPartition.acknowledgementBatches().size());
+        assertEquals(0L, fetchPartition.acknowledgementBatches().get(0).firstOffset());
+        assertEquals(2L, fetchPartition.acknowledgementBatches().get(0).lastOffset());
 
         assertEquals(1, builder1.data().forgottenTopicsData().size());
         assertEquals(tip0.topicId(), builder1.data().forgottenTopicsData().get(0).topicId());
@@ -1008,9 +1011,10 @@ public class ShareConsumeRequestManagerTest {
 
         // Verify the builder data for node1.
         assertEquals(1, builder2.data().topics().size());
-        assertEquals(tip1.topicId(), builder2.data().topics().get(0).topicId());
-        assertEquals(1, builder2.data().topics().get(0).partitions().size());
-        assertEquals(1, builder2.data().topics().get(0).partitions().get(0).partitionIndex());
+        fetchTopic = builder2.data().topics().stream().findFirst().get();
+        assertEquals(tip1.topicId(), fetchTopic.topicId());
+        assertEquals(1, fetchTopic.partitions().size());
+        assertEquals(1, fetchTopic.partitions().stream().findFirst().get().partitionIndex());
     }
 
     @Test
@@ -1049,9 +1053,10 @@ public class ShareConsumeRequestManagerTest {
         ShareFetchRequest.Builder builder = (ShareFetchRequest.Builder) pollResult.unsentRequests.get(0).requestBuilder();
 
         assertEquals(1, builder.data().topics().size());
-        assertEquals(tip1.topicId(), builder.data().topics().get(0).topicId());
-        assertEquals(1, builder.data().topics().get(0).partitions().size());
-        assertEquals(1, builder.data().topics().get(0).partitions().get(0).partitionIndex());
+        ShareFetchRequestData.FetchTopic fetchTopic = builder.data().topics().stream().findFirst().get();
+        assertEquals(tip1.topicId(), fetchTopic.topicId());
+        assertEquals(1, fetchTopic.partitions().size());
+        assertEquals(1, fetchTopic.partitions().stream().findFirst().get().partitionIndex());
         assertEquals(0, builder.data().forgottenTopicsData().size());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareSessionHandlerTest.java
@@ -458,7 +458,7 @@ public class ShareSessionHandlerTest {
         ShareFetchRequestData requestData = handler.newShareFetchBuilder(groupId, fetchConfig).build().data();
 
         // We should have cleared the unsent acknowledgements before this ShareFetch.
-        assertEquals(0, requestData.topics().get(0).partitions().get(0).acknowledgementBatches().size());
+        assertEquals(0, requestData.topics().stream().findFirst().get().partitions().stream().findFirst().get().acknowledgementBatches().size());
 
         ArrayList<TopicIdPartition> expectedToSend1 = new ArrayList<>();
         expectedToSend1.add(new TopicIdPartition(fooId, 1, "foo"));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -3817,12 +3817,13 @@ public class RequestResponseTest {
 
     private AlterShareGroupOffsetsResponse createAlterShareGroupOffsetsResponse() {
         AlterShareGroupOffsetsResponseData data = new AlterShareGroupOffsetsResponseData()
-            .setResponses(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic()
-                .setPartitions(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition()
-                    .setPartitionIndex(0)
-                    .setErrorCode(Errors.NONE.code())))
-                .setTopicName("topic")
-                .setTopicId(Uuid.randomUuid())));
+            .setResponses(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection(List.of(
+                new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic()
+                    .setPartitions(List.of(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition()
+                        .setPartitionIndex(0)
+                        .setErrorCode(Errors.NONE.code())))
+                    .setTopicName("topic")
+                    .setTopicId(Uuid.randomUuid())).iterator()));
         return new AlterShareGroupOffsetsResponse(data);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1447,10 +1447,10 @@ public class RequestResponseTest {
         ShareFetchRequestData data = new ShareFetchRequestData()
                 .setGroupId("group")
                 .setMemberId(Uuid.randomUuid().toString())
-                .setTopics(singletonList(new ShareFetchRequestData.FetchTopic()
+                .setTopics(new ShareFetchRequestData.FetchTopicCollection(List.of(new ShareFetchRequestData.FetchTopic()
                         .setTopicId(Uuid.randomUuid())
-                        .setPartitions(singletonList(new ShareFetchRequestData.FetchPartition()
-                                .setPartitionIndex(0)))));
+                        .setPartitions(new ShareFetchRequestData.FetchPartitionCollection(List.of(new ShareFetchRequestData.FetchPartition()
+                                .setPartitionIndex(0)).iterator()))).iterator()));
         return new ShareFetchRequest.Builder(data).build(version);
     }
 
@@ -1473,24 +1473,24 @@ public class RequestResponseTest {
     private ShareAcknowledgeRequest createShareAcknowledgeRequest(short version) {
         ShareAcknowledgeRequestData data = new ShareAcknowledgeRequestData()
                 .setMemberId(Uuid.randomUuid().toString())
-                .setTopics(singletonList(new ShareAcknowledgeRequestData.AcknowledgeTopic()
+                .setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic()
                         .setTopicId(Uuid.randomUuid())
-                        .setPartitions(singletonList(new ShareAcknowledgeRequestData.AcknowledgePartition()
+                        .setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(List.of(new ShareAcknowledgeRequestData.AcknowledgePartition()
                                 .setPartitionIndex(0)
                                 .setAcknowledgementBatches(singletonList(new ShareAcknowledgeRequestData.AcknowledgementBatch()
                                         .setFirstOffset(0)
                                         .setLastOffset(0)
-                                        .setAcknowledgeTypes(Collections.singletonList((byte) 0))))))));
+                                        .setAcknowledgeTypes(Collections.singletonList((byte) 0))))).iterator()))).iterator()));
         return new ShareAcknowledgeRequest.Builder(data).build(version);
     }
 
     private ShareAcknowledgeResponse createShareAcknowledgeResponse() {
         ShareAcknowledgeResponseData data = new ShareAcknowledgeResponseData();
-        data.setResponses(singletonList(new ShareAcknowledgeResponseData.ShareAcknowledgeTopicResponse()
+        data.setResponses(new ShareAcknowledgeResponseData.ShareAcknowledgeTopicResponseCollection(List.of(new ShareAcknowledgeResponseData.ShareAcknowledgeTopicResponse()
                 .setTopicId(Uuid.randomUuid())
                 .setPartitions(singletonList(new ShareAcknowledgeResponseData.PartitionData()
                         .setPartitionIndex(0)
-                        .setErrorCode(Errors.NONE.code())))));
+                        .setErrorCode(Errors.NONE.code())))).iterator()));
         data.setThrottleTimeMs(345);
         data.setErrorCode(Errors.NONE.code());
         return new ShareAcknowledgeResponse(data);

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -617,9 +617,9 @@ public class SharePartitionManagerTest {
         ShareFetchResponse resp2 = context2.updateAndGenerateResponseData(groupId, reqMetadata1.memberId(), respData2);
         assertEquals(Errors.NONE, resp2.error());
         assertEquals(1, resp2.data().responses().size());
-        assertEquals(barId, resp2.data().responses().get(0).topicId());
-        assertEquals(1, resp2.data().responses().get(0).partitions().size());
-        assertEquals(0, resp2.data().responses().get(0).partitions().get(0).partitionIndex());
+        assertEquals(barId, resp2.data().responses().stream().findFirst().get().topicId());
+        assertEquals(1, resp2.data().responses().stream().findFirst().get().partitions().size());
+        assertEquals(0, resp2.data().responses().stream().findFirst().get().partitions().get(0).partitionIndex());
         assertEquals(1, resp2.responseData(topicNames).size());
     }
 

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -3586,7 +3586,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
     val request = alterShareGroupOffsetsRequest
     val response = connectAndReceive[AlterShareGroupOffsetsResponse](request, listenerName = listenerName)
     assertEquals(1, response.data.responses.size)
-    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED.code, response.data.responses.get(0).partitions.get(0).errorCode, s"Unexpected response $response")
+    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED.code, response.data.responses.stream().findFirst().get().partitions.get(0).errorCode, s"Unexpected response $response")
   }
 
   private def sendAndReceiveFirstRegexHeartbeat(memberId: String,

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -725,9 +725,9 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
       .setGroupId(shareGroup)
       .setMemberId(Uuid.randomUuid().toString)
       .setShareSessionEpoch(1)
-      .setTopics(List(new ShareAcknowledgeRequestData.AcknowledgeTopic()
+      .setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic()
         .setTopicId(getTopicIds().getOrElse(tp.topic, Uuid.ZERO_UUID))
-        .setPartitions(List(
+        .setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(part)
             .setAcknowledgementBatches(List(
@@ -736,8 +736,8 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
                 .setLastOffset(1)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ).asJava)
-        ).asJava)
-      ).asJava)
+        ).iterator))
+      ).iterator))
 
     new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
   }
@@ -3261,7 +3261,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
 
     val request = createShareFetchRequest
     val response = connectAndReceive[ShareFetchResponse](request, listenerName = listenerName)
-    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED, Errors.forCode(response.data.responses.get(0).partitions.get(0).errorCode))
+    assertEquals(Errors.TOPIC_AUTHORIZATION_FAILED, Errors.forCode(response.data.responses.stream().findFirst().get().partitions.get(0).errorCode))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -13262,7 +13262,7 @@ class KafkaApisTest extends Logging {
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
 
     val alterShareGroupOffsetsResponse = new AlterShareGroupOffsetsResponseData()
-      .setResponses(List(
+      .setResponses(new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection(util.List.of(
         new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic()
           .setTopicName(topicName2)
           .setTopicId(topicId2)
@@ -13272,7 +13272,7 @@ class KafkaApisTest extends Logging {
               .setErrorCode(Errors.NONE.code())
               .setErrorMessage(Errors.NONE.message())
           ).asJava)
-      ).asJava)
+      ).iterator))
     resultFuture.complete(alterShareGroupOffsetsResponse)
     val response = verifyNoThrottling[AlterShareGroupOffsetsResponse](requestChannelRequest)
 
@@ -13281,9 +13281,9 @@ class KafkaApisTest extends Logging {
     assertEquals(2, response.errorCounts().get(Errors.TOPIC_AUTHORIZATION_FAILED))
     assertEquals(3, response.data().responses().size())
 
-    val bar = response.data().responses().get(0)
-    val foo = response.data().responses().get(1)
-    val zoo = response.data().responses().get(2)
+    val bar = response.data().responses().find("bar")
+    val foo = response.data().responses().find("foo")
+    val zoo = response.data().responses().find("zoo")
     assertEquals(topicName1, foo.topicName())
     assertEquals(topicId1, foo.topicId())
     assertEquals(topicName2, bar.topicName())

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4196,11 +4196,11 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(shareSessionEpoch).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(partitionIndex)))))
+            .setPartitionIndex(partitionIndex)).iterator))).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4212,12 +4212,13 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
   }
 
   @Test
@@ -4266,9 +4267,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -4277,8 +4278,8 @@ class KafkaApisTest extends Logging {
               .setLastOffset(9)
               .setAcknowledgeTypes(util.List.of(1.toByte))
           ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -4294,13 +4295,13 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -4311,12 +4312,13 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
   }
 
   @Test
@@ -4370,11 +4372,11 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -4386,20 +4388,21 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
 
     shareFetchRequestData = new ShareFetchRequestData().
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(-1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -4408,8 +4411,8 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -4446,11 +4449,11 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4510,9 +4513,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -4521,8 +4524,8 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4569,9 +4572,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -4580,8 +4583,8 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4627,11 +4630,11 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4643,12 +4646,13 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.REPLICA_NOT_AVAILABLE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records, topicResponses.get(0).partitions.get(0).records)
-    assertTrue(topicResponses.get(0).partitions.get(0).acquiredRecords.toArray().isEmpty)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.REPLICA_NOT_AVAILABLE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records, topicResponse.partitions.get(0).records)
+    assertTrue(topicResponse.partitions.get(0).acquiredRecords.toArray().isEmpty)
   }
 
   @Test
@@ -4691,11 +4695,11 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -4708,12 +4712,13 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
 
     val memberId2 = Uuid.randomUuid()
 
@@ -4722,11 +4727,11 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId2.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -4777,11 +4782,11 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -4794,22 +4799,23 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
 
     shareFetchRequestData = new ShareFetchRequestData().
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(2). // Invalid share session epoch, should have 1 for the second request.
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -4836,11 +4842,11 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(Uuid.randomUuid.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -4948,11 +4954,11 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(partitionIndex)))))
+            .setPartitionIndex(partitionIndex)).iterator))).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -4966,8 +4972,9 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
+    var topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
 
     compareResponsePartitions(
       partitionIndex,
@@ -4975,23 +4982,23 @@ class KafkaApisTest extends Logging {
       Errors.NONE.code,
       records1,
       expectedAcquiredRecords(0, 9, 1),
-      topicResponses.get(0).partitions.get(0)
+      topicResponse.partitions.get(0)
     )
 
     shareFetchRequestData = new ShareFetchRequestData().
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition().
             setPartitionIndex(partitionIndex).
             setAcknowledgementBatches(util.List.of(
               new ShareFetchRequestData.AcknowledgementBatch().
                 setFirstOffset(0).
                 setLastOffset(9).
-                setAcknowledgeTypes(util.List.of[java.lang.Byte](1.toByte))))))))
+                setAcknowledgeTypes(util.List.of[java.lang.Byte](1.toByte))))).iterator))).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -5003,8 +5010,9 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
+    topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
 
     compareResponsePartitions(
       partitionIndex,
@@ -5012,23 +5020,23 @@ class KafkaApisTest extends Logging {
       Errors.NONE.code,
       records2,
       expectedAcquiredRecords(10, 19, 1),
-      topicResponses.get(0).partitions.get(0)
+      topicResponse.partitions.get(0)
     )
 
     shareFetchRequestData = new ShareFetchRequestData().
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(2).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition().
             setPartitionIndex(partitionIndex).
             setAcknowledgementBatches(util.List.of(
               new ShareFetchRequestData.AcknowledgementBatch().
                 setFirstOffset(10).
                 setLastOffset(19).
-                setAcknowledgeTypes(util.List.of[java.lang.Byte](1.toByte))))))))
+                setAcknowledgeTypes(util.List.of[java.lang.Byte](1.toByte))))).iterator))).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -5040,8 +5048,9 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
+    topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
 
     compareResponsePartitions(
       partitionIndex,
@@ -5049,7 +5058,7 @@ class KafkaApisTest extends Logging {
       Errors.NONE.code,
       records3,
       expectedAcquiredRecords(20, 29, 1),
-      topicResponses.get(0).partitions.get(0)
+      topicResponse.partitions.get(0)
     )
   }
 
@@ -5255,24 +5264,24 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          ))
-      ))
+          ).iterator))
+      ).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -5349,14 +5358,14 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId3).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -5367,8 +5376,9 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId3, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId3, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
 
     compareResponsePartitions(
       0,
@@ -5376,21 +5386,21 @@ class KafkaApisTest extends Logging {
       Errors.NONE.code,
       records_t3_p1_1,
       expectedAcquiredRecords(54, 73, 1),
-      topicResponses.get(0).partitions.get(0)
+      topicResponse.partitions.get(0)
     )
 
     shareFetchRequestData = new ShareFetchRequestData().
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(2).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId4).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
       .setForgottenTopicsData(util.List.of(
         new ForgottenTopic()
           .setTopicId(topicId1)
@@ -5442,10 +5452,10 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(-1).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -5462,10 +5472,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(19)
                   .setAcknowledgeTypes(util.List.of(1.toByte)),
               ))
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -5482,10 +5492,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(26)
                   .setAcknowledgeTypes(util.List.of(1.toByte)),
               ))
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId3).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -5494,10 +5504,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(93)
                   .setAcknowledgeTypes(util.List.of(1.toByte)),
               )),
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId4).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -5506,8 +5516,8 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(24)
                   .setAcknowledgeTypes(util.List.of(1.toByte)),
               )),
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -5595,22 +5605,22 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(shareSessionEpoch).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -5728,22 +5738,22 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(shareSessionEpoch).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -5853,22 +5863,22 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(shareSessionEpoch).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -5994,28 +6004,28 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(shareSessionEpoch).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId3).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
-          )),
-      ))
+          ).iterator)),
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -6179,11 +6189,11 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
-            .setPartitionIndex(0)))))
+            .setPartitionIndex(0)).iterator))).iterator))
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
@@ -6195,20 +6205,21 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(records1, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    var topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(records1, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(0, 9, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
 
     shareFetchRequestData = new ShareFetchRequestData().
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -6217,8 +6228,8 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     request = buildRequest(shareFetchRequest)
@@ -6229,13 +6240,14 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).acknowledgeErrorCode)
-    assertEquals(records2, topicResponses.get(0).partitions.get(0).records)
-    assertArrayEquals(expectedAcquiredRecords(10, 19, 1).toArray(), topicResponses.get(0).partitions.get(0).acquiredRecords.toArray())
+    topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).acknowledgeErrorCode)
+    assertEquals(records2, topicResponse.partitions.get(0).records)
+    assertArrayEquals(expectedAcquiredRecords(10, 19, 1).toArray(), topicResponse.partitions.get(0).acquiredRecords.toArray())
   }
 
   @Test
@@ -6263,9 +6275,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -6274,8 +6286,8 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -6305,9 +6317,9 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6316,8 +6328,8 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))
-      ))
+        ).iterator))
+      ).iterator))
 
     val authorizer: Authorizer = mock(classOf[Authorizer])
     when(authorizer.authorize(any(), any())).thenReturn(util.List.of[AuthorizationResult](
@@ -6373,9 +6385,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(ShareRequestMetadata.FINAL_EPOCH).
-      setTopics(util.List.of(new ShareFetchRequestData.FetchTopic().
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(new ShareFetchRequestData.FetchTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
           new ShareFetchRequestData.FetchPartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -6384,7 +6396,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
@@ -6396,13 +6408,14 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).acknowledgeErrorCode)
-    assertEquals(MemoryRecords.EMPTY, topicResponses.get(0).partitions.get(0).records)
-    assertEquals(0, topicResponses.get(0).partitions.get(0).acquiredRecords.toArray().length)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).acknowledgeErrorCode)
+    assertEquals(MemoryRecords.EMPTY, topicResponse.partitions.get(0).records)
+    assertEquals(0, topicResponse.partitions.get(0).acquiredRecords.toArray().length)
   }
 
   @Test
@@ -6434,9 +6447,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6445,7 +6458,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6458,10 +6471,11 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
   }
 
   @Test
@@ -6489,9 +6503,9 @@ class KafkaApisTest extends Logging {
       .setGroupId(groupId)
       .setMemberId(memberId.toString)
       .setShareSessionEpoch(1)
-      .setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic()
+      .setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic()
         .setTopicId(topicId)
-        .setPartitions(util.List.of(
+        .setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -6500,7 +6514,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val request = buildRequest(shareAcknowledgeRequest)
@@ -6530,9 +6544,9 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6541,7 +6555,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val authorizer: Authorizer = mock(classOf[Authorizer])
     when(authorizer.authorize(any(), any())).thenReturn(util.List.of[AuthorizationResult](
@@ -6582,9 +6596,9 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6593,7 +6607,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6628,9 +6642,9 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6639,7 +6653,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6673,9 +6687,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6684,7 +6698,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(4) // end offset is less than base offset
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6698,10 +6712,11 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.INVALID_REQUEST.code, topicResponses.get(0).partitions.get(0).errorCode)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.INVALID_REQUEST.code, topicResponse.partitions.get(0).errorCode)
   }
 
   @Test
@@ -6743,9 +6758,9 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(0)
             .setAcknowledgementBatches(util.List.of(
@@ -6754,7 +6769,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(20)
                 .setAcknowledgeTypes(util.List.of(1.toByte,1.toByte,0.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte,1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6768,12 +6783,13 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, topicResponses.get(0).partitions.get(0).errorCode)
-    assertEquals(newLeaderId, topicResponses.get(0).partitions.get(0).currentLeader.leaderId)
-    assertEquals(newLeaderEpoch, topicResponses.get(0).partitions.get(0).currentLeader.leaderEpoch)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, topicResponse.partitions.get(0).errorCode)
+    assertEquals(newLeaderId, topicResponse.partitions.get(0).currentLeader.leaderId)
+    assertEquals(newLeaderEpoch, topicResponse.partitions.get(0).currentLeader.leaderEpoch)
     assertEquals(2, responseData.nodeEndpoints.asScala.head.nodeId)
   }
 
@@ -6801,9 +6817,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6812,7 +6828,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6863,9 +6879,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(ShareRequestMetadata.FINAL_EPOCH).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6874,7 +6890,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6887,10 +6903,11 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
   }
 
   @Test
@@ -6926,9 +6943,9 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(ShareRequestMetadata.FINAL_EPOCH).
-      setTopics(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(new ShareAcknowledgeRequestData.AcknowledgeTopic().
         setTopicId(topicId).
-        setPartitions(util.List.of(
+        setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
           new ShareAcknowledgeRequestData.AcknowledgePartition()
             .setPartitionIndex(partitionIndex)
             .setAcknowledgementBatches(util.List.of(
@@ -6937,7 +6954,7 @@ class KafkaApisTest extends Logging {
                 .setLastOffset(9)
                 .setAcknowledgeTypes(util.List.of(1.toByte))
             ))
-        ))))
+        ).iterator))).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
@@ -6950,10 +6967,11 @@ class KafkaApisTest extends Logging {
 
     assertEquals(Errors.NONE.code, responseData.errorCode)
     assertEquals(1, topicResponses.size())
-    assertEquals(topicId, topicResponses.get(0).topicId)
-    assertEquals(1, topicResponses.get(0).partitions.size())
-    assertEquals(partitionIndex, topicResponses.get(0).partitions.get(0).partitionIndex)
-    assertEquals(Errors.NONE.code, topicResponses.get(0).partitions.get(0).errorCode)
+    val topicResponse = topicResponses.stream.findFirst.get
+    assertEquals(topicId, topicResponse.topicId)
+    assertEquals(1, topicResponse.partitions.size())
+    assertEquals(partitionIndex, topicResponse.partitions.get(0).partitionIndex)
+    assertEquals(Errors.NONE.code, topicResponse.partitions.get(0).errorCode)
   }
 
   private def expectedAcquiredRecords(firstOffset: Long, lastOffset: Long, deliveryCount: Int): util.List[AcquiredRecords] = {
@@ -6974,10 +6992,10 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -6998,10 +7016,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(9)
                   .setAcknowledgeTypes(util.List.of(2.toByte))
               ))
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7012,8 +7030,8 @@ class KafkaApisTest extends Logging {
               )),
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(1)
-          ))
-      ))
+          ).iterator))
+      ).iterator))
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val topicNames = util.Map.of(topicId1, "foo1", topicId2, "foo2")
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
@@ -7041,10 +7059,10 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(
+      setTopics(new ShareFetchRequestData.FetchTopicCollection(util.List.of(
         new ShareFetchRequestData.FetchTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7061,10 +7079,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(9)
                   .setAcknowledgeTypes(util.List.of()) // wrong acknowledgement type here (can only be 0, 1, 2 or 3)
               ))
-          )),
+          ).iterator)),
         new ShareFetchRequestData.FetchTopic()
           .setTopicId(topicId2)
-          .setPartitions(util.List.of(
+          .setPartitions(new ShareFetchRequestData.FetchPartitionCollection(util.List.of(
             new ShareFetchRequestData.FetchPartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7073,8 +7091,8 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(65)
                   .setAcknowledgeTypes(util.List.of(3.toByte))
               ))
-          ))
-      ))
+          ).iterator))
+      ).iterator))
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val topicIdNames = util.Map.of(topicId1, "foo1") // topicId2 is not present in topicIdNames
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
@@ -7103,10 +7121,10 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7127,10 +7145,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(9)
                   .setAcknowledgeTypes(util.List.of(2.toByte))
               ))
-          )),
+          ).iterator)),
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7139,8 +7157,8 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(65)
                   .setAcknowledgeTypes(util.List.of(3.toByte))
               ))
-          ))
-      ))
+          ).iterator))
+      ).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val topicNames = util.Map.of(topicId1, "foo1", topicId2, "foo2")
@@ -7169,10 +7187,10 @@ class KafkaApisTest extends Logging {
       setGroupId("group").
       setMemberId(Uuid.randomUuid().toString).
       setShareSessionEpoch(0).
-      setTopics(util.List.of(
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7189,10 +7207,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(9)
                   .setAcknowledgeTypes(util.List.of) // wrong acknowledgement type here (can only be 0, 1, 2 or 3)
               ))
-          )),
+          ).iterator)),
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7201,8 +7219,8 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(65)
                   .setAcknowledgeTypes(util.List.of(3.toByte))
               ))
-          ))
-      ))
+          ).iterator))
+      ).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val topicIdNames = util.Map.of(topicId1, "foo1") // topicId2 not present in topicIdNames
@@ -7544,10 +7562,10 @@ class KafkaApisTest extends Logging {
       setGroupId(groupId).
       setMemberId(memberId.toString).
       setShareSessionEpoch(1).
-      setTopics(util.List.of(
+      setTopics(new ShareAcknowledgeRequestData.AcknowledgeTopicCollection(util.List.of(
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
           setTopicId(topicId1).
-          setPartitions(util.List.of(
+          setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7564,10 +7582,10 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(9)
                   .setAcknowledgeTypes(util.List.of(1.toByte))
               ))
-          )),
+          ).iterator)),
         new ShareAcknowledgeRequestData.AcknowledgeTopic().
           setTopicId(topicId2).
-          setPartitions(util.List.of(
+          setPartitions(new ShareAcknowledgeRequestData.AcknowledgePartitionCollection(util.List.of(
             new ShareAcknowledgeRequestData.AcknowledgePartition()
               .setPartitionIndex(0)
               .setAcknowledgementBatches(util.List.of(
@@ -7584,8 +7602,8 @@ class KafkaApisTest extends Logging {
                   .setLastOffset(9)
                   .setAcknowledgeTypes(util.List.of(1.toByte))
               ))
-          ))
-      ))
+          ).iterator))
+      ).iterator))
 
     val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData)
       .build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -197,8 +197,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -206,7 +206,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    val partitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val partitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
   }
 
@@ -272,10 +272,10 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
       assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
       assertEquals(1, shareFetchResponseData.responses().size())
-      val partitionsCount = shareFetchResponseData.responses().get(0).partitions().size()
+      val partitionsCount = shareFetchResponseData.responses().stream().findFirst().get().partitions().size()
       if (partitionsCount > 0) {
-        assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-        shareFetchResponseData.responses().get(0).partitions().asScala.foreach(partitionData => {
+        assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+        shareFetchResponseData.responses().stream().findFirst().get().partitions().asScala.foreach(partitionData => {
           if (!partitionData.acquiredRecords().isEmpty) {
             responses = responses :+ partitionData
           }
@@ -393,24 +393,24 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData1.errorCode)
     assertEquals(30000, shareFetchResponseData1.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData1.responses().size())
-    assertEquals(topicId, shareFetchResponseData1.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData1.responses().get(0).partitions().size())
-    val partitionData1 = shareFetchResponseData1.responses().get(0).partitions().get(0)
+    assertEquals(topicId, shareFetchResponseData1.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData1.responses().stream().findFirst().get().partitions().size())
+    val partitionData1 = shareFetchResponseData1.responses().stream().findFirst().get().partitions().get(0)
 
     val shareFetchResponseData2 = shareFetchResponse2.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData2.errorCode)
     assertEquals(30000, shareFetchResponseData2.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData2.responses().size())
-    assertEquals(topicId, shareFetchResponseData2.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData2.responses().get(0).partitions().size())
-    val partitionData2 = shareFetchResponseData2.responses().get(0).partitions().get(0)
+    assertEquals(topicId, shareFetchResponseData2.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData2.responses().stream().findFirst().get().partitions().size())
+    val partitionData2 = shareFetchResponseData2.responses().stream().findFirst().get().partitions().get(0)
 
     val shareFetchResponseData3 = shareFetchResponse3.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData3.errorCode)
     assertEquals(1, shareFetchResponseData3.responses().size())
-    assertEquals(topicId, shareFetchResponseData3.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData3.responses().get(0).partitions().size())
-    val partitionData3 = shareFetchResponseData3.responses().get(0).partitions().get(0)
+    assertEquals(topicId, shareFetchResponseData3.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData3.responses().stream().findFirst().get().partitions().size())
+    val partitionData3 = shareFetchResponseData3.responses().stream().findFirst().get().partitions().get(0)
 
     val expectedPartitionData1 = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(0)
@@ -491,8 +491,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -500,7 +500,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Send a Share Acknowledge request to acknowledge the fetched records
@@ -517,14 +517,14 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val shareAcknowledgeResponseData = shareAcknowledgeResponse.data()
     assertEquals(Errors.NONE.code, shareAcknowledgeResponseData.errorCode)
     assertEquals(1, shareAcknowledgeResponseData.responses().size())
-    assertEquals(topicId, shareAcknowledgeResponseData.responses().get(0).topicId())
-    assertEquals(1, shareAcknowledgeResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareAcknowledgeResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedAcknowledgePartitionData = new ShareAcknowledgeResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
 
-    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().get(0).partitions().get(0)
+    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareAcknowledgeResponsePartitions(expectedAcknowledgePartitionData, acknowledgePartitionData)
 
     // Producing 10 more records to the topic
@@ -540,8 +540,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -549,7 +549,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // Only the records from offset 10 onwards should be fetched because records at offsets 0-9 have been acknowledged
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
   }
 
@@ -611,8 +611,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(15000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -620,7 +620,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic created above
@@ -640,8 +640,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(15000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -649,7 +649,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // The records at offsets 0 to 9 will not be re fetched because they have been acknowledged
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic
@@ -665,8 +665,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(15000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -674,7 +674,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(20), Collections.singletonList(29), Collections.singletonList(1))) // Only the records from offset 20 onwards should be fetched because records at offsets 0-9 have been acknowledged before and 10 to 19 are currently acquired
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
   }
 
@@ -734,8 +734,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -743,7 +743,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Send a Share Acknowledge request to acknowledge the fetched records
@@ -760,14 +760,14 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val shareAcknowledgeResponseData = shareAcknowledgeResponse.data()
     assertEquals(Errors.NONE.code, shareAcknowledgeResponseData.errorCode)
     assertEquals(1, shareAcknowledgeResponseData.responses().size())
-    assertEquals(topicId, shareAcknowledgeResponseData.responses().get(0).topicId())
-    assertEquals(1, shareAcknowledgeResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareAcknowledgeResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedAcknowledgePartitionData = new ShareAcknowledgeResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
 
-    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().get(0).partitions().get(0)
+    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareAcknowledgeResponsePartitions(expectedAcknowledgePartitionData, acknowledgePartitionData)
 
     // Sending a third share fetch request to check if acknowledgements were done successfully
@@ -780,8 +780,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -789,7 +789,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(2))) // Records at offsets 0 to 9 should be fetched again because they were released with delivery count as 2
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
   }
 
@@ -849,8 +849,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -858,7 +858,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    val fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic created above
@@ -894,10 +894,10 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
       assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
       assertEquals(1, shareFetchResponseData.responses().size())
-      assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-      val responseSize = shareFetchResponseData.responses().get(0).partitions().size()
+      assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+      val responseSize = shareFetchResponseData.responses().stream().findFirst().get().partitions().size()
       if (responseSize > 0) {
-        acquiredRecords.addAll(shareFetchResponseData.responses().get(0).partitions().get(0).acquiredRecords())
+        acquiredRecords.addAll(shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0).acquiredRecords())
       }
       // There should be 2 acquired record batches finally -
       // 1. batch containing 0-9 offsets which were initially acknowledged as RELEASED.
@@ -968,8 +968,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -977,7 +977,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Send a Share Acknowledge request to acknowledge the fetched records
@@ -994,14 +994,14 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val shareAcknowledgeResponseData = shareAcknowledgeResponse.data()
     assertEquals(Errors.NONE.code, shareAcknowledgeResponseData.errorCode)
     assertEquals(1, shareAcknowledgeResponseData.responses().size())
-    assertEquals(topicId, shareAcknowledgeResponseData.responses().get(0).topicId())
-    assertEquals(1, shareAcknowledgeResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareAcknowledgeResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedAcknowledgePartitionData = new ShareAcknowledgeResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
 
-    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().get(0).partitions().get(0)
+    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareAcknowledgeResponsePartitions(expectedAcknowledgePartitionData, acknowledgePartitionData)
 
     // Producing 10 more records to the topic
@@ -1017,8 +1017,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1026,7 +1026,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // Only the records from offset 10 onwards should be fetched because records at offsets 0-9 have been rejected
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
   }
 
@@ -1086,8 +1086,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1095,7 +1095,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic created above
@@ -1115,8 +1115,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1124,7 +1124,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // The records at offsets 0 to 9 will not be re fetched because they have been rejected
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic
@@ -1140,8 +1140,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1149,7 +1149,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(20), Collections.singletonList(29), Collections.singletonList(1))) // Only the records from offset 20 onwards should be fetched because records at offsets 0-9 have been rejected before and 10 to 19 are currently acquired
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
   }
 
@@ -1211,8 +1211,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1220,7 +1220,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Send a Share Acknowledge request to acknowledge the fetched records
@@ -1237,14 +1237,14 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     var shareAcknowledgeResponseData = shareAcknowledgeResponse.data()
     assertEquals(Errors.NONE.code, shareAcknowledgeResponseData.errorCode)
     assertEquals(1, shareAcknowledgeResponseData.responses().size())
-    assertEquals(topicId, shareAcknowledgeResponseData.responses().get(0).topicId())
-    assertEquals(1, shareAcknowledgeResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareAcknowledgeResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedAcknowledgePartitionData = new ShareAcknowledgeResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
 
-    var acknowledgePartitionData = shareAcknowledgeResponseData.responses().get(0).partitions().get(0)
+    var acknowledgePartitionData = shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareAcknowledgeResponsePartitions(expectedAcknowledgePartitionData, acknowledgePartitionData)
 
     // Sending a third share fetch request to check if acknowledgements were done successfully
@@ -1257,8 +1257,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1266,7 +1266,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(2))) // Records at offsets 0 to 9 should be fetched again because they were released with delivery count as 2
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Send a Share Acknowledge request to acknowledge the fetched records
@@ -1282,14 +1282,14 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     shareAcknowledgeResponseData = shareAcknowledgeResponse.data()
     assertEquals(Errors.NONE.code, shareAcknowledgeResponseData.errorCode)
     assertEquals(1, shareAcknowledgeResponseData.responses().size())
-    assertEquals(topicId, shareAcknowledgeResponseData.responses().get(0).topicId())
-    assertEquals(1, shareAcknowledgeResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareAcknowledgeResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedAcknowledgePartitionData = new ShareAcknowledgeResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
 
-    acknowledgePartitionData = shareAcknowledgeResponseData.responses().get(0).partitions().get(0)
+    acknowledgePartitionData = shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareAcknowledgeResponsePartitions(expectedAcknowledgePartitionData, acknowledgePartitionData)
 
     // Producing 10 new records to the topic
@@ -1305,8 +1305,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1314,7 +1314,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // Only new records from offset 10 to 19 will be fetched, records at offsets 0 to 9 have been archived because delivery count limit has been exceeded
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
   }
 
@@ -1392,26 +1392,26 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val shareFetchResponseData1 = shareFetchResponse1.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData1.errorCode)
     assertEquals(1, shareFetchResponseData1.responses().size())
-    assertEquals(topicId, shareFetchResponseData1.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData1.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData1.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData1.responses().stream().findFirst().get().partitions().size())
 
-    val partitionData1 = shareFetchResponseData1.responses().get(0).partitions().get(0)
+    val partitionData1 = shareFetchResponseData1.responses().stream().findFirst().get().partitions().get(0)
 
     val shareFetchResponseData2 = shareFetchResponse2.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData2.errorCode)
     assertEquals(1, shareFetchResponseData2.responses().size())
-    assertEquals(topicId, shareFetchResponseData2.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData2.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData2.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData2.responses().stream().findFirst().get().partitions().size())
 
-    val partitionData2 = shareFetchResponseData2.responses().get(0).partitions().get(0)
+    val partitionData2 = shareFetchResponseData2.responses().stream().findFirst().get().partitions().get(0)
 
     val shareFetchResponseData3 = shareFetchResponse3.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData3.errorCode)
     assertEquals(1, shareFetchResponseData3.responses().size())
-    assertEquals(topicId, shareFetchResponseData3.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData3.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData3.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData3.responses().stream().findFirst().get().partitions().size())
 
-    val partitionData3 = shareFetchResponseData3.responses().get(0).partitions().get(0)
+    val partitionData3 = shareFetchResponseData3.responses().stream().findFirst().get().partitions().get(0)
 
     // There should be no common records between the 3 consumers as they are part of the same group
     assertTrue(partitionData1.acquiredRecords().get(0).lastOffset() < partitionData2.acquiredRecords().get(0).firstOffset())
@@ -1496,26 +1496,26 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val shareFetchResponseData1 = shareFetchResponse1.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData1.errorCode)
     assertEquals(1, shareFetchResponseData1.responses().size())
-    assertEquals(topicId, shareFetchResponseData1.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData1.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData1.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData1.responses().stream().findFirst().get().partitions().size())
 
-    val partitionData1 = shareFetchResponseData1.responses().get(0).partitions().get(0)
+    val partitionData1 = shareFetchResponseData1.responses().stream().findFirst().get().partitions().get(0)
 
     val shareFetchResponseData2 = shareFetchResponse2.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData2.errorCode)
     assertEquals(1, shareFetchResponseData2.responses().size())
-    assertEquals(topicId, shareFetchResponseData2.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData2.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData2.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData2.responses().stream().findFirst().get().partitions().size())
 
-    val partitionData2 = shareFetchResponseData2.responses().get(0).partitions().get(0)
+    val partitionData2 = shareFetchResponseData2.responses().stream().findFirst().get().partitions().get(0)
 
     val shareFetchResponseData3 = shareFetchResponse3.data()
     assertEquals(Errors.NONE.code, shareFetchResponseData3.errorCode)
     assertEquals(1, shareFetchResponseData3.responses().size())
-    assertEquals(topicId, shareFetchResponseData3.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData3.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData3.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData3.responses().stream().findFirst().get().partitions().size())
 
-    val partitionData3 = shareFetchResponseData3.responses().get(0).partitions().get(0)
+    val partitionData3 = shareFetchResponseData3.responses().stream().findFirst().get().partitions().get(0)
 
     // All the consumers should consume all the records since they are part of different groups
     assertEquals(partitionData1.acquiredRecords(), expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
@@ -1579,8 +1579,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1588,7 +1588,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic created above
@@ -1608,8 +1608,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1617,7 +1617,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // The records at offsets 0 to 9 will not be re fetched because they have been acknowledged
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Sending a final fetch request to close the session
@@ -1692,8 +1692,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     var expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1701,7 +1701,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    var fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    var fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Producing 10 more records to the topic created above
@@ -1721,8 +1721,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     expectedFetchPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1730,7 +1730,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1))) // The records at offsets 0 to 9 will not be re fetched because they have been acknowledged
 
-    fetchPartitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    fetchPartitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedFetchPartitionData, fetchPartitionData)
 
     // Sending a Share Acknowledge request to close the session
@@ -1747,14 +1747,14 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val shareAcknowledgeResponseData = shareAcknowledgeResponse.data()
     assertEquals(Errors.NONE.code, shareAcknowledgeResponseData.errorCode)
     assertEquals(1, shareAcknowledgeResponseData.responses().size())
-    assertEquals(topicId, shareAcknowledgeResponseData.responses().get(0).topicId())
-    assertEquals(1, shareAcknowledgeResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareAcknowledgeResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedAcknowledgePartitionData = new ShareAcknowledgeResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
 
-    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().get(0).partitions().get(0)
+    val acknowledgePartitionData = shareAcknowledgeResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareAcknowledgeResponsePartitions(expectedAcknowledgePartitionData, acknowledgePartitionData)
   }
 
@@ -1915,8 +1915,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -1924,7 +1924,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    val partitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val partitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
 
     // Sending a thord Share Fetch request with invalid share session epoch
@@ -1992,8 +1992,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -2001,7 +2001,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    val partitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val partitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
 
     // Sending Share Acknowledge request with invalid share session epoch
@@ -2075,16 +2075,15 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
-
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
       .setErrorCode(Errors.NONE.code())
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    val partitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val partitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
 
     // Sending a third Share Fetch request with wrong member Id
@@ -2241,8 +2240,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -2250,7 +2249,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(0), Collections.singletonList(9), Collections.singletonList(1)))
 
-    val partitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val partitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
 
     // Sending a Share Acknowledge request with wrong member Id
@@ -2331,10 +2330,10 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
       assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
       assertEquals(1, shareFetchResponseData.responses().size())
-      val partitionsCount = shareFetchResponseData.responses().get(0).partitions().size()
+      val partitionsCount = shareFetchResponseData.responses().stream().findFirst().get().partitions().size()
       if (partitionsCount > 0) {
-        assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-        shareFetchResponseData.responses().get(0).partitions().asScala.foreach(partitionData => {
+        assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+        shareFetchResponseData.responses().stream().findFirst().get().partitions().asScala.foreach(partitionData => {
           if (!partitionData.acquiredRecords().isEmpty) {
             responses = responses :+ partitionData
           }
@@ -2358,8 +2357,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses().size())
-    assertEquals(topicId, shareFetchResponseData.responses().get(0).topicId())
-    assertEquals(1, shareFetchResponseData.responses().get(0).partitions().size())
+    assertEquals(topicId, shareFetchResponseData.responses().stream().findFirst().get().topicId())
+    assertEquals(1, shareFetchResponseData.responses().stream().findFirst().get().partitions().size())
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition2)
@@ -2367,7 +2366,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code())
       .setAcquiredRecords(expectedAcquiredRecords(Collections.singletonList(10), Collections.singletonList(19), Collections.singletonList(1)))
 
-    val partitionData = shareFetchResponseData.responses().get(0).partitions().get(0)
+    val partitionData = shareFetchResponseData.responses().stream().findFirst().get().partitions().get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
   }
 
@@ -2425,8 +2424,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses.size)
-    assertEquals(topicId, shareFetchResponseData.responses.get(0).topicId)
-    assertEquals(1, shareFetchResponseData.responses.get(0).partitions.size)
+    assertEquals(topicId, shareFetchResponseData.responses.stream().findFirst().get().topicId)
+    assertEquals(1, shareFetchResponseData.responses.stream().findFirst().get().partitions.size)
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -2434,7 +2433,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code)
       .setAcquiredRecords(expectedAcquiredRecords(util.List.of(0), util.List.of(0), util.List.of(1)))
 
-    val partitionData = shareFetchResponseData.responses.get(0).partitions.get(0)
+    val partitionData = shareFetchResponseData.responses.stream().findFirst().get().partitions.get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
   }
 
@@ -2492,8 +2491,8 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     assertEquals(Errors.NONE.code, shareFetchResponseData.errorCode)
     assertEquals(30000, shareFetchResponseData.acquisitionLockTimeoutMs)
     assertEquals(1, shareFetchResponseData.responses.size)
-    assertEquals(topicId, shareFetchResponseData.responses.get(0).topicId)
-    assertEquals(1, shareFetchResponseData.responses.get(0).partitions.size)
+    assertEquals(topicId, shareFetchResponseData.responses.stream().findFirst().get().topicId)
+    assertEquals(1, shareFetchResponseData.responses.stream().findFirst().get().partitions.size)
 
     val expectedPartitionData = new ShareFetchResponseData.PartitionData()
       .setPartitionIndex(partition)
@@ -2501,7 +2500,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
       .setAcknowledgeErrorCode(Errors.NONE.code)
       .setAcquiredRecords(expectedAcquiredRecords(util.List.of(0, 1, 2, 3, 4), util.List.of(0, 1, 2, 3, 4), util.List.of(1, 1, 1, 1, 1)))
 
-    val partitionData = shareFetchResponseData.responses.get(0).partitions.get(0)
+    val partitionData = shareFetchResponseData.responses.stream().findFirst().get().partitions.get(0)
     compareFetchResponsePartitions(expectedPartitionData, partitionData)
   }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -702,7 +702,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             .setErrorMessage(error.message())
             .setResponses(response.responses());
         data.setResponses(
-            response.responses().stream()
+            new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection(response.responses().stream()
                 .map(topic -> {
                     AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic topicData = new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic()
                         .setTopicName(topic.topicName());
@@ -715,7 +715,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     });
                     return topicData;
                 })
-                .collect(Collectors.toList()));
+                .iterator()));
         // don't uninitialized share group state here, as we regard this alter share group offsets request failed.
         return data;
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8107,7 +8107,7 @@ public class GroupMetadataManager {
     ) {
         final long currentTimeMs = time.milliseconds();
         Group group = groups.get(groupId);
-        List<AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic> alterShareGroupOffsetsResponseTopics = new ArrayList<>();
+        AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection alterShareGroupOffsetsResponseTopics = new AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopicCollection();
 
         Map<Uuid, InitMapValue> initializingTopics = new HashMap<>();
         Map<Uuid, Map<Integer, Long>> offsetByTopicPartitions = new HashMap<>();


### PR DESCRIPTION
The mapKey optimisation can be used in some KIP-932 RPC schemas to
improve efficiency of some key-based accesses.

* AlterShareGroupOffsetsResponse
* ShareFetchRequest
* ShareFetchResponse
* ShareAcknowledgeRequest
* ShareAcknowledgeResponse

Reviewers: Andrew Schofield <aschofield@confluent.io>
