### PR TITLE
KAFKA-19347 Deduplicate ACLs when creating

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -93,6 +93,7 @@ public class AclControlManager {
     }
 
     ControllerResult<List<AclCreateResult>> createAcls(List<AclBinding> acls) {
+        Set<StandardAcl> aclsToCreate = new HashSet<>(acls.size());
         List<AclCreateResult> results = new ArrayList<>(acls.size());
         List<ApiMessageAndVersion> records =
                 BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
@@ -107,11 +108,17 @@ public class AclControlManager {
             }
             StandardAcl standardAcl = StandardAcl.fromAclBinding(acl);
             if (!existingAcls.contains(standardAcl)) {
-                StandardAclWithId standardAclWithId = new StandardAclWithId(newAclId(), standardAcl);
-                records.add(new ApiMessageAndVersion(standardAclWithId.toRecord(), (short) 0));
+                if (aclsToCreate.add(standardAcl)) {
+                    StandardAclWithId standardAclWithId = new StandardAclWithId(newAclId(), standardAcl);
+                    records.add(new ApiMessageAndVersion(standardAclWithId.toRecord(), (short) 0));
+                } else {
+                    log.debug("Ignoring duplicate ACL from request: {}", standardAcl);
+                }
             } else {
                 log.debug("Not creating ACL since it already exists: {}", standardAcl);
             }
+
+
             results.add(AclCreateResult.SUCCESS);
         }
         return new ControllerResult<>(records, results, true);

--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -337,6 +337,23 @@ public class AclControlManagerTest {
     }
 
     @Test
+    public void testCreateDedupe() {
+        AclControlManager manager = new AclControlManager.Builder().build();
+        MockClusterMetadataAuthorizer authorizer = new MockClusterMetadataAuthorizer();
+        authorizer.loadSnapshot(manager.idToAcl());
+
+        AclBinding aclBinding = new AclBinding(new ResourcePattern(TOPIC, "topic-1", LITERAL),
+                new AccessControlEntry("User:user", "10.0.0.1", AclOperation.ALL, ALLOW));
+
+        ControllerResult<List<AclCreateResult>> createResult = manager.createAcls(List.of(aclBinding, aclBinding));
+        RecordTestUtils.replayAll(manager, createResult.records());
+        assertEquals(1, createResult.records().size());
+
+        createResult = manager.createAcls(List.of(aclBinding));
+        assertEquals(0, createResult.records().size());
+    }
+
+    @Test
     public void testDeleteDedupe() {
         AclControlManager manager = new AclControlManager.Builder().build();
         MockClusterMetadataAuthorizer authorizer = new MockClusterMetadataAuthorizer();

--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -339,8 +339,6 @@ public class AclControlManagerTest {
     @Test
     public void testCreateDedupe() {
         AclControlManager manager = new AclControlManager.Builder().build();
-        MockClusterMetadataAuthorizer authorizer = new MockClusterMetadataAuthorizer();
-        authorizer.loadSnapshot(manager.idToAcl());
 
         AclBinding aclBinding = new AclBinding(new ResourcePattern(TOPIC, "topic-1", LITERAL),
                 new AccessControlEntry("User:user", "10.0.0.1", AclOperation.ALL, ALLOW));
@@ -348,16 +346,16 @@ public class AclControlManagerTest {
         ControllerResult<List<AclCreateResult>> createResult = manager.createAcls(List.of(aclBinding, aclBinding));
         RecordTestUtils.replayAll(manager, createResult.records());
         assertEquals(1, createResult.records().size());
+        assertEquals(1, manager.idToAcl().size());
 
         createResult = manager.createAcls(List.of(aclBinding));
         assertEquals(0, createResult.records().size());
+        assertEquals(1, manager.idToAcl().size());
     }
 
     @Test
     public void testDeleteDedupe() {
         AclControlManager manager = new AclControlManager.Builder().build();
-        MockClusterMetadataAuthorizer authorizer = new MockClusterMetadataAuthorizer();
-        authorizer.loadSnapshot(manager.idToAcl());
 
         AclBinding aclBinding = new AclBinding(new ResourcePattern(TOPIC, "topic-1", LITERAL),
                 new AccessControlEntry("User:user", "10.0.0.1", AclOperation.ALL, ALLOW));


### PR DESCRIPTION
In #19840, we broke de-duplication during ACL creation. This patch fixes
that and adds a test to cover this case.

Reviewers: Manikumar Reddy <manikumar.reddy@gmail.com>
