### PR TITLE
MINOR: Make feature lists immutable

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/Feature.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/Feature.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.kafka.server.common.UnitTestFeatureVersion.FV0.UT_FV0_0;
 
@@ -93,14 +92,14 @@ public enum Feature {
 
         TEST_AND_PRODUCTION_FEATURES = Arrays.stream(FEATURES).filter(feature ->
             !feature.name.startsWith("unit." + TestFeatureVersion.FEATURE_NAME)
-        ).collect(Collectors.toList());
+        ).toList();
 
         PRODUCTION_FEATURES = Arrays.stream(FEATURES).filter(feature ->
             !feature.name.equals(TEST_VERSION.featureName()) &&
             !feature.name.startsWith("unit." + TestFeatureVersion.FEATURE_NAME)
-        ).collect(Collectors.toList());
+        ).toList();
         PRODUCTION_FEATURE_NAMES = PRODUCTION_FEATURES.stream().map(feature ->
-                feature.name).collect(Collectors.toList());
+                feature.name).toList();
 
         validateDefaultValueAndLatestProductionValue(TEST_VERSION);
         for (Feature feature : PRODUCTION_FEATURES) {


### PR DESCRIPTION
Replaces `.collect(Collectors.toList())` with `.toList()` for feature
collections, ensuring they are immutable and preventing accidental
modification.

Reviewers: TaiJuWu <tjwu1217@gmail.com>, Yung
 <yungyung7654321@gmail.com>, Ken Huang <s7133700@gmail.com>, TengYao
 Chi <frankvicky@apache.org>
