### PR TITLE
MINOR: Clean up in ReassignPartitionsCommandTest

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -57,9 +57,7 @@ import org.junit.jupiter.api.Assertions;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -73,10 +71,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.server.config.QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG;
 import static org.apache.kafka.server.config.QuotaConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG;
@@ -139,14 +133,14 @@ public class ReassignPartitionsCommandTest {
                 "]}";
         runExecuteAssignment(false, assignment, -1L, -1L);
 
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            Map<TopicPartition, PartitionReassignmentState> finalAssignment = singletonMap(foo0,
-                    new PartitionReassignmentState(asList(3, 1, 2), asList(3, 1, 2), true));
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+            Map<TopicPartition, PartitionReassignmentState> finalAssignment = Map.of(foo0,
+                    new PartitionReassignmentState(List.of(3, 1, 2), List.of(3, 1, 2), true));
             // Wait for the assignment to complete
             waitForVerifyAssignment(admin, assignment, false,
                     new VerifyAssignmentResult(finalAssignment));
             TestUtils.waitForCondition(() -> {
-                ListOffsetsResultInfo result = admin.listOffsets(Collections.singletonMap(foo0, new OffsetSpec.LatestSpec())).partitionResult(foo0).get();
+                ListOffsetsResultInfo result = admin.listOffsets(Map.of(foo0, new OffsetSpec.LatestSpec())).partitionResult(foo0).get();
                 return result.offset() == 100;
             }, "Timeout for waiting offset");
         }
@@ -158,13 +152,13 @@ public class ReassignPartitionsCommandTest {
         TopicPartition foo0 = new TopicPartition("foo", 0);
         produceMessages(foo0.topic(), foo0.partition(), 100);
 
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             String assignment = "{\"version\":1,\"partitions\":" +
                     "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[3,1,2],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
                     "]}";
             generateAssignment(admin, assignment, "1,2,3", false);
-            Map<TopicPartition, PartitionReassignmentState> finalAssignment = singletonMap(foo0,
-                    new PartitionReassignmentState(asList(0, 1, 2), asList(3, 1, 2), true));
+            Map<TopicPartition, PartitionReassignmentState> finalAssignment = Map.of(foo0,
+                    new PartitionReassignmentState(List.of(0, 1, 2), List.of(3, 1, 2), true));
             waitForVerifyAssignment(admin, assignment, false,
                     new VerifyAssignmentResult(finalAssignment));
         }
@@ -180,22 +174,22 @@ public class ReassignPartitionsCommandTest {
                 "{\"topic\":\"baz\",\"partition\":2,\"replicas\":[3,2,1],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
                 "]}";
 
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             // Execute the assignment with a low throttle
             long initialThrottle = 1L;
             runExecuteAssignment(false, assignment, initialThrottle, -1L);
-            waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), initialThrottle);
+            waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), initialThrottle);
 
             // Now update the throttle and verify the reassignment completes
             long updatedThrottle = 300000L;
             runExecuteAssignment(true, assignment, updatedThrottle, -1L);
-            waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), updatedThrottle);
+            waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), updatedThrottle);
 
             Map<TopicPartition, PartitionReassignmentState> finalAssignment = new HashMap<>();
             finalAssignment.put(new TopicPartition("foo", 0),
-                    new PartitionReassignmentState(asList(0, 3, 2), asList(0, 3, 2), true));
+                    new PartitionReassignmentState(List.of(0, 3, 2), List.of(0, 3, 2), true));
             finalAssignment.put(new TopicPartition("baz", 2),
-                    new PartitionReassignmentState(asList(3, 2, 1), asList(3, 2, 1), true));
+                    new PartitionReassignmentState(List.of(3, 2, 1), List.of(3, 2, 1), true));
 
             // Now remove the throttles.
             waitForVerifyAssignment(admin, assignment, false,
@@ -220,23 +214,23 @@ public class ReassignPartitionsCommandTest {
         // Check that the assignment has not yet been started yet.
         Map<TopicPartition, PartitionReassignmentState> initialAssignment = new HashMap<>();
         initialAssignment.put(new TopicPartition("foo", 0),
-                new PartitionReassignmentState(asList(0, 1, 2), asList(0, 3, 2), true));
+                new PartitionReassignmentState(List.of(0, 1, 2), List.of(0, 3, 2), true));
         initialAssignment.put(new TopicPartition("baz", 2),
-                new PartitionReassignmentState(asList(0, 2, 1), asList(3, 2, 1), true));
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+                new PartitionReassignmentState(List.of(0, 2, 1), List.of(3, 2, 1), true));
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             assertEquals(new VerifyAssignmentResult(initialAssignment), runVerifyAssignment(admin, assignment, false));
             assertEquals(unthrottledBrokerConfigs, describeBrokerLevelThrottles(admin, unthrottledBrokerConfigs.keySet()));
 
             // Execute the assignment
             long interBrokerThrottle = 300000L;
             runExecuteAssignment(false, assignment, interBrokerThrottle, -1L);
-            waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), interBrokerThrottle);
+            waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), interBrokerThrottle);
 
             Map<TopicPartition, PartitionReassignmentState> finalAssignment = new HashMap<>();
             finalAssignment.put(new TopicPartition("foo", 0),
-                    new PartitionReassignmentState(asList(0, 3, 2), asList(0, 3, 2), true));
+                    new PartitionReassignmentState(List.of(0, 3, 2), List.of(0, 3, 2), true));
             finalAssignment.put(new TopicPartition("baz", 2),
-                    new PartitionReassignmentState(asList(3, 2, 1), asList(3, 2, 1), true));
+                    new PartitionReassignmentState(List.of(3, 2, 1), List.of(3, 2, 1), true));
 
             // Wait for the assignment to complete
             TestUtils.waitForCondition(() -> {
@@ -250,9 +244,9 @@ public class ReassignPartitionsCommandTest {
                             result.partStates.values().stream().allMatch(state -> state.done),
                             "Expected at least one partition reassignment to be ongoing when result = " + result
                     );
-                    assertEquals(asList(0, 3, 2), result.partStates.get(new TopicPartition("foo", 0)).targetReplicas);
-                    assertEquals(asList(3, 2, 1), result.partStates.get(new TopicPartition("baz", 2)).targetReplicas);
-                    waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), interBrokerThrottle);
+                    assertEquals(List.of(0, 3, 2), result.partStates.get(new TopicPartition("foo", 0)).targetReplicas);
+                    assertEquals(List.of(3, 2, 1), result.partStates.get(new TopicPartition("baz", 2)).targetReplicas);
+                    waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), interBrokerThrottle);
                     return false;
                 }
             }, "Expected reassignment to complete.");
@@ -260,7 +254,7 @@ public class ReassignPartitionsCommandTest {
             waitForVerifyAssignment(admin, assignment, true,
                     new VerifyAssignmentResult(finalAssignment));
             // The throttles should still have been preserved, since we ran with --preserve-throttles
-            waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), interBrokerThrottle);
+            waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), interBrokerThrottle);
             // Now remove the throttles.
             waitForVerifyAssignment(admin, assignment, false,
                     new VerifyAssignmentResult(finalAssignment));
@@ -285,7 +279,7 @@ public class ReassignPartitionsCommandTest {
         consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         TopicPartition part = new TopicPartition("baz", 2);
         try (Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps, new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
-            consumer.assign(singleton(part));
+            consumer.assign(Set.of(part));
             List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
             TestUtils.waitForCondition(() -> {
                 ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofMillis(100L));
@@ -294,9 +288,9 @@ public class ReassignPartitionsCommandTest {
             }, "Timeout for waiting enough records");
         }
         removeReplicationThrottleForPartitions(part);
-        Map<TopicPartition, PartitionReassignmentState> finalAssignment = singletonMap(part,
-                new PartitionReassignmentState(asList(3, 2, 1), asList(3, 2, 1), true));
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers())))  {
+        Map<TopicPartition, PartitionReassignmentState> finalAssignment = Map.of(part,
+                new PartitionReassignmentState(List.of(3, 2, 1), List.of(3, 2, 1), true));
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers())))  {
             waitForVerifyAssignment(admin, assignment, false,
                     new VerifyAssignmentResult(finalAssignment));
         }
@@ -339,14 +333,14 @@ public class ReassignPartitionsCommandTest {
                                 .filter(p -> p.partition() == foo0.partition())
                                 .flatMap(p -> p.isr().stream())
                                 .map(Node::id).collect(Collectors.toSet());
-                        return isr.containsAll(Arrays.asList(0, 1, 2, 3));
+                        return isr.containsAll(List.of(0, 1, 2, 3));
                     },
                     "Timed out while waiting for replica 3 to join the ISR"
             );
         }
 
         // Now cancel the assignment and verify that the partition is removed from cancelled replicas
-        assertEquals(Map.entry(singleton(foo0), Set.of()), runCancelAssignment(assignment, true, true));
+        assertEquals(Map.entry(Set.of(foo0), Set.of()), runCancelAssignment(assignment, true, true));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 3));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 4));
     }
@@ -367,22 +361,22 @@ public class ReassignPartitionsCommandTest {
 
         // Execute the assignment and wait for replica 3 (only) to join the ISR
         runExecuteAssignment(false, assignment, -1L, -1L);
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             TestUtils.waitForCondition(
                 () -> {
-                    Set<Integer> isr = admin.describeTopics(Collections.singleton(foo0.topic()))
+                    Set<Integer> isr = admin.describeTopics(Set.of(foo0.topic()))
                         .allTopicNames().get().get(foo0.topic()).partitions().stream()
                         .filter(p -> p.partition() == foo0.partition())
                         .flatMap(p -> p.isr().stream())
                         .map(Node::id).collect(Collectors.toSet());
-                    return isr.containsAll(Arrays.asList(0, 1, 2, 3));
+                    return isr.containsAll(List.of(0, 1, 2, 3));
                 },
                 "Timed out while waiting for replica 3 to join the ISR"
             );
         }
 
         // Now cancel the assignment and verify that the partition is removed from cancelled replicas
-        assertEquals(Map.entry(singleton(foo0), Set.of()), runCancelAssignment(assignment, true, true));
+        assertEquals(Map.entry(Set.of(foo0), Set.of()), runCancelAssignment(assignment, true, true));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 3));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 4));
     }
@@ -397,7 +391,7 @@ public class ReassignPartitionsCommandTest {
         produceMessages(topicPartition.topic(), topicPartition.partition(), 700);
 
         int targetBrokerId = 0;
-        List<Integer> replicas = asList(0, 1, 2);
+        List<Integer> replicas = List.of(0, 1, 2);
         LogDirReassignment reassignment = buildLogDirReassignment(topicPartition, targetBrokerId, replicas);
 
         // Start the replica move, but throttle it to be very slow so that it can't complete
@@ -405,30 +399,30 @@ public class ReassignPartitionsCommandTest {
         long logDirThrottle = 1L;
         runExecuteAssignment(false, reassignment.json, -1L, logDirThrottle);
 
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             // Check the output of --verify
             waitForVerifyAssignment(admin, reassignment.json, true,
-                    new VerifyAssignmentResult(singletonMap(
-                            topicPartition, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 2), true)
-                    ), false, singletonMap(
+                    new VerifyAssignmentResult(Map.of(
+                            topicPartition, new PartitionReassignmentState(List.of(0, 1, 2), List.of(0, 1, 2), true)
+                    ), false, Map.of(
                             new TopicPartitionReplica(topicPartition.topic(), topicPartition.partition(), 0),
                             new ActiveMoveState(reassignment.currentDir, reassignment.targetDir, reassignment.targetDir)
                     ), true));
-            waitForLogDirThrottle(admin, singleton(0), logDirThrottle);
+            waitForLogDirThrottle(admin, Set.of(0), logDirThrottle);
 
             // Remove the throttle
-            admin.incrementalAlterConfigs(singletonMap(
+            admin.incrementalAlterConfigs(Map.of(
                             new ConfigResource(ConfigResource.Type.BROKER, "0"),
-                            singletonList(new AlterConfigOp(
+                            List.of(new AlterConfigOp(
                                     new ConfigEntry(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, ""), AlterConfigOp.OpType.DELETE))))
                     .all().get();
             waitForBrokerLevelThrottles(admin, unthrottledBrokerConfigs);
 
             // Wait for the directory movement to complete.
             waitForVerifyAssignment(admin, reassignment.json, true,
-                    new VerifyAssignmentResult(singletonMap(
-                            topicPartition, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 2), true)
-                    ), false, singletonMap(
+                    new VerifyAssignmentResult(Map.of(
+                            topicPartition, new PartitionReassignmentState(List.of(0, 1, 2), List.of(0, 1, 2), true)
+                    ), false, Map.of(
                             new TopicPartitionReplica(topicPartition.topic(), topicPartition.partition(), 0),
                             new CompletedMoveState(reassignment.targetDir)
                     ), false));
@@ -445,24 +439,24 @@ public class ReassignPartitionsCommandTest {
         produceMessages(topicPartition.topic(), topicPartition.partition(), 700);
 
         int targetBrokerId = 0;
-        List<Integer> replicas = asList(0, 1, 2);
+        List<Integer> replicas = List.of(0, 1, 2);
         LogDirReassignment reassignment = buildLogDirReassignment(topicPartition, targetBrokerId, replicas);
 
         // Start the replica move with a low throttle so it does not complete
         long initialLogDirThrottle = 1L;
         runExecuteAssignment(false, reassignment.json, -1L, initialLogDirThrottle);
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            waitForLogDirThrottle(admin, new HashSet<>(singletonList(0)), initialLogDirThrottle);
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+            waitForLogDirThrottle(admin, new HashSet<>(List.of(0)), initialLogDirThrottle);
 
             // Now increase the throttle and verify that the log dir movement completes
             long updatedLogDirThrottle = 3000000L;
             runExecuteAssignment(true, reassignment.json, -1L, updatedLogDirThrottle);
-            waitForLogDirThrottle(admin, singleton(0), updatedLogDirThrottle);
+            waitForLogDirThrottle(admin, Set.of(0), updatedLogDirThrottle);
 
             waitForVerifyAssignment(admin, reassignment.json, true,
-                    new VerifyAssignmentResult(singletonMap(
-                            topicPartition, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 2), true)
-                    ), false, singletonMap(
+                    new VerifyAssignmentResult(Map.of(
+                            topicPartition, new PartitionReassignmentState(List.of(0, 1, 2), List.of(0, 1, 2), true)
+                    ), false, Map.of(
                             new TopicPartitionReplica(topicPartition.topic(), topicPartition.partition(), targetBrokerId),
                             new CompletedMoveState(reassignment.targetDir)
                     ), false));
@@ -487,23 +481,23 @@ public class ReassignPartitionsCommandTest {
     }
 
     private void createTopics() {
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             Map<Integer, List<Integer>> fooReplicasAssignments = new HashMap<>();
-            fooReplicasAssignments.put(0, asList(0, 1, 2));
-            fooReplicasAssignments.put(1, asList(1, 2, 3));
-            Assertions.assertDoesNotThrow(() -> admin.createTopics(Collections.singletonList(new NewTopic("foo", fooReplicasAssignments))).topicId("foo").get());
+            fooReplicasAssignments.put(0, List.of(0, 1, 2));
+            fooReplicasAssignments.put(1, List.of(1, 2, 3));
+            Assertions.assertDoesNotThrow(() -> admin.createTopics(List.of(new NewTopic("foo", fooReplicasAssignments))).topicId("foo").get());
             Assertions.assertDoesNotThrow(() -> clusterInstance.waitForTopic("foo", fooReplicasAssignments.size()));
 
             Map<Integer, List<Integer>> barReplicasAssignments = new HashMap<>();
-            barReplicasAssignments.put(0, asList(3, 2, 1));
-            Assertions.assertDoesNotThrow(() -> admin.createTopics(Collections.singletonList(new NewTopic("bar", barReplicasAssignments))).topicId("bar").get());
+            barReplicasAssignments.put(0, List.of(3, 2, 1));
+            Assertions.assertDoesNotThrow(() -> admin.createTopics(List.of(new NewTopic("bar", barReplicasAssignments))).topicId("bar").get());
             Assertions.assertDoesNotThrow(() -> clusterInstance.waitForTopic("bar", barReplicasAssignments.size()));
 
             Map<Integer, List<Integer>> bazReplicasAssignments = new HashMap<>();
-            bazReplicasAssignments.put(0, asList(1, 0, 2));
-            bazReplicasAssignments.put(1, asList(2, 0, 1));
-            bazReplicasAssignments.put(2, asList(0, 2, 1));
-            Assertions.assertDoesNotThrow(() -> admin.createTopics(Collections.singletonList(new NewTopic("baz", bazReplicasAssignments))).topicId("baz").get());
+            bazReplicasAssignments.put(0, List.of(1, 0, 2));
+            bazReplicasAssignments.put(1, List.of(2, 0, 1));
+            bazReplicasAssignments.put(2, List.of(0, 2, 1));
+            Assertions.assertDoesNotThrow(() -> admin.createTopics(List.of(new NewTopic("baz", bazReplicasAssignments))).topicId("baz").get());
             Assertions.assertDoesNotThrow(() -> clusterInstance.waitForTopic("baz", bazReplicasAssignments.size()));
         }
     }
@@ -531,10 +525,10 @@ public class ReassignPartitionsCommandTest {
         // Check that the assignment has not yet been started yet.
         Map<TopicPartition, PartitionReassignmentState> initialAssignment = new HashMap<>();
 
-        initialAssignment.put(foo0, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 3), true));
-        initialAssignment.put(bar0, new PartitionReassignmentState(asList(3, 2, 1), asList(3, 2, 0), true));
+        initialAssignment.put(foo0, new PartitionReassignmentState(List.of(0, 1, 2), List.of(0, 1, 3), true));
+        initialAssignment.put(bar0, new PartitionReassignmentState(List.of(3, 2, 1), List.of(3, 2, 0), true));
 
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             waitForVerifyAssignment(admin, assignment, false,
                     new VerifyAssignmentResult(initialAssignment));
 
@@ -542,8 +536,8 @@ public class ReassignPartitionsCommandTest {
             runExecuteAssignment(false, assignment, -1L, -1L);
             assertEquals(unthrottledBrokerConfigs, describeBrokerLevelThrottles(admin, unthrottledBrokerConfigs.keySet()));
             Map<TopicPartition, PartitionReassignmentState> finalAssignment = new HashMap<>();
-            finalAssignment.put(foo0, new PartitionReassignmentState(asList(0, 1, 3), asList(0, 1, 3), true));
-            finalAssignment.put(bar0, new PartitionReassignmentState(asList(3, 2, 0), asList(3, 2, 0), true));
+            finalAssignment.put(foo0, new PartitionReassignmentState(List.of(0, 1, 3), List.of(0, 1, 3), true));
+            finalAssignment.put(bar0, new PartitionReassignmentState(List.of(3, 2, 0), List.of(3, 2, 0), true));
 
             VerifyAssignmentResult verifyAssignmentResult = runVerifyAssignment(admin, assignment, false);
             assertFalse(verifyAssignmentResult.movesOngoing);
@@ -562,10 +556,10 @@ public class ReassignPartitionsCommandTest {
     }
 
     private void verifyReplicaDeleted(TopicPartitionReplica topicPartitionReplica) throws InterruptedException {
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             TestUtils.waitForCondition(
                     () -> {
-                        TopicDescription topicDescription = assertDoesNotThrow(() -> admin.describeTopics(singleton(topicPartitionReplica.topic())).topicNameValues().get(topicPartitionReplica.topic()).get());
+                        TopicDescription topicDescription = assertDoesNotThrow(() -> admin.describeTopics(Set.of(topicPartitionReplica.topic())).topicNameValues().get(topicPartitionReplica.topic()).get());
                         return topicDescription.partitions().stream().noneMatch(topicPartitionInfo -> {
                             if (topicPartitionInfo.partition() != topicPartitionReplica.partition()) {
                                 return false;
@@ -622,7 +616,7 @@ public class ReassignPartitionsCommandTest {
     private Map<Integer, Map<String, Long>> describeBrokerLevelThrottles(Admin admin, Collection<Integer> brokerIds) {
         return brokerIds.stream().collect(Collectors.toMap(Function.identity(), brokerId -> {
             ConfigResource brokerResource = new ConfigResource(ConfigResource.Type.BROKER, brokerId.toString());
-            Config brokerConfigs = assertDoesNotThrow(() -> admin.describeConfigs(singleton(brokerResource)).values()
+            Config brokerConfigs = assertDoesNotThrow(() -> admin.describeConfigs(Set.of(brokerResource)).values()
                     .get(brokerResource)
                     .get());
             return BROKER_LEVEL_THROTTLES.stream().collect(Collectors.toMap(Function.identity(),
@@ -645,7 +639,7 @@ public class ReassignPartitionsCommandTest {
     private LogDirReassignment buildLogDirReassignment(TopicPartition topicPartition,
                                                        int brokerId,
                                                        List<Integer> replicas) throws ExecutionException, InterruptedException {
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             DescribeLogDirsResult describeLogDirsResult = admin.describeLogDirs(
                     IntStream.range(0, 4).boxed().collect(Collectors.toList()));
 
@@ -706,7 +700,7 @@ public class ReassignPartitionsCommandTest {
                                       String reassignmentJson,
                                       Long interBrokerThrottle,
                                       Long replicaAlterLogDirsThrottle) throws RuntimeException {
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             executeAssignment(admin, additional, reassignmentJson,
                     interBrokerThrottle, replicaAlterLogDirsThrottle, 10000L, Time.SYSTEM, false);
         } catch (ExecutionException | InterruptedException | JsonProcessingException | TerseException e) {
@@ -721,9 +715,9 @@ public class ReassignPartitionsCommandTest {
     ) {
         Map<String, Object> config;
         if (useBootstrapServer) {
-            config = Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+            config = Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
         } else {
-            config = Collections.singletonMap(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG, clusterInstance.bootstrapControllers());
+            config = Map.of(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG, clusterInstance.bootstrapControllers());
         }
         try (Admin admin = Admin.create(config)) {
             return cancelAssignment(admin, jsonString, preserveThrottles, 10000L, Time.SYSTEM);
@@ -773,12 +767,12 @@ public class ReassignPartitionsCommandTest {
                     describeBrokerLevelThrottles(admin, unthrottledBrokerConfigs.keySet()));
             long interBrokerThrottle = 1L;
             runExecuteAssignment(false, assignment, interBrokerThrottle, -1L);
-            waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), interBrokerThrottle);
+            waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), interBrokerThrottle);
 
             Map<TopicPartition, PartitionReassignmentState> partStates = new HashMap<>();
 
-            partStates.put(foo0, new PartitionReassignmentState(asList(0, 1, 3, 2), asList(0, 1, 3), false));
-            partStates.put(baz1, new PartitionReassignmentState(asList(0, 2, 3, 1), asList(0, 2, 3), false));
+            partStates.put(foo0, new PartitionReassignmentState(List.of(0, 1, 3, 2), List.of(0, 1, 3), false));
+            partStates.put(baz1, new PartitionReassignmentState(List.of(0, 2, 3, 1), List.of(0, 2, 3), false));
 
             // Verify that the reassignment is running.  The very low throttle should keep it
             // from completing before this runs.
@@ -787,7 +781,7 @@ public class ReassignPartitionsCommandTest {
             // Cancel the reassignment.
             assertEquals(Map.entry(Set.of(foo0, baz1), Set.of()), runCancelAssignment(assignment, true, useBootstrapServer));
             // Broker throttles are still active because we passed --preserve-throttles
-            waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), interBrokerThrottle);
+            waitForInterBrokerThrottle(admin, List.of(0, 1, 2, 3), interBrokerThrottle);
             // Cancelling the reassignment again should reveal nothing to cancel.
             assertEquals(Map.entry(Set.of(), Set.of()), runCancelAssignment(assignment, false, useBootstrapServer));
             // This time, the broker throttles were removed.
@@ -804,9 +798,9 @@ public class ReassignPartitionsCommandTest {
      * Remove a set of throttled partitions and reset the overall replication quota.
      */
     private void removeReplicationThrottleForPartitions(TopicPartition part) {
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            removePartitionReplicaThrottles(admin, new HashSet<>(singleton(part)));
-            assertDoesNotThrow(() -> throttleAllBrokersReplication(admin, asList(0, 1, 2, 3), Integer.MAX_VALUE));
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+            removePartitionReplicaThrottles(admin, new HashSet<>(Set.of(part)));
+            assertDoesNotThrow(() -> throttleAllBrokersReplication(admin, List.of(0, 1, 2, 3), Integer.MAX_VALUE));
         }
     }
 
@@ -816,7 +810,7 @@ public class ReassignPartitionsCommandTest {
                     ConfigResource resource = new ConfigResource(TOPIC, tp.topic());
                     return new AbstractMap.SimpleEntry<>(
                             resource,
-                            asList(
+                            List.of(
                                     new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, ""),
                                             AlterConfigOp.OpType.DELETE),
                                     new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, ""),
@@ -834,9 +828,9 @@ public class ReassignPartitionsCommandTest {
      * of other partitions unaffected.
      */
     private void setReplicationThrottleForPartitions(TopicPartition topicPartition) {
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            assertDoesNotThrow(() -> throttleAllBrokersReplication(admin, singletonList(4), 1));
-            assertDoesNotThrow(() -> assignThrottledPartitionReplicas(admin, singletonMap(topicPartition, singletonList(4))));
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+            assertDoesNotThrow(() -> throttleAllBrokersReplication(admin, List.of(4), 1));
+            assertDoesNotThrow(() -> assignThrottledPartitionReplicas(admin, Map.of(topicPartition, List.of(4))));
         }
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -331,10 +331,10 @@ public class ReassignPartitionsCommandTest {
 
         // Execute the assignment and wait for replica 3 (only) to join the ISR
         runExecuteAssignment(false, assignment, -1L, -1L);
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             TestUtils.waitForCondition(
                     () -> {
-                        Set<Integer> isr = admin.describeTopics(Collections.singleton(foo0.topic()))
+                        Set<Integer> isr = admin.describeTopics(Set.of(foo0.topic()))
                                 .allTopicNames().get().get(foo0.topic()).partitions().stream()
                                 .filter(p -> p.partition() == foo0.partition())
                                 .flatMap(p -> p.isr().stream())
@@ -346,7 +346,7 @@ public class ReassignPartitionsCommandTest {
         }
 
         // Now cancel the assignment and verify that the partition is removed from cancelled replicas
-        assertEquals(new AbstractMap.SimpleImmutableEntry<>(singleton(foo0), Collections.emptySet()), runCancelAssignment(assignment, true, true));
+        assertEquals(Map.entry(singleton(foo0), Set.of()), runCancelAssignment(assignment, true, true));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 3));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 4));
     }
@@ -382,7 +382,7 @@ public class ReassignPartitionsCommandTest {
         }
 
         // Now cancel the assignment and verify that the partition is removed from cancelled replicas
-        assertEquals(new AbstractMap.SimpleImmutableEntry<>(singleton(foo0), Collections.emptySet()), runCancelAssignment(assignment, true, true));
+        assertEquals(Map.entry(singleton(foo0), Set.of()), runCancelAssignment(assignment, true, true));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 3));
         verifyReplicaDeleted(new TopicPartitionReplica(foo0.topic(), foo0.partition(), 4));
     }
@@ -768,7 +768,7 @@ public class ReassignPartitionsCommandTest {
                 "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1,3],\"log_dirs\":[\"any\",\"any\",\"any\"]}," +
                 "{\"topic\":\"baz\",\"partition\":1,\"replicas\":[0,2,3],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
                 "]}";
-        try (Admin admin = Admin.create(Collections.singletonMap(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
+        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             assertEquals(unthrottledBrokerConfigs,
                     describeBrokerLevelThrottles(admin, unthrottledBrokerConfigs.keySet()));
             long interBrokerThrottle = 1L;
@@ -783,13 +783,13 @@ public class ReassignPartitionsCommandTest {
             // Verify that the reassignment is running.  The very low throttle should keep it
             // from completing before this runs.
             waitForVerifyAssignment(admin, assignment, true,
-                    new VerifyAssignmentResult(partStates, true, Collections.emptyMap(), false));
+                    new VerifyAssignmentResult(partStates, true, Map.of(), false));
             // Cancel the reassignment.
-            assertEquals(new AbstractMap.SimpleImmutableEntry<>(Set.of(foo0, baz1), Collections.emptySet()), runCancelAssignment(assignment, true, useBootstrapServer));
+            assertEquals(Map.entry(Set.of(foo0, baz1), Set.of()), runCancelAssignment(assignment, true, useBootstrapServer));
             // Broker throttles are still active because we passed --preserve-throttles
             waitForInterBrokerThrottle(admin, asList(0, 1, 2, 3), interBrokerThrottle);
             // Cancelling the reassignment again should reveal nothing to cancel.
-            assertEquals(new AbstractMap.SimpleImmutableEntry<>(Collections.emptySet(), Collections.emptySet()), runCancelAssignment(assignment, false, useBootstrapServer));
+            assertEquals(Map.entry(Set.of(), Set.of()), runCancelAssignment(assignment, false, useBootstrapServer));
             // This time, the broker throttles were removed.
             waitForBrokerLevelThrottles(admin, unthrottledBrokerConfigs);
             // Verify that there are no ongoing reassignments.

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -799,7 +799,7 @@ public class ReassignPartitionsCommandTest {
      */
     private void removeReplicationThrottleForPartitions(TopicPartition part) {
         try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            removePartitionReplicaThrottles(admin, new HashSet<>(Set.of(part)));
+            removePartitionReplicaThrottles(admin, Set.of(part));
             assertDoesNotThrow(() -> throttleAllBrokersReplication(admin, List.of(0, 1, 2, 3), Integer.MAX_VALUE));
         }
     }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -446,7 +446,7 @@ public class ReassignPartitionsCommandTest {
         long initialLogDirThrottle = 1L;
         runExecuteAssignment(false, reassignment.json, -1L, initialLogDirThrottle);
         try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            waitForLogDirThrottle(admin, new HashSet<>(List.of(0)), initialLogDirThrottle);
+            waitForLogDirThrottle(admin, Set.of(0), initialLogDirThrottle);
 
             // Now increase the throttle and verify that the log dir movement completes
             long updatedLogDirThrottle = 3000000L;


### PR DESCRIPTION
see https://github.com/apache/kafka/pull/20003#discussion_r2164659673

Replace `SimpleImmutableEntry` by `Map.entry`.  Replace following
out-of-date APIs:

    Arrays.asList      Collections.singleton
Collections.singletonList      Collections.singletonMap

Reviewers: Jhen-Yung Hsu <jhenyunghsu@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
