### PR TITLE
MINOR: Improve ProcessorContext JavaDocs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -105,6 +105,13 @@ public interface ProcessorContext {
     /**
      * Get the state store given the store name.
      *
+     * <p>The returned state store represent one shard of the overall state, which belongs to the current task.
+     * The returned shard of the state store may only be used by the current
+     * {@link org.apache.kafka.streams.kstream.Transformer}, {@link org.apache.kafka.streams.kstream.ValueTransformer},
+     * or {@link org.apache.kafka.streams.kstream.ValueTransformerWithKey} instance.
+     * Sharing a shard across different transformers (ie, from different "sibling" tasks; same sub-topology but different
+     * partition) may lead to data corruption and/or data loss.
+     *
      * @param name The store name
      * @param <S> The type or interface of the store to return
      * @return The state store instance

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ProcessingContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ProcessingContext.java
@@ -107,6 +107,12 @@ public interface ProcessingContext {
     /**
      * Get the state store given the store name.
      *
+     * <p>The returned state store represent one shard of the overall state, which belongs to the current task.
+     * The returned shard of the state store may only be used by the current {@link Processor} or
+     * {@link FixedKeyProcessor} instance.
+     * Sharing a shard across different processors (ie, from different "sibling" tasks; same sub-topology but different
+     * partition) may lead to data corruption and/or data loss.
+     *
      * @param name The store name
      * @param <S> The type or interface of the store to return
      * @return The state store instance


### PR DESCRIPTION
Clarify that state stores are sharded, and shards cannot be shared
across Processors.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
