### PR TITLE
MINOR: Add missing tag to testShareGroups test

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2697,6 +2697,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     }
   }
 
+  @Test
   def testShareGroups(): Unit = {
     val testGroupId = "test_group_id"
     val testClientId = "test_client_id"


### PR DESCRIPTION
The commit 57ae6d6706ef3e68953e19c79dddd60ceb76adc9 had mistakenly
removed the `@Test` tag from a test. Adding it back.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>
