### PR TITLE
KAFKA-19415 Shuffle the order of readPartitionInfo when fetching data.

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -79,6 +79,7 @@ import java.util.function.Consumer
 import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
+import scala.util.Random
 
 /*
  * Result metadata of a log append operation on the log
@@ -1849,7 +1850,7 @@ class ReplicaManager(val config: KafkaConfig,
     var limitBytes = params.maxBytes
     val result = new mutable.ArrayBuffer[(TopicIdPartition, LogReadResult)]
     var minOneMessage = true
-    readPartitionInfo.foreach { case (tp, fetchInfo) =>
+    Random.shuffle(readPartitionInfo).foreach { case (tp, fetchInfo) =>
       val readResult = read(tp, fetchInfo, limitBytes, minOneMessage)
       val recordBatchSize = readResult.info.records.sizeInBytes
       // Once we read from a non-empty partition, we stop ignoring request and partition level size limits


### PR DESCRIPTION
Improve fairness of partition fetch order when clients fetch data to avoid partition starvation.
Randomly shuffles the `readPartitionInfo` sequence before iterating over it in the log read process.  
This change helps to avoid persistent partition hotspots and ensures fairer resource utilization when processing fetch requests.  
By shuffling the partitions, it prevents certain partitions from always being processed later, reducing the risk of starvation.  
The performance impact is negligible since the list is typically small.

see https://issues.apache.org/jira/browse/KAFKA-19415
