### PR TITLE
KAFKA-19311: Document commitAsync behavioral differences between Classic and Async Consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -910,7 +910,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
      * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
      * but only when the consumer is using the consumer group protocol.
-     * This guarantee does not hold when using the classic group protocol.
      *
      * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
      *             This fatal error can only occur if you are using automatic group management with {@link #subscribe(Collection)},
@@ -956,7 +955,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
      * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
      * but only when the consumer is using the consumer group protocol.
-     * This guarantee does not hold when using the classic group protocol.
      *
      * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
      *             This can only occur if you are using automatic group management with {@link #subscribe(Collection)},
@@ -1007,7 +1005,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
      * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
      * but only when the consumer is using the consumer group protocol.
-     * This guarantee does not hold when using the classic group protocol.
      *
      * @param offsets A map of offsets by partition with associated metadata
      * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
@@ -1060,7 +1057,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
      * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
      * but only when the consumer is using the consumer group protocol.
-     * This guarantee does not hold when using the classic group protocol.
      *
      * @param offsets A map of offsets by partition with associated metadata
      * @param timeout The maximum amount of time to await completion of the offset commit

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -908,7 +908,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * (in which case a {@link org.apache.kafka.common.errors.TimeoutException} is thrown to the caller).
      * <p>
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
-     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.
+     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
+     * but only when the consumer is using the consumer group protocol.
+     * This guarantee does not hold when using the classic group protocol.
      *
      * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
      *             This fatal error can only occur if you are using automatic group management with {@link #subscribe(Collection)},
@@ -952,7 +954,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * encountered (in which case it is thrown to the caller), or the passed timeout expires.
      * <p>
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
-     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.
+     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
+     * but only when the consumer is using the consumer group protocol.
+     * This guarantee does not hold when using the classic group protocol.
      *
      * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
      *             This can only occur if you are using automatic group management with {@link #subscribe(Collection)},
@@ -1001,7 +1005,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * (in which case a {@link org.apache.kafka.common.errors.TimeoutException} is thrown to the caller).
      * <p>
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
-     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.
+     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
+     * but only when the consumer is using the consumer group protocol.
+     * This guarantee does not hold when using the classic group protocol.
      *
      * @param offsets A map of offsets by partition with associated metadata
      * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
@@ -1052,7 +1058,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * encountered (in which case it is thrown to the caller), or the timeout expires.
      * <p>
      * Note that asynchronous offset commits sent previously with the {@link #commitAsync(OffsetCommitCallback)}
-     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.
+     * (or similar) are guaranteed to have their callbacks invoked prior to completion of this method,
+     * but only when the consumer is using the consumer group protocol.
+     * This guarantee does not hold when using the classic group protocol.
      *
      * @param offsets A map of offsets by partition with associated metadata
      * @param timeout The maximum amount of time to await completion of the offset commit


### PR DESCRIPTION
#15613 ensures that all `commitAsync` callbacks are triggered before
`commitSync` completes for `AsyncKafkaConsumer`. However, the related
changes to `ClassicKafkaConsumer`, #15693, were not merged. I assume
this
might be because we intend to gradually move toward using AsyncConsumer
instead.

In short, this behavioral difference should be documented.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
