### PR TITLE
KAFKA-19411: Fix deleteAcls bug which allows more deletions than max records per user op

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -202,7 +202,7 @@ public class AclControlManager {
             AclBinding binding = acl.toBinding();
             if (filter.matches(binding)) {
                 // check size limitation first before adding additional records
-                if (records.size() > MAX_RECORDS_PER_USER_OP) {
+                if (records.size() == MAX_RECORDS_PER_USER_OP) {
                     throw new BoundedListTooLongException("Cannot remove more than " +
                         MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.");
                 }

--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -185,7 +185,9 @@ public class AclControlManager {
                 AclDeleteResult result = deleteAclsForFilter(filter, records);
                 results.add(result);
             } catch (BoundedListTooLongException e) {
-                results.add(new AclDeleteResult(new InvalidRequestException(e.getMessage(), e)));
+                // we do not return partial results here because the fact that only a portion of the deletions
+                // succeeded can be easily missed due to response size. instead fail the entire response
+                throw new InvalidRequestException(e.getMessage(), e);
             } catch (Throwable e) {
                 results.add(new AclDeleteResult(ApiError.fromThrowable(e).exception()));
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -204,7 +204,7 @@ public class AclControlManager {
             AclBinding binding = acl.toBinding();
             if (filter.matches(binding)) {
                 // check size limitation first before adding additional records
-                if (records.size() == MAX_RECORDS_PER_USER_OP) {
+                if (records.size() >= MAX_RECORDS_PER_USER_OP) {
                     throw new BoundedListTooLongException("Cannot remove more than " +
                         MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.");
                 }

--- a/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AclControlManager.java
@@ -184,6 +184,8 @@ public class AclControlManager {
                 validateFilter(filter);
                 AclDeleteResult result = deleteAclsForFilter(filter, records);
                 results.add(result);
+            } catch (BoundedListTooLongException e) {
+                results.add(new AclDeleteResult(new InvalidRequestException(e.getMessage(), e)));
             } catch (Throwable e) {
                 results.add(new AclDeleteResult(ApiError.fromThrowable(e).exception()));
             }
@@ -199,13 +201,14 @@ public class AclControlManager {
             StandardAcl acl = entry.getValue();
             AclBinding binding = acl.toBinding();
             if (filter.matches(binding)) {
-                deleted.add(new AclBindingDeleteResult(binding));
-                records.add(new ApiMessageAndVersion(
-                    new RemoveAccessControlEntryRecord().setId(id), (short) 0));
+                // check size limitation first before adding additional records
                 if (records.size() > MAX_RECORDS_PER_USER_OP) {
                     throw new BoundedListTooLongException("Cannot remove more than " +
                         MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.");
                 }
+                deleted.add(new AclBindingDeleteResult(binding));
+                records.add(new ApiMessageAndVersion(
+                    new RemoveAccessControlEntryRecord().setId(id), (short) 0));
             }
         }
         return new AclDeleteResult(deleted);

--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -48,6 +48,7 @@ import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.authorizer.AuthorizationResult;
 import org.apache.kafka.server.authorizer.AuthorizerServerInfo;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.mutable.BoundedListTooLongException;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,7 @@ import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
 import static org.apache.kafka.common.resource.PatternType.LITERAL;
 import static org.apache.kafka.common.resource.PatternType.MATCH;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
 import static org.apache.kafka.metadata.authorizer.StandardAclWithIdTest.TEST_ACLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -379,5 +381,71 @@ public class AclControlManagerTest {
         assertEquals(1, deleteAclResultsBothFilters.records().size());
         assertEquals(id, ((RemoveAccessControlEntryRecord) deleteAclResultsBothFilters.records().get(0).message()).id());
         assertEquals(2, deleteAclResultsBothFilters.response().size());
+    }
+
+    @Test
+    public void testDeleteExceedsMaxRecords() {
+        AclControlManager manager = new AclControlManager.Builder().build();
+        MockClusterMetadataAuthorizer authorizer = new MockClusterMetadataAuthorizer();
+        authorizer.loadSnapshot(manager.idToAcl());
+
+        List<AclBinding> firstCreate = new ArrayList<>();
+        List<AclBinding> secondCreate = new ArrayList<>();
+
+        // create MAX_RECORDS_PER_USER_OP + 2 ACLs
+        for (int i = 0; i < MAX_RECORDS_PER_USER_OP + 2; i++) {
+            StandardAclWithId acl = new StandardAclWithId(Uuid.randomUuid(),
+                new StandardAcl(
+                    ResourceType.TOPIC,
+                    "mytopic_" + i,
+                    PatternType.LITERAL,
+                    "User:alice",
+                    "127.0.0.1",
+                    AclOperation.READ,
+                    AclPermissionType.ALLOW));
+
+            if (i % 2 == 0) {
+                // add to first create list
+                firstCreate.add(acl.toBinding());
+            } else {
+                // add to second create list
+                secondCreate.add(acl.toBinding());
+            }
+        }
+        ControllerResult<List<AclCreateResult>> firstCreateResult = manager.createAcls(firstCreate);
+        assertEquals((MAX_RECORDS_PER_USER_OP / 2) + 1, firstCreateResult.response().size());
+        for (AclCreateResult result : firstCreateResult.response()) {
+            assertTrue(result.exception().isEmpty());
+        }
+
+        ControllerResult<List<AclCreateResult>> secondCreateResult = manager.createAcls(secondCreate);
+        assertEquals((MAX_RECORDS_PER_USER_OP / 2) + 1, secondCreateResult.response().size());
+        for (AclCreateResult result : secondCreateResult.response()) {
+            assertTrue(result.exception().isEmpty());
+        }
+
+        RecordTestUtils.replayAll(manager, firstCreateResult.records());
+        RecordTestUtils.replayAll(manager, secondCreateResult.records());
+        assertFalse(manager.idToAcl().isEmpty());
+
+        ArrayList<AclBindingFilter> filters = new ArrayList<>();
+        for (int i = 0; i < MAX_RECORDS_PER_USER_OP + 2; i++) {
+            filters.add(new AclBindingFilter(
+                new ResourcePatternFilter(ResourceType.TOPIC, "mytopic_" + i, PatternType.LITERAL),
+                AccessControlEntryFilter.ANY));
+        }
+
+        ControllerResult<List<AclDeleteResult>> deleteResult =
+            manager.deleteAcls(filters);
+
+        assertEquals(MAX_RECORDS_PER_USER_OP + 2, deleteResult.response().size());
+        for (AclDeleteResult.AclBindingDeleteResult result :
+            deleteResult.response().get(0).aclBindingDeleteResults()) {
+            assertEquals(Optional.empty(), result.exception());
+        }
+        Exception exception = deleteResult.response().get(MAX_RECORDS_PER_USER_OP + 1).exception().get();
+        assertEquals(InvalidRequestException.class, exception.getClass());
+        assertEquals(BoundedListTooLongException.class, exception.getCause().getClass());
+        assertEquals("Cannot remove more than " + MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.", exception.getCause().getMessage());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -434,19 +434,8 @@ public class AclControlManagerTest {
                 AccessControlEntryFilter.ANY));
         }
 
-        ControllerResult<List<AclDeleteResult>> deleteResult =
-            manager.deleteAcls(filters);
-
-        assertEquals(MAX_RECORDS_PER_USER_OP + 2, deleteResult.response().size());
-        for (AclDeleteResult.AclBindingDeleteResult result :
-            deleteResult.response().get(MAX_RECORDS_PER_USER_OP - 1).aclBindingDeleteResults()) {
-            assertEquals(Optional.empty(), result.exception());
-        }
-        for (int i = MAX_RECORDS_PER_USER_OP; i < MAX_RECORDS_PER_USER_OP + 2; i++) {
-            Exception exception = deleteResult.response().get(i).exception().get();
-            assertEquals(InvalidRequestException.class, exception.getClass());
-            assertEquals(BoundedListTooLongException.class, exception.getCause().getClass());
-            assertEquals("Cannot remove more than " + MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.", exception.getCause().getMessage());
-        }
+        Exception exception = assertThrows(InvalidRequestException.class, () -> manager.deleteAcls(filters));
+        assertEquals(BoundedListTooLongException.class, exception.getCause().getClass());
+        assertEquals("Cannot remove more than " + MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.", exception.getCause().getMessage());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -404,11 +404,10 @@ public class AclControlManagerTest {
                     AclOperation.READ,
                     AclPermissionType.ALLOW));
 
+            // split acl creations between two create requests
             if (i % 2 == 0) {
-                // add to first create list
                 firstCreate.add(acl.toBinding());
             } else {
-                // add to second create list
                 secondCreate.add(acl.toBinding());
             }
         }
@@ -440,12 +439,14 @@ public class AclControlManagerTest {
 
         assertEquals(MAX_RECORDS_PER_USER_OP + 2, deleteResult.response().size());
         for (AclDeleteResult.AclBindingDeleteResult result :
-            deleteResult.response().get(0).aclBindingDeleteResults()) {
+            deleteResult.response().get(MAX_RECORDS_PER_USER_OP - 1).aclBindingDeleteResults()) {
             assertEquals(Optional.empty(), result.exception());
         }
-        Exception exception = deleteResult.response().get(MAX_RECORDS_PER_USER_OP + 1).exception().get();
-        assertEquals(InvalidRequestException.class, exception.getClass());
-        assertEquals(BoundedListTooLongException.class, exception.getCause().getClass());
-        assertEquals("Cannot remove more than " + MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.", exception.getCause().getMessage());
+        for (int i = MAX_RECORDS_PER_USER_OP; i < MAX_RECORDS_PER_USER_OP + 2; i++) {
+            Exception exception = deleteResult.response().get(i).exception().get();
+            assertEquals(InvalidRequestException.class, exception.getClass());
+            assertEquals(BoundedListTooLongException.class, exception.getCause().getClass());
+            assertEquals("Cannot remove more than " + MAX_RECORDS_PER_USER_OP + " acls in a single delete operation.", exception.getCause().getMessage());
+        }
     }
 }


### PR DESCRIPTION
If there are more deletion filters after we initially hit the
`MAX_RECORDS_PER_USER_OP` bound, we will add an additional deletion
record ontop of that for each additional filter.

The current error message returned to the client is not useful either,
adding logic so client doesn't just get `UNKNOWN_SERVER_EXCEPTION` with
no details returned.
