### PR TITLE
MINOR: Bump commons beanutils39

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -207,13 +207,13 @@ License Version 2.0:
 
 audience-annotations-0.12.0
 caffeine-2.9.3
-commons-beanutils-1.9.4
+commons-beanutils-1.11.0
 commons-cli-1.4
 commons-collections-3.2.2
 commons-digester-2.1
 commons-io-2.14.0
 commons-lang3-3.12.0
-commons-logging-1.2
+commons-logging-1.3.5
 commons-validator-1.7
 error_prone_annotations-2.10.0
 jackson-annotations-2.16.2

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,9 @@ allprojects {
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
           // be explicit about the reload4j version instead of relying on the transitive versions
-          libs.reload4j
+          libs.reload4j,
+          // Workaround before `commons-validator` has new release. See KAFKA-19359.
+          libs.commonsBeanutils,
         )
       }
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -91,6 +91,7 @@ versions += [
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   commonsIo: "2.14.0", // ZooKeeper dependency. Do not use, this is going away.
+  commonsBeanutils: "1.11.0",
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.10.2",
@@ -182,6 +183,7 @@ libs += [
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsIo: "commons-io:commons-io:$versions.commonsIo",
+  commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",


### PR DESCRIPTION
trunk PR: https://github.com/apache/kafka/pull/19939

Bump the commons-beanutils for https://github.com/advisories/GHSA-wxr5-93ph-8wr9. Since commons-validator
hasn't had new release with newer commons-beanutils versions, we manually bump it in kafka.