### PR TITLE
MINOR: DescribeAuthorizedOperationsTest cluster setting has been overridden

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DescribeAuthorizedOperationsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DescribeAuthorizedOperationsTest.java
@@ -69,8 +69,10 @@ public class DescribeAuthorizedOperationsTest {
         return List.of(
             ClusterConfig.defaultBuilder()
                 .setTypes(Set.of(Type.KRAFT))
-                .setServerProperties(Map.of(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, "1"))
-                .setServerProperties(Map.of(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1"))
+                .setServerProperties(Map.of(
+                    GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, "1",
+                    GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1"
+                ))
                 .setBrokerSecurityProtocol(SecurityProtocol.SASL_PLAINTEXT)
                 .setControllerSecurityProtocol(SecurityProtocol.SASL_PLAINTEXT)
                 .build()


### PR DESCRIPTION
The old approach `OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG` will override
`OFFSETS_TOPIC_PARTITIONS_CONFIG` config, this behaviour is not
expected, we should fix it.

Reviewers: TengYao Chi <frankvicky@apache.org>
