### PR TITLE
MINOR: Refactor awaitNonEmptyRecords to remove dead code and improve clarity

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -97,14 +97,10 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
     var result: ConsumerRecords[K, V] = null
 
     TestUtils.pollRecordsUntilTrue(consumer, (polledRecords: ConsumerRecords[K, V]) => {
-      if (polledRecords.records(partition).asScala.nonEmpty) {
-        result = polledRecords
-        true
-      } else {
-        false
-      }
+      val hasRecords = !polledRecords.records(partition).isEmpty
+      if (hasRecords) result = polledRecords
+      hasRecords
     }, s"Consumer did not consume any messages for partition $partition before timeout.", JTestUtils.DEFAULT_MAX_WAIT_MS, pollTimeoutMs)
-
     result
   }
 

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -94,12 +94,18 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
   def awaitNonEmptyRecords[K, V](consumer: Consumer[K, V],
                                  partition: TopicPartition,
                                  pollTimeoutMs: Long = 100): ConsumerRecords[K, V] = {
+    var result: ConsumerRecords[K, V] = null
+
     TestUtils.pollRecordsUntilTrue(consumer, (polledRecords: ConsumerRecords[K, V]) => {
-      if (polledRecords.records(partition).asScala.nonEmpty)
-        return polledRecords
-      false
+      if (polledRecords.records(partition).asScala.nonEmpty) {
+        result = polledRecords
+        true
+      } else {
+        false
+      }
     }, s"Consumer did not consume any messages for partition $partition before timeout.", JTestUtils.DEFAULT_MAX_WAIT_MS, pollTimeoutMs)
-    throw new IllegalStateException("Should have timed out before reaching here")
+
+    result
   }
 
   /**


### PR DESCRIPTION
This refactor improves the implementation of `awaitNonEmptyRecords` by:

- Removing the unreachable `throw new IllegalStateException` statement,
which was dead code due to `pollRecordsUntilTrue` throwing exceptions on
timeout.
- Eliminating the use of `return` inside the lambda, which relies on
non-local returns that can be confusing and error-prone in Scala.

Reviewers: Yung <yungyung7654321@gmail.com>, Ken Huang
 <s7133700@gmail.com>, TengYao Chi <frankvicky@apache.org>
