### PR TITLE
KAFKA-19305 Make ClientQuotaImage and TopicImage immutable

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2494,8 +2494,7 @@ public class KafkaAdminClient extends AdminClient {
                     DescribeClusterResponse response = (DescribeClusterResponse) abstractResponse;
                     Errors error = Errors.forCode(response.data().errorCode());
                     if (error != Errors.NONE) {
-                        ApiError apiError = new ApiError(error, response.data().errorMessage());
-                        handleFailure(apiError.exception());
+                        handleFailure(error.exception(response.data().errorMessage()));
                         return;
                     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2494,7 +2494,8 @@ public class KafkaAdminClient extends AdminClient {
                     DescribeClusterResponse response = (DescribeClusterResponse) abstractResponse;
                     Errors error = Errors.forCode(response.data().errorCode());
                     if (error != Errors.NONE) {
-                        handleFailure(error.exception(response.data().errorMessage()));
+                        ApiError apiError = new ApiError(error, response.data().errorMessage());
+                        handleFailure(apiError.exception());
                         return;
                     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -49,7 +49,7 @@ public final class ClientQuotaImage {
     }
 
     public Map<String, Double> quotas() {
-        return this.quotas;;
+        return this.quotas;
     }
 
     public void write(

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -91,17 +91,6 @@ public record ClientQuotaImage(Map<String, Double> quotas) {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof ClientQuotaImage other)) return false;
-        return quotas.equals(other.quotas);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(quotas);
-    }
-
-    @Override
     public String toString() {
         return new ClientQuotaImageNode(this).stringify();
     }

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 
 
 /**

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -48,12 +48,8 @@ public final class ClientQuotaImage {
         this.quotas = Collections.unmodifiableMap(quotas);
     }
 
-    Map<String, Double> quotas() {
-        return quotas;
-    }
-
-    public Map<String, Double> quotaMap() {
-        return this.quotas;
+    public Map<String, Double> quotas() {
+        return this.quotas;;
     }
 
     public void write(

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -39,17 +39,11 @@ import java.util.Objects;
  *
  * This class is thread-safe.
  */
-public final class ClientQuotaImage {
+public record ClientQuotaImage(Map<String, Double> quotas) {
     public static final ClientQuotaImage EMPTY = new ClientQuotaImage(Map.of());
 
-    private final Map<String, Double> quotas;
-
-    public ClientQuotaImage(Map<String, Double> quotas) {
-        this.quotas = Collections.unmodifiableMap(quotas);
-    }
-
-    public Map<String, Double> quotas() {
-        return this.quotas;
+    public ClientQuotaImage {
+        quotas = Collections.unmodifiableMap(quotas);
     }
 
     public void write(

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -45,7 +45,7 @@ public final class ClientQuotaImage {
     private final Map<String, Double> quotas;
 
     public ClientQuotaImage(Map<String, Double> quotas) {
-        this.quotas = quotas;
+        this.quotas = Collections.unmodifiableMap(quotas);
     }
 
     Map<String, Double> quotas() {

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -53,7 +53,7 @@ public final class ClientQuotaImage {
     }
 
     public Map<String, Double> quotaMap() {
-        return Collections.unmodifiableMap(quotas);
+        return this.quotas;
     }
 
     public void write(

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -35,31 +35,9 @@ import java.util.Objects;
  *
  * This class is thread-safe.
  */
-public final class TopicImage {
-    private final String name;
-
-    private final Uuid id;
-
-    private final Map<Integer, PartitionRegistration> partitions;
-
-    public TopicImage(String name,
-                      Uuid id,
-                      Map<Integer, PartitionRegistration> partitions) {
-        this.name = name;
-        this.id = id;
-        this.partitions = Collections.unmodifiableMap(partitions);
-    }
-
-    public String name() {
-        return name;
-    }
-
-    public Uuid id() {
-        return id;
-    }
-
-    public Map<Integer, PartitionRegistration> partitions() {
-        return partitions;
+public record TopicImage(String name, Uuid id, Map<Integer, PartitionRegistration> partitions) {
+    public TopicImage {
+        partitions = Collections.unmodifiableMap(partitions);
     }
 
     public void write(ImageWriter writer, ImageWriterOptions options) {

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -52,19 +52,6 @@ public record TopicImage(String name, Uuid id, Map<Integer, PartitionRegistratio
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof TopicImage other)) return false;
-        return name.equals(other.name) &&
-            id.equals(other.id) &&
-            partitions.equals(other.partitions);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, id, partitions);
-    }
-
-    @Override
     public String toString() {
         return new TopicImageNode(this).stringify();
     }

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -27,7 +27,6 @@ import org.apache.kafka.metadata.PartitionRegistration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 
 
 /**

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -24,6 +24,7 @@ import org.apache.kafka.image.writer.ImageWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.metadata.PartitionRegistration;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -46,7 +47,7 @@ public final class TopicImage {
                       Map<Integer, PartitionRegistration> partitions) {
         this.name = name;
         this.id = id;
-        this.partitions = partitions;
+        this.partitions = Collections.unmodifiableMap(partitions);
     }
 
     public String name() {

--- a/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotaImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotaImageNode.java
@@ -34,12 +34,12 @@ public class ClientQuotaImageNode implements MetadataNode {
 
     @Override
     public Collection<String> childNames() {
-        return image.quotaMap().keySet();
+        return image.quotas().keySet();
     }
 
     @Override
     public MetadataNode child(String name) {
-        Double result = image.quotaMap().get(name);
+        Double result = image.quotas().get(name);
         if (result == null) return null;
         return new MetadataLeafNode(result + "");
     }


### PR DESCRIPTION
This pull request addresses KAFKA-19305 by ensuring that collections
used in these classes are fully immutable.

## Changes

- Updated `ClientQuotaImage` and `TopicImage` by using
`Collections.unmodifiableMap` or `ImmutableMap` to prevent accidental or
intentional mutations after construction.

Reviewers: Alyssa Huang <ahuang@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
