### PR TITLE
MINOR: Add entity types in streams group RPCs

### DIFF
--- a/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeResponse.json
@@ -57,9 +57,9 @@
               "fields": [
                 { "name": "SubtopologyId", "type": "string", "versions": "0+",
                   "about": "String to uniquely identify the subtopology." },
-                { "name": "SourceTopics", "type": "[]string", "versions": "0+",
+                { "name": "SourceTopics", "type": "[]string", "versions": "0+", "entityType": "topicName",
                   "about": "The topics the subtopology reads from." },
-                { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
+                { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+", "entityType": "topicName",
                   "about": "The repartition topics the subtopology writes to." },
                 { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
                   "about": "The set of state changelog topics associated with this subtopology. Created automatically." },
@@ -154,7 +154,7 @@
         "about": "value of the config" }
     ]},
     { "name": "TopicInfo", "versions": "0+", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+",
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
@@ -20,7 +20,7 @@
   "name": "StreamsGroupHeartbeatRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",
-  // The StreamsGroupDescribeRequest API is added as part of KIP-1071 and is still under
+  // The StreamsGroupHeartbeatRequest API is added as part of KIP-1071 and is still under
   // development. Hence, the API is not exposed by default by brokers unless
   // explicitly enabled.
   "latestVersionUnstable": true,
@@ -50,13 +50,13 @@
           "fields": [
             { "name": "SubtopologyId", "type": "string", "versions": "0+",
               "about": "String to uniquely identify the subtopology. Deterministically generated from the topology" },
-            { "name": "SourceTopics", "type": "[]string", "versions": "0+",
+            { "name": "SourceTopics", "type": "[]string", "versions": "0+", "entityType": "topicName",
               "about": "The topics the topology reads from." },
             { "name": "SourceTopicRegex", "type": "[]string", "versions": "0+",
               "about": "The regular expressions identifying topics the subtopology reads from." },
             { "name": "StateChangelogTopics", "type": "[]TopicInfo", "versions": "0+",
               "about": "The set of state changelog topics associated with this subtopology. Created automatically." },
-            { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+",
+            { "name": "RepartitionSinkTopics", "type": "[]string", "versions": "0+", "entityType": "topicName",
               "about": "The repartition topics the subtopology writes to." },
             { "name": "RepartitionSourceTopics", "type": "[]TopicInfo", "versions": "0+",
               "about": "The set of source topics that are internally created repartition topics. Created automatically." },
@@ -104,7 +104,7 @@
         "about": "value of the config" }
     ]},
     { "name": "TopicInfo", "versions": "0+", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+",
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The name of the topic." },
       { "name": "Partitions", "type": "int32", "versions": "0+",
         "about": "The number of partitions in the topic. Can be 0 if no specific number of partitions is enforced. Always 0 for changelog topics." },

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -100,7 +100,7 @@
         "about": "A string representation of the status." }
     ]},
     { "name": "TopicPartition", "versions": "0+", "fields": [
-      { "name": "Topic", "type": "string", "versions": "0+",
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "topic name" },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "partitions" }


### PR DESCRIPTION
These can be used to implement transformations on top of the RPC
definitions. Group IDs were already marked. This PR additionally adds
the entityType for all topic names.

Reviewers: Matthias J. Sax <matthias@confluent.io>
