### PR TITLE
MINOR: Add group-coordinator label for pull requests

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -92,6 +92,12 @@ transactions:
       - any-glob-to-any-file:
           - 'transaction-coordinator/**'
 
+group-coordinator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'group-coordinator/**'
+          - 'coordinator-common/**'
+
 kip-932:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
This patch adds the group-coordinator label for pull requests.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
