### PR TITLE
MINOR: Add comment why we use thread-id filtering when registering metrics for KIP-1076

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
@@ -59,7 +59,7 @@ public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
     }
 
     /*
-       The KafkaMetric object is a singleton shared by all StreamThread instances.
+       The StreamMetrics object is a singleton shared by all StreamThread instances.
        So we need to make sure we only pass metrics for the current StreamThread that contains this
        MetricsReporter instance, which will register metrics with the embedded KafkaConsumer to pass
        through the telemetry pipeline.

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/StreamsThreadMetricsDelegatingReporter.java
@@ -58,6 +58,13 @@ public class StreamsThreadMetricsDelegatingReporter implements MetricsReporter {
         }
     }
 
+    /*
+       The KafkaMetric object is a singleton shared by all StreamThread instances.
+       So we need to make sure we only pass metrics for the current StreamThread that contains this
+       MetricsReporter instance, which will register metrics with the embedded KafkaConsumer to pass
+       through the telemetry pipeline.
+       Otherwise, Kafka Streams would register multiple metrics for all StreamThreads.
+     */
     private boolean tagMatchStreamOrStateUpdaterThreadId(final KafkaMetric metric) {
         final Map<String, String> tags = metric.metricName().tags();
         final boolean shouldInclude = tags.containsKey(THREAD_ID_TAG) && (tags.get(THREAD_ID_TAG).equals(threadId) ||


### PR DESCRIPTION
Adding a descriptive comment why it's necessary to filter metrics
registration by thread-id tags.  This is due to the fact that the
`StreamsMetric` is a singleton shared by all StreamThread instances, so
we need to make sure only add metrics for the current StreamThread
otherwise duplicate metrics are registered.

Reviewers: Matthias Sax <mjsax@apache.org>
