### PR TITLE
KAFKA-19352: Create offsets topic to fix flaky testCommitAsyncCompletedBeforeConsumerCloses

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
@@ -83,8 +83,6 @@ public class PlaintextConsumerCommitTest {
 
     @BeforeEach
     public void setup() throws InterruptedException {
-        // Create offsets topic
-        cluster.createTopic(Topic.GROUP_METADATA_TOPIC_NAME, Integer.parseInt(OFFSETS_TOPIC_PARTITIONS), Short.parseShort(OFFSETS_TOPIC_REPLICATION));
         cluster.createTopic(topic, 2, (short) BROKER_COUNT);
     }
 
@@ -455,10 +453,14 @@ public class PlaintextConsumerCommitTest {
 
     // TODO: This only works in the new consumer, but should be fixed for the old consumer as well
     @ClusterTest
-    public void testCommitAsyncCompletedBeforeConsumerCloses() {
+    public void testCommitAsyncCompletedBeforeConsumerCloses() throws InterruptedException {
         // This is testing the contract that asynchronous offset commit are completed before the consumer
         // is closed, even when no commit sync is performed as part of the close (due to auto-commit
         // disabled, or simply because there are no consumed offsets).
+
+        // Create offsets topic to ensure coordinator is available during close
+        cluster.createTopic(Topic.GROUP_METADATA_TOPIC_NAME, Integer.parseInt(OFFSETS_TOPIC_PARTITIONS), Short.parseShort(OFFSETS_TOPIC_REPLICATION));
+
         try (Producer<byte[], byte[]> producer = cluster.producer(Map.of(ProducerConfig.ACKS_CONFIG, "all"));
              var consumer = createConsumer(GroupProtocol.CONSUMER, false)
         ) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
@@ -83,6 +83,8 @@ public class PlaintextConsumerCommitTest {
 
     @BeforeEach
     public void setup() throws InterruptedException {
+        // Create offsets topic
+        cluster.createTopic(Topic.GROUP_METADATA_TOPIC_NAME, Integer.parseInt(OFFSETS_TOPIC_PARTITIONS), Short.parseShort(OFFSETS_TOPIC_REPLICATION));
         cluster.createTopic(topic, 2, (short) BROKER_COUNT);
     }
 


### PR DESCRIPTION
The flakiness occurs when the offsets topic does not yet exist. Hence,
the issue is mitigated by creating the offsets topic manually. This
serves as a workaround.  The root cause is tracked in
[KAFKA-19357](https://issues.apache.org/jira/browse/KAFKA-19357).

I ran the test 100 times on my Mac and all of them passed.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
