### PR TITLE
KAFKA-19155: Update docs/security.html for streams-related RPCs

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -2274,6 +2274,36 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
             <td></td>
         </tr>
         <tr>
+            <td>STREAMS_GROUP_HEARTBEAT (88)</td>
+            <td>Read</td>
+            <td>Group</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>STREAMS_GROUP_HEARTBEAT (88)</td>
+            <td>Describe</td>
+            <td>Topic</td>
+            <td>Required for all source topics and internal topics used in the topology of the group.</td>
+        </tr>
+        <tr>
+            <td>STREAMS_GROUP_HEARTBEAT (88)</td>
+            <td>Create</td>
+            <td>Topic</td>
+            <td>Required for all internal topics, for the broker to automatically create internal topics. Not required if internal topics exist.</td>
+        </tr>
+        <tr>
+            <td>STREAMS_GROUP_DESCRIBE (89)</td>
+            <td>Describe</td>
+            <td>Group</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>STREAMS_GROUP_DESCRIBE (89)</td>
+            <td>Describe</td>
+            <td>Topic</td>
+            <td>Required for all source topics and internal topics used in the topology of the group.</td>
+        </tr>
+        <tr>
             <td>DESCRIBE_SHARE_GROUP_OFFSETS (90)</td>
             <td>Describe</td>
             <td>Group</td>


### PR DESCRIPTION
We need to add the correct ACLs for the streams-related RPCs in
docs/security.html.

Reviewers: Andrew Schofield <aschofield@confluent.io>
