### PR TITLE
MINOR: Improve share coordinator record schemas

### DIFF
--- a/share-coordinator/src/main/resources/common/message/ShareSnapshotKey.json
+++ b/share-coordinator/src/main/resources/common/message/ShareSnapshotKey.json
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
-
 {
   "apiKey": 0,
   "type": "coordinator-key",

--- a/share-coordinator/src/main/resources/common/message/ShareSnapshotValue.json
+++ b/share-coordinator/src/main/resources/common/message/ShareSnapshotValue.json
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
-
 {
   "apiKey": 0,
   "type": "coordinator-value",
@@ -22,27 +20,27 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "SnapshotEpoch", "type": "uint16", "versions": "0",
+    { "name": "SnapshotEpoch", "type": "uint16", "versions": "0+",
       "about": "The snapshot epoch." },
     { "name": "StateEpoch", "type": "int32", "versions": "0+",
       "about": "The state epoch for this share-partition." },
     { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
       "about": "The leader epoch of the share-partition." },
-    { "name": "StartOffset", "type": "int64", "versions": "0",
+    { "name": "StartOffset", "type": "int64", "versions": "0+",
       "about": "The share-partition start offset." },
-    { "name": "CreateTimestamp", "type": "int64", "versions": "0",
+    { "name": "CreateTimestamp", "type": "int64", "versions": "0+",
       "about": "The time at which the state was created." },
-    { "name": "WriteTimestamp", "type": "int64", "versions": "0",
+    { "name": "WriteTimestamp", "type": "int64", "versions": "0+",
       "about": "The time at which the state was written or rewritten." },
-    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0",
+    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+",
       "about": "The state batches.", "fields": [
-      { "name": "FirstOffset", "type": "int64", "versions": "0",
+      { "name": "FirstOffset", "type": "int64", "versions": "0+",
         "about": "The first offset of this state batch." },
-      { "name": "LastOffset", "type": "int64", "versions": "0",
+      { "name": "LastOffset", "type": "int64", "versions": "0+",
         "about": "The last offset of this state batch." },
-      { "name": "DeliveryState", "type": "int8", "versions": "0",
+      { "name": "DeliveryState", "type": "int8", "versions": "0+",
         "about": "The delivery state - 0:Available,2:Acked,4:Archived." },
-      { "name": "DeliveryCount", "type": "int16", "versions": "0",
+      { "name": "DeliveryCount", "type": "int16", "versions": "0+",
         "about": "The delivery count." }
     ]}
   ]

--- a/share-coordinator/src/main/resources/common/message/ShareUpdateKey.json
+++ b/share-coordinator/src/main/resources/common/message/ShareUpdateKey.json
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
-
 {
   "apiKey": 1,
   "type": "coordinator-key",

--- a/share-coordinator/src/main/resources/common/message/ShareUpdateValue.json
+++ b/share-coordinator/src/main/resources/common/message/ShareUpdateValue.json
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
-
 {
   "apiKey": 1,
   "type": "coordinator-value",
@@ -22,21 +20,21 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "SnapshotEpoch", "type": "uint16", "versions": "0",
+    { "name": "SnapshotEpoch", "type": "uint16", "versions": "0+",
       "about": "The snapshot epoch." },
     { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
       "about": "The leader epoch of the share-partition." },
-    { "name": "StartOffset", "type": "int64", "versions": "0",
+    { "name": "StartOffset", "type": "int64", "versions": "0+",
       "about": "The share-partition start offset, or -1 if the start offset is not being updated." },
-    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0",
+    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+",
       "about": "The state batches that have been updated.", "fields": [
-      { "name": "FirstOffset", "type": "int64", "versions": "0",
+      { "name": "FirstOffset", "type": "int64", "versions": "0+",
         "about": "The first offset of this state batch." },
-      { "name": "LastOffset", "type": "int64", "versions": "0",
+      { "name": "LastOffset", "type": "int64", "versions": "0+",
         "about": "The last offset of this state batch." },
-      { "name": "DeliveryState", "type": "int8", "versions": "0",
+      { "name": "DeliveryState", "type": "int8", "versions": "0+",
         "about": "The delivery state - 0:Available,2:Acked,4:Archived." },
-      { "name": "DeliveryCount", "type": "int16", "versions": "0",
+      { "name": "DeliveryCount", "type": "int16", "versions": "0+",
         "about": "The delivery count." }
     ]}
   ]


### PR DESCRIPTION
This PR makes some very small improvements to the record schemas for the
share coordinator.

* It removes the health warnings about incompatible changes. All changes
are compatible now.
* It marks the fields in the values as version 0+, in common with all
other record schemas in Kafka.
Many were already 0+, so this just corrects the outliers.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Sushant Mahajan
 <smahajan@confluent.io>
