### PR TITLE
MINOR: Remove flakiness caused when producing aborted transaction in ShareConsumerTest

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -2623,8 +2623,9 @@ public class ShareConsumerTest {
         try {
             transactionalProducer.beginTransaction();
             ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp.topic(), tp.partition(), null, message.getBytes(), message.getBytes());
-            transactionalProducer.send(record);
+            Future<RecordMetadata> future = transactionalProducer.send(record);
             transactionalProducer.flush();
+            future.get(); // Ensure producer send is complete before aborting
             transactionalProducer.abortTransaction();
         } catch (Exception e) {
             transactionalProducer.abortTransaction();


### PR DESCRIPTION
### About
This PR attempts to removed the flakiness in
`testAlterReadCommittedToReadUncommittedIsolationLevelWithReleaseAck`
and `testAlterReadCommittedToReadUncommittedIsolationLevelWithRejectAck`
([link](https://develocity.apache.org/scans/tests?search.names=CI%20workflow%2CGit%20repository&search.relativeStartTime=P28D&search.rootProjectNames=kafka&search.tags=github%2Ctrunk&search.tasks=test&search.timeZoneId=Asia%2FCalcutta&search.values=CI%2Chttps:%2F%2Fgithub.com%2Fapache%2Fkafka&tests.container=org.apache.kafka.clients.consumer.ShareConsumerTest&tests.test=testAlterReadCommittedToReadUncommittedIsolationLevelWithReleaseAck()%5B2%5D)).
This flakiness could potentially be caused because we were not ensuring
that the aborted transaction record produce happened. In this PR, I have
added a blocking call to make sure the produce future completes before
we abort the transaction.

### Testing
The fix was tested locally by running the tests

Reviewers: Andrew Schofield <aschofield@confluent.io>
