### PR TITLE
KAFKA-19451: fix flaky test RemoteIndexCacheTest.testCacheEntryIsDeletedOnRemoval()

### DIFF
--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -331,6 +331,18 @@ public class RemoteIndexCacheTest {
         verify(cacheEntry.offsetIndex()).renameTo(any(File.class));
         verify(cacheEntry.txnIndex()).renameTo(any(File.class));
 
+        // wait until the delete method is invoked
+        TestUtils.waitForCondition(() -> {
+            try {
+                verify(cacheEntry.timeIndex()).deleteIfExists();
+                verify(cacheEntry.offsetIndex()).deleteIfExists();
+                verify(cacheEntry.txnIndex()).deleteIfExists();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }, "Failed to delete index file");
+
         // verify no index files on disk
         assertFalse(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.INDEX_FILE_SUFFIX).isPresent(),
                 "Offset index file should not be present on disk at " + tpDir.toPath());


### PR DESCRIPTION
**Problem Description**
In the `RemoteIndexCache.cleanup()` method, the asynchronous invocation
of `index.deleteIfExists()` may cause a conflict. When the
`getIndexFileFromRemoteCacheDir()` method is executed, it utilizes
`Files.walk()` to traverse all files in the directory path. If
`index.deleteIfExists()` is triggered during this traversal, a
`NoSuchFileException` will be thrown.

**Solution**
To resolve this issue, ensure that `index.deleteIfExists()` has been
fully executed before invoking `getIndexFileFromRemoteCacheDir()`.
