### PR TITLE
KAFKA-19418: Fix for flaky verifiable producer system test

### DIFF
--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -71,7 +71,7 @@ class TestVerifiableProducer(Test):
         wait_until(lambda: self.producer.num_acked > 5, timeout_sec=15,
              err_msg="Producer failed to start in a reasonable amount of time.")
 
-        assert is_version(node, [node.version.vstring], logger=self.logger)
+        assert is_version(node, [node.version.vstring], proc_grep_string=VerifiableProducer.__qualname__, logger=self.logger)
 
         self.producer.wait()
         num_produced = self.producer.num_acked
@@ -113,8 +113,8 @@ class TestVerifiableProducer(Test):
         wait_until(lambda: self.producer.num_acked > 5, timeout_sec=15,
              err_msg="Producer failed to start in a reasonable amount of time.")
 
-        # See above comment above regarding use of version.vstring (distutils.version.LooseVersion)
-        assert is_version(node, [node.version.vstring], logger=self.logger)
+        # See comment above regarding use of version.vstring (distutils.version.LooseVersion)
+        assert is_version(node, [node.version.vstring], proc_grep_string=VerifiableProducer.__qualname__, logger=self.logger)
 
         self.producer.wait()
         num_produced = self.producer.num_acked
@@ -144,8 +144,8 @@ class TestVerifiableProducer(Test):
         wait_until(lambda: self.producer.num_acked > 5, timeout_sec=15,
              err_msg="Producer failed to start in a reasonable amount of time.")
 
-        # See above comment above regarding use of version.vstring (distutils.version.LooseVersion)
-        assert is_version(node, [node.version.vstring], logger=self.logger)
+        # See comment above regarding use of version.vstring (distutils.version.LooseVersion)
+        assert is_version(node, [node.version.vstring], proc_grep_string=VerifiableProducer.__qualname__, logger=self.logger)
 
         self.producer.wait()
         num_produced = self.producer.num_acked


### PR DESCRIPTION
Fix to avoid flakiness in verifiable producer system test. The test
lists running processes and greps to find the VerifiableProducer one,
but wasn't providing an specific pattern to grep (so flaky if there were
more than one process containing the default grep pattern "kafka")

Fix by passing a "proc_grep_string"  to filter when looking for the
VerifiableProducer process.

All test pass successfully after the change.

Reviewers: PoAn Yang <payang@apache.org>, Andrew Schofield
 <aschofield@confluent.io>
