### PR TITLE
KAFKA-19336 Upgrade Jackson to 2.19.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -213,16 +213,16 @@ License Version 2.0:
 - commons-logging-1.3.2
 - commons-validator-1.9.0
 - hash4j-0.22.0
-- jackson-annotations-2.16.2
-- jackson-core-2.16.2
-- jackson-databind-2.16.2
-- jackson-dataformat-csv-2.16.2
-- jackson-dataformat-yaml-2.16.2
-- jackson-datatype-jdk8-2.16.2
-- jackson-jakarta-rs-base-2.16.2
-- jackson-jakarta-rs-json-provider-2.16.2
-- jackson-module-blackbird-2.16.2
-- jackson-module-jakarta-xmlbind-annotations-2.16.2
+- jackson-annotations-2.19.0
+- jackson-core-2.19.0
+- jackson-databind-2.19.0
+- jackson-dataformat-csv-2.19.0
+- jackson-dataformat-yaml-2.19.0
+- jackson-datatype-jdk8-2.19.0
+- jackson-jakarta-rs-base-2.19.0
+- jackson-jakarta-rs-json-provider-2.19.0
+- jackson-module-blackbird-2.19.0
+- jackson-module-jakarta-xmlbind-annotations-2.19.0
 - jakarta.inject-api-2.0.1
 - jakarta.validation-api-3.0.2
 - javassist-3.29.2-GA
@@ -251,7 +251,7 @@ License Version 2.0:
 - scala-logging_2.13-3.9.5
 - scala-reflect-2.13.16
 - snappy-java-1.1.10.5
-- snakeyaml-2.2
+- snakeyaml-2.4
 - swagger-annotations-2.2.25
 
 ===============================================================================

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJws.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJws.java
@@ -30,7 +30,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -299,8 +298,7 @@ public class OAuthBearerUnsecuredJws implements OAuthBearerToken {
             JsonNode jsonNode = new ObjectMapper().readTree(decode);
             if (jsonNode == null)
                 throw new OAuthBearerIllegalTokenException(OAuthBearerValidationResult.newFailure("malformed JSON"));
-            for (Iterator<Entry<String, JsonNode>> iterator = jsonNode.fields(); iterator.hasNext();) {
-                Entry<String, JsonNode> entry = iterator.next();
+            for (Entry<String, JsonNode> entry : jsonNode.properties()) {
                 retval.put(entry.getKey(), convert(entry.getValue()));
             }
             return Collections.unmodifiableMap(retval);

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -53,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -103,9 +102,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
             if (schema == null || keySchema.type() == Schema.Type.STRING) {
                 if (!value.isObject())
                     throw new DataException("Maps with string fields should be encoded as JSON objects, but found " + value.getNodeType());
-                Iterator<Map.Entry<String, JsonNode>> fieldIt = value.fields();
-                while (fieldIt.hasNext()) {
-                    Map.Entry<String, JsonNode> entry = fieldIt.next();
+                for (Map.Entry<String, JsonNode> entry : value.properties()) {
                     result.put(entry.getKey(), convertToConnect(valueSchema, entry.getValue(), config));
                 }
             } else {
@@ -540,9 +537,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
 
         JsonNode schemaParamsNode = jsonSchema.get(JsonSchema.SCHEMA_PARAMETERS_FIELD_NAME);
         if (schemaParamsNode != null && schemaParamsNode.isObject()) {
-            Iterator<Map.Entry<String, JsonNode>> paramsIt = schemaParamsNode.fields();
-            while (paramsIt.hasNext()) {
-                Map.Entry<String, JsonNode> entry = paramsIt.next();
+            for (Map.Entry<String, JsonNode> entry : schemaParamsNode.properties()) {
                 JsonNode paramValue = entry.getValue();
                 if (!paramValue.isTextual())
                     throw new DataException("Schema parameters must have string values.");

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,7 +62,7 @@ versions += [
   gradle: "8.14.1",
   grgit: "4.1.1",
   httpclient: "4.5.14",
-  jackson: "2.16.2",
+  jackson: "2.19.0",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "12.0.15",

--- a/server-common/src/main/java/org/apache/kafka/server/util/json/DecodeJson.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/json/DecodeJson.java
@@ -114,10 +114,8 @@ public interface DecodeJson<T> {
         return node -> {
             if (node.isObject()) {
                 Map<String, V> result = new HashMap<>();
-                Iterator<Map.Entry<String, JsonNode>> elements = node.fields();
-                while (elements.hasNext()) {
-                    Map.Entry<String, JsonNode> next = elements.next();
-                    result.put(next.getKey(), decodeJson.decode(next.getValue()));
+                for (Map.Entry<String, JsonNode> entry : node.properties()) {
+                    result.put(entry.getKey(), decodeJson.decode(entry.getValue()));
                 }
                 return result;
             }

--- a/server-common/src/main/java/org/apache/kafka/server/util/json/JsonObject.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/json/JsonObject.java
@@ -52,7 +52,7 @@ public class JsonObject implements JsonValue {
     }
 
     public Iterator<Map.Entry<String, JsonValue>> iterator() {
-        Iterator<Map.Entry<String, JsonNode>> iterator = node.fields();
+        Iterator<Map.Entry<String, JsonNode>> iterator = node.properties().iterator();
         Stream<Map.Entry<String, JsonNode>> stream = StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
 

--- a/server-common/src/main/java/org/apache/kafka/server/util/json/JsonObject.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/json/JsonObject.java
@@ -51,17 +51,6 @@ public class JsonObject implements JsonValue {
         return Optional.ofNullable(node().get(name)).map(JsonValue::apply);
     }
 
-    public Iterator<Map.Entry<String, JsonValue>> iterator() {
-        Iterator<Map.Entry<String, JsonNode>> iterator = node.properties().iterator();
-        Stream<Map.Entry<String, JsonNode>> stream = StreamSupport.stream(
-                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
-
-        Stream<Map.Entry<String, JsonValue>> results = stream.map(entry ->
-                new AbstractMap.SimpleEntry<>(entry.getKey(), JsonValue.apply(entry.getValue()))
-        );
-        return results.collect(Collectors.toList()).iterator();
-    }
-
     @Override
     public int hashCode() {
         return node().hashCode();

--- a/server-common/src/main/java/org/apache/kafka/server/util/json/JsonObject.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/json/JsonObject.java
@@ -21,15 +21,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import java.util.AbstractMap;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class JsonObject implements JsonValue {
     protected final ObjectNode node;

--- a/server-common/src/test/java/org/apache/kafka/server/util/JsonTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/JsonTest.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/server-common/src/test/java/org/apache/kafka/server/util/JsonTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/JsonTest.java
@@ -107,18 +107,6 @@ public class JsonTest {
     }
 
     @Test
-    public void testJsonObjectIterator() throws JsonProcessingException {
-        List<Map.Entry<String, JsonValue>> results = new ArrayList<>();
-        parse(JSON).asJsonObject().apply("object").asJsonObject().iterator().forEachRemaining(results::add);
-
-        Map.Entry<String, JsonValue> entryA = new AbstractMap.SimpleEntry<>("a", parse("true"));
-        AbstractMap.SimpleEntry<String, JsonValue> entryB = new AbstractMap.SimpleEntry<>("b", parse("false"));
-        List<Map.Entry<String, JsonValue>> expectedResult = List.of(entryA, entryB);
-
-        assertEquals(expectedResult, results);
-    }
-
-    @Test
     public void testJsonArrayIterator() throws JsonProcessingException {
         List<JsonValue> results = new ArrayList<>();
         parse(JSON).asJsonObject().apply("array").asJsonArray().iterator().forEachRemaining(results::add);

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/basic/BasicNode.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/basic/BasicNode.java
@@ -48,9 +48,7 @@ public class BasicNode implements Node {
         String hostname = "localhost";
         Set<String> tags = Collections.emptySet();
         Map<String, String> config = new HashMap<>();
-        for (Iterator<Map.Entry<String, JsonNode>> iter = root.fields();
-             iter.hasNext(); ) {
-            Map.Entry<String, JsonNode> entry = iter.next();
+        for (Map.Entry<String, JsonNode> entry : root.properties()) {
             String key = entry.getKey();
             JsonNode node = entry.getValue();
             if (key.equals("hostname")) {
@@ -58,7 +56,7 @@ public class BasicNode implements Node {
             } else if (key.equals("tags")) {
                 if (!node.isArray()) {
                     throw new RuntimeException("Expected the 'tags' field to be an " +
-                        "array of strings.");
+                            "array of strings.");
                 }
                 tags = new HashSet<>();
                 for (Iterator<JsonNode> tagIter = node.elements(); tagIter.hasNext(); ) {


### PR DESCRIPTION
`JsonNode.fields()` method has been deprecated by
- https://github.com/FasterXML/jackson-databind/issues/4863
- https://github.com/FasterXML/jackson-databind/pull/4871

So modified accordingly.

Reviewers: Luke Chen <showuon@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
