### PR TITLE
KAFKA-19395 - Updated Junit and mockito version and license information in NOTICE-binary for Jakarta RESTful Web Services Project

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -160,9 +160,9 @@ The project maintains the following source code repositories:
 
 This project leverages the following third party content.
 
-JUnit (5.13.1)
+JUnit (4.12)
 
-* License: Eclipse Public License v2.0
+* License: Eclipse Public License
 
 
 # Notices for Jakarta Annotations
@@ -248,7 +248,7 @@ javaee-api (7.0)
 
 * License: Apache-2.0 AND W3C
 
-JUnit (5.13.1)
+JUnit (5.10.2)
 
 * License: Eclipse Public License v2.0
 

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -252,10 +252,10 @@ JUnit (5.10.2)
 
 * License: Eclipse Public License v2.0
 
-Mockito (2.16.0)
+Mockito (5.11.0)
 
 * Project: http://site.mockito.org
-* Source: https://github.com/mockito/mockito/releases/tag/v2.16.0
+* Source: https://github.com/mockito/mockito/releases/tag/v5.11.0
 
 ## Cryptography
 

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -248,7 +248,7 @@ javaee-api (7.0)
 
 * License: Apache-2.0 AND W3C
 
-JUnit (5.10.2)
+JUnit (5.13.1)
 
 * License: Eclipse Public License v2.0
 

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -252,10 +252,10 @@ JUnit (5.10.2)
 
 * License: Eclipse Public License v2.0
 
-Mockito (5.11.0)
+Mockito (5.14.2)
 
 * Project: http://site.mockito.org
-* Source: https://github.com/mockito/mockito/releases/tag/v5.11.0
+* Source: https://github.com/mockito/mockito/releases/tag/v5.14.2
 
 ## Cryptography
 

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -160,9 +160,9 @@ The project maintains the following source code repositories:
 
 This project leverages the following third party content.
 
-JUnit (4.12)
+JUnit (5.13.1)
 
-* License: Eclipse Public License
+* License: Eclipse Public License v2.0
 
 
 # Notices for Jakarta Annotations
@@ -248,9 +248,9 @@ javaee-api (7.0)
 
 * License: Apache-2.0 AND W3C
 
-JUnit (4.11)
+JUnit (5.13.1)
 
-* License: Common Public License 1.0
+* License: Eclipse Public License v2.0
 
 Mockito (2.16.0)
 


### PR DESCRIPTION
Jira - https://issues.apache.org/jira/browse/KAFKA-19395

Updated Junit version and license information in NOTICE-binary for Jakarta RESTful Web Services Project

Github pom.xml for Jakarta rest project - https://github.com/jakartaee/rest/blob/36de36005d52fc06fc050aa6def415abb255a539/pom.xml#L114

Maven for Junit 5.10.2 version - https://mvnrepository.com/artifact/org.junit/junit-bom/5.10.2
