### PR TITLE
MINOR: document deprecated remote log manager thread pool config

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -28,6 +28,9 @@
     <li>The <code>org.apache.kafka.disallowed.login.modules</code> config was deprecated. Please use the <code>org.apache.kafka.allowed.login.modules</code>
         instead.
     </li>
+    <li>
+        The <code>remote.log.manager.thread.pool.size</code> config was deprecated. Please use the <code>remote.log.manager.follower.thread.pool.size</code> instead.
+    </li>
 </ul>
 
 


### PR DESCRIPTION
Add a note to the upgrade documentation indicating that
`remote.log.manager.thread.pool.size` has been deprecated. Users should
now use `remote.log.manager.follower.thread.pool.size` instead.

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>, Yung <yungyung7654321@gmail.com>, Xuan-Zhang Gong
 <gongxuanzhangmelt@gmail.com>, TengYao Chi <kitingiao@gmail.com>, Ken
 Huang <s7133700@gmail.com>
