### PR TITLE
KAFKA-18904: [4/N] Add ListClientMetricsResources metric if request is v0 ListConfigResources

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -227,6 +227,8 @@ object RequestChannel extends Logging {
           Seq(specifiedMetricName, header.apiKey.name)
         } else if (header.apiKey == ApiKeys.ADD_PARTITIONS_TO_TXN && body[AddPartitionsToTxnRequest].allVerifyOnlyRequest) {
             Seq(RequestMetrics.VERIFY_PARTITIONS_IN_TXN_METRIC_NAME)
+        } else if (header.apiKey == ApiKeys.LIST_CONFIG_RESOURCES && header.apiVersion == 0) {
+          Seq(RequestMetrics.LIST_CLIENT_METRICS_RESOURCES_METRIC_NAME, header.apiKey.name)
         } else {
           Seq(header.apiKey.name)
         }

--- a/server/src/main/java/org/apache/kafka/network/metrics/RequestChannelMetrics.java
+++ b/server/src/main/java/org/apache/kafka/network/metrics/RequestChannelMetrics.java
@@ -34,7 +34,12 @@ public class RequestChannelMetrics {
         for (ApiKeys apiKey : enabledApis) {
             metricsMap.put(apiKey.name, new RequestMetrics(apiKey.name));
         }
-        for (String name : Arrays.asList(RequestMetrics.CONSUMER_FETCH_METRIC_NAME, RequestMetrics.FOLLOW_FETCH_METRIC_NAME, RequestMetrics.VERIFY_PARTITIONS_IN_TXN_METRIC_NAME)) {
+        for (String name : Arrays.asList(
+            RequestMetrics.CONSUMER_FETCH_METRIC_NAME,
+            RequestMetrics.FOLLOW_FETCH_METRIC_NAME,
+            RequestMetrics.VERIFY_PARTITIONS_IN_TXN_METRIC_NAME,
+            RequestMetrics.LIST_CLIENT_METRICS_RESOURCES_METRIC_NAME
+        )) {
             metricsMap.put(name, new RequestMetrics(name));
         }
     }

--- a/server/src/main/java/org/apache/kafka/network/metrics/RequestMetrics.java
+++ b/server/src/main/java/org/apache/kafka/network/metrics/RequestMetrics.java
@@ -38,6 +38,9 @@ public class RequestMetrics {
     public static final String CONSUMER_FETCH_METRIC_NAME = ApiKeys.FETCH.name + "Consumer";
     public static final String FOLLOW_FETCH_METRIC_NAME = ApiKeys.FETCH.name + "Follower";
     public static final String VERIFY_PARTITIONS_IN_TXN_METRIC_NAME = ApiKeys.ADD_PARTITIONS_TO_TXN.name + "Verification";
+    // The ListClientMetricsResourcesRequest (v0) is renamed to ListConfigResourcesRequest (v1) in 4.1.
+    // To record correct request name, we keep the old name for v0 and use the new name for v1+.
+    public static final String LIST_CLIENT_METRICS_RESOURCES_METRIC_NAME = "ListClientMetricsResources";
     public static final String REQUESTS_PER_SEC = "RequestsPerSec";
     public static final String DEPRECATED_REQUESTS_PER_SEC = "DeprecatedRequestsPerSec";
     public static final String MESSAGE_CONVERSIONS_TIME_MS = "MessageConversionsTimeMs";


### PR DESCRIPTION
Before 4.1, the api key 74 is `ListClientMetricsResources`. After 4.1,
it's `ListConfigResources`. If users sent a v0 ListConfigResources to
broker, the metric doesn't record request with
`ListClientMetricsResources`. This PR is to add
`ListClientMetricsResources` metric if the request is v0
`ListConfigResources`.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
