### PR TITLE
KAFKA-19443: test-common ClusterInstance should make it easy to have more listeners

### DIFF
--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
@@ -121,8 +121,16 @@ public interface ClusterInstance {
 
     /**
      * The broker connect string which can be used by clients for bootstrapping
+     * using the broker listenerName
      */
     String bootstrapServers();
+
+    /**
+     * The broker connect string which can be used by clients for bootstrapping
+     * using an alternate listener
+     * @throws org.apache.kafka.common.KafkaException if listenerName is not defined
+     */
+    String bootstrapServers(ListenerName listenerName);
 
     /**
      * The broker connect string which can be used by clients for bootstrapping to the controller quorum.

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
@@ -121,14 +121,14 @@ public interface ClusterInstance {
 
     /**
      * The broker connect string which can be used by clients for bootstrapping
-     * using the broker listenerName
+     * using the default broker listenerName
      */
     String bootstrapServers();
 
     /**
      * The broker connect string which can be used by clients for bootstrapping
      * using an alternate listener
-     * @throws org.apache.kafka.common.KafkaException if listenerName is not defined
+     * @throws org.apache.kafka.common.KafkaException if the broker has no listener with this listenerName
      */
     String bootstrapServers(ListenerName listenerName);
 

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
@@ -621,8 +621,8 @@ public class KafkaClusterTestKit implements AutoCloseable {
             int port = broker.boundPort(ListenerName.normalised(listenerName.value()));
             if (port <= 0) {
                 throw new RuntimeException("Broker " + brokerId + " does not yet " +
-                                           "have a bound port for " + listenerName + ".  Did you start " +
-                                           "the cluster yet?");
+                    "have a bound port for " + listenerName + ".  Did you start " +
+                    "the cluster yet?");
             }
             bld.append(prefix).append("localhost:").append(port);
             prefix = ",";

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
@@ -606,20 +606,23 @@ public class KafkaClusterTestKit implements AutoCloseable {
     }
 
     public String bootstrapServers() {
+        return bootstrapServers(nodes.brokerListenerName());
+    }
+
+    public String bootstrapServers(ListenerName listenerName) {
         StringBuilder bld = new StringBuilder();
         String prefix = "";
         for (Entry<Integer, BrokerServer> entry : brokers.entrySet()) {
             int brokerId = entry.getKey();
             BrokerServer broker = entry.getValue();
-            ListenerName listenerName = nodes.brokerListenerName();
             // The KafkaConfig#listeners method normalizes the listener name.
             // The result from TestKitNodes#brokerListenerName method should be normalized as well,
             // so that it matches the listener name in the KafkaConfig.
             int port = broker.boundPort(ListenerName.normalised(listenerName.value()));
             if (port <= 0) {
                 throw new RuntimeException("Broker " + brokerId + " does not yet " +
-                    "have a bound port for " + listenerName + ".  Did you start " +
-                    "the cluster yet?");
+                                           "have a bound port for " + listenerName + ".  Did you start " +
+                                           "the cluster yet?");
             }
             bld.append(prefix).append("localhost:").append(port);
             prefix = ",";

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/RaftClusterInvocationContext.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/RaftClusterInvocationContext.java
@@ -146,6 +146,11 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
         }
 
         @Override
+        public String bootstrapServers(ListenerName listenerName) {
+            return clusterTestKit.bootstrapServers(listenerName);
+        }
+
+        @Override
         public String bootstrapControllers() {
             return clusterTestKit.bootstrapControllers();
         }


### PR DESCRIPTION
KAFKA-19443: test-common ClusterInstance should make it easy to have
more listeners

Add overloaded method  String
ClusterInstance.bootstrapServers(ListenerName listenerName);


