### PR TITLE
KAFKA-16894: share.version becomes stable feature for preview

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
@@ -24,12 +24,12 @@ public enum ShareVersion implements FeatureVersion {
     SV_0(0, MetadataVersion.MINIMUM_VERSION, Map.of()),
 
     // Version 1 enables share groups (KIP-932).
-    // This is a preview in 4.1, and production-ready in 4.2.
+    // This is a preview in 4.1, and expected to be production-ready in 4.2.
     SV_1(1, MetadataVersion.IBP_4_2_IV0, Map.of());
 
     public static final String FEATURE_NAME = "share.version";
 
-    public static final ShareVersion LATEST_PRODUCTION = SV_0;
+    public static final ShareVersion LATEST_PRODUCTION = SV_1;
 
     private final short featureLevel;
     private final MetadataVersion bootstrapMetadataVersion;


### PR DESCRIPTION
This PR sets `SV_1` as the latest-production share version. This means
for AK 4.1 it will be a preview feature, not enabled by default, but can
be enabled without turning on unstable features. This is analogous to
how ELR worked for AK 4.0.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
