### PR TITLE
MINOR: Remove unused DescribeTopicPartitionResponse.prepareResponse function

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
@@ -20,13 +20,11 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
-import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
@@ -68,16 +68,6 @@ public class DescribeTopicPartitionsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public static DescribeTopicPartitionsResponse prepareResponse(
-        int throttleTimeMs,
-        List<DescribeTopicPartitionsResponseTopic> topics
-    ) {
-        DescribeTopicPartitionsResponseData responseData = new DescribeTopicPartitionsResponseData();
-        responseData.setThrottleTimeMs(throttleTimeMs);
-        topics.forEach(topicResponse -> responseData.topics().add(topicResponse));
-        return new DescribeTopicPartitionsResponse(responseData);
-    }
-
     public static DescribeTopicPartitionsResponse parse(Readable readable, short version) {
         return new DescribeTopicPartitionsResponse(
             new DescribeTopicPartitionsResponseData(readable, version));


### PR DESCRIPTION
The prepareResponse function is no longer used anywhere in the codebase.
Removing unused code improves maintainability and readability.

Reviewers: PoAn Yang <payang@apache.org>, Yung
 <yungyung7654321@gmail.com>, TengYao Chi <frankvicky@apache.org>, Ken
 Huang <s7133700@gmail.com>
