### PR TITLE
MINOR: Correct ProducerFailureHandlingTest Typo, Use waitForTopic Instead of waitForDeletion

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/producer/ProducerFailureHandlingTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/producer/ProducerFailureHandlingTest.java
@@ -278,14 +278,12 @@ public class ProducerFailureHandlingTest {
         String topic10 = "topic10";
         try (Admin admin = clusterInstance.admin()) {
             admin.createTopics(List.of(new NewTopic(topic10, brokerSize, (short) brokerSize).configs(topicConfig)));
-            clusterInstance.waitTopicDeletion("topic10");
+            clusterInstance.waitForTopic("topic10", brokerSize);
         }
 
         // send a record that is too large for replication, but within the broker max message limit
-        byte[] value =
-                new byte[maxMessageSize - DefaultRecordBatch.RECORD_BATCH_OVERHEAD - DefaultRecord.MAX_RECORD_OVERHEAD];
-        Producer<byte[], byte[]> producer = clusterInstance.producer(producerConfig(-1));
-        try (producer) {
+        byte[] value = new byte[maxMessageSize - DefaultRecordBatch.RECORD_BATCH_OVERHEAD - DefaultRecord.MAX_RECORD_OVERHEAD];
+        try (Producer<byte[], byte[]> producer = clusterInstance.producer(producerConfig(-1))) {
             ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topic10, null, value);
             RecordMetadata recordMetadata = producer.send(producerRecord).get();
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/producer/ProducerFailureHandlingTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/producer/ProducerFailureHandlingTest.java
@@ -276,10 +276,7 @@ public class ProducerFailureHandlingTest {
 
         // create topic
         String topic10 = "topic10";
-        try (Admin admin = clusterInstance.admin()) {
-            admin.createTopics(List.of(new NewTopic(topic10, brokerSize, (short) brokerSize).configs(topicConfig)));
-            clusterInstance.waitForTopic("topic10", brokerSize);
-        }
+        clusterInstance.createTopic(topic10, brokerSize, (short) brokerSize, topicConfig);
 
         // send a record that is too large for replication, but within the broker max message limit
         byte[] value = new byte[maxMessageSize - DefaultRecordBatch.RECORD_BATCH_OVERHEAD - DefaultRecord.MAX_RECORD_OVERHEAD];


### PR DESCRIPTION
from https://github.com/apache/kafka/pull/19319#discussion_r2169555430

This pull request addresses a minor typo in the
ProducerFailureHandlingTest within the Apache Kafka project.
Specifically, it corrects an erroneous method call where waitForDeletion
was used instead of waitForTopic (or createTopic).

Reviewers: PoAn Yang <payang@apache.org>, TaiJuWu <tjwu1217@gmail.com>,
 Jhen-Yung Hsu <jhenyunghsu@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
