### PR TITLE
KAFKA-10357: Add new Kafka Streams exception classes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/InternalTopicsAlreadySetupException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InternalTopicsAlreadySetupException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class InternalTopicsAlreadySetupException extends StreamsException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InternalTopicsAlreadySetupException(final String message) {
+        super(message);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/MisconfiguredInternalTopicException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/MisconfiguredInternalTopicException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class MisconfiguredInternalTopicException extends StreamsException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MisconfiguredInternalTopicException(final String message) {
+        super(message);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/MissingInternalTopicsException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/MissingInternalTopicsException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+import java.util.List;
+
+public class MissingInternalTopicsException extends StreamsException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> topics;
+
+    /** 
+     * Constructs a new MissingInternalTopicsException.
+     * 
+     * @param message The detail message
+     * @param topics the list of missing internal topic names
+     */
+    public MissingInternalTopicsException(final String message, final List<String> topics) {
+        super(message);
+        this.topics = topics;
+    }
+
+    /**
+     * Returns the list of missing internal topics that caused the exception.
+     */
+    public List<String> topics() {
+        return topics;
+    }
+}


### PR DESCRIPTION
Add new exception classes as defined in KIP-698.

Reviewers: Matthias J. Sax <matthias@confluent.io>
