### PR TITLE
MINOR: replace test "catch exception" by assertThrows

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1974,7 +1974,9 @@ public class KafkaConsumerTest {
     @ParameterizedTest
     @EnumSource(GroupProtocol.class)
     public void testOperationsBySubscribingConsumerWithDefaultGroupId(GroupProtocol groupProtocol) {
-        assertThrows(InvalidConfigurationException.class, () -> newConsumer(groupProtocol, null, Optional.of(Boolean.TRUE)));
+        assertThrows(InvalidConfigurationException.class,
+            () -> newConsumer(groupProtocol, null, Optional.of(Boolean.TRUE)),
+            "Expected an InvalidConfigurationException");
 
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupProtocol, null)) {
             assertThrows(InvalidGroupIdException.class, () -> consumer.subscribe(Set.of(topic)));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1974,12 +1974,7 @@ public class KafkaConsumerTest {
     @ParameterizedTest
     @EnumSource(GroupProtocol.class)
     public void testOperationsBySubscribingConsumerWithDefaultGroupId(GroupProtocol groupProtocol) {
-        try {
-            newConsumer(groupProtocol, null, Optional.of(Boolean.TRUE));
-            fail("Expected an InvalidConfigurationException");
-        } catch (InvalidConfigurationException swallow) {
-            // OK, expected
-        }
+        assertThrows(InvalidConfigurationException.class, () -> newConsumer(groupProtocol, null, Optional.of(Boolean.TRUE)));
 
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupProtocol, null)) {
             assertThrows(InvalidGroupIdException.class, () -> consumer.subscribe(Set.of(topic)));
@@ -2087,7 +2082,7 @@ public class KafkaConsumerTest {
         client.prepareResponseFrom(joinGroupFollowerResponse(assignor, 1, memberId, leaderId, Errors.NONE), coordinator);
         client.prepareResponseFrom(syncGroupResponse(List.of(tp0), Errors.NONE), coordinator);
 
-        client.prepareResponseFrom(body -> body instanceof FetchRequest 
+        client.prepareResponseFrom(body -> body instanceof FetchRequest
             && ((FetchRequest) body).fetchData(topicNames).containsKey(new TopicIdPartition(topicId, tp0)), fetchResponse(tp0, 1, 1), node);
         time.sleep(heartbeatIntervalMs);
         Thread.sleep(heartbeatIntervalMs);
@@ -3563,9 +3558,9 @@ public void testPollIdleRatio(GroupProtocol groupProtocol) {
             Node node = metadata.fetch().nodes().get(0);
             client.prepareResponseFrom(FindCoordinatorResponse.prepareResponse(Errors.NONE, groupId, node), node);
         }
-        
+
         final KafkaConsumer<String, String> consumer = newConsumer(groupProtocol, time, client, subscription, metadata, assignor, false, groupInstanceId);
-        
+
         int maxPreparedResponses = GroupProtocol.CLASSIC.equals(groupProtocol) ? 10 : 1;
         for (int i = 0; i < maxPreparedResponses; i++) {
             client.prepareResponse(
@@ -3586,20 +3581,20 @@ public void testPollIdleRatio(GroupProtocol groupProtocol) {
     @EnumSource(GroupProtocol.class)
     public void testCommittedThrowsTimeoutExceptionForNoResponse(GroupProtocol groupProtocol) {
         Time time = new MockTime(Duration.ofSeconds(1).toMillis());
-        
+
         ConsumerMetadata metadata = createMetadata(subscription);
         MockClient client = new MockClient(time, metadata);
-        
+
         initMetadata(client, Map.of(topic, 2));
         Node node = metadata.fetch().nodes().get(0);
 
         client.prepareResponseFrom(FindCoordinatorResponse.prepareResponse(Errors.NONE, groupId, node), node);
         consumer = newConsumer(groupProtocol, time, client, subscription, metadata, assignor, true, groupInstanceId);
         consumer.assign(List.of(tp0));
-        
+
         // lookup coordinator
         Node coordinator = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
-        
+
         // try to get committed offsets for one topic-partition - but it is disconnected so there's no response and it will time out
         client.prepareResponseFrom(offsetResponse(Map.of(tp0, 0L), Errors.NONE), coordinator, true);
         org.apache.kafka.common.errors.TimeoutException timeoutException = assertThrows(org.apache.kafka.common.errors.TimeoutException.class,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1975,7 +1975,7 @@ public class KafkaConsumerTest {
     @EnumSource(GroupProtocol.class)
     public void testOperationsBySubscribingConsumerWithDefaultGroupId(GroupProtocol groupProtocol) {
         assertThrows(InvalidConfigurationException.class,
-            () -> newConsumer(groupProtocol, null, Optional.of(Boolean.TRUE)),
+            () -> newConsumer(groupProtocol, null, Optional.of(true)),
             "Expected an InvalidConfigurationException");
 
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupProtocol, null)) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -1603,7 +1603,8 @@ public class AbstractCoordinatorTest {
         mockClient.createPendingAuthenticationError(node, 300);
 
         assertThrows(AuthenticationException.class,
-            () -> coordinator.ensureCoordinatorReady(mockTime.timer(Long.MAX_VALUE)));
+            () -> coordinator.ensureCoordinatorReady(mockTime.timer(Long.MAX_VALUE)),
+            "Expected an authentication error.");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -1602,12 +1602,8 @@ public class AbstractCoordinatorTest {
 
         mockClient.createPendingAuthenticationError(node, 300);
 
-        try {
-            coordinator.ensureCoordinatorReady(mockTime.timer(Long.MAX_VALUE));
-            fail("Expected an authentication error.");
-        } catch (AuthenticationException e) {
-            // OK
-        }
+        assertThrows(AuthenticationException.class,
+            () -> coordinator.ensureCoordinatorReady(mockTime.timer(Long.MAX_VALUE)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3269,7 +3269,9 @@ public abstract class ConsumerCoordinatorTest {
     public void testAuthenticationFailureInEnsureActiveGroup() {
         client.createPendingAuthenticationError(node, 300);
 
-        assertThrows(AuthenticationException.class, () -> coordinator.ensureActiveGroup());
+        assertThrows(AuthenticationException.class,
+            () -> coordinator.ensureActiveGroup(),
+            "Expected an authentication error.");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3269,12 +3269,7 @@ public abstract class ConsumerCoordinatorTest {
     public void testAuthenticationFailureInEnsureActiveGroup() {
         client.createPendingAuthenticationError(node, 300);
 
-        try {
-            coordinator.ensureActiveGroup();
-            fail("Expected an authentication error.");
-        } catch (AuthenticationException e) {
-            // OK
-        }
+        assertThrows(AuthenticationException.class, () -> coordinator.ensureActiveGroup());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -135,7 +135,9 @@ public class ConfigDefTest {
             Map<String, Object> m = new HashMap<>();
             m.put("name", value);
             ConfigDef def = new ConfigDef().define("name", type, Importance.HIGH, "docs");
-            assertThrows(ConfigException.class, () -> def.parse(m));
+            assertThrows(ConfigException.class,
+                () -> def.parse(m),
+                "Expected a config exception on bad input for value " + value);
         }
     }
 
@@ -481,7 +483,9 @@ public class ConfigDefTest {
         for (Object value : badValues) {
             Map<String, Object> m = new HashMap<>();
             m.put("name", value);
-            assertThrows(ConfigException.class, () -> def.parse(m));
+            assertThrows(ConfigException.class,
+                () -> def.parse(m),
+                "Expected a config exception due to invalid value " + value);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -135,12 +135,7 @@ public class ConfigDefTest {
             Map<String, Object> m = new HashMap<>();
             m.put("name", value);
             ConfigDef def = new ConfigDef().define("name", type, Importance.HIGH, "docs");
-            try {
-                def.parse(m);
-                fail("Expected a config exception on bad input for value " + value);
-            } catch (ConfigException e) {
-                // this is good
-            }
+            assertThrows(ConfigException.class, () -> def.parse(m));
         }
     }
 
@@ -486,12 +481,7 @@ public class ConfigDefTest {
         for (Object value : badValues) {
             Map<String, Object> m = new HashMap<>();
             m.put("name", value);
-            try {
-                def.parse(m);
-                fail("Expected a config exception due to invalid value " + value);
-            } catch (ConfigException e) {
-                // this is good
-            }
+            assertThrows(ConfigException.class, () -> def.parse(m));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class RecordHeadersTest {
 
@@ -73,7 +72,7 @@ public class RecordHeadersTest {
         assertEquals(1, getCount(headers));
 
         headers.add(new RecordHeader("key3", "value3".getBytes()));
-        
+
         assertNull(headers.lastHeader("key"));
 
         assertHeader("key2", "value2", headers.lastHeader("key2"));
@@ -134,36 +133,20 @@ public class RecordHeadersTest {
         headers.add(new RecordHeader("key", "value".getBytes()));
         Iterator<Header> headerIteratorBeforeClose = headers.iterator();
         headers.setReadOnly();
-        try {
-            headers.add(new RecordHeader("key", "value".getBytes()));
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
+        // IllegalStateException expected as headers are closed.
+        assertThrows(IllegalStateException.class, () -> headers.add(new RecordHeader("key", "value".getBytes())));
 
-        try {
-            headers.remove("key");
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
+        // IllegalStateException expected as headers are closed.
+        assertThrows(IllegalStateException.class, () -> headers.remove("key"));
 
-        try {
-            Iterator<Header> headerIterator = headers.iterator();
-            headerIterator.next();
-            headerIterator.remove();
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
-        
-        try {
-            headerIteratorBeforeClose.next();
-            headerIteratorBeforeClose.remove();
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
+        Iterator<Header> headerIterator = headers.iterator();
+        headerIterator.next();
+        // IllegalStateException expected as headers are closed.
+        assertThrows(IllegalStateException.class, headerIterator::remove);
+
+        headerIteratorBeforeClose.next();
+        // IllegalStateException expected as headers are closed.
+        assertThrows(IllegalStateException.class, headerIterator::remove);
     }
 
     @Test
@@ -222,7 +205,7 @@ public class RecordHeadersTest {
     private int getCount(Headers headers) {
         return headers.toArray().length;
     }
-    
+
     static void assertHeader(String key, String value, Header actual) {
         assertEquals(key, actual.key());
         assertArrayEquals(value.getBytes(), actual.value());

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -133,20 +133,27 @@ public class RecordHeadersTest {
         headers.add(new RecordHeader("key", "value".getBytes()));
         Iterator<Header> headerIteratorBeforeClose = headers.iterator();
         headers.setReadOnly();
-        // IllegalStateException expected as headers are closed.
-        assertThrows(IllegalStateException.class, () -> headers.add(new RecordHeader("key", "value".getBytes())));
 
-        // IllegalStateException expected as headers are closed.
-        assertThrows(IllegalStateException.class, () -> headers.remove("key"));
+        assertThrows(IllegalStateException.class,
+            () -> headers.add(new RecordHeader("key", "value".getBytes())),
+            "IllegalStateException expected as headers are closed.");
+
+        assertThrows(IllegalStateException.class,
+            () -> headers.remove("key"),
+            "IllegalStateException expected as headers are closed.");
 
         Iterator<Header> headerIterator = headers.iterator();
         headerIterator.next();
-        // IllegalStateException expected as headers are closed.
-        assertThrows(IllegalStateException.class, headerIterator::remove);
+
+        assertThrows(IllegalStateException.class,
+            headerIterator::remove,
+            "IllegalStateException expected as headers are closed.");
 
         headerIteratorBeforeClose.next();
-        // IllegalStateException expected as headers are closed.
-        assertThrows(IllegalStateException.class, headerIterator::remove);
+
+        assertThrows(IllegalStateException.class,
+            headerIterator::remove,
+            "IllegalStateException expected as headers are closed.");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -64,7 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class MetricsTest {
     private static final Logger log = LoggerFactory.getLogger(MetricsTest.class);
@@ -98,12 +97,8 @@ public class MetricsTest {
         MetricName n2 = metrics.metricName("name", "group", "description", tags);
         assertEquals(n1, n2, "metric names created in two different ways should be equal");
 
-        try {
-            metrics.metricName("name", "group", "description", "key1");
-            fail("Creating MetricName with an odd number of keyValue should fail");
-        } catch (IllegalArgumentException e) {
-            // this is expected
-        }
+        // Creating MetricName with an odd number of keyValue should fail, IllegalArgumentException expected.
+        assertThrows(IllegalArgumentException.class, () -> metrics.metricName("name", "group", "description", "key1"));
     }
 
     @Test
@@ -419,20 +414,10 @@ public class MetricsTest {
         sensor.add(metrics.metricName("test1.total", "grp1"), new CumulativeSum(), new MetricConfig().quota(Quota.upperBound(5.0)));
         sensor.add(metrics.metricName("test2.total", "grp1"), new CumulativeSum(), new MetricConfig().quota(Quota.lowerBound(0.0)));
         sensor.record(5.0);
-        try {
-            sensor.record(1.0);
-            fail("Should have gotten a quota violation.");
-        } catch (QuotaViolationException e) {
-            // this is good
-        }
+        assertThrows(QuotaViolationException.class, () -> sensor.record(1.0));
         assertEquals(6.0, (Double) metrics.metrics().get(metrics.metricName("test1.total", "grp1")).metricValue(), EPS);
         sensor.record(-6.0);
-        try {
-            sensor.record(-1.0);
-            fail("Should have gotten a quota violation.");
-        } catch (QuotaViolationException e) {
-            // this is good
-        }
+        assertThrows(QuotaViolationException.class, () -> sensor.record(-1.0));
     }
 
     @Test
@@ -670,7 +655,7 @@ public class MetricsTest {
     private Double measure(Measurable rate, MetricConfig config) {
         return rate.measure(config, time.milliseconds());
     }
-    
+
     @Test
     public void testMetricInstances() {
         MetricName n1 = metrics.metricInstance(SampleMetrics.METRIC1, "key1", "value1", "key2", "value2");
@@ -680,13 +665,9 @@ public class MetricsTest {
         MetricName n2 = metrics.metricInstance(SampleMetrics.METRIC2, tags);
         assertEquals(n1, n2, "metric names created in two different ways should be equal");
 
-        try {
-            metrics.metricInstance(SampleMetrics.METRIC1, "key1");
-            fail("Creating MetricName with an odd number of keyValue should fail");
-        } catch (IllegalArgumentException e) {
-            // this is expected
-        }
-        
+        // Creating MetricName with an odd number of keyValue should fail, IllegalArgumentException expected.
+        assertThrows(IllegalArgumentException.class, () -> metrics.metricInstance(SampleMetrics.METRIC1, "key1"));
+
         Map<String, String> parentTagsWithValues = new HashMap<>();
         parentTagsWithValues.put("parent-tag", "parent-tag-value");
 
@@ -700,24 +681,15 @@ public class MetricsTest {
             assertEquals(filledOutTags.get("parent-tag"), "parent-tag-value", "parent-tag should be set properly");
             assertEquals(filledOutTags.get("child-tag"), "child-tag-value", "child-tag should be set properly");
 
-            try {
-                inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, parentTagsWithValues);
-                fail("Creating MetricName should fail if the child metrics are not defined at runtime");
-            } catch (IllegalArgumentException e) {
-                // this is expected
-            }
+            // Creating MetricName should throw IllegalArgumentException if the child metrics are not defined at runtime.
+            assertThrows(IllegalArgumentException.class, () -> inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, parentTagsWithValues));
 
-            try {
+            Map<String, String> runtimeTags = new HashMap<>();
+            runtimeTags.put("child-tag", "child-tag-value");
+            runtimeTags.put("tag-not-in-template", "unexpected-value");
 
-                Map<String, String> runtimeTags = new HashMap<>();
-                runtimeTags.put("child-tag", "child-tag-value");
-                runtimeTags.put("tag-not-in-template", "unexpected-value");
-
-                inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, runtimeTags);
-                fail("Creating MetricName should fail if there is a tag at runtime that is not in the template");
-            } catch (IllegalArgumentException e) {
-                // this is expected
-            }
+            // Creating MetricName should throw IllegalArgumentException if there is a tag at runtime that is not in the template.
+            assertThrows(IllegalArgumentException.class, () -> inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, runtimeTags));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -415,10 +415,14 @@ public class MetricsTest {
         sensor.add(metrics.metricName("test1.total", "grp1"), new CumulativeSum(), new MetricConfig().quota(Quota.upperBound(5.0)));
         sensor.add(metrics.metricName("test2.total", "grp1"), new CumulativeSum(), new MetricConfig().quota(Quota.lowerBound(0.0)));
         sensor.record(5.0);
-        assertThrows(QuotaViolationException.class, () -> sensor.record(1.0));
+        assertThrows(QuotaViolationException.class,
+            () -> sensor.record(1.0),
+            "Should have gotten a quota violation.");
         assertEquals(6.0, (Double) metrics.metrics().get(metrics.metricName("test1.total", "grp1")).metricValue(), EPS);
         sensor.record(-6.0);
-        assertThrows(QuotaViolationException.class, () -> sensor.record(-1.0));
+        assertThrows(QuotaViolationException.class,
+            () -> sensor.record(-1.0),
+            "Should have gotten a quota violation.");
     }
 
     @Test
@@ -666,8 +670,9 @@ public class MetricsTest {
         MetricName n2 = metrics.metricInstance(SampleMetrics.METRIC2, tags);
         assertEquals(n1, n2, "metric names created in two different ways should be equal");
 
-        // Creating MetricName with an odd number of keyValue should fail, IllegalArgumentException expected.
-        assertThrows(IllegalArgumentException.class, () -> metrics.metricInstance(SampleMetrics.METRIC1, "key1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> metrics.metricInstance(SampleMetrics.METRIC1, "key1"),
+            "Creating MetricName with an odd number of keyValue should fail, IllegalArgumentException expected.");
 
         Map<String, String> parentTagsWithValues = new HashMap<>();
         parentTagsWithValues.put("parent-tag", "parent-tag-value");

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -97,8 +97,9 @@ public class MetricsTest {
         MetricName n2 = metrics.metricName("name", "group", "description", tags);
         assertEquals(n1, n2, "metric names created in two different ways should be equal");
 
-        // Creating MetricName with an odd number of keyValue should fail, IllegalArgumentException expected.
-        assertThrows(IllegalArgumentException.class, () -> metrics.metricName("name", "group", "description", "key1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> metrics.metricName("name", "group", "description", "key1"),
+            "Creating MetricName with an odd number of keyValue should fail, IllegalArgumentException expected.");
     }
 
     @Test
@@ -681,15 +682,17 @@ public class MetricsTest {
             assertEquals(filledOutTags.get("parent-tag"), "parent-tag-value", "parent-tag should be set properly");
             assertEquals(filledOutTags.get("child-tag"), "child-tag-value", "child-tag should be set properly");
 
-            // Creating MetricName should throw IllegalArgumentException if the child metrics are not defined at runtime.
-            assertThrows(IllegalArgumentException.class, () -> inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, parentTagsWithValues));
+            assertThrows(IllegalArgumentException.class,
+                () -> inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, parentTagsWithValues),
+                "Creating MetricName should throw IllegalArgumentException if the child metrics are not defined at runtime.");
 
             Map<String, String> runtimeTags = new HashMap<>();
             runtimeTags.put("child-tag", "child-tag-value");
             runtimeTags.put("tag-not-in-template", "unexpected-value");
 
-            // Creating MetricName should throw IllegalArgumentException if there is a tag at runtime that is not in the template.
-            assertThrows(IllegalArgumentException.class, () -> inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, runtimeTags));
+            assertThrows(IllegalArgumentException.class,
+                () -> inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, runtimeTags),
+                "Creating MetricName should throw IllegalArgumentException if there is a tag at runtime that is not in the template.");
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -195,12 +195,7 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        try {
-            type.read(invalidBuffer);
-            fail("Array size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
     }
 
     @Test
@@ -213,12 +208,7 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        try {
-            type.read(invalidBuffer);
-            fail("Array size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
     }
 
     @Test
@@ -252,12 +242,7 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        try {
-            type.read(invalidBuffer);
-            fail("Array size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
     }
 
     @Test
@@ -270,12 +255,7 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        try {
-            type.read(invalidBuffer);
-            fail("Array size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
     }
 
     @Test
@@ -285,19 +265,10 @@ public class ProtocolSerializationTest {
         invalidBuffer.putShort((short) (stringBytes.length * 5));
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
-        try {
-            Type.STRING.read(invalidBuffer);
-            fail("String size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> Type.STRING.read(invalidBuffer));
+
         invalidBuffer.rewind();
-        try {
-            Type.NULLABLE_STRING.read(invalidBuffer);
-            fail("String size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> Type.NULLABLE_STRING.read(invalidBuffer));
     }
 
     @Test
@@ -307,12 +278,8 @@ public class ProtocolSerializationTest {
         invalidBuffer.putShort((short) -1);
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
-        try {
-            Type.STRING.read(invalidBuffer);
-            fail("String size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+
+        assertThrows(SchemaException.class, () -> Type.STRING.read(invalidBuffer));
     }
 
     @Test
@@ -322,19 +289,10 @@ public class ProtocolSerializationTest {
         invalidBuffer.putInt(stringBytes.length * 5);
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
-        try {
-            Type.BYTES.read(invalidBuffer);
-            fail("Bytes size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> Type.BYTES.read(invalidBuffer));
+
         invalidBuffer.rewind();
-        try {
-            Type.NULLABLE_BYTES.read(invalidBuffer);
-            fail("Bytes size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+        assertThrows(SchemaException.class, () -> Type.NULLABLE_BYTES.read(invalidBuffer));
     }
 
     @Test
@@ -344,12 +302,8 @@ public class ProtocolSerializationTest {
         invalidBuffer.putInt(-20);
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
-        try {
-            Type.BYTES.read(invalidBuffer);
-            fail("Bytes size not validated");
-        } catch (SchemaException e) {
-            // Expected exception
-        }
+
+        assertThrows(SchemaException.class, () -> Type.BYTES.read(invalidBuffer));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -195,7 +195,9 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> type.read(invalidBuffer),
+            "Array size not validated");
     }
 
     @Test
@@ -208,7 +210,9 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> type.read(invalidBuffer),
+            "Array size not validated");
     }
 
     @Test
@@ -242,7 +246,9 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> type.read(invalidBuffer),
+            "Array size not validated");
     }
 
     @Test
@@ -255,7 +261,9 @@ public class ProtocolSerializationTest {
         for (int i = 0; i < size; i++)
             invalidBuffer.put((byte) i);
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> type.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> type.read(invalidBuffer),
+            "Array size not validated");
     }
 
     @Test
@@ -265,10 +273,14 @@ public class ProtocolSerializationTest {
         invalidBuffer.putShort((short) (stringBytes.length * 5));
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> Type.STRING.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> Type.STRING.read(invalidBuffer),
+            "String size not validated");
 
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> Type.NULLABLE_STRING.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> Type.NULLABLE_STRING.read(invalidBuffer),
+            "String size not validated");
     }
 
     @Test
@@ -279,7 +291,9 @@ public class ProtocolSerializationTest {
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
 
-        assertThrows(SchemaException.class, () -> Type.STRING.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> Type.STRING.read(invalidBuffer),
+            "String size not validated");
     }
 
     @Test
@@ -289,10 +303,14 @@ public class ProtocolSerializationTest {
         invalidBuffer.putInt(stringBytes.length * 5);
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> Type.BYTES.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> Type.BYTES.read(invalidBuffer),
+            "Bytes size not validated");
 
         invalidBuffer.rewind();
-        assertThrows(SchemaException.class, () -> Type.NULLABLE_BYTES.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> Type.NULLABLE_BYTES.read(invalidBuffer),
+            "Bytes size not validated");
     }
 
     @Test
@@ -303,7 +321,9 @@ public class ProtocolSerializationTest {
         invalidBuffer.put(stringBytes);
         invalidBuffer.rewind();
 
-        assertThrows(SchemaException.class, () -> Type.BYTES.read(invalidBuffer));
+        assertThrows(SchemaException.class,
+            () -> Type.BYTES.read(invalidBuffer),
+            "Bytes size not validated");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -46,6 +46,7 @@ public class JoinGroupRequestTest {
         String[] invalidGroupInstanceIds = {"", "foo bar", "..", "foo:bar", "foo=bar", ".", new String(longString)};
 
         for (String instanceId : invalidGroupInstanceIds) {
+            // InvalidConfigurationException expected as instance id is invalid.
             assertThrows(InvalidConfigurationException.class, () -> JoinGroupRequest.validateGroupInstanceId(instanceId));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -46,8 +46,9 @@ public class JoinGroupRequestTest {
         String[] invalidGroupInstanceIds = {"", "foo bar", "..", "foo:bar", "foo=bar", ".", new String(longString)};
 
         for (String instanceId : invalidGroupInstanceIds) {
-            // InvalidConfigurationException expected as instance id is invalid.
-            assertThrows(InvalidConfigurationException.class, () -> JoinGroupRequest.validateGroupInstanceId(instanceId));
+            assertThrows(InvalidConfigurationException.class,
+                () -> JoinGroupRequest.validateGroupInstanceId(instanceId),
+                "InvalidConfigurationException expected as instance id is invalid.");
         }
     }
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class JoinGroupRequestTest {
 
@@ -47,12 +46,7 @@ public class JoinGroupRequestTest {
         String[] invalidGroupInstanceIds = {"", "foo bar", "..", "foo:bar", "foo=bar", ".", new String(longString)};
 
         for (String instanceId : invalidGroupInstanceIds) {
-            try {
-                JoinGroupRequest.validateGroupInstanceId(instanceId);
-                fail("No exception was thrown for invalid instance id: " + instanceId);
-            } catch (InvalidConfigurationException e) {
-                // Good
-            }
+            assertThrows(InvalidConfigurationException.class, () -> JoinGroupRequest.validateGroupInstanceId(instanceId));
         }
     }
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -495,7 +495,9 @@ public class RequestResponseTest {
         assertFalse(request.toString(true).contains("numPartitions"));
 
         request.clearPartitionRecords();
-        assertThrows(IllegalStateException.class, request::data);
+        assertThrows(IllegalStateException.class,
+            request::data,
+            "DataOrException should fail after clearPartitionRecords()");
 
         // `toString` should behave the same after `clearPartitionRecords`
         assertFalse(request.toString(false).contains("partitionSizes"));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -496,12 +496,7 @@ public class RequestResponseTest {
         assertFalse(request.toString(true).contains("numPartitions"));
 
         request.clearPartitionRecords();
-        try {
-            request.data();
-            fail("dataOrException should fail after clearPartitionRecords()");
-        } catch (IllegalStateException e) {
-            // OK
-        }
+        assertThrows(IllegalStateException.class, request::data);
 
         // `toString` should behave the same after `clearPartitionRecords`
         assertFalse(request.toString(false).contains("partitionSizes"));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -324,7 +324,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 // This class performs tests requests and responses for all API keys
 public class RequestResponseTest {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
@@ -210,8 +210,6 @@ public class RepartitionTopicNamingTest {
         joined.join(stream3, (v1, v2) -> v1 + v2, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(30L)),
             StreamJoined.<String, String, String>as("join-store").withName("join-repartition"));
 
-        builder.build();
-
         assertThrows(TopologyException.class, builder::build);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
@@ -38,8 +38,8 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class RepartitionTopicNamingTest {
 
@@ -83,20 +83,16 @@ public class RepartitionTopicNamingTest {
     // can't use same repartition topic name
     @Test
     public void shouldFailWithSameRepartitionTopicName() {
-        try {
-            final StreamsBuilder builder = new StreamsBuilder();
-            builder.<String, String>stream("topic").selectKey((k, v) -> k)
-                                            .groupByKey(Grouped.as("grouping"))
-                                            .count().toStream();
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.<String, String>stream("topic").selectKey((k, v) -> k)
+            .groupByKey(Grouped.as("grouping"))
+            .count().toStream();
 
-            builder.<String, String>stream("topicII").selectKey((k, v) -> k)
-                                              .groupByKey(Grouped.as("grouping"))
-                                              .count().toStream();
-            builder.build();
-            fail("Should not build re-using repartition topic name");
-        } catch (final TopologyException te) {
-              // ok
-        }
+        builder.<String, String>stream("topicII").selectKey((k, v) -> k)
+            .groupByKey(Grouped.as("grouping"))
+            .count().toStream();
+
+        assertThrows(TopologyException.class, builder::build);
     }
 
     @Test
@@ -202,24 +198,21 @@ public class RepartitionTopicNamingTest {
     // can't use same repartition topic name in joins
     @Test
     public void shouldFailWithSameRepartitionTopicNameInJoin() {
-        try {
-            final StreamsBuilder builder = new StreamsBuilder();
-            final KStream<String, String> stream1 = builder.<String, String>stream("topic").selectKey((k, v) -> k);
-            final KStream<String, String> stream2 = builder.<String, String>stream("topic2").selectKey((k, v) -> k);
-            final KStream<String, String> stream3 = builder.<String, String>stream("topic3").selectKey((k, v) -> k);
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, String> stream1 = builder.<String, String>stream("topic").selectKey((k, v) -> k);
+        final KStream<String, String> stream2 = builder.<String, String>stream("topic2").selectKey((k, v) -> k);
+        final KStream<String, String> stream3 = builder.<String, String>stream("topic3").selectKey((k, v) -> k);
 
-            final KStream<String, String> joined = stream1.join(stream2, (v1, v2) -> v1 + v2,
-                JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(30L)),
-                StreamJoined.<String, String, String>as("join-store").withName("join-repartition"));
+        final KStream<String, String> joined = stream1.join(stream2, (v1, v2) -> v1 + v2,
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(30L)),
+            StreamJoined.<String, String, String>as("join-store").withName("join-repartition"));
 
-            joined.join(stream3, (v1, v2) -> v1 + v2, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(30L)),
-                StreamJoined.<String, String, String>as("join-store").withName("join-repartition"));
+        joined.join(stream3, (v1, v2) -> v1 + v2, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(30L)),
+            StreamJoined.<String, String, String>as("join-store").withName("join-repartition"));
 
-            builder.build();
-            fail("Should not build re-using repartition topic name");
-        } catch (final TopologyException te) {
-            // ok
-        }
+        builder.build();
+
+        assertThrows(TopologyException.class, builder::build);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
@@ -92,7 +92,7 @@ public class RepartitionTopicNamingTest {
             .groupByKey(Grouped.as("grouping"))
             .count().toStream();
 
-        assertThrows(TopologyException.class, builder::build);
+        assertThrows(TopologyException.class, builder::build, "Should not build re-using repartition topic name");
     }
 
     @Test
@@ -210,7 +210,7 @@ public class RepartitionTopicNamingTest {
         joined.join(stream3, (v1, v2) -> v1 + v2, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(30L)),
             StreamJoined.<String, String, String>as("join-store").withName("join-repartition"));
 
-        assertThrows(TopologyException.class, builder::build);
+        assertThrows(TopologyException.class, builder::build, "Should not build re-using repartition topic name");
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -150,8 +150,9 @@ public class GlobalStreamThreadTest {
         // should throw as the MockConsumer hasn't been configured and there are no
         // partitions available
         final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
-        // Should have thrown StreamsException if start up failed.
-        assertThrows(StreamsException.class, () -> globalStreamThread.start());
+        assertThrows(StreamsException.class,
+            () -> globalStreamThread.start(),
+            "Should have thrown StreamsException if start up failed.");
 
         globalStreamThread.join();
         assertThat(globalStore.isOpen(), is(false));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -150,6 +150,7 @@ public class GlobalStreamThreadTest {
         // should throw as the MockConsumer hasn't been configured and there are no
         // partitions available
         final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
+        // Should have thrown StreamsException if start up failed.
         assertThrows(StreamsException.class, () -> globalStreamThread.start());
 
         globalStreamThread.join();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -150,12 +150,8 @@ public class GlobalStreamThreadTest {
         // should throw as the MockConsumer hasn't been configured and there are no
         // partitions available
         final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
-        try {
-            globalStreamThread.start();
-            fail("Should have thrown StreamsException if start up failed");
-        } catch (final StreamsException e) {
-            // ok
-        }
+        assertThrows(StreamsException.class, () -> globalStreamThread.start());
+
         globalStreamThread.join();
         assertThat(globalStore.isOpen(), is(false));
         assertFalse(globalStreamThread.stillRunning());


### PR DESCRIPTION
see https://github.com/apache/kafka/pull/19948#discussion_r2150617216,
replace test "catch exception" by assertThrows.

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, TengYao Chi <kitingiao@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
