### PR TITLE
MINOR: Add Docker version requirement and permission warning to README

### DIFF
--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -13,7 +13,7 @@ Kafka server can be started using following ways:
 - File input
 - Environment variables
 
-Installation Prepration
+Installation Preparation
 ------------
 
 Note that the `Docker` version **must be >= 20.10.4**.

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -32,8 +32,6 @@ Running in KRaft mode…
 
 To avoid this, **please upgrade Docker to 20.10.4 or later**.
 
-This issue was fixed in Docker [20.10.4 release](https://docs.docker.com/engine/release-notes/20.10/#20104), specifically in Use 0755 permissions when creating missing directories [moby/moby#42017](https://github.com/moby/moby/pull/42017).
-
 Running on default configs
 --------------------------
 

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -18,7 +18,7 @@ Installation Prepration
 
 Note that the `Docker` version **must be >= 20.10.4**.
 
-The prior Docker versions (e.g., 17.03.x–20.10.3) may cause permission errors when running the Kafka container, as they do not correctly set directory permissions when creating container paths like `/opt/kafka/config`.
+The prior Docker versions may cause permission errors when running the Kafka container, as they do not correctly set directory permissions when creating container paths like `/opt/kafka/config`.
 
 If you are using the prior version, you may encounter the following error during container startup:
 ```text

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -13,6 +13,27 @@ Kafka server can be started using following ways:
 - File input
 - Environment variables
 
+Installation Prepration
+------------
+
+Note that the `Docker` version **must be >= 20.10.4**.
+
+The prior Docker versions (e.g., 17.03.x–20.10.3) may cause permission errors when running the Kafka container, as they do not correctly set directory permissions when creating container paths like `/opt/kafka/config`.
+
+If you are using the prior version, you may encounter the following error during container startup:
+```text
+===> User
+uid=1000(appuser) gid=1000(appuser) groups=1000(appuser)
+===> Setting default values of environment variables if not already set.
+===> Configuring …
+Running in KRaft mode…
+/opt/kafka/config/ file not writable
+```
+
+To avoid this, **please upgrade Docker to 20.10.4 or later**.
+
+This issue was fixed in Docker [20.10.4 release](https://docs.docker.com/engine/release-notes/20.10/#20104), specifically in Use 0755 permissions when creating missing directories [moby/moby#42017](https://github.com/moby/moby/pull/42017).
+
 Running on default configs
 --------------------------
 


### PR DESCRIPTION
Adds a new section **"Installation Preparation"** to the Kafka Docker
examples README. It documents a known issue with Docker versions prior
to 20.10.4, where directory permissions (such as `/opt/kafka/config`)
are not properly set, causing startup failures for non-root users (e.g.,
`appuser`).

This issue was fixed in Docker [20.10.4
release](https://docs.docker.com/engine/release-notes/20.10/#20104),
specifically in Use 0755 permissions when creating missing directories
[moby/moby#42017](https://github.com/moby/moby/pull/42017).

Reviewers: Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Lan Ding
 <isDing_L@163.com>, Chia-Ping Tsai <chia7712@gmail.com>
