### PR TITLE
MINOR: fixing updateBrokerContactTime

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/QuorumControllerMetrics.java
@@ -267,11 +267,9 @@ public class QuorumControllerMetrics implements AutoCloseable {
     }
 
     public void updateBrokerContactTime(int brokerId) {
-        if (!brokerContactTimesMs.containsKey(brokerId)) {
-            brokerContactTimesMs.put(brokerId, new AtomicLong(time.milliseconds()));
-        } else {
-            brokerContactTimesMs.get(brokerId).set(time.milliseconds());
-        }
+        long currentTimeMs = time.milliseconds();
+        brokerContactTimesMs.computeIfAbsent(brokerId, id -> new AtomicLong(currentTimeMs))
+            .set(currentTimeMs);
     }
 
     public int timeSinceLastHeartbeatMs(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/QuorumControllerMetrics.java
@@ -267,9 +267,8 @@ public class QuorumControllerMetrics implements AutoCloseable {
     }
 
     public void updateBrokerContactTime(int brokerId) {
-        long currentTimeMs = time.milliseconds();
-        brokerContactTimesMs.computeIfAbsent(brokerId, id -> new AtomicLong(currentTimeMs))
-            .set(currentTimeMs);
+        AtomicLong contactTime = brokerContactTimesMs.computeIfAbsent(brokerId, k -> new AtomicLong());
+        contactTime.set(time.milliseconds());
     }
 
     public int timeSinceLastHeartbeatMs(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/QuorumControllerMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/QuorumControllerMetrics.java
@@ -267,7 +267,11 @@ public class QuorumControllerMetrics implements AutoCloseable {
     }
 
     public void updateBrokerContactTime(int brokerId) {
-        brokerContactTimesMs.putIfAbsent(brokerId, new AtomicLong(time.milliseconds()));
+        if (!brokerContactTimesMs.containsKey(brokerId)) {
+            brokerContactTimesMs.put(brokerId, new AtomicLong(time.milliseconds()));
+        } else {
+            brokerContactTimesMs.get(brokerId).set(time.milliseconds());
+        }
     }
 
     public int timeSinceLastHeartbeatMs(int brokerId) {

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/QuorumControllerMetricsTest.java
@@ -179,6 +179,8 @@ public class QuorumControllerMetricsTest {
             metrics.updateBrokerContactTime(brokerId);
             time.sleep(1000);
             assertEquals(1000, timeSinceLastHeartbeatReceivedMs.value());
+            metrics.updateBrokerContactTime(brokerId);
+            assertEquals(0, timeSinceLastHeartbeatReceivedMs.value());
             time.sleep(100000);
             assertEquals(sessionTimeoutMs, timeSinceLastHeartbeatReceivedMs.value());
             metrics.removeTimeSinceLastHeartbeatMetrics();


### PR DESCRIPTION
Fix `updateBrokerContactTime` so that existing brokers still have their
contact time updated when they are already tracked. Also, update the
unit test to test this case.

Reviewers: Kuan-Po Tseng <brandboat@gmail.com>, Yung
 <yungyung7654321@gmail.com>, TengYao Chi <frankvicky@apache.org>, Ken
 Huang <s7133700@gmail.com>
