### PR TITLE
MINOR: Remove unnecessary checks.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
@@ -48,7 +48,7 @@ public class ChildFirstClassLoader extends URLClassLoader {
     private static URL[] classpathToURLs(String classPath) {
         ArrayList<URL> urls = new ArrayList<>();
         for (String path : classPath.split(File.pathSeparator)) {
-            if (path == null || path.trim().isEmpty())
+            if (path.trim().isEmpty())
                 continue;
             File file = new File(path);
 


### PR DESCRIPTION
The `String.split` method never returns an array containing null
elements.

Reviewers: TengYao Chi <frankvicky@apache.org>, Ken Huang
 <s7133700@gmail.com>, Lan Ding <isDing_L@163.com>
