### PR TITLE
MINOR: Add tests on TxnOffsetCommit and EndTxnMarker protection against invalid producer epoch when TV2 is used

### DIFF
--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -298,7 +298,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     producerEpoch: Short,
     transactionalId: String,
     version: Short = ApiKeys.ADD_OFFSETS_TO_TXN.latestVersion(isUnstableApiEnabled)
-  ): AddOffsetsToTxnResponse = {
+  ): Unit = {
     val request = new AddOffsetsToTxnRequest.Builder(
       new AddOffsetsToTxnRequestData()
         .setTransactionalId(transactionalId)
@@ -309,7 +309,6 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
 
     val response = connectAndReceive[AddOffsetsToTxnResponse](request)
     assertEquals(new AddOffsetsToTxnResponseData(), response.data)
-    response
   }
 
   protected def initProducerId(

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -453,9 +453,9 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
   }
 
   protected def fetchOffset(
+    groupId: String,
     topic: String,
-    partition: Int,
-    groupId: String
+    partition: Int
   ): Long = {
     val groupIdRecord = fetchOffsets(
       group = new OffsetFetchRequestData.OffsetFetchRequestGroup()

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -19,14 +19,16 @@ package kafka.server
 import kafka.network.SocketServer
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.{TopicCollection, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.message.DeleteGroupsResponseData.{DeletableGroupResult, DeletableGroupResultCollection}
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse
 import org.apache.kafka.common.message.SyncGroupRequestData.SyncGroupRequestAssignment
-import org.apache.kafka.common.message.{AddOffsetsToTxnRequestData, AddOffsetsToTxnResponseData, ConsumerGroupDescribeRequestData, ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsRequestData, DeleteGroupsResponseData, DescribeGroupsRequestData, DescribeGroupsResponseData, EndTxnRequestData, HeartbeatRequestData, HeartbeatResponseData, InitProducerIdRequestData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeRequestData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData}
+import org.apache.kafka.common.message.WriteTxnMarkersRequestData.{WritableTxnMarker, WritableTxnMarkerTopic}
+import org.apache.kafka.common.message.{AddOffsetsToTxnRequestData, AddOffsetsToTxnResponseData, ConsumerGroupDescribeRequestData, ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData, DeleteGroupsRequestData, DeleteGroupsResponseData, DescribeGroupsRequestData, DescribeGroupsResponseData, EndTxnRequestData, HeartbeatRequestData, HeartbeatResponseData, InitProducerIdRequestData, JoinGroupRequestData, JoinGroupResponseData, LeaveGroupResponseData, ListGroupsRequestData, ListGroupsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteRequestData, OffsetDeleteResponseData, OffsetFetchRequestData, OffsetFetchResponseData, ShareGroupDescribeRequestData, ShareGroupDescribeResponseData, ShareGroupHeartbeatRequestData, ShareGroupHeartbeatResponseData, SyncGroupRequestData, SyncGroupResponseData, TxnOffsetCommitRequestData, TxnOffsetCommitResponseData, WriteTxnMarkersRequestData}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
-import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, AddOffsetsToTxnRequest, AddOffsetsToTxnResponse, ConsumerGroupDescribeRequest, ConsumerGroupDescribeResponse, ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse, DeleteGroupsRequest, DeleteGroupsResponse, DescribeGroupsRequest, DescribeGroupsResponse, EndTxnRequest, EndTxnResponse, HeartbeatRequest, HeartbeatResponse, InitProducerIdRequest, InitProducerIdResponse, JoinGroupRequest, JoinGroupResponse, LeaveGroupRequest, LeaveGroupResponse, ListGroupsRequest, ListGroupsResponse, OffsetCommitRequest, OffsetCommitResponse, OffsetDeleteRequest, OffsetDeleteResponse, OffsetFetchRequest, OffsetFetchResponse, ShareGroupDescribeRequest, ShareGroupDescribeResponse, ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse, SyncGroupRequest, SyncGroupResponse, TxnOffsetCommitRequest, TxnOffsetCommitResponse}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, AddOffsetsToTxnRequest, AddOffsetsToTxnResponse, ConsumerGroupDescribeRequest, ConsumerGroupDescribeResponse, ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse, DeleteGroupsRequest, DeleteGroupsResponse, DescribeGroupsRequest, DescribeGroupsResponse, EndTxnRequest, EndTxnResponse, HeartbeatRequest, HeartbeatResponse, InitProducerIdRequest, InitProducerIdResponse, JoinGroupRequest, JoinGroupResponse, LeaveGroupRequest, LeaveGroupResponse, ListGroupsRequest, ListGroupsResponse, OffsetCommitRequest, OffsetCommitResponse, OffsetDeleteRequest, OffsetDeleteResponse, OffsetFetchRequest, OffsetFetchResponse, ShareGroupDescribeRequest, ShareGroupDescribeResponse, ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse, SyncGroupRequest, SyncGroupResponse, TxnOffsetCommitRequest, TxnOffsetCommitResponse, WriteTxnMarkersRequest, WriteTxnMarkersResponse}
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.test.ClusterInstance
 import org.apache.kafka.common.utils.ProducerIdAndEpoch
@@ -296,7 +298,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     producerEpoch: Short,
     transactionalId: String,
     version: Short = ApiKeys.ADD_OFFSETS_TO_TXN.latestVersion(isUnstableApiEnabled)
-  ): Unit = {
+  ): AddOffsetsToTxnResponse = {
     val request = new AddOffsetsToTxnRequest.Builder(
       new AddOffsetsToTxnRequestData()
         .setTransactionalId(transactionalId)
@@ -307,6 +309,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
 
     val response = connectAndReceive[AddOffsetsToTxnResponse](request)
     assertEquals(new AddOffsetsToTxnResponseData(), response.data)
+    response
   }
 
   protected def initProducerId(
@@ -349,6 +352,35 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     ).build(version)
 
     assertEquals(expectedError, connectAndReceive[EndTxnResponse](request).error)
+  }
+
+  protected def writeTxnMarkers(
+    producerId: Long,
+    producerEpoch: Short,
+    committed: Boolean,
+    expectedError: Errors = Errors.NONE,
+    version: Short = ApiKeys.WRITE_TXN_MARKERS.latestVersion(isUnstableApiEnabled)
+  ): Unit = {
+    val request = new WriteTxnMarkersRequest.Builder(
+      new WriteTxnMarkersRequestData()
+        .setMarkers(List(
+          new WritableTxnMarker()
+            .setProducerId(producerId)
+            .setProducerEpoch(producerEpoch)
+            .setTransactionResult(committed)
+            .setTopics(List(
+              new WritableTxnMarkerTopic()
+                .setName(Topic.GROUP_METADATA_TOPIC_NAME)
+                .setPartitionIndexes(List[Integer](0).asJava)
+            ).asJava)
+            .setCoordinatorEpoch(0)
+        ).asJava)
+    ).build(version)
+
+    assertEquals(
+      expectedError.code,
+      connectAndReceive[WriteTxnMarkersResponse](request).data.markers.get(0).topics.get(0).partitions.get(0).errorCode
+    )
   }
 
   protected def fetchOffsets(
@@ -419,6 +451,27 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     sortTopicPartitions(groupResponse)
 
     groupResponse
+  }
+
+  protected def fetchOffset(
+    topic: String,
+    partition: Int,
+    groupId: String
+  ): Long = {
+    val groupIdRecord = fetchOffsets(
+      group = new OffsetFetchRequestData.OffsetFetchRequestGroup()
+        .setGroupId(groupId)
+        .setTopics(List(
+          new OffsetFetchRequestData.OffsetFetchRequestTopics()
+            .setName(topic)
+            .setPartitionIndexes(List[Integer](partition).asJava)
+        ).asJava),
+      requireStable = true,
+      version = 9
+    )
+    val topicRecord = groupIdRecord.topics.asScala.find(_.name == topic).head
+    val partitionRecord = topicRecord.partitions.asScala.find(_.partitionIndex == partition).head
+    partitionRecord.committedOffset
   }
 
   protected def deleteOffset(

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterTest, Clu
 import org.apache.kafka.common.utils.ProducerIdAndEpoch
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
-import org.junit.jupiter.api.Assertions.{assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertNotEquals, assertThrows}
 
 import scala.jdk.CollectionConverters._
 
@@ -75,8 +75,8 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
     val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol)
-    assertTrue(memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID)
-    assertTrue(memberEpoch != JoinGroupRequest.UNKNOWN_GENERATION_ID)
+    assertNotEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, memberId)
+    assertNotEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, memberEpoch)
 
     createTopic(topic, 1)
 
@@ -260,8 +260,8 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
     val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol)
-    assertTrue(memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID)
-    assertTrue(memberEpoch != JoinGroupRequest.UNKNOWN_GENERATION_ID)
+    assertNotEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, memberId)
+    assertNotEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, memberEpoch)
 
     createTopic(topic, 1)
 

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -51,6 +51,16 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
     testTxnOffsetCommit(false)
   }
 
+  @ClusterTest
+  def testDelayedTxnOffsetCommitWithBumpedEpochIsRejectedWithOldConsumerGroupProtocol(): Unit = {
+    testDelayedTxnOffsetCommitWithBumpedEpochIsRejected(true)
+  }
+
+  @ClusterTest
+  def testDelayedTxnOffsetCommitWithBumpedEpochIsRejectedWithNewConsumerGroupProtocol(): Unit = {
+    testDelayedTxnOffsetCommitWithBumpedEpochIsRejected(false)
+  }
+
   private def testTxnOffsetCommit(useNewProtocol: Boolean): Unit = {
     val topic = "topic"
     val partition = 0
@@ -235,15 +245,12 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
     partitionRecord.committedOffset
   }
 
-  @ClusterTest
-  def testDelayedTxnOffsetCommitWithBumpedEpochIsRejected(): Unit = {
+  private def testDelayedTxnOffsetCommitWithBumpedEpochIsRejected(useNewProtocol: Boolean): Unit = {
     val topic = "topic"
     val partition = 0
     val transactionalId = "txn"
     val groupId = "group"
     val offset = 100L
-
-    val useNewProtocol = true
 
     // Creates the __consumer_offsets and __transaction_state topics because it won't be created automatically
     // in this test because it does not use FindCoordinator API.

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -242,7 +242,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
     createTopic(topic, 1)
 
     for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
-      val useTV2 = version >= EndTxnRequest.LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2
+      val useTV2 = version > EndTxnRequest.LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2
 
       // Initialize producer. Wait until the coordinator finishes loading.
       var producerIdAndEpoch: ProducerIdAndEpoch = null

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -185,7 +185,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
       transactionalId = transactionalId
     )
 
-    val originalOffset = fetchOffset(topic, partition, groupId)
+    val originalOffset = fetchOffset(groupId, topic, partition)
 
     commitTxnOffset(
       groupId = groupId,
@@ -214,7 +214,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     TestUtils.waitUntilTrue(() =>
       try {
-        fetchOffset(topic, partition, groupId) == expectedOffset
+        fetchOffset(groupId, topic, partition) == expectedOffset
       } catch {
         case _: Throwable => false
       }, "txn commit offset validation failed"

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -258,7 +258,6 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     createTopic(topic, 1)
 
-    // The member ID must not be empty from version 3 onwards.
     for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
       val useTV2 = version >= 5
 

--- a/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
@@ -143,7 +143,7 @@ class WriteTxnMarkersRequestTest(cluster:ClusterInstance) extends GroupCoordinat
       // The offset is committed for TV1 and not committed for TV2.
       TestUtils.waitUntilTrue(() =>
         try {
-          fetchOffset(topic, partition, groupId) == (if (useTV2) -1L else offset + version)
+          fetchOffset(groupId, topic, partition) == (if (useTV2) -1L else offset + version)
         } catch {
           case _: Throwable => false
         }, "unexpected txn commit offset"
@@ -162,7 +162,7 @@ class WriteTxnMarkersRequestTest(cluster:ClusterInstance) extends GroupCoordinat
       // The offset is committed for TV2.
       TestUtils.waitUntilTrue(() =>
         try {
-          fetchOffset(topic, partition, groupId) == offset + version
+          fetchOffset(groupId, topic, partition) == offset + version
         } catch {
           case _: Throwable => false
         }, "txn commit offset validation failed"

--- a/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.utils.TestUtils
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{EndTxnRequest, JoinGroupRequest}
+import org.apache.kafka.common.test.ClusterInstance
+import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterTest, ClusterTestDefaults, Type}
+import org.apache.kafka.common.utils.ProducerIdAndEpoch
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
+import org.apache.kafka.coordinator.transaction.TransactionLogConfig
+import org.junit.jupiter.api.Assertions.assertNotEquals
+
+@ClusterTestDefaults(
+  types = Array(Type.KRAFT),
+  serverProperties = Array(
+    new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+    new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+    new ClusterConfigProperty(key = TransactionLogConfig.TRANSACTIONS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+    new ClusterConfigProperty(key = TransactionLogConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+  )
+)
+class WriteTxnMarkersRequestTest(cluster:ClusterInstance) extends GroupCoordinatorBaseRequestTest(cluster) {
+  @ClusterTest
+  def testDelayedWriteTxnMarkersShouldNotCommitTxnOffsetWithNewConsumerGroupProtocol(): Unit = {
+    testDelayedWriteTxnMarkersShouldNotCommitTxnOffset(true)
+  }
+
+  @ClusterTest
+  def testDelayedWriteTxnMarkersShouldNotCommitTxnOffsetWithOldConsumerGroupProtocol(): Unit = {
+    testDelayedWriteTxnMarkersShouldNotCommitTxnOffset(false)
+  }
+
+  private def testDelayedWriteTxnMarkersShouldNotCommitTxnOffset(useNewProtocol: Boolean): Unit = {
+    val topic = "topic"
+    val partition = 0
+    val transactionalId = "txn"
+    val groupId = "group"
+    val offset = 100L
+
+    // Creates the __consumer_offsets and __transaction_state topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    createOffsetsTopic()
+    createTransactionStateTopic()
+
+    // Join the consumer group. Note that we don't heartbeat here so we must use
+    // a session long enough for the duration of the test.
+    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol)
+    assertNotEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, memberId)
+    assertNotEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, memberEpoch)
+
+    createTopic(topic, 1)
+
+    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
+      val useTV2 = version > EndTxnRequest.LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2
+
+      // Initialize producer. Wait until the coordinator finishes loading.
+      var producerIdAndEpoch: ProducerIdAndEpoch = null
+      TestUtils.waitUntilTrue(() =>
+        try {
+          producerIdAndEpoch = initProducerId(
+            transactionalId = transactionalId,
+            producerIdAndEpoch = ProducerIdAndEpoch.NONE,
+            expectedError = Errors.NONE
+          )
+          true
+        } catch {
+          case _: Throwable => false
+        }, "initProducerId request failed"
+      )
+
+      addOffsetsToTxn(
+        groupId = groupId,
+        producerId = producerIdAndEpoch.producerId,
+        producerEpoch = producerIdAndEpoch.epoch,
+        transactionalId = transactionalId
+      )
+
+      // Complete the transaction.
+      endTxn(
+        producerId = producerIdAndEpoch.producerId,
+        producerEpoch = producerIdAndEpoch.epoch,
+        transactionalId = transactionalId,
+        isTransactionV2Enabled = useTV2,
+        committed = true,
+        expectedError = Errors.NONE
+      )
+
+      // Start a new transaction. Wait for the previous transaction to complete.
+      TestUtils.waitUntilTrue(() =>
+        try {
+          addOffsetsToTxn(
+            groupId = groupId,
+            producerId = producerIdAndEpoch.producerId,
+            producerEpoch = if (useTV2) (producerIdAndEpoch.epoch + 1).toShort else producerIdAndEpoch.epoch,
+            transactionalId = transactionalId
+          )
+          true
+        } catch {
+          case _: Throwable => false
+        }, "addOffsetsToTxn request failed"
+      )
+
+      commitTxnOffset(
+        groupId = groupId,
+        memberId = if (version >= 3) memberId else JoinGroupRequest.UNKNOWN_MEMBER_ID,
+        generationId = if (version >= 3) 1 else JoinGroupRequest.UNKNOWN_GENERATION_ID,
+        producerId = producerIdAndEpoch.producerId,
+        producerEpoch = if (useTV2) (producerIdAndEpoch.epoch + 1).toShort else producerIdAndEpoch.epoch,
+        transactionalId = transactionalId,
+        topic = topic,
+        partition = partition,
+        offset = offset + version,
+        expectedError = Errors.NONE,
+        version = version.toShort
+      )
+
+      // Delayed txn marker should be accepted for TV1 and rejected for TV2.
+      // Note that for the ideal case, producer epoch + 1 should also be rejected for TV2,
+      // which is still under fixing.
+      writeTxnMarkers(
+        producerId = producerIdAndEpoch.producerId,
+        producerEpoch = producerIdAndEpoch.epoch,
+        committed = true,
+        expectedError = if (useTV2) Errors.INVALID_PRODUCER_EPOCH else Errors.NONE
+      )
+
+      // The offset is committed for TV1 and not committed for TV2.
+      TestUtils.waitUntilTrue(() =>
+        try {
+          fetchOffset(topic, partition, groupId) == (if (useTV2) -1L else offset + version)
+        } catch {
+          case _: Throwable => false
+        }, "unexpected txn commit offset"
+      )
+
+      // Complete the transaction.
+      endTxn(
+        producerId = producerIdAndEpoch.producerId,
+        producerEpoch = if (useTV2) (producerIdAndEpoch.epoch + 1).toShort else producerIdAndEpoch.epoch,
+        transactionalId = transactionalId,
+        isTransactionV2Enabled = useTV2,
+        committed = true,
+        expectedError = Errors.NONE
+      )
+
+      // The offset is committed for TV2.
+      TestUtils.waitUntilTrue(() =>
+        try {
+          fetchOffset(topic, partition, groupId) == offset + version
+        } catch {
+          case _: Throwable => false
+        }, "txn commit offset validation failed"
+      )
+    }
+  }
+}


### PR DESCRIPTION
This patch adds an API level integration test for the producer epoch
verification when processing transactional offset commit and end txn
markers.

Reviewers: PoAn Yang <payang@apache.org>, TengYao Chi
 <kitingiao@gmail.com>, Sean Quah <squah@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
