### PR TITLE
MINOR: Improve the prompt in committer-tools/reviewers.py

### DIFF
--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -63,8 +63,8 @@ def append_message_to_pr_body(pr: int , message: str):
         return
 
     print(f"""New PR body will be:\n\n---\n{updated_pr_body}---\n""")
-    choice = input(f'Update the body of "{pr_title}"? [Y/n] ').strip()
-    if choice not in ['', 'y', 'Y']:
+    choice = input(f'Update the body of "{pr_title}"? [Y/n] ').strip().lower()
+    if choice not in ['', 'y']:
         print("Abort.")
         return
 

--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -63,8 +63,9 @@ def append_message_to_pr_body(pr: int , message: str):
         return
 
     print(f"""New PR body will be:\n\n---\n{updated_pr_body}---\n""")
-    choice = input(f'Update the body of "{pr_title}"? (y/n): ').strip().lower()
-    if choice in ['n', 'no']:
+    choice = input(f'Update the body of "{pr_title}"? [Y/n] ').strip()
+    if choice not in ['', 'y', 'Y']:
+        print("Abort.")
         return
 
     try:


### PR DESCRIPTION
Previously, the confirmation prompt for updating the PR body treated any
input other than 'n' as approval, which could lead to unintended
actions.

With this change, the update will only proceed if the user enters 'y',
'Y', or presses Enter. For any other input, the operation is canceled
and an Abort. message is printed. This makes the prompt behavior clearer
and more predictable.

Reviewers: TengYao Chi <frankvicky@apache.org>, PoAn Yang
 <payang@apache.org>, Kuan-Po Tseng <brandboat@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Lan Ding <isDing_L@163.com>
