### PR TITLE
MINOR Enable Gradle remote caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           java-version: 23
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.KAFKA_DEVELOCITY_ACCESS_KEY }}
       - name: Compile and validate
         env:
           SCAN_ARG: ${{ inputs.is-public-fork && '--no-scan' || '--scan' }}
@@ -204,7 +204,7 @@ jobs:
           java-version: ${{ matrix.java }}
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.KAFKA_DEVELOCITY_ACCESS_KEY }}
 
       # If the load-catalog job failed, we won't be able to download the artifact. Since we don't want this to fail
       # the overall workflow, so we'll continue here without a test catalog.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Compile and validate
         env:
           SCAN_ARG: ${{ inputs.is-public-fork && '--no-scan' || '--scan' }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.KAFKA_DEVELOCITY_ACCESS_KEY }}
         # Gradle flags
         # --build-cache:  Let Gradle restore the build cache
         # --info:         For now, we'll generate lots of logs while setting up the GH Actions

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -69,7 +69,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           java-version: ${{ matrix.java }}
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.KAFKA_DEVELOCITY_ACCESS_KEY }}
       - name: Download build scan archive
         id: download-build-scan
         uses: actions/download-artifact@v4

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           java-version: ${{ inputs.java-version }}
           gradle-cache-read-only: true
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.KAFKA_DEVELOCITY_ACCESS_KEY }}
 
       - name: Test
         timeout-minutes: 60

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,10 +61,11 @@ buildCache {
     remote(develocity.buildCache) {
         enabled = true
 
-        // Check for the presence of the DEVELOCITY_ACCESS_KEY environment variable as a proxy for whether this is a fork or not.
-        // Forks should not try to push to the remote cache as they will not have permission to do so.
+        // Check for the presence of the DEVELOCITY_ACCESS_KEY environment variable
+        // as a proxy for whether this is a fork or not. Forks should not try to push
+        // to the remote cache as they will not have permission to do so.
         def accessKey = System.getenv('DEVELOCITY_ACCESS_KEY')
-        push = isGithubActions
+        push = isGithubActions && accessKey
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -64,7 +64,7 @@ buildCache {
         // Check for the presence of the DEVELOCITY_ACCESS_KEY environment variable as a proxy for whether this is a fork or not.
         // Forks should not try to push to the remote cache as they will not have permission to do so.
         def accessKey = System.getenv('DEVELOCITY_ACCESS_KEY')
-        push = isGithubActions && accessKey
+        push = isGithubActions
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -59,7 +59,12 @@ buildCache {
     }
 
     remote(develocity.buildCache) {
-        enabled = false
+        enabled = true
+
+        // Check for the presence of the DEVELOCITY_ACCESS_KEY environment variable as a proxy for whether this is a fork or not.
+        // Forks should not try to push to the remote cache as they will not have permission to do so.
+        def accessKey = System.getenv('DEVELOCITY_ACCESS_KEY')
+        push = isGithubActions && accessKey
     }
 }
 


### PR DESCRIPTION
Now that the remote cache is available from
https://develocity.apache.org, let's use it. Courtesy of @clayburn

Only the CI system will be authorized to write to the cache, but anyone
(including un-authenticated users) can read from it.
