### PR TITLE
MINOR: Change snapshot epoch type to int32 in schema.

### DIFF
--- a/share-coordinator/src/main/resources/common/message/ShareSnapshotValue.json
+++ b/share-coordinator/src/main/resources/common/message/ShareSnapshotValue.json
@@ -20,7 +20,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "SnapshotEpoch", "type": "uint16", "versions": "0+",
+    { "name": "SnapshotEpoch", "type": "int32", "versions": "0+",
       "about": "The snapshot epoch." },
     { "name": "StateEpoch", "type": "int32", "versions": "0+",
       "about": "The state epoch for this share-partition." },

--- a/share-coordinator/src/main/resources/common/message/ShareUpdateValue.json
+++ b/share-coordinator/src/main/resources/common/message/ShareUpdateValue.json
@@ -20,7 +20,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "SnapshotEpoch", "type": "uint16", "versions": "0+",
+    { "name": "SnapshotEpoch", "type": "int32", "versions": "0+",
       "about": "The snapshot epoch." },
     { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
       "about": "The leader epoch of the share-partition." },


### PR DESCRIPTION
* `SnapshotEpoch` type in `ShareSnapshotValue.json` and
`ShareUpdateValue.json` is currently
`uint16` which might overflow under heavy traffic.
* To be consistent with other epochs, this PR updates the type to
`int32`.

Reviewers: Andrew Schofield <aschofield@confluent.io>, ShivsundarR
 <shr@confluent.io>
