### PR TITLE
KAFKA-18202: Add rejection for non-zero sequences in TV2 (KIP-890)

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2279,7 +2279,7 @@ class ReplicaManagerTest {
     val tp0 = new TopicPartition(topic, 0)
     val producerId = 24L
     val producerEpoch = 0.toShort
-    val sequence = 6
+    val sequence = 0
     val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
     val scheduler = new MockScheduler(time)
 
@@ -2346,7 +2346,7 @@ class ReplicaManagerTest {
     val tp0 = new TopicPartition(topic, 0)
     val producerId = 24L
     val producerEpoch = 0.toShort
-    val sequence = 6
+    val sequence = 0
     val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
 
     val replicaManager = setUpReplicaManagerWithMockedAddPartitionsToTxnManager(addPartitionsToTxnManager, List(tp0))
@@ -2355,7 +2355,7 @@ class ReplicaManagerTest {
         makeLeaderAndIsrRequest(topicIds(tp0.topic), tp0, Seq(0, 1), new LeaderAndIsr(1, List(0, 1).map(Int.box).asJava)),
         (_, _) => ())
 
-      // Start with sequence 6
+      // Start with sequence 0
       val transactionalRecords = MemoryRecords.withTransactionalRecords(Compression.NONE, producerId, producerEpoch, sequence,
         new SimpleRecord("message".getBytes))
 
@@ -2379,7 +2379,7 @@ class ReplicaManagerTest {
       assertEquals(Errors.INVALID_PRODUCER_ID_MAPPING, result.assertFired.error)
       assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))
 
-      // Try to append a higher sequence (7) after the first one failed with a retriable error.
+      // Try to append a higher sequence (1) after the first one failed with a retriable error.
       val transactionalRecords2 = MemoryRecords.withTransactionalRecords(Compression.NONE, producerId, producerEpoch, sequence + 1,
         new SimpleRecord("message".getBytes))
 
@@ -2481,7 +2481,7 @@ class ReplicaManagerTest {
     val tp0 = new TopicPartition(topic, 0)
     val producerId = 24L
     val producerEpoch = 0.toShort
-    val sequence = 6
+    val sequence = 0
     val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
 
     val replicaManager = setUpReplicaManagerWithMockedAddPartitionsToTxnManager(addPartitionsToTxnManager, List(tp0))

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
@@ -1139,6 +1139,47 @@ public class ProducerStateManagerTest {
     }
 
     @Test
+    public void testRejectNonZeroSequenceForDirectEpochBump() {
+        // Setup: Establish producer with epoch 0 and some sequence history
+        appendClientEntry(stateManager, producerId, epoch, 0, 0L, false);
+        appendClientEntry(stateManager, producerId, epoch, 1, 1L, false);
+        appendClientEntry(stateManager, producerId, epoch, 2, 2L, false);
+        
+        // Verify initial state
+        ProducerStateEntry initialEntry = getLastEntryOrElseThrownByProducerId(stateManager, producerId);
+        assertEquals(0, initialEntry.producerEpoch());
+        assertEquals(2, initialEntry.lastSeq());
+        assertFalse(initialEntry.isEmpty()); // Has batch metadata
+
+        ProducerAppendInfo appendInfo = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
+        
+        // Test Case 1: Epoch bump (0 -> 1) with non-zero sequence should be rejected
+        OutOfOrderSequenceException exception = assertThrows(OutOfOrderSequenceException.class,
+                () -> appendInfo.appendDataBatch(
+                    (short) 1,
+                    5,
+                    5,
+                    time.milliseconds(),
+                    new LogOffsetMetadata(3L), 3L, false)
+        );
+        
+        assertTrue(exception.getMessage().contains("Invalid sequence number for new epoch"));
+        assertTrue(exception.getMessage().contains("1 (request epoch)"));
+        assertTrue(exception.getMessage().contains("5 (seq. number)"));
+        assertTrue(exception.getMessage().contains("0 (current producer epoch)"));
+        
+        // Test Case 2: Epoch bump (0 -> 1) with sequence 0 should succeed
+        ProducerAppendInfo appendInfo2 = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
+        assertDoesNotThrow(() -> appendInfo2.appendDataBatch(
+                (short) 1,
+                0,
+                0,
+                time.milliseconds(),
+                new LogOffsetMetadata(3L), 3L, false)
+        );
+    }
+
+    @Test
     public void testLastStableOffsetCompletedTxn() {
         long segmentBaseOffset = 990000L;
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
@@ -1050,6 +1050,95 @@ public class ProducerStateManagerTest {
     }
 
     @Test
+    public void testRejectNonZeroSequenceForTransactionsV2WithEmptyState() {
+        // Create a verification state entry that supports epoch bump (transactions v2)
+        VerificationStateEntry verificationEntry = stateManager.maybeCreateVerificationStateEntry(
+            producerId,
+            0,
+            epoch,
+            true
+        );
+        
+        // Verify this is actually transactions v2
+        assertTrue(
+            verificationEntry.supportsEpochBump(),
+            "Should be using transactions v2 (supports epoch bump)"
+        );
+        
+        // Create ProducerAppendInfo with empty producer state
+        ProducerAppendInfo appendInfo = new ProducerAppendInfo(
+            partition,
+            producerId,
+            ProducerStateEntry.empty(producerId),
+            AppendOrigin.CLIENT,
+            verificationEntry
+        );
+        
+        // Attempting to append with non-zero sequence number should fail for transactions v2
+        OutOfOrderSequenceException exception = assertThrows(
+            OutOfOrderSequenceException.class,
+            () -> appendInfo.appendDataBatch(
+                epoch,
+                5,
+                5,
+                time.milliseconds(),
+                new LogOffsetMetadata(0L), 0L, false
+            )
+        );
+        
+        assertTrue(exception.getMessage().contains("Expected sequence 0 for " +
+            "transactions v2 idempotent producer"
+        ));
+        assertTrue(exception.getMessage().contains("5 (incoming seq. number)"));
+        
+        // Attempting to append with sequence 0 should succeed
+        assertDoesNotThrow(() -> appendInfo.appendDataBatch(
+            epoch,
+            0,
+            0,
+            time.milliseconds(),
+            new LogOffsetMetadata(0L), 0L, false)
+        );
+    }
+
+    @Test
+    public void testAllowNonZeroSequenceForTransactionsV1WithEmptyState() {
+        // Create a verification state entry that does NOT support epoch bump (transactions v1)
+        // Set lowest sequence to 5 to allow our test sequence to pass the verification check
+        VerificationStateEntry verificationEntry = stateManager.maybeCreateVerificationStateEntry(
+            producerId + 1,
+            5,
+            epoch,
+            false
+        );
+        
+        // Verify this is transactions v1
+        assertFalse(
+            verificationEntry.supportsEpochBump(),
+            "Should be using transactions v1 (does not support epoch bump)"
+        );
+        
+        // Create ProducerAppendInfo with empty producer state
+        ProducerAppendInfo appendInfo = new ProducerAppendInfo(
+            partition,
+            producerId + 1,
+            ProducerStateEntry.empty(producerId + 1),
+            AppendOrigin.CLIENT,
+            verificationEntry
+        );
+        
+        // Attempting to append with non-zero sequence number should succeed for transactions v1
+        // (our validation should not trigger)
+        assertDoesNotThrow(() -> appendInfo.appendDataBatch(
+            epoch,
+            5,
+            5,
+            time.milliseconds(),
+            new LogOffsetMetadata(0L), 0L, false)
+        );
+    }
+
+    @Test
     public void testLastStableOffsetCompletedTxn() {
         long segmentBaseOffset = 990000L;
 


### PR DESCRIPTION
This change handles rejecting non-zero sequences when there is an empty
producerIDState with TV2.  The scenario will be covered with the
re-triable OutOfOrderSequence error.

For Transactions V2 with empty state:  ✅ Only sequence 0 is allowed for
new producers or after state cleanup (new validation added)  ❌ Any
non-zero sequence is rejected with our specific error message  ❌ Epoch
bumps still require sequence 0 (existing validation remains)

For Transactions V1 with empty state:  ✅ ANY sequence number is allowed
(0, 5, 100, etc.)  ❌ Epoch bumps still require sequence 0 (existing
validation)

Reviewers: Justine Olshan <jolshan@confluent.io>, Artem Livshits
 <alivshits@confluent.io>
