### PR TITLE
KAFKA-19414: Remove 2PC public APIs from 4.1 until release (KIP-939)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -142,7 +142,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void initTransactions(boolean keepPreparedTxn) {
+    public void initTransactions() {
         verifyNotClosed();
         verifyNotFenced();
         if (this.transactionInitialized) {
@@ -201,18 +201,6 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public PreparedTxnState prepareTransaction() throws ProducerFencedException {
-        verifyNotClosed();
-        verifyNotFenced();
-        verifyTransactionsInitialized();
-        verifyTransactionInFlight();
-        
-        // Return a new PreparedTxnState with mock values for producerId and epoch
-        // Using 1000L and (short)1 as arbitrary values for a valid PreparedTxnState
-        return new PreparedTxnState(1000L, (short) 1);
-    }
-
-    @Override
     public void commitTransaction() throws ProducerFencedException {
         verifyNotClosed();
         verifyNotFenced();
@@ -255,27 +243,6 @@ public class MockProducer<K, V> implements Producer<K, V> {
         this.transactionCommitted = false;
         this.transactionAborted = true;
         this.transactionInFlight = false;
-    }
-
-    @Override
-    public void completeTransaction(PreparedTxnState preparedTxnState) throws ProducerFencedException {
-        verifyNotClosed();
-        verifyNotFenced();
-        verifyTransactionsInitialized();
-        
-        if (!this.transactionInFlight) {
-            throw new IllegalStateException("There is no prepared transaction to complete.");
-        }
-
-        // For testing purposes, we'll consider a prepared state with producerId=1000L and epoch=1 as valid
-        // This should match what's returned in prepareTransaction()
-        PreparedTxnState currentState = new PreparedTxnState(1000L, (short) 1);
-        
-        if (currentState.equals(preparedTxnState)) {
-            commitTransaction();
-        } else {
-            abortTransaction();
-        }
     }
 
     private synchronized void verifyNotClosed() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -42,14 +42,7 @@ public interface Producer<K, V> extends Closeable {
     /**
      * See {@link KafkaProducer#initTransactions()}
      */
-    default void initTransactions() {
-        initTransactions(false);
-    }
-
-    /**
-     * See {@link KafkaProducer#initTransactions(boolean)}
-     */
-    void initTransactions(boolean keepPreparedTxn);
+    void initTransactions();
 
     /**
      * See {@link KafkaProducer#beginTransaction()}
@@ -63,11 +56,6 @@ public interface Producer<K, V> extends Closeable {
                                   ConsumerGroupMetadata groupMetadata) throws ProducerFencedException;
 
     /**
-     * See {@link KafkaProducer#prepareTransaction()}
-     */
-    PreparedTxnState prepareTransaction() throws ProducerFencedException;
-
-    /**
      * See {@link KafkaProducer#commitTransaction()}
      */
     void commitTransaction() throws ProducerFencedException;
@@ -76,11 +64,6 @@ public interface Producer<K, V> extends Closeable {
      * See {@link KafkaProducer#abortTransaction()}
      */
     void abortTransaction() throws ProducerFencedException;
-
-    /**
-     * See {@link KafkaProducer#completeTransaction(PreparedTxnState)}
-     */
-    void completeTransaction(PreparedTxnState preparedTxnState) throws ProducerFencedException;
 
     /**
      * @see KafkaProducer#registerMetricForSubscription(KafkaMetric) 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -320,9 +320,7 @@ public class TransactionManager {
                     .setTransactionalId(transactionalId)
                     .setTransactionTimeoutMs(transactionTimeoutMs)
                     .setProducerId(producerIdAndEpoch.producerId)
-                    .setProducerEpoch(producerIdAndEpoch.epoch)
-                    .setEnable2Pc(enable2PC)
-                    .setKeepPreparedTxn(keepPreparedTxn);
+                    .setProducerEpoch(producerIdAndEpoch.epoch);
 
             InitProducerIdHandler handler = new InitProducerIdHandler(new InitProducerIdRequest.Builder(requestData),
                     isEpochBump);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.PreparedTxnState;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -4025,56 +4025,6 @@ public class TransactionManagerTest {
         assertFalse(transactionManager.hasOngoingTransaction());
     }
 
-    @Test
-    public void testInitializeTransactionsWithKeepPreparedTxn() {
-        doInitTransactionsWith2PCEnabled(true);
-        runUntil(transactionManager::hasProducerId);
-
-        // Expect a bumped epoch in the response.
-        assertTrue(transactionManager.hasProducerId());
-        assertFalse(transactionManager.hasOngoingTransaction());
-        assertEquals(ongoingProducerId, transactionManager.producerIdAndEpoch().producerId);
-        assertEquals(bumpedOngoingEpoch, transactionManager.producerIdAndEpoch().epoch);
-    }
-
-    @Test
-    public void testPrepareTransaction() {
-        doInitTransactionsWith2PCEnabled(false);
-        runUntil(transactionManager::hasProducerId);
-
-        // Begin a transaction
-        transactionManager.beginTransaction();
-        assertTrue(transactionManager.hasOngoingTransaction());
-
-        // Add a partition to the transaction
-        transactionManager.maybeAddPartition(tp0);
-
-        // Capture the current producer ID and epoch before preparing the response
-        long producerId = transactionManager.producerIdAndEpoch().producerId;
-        short epoch = transactionManager.producerIdAndEpoch().epoch;
-
-        // Simulate a produce request
-        try {
-            // Prepare the response before sending to ensure it's ready
-            prepareProduceResponse(Errors.NONE, producerId, epoch);
-
-            appendToAccumulator(tp0);
-            // Wait until the request is processed
-            runUntil(() -> !client.hasPendingResponses());
-        } catch (InterruptedException e) {
-            fail("Unexpected interruption: " + e);
-        }
-
-        transactionManager.prepareTransaction();
-        assertTrue(transactionManager.isPrepared());
-
-        PreparedTxnState preparedState = transactionManager.preparedTransactionState();
-        // Validate the state contains the correct serialized producer ID and epoch
-        assertEquals(producerId + ":" + epoch, preparedState.toString());
-        assertEquals(producerId, preparedState.producerId());
-        assertEquals(epoch, preparedState.epoch());
-    }
-
     private void prepareAddPartitionsToTxn(final Map<TopicPartition, Errors> errors) {
         AddPartitionsToTxnResult result = AddPartitionsToTxnResponse.resultForTransaction(AddPartitionsToTxnResponse.V3_AND_BELOW_TXN_ID, errors);
         AddPartitionsToTxnResponseData data = new AddPartitionsToTxnResponseData().setResultsByTopicV3AndBelow(result.topicResults()).setThrottleTimeMs(0);


### PR DESCRIPTION
We are removing some of the previously added public APIs until KIP-939
is ready to use.

Reviewers: Justine Olshan <jolshan@confluent.io>
