### PR TITLE
MINOR: rename exception `e` to `swallow` where appropriate

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1899,7 +1899,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
     private void sendFetches(Timer timer) {
         try {
             applicationEventHandler.addAndGet(new CreateFetchRequestsEvent(calculateDeadlineMs(timer)));
-        } catch (TimeoutException e) {
+        } catch (TimeoutException swallow) {
             // Can be ignored, per above comments.
         }
     }
@@ -2212,7 +2212,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
                     Timer pollInterval = time.timer(100L);
                     return ConsumerUtils.getResult(future, pollInterval);
                 }
-            } catch (TimeoutException e) {
+            } catch (TimeoutException swallow) {
                 // Ignore this as we will retry the event until the timeout expires.
             } finally {
                 timer.update();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1977,7 +1977,7 @@ public class KafkaConsumerTest {
         try {
             newConsumer(groupProtocol, null, Optional.of(Boolean.TRUE));
             fail("Expected an InvalidConfigurationException");
-        } catch (InvalidConfigurationException e) {
+        } catch (InvalidConfigurationException swallow) {
             // OK, expected
         }
 
@@ -2142,7 +2142,7 @@ public class KafkaConsumerTest {
                 future.get(100, TimeUnit.MILLISECONDS);
                 if (closeTimeoutMs != 0)
                     fail("Close completed without waiting for commit or leave response");
-            } catch (TimeoutException e) {
+            } catch (TimeoutException swallow) {
                 // Expected exception
             }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -183,7 +183,7 @@ public class AsyncKafkaConsumerTest {
             try {
                 consumer.close(CloseOptions.timeout(Duration.ZERO));
             } catch (Exception swallow) {
-                // best effort to clean up after each test, but may throw (ex. if callbacks where
+                // best effort to clean up after each test, but may throw (ex. if callbacks were
                 // throwing errors)
             }
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -182,7 +182,7 @@ public class AsyncKafkaConsumerTest {
         if (consumer != null) {
             try {
                 consumer.close(CloseOptions.timeout(Duration.ZERO));
-            } catch (Exception e) {
+            } catch (Exception swallow) {
                 // best effort to clean up after each test, but may throw (ex. if callbacks where
                 // throwing errors)
             }


### PR DESCRIPTION
I noticed that in commit
[a662bc56](https://github.com/apache/kafka/commit/a662bc56345d1d46d5f3340ea522d8158d09ca49),
renamed ignored exceptions `e` to `swallow`.

Here's a small patch to make that change consistent in other files:
AsyncKafkaConsumer.java, KafkaConsumerTest.java,
AsyncKafkaConsumerTest.java

Reviewers: Kirk True <kirk@kirktrue.pro>, Lan Ding <isDing_L@163.com>,
 Chia-Ping Tsai <chia7712@gmail.com>
