### PR TITLE
MINOR: LIST_CONFIG_RESOURCES in security.html

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -1838,7 +1838,7 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
             <td>ADD_OFFSETS_TO_TXN (25)</td>
             <td>Write</td>
             <td>TransactionalId</td>
-            <td>Similarly to ADD_PARTITIONS_TO_TXN this is only applicable to transactional request. It first checks
+            <td>Similarly to ADD_PARTITIONS_TO_TXN this is only applicable to transactional requests. It first checks
                 for Write action on the TransactionalId resource, then it checks whether it can Read on the given group
                 (below).</td>
         </tr>
@@ -2196,7 +2196,7 @@ RULE:[n:string](regexp)s/pattern/replacement/g/U</code></pre>
             <td></td>
         </tr>
         <tr>
-            <td>LIST_CLIENT_METRICS_RESOURCES (74)</td>
+            <td>LIST_CONFIG_RESOURCES (74)</td>
             <td>DescribeConfigs</td>
             <td>Cluster</td>
             <td></td>


### PR DESCRIPTION
The `LIST_CLIENT_METRICS_RESOURCES` RPC was generalised to all config
resources in AK 4.1 and the RPC was renamed to `LIST_CONFIG_RESOURCES`.
This PR updates the RPC authorisation table in the documentation.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
