### PR TITLE
MINOR: Use `pollUntilTrue` instead of `waitForCondition`

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/ClientsTestUtils.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/ClientsTestUtils.java
@@ -109,12 +109,31 @@ public class ClientsTestUtils {
     }
 
     public static void pollUntilTrue(
-            Consumer<byte[], byte[]> consumer,
-            Supplier<Boolean> testCondition,
-            long waitTimeMs, String msg
+        Consumer<byte[], byte[]> consumer,
+        Supplier<Boolean> testCondition,
+        String msg
+    ) throws InterruptedException {
+        pollUntilTrue(consumer, Duration.ofMillis(100), testCondition, 15_000L, msg);
+    }
+
+    public static void pollUntilTrue(
+        Consumer<byte[], byte[]> consumer,
+        Supplier<Boolean> testCondition,
+        long waitTimeMs,
+        String msg
+    ) throws InterruptedException {
+        pollUntilTrue(consumer, Duration.ofMillis(100), testCondition, waitTimeMs, msg);
+    }
+
+    public static void pollUntilTrue(
+        Consumer<byte[], byte[]> consumer,
+        Duration timeout,
+        Supplier<Boolean> testCondition,
+        long waitTimeMs, 
+        String msg
     ) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
-            consumer.poll(Duration.ofMillis(100));
+            consumer.poll(timeout);
             return testCondition.get();
         }, waitTimeMs, msg);
     }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCallbackTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCallbackTest.java
@@ -16,14 +16,13 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.clients.ClientsTestUtils;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.test.ClusterInstance;
-import org.apache.kafka.common.test.TestUtils;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -237,11 +236,9 @@ public class PlaintextConsumerCallbackTest {
                 // noop
             }
         });
-        TestUtils.waitForCondition(
-            () -> {
-                consumer.poll(Duration.ofMillis(100));
-                return partitionsAssigned.get();
-            },
+        ClientsTestUtils.pollUntilTrue(
+            consumer, 
+            partitionsAssigned::get, 
             "Timed out before expected rebalance completed"
         );
     }
@@ -272,11 +269,9 @@ public class PlaintextConsumerCallbackTest {
                     }
                 }
             });
-            TestUtils.waitForCondition(
-                () -> {
-                    consumer.poll(Duration.ofMillis(100));
-                    return partitionsAssigned.get();
-                },
+            ClientsTestUtils.pollUntilTrue(
+                consumer,
+                partitionsAssigned::get,
                 "Timed out before expected rebalance completed"
             );
         }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerPollTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerPollTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer;
 
 
+import org.apache.kafka.clients.ClientsTestUtils;
 import org.apache.kafka.clients.ClientsTestUtils.TestConsumerReassignmentListener;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.MetricName;
@@ -565,10 +566,11 @@ public class PlaintextConsumerPollTest {
 
             // Subscribe to different topic. This will trigger the delayed revocation exceeding rebalance timeout and get fenced
             consumer.subscribe(List.of(otherTopic), listener);
-            TestUtils.waitForCondition(() -> {
-                consumer.poll(Duration.ofMillis(100));
-                return rebalanceTimeoutExceeded.get();
-            }, "Timeout waiting for delayed callback to complete");
+            ClientsTestUtils.pollUntilTrue(
+                consumer,
+                rebalanceTimeoutExceeded::get,
+                "Timeout waiting for delayed callback to complete"
+            );
 
             // Verify consumer recovers after being fenced, being able to continue consuming.
             // (The member should automatically rejoin on the next poll, with the new topic as subscription)


### PR DESCRIPTION
We can use `pollUntilTrue` instead of `waitForCondition`, thus do a
little refactor to reduce the duplicate code

Reviewers: TengYao Chi <frankvicky@apache.org>, Lan Ding
 <isDing_L@163.com>, TaiJuWu <tjwu1217@gmail.com>
