### PR TITLE
KAFKA-19426: Correct the TopicBasedRemoteLogMetadataManager#initializeResources' retry default configure value to reasonable one

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -54,7 +54,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     public static final long DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MS = -1L;
     public static final short DEFAULT_REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR = 3;
     public static final long DEFAULT_REMOTE_LOG_METADATA_CONSUME_WAIT_MS = 2 * 60 * 1000L;
-    public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS = 2 * 60 * 1000L;
+    public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS = 5 * 60 * 1000L;
     public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS = 100L;
 
     public static final String REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor of remote log metadata topic.";


### PR DESCRIPTION
currently. the default value don't make sure the retry can always happen. 

For example: There are possible two timeout (2 * 60s) happen at TopicBasedRemoteLogMetadataManager#initializeResources
[2025-06-03 21:57:21,151] INFO Topic __remote_log_metadata does not exist. Error: Timed out waiting for a node assignment. Call: listNodes at
[2025-06-03 21:58:21,153] ERROR Encountered error while creating __remote_log_metadata topic. java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: createTopics at

And the default 2 minutes is very small so that it won't happen any retry in this case. 

At the sometimes. this original default configure value request the server must be ready within 2 minutes. Not every broker can reach this requirement.

So submit the change to increase the default value to 5 minutes.
