### PR TITLE
KAFKA-18913: Start state updater in task manager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -149,6 +149,11 @@ public class TaskManager {
         );
     }
 
+    void init() {
+        if (stateUpdater != null) {
+            this.stateUpdater.start();
+        }
+    }
     void setMainConsumer(final Consumer<byte[], byte[]> mainConsumer) {
         this.mainConsumer = mainConsumer;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -391,7 +391,6 @@ public class StreamThreadTest {
 
         // revoke nothing
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
         revokedPartitions = Collections.emptyList();
         rebalanceListener.onPartitionsRevoked(revokedPartitions);
 
@@ -919,7 +918,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
@@ -1192,7 +1191,6 @@ public class StreamThreadTest {
         thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
         thread.updateThreadMetadata("adminClientId");
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
         activeTasks.put(task1, Collections.singleton(t1p1));
@@ -1256,7 +1254,6 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1296,7 +1293,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, new StreamsConfig(props));
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1528,7 +1525,6 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<>();
@@ -1555,7 +1551,7 @@ public class StreamThreadTest {
         consumer.updatePartitions(topic1, Collections.singletonList(new PartitionInfo(topic1, 1, null, null, null)));
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1621,7 +1617,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1704,7 +1700,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.buildTopology();
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1799,7 +1795,7 @@ public class StreamThreadTest {
         consumer.updatePartitions(topic1, Collections.singletonList(new PartitionInfo(topic1, 1, null, null, null)));
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1864,7 +1860,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1946,7 +1942,7 @@ public class StreamThreadTest {
         );
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -2007,7 +2003,7 @@ public class StreamThreadTest {
         restoreConsumer.updateBeginningOffsets(offsets);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<>();
@@ -2271,7 +2267,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
         final List<TopicPartition> assignedPartitions = new ArrayList<>();
 
@@ -2351,7 +2347,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, stateUpdaterEnabled, processingThreadsEnabled);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
         final List<TopicPartition> assignedPartitions = new ArrayList<>();
 
@@ -2404,7 +2400,6 @@ public class StreamThreadTest {
         assertEquals(StreamThread.State.CREATED.name(), metadata.threadState());
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
         thread.setState(StreamThread.State.PARTITIONS_ASSIGNED);
         thread.setState(StreamThread.State.RUNNING);
@@ -2474,7 +2469,6 @@ public class StreamThreadTest {
         });
 
         thread.start();
-        maybeRunStateUpdater(stateUpdaterEnabled);
 
         TestUtils.waitForCondition(
             () -> mockRestoreConsumer.assignment().size() == 1,
@@ -2551,7 +2545,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, new StreamsConfig(properties));
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
@@ -3038,7 +3032,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
@@ -3412,7 +3406,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> clientInstanceIdFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3437,7 +3431,7 @@ public class StreamThreadTest {
     public void shouldReturnErrorIfMainConsumerInstanceIdNotInitialized(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3454,7 +3448,7 @@ public class StreamThreadTest {
     public void shouldReturnErrorIfRestoreConsumerInstanceIdNotInitialized(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3471,7 +3465,7 @@ public class StreamThreadTest {
     public void shouldReturnErrorIfProducerInstanceIdNotInitialized(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> producerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3489,7 +3483,7 @@ public class StreamThreadTest {
         clientSupplier.consumer.disableTelemetry();
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3507,7 +3501,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3527,7 +3521,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> producerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3545,7 +3539,7 @@ public class StreamThreadTest {
         clientSupplier.consumer.injectTimeoutException(-1);
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3570,7 +3564,7 @@ public class StreamThreadTest {
         clientSupplier.restoreConsumer.injectTimeoutException(-1);
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3598,7 +3592,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
-        maybeRunStateUpdater(stateUpdaterEnabled);
+        thread.taskManager().init();
 
         final Map<String, KafkaFuture<Uuid>> producerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -4148,12 +4142,6 @@ public class StreamThreadTest {
             Optional.empty(),
             null
         );
-    }
-
-    private void maybeRunStateUpdater(final boolean stateUpdaterEnabled) {
-        if (stateUpdaterEnabled) {
-            thread.taskManager().init();
-        }
     }
     
     private void runOnce(final boolean processingThreadsEnabled) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -110,6 +110,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -390,6 +391,7 @@ public class StreamThreadTest {
 
         // revoke nothing
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         revokedPartitions = Collections.emptyList();
         rebalanceListener.onPartitionsRevoked(revokedPartitions);
 
@@ -917,6 +919,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
@@ -1189,6 +1192,7 @@ public class StreamThreadTest {
         thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
         thread.updateThreadMetadata("adminClientId");
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
         activeTasks.put(task1, Collections.singleton(t1p1));
@@ -1252,6 +1256,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1291,6 +1296,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, new StreamsConfig(props));
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1522,6 +1528,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
 
         final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<>();
@@ -1548,6 +1555,7 @@ public class StreamThreadTest {
         consumer.updatePartitions(topic1, Collections.singletonList(new PartitionInfo(topic1, 1, null, null, null)));
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1613,6 +1621,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1695,6 +1704,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.buildTopology();
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1789,6 +1799,7 @@ public class StreamThreadTest {
         consumer.updatePartitions(topic1, Collections.singletonList(new PartitionInfo(topic1, 1, null, null, null)));
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1853,6 +1864,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1934,6 +1946,7 @@ public class StreamThreadTest {
         );
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1994,6 +2007,7 @@ public class StreamThreadTest {
         restoreConsumer.updateBeginningOffsets(offsets);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
 
         final Map<TaskId, Set<TopicPartition>> standbyTasks = new HashMap<>();
@@ -2257,6 +2271,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
         final List<TopicPartition> assignedPartitions = new ArrayList<>();
 
@@ -2336,6 +2351,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, stateUpdaterEnabled, processingThreadsEnabled);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptySet());
         final List<TopicPartition> assignedPartitions = new ArrayList<>();
 
@@ -2388,6 +2404,7 @@ public class StreamThreadTest {
         assertEquals(StreamThread.State.CREATED.name(), metadata.threadState());
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
         thread.setState(StreamThread.State.PARTITIONS_ASSIGNED);
         thread.setState(StreamThread.State.RUNNING);
@@ -2457,6 +2474,7 @@ public class StreamThreadTest {
         });
 
         thread.start();
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         TestUtils.waitForCondition(
             () -> mockRestoreConsumer.assignment().size() == 1,
@@ -2533,6 +2551,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, new StreamsConfig(properties));
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
@@ -3019,6 +3038,7 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, config);
 
         thread.setState(StreamThread.State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
 
         final TaskId task1 = new TaskId(0, t1p1.partition());
@@ -3392,6 +3412,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> clientInstanceIdFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3416,6 +3437,7 @@ public class StreamThreadTest {
     public void shouldReturnErrorIfMainConsumerInstanceIdNotInitialized(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3432,6 +3454,7 @@ public class StreamThreadTest {
     public void shouldReturnErrorIfRestoreConsumerInstanceIdNotInitialized(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3448,6 +3471,7 @@ public class StreamThreadTest {
     public void shouldReturnErrorIfProducerInstanceIdNotInitialized(final boolean stateUpdaterEnabled, final boolean processingThreadsEnabled) {
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> producerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3465,6 +3489,7 @@ public class StreamThreadTest {
         clientSupplier.consumer.disableTelemetry();
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3482,6 +3507,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3501,6 +3527,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> producerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3518,6 +3545,7 @@ public class StreamThreadTest {
         clientSupplier.consumer.injectTimeoutException(-1);
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3542,6 +3570,7 @@ public class StreamThreadTest {
         clientSupplier.restoreConsumer.injectTimeoutException(-1);
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> consumerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3569,6 +3598,7 @@ public class StreamThreadTest {
 
         thread = createStreamThread("clientId", stateUpdaterEnabled, processingThreadsEnabled);
         thread.setState(State.STARTING);
+        maybeRunStateUpdater(stateUpdaterEnabled);
 
         final Map<String, KafkaFuture<Uuid>> producerFutures = thread.clientInstanceIds(Duration.ZERO);
 
@@ -3585,9 +3615,10 @@ public class StreamThreadTest {
         );
     }
 
-    @Test
-    public void testNamedTopologyWithStreamsProtocol() {
-        final Properties props = configProps(false, false, false);
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testNamedTopologyWithStreamsProtocol(final boolean stateUpdaterEnabled) {
+        final Properties props = configProps(false, stateUpdaterEnabled, false);
         props.setProperty(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.toString());
         final StreamsConfig config = new StreamsConfig(props);
         final InternalTopologyBuilder topologyBuilder = new InternalTopologyBuilder(
@@ -3644,9 +3675,10 @@ public class StreamThreadTest {
         assertTrue(thread.streamsRebalanceData().isEmpty());
     }
 
-    @Test
-    public void testStreamsRebalanceDataWithExtraCopartition() {
-        final Properties props = configProps(false, false, false);
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testStreamsRebalanceDataWithExtraCopartition(final boolean stateUpdaterEnabled) {
+        final Properties props = configProps(false, stateUpdaterEnabled, false);
         props.setProperty(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.toString());
 
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
@@ -4116,6 +4148,12 @@ public class StreamThreadTest {
             Optional.empty(),
             null
         );
+    }
+
+    private void maybeRunStateUpdater(final boolean stateUpdaterEnabled) {
+        if (stateUpdaterEnabled) {
+            thread.taskManager().init();
+        }
     }
     
     private void runOnce(final boolean processingThreadsEnabled) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -34,10 +34,12 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -82,6 +84,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,6 +100,7 @@ import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.intersection;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.common.utils.Utils.union;
 import static org.apache.kafka.streams.processor.internals.TopologyMetadata.UNNAMED_TOPOLOGY;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
@@ -4835,6 +4839,44 @@ public class TaskManagerTest {
         // verify the startup Standby is now being used as an assigned Standby
         assertEquals(Collections.emptyMap(), taskManager.activeTaskMap());
         assertEquals(Collections.singletonMap(taskId00, startupTask), taskManager.standbyTaskMap());
+    }
+
+    @Test
+    public void shouldStartAndCleanlyShutdownStateUpdaterThread() {
+
+        final String stateUpdaterName = "test-state-updater";
+        final Metrics metrics = new Metrics(time);
+        final StreamsConfig config = new StreamsConfig(configProps());
+        final DefaultStateUpdater defaultStateUpdater =
+            new DefaultStateUpdater(stateUpdaterName, metrics, config, null, changeLogReader, topologyMetadata, time);
+
+        final TaskManager taskManager = new TaskManager(
+            time,
+            changeLogReader,
+            ProcessId.randomProcessId(),
+            "logPrefix",
+            activeTaskCreator,
+            standbyTaskCreator,
+            null,
+            topologyMetadata,
+            adminClient,
+            stateDirectory,
+            defaultStateUpdater,
+            null
+        );
+
+        taskManager.init();
+        assertTrue(defaultStateUpdater.isRunning());
+
+        defaultStateUpdater.shutdown(Duration.ofMinutes(1));
+        assertFalse(defaultStateUpdater.isRunning());
+    }
+
+    private Properties configProps() {
+        return mkObjectProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171")
+        ));
     }
 
     private static KafkaFutureImpl<DeletedRecords> completedFuture() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -34,12 +34,10 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Measurable;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -63,6 +61,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -84,7 +84,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -100,7 +99,6 @@ import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.intersection;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.common.utils.Utils.union;
 import static org.apache.kafka.streams.processor.internals.TopologyMetadata.UNNAMED_TOPOLOGY;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
@@ -4841,42 +4839,16 @@ public class TaskManagerTest {
         assertEquals(Collections.singletonMap(taskId00, startupTask), taskManager.standbyTaskMap());
     }
 
-    @Test
-    public void shouldStartAndCleanlyShutdownStateUpdaterThread() {
-
-        final String stateUpdaterName = "test-state-updater";
-        final Metrics metrics = new Metrics(time);
-        final StreamsConfig config = new StreamsConfig(configProps());
-        final DefaultStateUpdater defaultStateUpdater =
-            new DefaultStateUpdater(stateUpdaterName, metrics, config, null, changeLogReader, topologyMetadata, time);
-
-        final TaskManager taskManager = new TaskManager(
-            time,
-            changeLogReader,
-            ProcessId.randomProcessId(),
-            "logPrefix",
-            activeTaskCreator,
-            standbyTaskCreator,
-            null,
-            topologyMetadata,
-            adminClient,
-            stateDirectory,
-            defaultStateUpdater,
-            null
-        );
-
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void shouldStartStateUpdaterOnInit(final boolean stateUpdaterEnabled) {
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, stateUpdaterEnabled);
         taskManager.init();
-        assertTrue(defaultStateUpdater.isRunning());
-
-        defaultStateUpdater.shutdown(Duration.ofMinutes(1));
-        assertFalse(defaultStateUpdater.isRunning());
-    }
-
-    private Properties configProps() {
-        return mkObjectProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171")
-        ));
+        if (stateUpdaterEnabled) {
+            verify(stateUpdater).start();
+        } else {
+            verify(stateUpdater, never()).start();
+        }
     }
 
     private static KafkaFutureImpl<DeletedRecords> completedFuture() {


### PR DESCRIPTION
Updated the code to start the State Updater Thread only after the Stream
Thread is started.

Changes done :
1. Moved the starting of the StateUpdater thread to a new init method in
the TaskManager.
2. Called the init of TaskManager in the run method of the StreamThread.
3. Updated the test cases in the StreamThreadTest to mimic the
aforementioned behaviour.

Reviewers: Bruno Cadonna <cadonna@apache.org>
