### PR TITLE
KAFKA-19440: Handle top-level errors in AlterShareGroupOffsets RPC

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterShareGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterShareGroupOffsetsResult.java
@@ -20,12 +20,10 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.apache.kafka.common.protocol.Errors;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * The result of the {@link Admin#alterShareGroupOffsets(String, Map, AlterShareGroupOffsetsOptions)} call.
@@ -35,9 +33,9 @@ import java.util.stream.Collectors;
 @InterfaceStability.Evolving
 public class AlterShareGroupOffsetsResult {
 
-    private final KafkaFuture<Map<TopicPartition, Errors>> future;
+    private final KafkaFuture<Map<TopicPartition, ApiException>> future;
 
-    AlterShareGroupOffsetsResult(KafkaFuture<Map<TopicPartition, Errors>> future) {
+    AlterShareGroupOffsetsResult(KafkaFuture<Map<TopicPartition, ApiException>> future) {
         this.future = future;
     }
 
@@ -54,11 +52,11 @@ public class AlterShareGroupOffsetsResult {
                 result.completeExceptionally(new IllegalArgumentException(
                     "Alter offset for partition \"" + partition + "\" was not attempted"));
             } else {
-                final Errors error = topicPartitions.get(partition);
-                if (error == Errors.NONE) {
+                final ApiException exception = topicPartitions.get(partition);
+                if (exception == null) {
                     result.complete(null);
                 } else {
-                    result.completeExceptionally(error.exception());
+                    result.completeExceptionally(exception);
                 }
             }
         });
@@ -70,20 +68,13 @@ public class AlterShareGroupOffsetsResult {
      * Return a future which succeeds if all the alter offsets succeed.
      */
     public KafkaFuture<Void> all() {
-        return this.future.thenApply(topicPartitionErrorsMap ->  {
-            List<TopicPartition> partitionsFailed = topicPartitionErrorsMap.entrySet()
-                .stream()
-                .filter(e -> e.getValue() != Errors.NONE)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
-            for (Errors error : topicPartitionErrorsMap.values()) {
-                if (error != Errors.NONE) {
-                    throw error.exception(
-                        "Failed altering share group offsets for the following partitions: " + partitionsFailed);
+        return this.future.thenApply(topicPartitionErrorsMap -> {
+            for (ApiException exception : topicPartitionErrorsMap.values()) {
+                if (exception != null) {
+                    throw exception;
                 }
             }
             return null;
         });
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterShareGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterShareGroupOffsetsResult.java
@@ -22,8 +22,11 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.protocol.Errors;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * The result of the {@link Admin#alterShareGroupOffsets(String, Map, AlterShareGroupOffsetsOptions)} call.
@@ -66,12 +69,19 @@ public class AlterShareGroupOffsetsResult {
 
     /**
      * Return a future which succeeds if all the alter offsets succeed.
+     * If not, the first topic error shall be returned.
      */
     public KafkaFuture<Void> all() {
-        return this.future.thenApply(topicPartitionErrorsMap -> {
+        return this.future.thenApply(topicPartitionErrorsMap ->  {
+            List<TopicPartition> partitionsFailed = topicPartitionErrorsMap.entrySet()
+                .stream()
+                .filter(e -> e.getValue() != null)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
             for (ApiException exception : topicPartitionErrorsMap.values()) {
                 if (exception != null) {
-                    throw exception;
+                    throw Errors.forException(exception).exception(
+                        "Failed altering group offsets for the following partitions: " + partitionsFailed);
                 }
             }
             return null;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3805,7 +3805,7 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public AlterShareGroupOffsetsResult alterShareGroupOffsets(String groupId, Map<TopicPartition, Long> offsets, AlterShareGroupOffsetsOptions options) {
-        SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, Errors>> future = AlterShareGroupOffsetsHandler.newFuture(groupId);
+        SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, ApiException>> future = AlterShareGroupOffsetsHandler.newFuture(groupId);
         AlterShareGroupOffsetsHandler handler = new AlterShareGroupOffsetsHandler(groupId, offsets, logContext);
         invokeDriver(handler, future, options.timeoutMs);
         return new AlterShareGroupOffsetsResult(future.get(CoordinatorKey.byGroupId(groupId)));

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3804,7 +3804,9 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public AlterShareGroupOffsetsResult alterShareGroupOffsets(String groupId, Map<TopicPartition, Long> offsets, AlterShareGroupOffsetsOptions options) {
+    public AlterShareGroupOffsetsResult alterShareGroupOffsets(final String groupId,
+                                                               final Map<TopicPartition, Long> offsets,
+                                                               final AlterShareGroupOffsetsOptions options) {
         SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, ApiException>> future = AlterShareGroupOffsetsHandler.newFuture(groupId);
         AlterShareGroupOffsetsHandler handler = new AlterShareGroupOffsetsHandler(groupId, offsets, logContext);
         invokeDriver(handler, future, options.timeoutMs);
@@ -3821,7 +3823,9 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public DeleteShareGroupOffsetsResult deleteShareGroupOffsets(String groupId, Set<String> topics, DeleteShareGroupOffsetsOptions options) {
+    public DeleteShareGroupOffsetsResult deleteShareGroupOffsets(final String groupId,
+                                                                 final Set<String> topics,
+                                                                 final DeleteShareGroupOffsetsOptions options) {
         SimpleAdminApiFuture<CoordinatorKey, Map<String, ApiException>> future = DeleteShareGroupOffsetsHandler.newFuture(groupId);
         DeleteShareGroupOffsetsHandler handler = new DeleteShareGroupOffsetsHandler(groupId, topics, logContext);
         invokeDriver(handler, future, options.timeoutMs);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterShareGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterShareGroupOffsetsHandler.java
@@ -51,7 +51,6 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
 
     private final CoordinatorStrategy lookupStrategy;
 
-
     public AlterShareGroupOffsetsHandler(String groupId, Map<TopicPartition, Long> offsets, LogContext logContext) {
         this.groupId = CoordinatorKey.byGroupId(groupId);
         this.offsets = offsets;
@@ -61,6 +60,13 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
 
     public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, ApiException>> newFuture(String groupId) {
         return AdminApiFuture.forKeys(Set.of(CoordinatorKey.byGroupId(groupId)));
+    }
+
+    private void validateKeys(Set<CoordinatorKey> groupIds) {
+        if (!groupIds.equals(Set.of(groupId))) {
+            throw new IllegalArgumentException("Received unexpected group ids " + groupIds +
+                " (expected only " + Set.of(groupId) + ")");
+        }
     }
 
     @Override
@@ -87,19 +93,28 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
 
     @Override
     public ApiResult<CoordinatorKey, Map<TopicPartition, ApiException>> handleResponse(Node broker, Set<CoordinatorKey> keys, AbstractResponse abstractResponse) {
+        validateKeys(keys);
+
         AlterShareGroupOffsetsResponse response = (AlterShareGroupOffsetsResponse) abstractResponse;
+        final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
+        final Set<CoordinatorKey> groupsToRetry = new HashSet<>();
+        final Map<TopicPartition, ApiException> partitionResults = new HashMap<>();
 
-        final Errors topLevelError = Errors.forCode(response.data().errorCode());
-        final String topLevelErrorMessage = response.data().errorMessage();
+        if (response.data().errorCode() != Errors.NONE.code()) {
+            final Errors topLevelError = Errors.forCode(response.data().errorCode());
+            final String topLevelErrorMessage = response.data().errorMessage();
 
-        if (topLevelError != Errors.NONE) {
-            final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
-            final Map<CoordinatorKey, Throwable> groupsFailed = new HashMap<>();
-            handleGroupError(groupId, topLevelError, topLevelErrorMessage, groupsToUnmap, groupsFailed);
-
-            return new ApiResult<>(Map.of(), groupsFailed, new ArrayList<>(groupsToUnmap));
+            offsets.forEach((topicPartition, offset) ->
+                handleError(
+                    groupId,
+                    topicPartition,
+                    topLevelError,
+                    topLevelErrorMessage,
+                    partitionResults,
+                    groupsToUnmap,
+                    groupsToRetry
+                ));
         } else {
-            final Map<TopicPartition, ApiException> partitionResults = new HashMap<>();
             response.data().responses().forEach(topic -> topic.partitions().forEach(partition -> {
                 if (partition.errorCode() != Errors.NONE.code()) {
                     final Errors partitionError = Errors.forCode(partition.errorCode());
@@ -109,22 +124,29 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
                 }
                 partitionResults.put(new TopicPartition(topic.topicName(), partition.partitionIndex()), Errors.forCode(partition.errorCode()).exception(partition.errorMessage()));
             }));
+        }
 
+        if (groupsToUnmap.isEmpty() && groupsToRetry.isEmpty()) {
             return ApiResult.completed(groupId, partitionResults);
+        } else {
+            return ApiResult.unmapped(new ArrayList<>(groupsToUnmap));
         }
     }
 
-    private void handleGroupError(
+    private void handleError(
         CoordinatorKey groupId,
+        TopicPartition topicPartition,
         Errors error,
         String errorMessage,
+        Map<TopicPartition, ApiException> partitionResults,
         Set<CoordinatorKey> groupsToUnmap,
-        Map<CoordinatorKey, Throwable> groupsFailed
+        Set<CoordinatorKey> groupsToRetry
     ) {
         switch (error) {
             case COORDINATOR_LOAD_IN_PROGRESS:
             case REBALANCE_IN_PROGRESS:
                 log.debug("AlterShareGroupOffsets request for group id {} returned error {}. Will retry." + errorMessage, groupId.idValue, error);
+                groupsToRetry.add(groupId);
                 break;
             case COORDINATOR_NOT_AVAILABLE:
             case NOT_COORDINATOR:
@@ -139,11 +161,11 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
             case KAFKA_STORAGE_ERROR:
             case GROUP_AUTHORIZATION_FAILED:
                 log.debug("AlterShareGroupOffsets request for group id {} failed due to error {}." + errorMessage, groupId.idValue, error);
-                groupsFailed.put(groupId, error.exception(errorMessage));
+                partitionResults.put(topicPartition, error.exception(errorMessage));
                 break;
             default:
                 log.error("AlterShareGroupOffsets request for group id {} failed due to unexpected error {}." + errorMessage, groupId.idValue, error);
-                groupsFailed.put(groupId, error.exception(errorMessage));
+                partitionResults.put(topicPartition, error.exception(errorMessage));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterShareGroupOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AlterShareGroupOffsetsHandler.java
@@ -21,8 +21,8 @@ import org.apache.kafka.clients.admin.AlterShareGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.AlterShareGroupOffsetsRequestData;
-import org.apache.kafka.common.message.AlterShareGroupOffsetsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.AlterShareGroupOffsetsRequest;
@@ -33,7 +33,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,7 +41,7 @@ import java.util.Set;
 /**
  * This class is the handler for {@link KafkaAdminClient#alterShareGroupOffsets(String, Map, AlterShareGroupOffsetsOptions)} call
  */
-public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<CoordinatorKey, Map<TopicPartition, Errors>> {
+public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<CoordinatorKey, Map<TopicPartition, ApiException>> {
 
     private final CoordinatorKey groupId;
 
@@ -60,8 +59,8 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
         this.lookupStrategy = new CoordinatorStrategy(FindCoordinatorRequest.CoordinatorType.GROUP, logContext);
     }
 
-    public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, Errors>> newFuture(String groupId) {
-        return AdminApiFuture.forKeys(Collections.singleton(CoordinatorKey.byGroupId(groupId)));
+    public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, ApiException>> newFuture(String groupId) {
+        return AdminApiFuture.forKeys(Set.of(CoordinatorKey.byGroupId(groupId)));
     }
 
     @Override
@@ -87,57 +86,49 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
     }
 
     @Override
-    public ApiResult<CoordinatorKey, Map<TopicPartition, Errors>> handleResponse(Node broker, Set<CoordinatorKey> keys, AbstractResponse abstractResponse) {
+    public ApiResult<CoordinatorKey, Map<TopicPartition, ApiException>> handleResponse(Node broker, Set<CoordinatorKey> keys, AbstractResponse abstractResponse) {
         AlterShareGroupOffsetsResponse response = (AlterShareGroupOffsetsResponse) abstractResponse;
-        final Map<TopicPartition, Errors> partitionResults = new HashMap<>();
-        final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
-        final Set<CoordinatorKey> groupsToRetry = new HashSet<>();
 
-        for (AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponseTopic topic : response.data().responses()) {
-            for (AlterShareGroupOffsetsResponseData.AlterShareGroupOffsetsResponsePartition partition : topic.partitions()) {
-                TopicPartition topicPartition = new TopicPartition(topic.topicName(), partition.partitionIndex());
-                Errors error = Errors.forCode(partition.errorCode());
+        final Errors topLevelError = Errors.forCode(response.data().errorCode());
+        final String topLevelErrorMessage = response.data().errorMessage();
 
-                if (error != Errors.NONE) {
-                    handleError(
-                        groupId,
-                        topicPartition,
-                        error,
-                        partitionResults,
-                        groupsToUnmap,
-                        groupsToRetry
-                    );
-                } else {
-                    partitionResults.put(topicPartition, error);
-                }
-            }
-        }
+        if (topLevelError != Errors.NONE) {
+            final Set<CoordinatorKey> groupsToUnmap = new HashSet<>();
+            final Map<CoordinatorKey, Throwable> groupsFailed = new HashMap<>();
+            handleGroupError(groupId, topLevelError, topLevelErrorMessage, groupsToUnmap, groupsFailed);
 
-        if (groupsToUnmap.isEmpty() && groupsToRetry.isEmpty()) {
-            return ApiResult.completed(groupId, partitionResults);
+            return new ApiResult<>(Map.of(), groupsFailed, new ArrayList<>(groupsToUnmap));
         } else {
-            return ApiResult.unmapped(new ArrayList<>(groupsToUnmap));
+            final Map<TopicPartition, ApiException> partitionResults = new HashMap<>();
+            response.data().responses().forEach(topic -> topic.partitions().forEach(partition -> {
+                if (partition.errorCode() != Errors.NONE.code()) {
+                    final Errors partitionError = Errors.forCode(partition.errorCode());
+                    final String partitionErrorMessage = partition.errorMessage();
+                    log.debug("AlterShareGroupOffsets request for group id {} and topic-partition {}-{} failed and returned error {}." + partitionErrorMessage,
+                        groupId.idValue, topic.topicName(), partition.partitionIndex(), partitionError);
+                }
+                partitionResults.put(new TopicPartition(topic.topicName(), partition.partitionIndex()), Errors.forCode(partition.errorCode()).exception(partition.errorMessage()));
+            }));
+
+            return ApiResult.completed(groupId, partitionResults);
         }
     }
 
-    private void handleError(
-            CoordinatorKey groupId,
-            TopicPartition topicPartition,
-            Errors error,
-            Map<TopicPartition, Errors> partitionResults,
-            Set<CoordinatorKey> groupsToUnmap,
-            Set<CoordinatorKey> groupsToRetry
+    private void handleGroupError(
+        CoordinatorKey groupId,
+        Errors error,
+        String errorMessage,
+        Set<CoordinatorKey> groupsToUnmap,
+        Map<CoordinatorKey, Throwable> groupsFailed
     ) {
         switch (error) {
             case COORDINATOR_LOAD_IN_PROGRESS:
             case REBALANCE_IN_PROGRESS:
-                log.debug("AlterShareGroupOffsets request for group id {} returned error {}. Will retry.",
-                        groupId.idValue, error);
-                groupsToRetry.add(groupId);
+                log.debug("AlterShareGroupOffsets request for group id {} returned error {}. Will retry." + errorMessage, groupId.idValue, error);
                 break;
             case COORDINATOR_NOT_AVAILABLE:
             case NOT_COORDINATOR:
-                log.debug("AlterShareGroupOffsets request for group id {} returned error {}. Will rediscover the coordinator and retry.",
+                log.debug("AlterShareGroupOffsets request for group id {} returned error {}. Will rediscover the coordinator and retry." + errorMessage,
                         groupId.idValue, error);
                 groupsToUnmap.add(groupId);
                 break;
@@ -147,14 +138,12 @@ public class AlterShareGroupOffsetsHandler extends AdminApiHandler.Batched<Coord
             case UNKNOWN_SERVER_ERROR:
             case KAFKA_STORAGE_ERROR:
             case GROUP_AUTHORIZATION_FAILED:
-                log.debug("AlterShareGroupOffsets request for group id {} and partition {} failed due" +
-                        " to error {}.", groupId.idValue, topicPartition, error);
-                partitionResults.put(topicPartition, error);
+                log.debug("AlterShareGroupOffsets request for group id {} failed due to error {}." + errorMessage, groupId.idValue, error);
+                groupsFailed.put(groupId, error.exception(errorMessage));
                 break;
             default:
-                log.error("AlterShareGroupOffsets request for group id {} and partition {} failed due" +
-                        " to unexpected error {}.", groupId.idValue, topicPartition, error);
-                partitionResults.put(topicPartition, error);
+                log.error("AlterShareGroupOffsets request for group id {} failed due to unexpected error {}." + errorMessage, groupId.idValue, error);
+                groupsFailed.put(groupId, error.exception(errorMessage));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsRequest.java
@@ -53,26 +53,31 @@ public class AlterShareGroupOffsetsRequest extends AbstractRequest {
     }
 
     @Override
-    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
-        Errors error = Errors.forException(e);
-        return new AlterShareGroupOffsetsResponse(getErrorResponse(throttleTimeMs, error));
+    public AlterShareGroupOffsetsResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        return getErrorResponse(throttleTimeMs, Errors.forException(e));
     }
 
-    public static AlterShareGroupOffsetsResponseData getErrorResponse(int throttleTimeMs, Errors error) {
-        return new AlterShareGroupOffsetsResponseData()
-            .setThrottleTimeMs(throttleTimeMs)
-            .setErrorCode(error.code())
-            .setErrorMessage(error.message());
+    public AlterShareGroupOffsetsResponse getErrorResponse(int throttleTimeMs, Errors error) {
+        return getErrorResponse(throttleTimeMs, error.code(), error.message());
     }
 
-    public static AlterShareGroupOffsetsResponseData getErrorResponse(Errors error) {
-        return getErrorResponse(error.code(), error.message());
-    }
-
-    public static AlterShareGroupOffsetsResponseData getErrorResponse(short errorCode, String errorMessage) {
-        return new AlterShareGroupOffsetsResponseData()
+    public AlterShareGroupOffsetsResponse getErrorResponse(int throttleTimeMs, short errorCode, String message) {
+        return new AlterShareGroupOffsetsResponse(
+            new AlterShareGroupOffsetsResponseData()
+                .setThrottleTimeMs(throttleTimeMs)
                 .setErrorCode(errorCode)
-                .setErrorMessage(errorMessage);
+                .setErrorMessage(message)
+        );
+    }
+
+    public static AlterShareGroupOffsetsResponseData getErrorResponseData(Errors error) {
+        return getErrorResponseData(error.code(), error.message());
+    }
+
+    public static AlterShareGroupOffsetsResponseData getErrorResponseData(short errorCode, String errorMessage) {
+        return new AlterShareGroupOffsetsResponseData()
+            .setErrorCode(errorCode)
+            .setErrorMessage(errorMessage);
     }
 
     public static AlterShareGroupOffsetsRequest parse(Readable readable, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsRequest.java
@@ -71,13 +71,13 @@ public class AlterShareGroupOffsetsRequest extends AbstractRequest {
     }
 
     public static AlterShareGroupOffsetsResponseData getErrorResponseData(Errors error) {
-        return getErrorResponseData(error.code(), error.message());
+        return getErrorResponseData(error, null);
     }
 
-    public static AlterShareGroupOffsetsResponseData getErrorResponseData(short errorCode, String errorMessage) {
+    public static AlterShareGroupOffsetsResponseData getErrorResponseData(Errors error, String errorMessage) {
         return new AlterShareGroupOffsetsResponseData()
-            .setErrorCode(errorCode)
-            .setErrorMessage(errorMessage);
+            .setErrorCode(error.code())
+            .setErrorMessage(errorMessage == null ? error.message() : errorMessage);
     }
 
     public static AlterShareGroupOffsetsRequest parse(Readable readable, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsRequest.java
@@ -80,12 +80,18 @@ public class DeleteShareGroupOffsetsRequest extends AbstractRequest {
     }
 
     public static DeleteShareGroupOffsetsResponseData getErrorDeleteResponseData(Errors error) {
-        return getErrorDeleteResponseData(error.code(), error.message());
+        return getErrorDeleteResponseData(error, null);
     }
 
     public static DeleteShareGroupOffsetsResponseData getErrorDeleteResponseData(short errorCode, String errorMessage) {
         return new DeleteShareGroupOffsetsResponseData()
             .setErrorCode(errorCode)
-            .setErrorMessage(errorMessage);
+            .setErrorMessage(errorMessage == null ? Errors.forCode(errorCode).message(): errorMessage);
+    }
+
+    public static DeleteShareGroupOffsetsResponseData getErrorDeleteResponseData(Errors error, String errorMessage) {
+        return new DeleteShareGroupOffsetsResponseData()
+            .setErrorCode(error.code())
+            .setErrorMessage(errorMessage == null ? error.message() : errorMessage);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsRequest.java
@@ -86,7 +86,7 @@ public class DeleteShareGroupOffsetsRequest extends AbstractRequest {
     public static DeleteShareGroupOffsetsResponseData getErrorDeleteResponseData(short errorCode, String errorMessage) {
         return new DeleteShareGroupOffsetsResponseData()
             .setErrorCode(errorCode)
-            .setErrorMessage(errorMessage == null ? Errors.forCode(errorCode).message(): errorMessage);
+            .setErrorMessage(errorMessage == null ? Errors.forCode(errorCode).message() : errorMessage);
     }
 
     public static DeleteShareGroupOffsetsResponseData getErrorDeleteResponseData(Errors error, String errorMessage) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3756,7 +3756,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val groupId = alterShareGroupOffsetsRequest.data.groupId
 
     if (!isShareGroupProtocolEnabled) {
-      requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, Errors.UNSUPPORTED_VERSION.exception))
+      requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
       return CompletableFuture.completedFuture[Unit](())
     } else if (!authHelper.authorize(request.context, READ, GROUP, groupId)) {
       requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(Errors.GROUP_AUTHORIZATION_FAILED.exception))
@@ -3792,6 +3792,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       ).handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(exception))
+        } else if (response.errorCode() != Errors.NONE.code) {
+          requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, response.errorCode(), response.errorMessage()))
         } else {
           requestHelper.sendMaybeThrottle(request, responseBuilder.merge(response, metadataCache.topicNamesToIds()).build())
         }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3778,7 +3778,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           case Some(error) =>
             topic.partitions().forEach(partition => responseBuilder.addPartition(topic.topicName(), partition.partitionIndex(), metadataCache.topicNamesToIds(), error.error))
           case None =>
-            authorizedTopicPartitions.add(topic)
+            authorizedTopicPartitions.add(topic.duplicate)
         }
       })
 
@@ -3831,15 +3831,6 @@ class KafkaApis(val requestChannel: RequestChannel,
       } else {
         authorizedTopics.add(topic)
       }
-    }
-
-    if (authorizedTopics.isEmpty) {
-      requestHelper.sendMaybeThrottle(
-        request,
-        new DeleteShareGroupOffsetsResponse(
-          new DeleteShareGroupOffsetsResponseData()
-            .setResponses(deleteShareGroupOffsetsResponseTopics)))
-      return CompletableFuture.completedFuture[Unit](())
     }
 
     groupCoordinator.deleteShareGroupOffsets(

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3766,9 +3766,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
       alterShareGroupOffsetsRequest.data.topics.forEach(topic => {
         val topicError = {
-          if (!authHelper.authorize(request.context, READ, TOPIC, topic.topicName())) {
+          if (!authHelper.authorize(request.context, READ, TOPIC, topic.topicName)) {
             Some(new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED))
-          } else if (!metadataCache.contains(topic.topicName())) {
+          } else if (!metadataCache.contains(topic.topicName)) {
             Some(new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION))
           } else {
             None
@@ -3776,7 +3776,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
         topicError match {
           case Some(error) =>
-            topic.partitions().forEach(partition => responseBuilder.addPartition(topic.topicName(), partition.partitionIndex(), metadataCache.topicNamesToIds(), error.error))
+            topic.partitions.forEach(partition => responseBuilder.addPartition(topic.topicName, partition.partitionIndex, metadataCache.topicNamesToIds, error.error))
           case None =>
             authorizedTopicPartitions.add(topic.duplicate)
         }
@@ -3792,10 +3792,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       ).handle[Unit] { (response, exception) =>
         if (exception != null) {
           requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(exception))
-        } else if (response.errorCode() != Errors.NONE.code) {
-          requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, response.errorCode(), response.errorMessage()))
+        } else if (response.errorCode != Errors.NONE.code) {
+          requestHelper.sendMaybeThrottle(request, alterShareGroupOffsetsRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, response.errorCode, response.errorMessage))
         } else {
-          requestHelper.sendMaybeThrottle(request, responseBuilder.merge(response, metadataCache.topicNamesToIds()).build())
+          requestHelper.sendMaybeThrottle(request, responseBuilder.merge(response, metadataCache.topicNamesToIds).build())
         }
       }
     }
@@ -3826,7 +3826,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           new DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic()
             .setTopicName(topic.topicName)
             .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
-            .setErrorMessage(Errors.TOPIC_AUTHORIZATION_FAILED.message())
+            .setErrorMessage(Errors.TOPIC_AUTHORIZATION_FAILED.message)
         )
       } else {
         authorizedTopics.add(topic)
@@ -3840,12 +3840,12 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (exception != null) {
         requestHelper.sendMaybeThrottle(request, deleteShareGroupOffsetsRequest.getErrorResponse(
           AbstractResponse.DEFAULT_THROTTLE_TIME,
-          Errors.forException(exception).code(),
-          exception.getMessage()))
+          Errors.forException(exception).code,
+          exception.getMessage))
       } else if (responseData.errorCode() != Errors.NONE.code) {
         requestHelper.sendMaybeThrottle(
           request,
-          deleteShareGroupOffsetsRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, responseData.errorCode(), responseData.errorMessage())
+          deleteShareGroupOffsetsRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, responseData.errorCode, responseData.errorMessage)
         )
       } else {
         responseData.responses.forEach { topic => {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -3254,6 +3254,18 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
     removeAllClientAcls()
   }
 
+  private def createEmptyShareGroup(): Unit = {
+    createTopicWithBrokerPrincipal(topic)
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WILDCARD_HOST, READ, ALLOW)), shareGroupResource)
+    addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WILDCARD_HOST, READ, ALLOW)), topicResource)
+    shareConsumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, shareGroup)
+    val consumer = createShareConsumer()
+    consumer.subscribe(util.Set.of(topic))
+    consumer.poll(Duration.ofMillis(500L))
+    consumer.close()
+    removeAllClientAcls()
+  }
+
   @Test
   def testShareGroupDescribeWithGroupDescribeAndTopicDescribeAcl(): Unit = {
     createShareGroupToDescribe()
@@ -3614,6 +3626,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
 
   @Test
   def testDeleteShareGroupOffsetsWithoutTopicReadAcl(): Unit = {
+    createEmptyShareGroup()
     addAndVerifyAcls(shareGroupDeleteAcl(shareGroupResource), shareGroupResource)
 
     val request = deleteShareGroupOffsetsRequest
@@ -3663,6 +3676,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
 
   @Test
   def testAlterShareGroupOffsetsWithoutTopicReadAcl(): Unit = {
+    createEmptyShareGroup()
     addAndVerifyAcls(shareGroupReadAcl(shareGroupResource), shareGroupResource)
 
     val request = alterShareGroupOffsetsRequest

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -12863,10 +12863,18 @@ class KafkaApisTest extends Logging {
   def testDeleteShareGroupOffsetsRequestEmptyTopicsSuccess(): Unit = {
     metadataCache = initializeMetadataCacheWithShareGroupsEnabled()
 
-    val deleteShareGroupOffsetsRequest = new DeleteShareGroupOffsetsRequestData()
+    val deleteShareGroupOffsetsRequestData = new DeleteShareGroupOffsetsRequestData()
       .setGroupId("group")
 
-    val requestChannelRequest = buildRequest(new DeleteShareGroupOffsetsRequest.Builder(deleteShareGroupOffsetsRequest).build)
+    val requestChannelRequest = buildRequest(new DeleteShareGroupOffsetsRequest.Builder(deleteShareGroupOffsetsRequestData).build)
+
+    val groupCoordinatorResponse: DeleteShareGroupOffsetsResponseData = new DeleteShareGroupOffsetsResponseData()
+      .setErrorCode(Errors.NONE.code())
+
+    when(groupCoordinator.deleteShareGroupOffsets(
+      requestChannelRequest.context,
+      deleteShareGroupOffsetsRequestData
+    )).thenReturn(CompletableFuture.completedFuture(groupCoordinatorResponse))
 
     val resultFuture = new CompletableFuture[DeleteShareGroupOffsetsResponseData]
     kafkaApis = createKafkaApis()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -1233,13 +1233,17 @@ public class GroupCoordinatorService implements GroupCoordinator {
      * See {@link GroupCoordinator#alterShareGroupOffsets(AuthorizableRequestContext, String, AlterShareGroupOffsetsRequestData)}.
      */
     @Override
-    public CompletableFuture<AlterShareGroupOffsetsResponseData> alterShareGroupOffsets(AuthorizableRequestContext context, String groupId, AlterShareGroupOffsetsRequestData request) {
+    public CompletableFuture<AlterShareGroupOffsetsResponseData> alterShareGroupOffsets(
+        AuthorizableRequestContext context,
+        String groupId,
+        AlterShareGroupOffsetsRequestData request
+    ) {
         if (!isActive.get() || metadataImage == null) {
-            return CompletableFuture.completedFuture(AlterShareGroupOffsetsRequest.getErrorResponse(Errors.COORDINATOR_NOT_AVAILABLE));
+            return CompletableFuture.completedFuture(AlterShareGroupOffsetsRequest.getErrorResponseData(Errors.COORDINATOR_NOT_AVAILABLE));
         }
         
         if (groupId == null || groupId.isEmpty()) {
-            return CompletableFuture.completedFuture(AlterShareGroupOffsetsRequest.getErrorResponse(Errors.INVALID_GROUP_ID));
+            return CompletableFuture.completedFuture(AlterShareGroupOffsetsRequest.getErrorResponseData(Errors.INVALID_GROUP_ID));
         }
 
         if (request.topics() == null || request.topics().isEmpty()) {
@@ -1257,7 +1261,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "share-group-offsets-alter",
             request,
             exception,
-            (error, message) -> AlterShareGroupOffsetsRequest.getErrorResponse(error),
+            (error, __) -> AlterShareGroupOffsetsRequest.getErrorResponseData(error),
             log
         ));
     }
@@ -1822,26 +1826,18 @@ public class GroupCoordinatorService implements GroupCoordinator {
         AuthorizableRequestContext context,
         DeleteShareGroupOffsetsRequestData requestData
     ) {
-        if (!isActive.get()) {
-            return CompletableFuture.completedFuture(
-                DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(Errors.COORDINATOR_NOT_AVAILABLE));
-        }
-
-        if (metadataImage == null) {
-            return CompletableFuture.completedFuture(
-                DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(Errors.COORDINATOR_NOT_AVAILABLE));
+        if (!isActive.get() || metadataImage == null) {
+            return CompletableFuture.completedFuture(DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(Errors.COORDINATOR_NOT_AVAILABLE));
         }
 
         String groupId = requestData.groupId();
 
         if (!isGroupIdNotEmpty(groupId)) {
-            return CompletableFuture.completedFuture(
-                DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(Errors.INVALID_GROUP_ID));
+            return CompletableFuture.completedFuture(DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(Errors.INVALID_GROUP_ID));
         }
 
         if (requestData.topics() == null || requestData.topics().isEmpty()) {
-            return CompletableFuture.completedFuture(
-                new DeleteShareGroupOffsetsResponseData()
+            return CompletableFuture.completedFuture(new DeleteShareGroupOffsetsResponseData()
             );
         }
 
@@ -1850,15 +1846,14 @@ public class GroupCoordinatorService implements GroupCoordinator {
             topicPartitionFor(groupId),
             Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.initiateDeleteShareGroupOffsets(groupId, requestData)
-        )
-            .thenCompose(resultHolder -> deleteShareGroupOffsetsState(groupId, resultHolder))
-            .exceptionally(exception -> handleOperationException(
-                "initiate-delete-share-group-offsets",
-                groupId,
-                exception,
-                (error, __) -> DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(error),
-                log
-            ));
+        ).thenCompose(resultHolder -> deleteShareGroupOffsetsState(groupId, resultHolder)
+        ).exceptionally(exception -> handleOperationException(
+            "initiate-delete-share-group-offsets",
+            groupId,
+            exception,
+            (error, __) -> DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(error),
+            log
+        ));
     }
 
     private CompletableFuture<DeleteShareGroupOffsetsResponseData> deleteShareGroupOffsetsState(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -698,6 +698,10 @@ public class GroupCoordinatorService implements GroupCoordinator {
         InitializeShareGroupStateParameters request,
         AlterShareGroupOffsetsResponseData response
     ) {
+        if (request.groupTopicPartitionData().topicsData().isEmpty()) {
+            return CompletableFuture.completedFuture(response);
+        }
+
         return persister.initializeState(request)
             .handle((result, exp) -> {
                 if (exp == null) {
@@ -1246,7 +1250,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return CompletableFuture.completedFuture(AlterShareGroupOffsetsRequest.getErrorResponseData(Errors.INVALID_GROUP_ID));
         }
 
-        if (request.topics() == null || request.topics().isEmpty()) {
+        if (request.topics() == null) {
             return CompletableFuture.completedFuture(new AlterShareGroupOffsetsResponseData());
         }
 
@@ -1261,7 +1265,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "share-group-offsets-alter",
             request,
             exception,
-            (error, __) -> AlterShareGroupOffsetsRequest.getErrorResponseData(error),
+            (error, message) -> AlterShareGroupOffsetsRequest.getErrorResponseData(error, message),
             log
         ));
     }
@@ -1836,7 +1840,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return CompletableFuture.completedFuture(DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(Errors.INVALID_GROUP_ID));
         }
 
-        if (requestData.topics() == null || requestData.topics().isEmpty()) {
+        if (requestData.topics() == null) {
             return CompletableFuture.completedFuture(new DeleteShareGroupOffsetsResponseData()
             );
         }
@@ -1851,7 +1855,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "initiate-delete-share-group-offsets",
             groupId,
             exception,
-            (error, __) -> DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(error),
+            (error, message) -> DeleteShareGroupOffsetsRequest.getErrorDeleteResponseData(error, message),
             log
         ));
     }


### PR DESCRIPTION
While testing the code in https://github.com/apache/kafka/pull/19820, it
became clear that the error handling problems were due to the underlying
Admin API. This PR fixes the error handling for top-level errors in the
AlterShareGroupOffsets RPC.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Lan Ding
 <isDing_L@163.com>, TaiJuWu <tjwu1217@gmail.com>
