### PR TITLE
KAFKA-19392: Fix metadata.log.segment.ms not being applied

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -593,6 +593,7 @@ object KafkaMetadataLog extends Logging {
       props.setProperty(LogConfig.INTERNAL_SEGMENT_BYTES_CONFIG, config.internalSegmentBytes().toString)
     else
       props.setProperty(TopicConfig.SEGMENT_BYTES_CONFIG, config.logSegmentBytes.toString)
+    props.setProperty(TopicConfig.SEGMENT_MS_CONFIG, config.logSegmentMillis.toString)
     props.setProperty(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG, ServerLogConfigs.LOG_DELETE_DELAY_MS_DEFAULT.toString)
 
     // Disable time and byte retention when deleting segments

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -1011,6 +1011,13 @@ final class KafkaMetadataLogTest {
   }
 
   @Test
+  def testSegmentMsConfigIsSetInMetadataLog(): Unit = {
+    val log = buildMetadataLog(tempDir, mockTime)
+
+    assertEquals(DefaultMetadataLogConfig.logSegmentMillis, log.log.config().segmentMs)
+  }
+
+  @Test
   def testSegmentsLessThanLatestSnapshot(): Unit = {
     val config = createMetadataLogConfig(
       10240,


### PR DESCRIPTION
The original `props.setProperty(TopicConfig.SEGMENT_MS_CONFIG,
config.logSegmentMillis.toString)` in the `KafkaMetadataLog` constructor
was accidentally removed in #19371. Add a test to ensure this property
is properly  assigned.

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
