### PR TITLE
KAFKA-19408 : Add check for compression type mismatch for push telemetry requests

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -200,6 +200,8 @@ public class ClientMetricsManager implements AutoCloseable {
         try {
             // Validate the push request parameters for the client instance.
             validatePushRequest(request, clientInstance, now);
+        } catch (InvalidRequestException exception) {
+            log.info("Invalid request for client instance id: [{}] . Continuing with the request.", clientInstanceId, exception);
         } catch (ApiException exception) {
             log.debug("Error validating push telemetry request from client [{}]", clientInstanceId, exception);
             clientInstance.lastKnownError(Errors.forException(exception));
@@ -399,7 +401,8 @@ public class ClientMetricsManager implements AutoCloseable {
         }
     }
 
-    private void validatePushRequest(PushTelemetryRequest request, ClientMetricsInstance clientInstance, long timestamp) {
+    // Visible for testing
+    void validatePushRequest(PushTelemetryRequest request, ClientMetricsInstance clientInstance, long timestamp) {
 
         if (clientInstance.terminating()) {
             String msg = String.format(
@@ -432,6 +435,15 @@ public class ClientMetricsManager implements AutoCloseable {
             String msg = String.format("Telemetry request from [%s] is larger than the maximum allowed size [%s]",
                 request.data().clientInstanceId(), clientTelemetryMaxBytes);
             throw new TelemetryTooLargeException(msg);
+        }
+
+        // Client library picks the first compression type from the list of supported compression types send by the broker.
+        // If compression type send in push telemetry request is different from the preferred compression type by broker, 
+        // it means that client has ignored the preferred compression type and sent the invalid request
+        if (request.data().compressionType() != SUPPORTED_COMPRESSION_TYPES.get(0)) {
+            String msg = String.format("Compression type [%s] is received in push telemetry is different from the preferred compression type [%s] for client instance id: [%s]",
+                    CompressionType.forId(request.data().compressionType()), CompressionType.forId(SUPPORTED_COMPRESSION_TYPES.get(0)), request.data().clientInstanceId());
+            throw new InvalidRequestException(msg);
         }
     }
 

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -200,8 +200,6 @@ public class ClientMetricsManager implements AutoCloseable {
         try {
             // Validate the push request parameters for the client instance.
             validatePushRequest(request, clientInstance, now);
-        } catch (InvalidRequestException exception) {
-            log.info("Invalid request for client instance id: [{}] . Continuing with the request.", clientInstanceId, exception);
         } catch (ApiException exception) {
             log.debug("Error validating push telemetry request from client [{}]", clientInstanceId, exception);
             clientInstance.lastKnownError(Errors.forException(exception));
@@ -401,8 +399,7 @@ public class ClientMetricsManager implements AutoCloseable {
         }
     }
 
-    // Visible for testing
-    void validatePushRequest(PushTelemetryRequest request, ClientMetricsInstance clientInstance, long timestamp) {
+    private void validatePushRequest(PushTelemetryRequest request, ClientMetricsInstance clientInstance, long timestamp) {
 
         if (clientInstance.terminating()) {
             String msg = String.format(
@@ -439,11 +436,12 @@ public class ClientMetricsManager implements AutoCloseable {
 
         // Client library picks the first compression type from the list of supported compression types send by the broker.
         // If compression type send in push telemetry request is different from the preferred compression type by broker, 
-        // it means that client has ignored the preferred compression type and sent the invalid request
+        // it means that client has ignored the preferred compression type. 
+        // This is not an error, so log a warning and continue with the push telemetry request.
         if (request.data().compressionType() != SUPPORTED_COMPRESSION_TYPES.get(0)) {
-            String msg = String.format("Compression type [%s] is received in push telemetry is different from the preferred compression type [%s] for client instance id: [%s]",
+            String msg = String.format("Compression type [%s] is received in push telemetry is different from the preferred compression type [%s] for client instance id: [%s]. Continuing with the push telemetry request.",
                     CompressionType.forId(request.data().compressionType()), CompressionType.forId(SUPPORTED_COMPRESSION_TYPES.get(0)), request.data().clientInstanceId());
-            throw new InvalidRequestException(msg);
+            log.info(msg);
         }
     }
 

--- a/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
@@ -61,7 +61,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1412,59 +1411,6 @@ public class ClientMetricsManagerTest {
         // Metrics size should remain same.
         assertEquals(12, kafkaMetrics.metrics().size());
         assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
-    }
-
-    @Test
-    public void testPushTelemetryInvalidCompressionType() throws Exception {
-        try (
-                Metrics kafkaMetrics = new Metrics();
-                ClientMetricsManager clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics)
-        ) {
-            // Get initial subscription
-            GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
-                    new GetTelemetrySubscriptionsRequestData(), true).build();
-
-            GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
-                    subscriptionsRequest, ClientMetricsTestUtils.requestContext());
-
-            ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
-
-            // Non-preferred compression type in push telemetry request (push telemetry sends gzip when zstd is preferred)
-            PushTelemetryRequest mismatchRequest = new PushTelemetryRequest.Builder(
-                    new PushTelemetryRequestData()
-                            .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                            .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
-                            .setCompressionType(CompressionType.GZIP.id), true).build();
-
-            // Preferred compression type in push telemetry request (push telemetry sends zstd when zstd is preferred)
-            PushTelemetryRequest matchRequest = new PushTelemetryRequest.Builder(
-                new PushTelemetryRequestData()
-                        .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                        .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
-                        .setCompressionType(CompressionType.ZSTD.id), true).build();
-
-            // Validate function throws InvalidRequestException for compression type mismatch
-            assertThrows(InvalidRequestException.class,
-                () -> clientMetricsManager.validatePushRequest(mismatchRequest, instance, time.milliseconds()));
-
-            // Push telemetry request should succeed even when compression type is mismatched
-            time.sleep(ClientMetricsConfigs.INTERVAL_MS_DEFAULT);
-            PushTelemetryResponse mismatchResponse = clientMetricsManager.processPushTelemetryRequest(
-                    mismatchRequest, ClientMetricsTestUtils.requestContext());
-            assertEquals(Errors.NONE, mismatchResponse.error());
-
-
-            // Validate function does not throw exception for matching compression type
-            time.sleep(ClientMetricsConfigs.INTERVAL_MS_DEFAULT);
-            assertDoesNotThrow(() -> 
-                clientMetricsManager.validatePushRequest(matchRequest, instance, time.milliseconds()));
-
-            // Push telemetry request should succeed as expected
-            time.sleep(ClientMetricsConfigs.INTERVAL_MS_DEFAULT);
-            PushTelemetryResponse matchResponse = clientMetricsManager.processPushTelemetryRequest(
-                    matchRequest, ClientMetricsTestUtils.requestContext());
-            assertEquals(Errors.NONE, matchResponse.error());
-        }
     }
 
     private KafkaMetric getMetric(String name) throws Exception {

--- a/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1411,6 +1412,59 @@ public class ClientMetricsManagerTest {
         // Metrics size should remain same.
         assertEquals(12, kafkaMetrics.metrics().size());
         assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+    }
+
+    @Test
+    public void testPushTelemetryInvalidCompressionType() throws Exception {
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics)
+        ) {
+            // Get initial subscription
+            GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
+                    new GetTelemetrySubscriptionsRequestData(), true).build();
+
+            GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
+                    subscriptionsRequest, ClientMetricsTestUtils.requestContext());
+
+            ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
+
+            // Non-preferred compression type in push telemetry request (push telemetry sends gzip when zstd is preferred)
+            PushTelemetryRequest mismatchRequest = new PushTelemetryRequest.Builder(
+                    new PushTelemetryRequestData()
+                            .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                            .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                            .setCompressionType(CompressionType.GZIP.id), true).build();
+
+            // Preferred compression type in push telemetry request (push telemetry sends zstd when zstd is preferred)
+            PushTelemetryRequest matchRequest = new PushTelemetryRequest.Builder(
+                new PushTelemetryRequestData()
+                        .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                        .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                        .setCompressionType(CompressionType.ZSTD.id), true).build();
+
+            // Validate function throws InvalidRequestException for compression type mismatch
+            assertThrows(InvalidRequestException.class,
+                () -> clientMetricsManager.validatePushRequest(mismatchRequest, instance, time.milliseconds()));
+
+            // Push telemetry request should succeed even when compression type is mismatched
+            time.sleep(ClientMetricsConfigs.INTERVAL_MS_DEFAULT);
+            PushTelemetryResponse mismatchResponse = clientMetricsManager.processPushTelemetryRequest(
+                    mismatchRequest, ClientMetricsTestUtils.requestContext());
+            assertEquals(Errors.NONE, mismatchResponse.error());
+
+
+            // Validate function does not throw exception for matching compression type
+            time.sleep(ClientMetricsConfigs.INTERVAL_MS_DEFAULT);
+            assertDoesNotThrow(() -> 
+                clientMetricsManager.validatePushRequest(matchRequest, instance, time.milliseconds()));
+
+            // Push telemetry request should succeed as expected
+            time.sleep(ClientMetricsConfigs.INTERVAL_MS_DEFAULT);
+            PushTelemetryResponse matchResponse = clientMetricsManager.processPushTelemetryRequest(
+                    matchRequest, ClientMetricsTestUtils.requestContext());
+            assertEquals(Errors.NONE, matchResponse.error());
+        }
     }
 
     private KafkaMetric getMetric(String name) throws Exception {


### PR DESCRIPTION
The current issue is that when a client sends a push telemetry request with a compression type different from the broker's preferred compression type (the first in the list of supported compression types), the request is accepted without any log on the broker side.

To address this, we propose adding log statement in broker side.