### PR TITLE
KAFKA-18486: Update activeProducerState wih KRaft mechanism in ReplicaManagerTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -4456,33 +4456,77 @@ class ReplicaManagerTest {
       val oofProducerState = replicaManager.activeProducerState(oofPartition)
       assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, Errors.forCode(oofProducerState.errorCode))
 
-      // This API is supported by both leaders and followers
-
       val barPartition = new TopicPartition("bar", 0)
-      val barLeaderAndIsrRequest = makeLeaderAndIsrRequest(
-        topicId = Uuid.randomUuid(),
-        topicPartition = barPartition,
-        replicas = Seq(brokerId),
-        leaderAndIsr = new LeaderAndIsr(brokerId, List(brokerId).map(Int.box).asJava)
-      )
-      replicaManager.becomeLeaderOrFollower(0, barLeaderAndIsrRequest, (_, _) => ())
+      val barTopicId = Uuid.randomUuid()
+
+      val leaderDelta = createLeaderDelta(barTopicId, barPartition, brokerId)
+      val leaderMetadataImage = imageFromTopics(leaderDelta.apply())
+      replicaManager.applyDelta(leaderDelta, leaderMetadataImage)
+
       val barProducerState = replicaManager.activeProducerState(barPartition)
       assertEquals(Errors.NONE, Errors.forCode(barProducerState.errorCode))
 
-      val otherBrokerId = 1
       val bazPartition = new TopicPartition("baz", 0)
-      val bazLeaderAndIsrRequest = makeLeaderAndIsrRequest(
-        topicId = Uuid.randomUuid(),
-        topicPartition = bazPartition,
-        replicas = Seq(brokerId, otherBrokerId),
-        leaderAndIsr = new LeaderAndIsr(otherBrokerId, List(brokerId, otherBrokerId).map(Int.box).asJava)
-      )
-      replicaManager.becomeLeaderOrFollower(0, bazLeaderAndIsrRequest, (_, _) => ())
+      val bazTopicId = Uuid.randomUuid()
+      val otherBrokerId = 1
+
+      val followerDelta = createFollowerDelta(bazTopicId, bazPartition, brokerId, otherBrokerId)
+      val followerMetadataImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerMetadataImage)
+
       val bazProducerState = replicaManager.activeProducerState(bazPartition)
       assertEquals(Errors.NONE, Errors.forCode(bazProducerState.errorCode))
+
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
+  }
+
+  private def createLeaderDelta(topicId: Uuid, partition: TopicPartition, leaderId: Int): TopicsDelta = {
+    val delta = new TopicsDelta(TopicsImage.EMPTY)
+
+    // First add the topic
+    delta.replay(new TopicRecord()
+      .setName(partition.topic)
+      .setTopicId(topicId)
+    )
+
+    delta.replay(new PartitionRecord()
+      .setPartitionId(partition.partition)
+      .setTopicId(topicId)
+      .setReplicas(util.Arrays.asList(leaderId))
+      .setIsr(util.Arrays.asList(leaderId))
+      .setRemovingReplicas(Collections.emptyList())
+      .setAddingReplicas(Collections.emptyList())
+      .setLeader(leaderId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0)
+    )
+
+    delta
+  }
+
+  private def createFollowerDelta(topicId: Uuid, partition: TopicPartition, followerId: Int, leaderId: Int): TopicsDelta = {
+    val delta = new TopicsDelta(TopicsImage.EMPTY)
+
+    delta.replay(new TopicRecord()
+      .setName(partition.topic)
+      .setTopicId(topicId)
+    )
+
+    delta.replay(new PartitionRecord()
+      .setPartitionId(partition.partition)
+      .setTopicId(topicId)
+      .setReplicas(util.Arrays.asList(followerId, leaderId))
+      .setIsr(util.Arrays.asList(followerId, leaderId))
+      .setRemovingReplicas(Collections.emptyList())
+      .setAddingReplicas(Collections.emptyList())
+      .setLeader(leaderId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0)
+    )
+
+    delta
   }
 
   val FOO_UUID = Uuid.fromString("fFJBx0OmQG-UqeaT6YaSwA")

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -4484,8 +4484,7 @@ class ReplicaManagerTest {
 
   private def createLeaderDelta(topicId: Uuid, partition: TopicPartition, leaderId: Int): TopicsDelta = {
     val delta = new TopicsDelta(TopicsImage.EMPTY)
-
-    // First add the topic
+    
     delta.replay(new TopicRecord()
       .setName(partition.topic)
       .setTopicId(topicId)


### PR DESCRIPTION
Description:
* replace RPC with KRaft mechanism to test activeProducerState in
ReplicaManagerTest

Reviewers: TaiJuWu <tjwu1217@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
