### PR TITLE
KAFKA-19362: Finalize homogeneous simple share assignor

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -26,6 +26,8 @@ import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssign
 import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
 import org.apache.kafka.coordinator.group.modern.MemberAssignmentImpl;
 import org.apache.kafka.server.common.TopicIdPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +36,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,7 +43,7 @@ import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.H
 
 /**
  * A simple partition assignor for share groups that assigns partitions of the subscribed topics
- * based on the rules defined in KIP-932 to different members. It is not rack-aware.
+ * to different members based on the rules defined in KIP-932. It is not rack-aware.
  * <p>
  * Assignments are done according to the following principles:
  * <ol>
@@ -56,51 +57,39 @@ import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.H
  * Balance is prioritized above stickiness.
  */
 public class SimpleAssignor implements ShareGroupPartitionAssignor {
-
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleAssignor.class);
     private static final String SIMPLE_ASSIGNOR_NAME = "simple";
 
+    /**
+     * Unique name for this assignor.
+     */
     @Override
     public String name() {
         return SIMPLE_ASSIGNOR_NAME;
     }
 
+    /**
+     * Assigns partitions to group members based on the given assignment specification and topic metadata.
+     *
+     * @param groupSpec                The assignment spec which includes member metadata.
+     * @param subscribedTopicDescriber The topic and partition metadata describer.
+     * @return The new assignment for the group.
+     */
     @Override
-    public GroupAssignment assign(
-        GroupSpec groupSpec,
-        SubscribedTopicDescriber subscribedTopicDescriber
-    ) throws PartitionAssignorException {
+    public GroupAssignment assign(GroupSpec groupSpec, SubscribedTopicDescriber subscribedTopicDescriber) throws PartitionAssignorException {
         if (groupSpec.memberIds().isEmpty())
             return new GroupAssignment(Map.of());
 
         if (groupSpec.subscriptionType().equals(HOMOGENEOUS)) {
-            return assignHomogeneous(groupSpec, subscribedTopicDescriber);
+            LOG.debug("Detected that all members are subscribed to the same set of topics, invoking the homogeneous assignment algorithm");
+            return new SimpleHomogeneousAssignmentBuilder(groupSpec, subscribedTopicDescriber).build();
         } else {
+            LOG.debug("Detected that the members are subscribed to different sets of topics, invoking the heterogeneous assignment algorithm");
             return assignHeterogeneous(groupSpec, subscribedTopicDescriber);
         }
     }
 
-    private GroupAssignment assignHomogeneous(
-        GroupSpec groupSpec,
-        SubscribedTopicDescriber subscribedTopicDescriber
-    ) {
-        Set<Uuid> subscribedTopicIds = groupSpec.memberSubscription(groupSpec.memberIds().iterator().next())
-            .subscribedTopicIds();
-        if (subscribedTopicIds.isEmpty())
-            return new GroupAssignment(Map.of());
-
-        // Subscribed topic partitions for the share group.
-        List<TopicIdPartition> targetPartitions = computeTargetPartitions(
-            groupSpec, subscribedTopicIds, subscribedTopicDescriber);
-
-        // The current assignment from topic partition to members.
-        Map<TopicIdPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
-        return newAssignmentHomogeneous(groupSpec, subscribedTopicIds, targetPartitions, currentAssignment);
-    }
-
-    private GroupAssignment assignHeterogeneous(
-        GroupSpec groupSpec,
-        SubscribedTopicDescriber subscribedTopicDescriber
-    ) {
+    private GroupAssignment assignHeterogeneous(GroupSpec groupSpec, SubscribedTopicDescriber subscribedTopicDescriber) {
         Map<String, List<TopicIdPartition>> memberToPartitionsSubscription = new HashMap<>();
         for (String memberId : groupSpec.memberIds()) {
             MemberSubscription spec = groupSpec.memberSubscription(memberId);
@@ -108,22 +97,23 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
                 continue;
 
             // Subscribed topic partitions for the share group member.
-            List<TopicIdPartition> targetPartitions = computeTargetPartitions(
-                groupSpec, spec.subscribedTopicIds(), subscribedTopicDescriber);
+            List<TopicIdPartition> targetPartitions = computeTargetPartitions(groupSpec, spec.subscribedTopicIds(), subscribedTopicDescriber);
             memberToPartitionsSubscription.put(memberId, targetPartitions);
         }
 
         // The current assignment from topic partition to members.
         Map<TopicIdPartition, List<String>> currentAssignment = currentAssignment(groupSpec);
+
         return newAssignmentHeterogeneous(groupSpec, memberToPartitionsSubscription, currentAssignment);
     }
 
     /**
      * Get the current assignment by topic partitions.
+     *
      * @param groupSpec The group metadata specifications.
      * @return the current assignment for subscribed topic partitions to memberIds.
      */
-    private Map<TopicIdPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
+    static Map<TopicIdPartition, List<String>> currentAssignment(GroupSpec groupSpec) {
         Map<TopicIdPartition, List<String>> assignment = new HashMap<>();
 
         for (String member : groupSpec.memberIds()) {
@@ -131,80 +121,16 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             assignedTopicPartitions.forEach((topicId, partitions) -> partitions.forEach(
                 partition -> assignment.computeIfAbsent(new TopicIdPartition(topicId, partition), k -> new ArrayList<>()).add(member)));
         }
+
         return assignment;
     }
 
     /**
-     * This function computes the new assignment for a homogeneous group.
-     * @param groupSpec           The group metadata specifications.
-     * @param subscribedTopicIds  The set of all the subscribed topic ids for the group.
-     * @param targetPartitions    The list of all topic partitions that need assignment.
-     * @param currentAssignment   The current assignment for subscribed topic partitions to memberIds.
-     * @return the new partition assignment for the members of the group.
-     */
-    private GroupAssignment newAssignmentHomogeneous(
-        GroupSpec groupSpec,
-        Set<Uuid> subscribedTopicIds,
-        List<TopicIdPartition> targetPartitions,
-        Map<TopicIdPartition, List<String>> currentAssignment
-    ) {
-        // For entirely balanced assignment, we would expect (numTargetPartitions / numGroupMembers) partitions per member, rounded upwards.
-        // That can be expressed as         Math.ceil(numTargetPartitions / (double) numGroupMembers)
-        // Using integer arithmetic, as     (numTargetPartitions + numGroupMembers - 1) / numGroupMembers
-        int numGroupMembers = groupSpec.memberIds().size();
-        int numTargetPartitions = targetPartitions.size();
-        int desiredAssignmentCount = (numTargetPartitions + numGroupMembers - 1) / numGroupMembers;
-
-        Map<TopicIdPartition, List<String>> newAssignment = newHashMap(numTargetPartitions);
-
-        // Hash member IDs to topic partitions. Each member will be assigned one partition, but some partitions
-        // might have been assigned to more than one member.
-        memberHashAssignment(groupSpec.memberIds(), targetPartitions, newAssignment);
-
-        // Combine current and new hashed assignments, sized to accommodate the expected number of mappings.
-        Map<String, Set<TopicIdPartition>> finalAssignment = newHashMap(numGroupMembers);
-        Map<TopicIdPartition, Set<String>> finalAssignmentByPartition = newHashMap(numTargetPartitions);
-
-        // First, take the members assigned by hashing.
-        newAssignment.forEach((targetPartition, members) -> members.forEach(member -> {
-            finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition);
-            finalAssignmentByPartition.computeIfAbsent(targetPartition, k -> new HashSet<>()).add(member);
-        }));
-
-        // Then, take the members from the current assignment, making sure that no member has too many assigned partitions.
-        // When combining current assignment, we need to only consider the topics in current assignment that are also being
-        // subscribed in the new assignment as well.
-        currentAssignment.forEach((targetPartition, members) -> {
-            if (subscribedTopicIds.contains(targetPartition.topicId())) {
-                members.forEach(member -> {
-                    if (groupSpec.memberIds().contains(member)) {
-                        Set<TopicIdPartition> memberPartitions = finalAssignment.computeIfAbsent(member, k -> new HashSet<>());
-                        if ((memberPartitions.size() < desiredAssignmentCount) && !newAssignment.containsKey(targetPartition)) {
-                            memberPartitions.add(targetPartition);
-                            finalAssignmentByPartition.computeIfAbsent(targetPartition, k -> new HashSet<>()).add(member);
-                        }
-                    }
-                });
-            }
-        });
-
-        // Finally, round-robin assignment for unassigned partitions which do not already have members assigned.
-        // The order of steps differs slightly from KIP-932 because the desired assignment count has been taken into
-        // account when copying partitions across from the current assignment, and this is more convenient.
-        List<TopicIdPartition> unassignedPartitions = targetPartitions.stream()
-            .filter(targetPartition -> !finalAssignmentByPartition.containsKey(targetPartition))
-            .toList();
-
-        roundRobinAssignmentWithCount(groupSpec.memberIds(), unassignedPartitions, finalAssignment, desiredAssignmentCount);
-
-        return groupAssignment(finalAssignment, groupSpec.memberIds());
-    }
-
-    /**
      * This function computes the new assignment for a heterogeneous group.
-     * @param groupSpec                       The group metadata specifications.
-     * @param memberToPartitionsSubscription  The member to subscribed topic partitions map.
-     * @param currentAssignment               The current assignment for subscribed topic partitions to memberIds.
+     *
+     * @param groupSpec                      The group metadata specifications.
+     * @param memberToPartitionsSubscription The member to subscribed topic partitions map.
+     * @param currentAssignment              The current assignment for subscribed topic partitions to memberIds.
      * @return the new partition assignment for the members of the group.
      */
     private GroupAssignment newAssignmentHeterogeneous(
@@ -260,10 +186,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
     /**
      * This function updates assignment by hashing the member IDs of the members and maps the partitions assigned to the
      * members based on the hash, one partition per member. This gives approximately even balance.
-     * @param memberIds           The member ids to which the topic partitions need to be assigned.
-     * @param partitionsToAssign  The subscribed topic partitions which needs assignment.
-     * @param assignment          The existing assignment by topic partition. We need to pass it as a parameter because this
-     *                            method can be called multiple times for heterogeneous assignment.
+     *
+     * @param memberIds          The member ids to which the topic partitions need to be assigned.
+     * @param partitionsToAssign The subscribed topic partitions which needs assignment.
+     * @param assignment         The existing assignment by topic partition. We need to pass it as a parameter because this
+     *                           method can be called multiple times for heterogeneous assignment.
      */
     // Visible for testing
     void memberHashAssignment(
@@ -282,10 +209,11 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
 
     /**
      * This functions assigns topic partitions to members by a round-robin approach and updates the existing assignment.
-     * @param memberIds                 The member ids to which the topic partitions need to be assigned, should be non-empty.
-     * @param partitionsToAssign        The subscribed topic partitions which needs assignment.
-     * @param assignment                The existing assignment by topic partition. We need to pass it as a parameter because this
-     *                                  method can be called multiple times for heterogeneous assignment.
+     *
+     * @param memberIds          The member ids to which the topic partitions need to be assigned, should be non-empty.
+     * @param partitionsToAssign The subscribed topic partitions which needs assignment.
+     * @param assignment         The existing assignment by topic partition. We need to pass it as a parameter because this
+     *                           method can be called multiple times for heterogeneous assignment.
      */
     // Visible for testing
     void roundRobinAssignment(
@@ -305,50 +233,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         }
     }
 
-    /**
-     * This functions assigns topic partitions to members by a round-robin approach and updates the existing assignment.
-     * @param memberIds                 The member ids to which the topic partitions need to be assigned, should be non-empty.
-     * @param partitionsToAssign        The subscribed topic partitions which need assignment.
-     * @param assignment                The existing assignment by topic partition. We need to pass it as a parameter because this
-     *                                  method can be called multiple times for heterogeneous assignment.
-     * @param desiredAssignmentCount    The number of partitions which can be assigned to each member to give even balance.
-     *                                  Note that this number can be exceeded by one to allow for situations
-     *                                  in which we have hashing collisions.
-     */
-    void roundRobinAssignmentWithCount(
-        Collection<String> memberIds,
-        List<TopicIdPartition> partitionsToAssign,
-        Map<String, Set<TopicIdPartition>> assignment,
-        int desiredAssignmentCount
-    ) {
-        Collection<String> memberIdsCopy = new LinkedHashSet<>(memberIds);
-
-        // We iterate through the target partitions which are not in the assignment and assign a memberId to them.
-        // In case we run out of members (memberIds < partitionsToAssign), we again start from the starting index of memberIds.
-        Iterator<String> memberIdIterator = memberIdsCopy.iterator();
-        ListIterator<TopicIdPartition> partitionListIterator = partitionsToAssign.listIterator();
-        while (partitionListIterator.hasNext()) {
-            TopicIdPartition partition = partitionListIterator.next();
-            if (!memberIdIterator.hasNext()) {
-                memberIdIterator = memberIdsCopy.iterator();
-                if (memberIdsCopy.isEmpty()) {
-                    // This should never happen, but guarding against an infinite loop
-                    throw new PartitionAssignorException("Inconsistent number of member IDs");
-                }
-            }
-            String memberId = memberIdIterator.next();
-            Set<TopicIdPartition> memberPartitions = assignment.computeIfAbsent(memberId, k -> new HashSet<>());
-            // We are prepared to add one more partition, even if the desired assignment count is already reached.
-            if (memberPartitions.size() <= desiredAssignmentCount) {
-                memberPartitions.add(partition);
-            } else {
-                memberIdIterator.remove();
-                partitionListIterator.previous();
-            }
-        }
-    }
-
-    private List<TopicIdPartition> computeTargetPartitions(
+    static List<TopicIdPartition> computeTargetPartitions(
         GroupSpec groupSpec,
         Set<Uuid> subscribedTopicIds,
         SubscribedTopicDescriber subscribedTopicDescriber
@@ -358,8 +243,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             int numPartitions = subscribedTopicDescriber.numPartitions(topicId);
             if (numPartitions == -1) {
                 throw new PartitionAssignorException(
-                    "Members are subscribed to topic " + topicId
-                        + " which doesn't exist in the topic metadata."
+                    "Members are subscribed to topic " + topicId + " which doesn't exist in the topic metadata."
                 );
             }
 
@@ -369,6 +253,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
                 }
             }
         });
+
         return targetPartitions;
     }
 
@@ -391,7 +276,15 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         return new GroupAssignment(members);
     }
 
-    private static <K, V> HashMap<K, V> newHashMap(int numMappings) {
+    //
+    // Utility methods to construct collection classes with known capacity.
+    // Equivalent to HashMap.newHashMap and HashSet.newHashSet which are introduced in Java 19.
+    //
+    static <K, V> HashMap<K, V> newHashMap(int numMappings) {
         return new HashMap<>((int) (((numMappings + 1) / 0.75f) + 1));
+    }
+
+    static <K> HashSet<K> newHashSet(int numElements) {
+        return new HashSet<>((int) (((numElements + 1) / 0.75f) + 1));
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -58,7 +58,7 @@ import static org.apache.kafka.coordinator.group.api.assignor.SubscriptionType.H
  * Balance is prioritized above stickiness.
  */
 public class SimpleAssignor implements ShareGroupPartitionAssignor {
-    private static final Logger LOG = LoggerFactory.getLogger(SimpleAssignor.class);
+    private static final Logger log = LoggerFactory.getLogger(SimpleAssignor.class);
     private static final String SIMPLE_ASSIGNOR_NAME = "simple";
 
     /**
@@ -82,10 +82,10 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             return new GroupAssignment(Map.of());
 
         if (groupSpec.subscriptionType().equals(HOMOGENEOUS)) {
-            LOG.debug("Detected that all members are subscribed to the same set of topics, invoking the homogeneous assignment algorithm");
+            log.debug("Detected that all members are subscribed to the same set of topics, invoking the homogeneous assignment algorithm");
             return new SimpleHomogeneousAssignmentBuilder(groupSpec, subscribedTopicDescriber).build();
         } else {
-            LOG.debug("Detected that the members are subscribed to different sets of topics, invoking the heterogeneous assignment algorithm");
+            log.debug("Detected that the members are subscribed to different sets of topics, invoking the heterogeneous assignment algorithm");
             return assignHeterogeneous(groupSpec, subscribedTopicDescriber);
         }
     }
@@ -98,7 +98,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
                 continue;
 
             // Subscribed topic partitions for the share group member.
-            List<TopicIdPartition> targetPartitions = computeTargetPartitions(groupSpec, spec.subscribedTopicIds(), subscribedTopicDescriber);
+            List<TopicIdPartition> targetPartitions = AssignorHelpers.computeTargetPartitions(groupSpec, spec.subscribedTopicIds(), subscribedTopicDescriber);
             memberToPartitionsSubscription.put(memberId, targetPartitions);
         }
 
@@ -168,7 +168,7 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
             roundRobinAssignment(topicToMemberSubscription.get(unassignedTopic), unassignedPartitions.get(unassignedTopic), newAssignment));
 
         // Step 3: We combine current assignment and new assignment.
-        Map<String, Set<TopicIdPartition>> finalAssignment = newHashMap(numGroupMembers);
+        Map<String, Set<TopicIdPartition>> finalAssignment = AssignorHelpers.newHashMap(numGroupMembers);
 
         newAssignment.forEach((targetPartition, members) -> members.forEach(member ->
             finalAssignment.computeIfAbsent(member, k -> new HashSet<>()).add(targetPartition)));
@@ -234,30 +234,6 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         }
     }
 
-    static List<TopicIdPartition> computeTargetPartitions(
-        GroupSpec groupSpec,
-        Set<Uuid> subscribedTopicIds,
-        SubscribedTopicDescriber subscribedTopicDescriber
-    ) {
-        List<TopicIdPartition> targetPartitions = new ArrayList<>();
-        subscribedTopicIds.forEach(topicId -> {
-            int numPartitions = subscribedTopicDescriber.numPartitions(topicId);
-            if (numPartitions == -1) {
-                throw new PartitionAssignorException(
-                    "Members are subscribed to topic " + topicId + " which doesn't exist in the topic metadata."
-                );
-            }
-
-            for (int partition = 0; partition < numPartitions; partition++) {
-                if (groupSpec.isPartitionAssignable(topicId, partition)) {
-                    targetPartitions.add(new TopicIdPartition(topicId, partition));
-                }
-            }
-        });
-
-        return targetPartitions;
-    }
-
     private GroupAssignment groupAssignment(
         Map<String, Set<TopicIdPartition>> assignmentByMember,
         Collection<String> allGroupMembers
@@ -275,17 +251,5 @@ public class SimpleAssignor implements ShareGroupPartitionAssignor {
         });
 
         return new GroupAssignment(members);
-    }
-
-    //
-    // Utility methods to construct collection classes with known capacity.
-    // Equivalent to HashMap.newHashMap and HashSet.newHashSet which are introduced in Java 19.
-    //
-    static <K, V> HashMap<K, V> newHashMap(int numMappings) {
-        return new HashMap<>((int) (((numMappings + 1) / 0.75f) + 1));
-    }
-
-    static <K> HashSet<K> newHashSet(int numElements) {
-        return new HashSet<>((int) (((numElements + 1) / 0.75f) + 1));
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleAssignor.java
@@ -26,6 +26,7 @@ import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssign
 import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
 import org.apache.kafka.coordinator.group.modern.MemberAssignmentImpl;
 import org.apache.kafka.server.common.TopicIdPartition;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -182,10 +182,9 @@ public class SimpleHomogeneousAssignmentBuilder {
     /**
      * Here's the step-by-step breakdown of the assignment process:
      * <ol>
-     *   <li>Revoke partitions from the existing assignment that are no longer part of each member's
-     *     subscriptions.</li>
-     *   <li>Revoke any partitions which are shared more than desired.</li>
+     *   <li>Revoke partitions from the existing assignment that are no longer part of each member's subscriptions.</li>
      *   <li>Revoke partitions from members which have too many partitions.</li>
+     *   <li>Revoke any partitions which are shared more than desired.</li>
      *   <li>Assign any partitions which have insufficient members assigned.</li>
      * </ol>
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -196,9 +196,9 @@ public class SimpleHomogeneousAssignmentBuilder {
 
         revokeUnassignablePartitions();
 
-        revokeOversharedPartitions();
-
         revokeOverfilledMembers();
+
+        revokeOversharedPartitions();
 
         // Add in any partitions which are currently not in the assignment.
         targetPartitions.forEach(topicPartition -> finalAssignmentByPartition.computeIfAbsent(topicPartition, k -> new HashSet<>()));
@@ -274,59 +274,7 @@ public class SimpleHomogeneousAssignmentBuilder {
     }
 
     /**
-     * Revoke any over-shared partitions. Prefer to revoke from overfilled members first.
-     */
-    private void revokeOversharedPartitions() {
-        finalAssignmentByPartition.forEach((topicPartition, assignedMembers) -> {
-            int assignedMemberCount = assignedMembers.size();
-            if (assignedMemberCount > desiredSharing) {
-                Iterator<Integer> assignedMemberIterator = assignedMembers.iterator();
-                while (assignedMemberIterator.hasNext()) {
-                    Integer memberIndex = assignedMemberIterator.next();
-                    if (overfilledMembers.contains(memberIndex)) {
-                        Set<Integer> partitions = newGroupAssignment.get(memberIndex).get(topicPartition.topicId());
-                        if (partitions.remove(topicPartition.partitionId())) {
-                            assignedMemberCount--;
-                            assignedMemberIterator.remove();
-                            finalAssignmentByMember.get(memberIndex).remove(topicPartition);
-                            unfilledMembers.add(memberIndex);
-                        }
-                    }
-                    if (assignedMemberCount <= desiredSharing) {
-                        break;
-                    }
-                }
-            }
-            if (assignedMemberCount > desiredSharing) {
-                Iterator<Integer> assignedMemberIterator = assignedMembers.iterator();
-                while (assignedMemberIterator.hasNext()) {
-                    Integer memberIndex = assignedMemberIterator.next();
-                    if (!overfilledMembers.contains(memberIndex)) {
-                        Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberIndex);
-                        if (newMemberAssignment == null) {
-                            newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberIndex));
-                            newGroupAssignment.put(memberIndex, newMemberAssignment);
-                        }
-                        Set<Integer> partitions = newMemberAssignment.get(topicPartition.topicId());
-                        if (partitions != null) {
-                            if (partitions.remove(topicPartition.partitionId())) {
-                                assignedMemberCount--;
-                                assignedMemberIterator.remove();
-                                finalAssignmentByMember.get(memberIndex).remove(topicPartition);
-                                unfilledMembers.add(memberIndex);
-                            }
-                        }
-                    }
-                    if (assignedMemberCount <= desiredSharing) {
-                        break;
-                    }
-                }
-            }
-        });
-    }
-
-    /**
-     * Revoke partitions from members which are still overfilled.
+     * Revoke partitions from members which are overfilled.
      */
     private void revokeOverfilledMembers() {
         if (overfilledMembers.isEmpty())
@@ -339,9 +287,42 @@ public class SimpleHomogeneousAssignmentBuilder {
                 Iterator<TopicIdPartition> iterator = memberFinalAssignment.iterator();
                 while (iterator.hasNext()) {
                     TopicIdPartition topicPartition = iterator.next();
+                    newGroupAssignment.get(memberIndex).get(topicPartition.topicId()).remove(topicPartition.partitionId());
                     finalAssignmentByPartition.get(topicPartition).remove(memberIndex);
                     iterator.remove();
                     if (memberFinalAssignment.size() == memberDesiredAssignmentCount) {
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Revoke any over-shared partitions.
+     */
+    private void revokeOversharedPartitions() {
+        finalAssignmentByPartition.forEach((topicPartition, assignedMembers) -> {
+            int assignedMemberCount = assignedMembers.size();
+            if (assignedMemberCount > desiredSharing) {
+                Iterator<Integer> assignedMemberIterator = assignedMembers.iterator();
+                while (assignedMemberIterator.hasNext()) {
+                    Integer memberIndex = assignedMemberIterator.next();
+                    Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberIndex);
+                    if (newMemberAssignment == null) {
+                        newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberIndex));
+                        newGroupAssignment.put(memberIndex, newMemberAssignment);
+                    }
+                    Set<Integer> partitions = newMemberAssignment.get(topicPartition.topicId());
+                    if (partitions != null) {
+                        if (partitions.remove(topicPartition.partitionId())) {
+                            assignedMemberCount--;
+                            assignedMemberIterator.remove();
+                            finalAssignmentByMember.get(memberIndex).remove(topicPartition);
+                            unfilledMembers.add(memberIndex);
+                        }
+                    }
+                    if (assignedMemberCount <= desiredSharing) {
                         break;
                     }
                 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -20,11 +20,11 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.coordinator.group.api.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.GroupSpec;
 import org.apache.kafka.coordinator.group.api.assignor.MemberAssignment;
-import org.apache.kafka.coordinator.group.api.assignor.PartitionAssignorException;
 import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
 import org.apache.kafka.coordinator.group.modern.MemberAssignmentImpl;
 import org.apache.kafka.server.common.TopicIdPartition;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.computeTargetPartitions;
-import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.currentAssignment;
 import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHashMap;
 import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHashSet;
 
@@ -54,24 +53,24 @@ import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHash
 public class SimpleHomogeneousAssignmentBuilder {
 
     /**
-     * The group metadata specification.
-     */
-    private final GroupSpec groupSpec;
-
-    /**
      * The list of all the topic Ids that the share group is subscribed to.
      */
     private final Set<Uuid> subscribedTopicIds;
 
     /**
+     * The list of members in the consumer group.
+     */
+    private final List<String> memberIds;
+
+    /**
+     * Maps member ids to their indices in the memberIds list.
+     */
+    private final Map<String, Integer> memberIndices;
+
+    /**
      * The list of all the topic-partitions assignable for the share group.
      */
     private final List<TopicIdPartition> targetPartitions;
-
-    /**
-     * The current assignment from topic partition to members.
-     */
-    private final Map<TopicIdPartition, List<String>> currentAssignment;
 
     /**
      * The number of members in the share group.
@@ -87,56 +86,74 @@ public class SimpleHomogeneousAssignmentBuilder {
 
     /**
      * The desired number of assignments for each share group member.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Map<String, Integer> desiredAssignmentCount;
+    private final int[] desiredAssignmentCount;
 
     /**
      * The share group assignment from the group metadata specification at the start of the assignment operation.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Map<String, Map<Uuid, Set<Integer>>> oldGroupAssignment;
+    private final Map<Integer, Map<Uuid, Set<Integer>>> oldGroupAssignment;
 
     /**
      * The share group assignment calculated iteratively by the assignment operation. Entries in this map override those
      * in the old group assignment map.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Map<String, Map<Uuid, Set<Integer>>> newGroupAssignment;
+    private final Map<Integer, Map<Uuid, Set<Integer>>> newGroupAssignment;
 
     /**
      * The final assignment keyed by topic-partition.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Map<TopicIdPartition, Set<String>> finalAssignmentByPartition;
+    private final Map<TopicIdPartition, Set<Integer>> finalAssignmentByPartition;
 
     /**
      * The final assignment keyed by member ID.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Map<String, Set<TopicIdPartition>> finalAssignmentByMember;
+    private final Map<Integer, Set<TopicIdPartition>> finalAssignmentByMember;
 
     /**
      * The set of members which have too few assigned partitions.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Set<String> unfilledMembers;
+    private final Set<Integer> unfilledMembers;
 
     /**
      * The set of members which have too many assigned partitions.
+     * <p>
+     * Members are stored as integer indices into the memberIds array.
      */
-    private final Set<String> overfilledMembers;
+    private final Set<Integer> overfilledMembers;
 
     public SimpleHomogeneousAssignmentBuilder(GroupSpec groupSpec, SubscribedTopicDescriber subscribedTopicDescriber) {
-        this.groupSpec = groupSpec;
         this.subscribedTopicIds = groupSpec.memberSubscription(groupSpec.memberIds().iterator().next()).subscribedTopicIds();
+
+        // Number the members 0 to M - 1.
+        this.numGroupMembers = groupSpec.memberIds().size();
+        this.memberIds = new ArrayList<>(groupSpec.memberIds());
+        this.memberIndices = newHashMap(numGroupMembers);
+        for (int memberIndex = 0; memberIndex < numGroupMembers; memberIndex++) {
+            memberIndices.put(memberIds.get(memberIndex), memberIndex);
+        }
 
         this.targetPartitions = computeTargetPartitions(groupSpec, subscribedTopicIds, subscribedTopicDescriber);
 
-        this.currentAssignment = currentAssignment(groupSpec);
-
-        this.numGroupMembers = groupSpec.memberIds().size();
         int numTargetPartitions = targetPartitions.size();
         if (numTargetPartitions == 0) {
             this.desiredSharing = 0;
         } else {
             this.desiredSharing = (numGroupMembers + numTargetPartitions - 1) / numTargetPartitions;
         }
-        this.desiredAssignmentCount = newHashMap(numGroupMembers);
+        this.desiredAssignmentCount = new int[numGroupMembers];
         this.oldGroupAssignment = newHashMap(numGroupMembers);
         this.newGroupAssignment = newHashMap(numGroupMembers);
         this.finalAssignmentByPartition = newHashMap(numTargetPartitions);
@@ -145,19 +162,20 @@ public class SimpleHomogeneousAssignmentBuilder {
         this.overfilledMembers = newHashSet(numGroupMembers);
 
         // Extract the old group assignment from the group metadata specification.
-        groupSpec.memberIds().forEach(memberId -> oldGroupAssignment.put(memberId, groupSpec.memberAssignment(memberId).partitions()));
+        groupSpec.memberIds().forEach(memberId -> {
+            int memberIndex = memberIndices.get(memberId);
+            oldGroupAssignment.put(memberIndex, groupSpec.memberAssignment(memberId).partitions());
+        });
 
         // Calculate the desired number of assignments for each member.
         // The precise desired assignment count per target partition. This can be a fractional number.
         // We would expect (numGroupMembers / numTargetPartitions) assignments per partition, rounded upwards.
         // Using integer arithmetic:  (numGroupMembers + numTargetPartitions - 1) / numTargetPartitions
         double preciseDesiredAssignmentCount = desiredSharing * numTargetPartitions / (double) numGroupMembers;
-        int membersAnalyzed = 0;
-        for (Map.Entry<String, Map<Uuid, Set<Integer>>> entry : oldGroupAssignment.entrySet()) {
-            String memberId = entry.getKey();
-            int desiredAssignmentCountForMember = (int) Math.ceil(preciseDesiredAssignmentCount * (double) (++membersAnalyzed)) -
-                (int) Math.ceil(preciseDesiredAssignmentCount * (double) (membersAnalyzed - 1));
-            desiredAssignmentCount.put(memberId, desiredAssignmentCountForMember);
+        for (int memberIndex = 0; memberIndex < numGroupMembers; memberIndex++) {
+            desiredAssignmentCount[memberIndex] =
+                (int) Math.ceil(preciseDesiredAssignmentCount * (double) (memberIndex + 1)) -
+                    (int) Math.ceil(preciseDesiredAssignmentCount * (double) memberIndex);
         }
     }
 
@@ -176,11 +194,11 @@ public class SimpleHomogeneousAssignmentBuilder {
             return new GroupAssignment(Map.of());
         }
 
-        revokeUnsubscribedPartitions();
+        revokeUnassignablePartitions();
 
-        maybeRevokeOversharedPartitions();
+        revokeOversharedPartitions();
 
-        maybeRevokeOverfilledMembers();
+        revokeOverfilledMembers();
 
         // Add in any partitions which are currently not in the assignment.
         targetPartitions.forEach(topicPartition -> finalAssignmentByPartition.computeIfAbsent(topicPartition, k -> new HashSet<>()));
@@ -189,14 +207,14 @@ public class SimpleHomogeneousAssignmentBuilder {
 
         // Combine the old and the new group assignments to give the result.
         Map<String, MemberAssignment> targetAssignment = newHashMap(numGroupMembers);
-        groupSpec.memberIds().forEach(memberId -> {
-            Map<Uuid, Set<Integer>> memberAssignment = newGroupAssignment.get(memberId);
+        for (int memberIndex = 0; memberIndex < numGroupMembers; memberIndex++) {
+            Map<Uuid, Set<Integer>> memberAssignment = newGroupAssignment.get(memberIndex);
             if (memberAssignment == null) {
-                targetAssignment.put(memberId, new MemberAssignmentImpl(oldGroupAssignment.get(memberId)));
+                targetAssignment.put(memberIds.get(memberIndex), new MemberAssignmentImpl(oldGroupAssignment.get(memberIndex)));
             } else {
-                targetAssignment.put(memberId, new MemberAssignmentImpl(memberAssignment));
+                targetAssignment.put(memberIds.get(memberIndex), new MemberAssignmentImpl(memberAssignment));
             }
-        });
+        }
 
         return new GroupAssignment(targetAssignment);
     }
@@ -206,13 +224,13 @@ public class SimpleHomogeneousAssignmentBuilder {
      * When looking at the current assignment, we need to only consider the topics in the current assignment that are
      * also being subscribed in the new assignment.
      */
-    private void revokeUnsubscribedPartitions() {
-        for (Map.Entry<String, Map<Uuid, Set<Integer>>> entry : oldGroupAssignment.entrySet()) {
-            String memberId = entry.getKey();
+    private void revokeUnassignablePartitions() {
+        for (Map.Entry<Integer, Map<Uuid, Set<Integer>>> entry : oldGroupAssignment.entrySet()) {
+            Integer memberIndex = entry.getKey();
             Map<Uuid, Set<Integer>> oldMemberAssignment = entry.getValue();
             Map<Uuid, Set<Integer>> newMemberAssignment = null;
             int memberAssignedPartitions = 0;
-            int desiredAssignmentCountForMember = desiredAssignmentCount.get(memberId);
+            int desiredAssignmentCountForMember = desiredAssignmentCount[memberIndex];
 
             for (Map.Entry<Uuid, Set<Integer>> oldMemberPartitions : oldMemberAssignment.entrySet()) {
                 Uuid topicId = oldMemberPartitions.getKey();
@@ -222,8 +240,8 @@ public class SimpleHomogeneousAssignmentBuilder {
                     for (int partition : assignedPartitions) {
                         TopicIdPartition topicPartition = new TopicIdPartition(topicId, partition);
                         memberAssignedPartitions++;
-                        finalAssignmentByPartition.computeIfAbsent(topicPartition, k -> new HashSet<>()).add(memberId);
-                        finalAssignmentByMember.computeIfAbsent(memberId, k -> new HashSet<>()).add(topicPartition);
+                        finalAssignmentByPartition.computeIfAbsent(topicPartition, k -> new HashSet<>()).add(memberIndex);
+                        finalAssignmentByMember.computeIfAbsent(memberIndex, k -> new HashSet<>()).add(topicPartition);
                         if (memberAssignedPartitions >= desiredAssignmentCountForMember) {
                             if (newMemberAssignment == null) {
                                 // If the new assignment is null, we create a deep copy of the
@@ -244,13 +262,13 @@ public class SimpleHomogeneousAssignmentBuilder {
             }
 
             if (newMemberAssignment != null) {
-                newGroupAssignment.put(memberId, newMemberAssignment);
+                newGroupAssignment.put(memberIndex, newMemberAssignment);
             }
 
             if (memberAssignedPartitions < desiredAssignmentCountForMember) {
-                unfilledMembers.add(memberId);
+                unfilledMembers.add(memberIndex);
             } else if (memberAssignedPartitions > desiredAssignmentCountForMember) {
-                overfilledMembers.add(memberId);
+                overfilledMembers.add(memberIndex);
             }
         }
     }
@@ -258,18 +276,21 @@ public class SimpleHomogeneousAssignmentBuilder {
     /**
      * Revoke any over-shared partitions. Prefer to revoke from overfilled members first.
      */
-    private void maybeRevokeOversharedPartitions() {
-        // Remove any over-shared partitions.
-        currentAssignment.forEach((topicPartition, assignedMembers) -> {
+    private void revokeOversharedPartitions() {
+        finalAssignmentByPartition.forEach((topicPartition, assignedMembers) -> {
             int assignedMemberCount = assignedMembers.size();
             if (assignedMemberCount > desiredSharing) {
-                for (String memberId : assignedMembers) {
-                    if (overfilledMembers.contains(memberId)) {
-                        newGroupAssignment.get(memberId).get(topicPartition.topicId()).remove(topicPartition.partitionId());
-                        assignedMemberCount--;
-                        finalAssignmentByPartition.get(topicPartition).remove(memberId);
-                        finalAssignmentByMember.get(memberId).remove(topicPartition);
-                        unfilledMembers.add(memberId);
+                Iterator<Integer> assignedMemberIterator = assignedMembers.iterator();
+                while (assignedMemberIterator.hasNext()) {
+                    Integer memberIndex = assignedMemberIterator.next();
+                    if (overfilledMembers.contains(memberIndex)) {
+                        Set<Integer> partitions = newGroupAssignment.get(memberIndex).get(topicPartition.topicId());
+                        if (partitions.remove(topicPartition.partitionId())) {
+                            assignedMemberCount--;
+                            assignedMemberIterator.remove();
+                            finalAssignmentByMember.get(memberIndex).remove(topicPartition);
+                            unfilledMembers.add(memberIndex);
+                        }
                     }
                     if (assignedMemberCount <= desiredSharing) {
                         break;
@@ -277,18 +298,24 @@ public class SimpleHomogeneousAssignmentBuilder {
                 }
             }
             if (assignedMemberCount > desiredSharing) {
-                for (String memberId : assignedMembers) {
-                    if (!overfilledMembers.contains(memberId)) {
-                        Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberId);
+                Iterator<Integer> assignedMemberIterator = assignedMembers.iterator();
+                while (assignedMemberIterator.hasNext()) {
+                    Integer memberIndex = assignedMemberIterator.next();
+                    if (!overfilledMembers.contains(memberIndex)) {
+                        Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberIndex);
                         if (newMemberAssignment == null) {
-                            newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberId));
-                            newGroupAssignment.put(memberId, newMemberAssignment);
+                            newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberIndex));
+                            newGroupAssignment.put(memberIndex, newMemberAssignment);
                         }
-                        newMemberAssignment.get(topicPartition.topicId()).remove(topicPartition.partitionId());
-                        assignedMemberCount--;
-                        finalAssignmentByPartition.get(topicPartition).remove(memberId);
-                        finalAssignmentByMember.get(memberId).remove(topicPartition);
-                        unfilledMembers.add(memberId);
+                        Set<Integer> partitions = newMemberAssignment.get(topicPartition.topicId());
+                        if (partitions != null) {
+                            if (partitions.remove(topicPartition.partitionId())) {
+                                assignedMemberCount--;
+                                assignedMemberIterator.remove();
+                                finalAssignmentByMember.get(memberIndex).remove(topicPartition);
+                                unfilledMembers.add(memberIndex);
+                            }
+                        }
                     }
                     if (assignedMemberCount <= desiredSharing) {
                         break;
@@ -296,23 +323,25 @@ public class SimpleHomogeneousAssignmentBuilder {
                 }
             }
         });
-
     }
 
     /**
      * Revoke partitions from members which are still overfilled.
      */
-    private void maybeRevokeOverfilledMembers() {
-        overfilledMembers.forEach(memberId -> {
-            int desiredAssignmentCountForMember = desiredAssignmentCount.get(memberId);
-            Set<TopicIdPartition> finalAssignmentForMember = finalAssignmentByMember.get(memberId);
-            if (finalAssignmentForMember.size() > desiredAssignmentCountForMember) {
-                Iterator<TopicIdPartition> iterator = finalAssignmentForMember.iterator();
+    private void revokeOverfilledMembers() {
+        if (overfilledMembers.isEmpty())
+            return;
+
+        overfilledMembers.forEach(memberIndex -> {
+            int memberDesiredAssignmentCount = desiredAssignmentCount[memberIndex];
+            Set<TopicIdPartition> memberFinalAssignment = finalAssignmentByMember.get(memberIndex);
+            if (memberFinalAssignment.size() > memberDesiredAssignmentCount) {
+                Iterator<TopicIdPartition> iterator = memberFinalAssignment.iterator();
                 while (iterator.hasNext()) {
                     TopicIdPartition topicPartition = iterator.next();
-                    finalAssignmentByPartition.get(topicPartition).remove(memberId);
+                    finalAssignmentByPartition.get(topicPartition).remove(memberIndex);
                     iterator.remove();
-                    if (finalAssignmentForMember.size() == desiredAssignmentCountForMember) {
+                    if (memberFinalAssignment.size() == memberDesiredAssignmentCount) {
                         break;
                     }
                 }
@@ -321,37 +350,58 @@ public class SimpleHomogeneousAssignmentBuilder {
     }
 
     /**
-     * Assign partitions to unfilled members.
+     * Assign partitions to unfilled members. It repeatedly iterates through the unfilled members while running
+     * once thrown the set of partitions. When a partition is found that has insufficient sharing, it attempts to assign
+     * to one of the partitions.
+     * <p>
+     * There is one tricky cases here and that's where a partition wants another assignment, but none of the unfilled
+     * members are able to take it (because they already have that partition). In this situation, we just accept that
+     * no additional assignments for this partition could be made and carry on. In theory, a different shuffling of the
+     * partitions would be able to achieve better balance, but it's harmless tolerating a slight imbalance in this case.
+     * <p>
+     * Note that finalAssignmentByMember is not maintained by this method which is expected to be the final step in the
+     * computation.
      */
     private void assignRemainingPartitions() {
-        // Finally, round-robin assignment for under-assigned partitions.
-        Iterator<String> memberIdIterator = unfilledMembers.iterator();
-        for (Map.Entry<TopicIdPartition, Set<String>> partitionAssignment : finalAssignmentByPartition.entrySet()) {
-            TopicIdPartition topicIdPartition = partitionAssignment.getKey();
-            Set<String> membersAssigned = partitionAssignment.getValue();
+        if (unfilledMembers.isEmpty())
+            return;
 
-            while (membersAssigned.size() < desiredSharing) {
-                if (!memberIdIterator.hasNext()) {
-                    memberIdIterator = unfilledMembers.iterator();
-                    if (unfilledMembers.isEmpty()) {
-                        // This should never happen, but guarding against an infinite loop
-                        throw new PartitionAssignorException("Inconsistent number of member IDs");
+        Iterator<Integer> memberIterator = unfilledMembers.iterator();
+        boolean partitionAssignedForThisIterator = false;
+        for (Map.Entry<TopicIdPartition, Set<Integer>> partitionAssignment : finalAssignmentByPartition.entrySet()) {
+            TopicIdPartition topicPartition = partitionAssignment.getKey();
+            Set<Integer> membersAssigned = partitionAssignment.getValue();
+
+            if (membersAssigned.size() < desiredSharing) {
+                int assignmentsToMake = desiredSharing - membersAssigned.size();
+                while (assignmentsToMake > 0) {
+                    if (!memberIterator.hasNext()) {
+                        if (!partitionAssignedForThisIterator) {
+                            break;
+                        }
+                        memberIterator = unfilledMembers.iterator();
+                        partitionAssignedForThisIterator = false;
+                    }
+                    int memberIndex = memberIterator.next();
+                    if (!membersAssigned.contains(memberIndex)) {
+                        Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberIndex);
+                        if (newMemberAssignment == null) {
+                            newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberIndex));
+                            newGroupAssignment.put(memberIndex, newMemberAssignment);
+                        }
+                        newMemberAssignment.computeIfAbsent(topicPartition.topicId(), k -> new HashSet<>()).add(topicPartition.partitionId());
+                        finalAssignmentByMember.computeIfAbsent(memberIndex, k -> new HashSet<>()).add(topicPartition);
+                        assignmentsToMake--;
+                        partitionAssignedForThisIterator = true;
+                        if (finalAssignmentByMember.get(memberIndex).size() >= desiredAssignmentCount[memberIndex]) {
+                            memberIterator.remove();
+                        }
                     }
                 }
+            }
 
-                String memberId = memberIdIterator.next();
-                if (!membersAssigned.contains(memberId)) {
-                    Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberId);
-                    if (newMemberAssignment == null) {
-                        newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberId));
-                        newGroupAssignment.put(memberId, newMemberAssignment);
-                    }
-                    newMemberAssignment.computeIfAbsent(topicIdPartition.topicId(), k -> new HashSet<>()).add(topicIdPartition.partitionId());
-                    if (newMemberAssignment.get(topicIdPartition.topicId()).size() > desiredAssignmentCount.get(memberId)) {
-                        memberIdIterator.remove();
-                    }
-                    membersAssigned.add(memberId);
-                }
+            if (unfilledMembers.isEmpty()) {
+                break;
             }
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.assignor;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.api.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.api.assignor.GroupSpec;
+import org.apache.kafka.coordinator.group.api.assignor.MemberAssignment;
+import org.apache.kafka.coordinator.group.api.assignor.PartitionAssignorException;
+import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
+import org.apache.kafka.coordinator.group.modern.MemberAssignmentImpl;
+import org.apache.kafka.server.common.TopicIdPartition;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.computeTargetPartitions;
+import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.currentAssignment;
+import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHashMap;
+import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHashSet;
+
+/**
+ * The homogeneous simple assignment builder is used to generate the target assignment for a share group with
+ * all its members subscribed to the same set of topics.
+ * <p>
+ * Assignments are done according to the following principles:
+ * <ol>
+ *   <li>Balance:          Ensure partitions are distributed equally among all members.
+ *                         The difference in assignments sizes between any two members
+ *                         should not exceed one partition.</li>
+ *   <li>Stickiness:       Minimize partition movements among members by retaining
+ *                         as much of the existing assignment as possible.</li>
+ * </ol>
+ * <p>
+ * Balance is prioritized above stickiness.
+ */
+public class SimpleHomogeneousAssignmentBuilder {
+
+    /**
+     * The group metadata specification.
+     */
+    private final GroupSpec groupSpec;
+
+    /**
+     * The list of all the topic Ids that the share group is subscribed to.
+     */
+    private final Set<Uuid> subscribedTopicIds;
+
+    /**
+     * The list of all the topic-partitions assignable for the share group.
+     */
+    private final List<TopicIdPartition> targetPartitions;
+
+    /**
+     * The current assignment from topic partition to members.
+     */
+    private final Map<TopicIdPartition, List<String>> currentAssignment;
+
+    /**
+     * The number of members in the share group.
+     */
+    private final int numGroupMembers;
+
+    /**
+     * The desired sharing for each target partition.
+     * For entirely balanced assignment, we would expect (numTargetPartitions / numGroupMembers) partitions per member, rounded upwards.
+     * That can be expressed as:  Math.ceil(numTargetPartitions / (double) numGroupMembers)
+     */
+    private final int desiredSharing;
+
+    /**
+     * The desired number of assignments for each share group member.
+     */
+    private final Map<String, Integer> desiredAssignmentCount;
+
+    /**
+     * The share group assignment from the group metadata specification at the start of the assignment operation.
+     */
+    private final Map<String, Map<Uuid, Set<Integer>>> oldGroupAssignment;
+
+    /**
+     * The share group assignment calculated iteratively by the assignment operation. Entries in this map override those
+     * in the old group assignment map.
+     */
+    private final Map<String, Map<Uuid, Set<Integer>>> newGroupAssignment;
+
+    /**
+     * The final assignment keyed by topic-partition.
+     */
+    private final Map<TopicIdPartition, Set<String>> finalAssignmentByPartition;
+
+    /**
+     * The final assignment keyed by member ID.
+     */
+    private final Map<String, Set<TopicIdPartition>> finalAssignmentByMember;
+
+    /**
+     * The set of members which have too few assigned partitions.
+     */
+    private final Set<String> unfilledMembers;
+
+    /**
+     * The set of members which have too many assigned partitions.
+     */
+    private final Set<String> overfilledMembers;
+
+    public SimpleHomogeneousAssignmentBuilder(GroupSpec groupSpec, SubscribedTopicDescriber subscribedTopicDescriber) {
+        this.groupSpec = groupSpec;
+        this.subscribedTopicIds = groupSpec.memberSubscription(groupSpec.memberIds().iterator().next()).subscribedTopicIds();
+
+        this.targetPartitions = computeTargetPartitions(groupSpec, subscribedTopicIds, subscribedTopicDescriber);
+
+        this.currentAssignment = currentAssignment(groupSpec);
+
+        this.numGroupMembers = groupSpec.memberIds().size();
+        int numTargetPartitions = targetPartitions.size();
+        if (numTargetPartitions == 0) {
+            this.desiredSharing = 0;
+        } else {
+            this.desiredSharing =(numGroupMembers + numTargetPartitions - 1) / numTargetPartitions;
+        }
+        this.desiredAssignmentCount = newHashMap(numGroupMembers);
+        this.oldGroupAssignment = newHashMap(numGroupMembers);
+        this.newGroupAssignment = newHashMap(numGroupMembers);
+        this.finalAssignmentByPartition = newHashMap(numTargetPartitions);
+        this.finalAssignmentByMember = newHashMap(numGroupMembers);
+        this.unfilledMembers = newHashSet(numGroupMembers);
+        this.overfilledMembers = newHashSet(numGroupMembers);
+
+        // Extract the old group assignment from the group metadata specification.
+        groupSpec.memberIds().forEach(memberId -> oldGroupAssignment.put(memberId, groupSpec.memberAssignment(memberId).partitions()));
+
+        // Calculate the desired number of assignments for each member.
+        // The precise desired assignment count per target partition. This can be a fractional number.
+        // We would expect (numGroupMembers / numTargetPartitions) assignments per partition, rounded upwards.
+        // Using integer arithmetic:  (numGroupMembers + numTargetPartitions - 1) / numTargetPartitions
+        double preciseDesiredAssignmentCount = desiredSharing * numTargetPartitions / (double) numGroupMembers;
+        int membersAnalyzed = 0;
+        for (Map.Entry<String, Map<Uuid, Set<Integer>>> entry : oldGroupAssignment.entrySet()) {
+            String memberId = entry.getKey();
+            int desiredAssignmentCountForMember = (int) Math.ceil(preciseDesiredAssignmentCount * (double) (++membersAnalyzed)) -
+                (int) Math.ceil(preciseDesiredAssignmentCount * (double) (membersAnalyzed - 1));
+            desiredAssignmentCount.put(memberId, desiredAssignmentCountForMember);
+        }
+    }
+
+    /**
+     * Here's the step-by-step breakdown of the assignment process:
+     * <ol>
+     *   <li>Revoke partitions from the existing assignment that are no longer part of each member's
+     *     subscriptions.</li>
+     *   <li>Revoke any partitions which are shared more than desired.</li>
+     *   <li>Revoke partitions from members which have too many partitions.</li>
+     *   <li>Assign any partitions which have insufficient members assigned.</li>
+     * </ol>
+     */
+    public GroupAssignment build() {
+        if (subscribedTopicIds.isEmpty()) {
+            return new GroupAssignment(Map.of());
+        }
+
+        revokeUnsubscribedPartitions();
+
+        maybeRevokeOversharedPartitions();
+
+        maybeRevokeOverfilledMembers();
+
+        // Add in any partitions which are currently not in the assignment.
+        targetPartitions.forEach(topicPartition -> finalAssignmentByPartition.computeIfAbsent(topicPartition, k -> new HashSet<>()));
+
+        assignRemainingPartitions();
+
+        // Combine the old and the new group assignments to give the result.
+        Map<String, MemberAssignment> targetAssignment = newHashMap(numGroupMembers);
+        groupSpec.memberIds().forEach(memberId -> {
+            Map<Uuid, Set<Integer>> memberAssignment = newGroupAssignment.get(memberId);
+            if (memberAssignment == null) {
+                targetAssignment.put(memberId, new MemberAssignmentImpl(oldGroupAssignment.get(memberId)));
+            } else {
+                targetAssignment.put(memberId, new MemberAssignmentImpl(memberAssignment));
+            }
+        });
+
+        return new GroupAssignment(targetAssignment);
+    }
+
+    /**
+     * Examine the members from the current assignment, making sure that no member has too many assigned partitions.
+     * When looking at the current assignment, we need to only consider the topics in the current assignment that are
+     * also being subscribed in the new assignment.
+     */
+    private void revokeUnsubscribedPartitions() {
+        for (Map.Entry<String, Map<Uuid, Set<Integer>>> entry : oldGroupAssignment.entrySet()) {
+            String memberId = entry.getKey();
+            Map<Uuid, Set<Integer>> oldMemberAssignment = entry.getValue();
+            Map<Uuid, Set<Integer>> newMemberAssignment = null;
+            int memberAssignedPartitions = 0;
+            int desiredAssignmentCountForMember = desiredAssignmentCount.get(memberId);
+
+            for (Map.Entry<Uuid, Set<Integer>> oldMemberPartitions : oldMemberAssignment.entrySet()) {
+                Uuid topicId = oldMemberPartitions.getKey();
+                Set<Integer> assignedPartitions = oldMemberPartitions.getValue();
+
+                if (subscribedTopicIds.contains(topicId)) {
+                    for (int partition : assignedPartitions) {
+                        TopicIdPartition topicPartition = new TopicIdPartition(topicId, partition);
+                        memberAssignedPartitions++;
+                        finalAssignmentByPartition.computeIfAbsent(topicPartition, k -> new HashSet<>()).add(memberId);
+                        finalAssignmentByMember.computeIfAbsent(memberId, k -> new HashSet<>()).add(topicPartition);
+                        if (memberAssignedPartitions >= desiredAssignmentCountForMember) {
+                            if (newMemberAssignment == null) {
+                                // If the new assignment is null, we create a deep copy of the
+                                // original assignment so that we can alter it.
+                                newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldMemberAssignment);
+                            }
+                        }
+                    }
+                } else {
+                    if (newMemberAssignment == null) {
+                        // If the new member assignment is null, we create a deep copy of the
+                        // original assignment so we can alter it.
+                        newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldMemberAssignment);
+                    }
+                    // Remove the entire topic.
+                    newMemberAssignment.remove(topicId);
+                }
+            }
+
+            if (newMemberAssignment != null) {
+                newGroupAssignment.put(memberId, newMemberAssignment);
+            }
+
+            if (memberAssignedPartitions < desiredAssignmentCountForMember) {
+                unfilledMembers.add(memberId);
+            } else if (memberAssignedPartitions > desiredAssignmentCountForMember) {
+                overfilledMembers.add(memberId);
+            }
+        }
+    }
+
+    /**
+     * Revoke any over-shared partitions. Prefer to revoke from overfilled members first.
+     */
+    private void maybeRevokeOversharedPartitions() {
+        // Remove any over-shared partitions.
+        currentAssignment.forEach((topicPartition, assignedMembers) -> {
+            int assignedMemberCount = assignedMembers.size();
+            if (assignedMemberCount > desiredSharing) {
+                for (String memberId : assignedMembers) {
+                    if (overfilledMembers.contains(memberId)) {
+                        newGroupAssignment.get(memberId).get(topicPartition.topicId()).remove(topicPartition.partitionId());
+                        assignedMemberCount--;
+                        finalAssignmentByPartition.get(topicPartition).remove(memberId);
+                        finalAssignmentByMember.get(memberId).remove(topicPartition);
+                        unfilledMembers.add(memberId);
+                    }
+                    if (assignedMemberCount <= desiredSharing) {
+                        break;
+                    }
+                }
+            }
+            if (assignedMemberCount > desiredSharing) {
+                for (String memberId : assignedMembers) {
+                    if (!overfilledMembers.contains(memberId)) {
+                        Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberId);
+                        if (newMemberAssignment == null) {
+                            newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberId));
+                            newGroupAssignment.put(memberId, newMemberAssignment);
+                        }
+                        newMemberAssignment.get(topicPartition.topicId()).remove(topicPartition.partitionId());
+                        assignedMemberCount--;
+                        finalAssignmentByPartition.get(topicPartition).remove(memberId);
+                        finalAssignmentByMember.get(memberId).remove(topicPartition);
+                        unfilledMembers.add(memberId);
+                    }
+                    if (assignedMemberCount <= desiredSharing) {
+                        break;
+                    }
+                }
+            }
+        });
+
+    }
+
+    /**
+     * Revoke partitions from members which are still overfilled.
+     */
+    private void maybeRevokeOverfilledMembers() {
+        overfilledMembers.forEach(memberId -> {
+            int desiredAssignmentCountForMember = desiredAssignmentCount.get(memberId);
+            Set<TopicIdPartition> finalAssignmentForMember = finalAssignmentByMember.get(memberId);
+            if (finalAssignmentForMember.size() > desiredAssignmentCountForMember) {
+                Iterator<TopicIdPartition> iterator = finalAssignmentForMember.iterator();
+                while (iterator.hasNext()) {
+                    TopicIdPartition topicPartition = iterator.next();
+                    finalAssignmentByPartition.get(topicPartition).remove(memberId);
+                    iterator.remove();
+                    if (finalAssignmentForMember.size() == desiredAssignmentCountForMember) {
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Assign partitions to unfilled members.
+     */
+    private void assignRemainingPartitions() {
+        // Finally, round-robin assignment for under-assigned partitions.
+        Iterator<String> memberIdIterator = unfilledMembers.iterator();
+        for (Map.Entry<TopicIdPartition, Set<String>> partitionAssignment : finalAssignmentByPartition.entrySet()) {
+            TopicIdPartition topicIdPartition = partitionAssignment.getKey();
+            Set<String> membersAssigned = partitionAssignment.getValue();
+
+            while (membersAssigned.size() < desiredSharing) {
+                if (!memberIdIterator.hasNext()) {
+                    memberIdIterator = unfilledMembers.iterator();
+                    if (unfilledMembers.isEmpty()) {
+                        // This should never happen, but guarding against an infinite loop
+                        throw new PartitionAssignorException("Inconsistent number of member IDs");
+                    }
+                }
+
+                String memberId = memberIdIterator.next();
+                if (!membersAssigned.contains(memberId)) {
+                    Map<Uuid, Set<Integer>> newMemberAssignment = newGroupAssignment.get(memberId);
+                    if (newMemberAssignment == null) {
+                        newMemberAssignment = AssignorHelpers.deepCopyAssignment(oldGroupAssignment.get(memberId));
+                        newGroupAssignment.put(memberId, newMemberAssignment);
+                    }
+                    newMemberAssignment.computeIfAbsent(topicIdPartition.topicId(), k -> new HashSet<>()).add(topicIdPartition.partitionId());
+                    if (newMemberAssignment.get(topicIdPartition.topicId()).size() > desiredAssignmentCount.get(memberId)) {
+                        memberIdIterator.remove();
+                    }
+                    membersAssigned.add(memberId);
+                }
+            }
+        }
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -107,14 +107,14 @@ public class SimpleHomogeneousAssignmentBuilder {
     private final Map<Integer, Map<Uuid, Set<Integer>>> newGroupAssignment;
 
     /**
-     * The final assignment keyed by topic-partition.
+     * The final assignment keyed by topic-partition mapping to member.
      * <p>
      * Members are stored as integer indices into the memberIds array.
      */
     private final Map<TopicIdPartition, Set<Integer>> finalAssignmentByPartition;
 
     /**
-     * The final assignment keyed by member ID.
+     * The final assignment keyed by member ID mapping to topic-partitions.
      * <p>
      * Members are stored as integer indices into the memberIds array.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -31,10 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.computeTargetPartitions;
-import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHashMap;
-import static org.apache.kafka.coordinator.group.assignor.SimpleAssignor.newHashSet;
-
 /**
  * The homogeneous simple assignment builder is used to generate the target assignment for a share group with
  * all its members subscribed to the same set of topics.
@@ -140,12 +136,12 @@ public class SimpleHomogeneousAssignmentBuilder {
         // Number the members 0 to M - 1.
         this.numGroupMembers = groupSpec.memberIds().size();
         this.memberIds = new ArrayList<>(groupSpec.memberIds());
-        this.memberIndices = newHashMap(numGroupMembers);
+        this.memberIndices = AssignorHelpers.newHashMap(numGroupMembers);
         for (int memberIndex = 0; memberIndex < numGroupMembers; memberIndex++) {
             memberIndices.put(memberIds.get(memberIndex), memberIndex);
         }
 
-        this.targetPartitions = computeTargetPartitions(groupSpec, subscribedTopicIds, subscribedTopicDescriber);
+        this.targetPartitions = AssignorHelpers.computeTargetPartitions(groupSpec, subscribedTopicIds, subscribedTopicDescriber);
 
         int numTargetPartitions = targetPartitions.size();
         if (numTargetPartitions == 0) {
@@ -154,12 +150,12 @@ public class SimpleHomogeneousAssignmentBuilder {
             this.desiredSharing = (numGroupMembers + numTargetPartitions - 1) / numTargetPartitions;
         }
         this.desiredAssignmentCount = new int[numGroupMembers];
-        this.oldGroupAssignment = newHashMap(numGroupMembers);
-        this.newGroupAssignment = newHashMap(numGroupMembers);
-        this.finalAssignmentByPartition = newHashMap(numTargetPartitions);
-        this.finalAssignmentByMember = newHashMap(numGroupMembers);
-        this.unfilledMembers = newHashSet(numGroupMembers);
-        this.overfilledMembers = newHashSet(numGroupMembers);
+        this.oldGroupAssignment = AssignorHelpers.newHashMap(numGroupMembers);
+        this.newGroupAssignment = AssignorHelpers.newHashMap(numGroupMembers);
+        this.finalAssignmentByPartition = AssignorHelpers.newHashMap(numTargetPartitions);
+        this.finalAssignmentByMember = AssignorHelpers.newHashMap(numGroupMembers);
+        this.unfilledMembers = AssignorHelpers.newHashSet(numGroupMembers);
+        this.overfilledMembers = AssignorHelpers.newHashSet(numGroupMembers);
 
         // Extract the old group assignment from the group metadata specification.
         groupSpec.memberIds().forEach(memberId -> {
@@ -193,6 +189,7 @@ public class SimpleHomogeneousAssignmentBuilder {
             return new GroupAssignment(Map.of());
         }
 
+        // The order of steps here is not that significant, but assignRemainingPartitions must go last.
         revokeUnassignablePartitions();
 
         revokeOverfilledMembers();
@@ -205,7 +202,7 @@ public class SimpleHomogeneousAssignmentBuilder {
         assignRemainingPartitions();
 
         // Combine the old and the new group assignments to give the result.
-        Map<String, MemberAssignment> targetAssignment = newHashMap(numGroupMembers);
+        Map<String, MemberAssignment> targetAssignment = AssignorHelpers.newHashMap(numGroupMembers);
         for (int memberIndex = 0; memberIndex < numGroupMembers; memberIndex++) {
             Map<Uuid, Set<Integer>> memberAssignment = newGroupAssignment.get(memberIndex);
             if (memberAssignment == null) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/SimpleHomogeneousAssignmentBuilder.java
@@ -134,7 +134,7 @@ public class SimpleHomogeneousAssignmentBuilder {
         if (numTargetPartitions == 0) {
             this.desiredSharing = 0;
         } else {
-            this.desiredSharing =(numGroupMembers + numTargetPartitions - 1) / numTargetPartitions;
+            this.desiredSharing = (numGroupMembers + numTargetPartitions - 1) / numTargetPartitions;
         }
         this.desiredAssignmentCount = newHashMap(numGroupMembers);
         this.oldGroupAssignment = newHashMap(numGroupMembers);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/ShareGroupAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/ShareGroupAssignorBenchmark.java
@@ -95,7 +95,7 @@ public class ShareGroupAssignorBenchmark {
     @Param({"1", "10", "100"})
     private int partitionCount;
 
-    @Param({"10", "100"})
+    @Param({"1", "10", "100"})
     private int topicCount;
 
     @Param({"HOMOGENEOUS", "HETEROGENEOUS"})


### PR DESCRIPTION
Finalise the share group SimpleAssignor for homogeneous subscriptions.
The assignor code is much more accurate about the number of partitions
assigned to each member, and the number of members assigned for each
partition. It eliminates the idea of hash-based assignment because that
has been shown to the unhelpful. The revised code is very much more
effective at assigning evenly as the number of members grows and shrinks
over time.

A future PR will address the code for heterogeneous subscriptions.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
