### PR TITLE
:wrench: Add Gradle option to start broker outside CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ ext {
     libs.log4j2Api,
     libs.log4j2Core
   ]
-  
+
 }
 
 allprojects {
@@ -548,7 +548,7 @@ subprojects {
         maxFailures = userMaxTestRetryFailures
       }
     }
-    
+
     finalizedBy("copyTestXml")
   }
 
@@ -1025,6 +1025,7 @@ project(':core') {
     implementation libs.scalaReflect
     implementation libs.scalaLogging
     implementation libs.slf4jApi
+    runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.24.3"
     implementation libs.re2j
 
     testImplementation project(':clients').sourceSets.test.output
@@ -1072,6 +1073,21 @@ project(':core') {
       highlighting = false
       minimumRate = 0.0
     }
+  }
+
+  tasks.register("runKafkaBroker", JavaExec) {
+    group = "nilext"
+    description = "Run Kafka broker with Gradle-managed classpath"
+
+    mainClass.set("kafka.Kafka")
+    classpath = sourceSets.main.runtimeClasspath
+
+    jvmArgs = [
+            "-Dlog4j2.configurationFile=$rootDir/config/log4j2.yaml",
+            "-Dkafka.logs.dir=/tmp/kafka-logs"
+    ]
+
+    args = ["$rootDir/config/server.properties"]
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {


### PR DESCRIPTION
The only way to start a broker was to run `./bin/kafka-server-start.sh config/server.properties`. However, this would require the code to be compiled, making it very difficult to attach a debugger so testing purposes.

Needed to include `runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.24.3"`, as otherwise there would be no implementation that actually outputs any logs to CLI. My guess is that by running the shell command, a log4j implementation is injected automatically. However, when running from Gradle, unless specified (what we did), the system cannot locate any implementation, but rather just the interface.

This is hacky, but will do it for the moment.
