### PR TITLE
MINOR: Update opentelemetry-proto dependency

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -245,7 +245,7 @@ License Version 2.0:
 - lz4-java-1.8.0
 - maven-artifact-3.9.6
 - metrics-core-2.2.0
-- opentelemetry-proto-1.0.0-alpha
+- opentelemetry-proto-1.3.2-alpha
 - plexus-utils-3.5.1
 - rocksdbjni-9.7.3
 - scala-library-2.13.16

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -109,7 +109,7 @@ versions += [
   mavenArtifact: "3.9.6",
   metrics: "2.2.0",
   mockito: "5.14.2",
-  opentelemetryProto: "1.0.0-alpha",
+  opentelemetryProto: "1.3.2-alpha",
   protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.2",
   re2j: "1.8",


### PR DESCRIPTION
Update opentelemetry-proto from 1.0.0-alpha to 1.3.2-alpha.

OpenTelemetry-Proto versions from v1.0.0 up to and including v1.3.2
introduce no breaking changes.

[release
note](https://github.com/open-telemetry/opentelemetry-proto/releases)

For example, starting with v1.4.0, protobuf-java was updated to version
4.28.3. To mitigate the risk of protobuf compatibility issues, upgrading
to v1.3.2 first allows the existing protobuf version to remain unchanged
for now.

Reviewers: poorv Mittal <apoorvmittal10@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
