### PR TITLE
KAFKA-19367: Follow up bug fix

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -906,6 +906,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
           if (err == Errors.NONE) {
             responseCallback(err, producerIdCopy, producerEpochCopy)
           } else {
+            System.out.println("Returning " + err + " error code to client for " + transactionalId + "'s EndTransaction request")
             debug(s"Aborting append of $txnMarkerResult to transaction log with coordinator and returning $err error to client for $transactionalId's EndTransaction request")
             responseCallback(err, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH)
           }
@@ -966,6 +967,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 case Right((txnMetadata, newPreSendMetadata)) =>
                   // we can respond to the client immediately and continue to write the txn markers if
                   // the log append was successful
+                  System.out.println("Responding to the client immediately with preSendMetadata " + newPreSendMetadata)
                   responseCallback(Errors.NONE, newPreSendMetadata.producerId, newPreSendMetadata.producerEpoch)
 
                   txnMarkerChannelManager.addTxnMarkersToSend(coordinatorEpoch, txnMarkerResult, txnMetadata, newPreSendMetadata)

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -117,7 +117,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                            expectedProducerIdAndEpoch: Option[ProducerIdAndEpoch],
                            responseCallback: InitProducerIdCallback,
                            requestLocal: RequestLocal = RequestLocal.noCaching): Unit = {
-    System.out.println("handle init pid called with transactionalId " + transactionalId)
     if (transactionalId == null) {
       // if the transactional id is null, then always blindly accept the request
       // and return a new producerId from the producerId manager
@@ -170,7 +169,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
         existingEpochAndMetadata =>
           val coordinatorEpoch = existingEpochAndMetadata.coordinatorEpoch
           val txnMetadata = existingEpochAndMetadata.transactionMetadata
-          println("existing metadata before prepareInitProducerIdTransit is " + txnMetadata)
+
           txnMetadata.inLock {
             prepareInitProducerIdTransit(transactionalId, resolvedTxnTimeoutMs, coordinatorEpoch, txnMetadata,
               expectedProducerIdAndEpoch)
@@ -186,16 +185,11 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
             // abort the ongoing transaction and then return CONCURRENT_TRANSACTIONS to let client wait and retry
             def sendRetriableErrorCallback(error: Errors, newProducerId: Long, newProducerEpoch: Short): Unit = {
               if (error != Errors.NONE) {
-                System.out.println("send retribale error callback in handle init pid main error")
-                System.out.println("new metadata is " + newMetadata)
-                System.out.println("existing metadata is " + txnManager.getTransactionState(transactionalId))
                 responseCallback(initTransactionError(error))
               } else {
-                System.out.println("send retribale error callback in handle init pid concurrent txn with new metadata " + newMetadata)
                 responseCallback(initTransactionError(Errors.CONCURRENT_TRANSACTIONS))
               }
             }
-            System.out.println("we got to before end txn in handle init pid")
             endTransaction(transactionalId,
               newMetadata.producerId,
               newMetadata.producerEpoch,
@@ -761,7 +755,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
       endTransactionWithTV1(transactionalId, producerId, producerEpoch, txnMarkerResult, isFromClient, responseCallback, requestLocal)
       return
     }
-    System.out.println("End transaction with producer epoch " + producerEpoch + " and producer id " + producerId)
     var isEpochFence = false
     if (transactionalId == null || transactionalId.isEmpty)
       responseCallback(Errors.INVALID_REQUEST, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH)
@@ -906,7 +899,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
           if (err == Errors.NONE) {
             responseCallback(err, producerIdCopy, producerEpochCopy)
           } else {
-            System.out.println("Returning " + err + " error code to client for " + transactionalId + "'s EndTransaction request")
             debug(s"Aborting append of $txnMarkerResult to transaction log with coordinator and returning $err error to client for $transactionalId's EndTransaction request")
             responseCallback(err, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH)
           }
@@ -967,7 +959,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 case Right((txnMetadata, newPreSendMetadata)) =>
                   // we can respond to the client immediately and continue to write the txn markers if
                   // the log append was successful
-                  System.out.println("Responding to the client immediately with preSendMetadata " + newPreSendMetadata)
                   responseCallback(Errors.NONE, newPreSendMetadata.producerId, newPreSendMetadata.producerEpoch)
 
                   txnMarkerChannelManager.addTxnMarkersToSend(coordinatorEpoch, txnMarkerResult, txnMetadata, newPreSendMetadata)
@@ -985,7 +976,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                   case Some(epochAndMetadata) =>
                     if (epochAndMetadata.coordinatorEpoch == coordinatorEpoch) {
                       // For TV2, we allow re-bumping the epoch on retry, so don't set hasFailedEpochFence = true
-                      System.out.println("We reached send txn markers callback where we removed the setting")
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
                         s"with error $error")
                     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -684,7 +684,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                       // This was attempted epoch fence that failed, so mark this state on the metadata
                       epochAndMetadata.transactionMetadata.hasFailedEpochFence = true
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
-                        s"with error $error. The epoch was increased to ${newMetadata.producerEpoch} but not returned to the client")
+                        s"with error $error")
                     }
                 }
               }
@@ -980,7 +980,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                       // This was attempted epoch fence that failed, so mark this state on the metadata
                       epochAndMetadata.transactionMetadata.hasFailedEpochFence = true
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
-                        s"with error $error. The epoch was increased to ${newMetadata.producerEpoch} but not returned to the client")
+                        s"with error $error")
                     }
                 }
               }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -977,8 +977,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
 
                   case Some(epochAndMetadata) =>
                     if (epochAndMetadata.coordinatorEpoch == coordinatorEpoch) {
-                      // This was attempted epoch fence that failed, so mark this state on the metadata
-                      epochAndMetadata.transactionMetadata.hasFailedEpochFence = true
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
                         s"with error $error")
                     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -117,7 +117,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                            expectedProducerIdAndEpoch: Option[ProducerIdAndEpoch],
                            responseCallback: InitProducerIdCallback,
                            requestLocal: RequestLocal = RequestLocal.noCaching): Unit = {
-
+    System.out.println("handle init pid called with transactionalId " + transactionalId)
     if (transactionalId == null) {
       // if the transactional id is null, then always blindly accept the request
       // and return a new producerId from the producerId manager
@@ -186,12 +186,16 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
             // abort the ongoing transaction and then return CONCURRENT_TRANSACTIONS to let client wait and retry
             def sendRetriableErrorCallback(error: Errors, newProducerId: Long, newProducerEpoch: Short): Unit = {
               if (error != Errors.NONE) {
+                System.out.println("send retribale error callback in handle init pid main error")
+                System.out.println("new metadata is " + newMetadata)
+                System.out.println("existing metadata is " + txnManager.getTransactionState(transactionalId))
                 responseCallback(initTransactionError(error))
               } else {
+                System.out.println("send retribale error callback in handle init pid concurrent txn")
                 responseCallback(initTransactionError(Errors.CONCURRENT_TRANSACTIONS))
               }
             }
-
+            System.out.println("we got to before end txn in handle init pid")
             endTransaction(transactionalId,
               newMetadata.producerId,
               newMetadata.producerEpoch,
@@ -684,7 +688,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                       // This was attempted epoch fence that failed, so mark this state on the metadata
                       epochAndMetadata.transactionMetadata.hasFailedEpochFence = true
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
-                        s"with error $error")
+                        s"with error $error. The epoch was increased to ${newMetadata.producerEpoch} but not returned to the client")
                     }
                 }
               }
@@ -757,6 +761,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
       endTransactionWithTV1(transactionalId, producerId, producerEpoch, txnMarkerResult, isFromClient, responseCallback, requestLocal)
       return
     }
+    System.out.println("End transaction with producer epoch " + producerEpoch + " and producer id " + producerId)
     var isEpochFence = false
     if (transactionalId == null || transactionalId.isEmpty)
       responseCallback(Errors.INVALID_REQUEST, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH)
@@ -977,6 +982,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
 
                   case Some(epochAndMetadata) =>
                     if (epochAndMetadata.coordinatorEpoch == coordinatorEpoch) {
+                      // For TV2, we allow re-bumping the epoch on retry, so don't set hasFailedEpochFence = true
+                      System.out.println("We reached send txn markers callback where we removed the setting")
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
                         s"with error $error")
                     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -977,7 +977,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
 
                   case Some(epochAndMetadata) =>
                     if (epochAndMetadata.coordinatorEpoch == coordinatorEpoch) {
-                      // For TV2, we allow re-bumping the epoch on retry, so don't set hasFailedEpochFence = true
+                      // For TV2, we allow re-bumping the epoch on retry, since we don't complete the epoch bump.
+                      // Therefore, we don't set hasFailedEpochFence = true.
                       warn(s"The coordinator failed to write an epoch fence transition for producer $transactionalId to the transaction log " +
                         s"with error $error")
                     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -170,7 +170,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
         existingEpochAndMetadata =>
           val coordinatorEpoch = existingEpochAndMetadata.coordinatorEpoch
           val txnMetadata = existingEpochAndMetadata.transactionMetadata
-
+          println("existing metadata before prepareInitProducerIdTransit is " + txnMetadata)
           txnMetadata.inLock {
             prepareInitProducerIdTransit(transactionalId, resolvedTxnTimeoutMs, coordinatorEpoch, txnMetadata,
               expectedProducerIdAndEpoch)
@@ -191,7 +191,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 System.out.println("existing metadata is " + txnManager.getTransactionState(transactionalId))
                 responseCallback(initTransactionError(error))
               } else {
-                System.out.println("send retribale error callback in handle init pid concurrent txn")
+                System.out.println("send retribale error callback in handle init pid concurrent txn with new metadata " + newMetadata)
                 responseCallback(initTransactionError(Errors.CONCURRENT_TRANSACTIONS))
               }
             }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -117,6 +117,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                            expectedProducerIdAndEpoch: Option[ProducerIdAndEpoch],
                            responseCallback: InitProducerIdCallback,
                            requestLocal: RequestLocal = RequestLocal.noCaching): Unit = {
+
     if (transactionalId == null) {
       // if the transactional id is null, then always blindly accept the request
       // and return a new producerId from the producerId manager
@@ -190,6 +191,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 responseCallback(initTransactionError(Errors.CONCURRENT_TRANSACTIONS))
               }
             }
+
             endTransaction(transactionalId,
               newMetadata.producerId,
               newMetadata.producerEpoch,

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -192,6 +192,8 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
   def prepareAbortOrCommit(newState: TransactionState, clientTransactionVersion: TransactionVersion, nextProducerId: Long, updateTimestamp: Long, noPartitionAdded: Boolean): TxnTransitMetadata = {
     val (updatedProducerEpoch, updatedLastProducerEpoch) = if (clientTransactionVersion.supportsEpochBump()) {
       // We already ensured that we do not overflow here. MAX_SHORT is the highest possible value.
+      System.out.println("we reached here for prepare abort or commit for transaction state " + newState)
+      System.out.println("the current producer epoch is: "  + producerEpoch + " and it is bumped to x+1 ")
       ((producerEpoch + 1).toShort, producerEpoch)
     } else {
       (producerEpoch, lastProducerEpoch)
@@ -213,7 +215,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
 
   def prepareComplete(updateTimestamp: Long): TxnTransitMetadata = {
     val newState = if (state == TransactionState.PREPARE_COMMIT) TransactionState.COMPLETE_COMMIT else TransactionState.COMPLETE_ABORT
-
+    System.out.println("Inside prepare complete for transaction state " + newState)
     // Since the state change was successfully written to the log, unset the flag for a failed epoch fence
     hasFailedEpochFence = false
     val (updatedProducerId, updatedProducerEpoch) =
@@ -293,6 +295,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
       val transitMetadata = new TxnTransitMetadata(producerId, this.producerId, nextProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs, state,
         topicPartitions.asJava, txnStartTimestamp, txnLastUpdateTimestamp, clientTransactionVersion)
       debug(s"TransactionalId ${this.transactionalId} prepare transition from ${this.state} to $transitMetadata")
+      System.out.println("Prepare transaction state transition from " + this.state + " to: " + transitMetadata)
       pendingState = Some(state)
       transitMetadata
     } else {
@@ -358,6 +361,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
           if (!validProducerEpoch(transitMetadata) ||
             txnTimeoutMs != transitMetadata.txnTimeoutMs ||
             transitMetadata.txnStartTimestamp == -1) {
+            System.out.println("Are we here in complete transition to complete abort")
             throwStateTransitionFailure(transitMetadata)
           }
 
@@ -378,6 +382,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
       }
 
       debug(s"TransactionalId $transactionalId complete transition from $state to $transitMetadata")
+      System.out.println("Transition complete from " + state + " to: " + transitMetadata)
       producerId = transitMetadata.producerId
       prevProducerId = transitMetadata.prevProducerId
       nextProducerId = transitMetadata.nextProducerId

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -98,6 +98,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     // If we've already failed to fence an epoch (because the write to the log failed), we don't increase it again.
     // This is safe because we never return the epoch to client if we fail to fence the epoch
     val bumpedEpoch = if (hasFailedEpochFence) producerEpoch else (producerEpoch + 1).toShort
+
     prepareTransitionTo(
       state = TransactionState.PREPARE_EPOCH_FENCE,
       producerEpoch = bumpedEpoch,
@@ -212,6 +213,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
 
   def prepareComplete(updateTimestamp: Long): TxnTransitMetadata = {
     val newState = if (state == TransactionState.PREPARE_COMMIT) TransactionState.COMPLETE_COMMIT else TransactionState.COMPLETE_ABORT
+
     // Since the state change was successfully written to the log, unset the flag for a failed epoch fence
     hasFailedEpochFence = false
     val (updatedProducerId, updatedProducerEpoch) =

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -98,7 +98,6 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     // If we've already failed to fence an epoch (because the write to the log failed), we don't increase it again.
     // This is safe because we never return the epoch to client if we fail to fence the epoch
     val bumpedEpoch = if (hasFailedEpochFence) producerEpoch else (producerEpoch + 1).toShort
-    System.out.println("Prepare transition to fence producer epoch for transaction state " + state)
     prepareTransitionTo(
       state = TransactionState.PREPARE_EPOCH_FENCE,
       producerEpoch = bumpedEpoch,
@@ -192,8 +191,6 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
   def prepareAbortOrCommit(newState: TransactionState, clientTransactionVersion: TransactionVersion, nextProducerId: Long, updateTimestamp: Long, noPartitionAdded: Boolean): TxnTransitMetadata = {
     val (updatedProducerEpoch, updatedLastProducerEpoch) = if (clientTransactionVersion.supportsEpochBump()) {
       // We already ensured that we do not overflow here. MAX_SHORT is the highest possible value.
-      System.out.println("we reached here for prepare abort or commit for transaction state " + newState)
-      System.out.println("the current producer epoch is: "  + producerEpoch + " and it is bumped to x+1 ")
       ((producerEpoch + 1).toShort, producerEpoch)
     } else {
       (producerEpoch, lastProducerEpoch)
@@ -215,7 +212,6 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
 
   def prepareComplete(updateTimestamp: Long): TxnTransitMetadata = {
     val newState = if (state == TransactionState.PREPARE_COMMIT) TransactionState.COMPLETE_COMMIT else TransactionState.COMPLETE_ABORT
-    System.out.println("Inside prepare complete for transaction state " + newState)
     // Since the state change was successfully written to the log, unset the flag for a failed epoch fence
     hasFailedEpochFence = false
     val (updatedProducerId, updatedProducerEpoch) =
@@ -295,7 +291,6 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
       val transitMetadata = new TxnTransitMetadata(producerId, this.producerId, nextProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs, state,
         topicPartitions.asJava, txnStartTimestamp, txnLastUpdateTimestamp, clientTransactionVersion)
       debug(s"TransactionalId ${this.transactionalId} prepare transition from ${this.state} to $transitMetadata")
-      System.out.println("Prepare transaction state transition from " + this.state + " to: " + transitMetadata)
       pendingState = Some(state)
       transitMetadata
     } else {
@@ -361,7 +356,6 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
           if (!validProducerEpoch(transitMetadata) ||
             txnTimeoutMs != transitMetadata.txnTimeoutMs ||
             transitMetadata.txnStartTimestamp == -1) {
-            System.out.println("Are we here in complete transition to complete abort")
             throwStateTransitionFailure(transitMetadata)
           }
 
@@ -382,7 +376,6 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
       }
 
       debug(s"TransactionalId $transactionalId complete transition from $state to $transitMetadata")
-      System.out.println("Transition complete from " + state + " to: " + transitMetadata)
       producerId = transitMetadata.producerId
       prevProducerId = transitMetadata.prevProducerId
       nextProducerId = transitMetadata.nextProducerId

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -98,7 +98,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     // If we've already failed to fence an epoch (because the write to the log failed), we don't increase it again.
     // This is safe because we never return the epoch to client if we fail to fence the epoch
     val bumpedEpoch = if (hasFailedEpochFence) producerEpoch else (producerEpoch + 1).toShort
-
+    System.out.println("Prepare transition to fence producer epoch for transaction state " + state)
     prepareTransitionTo(
       state = TransactionState.PREPARE_EPOCH_FENCE,
       producerEpoch = bumpedEpoch,

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -2059,7 +2059,6 @@ class TransactionCoordinatorTest {
     // Mock the transactionMarkerChannelManager to simulate the second write (PREPARE_ABORT -> COMPLETE_ABORT)
     doAnswer(invocation => {
       val newMetadata = invocation.getArgument[TxnTransitMetadata](3)
-      System.out.println("TEST: new metadata for invoking the complete abort thing: " + newMetadata)
       // Simulate the completion of transaction markers and the second write
       // This would normally happen asynchronously after markers are sent
       txnMetadata.completeTransitionTo(newMetadata) // This transitions to COMPLETE_ABORT

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -1981,9 +1981,9 @@ class TransactionCoordinatorTest {
   }
 
   @Test
-  def testHasFailedEpochFenceNotSetOnFailedWriteForTV2(): Unit = {
-    // Test that for TV2, hasFailedEpochFence is NOT set to true when epoch fence writes fail,
-    // allowing epoch re-bumping on retry (unlike TV1 behavior)
+  def testTV2AllowsEpochReBumpingAfterFailedWrite(): Unit = {
+    // Test the complete TV2 flow: failed write → epoch fence → abort → retry with epoch bump
+    // This demonstrates that TV2 allows epoch re-bumping after failed writes (unlike TV1)
     val producerEpoch = 1.toShort
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, RecordBatch.NO_PRODUCER_ID,
       producerEpoch, RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, TransactionState.ONGOING, partitions, time.milliseconds(), time.milliseconds(), TV_2)
@@ -2082,8 +2082,51 @@ class TransactionCoordinatorTest {
       initProducerIdMockCallback
     )
 
+    // The second attempt should return CONCURRENT_TRANSACTIONS (this is intentional)
+    assertEquals(InitProducerIdResult(-1, -1, Errors.CONCURRENT_TRANSACTIONS), result)
+
     // The transactionMarkerChannelManager mock should have completed the transition to COMPLETE_ABORT
     // Verify that hasFailedEpochFence was never set to true for TV2, allowing future epoch bumps
+    assertFalse(txnMetadata.hasFailedEpochFence)
+
+    // Third attempt: Client retries after CONCURRENT_TRANSACTIONS
+    reset(transactionManager)
+    when(transactionManager.validateTransactionTimeoutMs(anyBoolean(), anyInt()))
+      .thenReturn(true)
+    when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
+      .thenReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
+    when(transactionManager.transactionVersionLevel()).thenReturn(TV_2)
+
+    when(transactionManager.appendTransactionToLog(
+      ArgumentMatchers.eq(transactionalId),
+      ArgumentMatchers.eq(coordinatorEpoch),
+      any(),
+      any(),
+      any(),
+      any()
+    )).thenAnswer(invocation => {
+      val newMetadata = invocation.getArgument[TxnTransitMetadata](2)
+      val callback = invocation.getArgument[Errors => Unit](3)
+      
+      // Complete the transition and call the callback with success
+      txnMetadata.completeTransitionTo(newMetadata)
+      callback.apply(Errors.NONE)
+    })
+
+    coordinator.handleInitProducerId(
+      transactionalId,
+      txnTimeoutMs,
+      enableTwoPCFlag = false,
+      keepPreparedTxn = false,
+      None,
+      initProducerIdMockCallback
+    )
+
+    // The third attempt should succeed with epoch 3 (2 + 1)
+    // This demonstrates that TV2 allows epoch re-bumping after failed writes
+    assertEquals(InitProducerIdResult(producerId, 3.toShort, Errors.NONE), result)
+    
+    // Final verification that hasFailedEpochFence was never set to true for TV2
     assertFalse(txnMetadata.hasFailedEpochFence)
   }
 }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.{CsvSource, ValueSource}
 import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
+import org.mockito.Mockito.doAnswer
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -1980,7 +1981,9 @@ class TransactionCoordinatorTest {
   }
 
   @Test
-  def testReBumpAllowedOnFailedWriteForTV2(): Unit = {
+  def testHasFailedEpochFenceNotSetOnFailedWriteForTV2(): Unit = {
+    // Test that for TV2, hasFailedEpochFence is NOT set to true when epoch fence writes fail,
+    // allowing epoch re-bumping on retry (unlike TV1 behavior)
     val producerEpoch = 1.toShort
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, RecordBatch.NO_PRODUCER_ID,
       producerEpoch, RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, TransactionState.ONGOING, partitions, time.milliseconds(), time.milliseconds(), TV_2)
@@ -2047,11 +2050,28 @@ class TransactionCoordinatorTest {
     )).thenAnswer(invocation => {
       val newMetadata = invocation.getArgument[TxnTransitMetadata](2)
       val callback = invocation.getArgument[Errors => Unit](3)
-
+      
       // Complete the transition and call the callback with success
       txnMetadata.completeTransitionTo(newMetadata)
       callback.apply(Errors.NONE)
     })
+
+    // Mock the transactionMarkerChannelManager to simulate the second write (PREPARE_ABORT -> COMPLETE_ABORT)
+    doAnswer(invocation => {
+      val newMetadata = invocation.getArgument[TxnTransitMetadata](3)
+      System.out.println("TEST: new metadata for invoking the complete abort thing: " + newMetadata)
+      // Simulate the completion of transaction markers and the second write
+      // This would normally happen asynchronously after markers are sent
+      txnMetadata.completeTransitionTo(newMetadata) // This transitions to COMPLETE_ABORT
+      txnMetadata.pendingState = None
+      
+      null
+    }).when(transactionMarkerChannelManager).addTxnMarkersToSend(
+      ArgumentMatchers.eq(coordinatorEpoch),
+      ArgumentMatchers.eq(TransactionResult.ABORT),
+      ArgumentMatchers.eq(txnMetadata),
+      any()
+    )
 
     coordinator.handleInitProducerId(
       transactionalId,
@@ -2061,5 +2081,9 @@ class TransactionCoordinatorTest {
       None,
       initProducerIdMockCallback
     )
+
+    // The transactionMarkerChannelManager mock should have completed the transition to COMPLETE_ABORT
+    // Verify that hasFailedEpochFence was never set to true for TV2, allowing future epoch bumps
+    assertFalse(txnMetadata.hasFailedEpochFence)
   }
 }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -1978,4 +1978,88 @@ class TransactionCoordinatorTest {
     else
       producerEpoch
   }
+
+  @Test
+  def testReBumpAllowedOnFailedWriteForTV2(): Unit = {
+    val producerEpoch = 1.toShort
+    val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, RecordBatch.NO_PRODUCER_ID,
+      producerEpoch, RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, TransactionState.ONGOING, partitions, time.milliseconds(), time.milliseconds(), TV_2)
+
+    when(transactionManager.validateTransactionTimeoutMs(anyBoolean(), anyInt()))
+      .thenReturn(true)
+    when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
+      .thenReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
+    when(transactionManager.transactionVersionLevel()).thenReturn(TV_2)
+
+    // First attempt fails with COORDINATOR_NOT_AVAILABLE
+    when(transactionManager.appendTransactionToLog(
+      ArgumentMatchers.eq(transactionalId),
+      ArgumentMatchers.eq(coordinatorEpoch),
+      any(),
+      any(),
+      any(),
+      any()
+    )).thenAnswer(invocation => {
+      val callback = invocation.getArgument[Errors => Unit](3)
+
+      // Simulate the real TransactionStateManager behavior: reset pendingState on failure
+      // since handleInitProducerId doesn't provide a custom retryOnError function
+      txnMetadata.pendingState = None
+
+      // For TV2, hasFailedEpochFence is NOT set to true, allowing epoch bumps on retry
+      // The epoch remains at its original value (1) since completeTransitionTo was never called
+
+      callback.apply(Errors.COORDINATOR_NOT_AVAILABLE)
+    })
+
+    coordinator.handleInitProducerId(
+      transactionalId,
+      txnTimeoutMs,
+      enableTwoPCFlag = false,
+      keepPreparedTxn = false,
+      None,
+      initProducerIdMockCallback
+    )
+    assertEquals(InitProducerIdResult(-1, -1, Errors.COORDINATOR_NOT_AVAILABLE), result)
+
+    // After the first failed attempt, the state should be:
+    // - hasFailedEpochFence = false (NOT set for TV2)
+    // - pendingState = None (reset by TransactionStateManager)
+    // - producerEpoch = 1 (unchanged since completeTransitionTo was never called)
+    // - transaction still ONGOING
+
+    // Second attempt: Should abort the ongoing transaction
+    reset(transactionManager)
+    when(transactionManager.validateTransactionTimeoutMs(anyBoolean(), anyInt()))
+      .thenReturn(true)
+    when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
+      .thenReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
+    when(transactionManager.transactionVersionLevel()).thenReturn(TV_2)
+
+    // Mock the appendTransactionToLog to succeed for the endTransaction call
+    when(transactionManager.appendTransactionToLog(
+      ArgumentMatchers.eq(transactionalId),
+      ArgumentMatchers.eq(coordinatorEpoch),
+      any(),
+      any(),
+      any(),
+      any()
+    )).thenAnswer(invocation => {
+      val newMetadata = invocation.getArgument[TxnTransitMetadata](2)
+      val callback = invocation.getArgument[Errors => Unit](3)
+
+      // Complete the transition and call the callback with success
+      txnMetadata.completeTransitionTo(newMetadata)
+      callback.apply(Errors.NONE)
+    })
+
+    coordinator.handleInitProducerId(
+      transactionalId,
+      txnTimeoutMs,
+      enableTwoPCFlag = false,
+      keepPreparedTxn = false,
+      None,
+      initProducerIdMockCallback
+    )
+  }
 }


### PR DESCRIPTION
This is a follow up to [https://github.com/apache/kafka/pull/19910](url)
`The coordinator failed to write an epoch fence transition for producer
jt142 to the transaction log with error COORDINATOR_NOT_AVAILABLE. The
epoch was increased to 2 but not returned to the client
(kafka.coordinator.transaction.TransactionCoordinator)` -- as we don't
bump the epoch with this change, we should also update the message to
not say "increased" and remove the
**epochAndMetadata.transactionMetadata.hasFailedEpochFence = true** line

In the test, the expected behavior is:
1) First append transaction to the log fails with
COORDINATOR_NOT_AVAILABLE (epoch 1)
2) We try init_pid again, this time the SINGLE epoch bump succeeds, and
the following things happen simultaneously (epoch 2)
     -> Transition to COMPLETE_ABORT
     -> Return CONCURRENT_TRANSACTION error to the client
3) The client retries, and there is another epoch bump; state
transitions to EMPTY (epoch 3)

Reviewers: Justine Olshan <jolshan@confluent.io>, Artem Livshits
 <alivshits@confluent.io>
