### PR TITLE
MINOR: Fix typo to actually use rocksdb setOptimizeFiltersForHits

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -195,7 +195,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         filter = new BloomFilter();
         tableConfig.setFilterPolicy(filter);
 
-        userSpecifiedOptions.optimizeFiltersForHits();
+        userSpecifiedOptions.setOptimizeFiltersForHits(true);
         userSpecifiedOptions.setTableFormatConfig(tableConfig);
         userSpecifiedOptions.setWriteBufferSize(WRITE_BUFFER_SIZE);
         userSpecifiedOptions.setCompressionType(COMPRESSION_TYPE);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1256,7 +1256,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             if (enableBloomFilters) {
                 filter = new BloomFilter();
                 tableConfig.setFilterPolicy(filter);
-                options.optimizeFiltersForHits();
+                options.setOptimizeFiltersForHits(true);
                 bloomFiltersSet = true;
             } else {
                 options.setOptimizeFiltersForHits(false);


### PR DESCRIPTION
This PR fixes a typo in the `RocksDBStore` where it currently uses a
getter named `optimizeFiltersForHits`. However, to set the flag to true,
we have to use `setOptimizeFiltersForHits(true)` instead.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
