### PR TITLE
MINOR: Cleanups in storage module

### DIFF
--- a/core/src/main/java/kafka/server/share/DelayedShareFetch.java
+++ b/core/src/main/java/kafka/server/share/DelayedShareFetch.java
@@ -512,11 +512,11 @@ public class DelayedShareFetch extends DelayedOperation {
         // extend it to support other FetchIsolation types.
         FetchIsolation isolationType = shareFetch.fetchParams().isolation;
         if (isolationType == FetchIsolation.LOG_END)
-            return offsetSnapshot.logEndOffset;
+            return offsetSnapshot.logEndOffset();
         else if (isolationType == FetchIsolation.HIGH_WATERMARK)
-            return offsetSnapshot.highWatermark;
+            return offsetSnapshot.highWatermark();
         else
-            return offsetSnapshot.lastStableOffset;
+            return offsetSnapshot.lastStableOffset();
 
     }
 
@@ -835,8 +835,8 @@ public class DelayedShareFetch extends DelayedOperation {
             for (RemoteFetch remoteFetch : pendingRemoteFetchesOpt.get().remoteFetches()) {
                 if (remoteFetch.remoteFetchResult().isDone()) {
                     RemoteLogReadResult remoteLogReadResult = remoteFetch.remoteFetchResult().get();
-                    if (remoteLogReadResult.error.isPresent()) {
-                        Throwable error = remoteLogReadResult.error.get();
+                    if (remoteLogReadResult.error().isPresent()) {
+                        Throwable error = remoteLogReadResult.error().get();
                         // If there is any error for the remote fetch topic partition, we populate the error accordingly.
                         shareFetchPartitionData.add(
                             new ShareFetchPartitionData(
@@ -846,7 +846,7 @@ public class DelayedShareFetch extends DelayedOperation {
                             )
                         );
                     } else {
-                        FetchDataInfo info = remoteLogReadResult.fetchDataInfo.get();
+                        FetchDataInfo info = remoteLogReadResult.fetchDataInfo().get();
                         TopicIdPartition topicIdPartition = remoteFetch.topicIdPartition();
                         LogReadResult logReadResult = remoteFetch.logReadResult();
                         shareFetchPartitionData.add(

--- a/server/src/test/java/org/apache/kafka/server/util/SchedulerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/util/SchedulerTest.java
@@ -177,9 +177,9 @@ public class SchedulerTest {
                 leaderEpochCache,
                 producerStateManager,
                 new ConcurrentHashMap<>(), false).load();
-        LocalLog localLog = new LocalLog(logDir, logConfig, segments, offsets.recoveryPoint,
-                offsets.nextOffsetMetadata, scheduler, mockTime, topicPartition, logDirFailureChannel);
-        UnifiedLog log = new UnifiedLog(offsets.logStartOffset,
+        LocalLog localLog = new LocalLog(logDir, logConfig, segments, offsets.recoveryPoint(),
+                offsets.nextOffsetMetadata(), scheduler, mockTime, topicPartition, logDirFailureChannel);
+        UnifiedLog log = new UnifiedLog(offsets.logStartOffset(),
                 localLog,
                 brokerTopicStats,
                 producerIdExpirationCheckIntervalMs,

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerConfig.java
@@ -25,13 +25,4 @@ package org.apache.kafka.server.log.remote.quota;
  */
 public record RLMQuotaManagerConfig(long quotaBytesPerSecond, int numQuotaSamples, int quotaWindowSizeSeconds) {
     public static final int INACTIVE_SENSOR_EXPIRATION_TIME_SECONDS = 3600;
-
-    @Override
-    public String toString() {
-        return "RLMQuotaManagerConfig{" +
-            "quotaBytesPerSecond=" + quotaBytesPerSecond +
-            ", numQuotaSamples=" + numQuotaSamples +
-            ", quotaWindowSizeSeconds=" + quotaWindowSizeSeconds +
-            '}';
-    }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerConfig.java
@@ -16,37 +16,15 @@
  */
 package org.apache.kafka.server.log.remote.quota;
 
-public class RLMQuotaManagerConfig {
+/**
+ * Configuration settings for quota management
+ *
+ * @param quotaBytesPerSecond    The quota in bytes per second
+ * @param numQuotaSamples        The number of samples to retain in memory
+ * @param quotaWindowSizeSeconds The time span of each sample
+ */
+public record RLMQuotaManagerConfig(long quotaBytesPerSecond, int numQuotaSamples, int quotaWindowSizeSeconds) {
     public static final int INACTIVE_SENSOR_EXPIRATION_TIME_SECONDS = 3600;
-
-    private final long quotaBytesPerSecond;
-    private final int numQuotaSamples;
-    private final int quotaWindowSizeSeconds;
-
-    /**
-     * Configuration settings for quota management
-     *
-     * @param quotaBytesPerSecond    The quota in bytes per second
-     * @param numQuotaSamples        The number of samples to retain in memory
-     * @param quotaWindowSizeSeconds The time span of each sample
-     */
-    public RLMQuotaManagerConfig(long quotaBytesPerSecond, int numQuotaSamples, int quotaWindowSizeSeconds) {
-        this.quotaBytesPerSecond = quotaBytesPerSecond;
-        this.numQuotaSamples = numQuotaSamples;
-        this.quotaWindowSizeSeconds = quotaWindowSizeSeconds;
-    }
-
-    public long quotaBytesPerSecond() {
-        return quotaBytesPerSecond;
-    }
-
-    public int numQuotaSamples() {
-        return numQuotaSamples;
-    }
-
-    public int quotaWindowSizeSeconds() {
-        return quotaWindowSizeSeconds;
-    }
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -188,10 +188,11 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup("kafka.log.remote", "RemoteLogManager");
 
     // The endpoint for remote log metadata manager to connect to
-    private Optional<Endpoint> endpoint = Optional.empty();
+    private final Optional<Endpoint> endpoint;
+    private final Timer remoteReadTimer;
+
     private boolean closed = false;
 
-    private final Timer remoteReadTimer;
     private volatile DelayedOperationPurgatory<DelayedRemoteListOffsets> delayedRemoteListOffsetsPurgatory;
 
     /**
@@ -1010,7 +1011,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
             List<EpochEntry> epochEntries = getLeaderEpochEntries(log, segment.baseOffset(), nextSegmentBaseOffset);
             Map<Integer, Long> segmentLeaderEpochs = new HashMap<>(epochEntries.size());
-            epochEntries.forEach(entry -> segmentLeaderEpochs.put(entry.epoch, entry.startOffset));
+            epochEntries.forEach(entry -> segmentLeaderEpochs.put(entry.epoch(), entry.startOffset()));
 
             boolean isTxnIdxEmpty = segment.txnIndex().isEmpty();
             RemoteLogSegmentMetadata copySegmentStartedRlsm = new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), endOffset,
@@ -1071,7 +1072,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
             // `epochEntries` cannot be empty, there is a pre-condition validation in RemoteLogSegmentMetadata
             // constructor
-            int lastEpochInSegment = epochEntries.get(epochEntries.size() - 1).epoch;
+            int lastEpochInSegment = epochEntries.get(epochEntries.size() - 1).epoch();
             copiedOffsetOption = Optional.of(new OffsetAndEpoch(endOffset, lastEpochInSegment));
             // Update the highest offset in remote storage for this partition's log so that the local log segments
             // are not deleted before they are copied to remote storage.
@@ -1206,7 +1207,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                                                                              RemoteLogSegmentMetadata metadata)
                     throws RemoteStorageException, ExecutionException, InterruptedException {
                 boolean isSegmentDeleted = deleteRemoteLogSegment(metadata, 
-                    ignored -> metadata.segmentLeaderEpochs().keySet().stream().allMatch(epoch -> epoch < earliestEpochEntry.epoch));
+                    ignored -> metadata.segmentLeaderEpochs().keySet().stream().allMatch(epoch -> epoch < earliestEpochEntry.epoch()));
                 if (isSegmentDeleted) {
                     logger.info("Deleted remote log segment {} due to leader-epoch-cache truncation. " +
                                     "Current earliest-epoch-entry: {}, segment-end-offset: {} and segment-epochs: {}",
@@ -1375,7 +1376,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             if (earliestEpochEntryOptional.isPresent()) {
                 EpochEntry earliestEpochEntry = earliestEpochEntryOptional.get();
                 Iterator<Integer> epochsToClean = remoteLeaderEpochs.stream()
-                        .filter(remoteEpoch -> remoteEpoch < earliestEpochEntry.epoch)
+                        .filter(remoteEpoch -> remoteEpoch < earliestEpochEntry.epoch())
                         .iterator();
 
                 List<RemoteLogSegmentMetadata> listOfSegmentsToBeCleaned = new ArrayList<>();
@@ -1658,11 +1659,11 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     }
 
     public FetchDataInfo read(RemoteStorageFetchInfo remoteStorageFetchInfo) throws RemoteStorageException, IOException {
-        int fetchMaxBytes = remoteStorageFetchInfo.fetchMaxBytes;
-        TopicPartition tp = remoteStorageFetchInfo.topicIdPartition.topicPartition();
-        FetchRequest.PartitionData fetchInfo = remoteStorageFetchInfo.fetchInfo;
+        int fetchMaxBytes = remoteStorageFetchInfo.fetchMaxBytes();
+        TopicPartition tp = remoteStorageFetchInfo.topicIdPartition().topicPartition();
+        FetchRequest.PartitionData fetchInfo = remoteStorageFetchInfo.fetchInfo();
 
-        boolean includeAbortedTxns = remoteStorageFetchInfo.fetchIsolation == FetchIsolation.TXN_COMMITTED;
+        boolean includeAbortedTxns = remoteStorageFetchInfo.fetchIsolation() == FetchIsolation.TXN_COMMITTED;
 
         long offset = fetchInfo.fetchOffset;
         int maxBytes = Math.min(fetchMaxBytes, fetchInfo.maxBytes);
@@ -1714,14 +1715,14 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             // An empty record is sent instead of an incomplete batch when
             //  - there is no minimum-one-message constraint and
             //  - the first batch size is more than maximum bytes that can be sent and
-            if (!remoteStorageFetchInfo.minOneMessage && firstBatchSize > maxBytes) {
+            if (!remoteStorageFetchInfo.minOneMessage() && firstBatchSize > maxBytes) {
                 LOGGER.debug("Returning empty record for offset {} in partition {} because the first batch size {} " +
                         "is greater than max fetch bytes {}", offset, tp, firstBatchSize, maxBytes);
                 return new FetchDataInfo(new LogOffsetMetadata(offset), MemoryRecords.EMPTY);
             }
 
             int updatedFetchSize =
-                    remoteStorageFetchInfo.minOneMessage && firstBatchSize > maxBytes ? firstBatchSize : maxBytes;
+                    remoteStorageFetchInfo.minOneMessage() && firstBatchSize > maxBytes ? firstBatchSize : maxBytes;
 
             ByteBuffer buffer = ByteBuffer.allocate(updatedFetchSize);
             int remainingBytes = updatedFetchSize;
@@ -1770,7 +1771,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
         OffsetIndex offsetIndex = indexCache.getIndexEntry(segmentMetadata).offsetIndex();
         long upperBoundOffset = offsetIndex.fetchUpperBoundOffset(startOffsetPosition, fetchSize)
-                .map(position -> position.offset).orElse(segmentMetadata.endOffset() + 1);
+                .map(OffsetPosition::offset).orElse(segmentMetadata.endOffset() + 1);
 
         final Set<FetchResponseData.AbortedTransaction> abortedTransactions = new HashSet<>();
 
@@ -1815,8 +1816,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             if (txnIndexOpt.isPresent()) {
                 TransactionIndex txnIndex = txnIndexOpt.get();
                 TxnIndexSearchResult searchResult = txnIndex.collectAbortedTxns(startOffset, upperBoundOffset);
-                accumulator.accept(searchResult.abortedTransactions);
-                isSearchComplete = searchResult.isComplete;
+                accumulator.accept(searchResult.abortedTransactions());
+                isSearchComplete = searchResult.isComplete();
             }
             if (!isSearchComplete) {
                 currentMetadataOpt = findNextSegmentWithTxnIndex(tp, currentMetadata.endOffset() + 1, leaderEpochCache);
@@ -1844,8 +1845,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             TransactionIndex txnIndex = localLogSegments.next().txnIndex();
             if (txnIndex != null) {
                 TxnIndexSearchResult searchResult = txnIndex.collectAbortedTxns(startOffset, upperBoundOffset);
-                accumulator.accept(searchResult.abortedTransactions);
-                if (searchResult.isComplete) {
+                accumulator.accept(searchResult.abortedTransactions());
+                if (searchResult.isComplete()) {
                     return;
                 }
             }
@@ -1886,9 +1887,9 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         }
         int initialEpoch = initialEpochOpt.getAsInt();
         for (EpochEntry epochEntry : leaderEpochCache.epochEntries()) {
-            if (epochEntry.epoch >= initialEpoch) {
-                long startOffset = Math.max(epochEntry.startOffset, offset);
-                Optional<RemoteLogSegmentMetadata> metadataOpt = fetchNextSegmentWithTxnIndex(tp, epochEntry.epoch, startOffset);
+            if (epochEntry.epoch() >= initialEpoch) {
+                long startOffset = Math.max(epochEntry.startOffset(), offset);
+                Optional<RemoteLogSegmentMetadata> metadataOpt = fetchNextSegmentWithTxnIndex(tp, epochEntry.epoch(), startOffset);
                 if (metadataOpt.isPresent()) {
                     return metadataOpt;
                 }
@@ -1917,7 +1918,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         LeaderEpochFileCache leaderEpochCache = log.leaderEpochCache();
         Optional<EpochEntry> maybeEpochEntry = leaderEpochCache.latestEntry();
         while (offsetAndEpoch == null && maybeEpochEntry.isPresent()) {
-            int epoch = maybeEpochEntry.get().epoch;
+            int epoch = maybeEpochEntry.get().epoch();
             Optional<Long> highestRemoteOffsetOpt =
                     remoteLogMetadataManagerPlugin.get().highestOffsetForEpoch(topicIdPartition, epoch);
             if (highestRemoteOffsetOpt.isPresent()) {
@@ -1946,7 +1947,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         Optional<Long> logStartOffset = Optional.empty();
         LeaderEpochFileCache leaderEpochCache = log.leaderEpochCache();
         OptionalInt earliestEpochOpt = leaderEpochCache.earliestEntry()
-                .map(epochEntry -> OptionalInt.of(epochEntry.epoch))
+                .map(epochEntry -> OptionalInt.of(epochEntry.epoch()))
                 .orElseGet(OptionalInt::empty);
         while (logStartOffset.isEmpty() && earliestEpochOpt.isPresent()) {
             Iterator<RemoteLogSegmentMetadata> iterator =

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogReader.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogReader.java
@@ -51,7 +51,7 @@ public class RemoteLogReader implements Callable<Void> {
         this.rlm = rlm;
         this.brokerTopicStats = brokerTopicStats;
         this.callback = callback;
-        this.brokerTopicStats.topicStats(fetchInfo.topicIdPartition.topic()).remoteFetchRequestRate().mark();
+        this.brokerTopicStats.topicStats(fetchInfo.topicIdPartition().topic()).remoteFetchRequestRate().mark();
         this.brokerTopicStats.allTopicsStats().remoteFetchRequestRate().mark();
         this.quotaManager = quotaManager;
         this.remoteReadTimer = remoteReadTimer;
@@ -61,21 +61,21 @@ public class RemoteLogReader implements Callable<Void> {
     public Void call() {
         RemoteLogReadResult result;
         try {
-            LOGGER.debug("Reading records from remote storage for topic partition {}", fetchInfo.topicIdPartition);
+            LOGGER.debug("Reading records from remote storage for topic partition {}", fetchInfo.topicIdPartition());
             FetchDataInfo fetchDataInfo = remoteReadTimer.time(() -> rlm.read(fetchInfo));
-            brokerTopicStats.topicStats(fetchInfo.topicIdPartition.topic()).remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
+            brokerTopicStats.topicStats(fetchInfo.topicIdPartition().topic()).remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
             brokerTopicStats.allTopicsStats().remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
             result = new RemoteLogReadResult(Optional.of(fetchDataInfo), Optional.empty());
         } catch (OffsetOutOfRangeException e) {
             result = new RemoteLogReadResult(Optional.empty(), Optional.of(e));
         } catch (Exception e) {
-            brokerTopicStats.topicStats(fetchInfo.topicIdPartition.topic()).failedRemoteFetchRequestRate().mark();
+            brokerTopicStats.topicStats(fetchInfo.topicIdPartition().topic()).failedRemoteFetchRequestRate().mark();
             brokerTopicStats.allTopicsStats().failedRemoteFetchRequestRate().mark();
-            LOGGER.error("Error occurred while reading the remote data for {}", fetchInfo.topicIdPartition, e);
+            LOGGER.error("Error occurred while reading the remote data for {}", fetchInfo.topicIdPartition(), e);
             result = new RemoteLogReadResult(Optional.empty(), Optional.of(e));
         }
-        LOGGER.debug("Finished reading records from remote storage for topic partition {}", fetchInfo.topicIdPartition);
-        quotaManager.record(result.fetchDataInfo.map(fetchDataInfo -> fetchDataInfo.records.sizeInBytes()).orElse(0));
+        LOGGER.debug("Finished reading records from remote storage for topic partition {}", fetchInfo.topicIdPartition());
+        quotaManager.record(result.fetchDataInfo().map(fetchDataInfo -> fetchDataInfo.records.sizeInBytes()).orElse(0));
         callback.accept(result);
         return null;
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandler.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandler.java
@@ -94,7 +94,7 @@ public class CleanShutdownFileHandler {
             Content content = Json.parseStringAs(text, Content.class);
             return OptionalLong.of(content.brokerEpoch);
         } catch (Exception e) {
-            logger.debug("Fail to read the clean shutdown file in {}:{}", cleanShutdownFile.toPath(), e);
+            logger.debug("Fail to read the clean shutdown file in {}", cleanShutdownFile.toPath(), e);
             return OptionalLong.empty();
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandler.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandler.java
@@ -94,7 +94,7 @@ public class CleanShutdownFileHandler {
             Content content = Json.parseStringAs(text, Content.class);
             return OptionalLong.of(content.brokerEpoch);
         } catch (Exception e) {
-            logger.debug("Fail to read the clean shutdown file in " + cleanShutdownFile.toPath() + ":" + e);
+            logger.debug("Fail to read the clean shutdown file in {}:{}", cleanShutdownFile.toPath(), e);
             return OptionalLong.empty();
         }
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/LeaderEpochCheckpointFile.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/LeaderEpochCheckpointFile.java
@@ -74,7 +74,7 @@ public class LeaderEpochCheckpointFile {
     private static class Formatter implements EntryFormatter<EpochEntry> {
 
         public String toString(EpochEntry entry) {
-            return entry.epoch + " " + entry.startOffset;
+            return entry.epoch() + " " + entry.startOffset();
         }
 
         public Optional<EpochEntry> fromString(String line) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/OffsetCheckpointFile.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/OffsetCheckpointFile.java
@@ -92,15 +92,7 @@ public class OffsetCheckpointFile {
         }
     }
 
-    static class TopicPartitionOffset {
-
-        final TopicPartition tp;
-        final long offset;
-
-        TopicPartitionOffset(TopicPartition tp, long offset) {
-            this.tp = tp;
-            this.offset = offset;
-        }
+    record TopicPartitionOffset(TopicPartition tp, long offset) {
     }
 
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadata.java
@@ -19,22 +19,7 @@ package org.apache.kafka.storage.internals.checkpoint;
 
 import org.apache.kafka.common.Uuid;
 
-public class PartitionMetadata {
-    private final int version;
-    private final Uuid topicId;
-
-    public PartitionMetadata(int version, Uuid topicId) {
-        this.version = version;
-        this.topicId = topicId;
-    }
-
-    public int version() {
-        return version;
-    }
-
-    public Uuid topicId() {
-        return topicId;
-    }
+public record PartitionMetadata(int version, Uuid topicId) {
 
     public String encode() {
         return "version: " + version + "\ntopic_id: " + topicId;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbortedTxn.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbortedTxn.java
@@ -44,7 +44,7 @@ public class AbortedTxn {
     }
 
     public AbortedTxn(CompletedTxn completedTxn, long lastStableOffset) {
-        this(completedTxn.producerId, completedTxn.firstOffset, completedTxn.lastOffset, lastStableOffset);
+        this(completedTxn.producerId(), completedTxn.firstOffset(), completedTxn.lastOffset(), lastStableOffset);
     }
 
     public AbortedTxn(long producerId, long firstOffset, long lastOffset, long lastStableOffset) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -503,12 +503,10 @@ public abstract class AbstractIndex implements Closeable {
 
         // check if the target offset is smaller than the least offset
         if (compareIndexEntry(parseEntry(idx, 0), target, searchEntity) > 0) {
-            switch (searchResultType) {
-                case LARGEST_LOWER_BOUND:
-                    return -1;
-                case SMALLEST_UPPER_BOUND:
-                    return 0;
-            }
+            return switch (searchResultType) {
+                case LARGEST_LOWER_BOUND -> -1;
+                case SMALLEST_UPPER_BOUND -> 0;
+            };
         }
 
         return binarySearch(idx, target, searchEntity, searchResultType, 0, firstHotEntry);
@@ -544,18 +542,10 @@ public abstract class AbstractIndex implements Closeable {
     }
 
     private int compareIndexEntry(IndexEntry indexEntry, long target, IndexSearchType searchEntity) {
-        int result;
-        switch (searchEntity) {
-            case KEY:
-                result = Long.compare(indexEntry.indexKey(), target);
-                break;
-            case VALUE:
-                result = Long.compare(indexEntry.indexValue(), target);
-                break;
-            default:
-                throw new IllegalStateException("Unexpected IndexSearchType: " + searchEntity);
-        }
-        return result;
+        return switch (searchEntity) {
+            case KEY -> Long.compare(indexEntry.indexKey(), target);
+            case VALUE -> Long.compare(indexEntry.indexValue(), target);
+        };
     }
 
     private OptionalInt toRelative(long offset) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/BatchMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/BatchMetadata.java
@@ -18,23 +18,7 @@ package org.apache.kafka.storage.internals.log;
 
 import org.apache.kafka.common.record.DefaultRecordBatch;
 
-public class BatchMetadata {
-
-    public final int lastSeq;
-    public final long lastOffset;
-    public final int offsetDelta;
-    public final long timestamp;
-
-    public BatchMetadata(
-            int lastSeq,
-            long lastOffset,
-            int offsetDelta,
-            long timestamp) {
-        this.lastSeq = lastSeq;
-        this.lastOffset = lastOffset;
-        this.offsetDelta = offsetDelta;
-        this.timestamp = timestamp;
-    }
+public record BatchMetadata(int lastSeq, long lastOffset, int offsetDelta, long timestamp) {
 
     public int firstSeq() {
         return DefaultRecordBatch.decrementSequence(lastSeq, offsetDelta);
@@ -42,28 +26,6 @@ public class BatchMetadata {
 
     public long firstOffset() {
         return lastOffset - offsetDelta;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        BatchMetadata that = (BatchMetadata) o;
-
-        return lastSeq == that.lastSeq &&
-                lastOffset == that.lastOffset &&
-                offsetDelta == that.offsetDelta &&
-                timestamp == that.timestamp;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = lastSeq;
-        result = 31 * result + Long.hashCode(lastOffset);
-        result = 31 * result + offsetDelta;
-        result = 31 * result + Long.hashCode(timestamp);
-        return result;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/Cleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/Cleaner.java
@@ -338,10 +338,10 @@ public class Cleaner {
                 //    last producer epoch, which is needed to ensure fencing.
                 boolean isBatchLastRecordOfProducer = Optional.ofNullable(lastRecordsOfActiveProducers.get(batch.producerId()))
                         .map(lastRecord -> {
-                            if (lastRecord.lastDataOffset.isPresent()) {
-                                return batch.lastOffset() == lastRecord.lastDataOffset.getAsLong();
+                            if (lastRecord.lastDataOffset().isPresent()) {
+                                return batch.lastOffset() == lastRecord.lastDataOffset().getAsLong();
                             } else {
-                                return batch.isControlBatch() && batch.producerEpoch() == lastRecord.producerEpoch;
+                                return batch.isControlBatch() && batch.producerEpoch() == lastRecord.producerEpoch();
                             }
                         })
                         .orElse(false);
@@ -702,7 +702,7 @@ public class Cleaner {
                                              int maxLogMessageSize,
                                              CleanedTransactionMetadata transactionMetadata,
                                              CleanerStats stats) throws IOException, DigestException {
-        int position = segment.offsetIndex().lookup(startOffset).position;
+        int position = segment.offsetIndex().lookup(startOffset).position();
         int maxDesiredMapSize = (int) (map.slots() * dupBufferLoadFactor);
 
         while (position < segment.log().sizeInBytes()) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/CompletedTxn.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/CompletedTxn.java
@@ -27,13 +27,4 @@ package org.apache.kafka.storage.internals.log;
  * @param isAborted   Whether the transaction was aborted
  */
 public record CompletedTxn(long producerId, long firstOffset, long lastOffset, boolean isAborted) {
-
-    @Override
-    public String toString() {
-        return "CompletedTxn(producerId=" + producerId +
-            ", firstOffset=" + firstOffset +
-            ", lastOffset=" + lastOffset +
-            ", isAborted=" + isAborted +
-            ')';
-    }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/CompletedTxn.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/CompletedTxn.java
@@ -19,50 +19,14 @@ package org.apache.kafka.storage.internals.log;
 /**
  * A class used to hold useful metadata about a completed transaction. This is used to build
  * the transaction index after appending to the log.
+ *
+ * @param producerId  The ID of the producer
+ * @param firstOffset The first offset (inclusive) of the transaction
+ * @param lastOffset  The last offset (inclusive) of the transaction. This is always the offset of the
+ *                    COMMIT/ABORT control record which indicates the transaction's completion.
+ * @param isAborted   Whether the transaction was aborted
  */
-public class CompletedTxn {
-    public final long producerId;
-    public final long firstOffset;
-    public final long lastOffset;
-    public final boolean isAborted;
-
-    /**
-     * Create an instance of this class.
-     *
-     * @param producerId  The ID of the producer
-     * @param firstOffset The first offset (inclusive) of the transaction
-     * @param lastOffset  The last offset (inclusive) of the transaction. This is always the offset of the
-     *                    COMMIT/ABORT control record which indicates the transaction's completion.
-     * @param isAborted   Whether the transaction was aborted
-     */
-    public CompletedTxn(long producerId, long firstOffset, long lastOffset, boolean isAborted) {
-        this.producerId = producerId;
-        this.firstOffset = firstOffset;
-        this.lastOffset = lastOffset;
-        this.isAborted = isAborted;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        CompletedTxn that = (CompletedTxn) o;
-
-        return producerId == that.producerId
-            && firstOffset == that.firstOffset
-            && lastOffset == that.lastOffset
-            && isAborted == that.isAborted;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Long.hashCode(producerId);
-        result = 31 * result + Long.hashCode(firstOffset);
-        result = 31 * result + Long.hashCode(lastOffset);
-        result = 31 * result + Boolean.hashCode(isAborted);
-        return result;
-    }
+public record CompletedTxn(long producerId, long firstOffset, long lastOffset, boolean isAborted) {
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/EpochEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/EpochEntry.java
@@ -17,29 +17,7 @@
 package org.apache.kafka.storage.internals.log;
 
 // Mapping of epoch to the first offset of the subsequent epoch
-public class EpochEntry {
-    public final int epoch;
-    public final long startOffset;
-
-    public EpochEntry(int epoch, long startOffset) {
-        this.epoch = epoch;
-        this.startOffset = startOffset;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        EpochEntry that = (EpochEntry) o;
-        return epoch == that.epoch && startOffset == that.startOffset;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = epoch;
-        result = 31 * result + Long.hashCode(startOffset);
-        return result;
-    }
+public record EpochEntry(int epoch, long startOffset) {
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LastRecord.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LastRecord.java
@@ -29,22 +29,6 @@ public record LastRecord(OptionalLong lastDataOffset, short producerEpoch) {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        LastRecord that = (LastRecord) o;
-
-        return producerEpoch == that.producerEpoch &&
-                lastDataOffset.equals(that.lastDataOffset);
-    }
-
-    @Override
-    public int hashCode() {
-        return 31 * lastDataOffset.hashCode() + producerEpoch;
-    }
-
-    @Override
     public String toString() {
         return "LastRecord(" +
                 "lastDataOffset=" + lastDataOffset +

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LastRecord.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LastRecord.java
@@ -23,14 +23,9 @@ import java.util.OptionalLong;
  * The last written record for a given producer. The last data offset may be undefined
  * if the only log entry for a producer is a transaction marker.
  */
-public final class LastRecord {
-    public final OptionalLong lastDataOffset;
-    public final short producerEpoch;
-
-    public LastRecord(OptionalLong lastDataOffset, short producerEpoch) {
+public record LastRecord(OptionalLong lastDataOffset, short producerEpoch) {
+    public LastRecord {
         Objects.requireNonNull(lastDataOffset, "lastDataOffset must be non null");
-        this.lastDataOffset = lastDataOffset;
-        this.producerEpoch = producerEpoch;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
@@ -100,13 +100,7 @@ public class LazyIndex<T extends AbstractIndex> implements Closeable {
 
     }
 
-    private static class IndexValue<T extends AbstractIndex> implements IndexWrapper {
-
-        private final T index;
-
-        IndexValue(T index) {
-            this.index = index;
-        }
+    private record IndexValue<T extends AbstractIndex>(T index) implements IndexWrapper {
 
         @Override
         public File file() {
@@ -235,14 +229,10 @@ public class LazyIndex<T extends AbstractIndex> implements Closeable {
 
     @SuppressWarnings("unchecked")
     private T loadIndex(File file) throws IOException {
-        switch (indexType) {
-            case OFFSET:
-                return (T) new OffsetIndex(file, baseOffset, maxIndexSize, true);
-            case TIME:
-                return (T) new TimeIndex(file, baseOffset, maxIndexSize, true);
-            default:
-                throw new IllegalStateException("Unexpected indexType " + indexType);
-        }
+        return switch (indexType) {
+            case OFFSET -> (T) new OffsetIndex(file, baseOffset, maxIndexSize, true);
+            case TIME -> (T) new TimeIndex(file, baseOffset, maxIndexSize, true);
+        };
     }
 
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
@@ -100,7 +100,13 @@ public class LazyIndex<T extends AbstractIndex> implements Closeable {
 
     }
 
-    private record IndexValue<T extends AbstractIndex>(T index) implements IndexWrapper {
+    private static class IndexValue<T extends AbstractIndex> implements IndexWrapper {
+
+        private final T index;
+
+        IndexValue(T index) {
+            this.index = index;
+        }
 
         @Override
         public File file() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LoadedLogOffsets.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LoadedLogOffsets.java
@@ -18,11 +18,7 @@ package org.apache.kafka.storage.internals.log;
 
 import java.util.Objects;
 
-public class LoadedLogOffsets {
-    public final long logStartOffset;
-    public final long recoveryPoint;
-    public final LogOffsetMetadata nextOffsetMetadata;
-
+public record LoadedLogOffsets(long logStartOffset, long recoveryPoint, LogOffsetMetadata nextOffsetMetadata) {
     public LoadedLogOffsets(final long logStartOffset,
                             final long recoveryPoint,
                             final LogOffsetMetadata nextOffsetMetadata) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LoadedLogOffsets.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LoadedLogOffsets.java
@@ -28,29 +28,6 @@ public record LoadedLogOffsets(long logStartOffset, long recoveryPoint, LogOffse
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final LoadedLogOffsets that = (LoadedLogOffsets) o;
-        return logStartOffset == that.logStartOffset
-                && recoveryPoint == that.recoveryPoint
-                && nextOffsetMetadata.equals(that.nextOffsetMetadata);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Long.hashCode(logStartOffset);
-        result = 31 * result + Long.hashCode(recoveryPoint);
-        result = 31 * result + nextOffsetMetadata.hashCode();
-        return result;
-    }
-
-    @Override
     public String toString() {
         return "LoadedLogOffsets(" +
                 "logStartOffset=" + logStartOffset +

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LocalLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LocalLog.java
@@ -752,7 +752,7 @@ public class LocalLog {
             throw new KafkaException("dir should not be null");
         }
         String dirName = dir.getName();
-        if (dirName.isEmpty() || !dirName.contains("-")) {
+        if (!dirName.contains("-")) {
             throw exception(dir);
         }
         if (dirName.endsWith(DELETE_DIR_SUFFIX) && !DELETE_DIR_PATTERN.matcher(dirName).matches() ||

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LocalLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LocalLog.java
@@ -557,8 +557,8 @@ public class LocalLog {
         while (segmentEntryOpt.isPresent()) {
             LogSegment segment = segmentEntryOpt.get();
             TxnIndexSearchResult searchResult = segment.collectAbortedTxns(startOffset, upperBoundOffset);
-            accumulator.accept(searchResult.abortedTransactions);
-            if (searchResult.isComplete) return;
+            accumulator.accept(searchResult.abortedTransactions());
+            if (searchResult.isComplete()) return;
             segmentEntryOpt = nextItem(higherSegments);
         }
     }
@@ -1055,20 +1055,12 @@ public class LocalLog {
         return deletedNotReplaced;
     }
 
-    public static class SplitSegmentResult {
-
-        public final List<LogSegment> deletedSegments;
-        public final List<LogSegment> newSegments;
-
-        /**
-         * Holds the result of splitting a segment into one or more segments, see LocalLog.splitOverflowedSegment().
-         *
-         * @param deletedSegments segments deleted when splitting a segment
-         * @param newSegments new segments created when splitting a segment
-         */
-        public SplitSegmentResult(List<LogSegment> deletedSegments, List<LogSegment> newSegments) {
-            this.deletedSegments = deletedSegments;
-            this.newSegments = newSegments;
-        }
+    /**
+     * Holds the result of splitting a segment into one or more segments, see LocalLog.splitOverflowedSegment().
+     *
+     * @param deletedSegments segments deleted when splitting a segment
+     * @param newSegments     new segments created when splitting a segment
+     */
+    public record SplitSegmentResult(List<LogSegment> deletedSegments, List<LogSegment> newSegments) {
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -339,28 +339,20 @@ public class LogConfig extends AbstractConfig {
     }
 
     private Optional<Compression> getCompression() {
-        switch (compressionType) {
-            case GZIP:
-                return Optional.of(Compression.gzip()
-                        .level(getInt(TopicConfig.COMPRESSION_GZIP_LEVEL_CONFIG))
-                        .build());
-            case LZ4:
-                return Optional.of(Compression.lz4()
-                        .level(getInt(TopicConfig.COMPRESSION_LZ4_LEVEL_CONFIG))
-                        .build());
-            case ZSTD:
-                return Optional.of(Compression.zstd()
-                        .level(getInt(TopicConfig.COMPRESSION_ZSTD_LEVEL_CONFIG))
-                        .build());
-            case SNAPPY:
-                return Optional.of(Compression.snappy().build());
-            case UNCOMPRESSED:
-                return Optional.of(Compression.NONE);
-            case PRODUCER:
-                return Optional.empty();
-            default:
-                throw new IllegalArgumentException("Invalid value for " + TopicConfig.COMPRESSION_TYPE_CONFIG);
-        }
+        return switch (compressionType) {
+            case GZIP -> Optional.of(Compression.gzip()
+                    .level(getInt(TopicConfig.COMPRESSION_GZIP_LEVEL_CONFIG))
+                    .build());
+            case LZ4 -> Optional.of(Compression.lz4()
+                    .level(getInt(TopicConfig.COMPRESSION_LZ4_LEVEL_CONFIG))
+                    .build());
+            case ZSTD -> Optional.of(Compression.zstd()
+                    .level(getInt(TopicConfig.COMPRESSION_ZSTD_LEVEL_CONFIG))
+                    .build());
+            case SNAPPY -> Optional.of(Compression.snappy().build());
+            case UNCOMPRESSED -> Optional.of(Compression.NONE);
+            case PRODUCER -> Optional.empty();
+        };
     }
 
     public int segmentSize() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogLoader.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogLoader.java
@@ -338,7 +338,7 @@ public class LogLoader {
                         scheduler,
                         logDirFailureChannel,
                         logPrefix);
-                deleteProducerSnapshotsAsync(result.deletedSegments);
+                deleteProducerSnapshotsAsync(result.deletedSegments());
             }
         }
     }
@@ -438,15 +438,7 @@ public class LogLoader {
         return Optional.empty();
     }
 
-    static class RecoveryOffsets {
-
-        final long newRecoveryPoint;
-        final long nextOffset;
-
-        RecoveryOffsets(long newRecoveryPoint, long nextOffset) {
-            this.newRecoveryPoint = newRecoveryPoint;
-            this.nextOffset = nextOffset;
-        }
+    record RecoveryOffsets(long newRecoveryPoint, long nextOffset) {
     }
 
     /**

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetSnapshot.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetSnapshot.java
@@ -16,52 +16,13 @@
  */
 package org.apache.kafka.storage.internals.log;
 
-import java.util.Objects;
-
 /**
  * Container class which represents a snapshot of the significant offsets for a partition. This allows fetching
  * of these offsets atomically without the possibility of a leader change affecting their consistency relative
  * to each other. See {@link UnifiedLog#fetchOffsetSnapshot()}.
  */
-public class LogOffsetSnapshot {
-
-    public final long logStartOffset;
-    public final LogOffsetMetadata logEndOffset;
-    public final LogOffsetMetadata highWatermark;
-    public final LogOffsetMetadata lastStableOffset;
-
-    public LogOffsetSnapshot(long logStartOffset,
-                             LogOffsetMetadata logEndOffset,
-                             LogOffsetMetadata highWatermark,
-                             LogOffsetMetadata lastStableOffset) {
-
-        this.logStartOffset = logStartOffset;
-        this.logEndOffset = logEndOffset;
-        this.highWatermark = highWatermark;
-        this.lastStableOffset = lastStableOffset;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        LogOffsetSnapshot that = (LogOffsetSnapshot) o;
-
-        return logStartOffset == that.logStartOffset &&
-                Objects.equals(logEndOffset, that.logEndOffset) &&
-                Objects.equals(highWatermark, that.highWatermark) &&
-                Objects.equals(lastStableOffset, that.lastStableOffset);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = (int) (logStartOffset ^ (logStartOffset >>> 32));
-        result = 31 * result + (logEndOffset != null ? logEndOffset.hashCode() : 0);
-        result = 31 * result + (highWatermark != null ? highWatermark.hashCode() : 0);
-        result = 31 * result + (lastStableOffset != null ? lastStableOffset.hashCode() : 0);
-        return result;
-    }
+public record LogOffsetSnapshot(long logStartOffset, LogOffsetMetadata logEndOffset, LogOffsetMetadata highWatermark,
+                                LogOffsetMetadata lastStableOffset) {
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogReadInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogReadInfo.java
@@ -23,28 +23,8 @@ import java.util.Optional;
 /**
  * Structure used for lower level reads using {@link kafka.cluster.Partition#fetchRecords()}.
  */
-public class LogReadInfo {
-
-    public final FetchDataInfo fetchedData;
-    public final Optional<FetchResponseData.EpochEndOffset> divergingEpoch;
-    public final long highWatermark;
-    public final long logStartOffset;
-    public final long logEndOffset;
-    public final long lastStableOffset;
-
-    public LogReadInfo(FetchDataInfo fetchedData,
-                       Optional<FetchResponseData.EpochEndOffset> divergingEpoch,
-                       long highWatermark,
-                       long logStartOffset,
-                       long logEndOffset,
-                       long lastStableOffset) {
-        this.fetchedData = fetchedData;
-        this.divergingEpoch = divergingEpoch;
-        this.highWatermark = highWatermark;
-        this.logStartOffset = logStartOffset;
-        this.logEndOffset = logEndOffset;
-        this.lastStableOffset = lastStableOffset;
-    }
+public record LogReadInfo(FetchDataInfo fetchedData, Optional<FetchResponseData.EpochEndOffset> divergingEpoch,
+                          long highWatermark, long logStartOffset, long logEndOffset, long lastStableOffset) {
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -165,11 +165,11 @@ public class LogSegment implements Closeable {
     }
 
     public boolean shouldRoll(RollParams rollParams) throws IOException {
-        boolean reachedRollMs = timeWaitedForRoll(rollParams.now, rollParams.maxTimestampInMessages) > rollParams.maxSegmentMs - rollJitterMs;
+        boolean reachedRollMs = timeWaitedForRoll(rollParams.now(), rollParams.maxTimestampInMessages()) > rollParams.maxSegmentMs() - rollJitterMs;
         int size = size();
-        return size > rollParams.maxSegmentBytes - rollParams.messagesSize ||
+        return size > rollParams.maxSegmentBytes() - rollParams.messagesSize() ||
             (size > 0 && reachedRollMs) ||
-            offsetIndex().isFull() || timeIndex().isFull() || !canConvertToRelativeOffset(rollParams.maxOffsetInMessages);
+            offsetIndex().isFull() || timeIndex().isFull() || !canConvertToRelativeOffset(rollParams.maxOffsetInMessages());
     }
 
     public void resizeIndexes(int size) throws IOException {
@@ -215,14 +215,14 @@ public class LogSegment implements Closeable {
      * Note that this may result in time index materialization.
      */
     public long maxTimestampSoFar() throws IOException {
-        return readMaxTimestampAndOffsetSoFar().timestamp;
+        return readMaxTimestampAndOffsetSoFar().timestamp();
     }
 
     /**
      * Note that this may result in time index materialization.
      */
     private long shallowOffsetOfMaxTimestampSoFar() throws IOException {
-        return readMaxTimestampAndOffsetSoFar().offset;
+        return readMaxTimestampAndOffsetSoFar().offset();
     }
 
     /* Return the size in bytes of this log segment */
@@ -346,7 +346,7 @@ public class LogSegment implements Closeable {
 
     /* not thread safe */
     public void updateTxnIndex(CompletedTxn completedTxn, long lastStableOffset) throws IOException {
-        if (completedTxn.isAborted) {
+        if (completedTxn.isAborted()) {
             LOGGER.trace("Writing aborted transaction {} to transaction index, last stable offset is {}", completedTxn, lastStableOffset);
             txnIndex.append(new AbortedTxn(completedTxn, lastStableOffset));
         }
@@ -393,7 +393,7 @@ public class LogSegment implements Closeable {
      */
     LogOffsetPosition translateOffset(long offset, int startingFilePosition) throws IOException {
         OffsetPosition mapping = offsetIndex().lookup(offset);
-        return log.searchForOffsetFromPosition(offset, Math.max(mapping.position, startingFilePosition));
+        return log.searchForOffsetFromPosition(offset, Math.max(mapping.position(), startingFilePosition));
     }
 
     /**
@@ -460,7 +460,7 @@ public class LogSegment implements Closeable {
 
     public OptionalLong fetchUpperBoundOffset(OffsetPosition startOffsetPosition, int fetchSize) throws IOException {
         return offsetIndex().fetchUpperBoundOffset(startOffsetPosition, fetchSize)
-                .map(offsetPosition -> OptionalLong.of(offsetPosition.offset)).orElseGet(OptionalLong::empty);
+                .map(offsetPosition -> OptionalLong.of(offsetPosition.offset())).orElseGet(OptionalLong::empty);
     }
 
     /**
@@ -541,7 +541,7 @@ public class LogSegment implements Closeable {
         return "LogSegment(baseOffset=" + baseOffset +
             ", size=" + size() +
             ", lastModifiedTime=" + lastModified() +
-            ", largestRecordTimestamp=" + maxTimestampAndOffsetSoFar.timestamp +
+            ", largestRecordTimestamp=" + maxTimestampAndOffsetSoFar.timestamp() +
             ")";
     }
 
@@ -590,11 +590,11 @@ public class LogSegment implements Closeable {
     private TimestampOffset readLargestTimestamp() throws IOException {
         // Get the last time index entry. If the time index is empty, it will return (-1, baseOffset)
         TimestampOffset lastTimeIndexEntry = timeIndex().lastEntry();
-        OffsetPosition offsetPosition = offsetIndex().lookup(lastTimeIndexEntry.offset);
+        OffsetPosition offsetPosition = offsetIndex().lookup(lastTimeIndexEntry.offset());
 
         // Scan the rest of the messages to see if there is a larger timestamp after the last time index entry.
-        FileRecords.TimestampAndOffset maxTimestampOffsetAfterLastEntry = log.largestTimestampAfter(offsetPosition.position);
-        if (maxTimestampOffsetAfterLastEntry.timestamp > lastTimeIndexEntry.timestamp)
+        FileRecords.TimestampAndOffset maxTimestampOffsetAfterLastEntry = log.largestTimestampAfter(offsetPosition.position());
+        if (maxTimestampOffsetAfterLastEntry.timestamp > lastTimeIndexEntry.timestamp())
             return new TimestampOffset(maxTimestampOffsetAfterLastEntry.timestamp, maxTimestampOffsetAfterLastEntry.offset);
 
         return lastTimeIndexEntry;
@@ -612,7 +612,7 @@ public class LogSegment implements Closeable {
             return baseOffset;
         else
             return fetchData.records.lastBatch()
-                .map(batch -> batch.nextOffset())
+                .map(RecordBatch::nextOffset)
                 .orElse(baseOffset);
     }
 
@@ -750,7 +750,7 @@ public class LogSegment implements Closeable {
     public Optional<FileRecords.TimestampAndOffset> findOffsetByTimestamp(long timestampMs, long startingOffset) throws IOException {
         // Get the index entry with a timestamp less than or equal to the target timestamp
         TimestampOffset timestampOffset = timeIndex().lookup(timestampMs);
-        int position = offsetIndex().lookup(Math.max(timestampOffset.offset, startingOffset)).position;
+        int position = offsetIndex().lookup(Math.max(timestampOffset.offset(), startingOffset)).position();
 
         // Search the timestamp
         return Optional.ofNullable(log.searchForTimestamp(timestampMs, position, startingOffset));
@@ -770,9 +770,9 @@ public class LogSegment implements Closeable {
      * Close file handlers used by the log segment but don't write to disk. This is used when the disk may have failed
      */
     void closeHandlers() {
-        Utils.swallow(LOGGER, Level.WARN, "offsetIndex", () -> lazyOffsetIndex.closeHandler());
-        Utils.swallow(LOGGER, Level.WARN, "timeIndex", () -> lazyTimeIndex.closeHandler());
-        Utils.swallow(LOGGER, Level.WARN, "log", () -> log.closeHandlers());
+        Utils.swallow(LOGGER, Level.WARN, "offsetIndex", lazyOffsetIndex::closeHandler);
+        Utils.swallow(LOGGER, Level.WARN, "timeIndex", lazyTimeIndex::closeHandler);
+        Utils.swallow(LOGGER, Level.WARN, "log", log::closeHandlers);
         Utils.closeQuietly(txnIndex, "txnIndex", LOGGER);
     }
 
@@ -782,10 +782,10 @@ public class LogSegment implements Closeable {
     public void deleteIfExists() throws IOException {
         try {
             Utils.tryAll(List.of(
-                () -> deleteTypeIfExists(() -> log.deleteIfExists(), "log", log.file(), true),
-                () -> deleteTypeIfExists(() -> lazyOffsetIndex.deleteIfExists(), "offset index", offsetIndexFile(), true),
-                () -> deleteTypeIfExists(() -> lazyTimeIndex.deleteIfExists(), "time index", timeIndexFile(), true),
-                () -> deleteTypeIfExists(() -> txnIndex.deleteIfExists(), "transaction index", txnIndex.file(), false)));
+                () -> deleteTypeIfExists(log::deleteIfExists, "log", log.file(), true),
+                () -> deleteTypeIfExists(lazyOffsetIndex::deleteIfExists, "offset index", offsetIndexFile(), true),
+                () -> deleteTypeIfExists(lazyTimeIndex::deleteIfExists, "time index", timeIndexFile(), true),
+                () -> deleteTypeIfExists(txnIndex::deleteIfExists, "transaction index", txnIndex.file(), false)));
         } catch (Throwable t) {
             if (t instanceof IOException)
                 throw (IOException) t;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java
@@ -60,32 +60,11 @@ public class LogValidator {
         void recordNoKeyCompactedTopic();
     }
 
-    public static class ValidationResult {
-        public final long logAppendTimeMs;
-        public final MemoryRecords validatedRecords;
-        public final long maxTimestampMs;
-        public final boolean messageSizeMaybeChanged;
-        public final RecordValidationStats recordValidationStats;
-
-        public ValidationResult(long logAppendTimeMs, MemoryRecords validatedRecords, long maxTimestampMs,
-                                boolean messageSizeMaybeChanged,
-                                RecordValidationStats recordValidationStats) {
-            this.logAppendTimeMs = logAppendTimeMs;
-            this.validatedRecords = validatedRecords;
-            this.maxTimestampMs = maxTimestampMs;
-            this.messageSizeMaybeChanged = messageSizeMaybeChanged;
-            this.recordValidationStats = recordValidationStats;
-        }
+    public record ValidationResult(long logAppendTimeMs, MemoryRecords validatedRecords, long maxTimestampMs,
+                                   boolean messageSizeMaybeChanged, RecordValidationStats recordValidationStats) {
     }
 
-    private static class ApiRecordError {
-        final Errors apiError;
-        final RecordError recordError;
-
-        private ApiRecordError(Errors apiError, RecordError recordError) {
-            this.apiError = apiError;
-            this.recordError = recordError;
-        }
+    private record ApiRecordError(Errors apiError, RecordError recordError) {
     }
 
     private final MemoryRecords records;
@@ -204,7 +183,7 @@ public class LogValidator {
                 Optional<ApiRecordError> recordError = validateRecord(batch, topicPartition,
                     record, recordIndex, now, timestampType, timestampBeforeMaxMs, timestampAfterMaxMs, compactedTopic,
                     metricsRecorder);
-                recordError.ifPresent(e -> recordErrors.add(e));
+                recordError.ifPresent(recordErrors::add);
                 // we fail the batch if any record fails, so we stop appending if any record fails
                 if (recordErrors.isEmpty())
                     builder.appendWithOffset(offsetCounter.value++, record);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/OffsetPosition.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/OffsetPosition.java
@@ -21,14 +21,7 @@ package org.apache.kafka.storage.internals.log;
  * in some log file of the beginning of the message set entry with the
  * given offset.
  */
-public final class OffsetPosition implements IndexEntry {
-    public final long offset;
-    public final int position;
-
-    public OffsetPosition(long offset, int position) {
-        this.offset = offset;
-        this.position = position;
-    }
+public record OffsetPosition(long offset, int position) implements IndexEntry {
 
     @Override
     public long indexKey() {
@@ -38,26 +31,6 @@ public final class OffsetPosition implements IndexEntry {
     @Override
     public long indexValue() {
         return position;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        OffsetPosition that = (OffsetPosition) o;
-
-        return offset == that.offset
-            && position == that.position;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Long.hashCode(offset);
-        result = 31 * result + position;
-        return result;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/OffsetResultHolder.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/OffsetResultHolder.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 public class OffsetResultHolder {
 
     private Optional<TimestampAndOffset> timestampAndOffsetOpt;
-    private Optional<AsyncOffsetReadFutureHolder<FileRecordsOrError>> futureHolderOpt;
+    private final Optional<AsyncOffsetReadFutureHolder<FileRecordsOrError>> futureHolderOpt;
     private Optional<ApiException> maybeOffsetsError = Optional.empty();
     private Optional<Long> lastFetchableOffset = Optional.empty();
 
@@ -95,51 +95,20 @@ public class OffsetResultHolder {
         return result;
     }
 
-    public static class FileRecordsOrError {
-        private Optional<Exception> exception;
-        private Optional<TimestampAndOffset> timestampAndOffset;
-
-        public FileRecordsOrError(
-                Optional<Exception> exception,
-                Optional<TimestampAndOffset> timestampAndOffset
-        ) {
+    public record FileRecordsOrError(Optional<Exception> exception, Optional<TimestampAndOffset> timestampAndOffset) {
+        public FileRecordsOrError {
             if (exception.isPresent() && timestampAndOffset.isPresent()) {
                 throw new IllegalArgumentException("Either exception or timestampAndOffset should be present, but not both");
             }
-            this.exception = exception;
-            this.timestampAndOffset = timestampAndOffset;
         }
 
-        public Optional<Exception> exception() {
-            return exception;
-        }
-
-        public Optional<TimestampAndOffset> timestampAndOffset() {
-            return timestampAndOffset;
-        }
-        
         public boolean hasException() {
             return exception.isPresent();
         }
-        
+
         public boolean hasTimestampAndOffset() {
             return timestampAndOffset.isPresent();
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            FileRecordsOrError that = (FileRecordsOrError) o;
-            return Objects.equals(exception, that.exception) && Objects.equals(timestampAndOffset, that.timestampAndOffset);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = Objects.hashCode(exception);
-            result = 31 * result + Objects.hashCode(timestampAndOffset);
-            return result;
-        }
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateEntry.java
@@ -60,7 +60,7 @@ public class ProducerStateEntry {
     }
 
     public int lastSeq() {
-        return isEmpty() ? RecordBatch.NO_SEQUENCE : batchMetadata.getLast().lastSeq;
+        return isEmpty() ? RecordBatch.NO_SEQUENCE : batchMetadata.getLast().lastSeq();
     }
 
     public long firstDataOffset() {
@@ -68,11 +68,11 @@ public class ProducerStateEntry {
     }
 
     public long lastDataOffset() {
-        return isEmpty() ? -1L : batchMetadata.getLast().lastOffset;
+        return isEmpty() ? -1L : batchMetadata.getLast().lastOffset();
     }
 
     public int lastOffsetDelta() {
-        return isEmpty() ? 0 : batchMetadata.getLast().offsetDelta;
+        return isEmpty() ? 0 : batchMetadata.getLast().offsetDelta();
     }
 
     public boolean isEmpty() {
@@ -138,7 +138,7 @@ public class ProducerStateEntry {
 
     // Return the batch metadata of the cached batch having the exact sequence range, if any.
     Optional<BatchMetadata> batchWithSequenceRange(int firstSeq, int lastSeq) {
-        Stream<BatchMetadata> duplicate = batchMetadata.stream().filter(metadata -> firstSeq == metadata.firstSeq() && lastSeq == metadata.lastSeq);
+        Stream<BatchMetadata> duplicate = batchMetadata.stream().filter(metadata -> firstSeq == metadata.firstSeq() && lastSeq == metadata.lastSeq());
         return duplicate.findFirst();
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -524,9 +524,9 @@ public class ProducerStateManager {
      * transaction index, but the completion must be done only after successfully appending to the index.
      */
     public long lastStableOffset(CompletedTxn completedTxn) {
-        return findNextIncompleteTxn(completedTxn.producerId)
+        return findNextIncompleteTxn(completedTxn.producerId())
                 .map(x -> x.firstOffset.messageOffset)
-                .orElse(completedTxn.lastOffset + 1);
+                .orElse(completedTxn.lastOffset() + 1);
     }
 
     private Optional<TxnMetadata> findNextIncompleteTxn(long producerId) {
@@ -543,13 +543,13 @@ public class ProducerStateManager {
      * advancing the first unstable offset.
      */
     public void completeTxn(CompletedTxn completedTxn) {
-        TxnMetadata txnMetadata = ongoingTxns.remove(completedTxn.firstOffset);
+        TxnMetadata txnMetadata = ongoingTxns.remove(completedTxn.firstOffset());
         if (txnMetadata == null)
             throw new IllegalArgumentException("Attempted to complete transaction " + completedTxn + " on partition "
                     + topicPartition + " which was not started");
 
-        txnMetadata.lastOffset = OptionalLong.of(completedTxn.lastOffset);
-        unreplicatedTxns.put(completedTxn.firstOffset, txnMetadata);
+        txnMetadata.lastOffset = OptionalLong.of(completedTxn.lastOffset());
+        unreplicatedTxns.put(completedTxn.firstOffset(), txnMetadata);
         updateOldestTxnTimestamp();
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -423,7 +423,7 @@ public class RemoteIndexCache implements Closeable {
     public int lookupOffset(RemoteLogSegmentMetadata remoteLogSegmentMetadata, long offset) {
         lock.readLock().lock();
         try {
-            return getIndexEntry(remoteLogSegmentMetadata).lookupOffset(offset).position;
+            return getIndexEntry(remoteLogSegmentMetadata).lookupOffset(offset).position();
         } finally {
             lock.readLock().unlock();
         }
@@ -432,7 +432,7 @@ public class RemoteIndexCache implements Closeable {
     public int lookupTimestamp(RemoteLogSegmentMetadata remoteLogSegmentMetadata, long timestamp, long startingOffset) {
         lock.readLock().lock();
         try {
-            return getIndexEntry(remoteLogSegmentMetadata).lookupTimestamp(timestamp, startingOffset).position;
+            return getIndexEntry(remoteLogSegmentMetadata).lookupTimestamp(timestamp, startingOffset).position();
         } finally {
             lock.readLock().unlock();
         }
@@ -542,7 +542,7 @@ public class RemoteIndexCache implements Closeable {
                 if (cleanStarted)
                     throw new IllegalStateException("This entry is marked for cleanup");
                 TimestampOffset timestampOffset = timeIndex.lookup(timestamp);
-                return offsetIndex.lookup(Math.max(startingOffset, timestampOffset.offset));
+                return offsetIndex.lookup(Math.max(startingOffset, timestampOffset.offset()));
             } finally {
                 entryLock.readLock().unlock();
             }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteLogReadResult.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteLogReadResult.java
@@ -18,12 +18,5 @@ package org.apache.kafka.storage.internals.log;
 
 import java.util.Optional;
 
-public class RemoteLogReadResult {
-    public final Optional<FetchDataInfo> fetchDataInfo;
-    public final Optional<Throwable> error;
-
-    public RemoteLogReadResult(Optional<FetchDataInfo> fetchDataInfo, Optional<Throwable> error) {
-        this.fetchDataInfo = fetchDataInfo;
-        this.error = error;
-    }
+public record RemoteLogReadResult(Optional<FetchDataInfo> fetchDataInfo, Optional<Throwable> error) {
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageFetchInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageFetchInfo.java
@@ -20,22 +20,8 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.server.storage.log.FetchIsolation;
 
-public class RemoteStorageFetchInfo {
-
-    public final int fetchMaxBytes;
-    public final boolean minOneMessage;
-    public final TopicIdPartition topicIdPartition;
-    public final FetchRequest.PartitionData fetchInfo;
-    public final FetchIsolation fetchIsolation;
-
-    public RemoteStorageFetchInfo(int fetchMaxBytes, boolean minOneMessage, TopicIdPartition topicIdPartition,
-                                  FetchRequest.PartitionData fetchInfo, FetchIsolation fetchIsolation) {
-        this.fetchMaxBytes = fetchMaxBytes;
-        this.minOneMessage = minOneMessage;
-        this.topicIdPartition = topicIdPartition;
-        this.fetchInfo = fetchInfo;
-        this.fetchIsolation = fetchIsolation;
-    }
+public record RemoteStorageFetchInfo(int fetchMaxBytes, boolean minOneMessage, TopicIdPartition topicIdPartition,
+                                     FetchRequest.PartitionData fetchInfo, FetchIsolation fetchIsolation) {
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RollParams.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RollParams.java
@@ -19,29 +19,8 @@ package org.apache.kafka.storage.internals.log;
 /**
  * A class used to hold params required to decide to rotate a log segment or not.
  */
-public class RollParams {
-
-    public final long maxSegmentMs;
-    public final int maxSegmentBytes;
-    public final long maxTimestampInMessages;
-    public final long maxOffsetInMessages;
-    public final int messagesSize;
-    public final long now;
-
-    public RollParams(long maxSegmentMs,
-               int maxSegmentBytes,
-               long maxTimestampInMessages,
-               long maxOffsetInMessages,
-               int messagesSize,
-               long now) {
-
-        this.maxSegmentMs = maxSegmentMs;
-        this.maxSegmentBytes = maxSegmentBytes;
-        this.maxTimestampInMessages = maxTimestampInMessages;
-        this.maxOffsetInMessages = maxOffsetInMessages;
-        this.messagesSize = messagesSize;
-        this.now = now;
-    }
+public record RollParams(long maxSegmentMs, int maxSegmentBytes, long maxTimestampInMessages, long maxOffsetInMessages,
+                         int messagesSize, long now) {
 
     @Override
     public String toString() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
@@ -68,14 +68,14 @@ public class TimeIndex extends AbstractIndex {
         this.lastEntry = lastEntryFromIndexFile();
 
         log.debug("Loaded index file {} with maxEntries = {}, maxIndexSize = {}, entries = {}, lastOffset = {}, file position = {}",
-            file.getAbsolutePath(), maxEntries(), maxIndexSize, entries(), lastEntry.offset, mmap().position());
+            file.getAbsolutePath(), maxEntries(), maxIndexSize, entries(), lastEntry.offset(), mmap().position());
     }
 
     @Override
     public void sanityCheck() {
         TimestampOffset entry = lastEntry();
-        long lastTimestamp = entry.timestamp;
-        long lastOffset = entry.offset;
+        long lastTimestamp = entry.timestamp();
+        long lastOffset = entry.offset();
         inRemapReadLock(() -> {
             if (entries() != 0 && lastTimestamp < timestamp(mmap(), 0))
                 throw new CorruptIndexException("Corrupt time index found, time index file (" + file().getAbsolutePath() + ") has "
@@ -190,17 +190,17 @@ public class TimeIndex extends AbstractIndex {
             // because that could happen in the following two scenarios:
             // 1. A log segment is closed.
             // 2. LogSegment.onBecomeInactiveSegment() is called when an active log segment is rolled.
-            if (entries() != 0 && offset < lastEntry.offset)
+            if (entries() != 0 && offset < lastEntry.offset())
                 throw new InvalidOffsetException("Attempt to append an offset (" + offset + ") to slot " + entries()
-                    + " no larger than the last offset appended (" + lastEntry.offset + ") to " + file().getAbsolutePath());
-            if (entries() != 0 && timestamp < lastEntry.timestamp)
+                    + " no larger than the last offset appended (" + lastEntry.offset() + ") to " + file().getAbsolutePath());
+            if (entries() != 0 && timestamp < lastEntry.timestamp())
                 throw new IllegalStateException("Attempt to append a timestamp (" + timestamp + ") to slot " + entries()
-                    + " no larger than the last timestamp appended (" + lastEntry.timestamp + ") to " + file().getAbsolutePath());
+                    + " no larger than the last timestamp appended (" + lastEntry.timestamp() + ") to " + file().getAbsolutePath());
 
             // We only append to the time index when the timestamp is greater than the last inserted timestamp.
             // If all the messages are in message format v0, the timestamp will always be NoTimestamp. In that case, the time
             // index will be empty.
-            if (timestamp > lastEntry.timestamp) {
+            if (timestamp > lastEntry.timestamp()) {
                 log.trace("Adding index entry {} => {} to {}.", timestamp, offset, file().getAbsolutePath());
                 MappedByteBuffer mmap = mmap();
                 mmap.putLong(timestamp);
@@ -269,7 +269,7 @@ public class TimeIndex extends AbstractIndex {
             super.truncateToEntries0(entries);
             this.lastEntry = lastEntryFromIndexFile();
             log.debug("Truncated index {} to {} entries; position is now {} and last entry is now {}",
-                file().getAbsolutePath(), entries, mmap().position(), lastEntry.offset);
+                file().getAbsolutePath(), entries, mmap().position(), lastEntry.offset());
         });
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TimestampOffset.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TimestampOffset.java
@@ -19,24 +19,13 @@ package org.apache.kafka.storage.internals.log;
 /**
  * The mapping between a timestamp to a message offset. The entry means that any message whose timestamp is greater
  * than that timestamp must be at or after that offset.
+ *
+ * @param timestamp The max timestamp before the given offset.
+ * @param offset    The message offset.
  */
-public class TimestampOffset implements IndexEntry {
+public record TimestampOffset(long timestamp, long offset) implements IndexEntry {
 
     public static final TimestampOffset UNKNOWN = new TimestampOffset(-1, -1);
-
-    public final long timestamp;
-    public final long offset;
-
-    /**
-     * Create a TimestampOffset with the provided parameters.
-     *
-     * @param timestamp The max timestamp before the given offset.
-     * @param offset The message offset.
-     */
-    public TimestampOffset(long timestamp, long offset) {
-        this.timestamp = timestamp;
-        this.offset = offset;
-    }
 
     @Override
     public long indexKey() {
@@ -46,26 +35,6 @@ public class TimestampOffset implements IndexEntry {
     @Override
     public long indexValue() {
         return offset;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        TimestampOffset that = (TimestampOffset) o;
-
-        return timestamp == that.timestamp
-            && offset == that.offset;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Long.hashCode(timestamp);
-        result = 31 * result + Long.hashCode(offset);
-        return result;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -47,13 +47,7 @@ import java.util.function.Supplier;
  */
 public class TransactionIndex implements Closeable {
 
-    private static class AbortedTxnWithPosition {
-        final AbortedTxn txn;
-        final int position;
-        AbortedTxnWithPosition(AbortedTxn txn, int position) {
-            this.txn = txn;
-            this.position = position;
-        }
+    private record AbortedTxnWithPosition(AbortedTxn txn, int position) {
     }
 
     private final long startOffset;
@@ -232,7 +226,7 @@ public class TransactionIndex implements Closeable {
 
         PrimitiveRef.IntRef position = PrimitiveRef.ofInt(0);
 
-        return () -> new Iterator<AbortedTxnWithPosition>() {
+        return () -> new Iterator<>() {
 
             @Override
             public boolean hasNext() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TxnIndexSearchResult.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TxnIndexSearchResult.java
@@ -19,10 +19,7 @@ package org.apache.kafka.storage.internals.log;
 import java.util.Collections;
 import java.util.List;
 
-public class TxnIndexSearchResult {
-    public final List<AbortedTxn> abortedTransactions;
-    public final boolean isComplete;
-
+public record TxnIndexSearchResult(List<AbortedTxn> abortedTransactions, boolean isComplete) {
     public TxnIndexSearchResult(List<AbortedTxn> abortedTransactions, boolean isComplete) {
         this.abortedTransactions = Collections.unmodifiableList(abortedTransactions);
         this.isComplete = isComplete;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
@@ -31,9 +31,9 @@ public class VerificationStateEntry {
 
     private final long timestamp;
     private final VerificationGuard verificationGuard;
+    private final boolean supportsEpochBump;
     private int lowestSequence;
     private short epoch;
-    private boolean supportsEpochBump;
 
     public VerificationStateEntry(long timestamp, int sequence, short epoch, boolean supportsEpochBump) {
         this.timestamp = timestamp;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -160,7 +160,7 @@ public class RemoteLogSegmentLifecycleTest {
             for (Map.Entry<EpochEntry, RemoteLogSegmentMetadata> entry : expectedEpochEntryToMetadata.entrySet()) {
                 EpochEntry epochEntry = entry.getKey();
                 Optional<RemoteLogSegmentMetadata> actualMetadataOpt = metadataManager
-                        .remoteLogSegmentMetadata(topicIdPartition, epochEntry.epoch, epochEntry.startOffset);
+                        .remoteLogSegmentMetadata(topicIdPartition, epochEntry.epoch(), epochEntry.startOffset());
                 RemoteLogSegmentMetadata expectedSegmentMetadata = entry.getValue();
                 if (expectedSegmentMetadata != null) {
                     assertEquals(Optional.of(expectedSegmentMetadata), actualMetadataOpt);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
@@ -537,35 +537,23 @@ public final class LocalTieredStorage implements RemoteStorageManager {
     }
 
     private EventType getEventTypeForFetch(IndexType indexType) {
-        switch (indexType) {
-            case OFFSET:
-                return FETCH_OFFSET_INDEX;
-            case TIMESTAMP:
-                return FETCH_TIME_INDEX;
-            case PRODUCER_SNAPSHOT:
-                return FETCH_PRODUCER_SNAPSHOT;
-            case TRANSACTION:
-                return FETCH_TRANSACTION_INDEX;
-            case LEADER_EPOCH:
-                return FETCH_LEADER_EPOCH_CHECKPOINT;
-        }
-        return FETCH_SEGMENT;
+        return switch (indexType) {
+            case OFFSET -> FETCH_OFFSET_INDEX;
+            case TIMESTAMP -> FETCH_TIME_INDEX;
+            case PRODUCER_SNAPSHOT -> FETCH_PRODUCER_SNAPSHOT;
+            case TRANSACTION -> FETCH_TRANSACTION_INDEX;
+            case LEADER_EPOCH -> FETCH_LEADER_EPOCH_CHECKPOINT;
+        };
     }
 
     private RemoteLogSegmentFileset.RemoteLogSegmentFileType getLogSegmentFileType(IndexType indexType) {
-        switch (indexType) {
-            case OFFSET:
-                return OFFSET_INDEX;
-            case TIMESTAMP:
-                return TIME_INDEX;
-            case PRODUCER_SNAPSHOT:
-                return PRODUCER_SNAPSHOT;
-            case TRANSACTION:
-                return TRANSACTION_INDEX;
-            case LEADER_EPOCH:
-                return LEADER_EPOCH_CHECKPOINT;
-        }
-        return SEGMENT;
+        return switch (indexType) {
+            case OFFSET -> OFFSET_INDEX;
+            case TIMESTAMP -> TIME_INDEX;
+            case PRODUCER_SNAPSHOT -> PRODUCER_SNAPSHOT;
+            case TRANSACTION -> TRANSACTION_INDEX;
+            case LEADER_EPOCH -> LEADER_EPOCH_CHECKPOINT;
+        };
     }
 
     public int brokerId() {

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -555,8 +555,8 @@ public class RemoteLogManagerTest {
         verify(remoteLogMetadataManager).addRemoteLogSegmentMetadata(remoteLogSegmentMetadataArg.capture());
         // The old segment should only contain leader epoch [0->0, 1->100] since its offset range is [0, 149]
         Map<Integer, Long> expectedLeaderEpochs = new TreeMap<>();
-        expectedLeaderEpochs.put(epochEntry0.epoch, epochEntry0.startOffset);
-        expectedLeaderEpochs.put(epochEntry1.epoch, epochEntry1.startOffset);
+        expectedLeaderEpochs.put(epochEntry0.epoch(), epochEntry0.startOffset());
+        expectedLeaderEpochs.put(epochEntry1.epoch(), epochEntry1.startOffset());
         verifyRemoteLogSegmentMetadata(remoteLogSegmentMetadataArg.getValue(), oldSegmentStartOffset, oldSegmentEndOffset, expectedLeaderEpochs);
 
         // verify copyLogSegmentData is passing the RemoteLogSegmentMetadata we created above
@@ -1620,15 +1620,12 @@ public class RemoteLogManagerTest {
                             metadata.startOffset(), maxEntries * 8);
                     TimeIndex timeIdx = new TimeIndex(new File(tpDir, metadata.startOffset() + UnifiedLog.TIME_INDEX_FILE_SUFFIX),
                             metadata.startOffset(), maxEntries * 12);
-                    switch (indexType) {
-                        case OFFSET:
-                            return Files.newInputStream(offsetIdx.file().toPath());
-                        case TIMESTAMP:
-                            return Files.newInputStream(timeIdx.file().toPath());
-                        case TRANSACTION:
-                            return Files.newInputStream(txnIdxFile.toPath());
-                    }
-                    return null;
+                    return switch (indexType) {
+                        case OFFSET -> Files.newInputStream(offsetIdx.file().toPath());
+                        case TIMESTAMP -> Files.newInputStream(timeIdx.file().toPath());
+                        case TRANSACTION -> Files.newInputStream(txnIdxFile.toPath());
+                        default -> null;
+                    };
                 });
 
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
@@ -3078,7 +3075,7 @@ public class RemoteLogManagerTest {
         LeaderEpochFileCache cache = new LeaderEpochFileCache(null, myCheckpoint, scheduler);
         cache.truncateFromStartAsyncFlush(startOffset);
         cache.truncateFromEndAsyncFlush(endOffset);
-        return myCheckpoint.read().stream().collect(Collectors.toMap(e -> e.epoch, e -> e.startOffset));
+        return myCheckpoint.read().stream().collect(Collectors.toMap(EpochEntry::epoch, EpochEntry::startOffset));
     }
 
     @Test

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogReaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogReaderTest.java
@@ -79,9 +79,9 @@ public class RemoteLogReaderTest {
         ArgumentCaptor<RemoteLogReadResult> remoteLogReadResultArg = ArgumentCaptor.forClass(RemoteLogReadResult.class);
         verify(callback, times(1)).accept(remoteLogReadResultArg.capture());
         RemoteLogReadResult actualRemoteLogReadResult = remoteLogReadResultArg.getValue();
-        assertFalse(actualRemoteLogReadResult.error.isPresent());
-        assertTrue(actualRemoteLogReadResult.fetchDataInfo.isPresent());
-        assertEquals(fetchDataInfo, actualRemoteLogReadResult.fetchDataInfo.get());
+        assertFalse(actualRemoteLogReadResult.error().isPresent());
+        assertTrue(actualRemoteLogReadResult.fetchDataInfo().isPresent());
+        assertEquals(fetchDataInfo, actualRemoteLogReadResult.fetchDataInfo().get());
 
         // verify the record method on quota manager was called with the expected value
         ArgumentCaptor<Double> recordedArg = ArgumentCaptor.forClass(Double.class);
@@ -112,8 +112,8 @@ public class RemoteLogReaderTest {
         ArgumentCaptor<RemoteLogReadResult> remoteLogReadResultArg = ArgumentCaptor.forClass(RemoteLogReadResult.class);
         verify(callback, times(1)).accept(remoteLogReadResultArg.capture());
         RemoteLogReadResult actualRemoteLogReadResult = remoteLogReadResultArg.getValue();
-        assertTrue(actualRemoteLogReadResult.error.isPresent());
-        assertFalse(actualRemoteLogReadResult.fetchDataInfo.isPresent());
+        assertTrue(actualRemoteLogReadResult.error().isPresent());
+        assertFalse(actualRemoteLogReadResult.fetchDataInfo().isPresent());
 
         // verify the record method on quota manager was called with the expected value
         ArgumentCaptor<Double> recordedArg = ArgumentCaptor.forClass(Double.class);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentFileset.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentFileset.java
@@ -245,7 +245,7 @@ public final class RemoteLogSegmentFileset {
         final Optional<File> notAFile = files.stream().filter(f -> f.exists() && !f.isFile()).findAny();
 
         if (notAFile.isPresent()) {
-            LOGGER.warn(format("Found unexpected directory %s. Will not delete.", notAFile.get().getAbsolutePath()));
+            LOGGER.warn("Found unexpected directory {}. Will not delete.", notAFile.get().getAbsolutePath());
             return false;
         }
 
@@ -254,13 +254,13 @@ public final class RemoteLogSegmentFileset {
 
     public static boolean deleteQuietly(final File file) {
         try {
-            LOGGER.trace("Deleting " + file.getAbsolutePath());
+            LOGGER.trace("Deleting {}", file.getAbsolutePath());
             if (!file.exists()) {
                 return true;
             }
             return file.delete();
         } catch (final Exception e) {
-            LOGGER.error(format("Encountered error while deleting %s", file.getAbsolutePath()));
+            LOGGER.error("Encountered error while deleting {}", file.getAbsolutePath());
         }
 
         return false;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentFileset.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentFileset.java
@@ -260,7 +260,7 @@ public final class RemoteLogSegmentFileset {
             }
             return file.delete();
         } catch (final Exception e) {
-            LOGGER.error("Encountered error while deleting {}", file.getAbsolutePath());
+            LOGGER.error("Encountered error while deleting {}", file.getAbsolutePath(), e);
         }
 
         return false;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteTopicPartitionDirectory.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteTopicPartitionDirectory.java
@@ -119,7 +119,7 @@ public final class RemoteTopicPartitionDirectory {
         final boolean existed = directory.exists();
 
         if (!existed) {
-            LOGGER.info("Creating directory: " + directory.getAbsolutePath());
+            LOGGER.info("Creating directory: {}", directory.getAbsolutePath());
             directory.mkdirs();
         }
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandlerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandlerTest.java
@@ -45,7 +45,7 @@ class CleanShutdownFileHandlerTest {
         assertDoesNotThrow(() -> cleanShutdownFileHandler.write(10L));
         assertTrue(cleanShutdownFileHandler.exists());
         assertEquals(OptionalLong.of(10L), cleanShutdownFileHandler.read());
-        assertDoesNotThrow(() -> cleanShutdownFileHandler.delete());
+        assertDoesNotThrow(cleanShutdownFileHandler::delete);
         assertFalse(cleanShutdownFileHandler.exists());
     }
 
@@ -56,7 +56,7 @@ class CleanShutdownFileHandlerTest {
         CleanShutdownFileHandler cleanShutdownFileHandler = new CleanShutdownFileHandler(logDir.getPath());
         assertDoesNotThrow(() -> cleanShutdownFileHandler.write(10L, 0));
         assertTrue(cleanShutdownFileHandler.exists());
-        assertDoesNotThrow(() -> cleanShutdownFileHandler.delete());
+        assertDoesNotThrow(cleanShutdownFileHandler::delete);
         assertFalse(cleanShutdownFileHandler.exists());
         assertEquals(OptionalLong.empty(), cleanShutdownFileHandler.read());
     }
@@ -75,7 +75,7 @@ class CleanShutdownFileHandlerTest {
 
         assertTrue(cleanShutdownFileHandler.exists());
         assertEquals(OptionalLong.of(10L), cleanShutdownFileHandler.read());
-        assertDoesNotThrow(() -> cleanShutdownFileHandler.delete());
+        assertDoesNotThrow(cleanShutdownFileHandler::delete);
         assertFalse(cleanShutdownFileHandler.exists());
     }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
@@ -824,8 +824,8 @@ public class LogSegmentTest {
         segment.append(2L, record);
 
         assertEquals(2, segment.offsetIndex().entries());
-        assertEquals(1, segment.offsetIndex().entry(0).offset);
-        assertEquals(2, segment.offsetIndex().entry(1).offset);
+        assertEquals(1, segment.offsetIndex().entry(0).offset());
+        assertEquals(2, segment.offsetIndex().entry(1).offset());
 
         assertEquals(2, segment.timeIndex().entries());
         assertEquals(new TimestampOffset(1, 1), segment.timeIndex().entry(0));
@@ -857,8 +857,8 @@ public class LogSegmentTest {
         segment.append(2L, record);
 
         assertEquals(2, segment.offsetIndex().entries());
-        assertEquals(1, segment.offsetIndex().entry(0).offset);
-        assertEquals(2, segment.offsetIndex().entry(1).offset);
+        assertEquals(1, segment.offsetIndex().entry(0).offset());
+        assertEquals(2, segment.offsetIndex().entry(1).offset());
 
         assertEquals(2, segment.timeIndex().entries());
         assertEquals(new TimestampOffset(1, 0), segment.timeIndex().entry(0));

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogValidatorTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogValidatorTest.java
@@ -121,7 +121,7 @@ public class LogValidatorTest {
             } else {
                 ValidationResult result = validateMessages(invalidRecords, version.value, CompressionType.GZIP, compression);
                 List<Long> recordsResult = new ArrayList<>();
-                result.validatedRecords.records().forEach(s -> recordsResult.add(s.offset()));
+                result.validatedRecords().records().forEach(s -> recordsResult.add(s.offset()));
                 assertEquals(LongStream.range(0, numRecords).boxed().toList(), recordsResult);
             }
         });
@@ -226,7 +226,7 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        MemoryRecords validatedRecords = validatedResults.validatedRecords;
+        MemoryRecords validatedRecords = validatedResults.validatedRecords();
 
         for (RecordBatch batch : validatedRecords.batches()) {
             assertTrue(batch.isValid());
@@ -238,11 +238,11 @@ public class LogValidatorTest {
             assertEquals(RecordBatch.NO_SEQUENCE, batch.baseSequence());
         }
 
-        assertEquals(timestamp, validatedResults.maxTimestampMs);
-        assertTrue(validatedResults.messageSizeMaybeChanged, "Message size should have been changed");
+        assertEquals(timestamp, validatedResults.maxTimestampMs());
+        assertTrue(validatedResults.messageSizeMaybeChanged(), "Message size should have been changed");
 
         verifyRecordValidationStats(
-                validatedResults.recordValidationStats,
+                validatedResults.recordValidationStats(),
                 3,
                 records,
                 true
@@ -272,7 +272,7 @@ public class LogValidatorTest {
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
-        MemoryRecords validatedRecords = validatedResults.validatedRecords;
+        MemoryRecords validatedRecords = validatedResults.validatedRecords();
 
         for (RecordBatch batch : validatedRecords.batches()) {
             assertTrue(batch.isValid());
@@ -283,11 +283,11 @@ public class LogValidatorTest {
             assertEquals(RecordBatch.NO_PRODUCER_ID, batch.producerId());
             assertEquals(RecordBatch.NO_SEQUENCE, batch.baseSequence());
         }
-        assertEquals(RecordBatch.NO_TIMESTAMP, validatedResults.maxTimestampMs,
+        assertEquals(RecordBatch.NO_TIMESTAMP, validatedResults.maxTimestampMs(),
                 "Max timestamp should be " + RecordBatch.NO_TIMESTAMP);
-        assertTrue(validatedResults.messageSizeMaybeChanged, "Message size should have been changed");
+        assertTrue(validatedResults.messageSizeMaybeChanged(), "Message size should have been changed");
 
-        verifyRecordValidationStats(validatedResults.recordValidationStats, 3, records, true);
+        verifyRecordValidationStats(validatedResults.recordValidationStats(), 3, records, true);
     }
 
     @ParameterizedTest
@@ -354,7 +354,7 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        MemoryRecords validatedRecords = validatingResults.validatedRecords;
+        MemoryRecords validatedRecords = validatingResults.validatedRecords();
 
         int i = 0;
         for (RecordBatch batch : validatedRecords.batches()) {
@@ -374,16 +374,16 @@ public class LogValidatorTest {
             }
         }
 
-        assertEquals(now + 1, validatingResults.maxTimestampMs,
+        assertEquals(now + 1, validatingResults.maxTimestampMs(),
                 "Max timestamp should be " + (now + 1));
 
         // Both V2 and V1 have single batch in the validated records when compression is enabled, and hence their shallow
         // OffsetOfMaxTimestamp is the last offset of the single batch
         assertEquals(1, iteratorSize(validatedRecords.batches().iterator()));
-        assertTrue(validatingResults.messageSizeMaybeChanged,
+        assertTrue(validatingResults.messageSizeMaybeChanged(),
                 "Message size should have been changed");
 
-        verifyRecordValidationStats(validatingResults.recordValidationStats, 3, records, true);
+        verifyRecordValidationStats(validatingResults.recordValidationStats(), 3, records, true);
     }
 
     private MemoryRecords recordsWithInvalidInnerMagic(byte batchMagicValue, byte recordMagicValue, Compression codec) {
@@ -545,12 +545,12 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        MemoryRecords validatedRecords = validatedResults.validatedRecords;
+        MemoryRecords validatedRecords = validatedResults.validatedRecords();
 
         int i = 0;
         for (RecordBatch batch : validatedRecords.batches()) {
             assertTrue(batch.isValid());
-            assertEquals(batch.timestampType(), TimestampType.CREATE_TIME);
+            assertEquals(TimestampType.CREATE_TIME, batch.timestampType());
             maybeCheckBaseTimestamp(timestampSeq.get(0), batch);
             assertEquals(batch.maxTimestamp(), TestUtils.toList(batch).stream().map(Record::timestamp).max(Long::compare).get());
             assertEquals(producerEpoch, batch.producerEpoch());
@@ -565,11 +565,11 @@ public class LogValidatorTest {
             }
         }
 
-        assertEquals(now + 1, validatedResults.maxTimestampMs, "Max timestamp should be " + (now + 1));
+        assertEquals(now + 1, validatedResults.maxTimestampMs(), "Max timestamp should be " + (now + 1));
 
-        assertFalse(validatedResults.messageSizeMaybeChanged, "Message size should not have been changed");
+        assertFalse(validatedResults.messageSizeMaybeChanged(), "Message size should not have been changed");
 
-        verifyRecordValidationStats(validatedResults.recordValidationStats, 0, records, true);
+        verifyRecordValidationStats(validatedResults.recordValidationStats(), 0, records, true);
     }
 
     private MemoryRecords createRecords(List<byte[]> records,
@@ -883,7 +883,7 @@ public class LogValidatorTest {
                         PrimitiveRef.ofLong(offset),
                         metricsRecorder,
                         RequestLocal.withThreadConfinedCaching().bufferSupplier()
-                ).validatedRecords, offset
+                ).validatedRecords(), offset
         );
     }
 
@@ -914,7 +914,7 @@ public class LogValidatorTest {
                         PrimitiveRef.ofLong(offset),
                         metricsRecorder,
                         RequestLocal.withThreadConfinedCaching().bufferSupplier()
-                ).validatedRecords,
+                ).validatedRecords(),
                 offset
         );
     }
@@ -944,7 +944,7 @@ public class LogValidatorTest {
                 PrimitiveRef.ofLong(offset),
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords;
+        ).validatedRecords();
 
         checkOffsets(messageWithOffset, offset);
     }
@@ -974,7 +974,7 @@ public class LogValidatorTest {
                 PrimitiveRef.ofLong(offset),
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords;
+        ).validatedRecords();
 
         checkOffsets(messageWithOffset, offset);
     }
@@ -1005,7 +1005,7 @@ public class LogValidatorTest {
                 PrimitiveRef.ofLong(offset),
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords;
+        ).validatedRecords();
 
         checkOffsets(compressedMessagesWithOffset, offset);
     }
@@ -1036,7 +1036,7 @@ public class LogValidatorTest {
                 PrimitiveRef.ofLong(offset),
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords;
+        ).validatedRecords();
 
         checkOffsets(compressedMessagesWithOffset, offset);
     }
@@ -1067,9 +1067,9 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        checkOffsets(validatedResults.validatedRecords, offset);
+        checkOffsets(validatedResults.validatedRecords(), offset);
         verifyRecordValidationStats(
-                validatedResults.recordValidationStats,
+                validatedResults.recordValidationStats(),
                 3, // numConvertedRecords
                 records,
                 false // compressed
@@ -1102,9 +1102,9 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        checkOffsets(validatedResults.validatedRecords, offset);
+        checkOffsets(validatedResults.validatedRecords(), offset);
         verifyRecordValidationStats(
-                validatedResults.recordValidationStats,
+                validatedResults.recordValidationStats(),
                 3, // numConvertedRecords
                 records,
                 false // compressed
@@ -1138,9 +1138,9 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        checkOffsets(validatedResults.validatedRecords, offset);
+        checkOffsets(validatedResults.validatedRecords(), offset);
         verifyRecordValidationStats(
-                validatedResults.recordValidationStats,
+                validatedResults.recordValidationStats(),
                 3, // numConvertedRecords
                 records,
                 true // compressed
@@ -1174,9 +1174,9 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        checkOffsets(validatedResults.validatedRecords, offset);
+        checkOffsets(validatedResults.validatedRecords(), offset);
         verifyRecordValidationStats(
-                validatedResults.recordValidationStats,
+                validatedResults.recordValidationStats(),
                 3, // numConvertedRecords
                 records,
                 true // compressed
@@ -1231,7 +1231,7 @@ public class LogValidatorTest {
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
-        MemoryRecords validatedRecords = result.validatedRecords;
+        MemoryRecords validatedRecords = result.validatedRecords();
         assertEquals(1, TestUtils.toList(validatedRecords.batches()).size());
         assertFalse(TestUtils.toList(validatedRecords.batches()).get(0).isCompressed());
     }
@@ -1259,7 +1259,7 @@ public class LogValidatorTest {
                 PrimitiveRef.ofLong(offset),
                 metricsRecorder,
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1284,7 +1284,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1307,7 +1307,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1331,7 +1331,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1355,7 +1355,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1380,7 +1380,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1457,7 +1457,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
 
@@ -1483,7 +1483,7 @@ public class LogValidatorTest {
                 AppendOrigin.CLIENT
         ).validateMessagesAndAssignOffsets(
                 PrimitiveRef.ofLong(offset), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
-        ).validatedRecords, offset);
+        ).validatedRecords(), offset);
     }
 
     @Test
@@ -1513,7 +1513,7 @@ public class LogValidatorTest {
                 PrimitiveRef.ofLong(0L), metricsRecorder, RequestLocal.withThreadConfinedCaching().bufferSupplier()
         ));
 
-        assertEquals(metricsRecorder.recordInvalidOffsetCount, 1);
+        assertEquals(1, metricsRecorder.recordInvalidOffsetCount);
     }
 
     @Test
@@ -1702,8 +1702,8 @@ public class LogValidatorTest {
         );
 
         // Ensure validated records have not been changed so they are the same as the producer records
-        assertEquals(recordsGzipMax, result.validatedRecords);
-        assertNotEquals(recordsGzipMin, result.validatedRecords);
+        assertEquals(recordsGzipMax, result.validatedRecords());
+        assertNotEquals(recordsGzipMin, result.validatedRecords());
     }
 
     @Test
@@ -1740,7 +1740,7 @@ public class LogValidatorTest {
         );
 
         // Ensure validated records have been recompressed and match lz4 min level
-        assertEquals(recordsLz4Min, result.validatedRecords);
+        assertEquals(recordsLz4Min, result.validatedRecords());
     }
 
     @ParameterizedTest
@@ -1798,7 +1798,7 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        MemoryRecords validatedRecords = validatingResults.validatedRecords;
+        MemoryRecords validatedRecords = validatingResults.validatedRecords();
 
         int i = 0;
         for (RecordBatch batch : validatedRecords.batches()) {
@@ -1820,7 +1820,7 @@ public class LogValidatorTest {
         }
 
         assertEquals(i, offsetCounter.value);
-        assertEquals(now + 1, validatingResults.maxTimestampMs,
+        assertEquals(now + 1, validatingResults.maxTimestampMs(),
                 "Max timestamp should be " + (now + 1));
 
         if (magic >= RecordBatch.MAGIC_VALUE_V2) {
@@ -1829,9 +1829,9 @@ public class LogValidatorTest {
             assertEquals(3, iteratorSize(records.batches().iterator()));
         }
 
-        assertFalse(validatingResults.messageSizeMaybeChanged,
+        assertFalse(validatingResults.messageSizeMaybeChanged(),
                 "Message size should not have been changed");
-        verifyRecordValidationStats(validatingResults.recordValidationStats, 0, records, false);
+        verifyRecordValidationStats(validatingResults.recordValidationStats(), 0, records, false);
     }
 
     private void assertInvalidBatchCountOverrides(int lastOffsetDelta, int count) {
@@ -1890,7 +1890,7 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        MemoryRecords validatedRecords = validatedResults.validatedRecords;
+        MemoryRecords validatedRecords = validatedResults.validatedRecords();
         assertEquals(records.sizeInBytes(), validatedRecords.sizeInBytes(),
                 "message set size should not change");
         long now = mockTime.milliseconds();
@@ -1898,12 +1898,12 @@ public class LogValidatorTest {
             validateLogAppendTime(now, 1234L, batch);
         assertTrue(validatedRecords.batches().iterator().next().isValid(),
                 "MessageSet should still valid");
-        assertEquals(now, validatedResults.maxTimestampMs,
+        assertEquals(now, validatedResults.maxTimestampMs(),
                 "Max timestamp should be " + now);
-        assertFalse(validatedResults.messageSizeMaybeChanged,
+        assertFalse(validatedResults.messageSizeMaybeChanged(),
                 "Message size should not have been changed");
 
-        verifyRecordValidationStats(validatedResults.recordValidationStats, 0, records, true);
+        verifyRecordValidationStats(validatedResults.recordValidationStats(), 0, records, true);
     }
 
     @ParameterizedTest
@@ -1932,18 +1932,18 @@ public class LogValidatorTest {
                 RequestLocal.withThreadConfinedCaching().bufferSupplier()
         );
 
-        MemoryRecords validatedRecords = validatedResults.validatedRecords;
+        MemoryRecords validatedRecords = validatedResults.validatedRecords();
         assertEquals(iteratorSize(records.records().iterator()), iteratorSize(validatedRecords.records().iterator()),
                 "message set size should not change");
         long now = mockTime.milliseconds();
         validatedRecords.batches().forEach(batch -> validateLogAppendTime(now, -1, batch));
         assertTrue(validatedRecords.batches().iterator().next().isValid(),
                 "MessageSet should still valid");
-        assertEquals(now, validatedResults.maxTimestampMs, String.format("Max timestamp should be %d", now));
-        assertTrue(validatedResults.messageSizeMaybeChanged,
+        assertEquals(now, validatedResults.maxTimestampMs(), String.format("Max timestamp should be %d", now));
+        assertTrue(validatedResults.messageSizeMaybeChanged(),
                 "Message size may have been changed");
 
-        RecordValidationStats stats = validatedResults.recordValidationStats;
+        RecordValidationStats stats = validatedResults.recordValidationStats();
         verifyRecordValidationStats(stats, 3, records, true);
     }
 
@@ -1973,7 +1973,7 @@ public class LogValidatorTest {
         );
         assertEquals(offsetCounter.value, iteratorSize(records.records().iterator()));
 
-        MemoryRecords validatedRecords = validatedResults.validatedRecords;
+        MemoryRecords validatedRecords = validatedResults.validatedRecords();
         assertEquals(iteratorSize(records.records().iterator()), iteratorSize(validatedRecords.records().iterator()), "message set size should not change");
 
         long now = mockTime.milliseconds();
@@ -1983,14 +1983,14 @@ public class LogValidatorTest {
         }
 
         if (magic == RecordBatch.MAGIC_VALUE_V0) {
-            assertEquals(RecordBatch.NO_TIMESTAMP, validatedResults.maxTimestampMs);
+            assertEquals(RecordBatch.NO_TIMESTAMP, validatedResults.maxTimestampMs());
         } else {
-            assertEquals(now, validatedResults.maxTimestampMs);
+            assertEquals(now, validatedResults.maxTimestampMs());
         }
 
-        assertFalse(validatedResults.messageSizeMaybeChanged, "Message size should not have been changed");
+        assertFalse(validatedResults.messageSizeMaybeChanged(), "Message size should not have been changed");
 
-        verifyRecordValidationStats(validatedResults.recordValidationStats, 0, records, false);
+        verifyRecordValidationStats(validatedResults.recordValidationStats(), 0, records, false);
     }
 
     /**
@@ -1998,7 +1998,7 @@ public class LogValidatorTest {
      */
     void validateLogAppendTime(long expectedLogAppendTime, long expectedBaseTimestamp, RecordBatch batch) {
         assertTrue(batch.isValid());
-        assertEquals(batch.timestampType(), TimestampType.LOG_APPEND_TIME);
+        assertEquals(TimestampType.LOG_APPEND_TIME, batch.timestampType());
         assertEquals(expectedLogAppendTime, batch.maxTimestamp(), "Unexpected max timestamp of batch $batch");
         maybeCheckBaseTimestamp(expectedBaseTimestamp, batch);
         batch.forEach(record -> {

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetIndexTest.java
@@ -90,7 +90,7 @@ public class OffsetIndexTest {
                 rightAnswer = new OffsetPosition(index.baseOffset(), 0);
             } else {
                 Map.Entry<Long, OffsetPosition> lastEntry = valMap.floorEntry((long) offset);
-                rightAnswer = new OffsetPosition(lastEntry.getKey(), lastEntry.getValue().position);
+                rightAnswer = new OffsetPosition(lastEntry.getKey(), lastEntry.getValue().position());
             }
             assertEquals(rightAnswer, index.lookup(offset),
                     "The index should give the same answer as the sorted map");
@@ -151,7 +151,7 @@ public class OffsetIndexTest {
         assertEquals(Optional.empty(), index.fetchUpperBoundOffset(first, 5));
 
         Stream.of(first, second, third, fourth)
-                .forEach(offsetPosition -> index.append(offsetPosition.offset, offsetPosition.position));
+                .forEach(offsetPosition -> index.append(offsetPosition.offset(), offsetPosition.position()));
 
         assertEquals(Optional.of(second), index.fetchUpperBoundOffset(first, 5));
         assertEquals(Optional.of(second), index.fetchUpperBoundOffset(first, 10));
@@ -167,13 +167,13 @@ public class OffsetIndexTest {
     public void testReopen() throws IOException {
         OffsetPosition first = new OffsetPosition(51, 0);
         OffsetPosition sec = new OffsetPosition(52, 1);
-        index.append(first.offset, first.position);
-        index.append(sec.offset, sec.position);
+        index.append(first.offset(), first.position());
+        index.append(sec.offset(), sec.position());
         index.close();
         OffsetIndex idxRo = new OffsetIndex(index.file(), index.baseOffset());
-        assertEquals(first, idxRo.lookup(first.offset));
-        assertEquals(sec, idxRo.lookup(sec.offset));
-        assertEquals(sec.offset, idxRo.lastOffset());
+        assertEquals(first, idxRo.lookup(first.offset()));
+        assertEquals(sec, idxRo.lookup(sec.offset()));
+        assertEquals(sec.offset(), idxRo.lastOffset());
         assertEquals(2, idxRo.entries());
         assertWriteFails("Append should fail on read-only index", idxRo, 53);
     }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetMapTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetMapTest.java
@@ -36,7 +36,7 @@ public class OffsetMapTest {
         SkimpyOffsetMap map = new SkimpyOffsetMap(items * 48);
         IntStream.range(0, items).forEach(i -> assertDoesNotThrow(() -> map.put(key(i), i)));
         for (int i = 0; i < items; i++) {
-            assertEquals(map.get(key(i)), i);
+            assertEquals(i, map.get(key(i)));
         }
     }
 
@@ -45,7 +45,7 @@ public class OffsetMapTest {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         IntStream.range(0, 10).forEach(i -> assertDoesNotThrow(() -> map.put(key(i), i)));
         for (int i = 0; i < 10; i++) {
-            assertEquals(map.get(key(i)), i);
+            assertEquals(i, map.get(key(i)));
         }
         map.clear();
         for (int i = 0; i < 10; i++) {
@@ -61,8 +61,8 @@ public class OffsetMapTest {
             map.put(key(i), i);
             i++;
         }
-        assertEquals(map.get(key(i)), -1);
-        assertEquals(map.get(key(i - 1)), i - 1);
+        assertEquals(-1, map.get(key(i)));
+        assertEquals(i - 1, map.get(key(i - 1)));
     }
 
     @Test
@@ -74,9 +74,9 @@ public class OffsetMapTest {
             i++;
         }
         int lastOffsets = 40;
-        assertEquals(map.get(key(i - 1)), i - 1);
+        assertEquals(i - 1, map.get(key(i - 1)));
         map.updateLatestOffset(lastOffsets);
-        assertEquals(map.get(key(lastOffsets)), lastOffsets);
+        assertEquals(lastOffsets, map.get(key(lastOffsets)));
     }
 
     @Test
@@ -87,17 +87,17 @@ public class OffsetMapTest {
             map.put(key(i), i);
             i++;
         }
-        assertEquals(map.latestOffset(), i - 1);
+        assertEquals(i - 1, map.latestOffset());
     }
     
     @Test
     public void testUtilization() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
-        assertEquals(map.utilization(), 0.0);
+        assertEquals(0.0, map.utilization());
         while (map.size() < map.slots()) {
             map.put(key(i), i);
-            assertEquals(map.utilization(), (double) map.size() / map.slots());
+            assertEquals((double) map.size() / map.slots(), map.utilization());
             i++;
         }
     }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
@@ -382,10 +382,10 @@ public class ProducerStateManagerTest {
         CompletedTxn completedTxn = appendInfo.appendEndTxnMarker(endTxnMarker, epoch, 40L, time.milliseconds())
                 .orElseThrow(() -> new RuntimeException("The transaction should be completed"));
 
-        assertEquals(producerId, completedTxn.producerId);
-        assertEquals(16L, completedTxn.firstOffset);
-        assertEquals(40L, completedTxn.lastOffset);
-        assertFalse(completedTxn.isAborted);
+        assertEquals(producerId, completedTxn.producerId());
+        assertEquals(16L, completedTxn.firstOffset());
+        assertEquals(40L, completedTxn.lastOffset());
+        assertFalse(completedTxn.isAborted());
 
         ProducerStateEntry lastEntry = appendInfo.toEntry();
         // verify that appending the transaction marker doesn't affect the metadata of the cached record batches.

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -172,15 +172,15 @@ public class RemoteIndexCacheTest {
         OffsetIndex offsetIndex = cache.getIndexEntry(rlsMetadata).offsetIndex();
         OffsetPosition offsetPosition1 = offsetIndex.entry(1);
         // this call should have invoked fetchOffsetIndex, fetchTimestampIndex once
-        int resultPosition = cache.lookupOffset(rlsMetadata, offsetPosition1.offset);
-        assertEquals(offsetPosition1.position, resultPosition);
+        int resultPosition = cache.lookupOffset(rlsMetadata, offsetPosition1.offset());
+        assertEquals(offsetPosition1.position(), resultPosition);
         verifyFetchIndexInvocation(1, List.of(IndexType.OFFSET, IndexType.TIMESTAMP));
 
         // this should not cause fetching index from RemoteStorageManager as it is already fetched earlier
         reset(rsm);
         OffsetPosition offsetPosition2 = offsetIndex.entry(2);
-        int resultPosition2 = cache.lookupOffset(rlsMetadata, offsetPosition2.offset);
-        assertEquals(offsetPosition2.position, resultPosition2);
+        int resultPosition2 = cache.lookupOffset(rlsMetadata, offsetPosition2.offset());
+        assertEquals(offsetPosition2.position(), resultPosition2);
         assertNotNull(cache.getIndexEntry(rlsMetadata));
         verifyNoInteractions(rsm);
     }
@@ -219,7 +219,7 @@ public class RemoteIndexCacheTest {
         // offsetIndex.lookup() returns OffsetPosition(baseOffset, 0) for offsets smaller than the last entry in the offset index.
         OffsetPosition nonExistentOffsetPosition = new OffsetPosition(baseOffset, 0);
         long lowerOffsetThanBaseOffset = offsetIndex.baseOffset() - 1;
-        assertEquals(nonExistentOffsetPosition.position, cache.lookupOffset(rlsMetadata, lowerOffsetThanBaseOffset));
+        assertEquals(nonExistentOffsetPosition.position(), cache.lookupOffset(rlsMetadata, lowerOffsetThanBaseOffset));
     }
 
     @Test
@@ -1088,12 +1088,12 @@ public class RemoteIndexCacheTest {
                 name -> name.contains(segmentUuid.toString()) && name.endsWith(LogFileUtils.DELETED_FILE_SUFFIX)));
         // Ensure that the `indexEntry` object still able to access the renamed index files after being marked for deletion
         OffsetPosition offsetPosition = indexEntry.offsetIndex().entry(2);
-        assertEquals(offsetPosition.position, indexEntry.lookupOffset(offsetPosition.offset).position);
+        assertEquals(offsetPosition.position(), indexEntry.lookupOffset(offsetPosition.offset()).position());
         assertNull(cache.internalCache().asMap().get(segmentUuid));
         verifyFetchIndexInvocation(1);
 
         // Once the entry gets removed from cache, the subsequent call to the cache should re-fetch the entry from remote.
-        assertEquals(offsetPosition.position, cache.lookupOffset(rlsMetadata, offsetPosition.offset));
+        assertEquals(offsetPosition.position(), cache.lookupOffset(rlsMetadata, offsetPosition.offset()));
         verifyFetchIndexInvocation(2);
         RemoteIndexCache.Entry indexEntry2 = cache.getIndexEntry(rlsMetadata);
         assertNotNull(indexEntry2);
@@ -1111,18 +1111,18 @@ public class RemoteIndexCacheTest {
         assertEquals(3, countFiles(cacheDir, name -> true));
         assertEquals(3, countFiles(cacheDir,
                 name -> name.contains(segmentUuid.toString()) && name.endsWith(LogFileUtils.DELETED_FILE_SUFFIX)));
-        assertEquals(offsetPosition.position, indexEntry.lookupOffset(offsetPosition.offset).position);
-        assertEquals(offsetPosition.position, indexEntry2.lookupOffset(offsetPosition.offset).position);
+        assertEquals(offsetPosition.position(), indexEntry.lookupOffset(offsetPosition.offset()).position());
+        assertEquals(offsetPosition.position(), indexEntry2.lookupOffset(offsetPosition.offset()).position());
 
         indexEntry.cleanup();
         assertEquals(0, countFiles(cacheDir, name -> true));
-        assertThrows(IllegalStateException.class, () -> indexEntry.lookupOffset(offsetPosition.offset));
-        assertEquals(offsetPosition.position, indexEntry2.lookupOffset(offsetPosition.offset).position);
+        assertThrows(IllegalStateException.class, () -> indexEntry.lookupOffset(offsetPosition.offset()));
+        assertEquals(offsetPosition.position(), indexEntry2.lookupOffset(offsetPosition.offset()).position());
 
         indexEntry2.cleanup();
         assertEquals(0, countFiles(cacheDir, name -> true));
-        assertThrows(IllegalStateException.class, () -> indexEntry.lookupOffset(offsetPosition.offset));
-        assertThrows(IllegalStateException.class, () -> indexEntry2.lookupOffset(offsetPosition.offset));
+        assertThrows(IllegalStateException.class, () -> indexEntry.lookupOffset(offsetPosition.offset()));
+        assertThrows(IllegalStateException.class, () -> indexEntry2.lookupOffset(offsetPosition.offset()));
     }
 
     private int countFiles(File cacheDir, Predicate<String> condition) {

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TimeIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TimeIndexTest.java
@@ -116,8 +116,8 @@ public class TimeIndexTest {
             @Override
             public TimestampOffset lastEntry() {
                 TimestampOffset superLastEntry = super.lastEntry();
-                long offset = shouldCorruptOffset ? this.baseOffset() - 1 : superLastEntry.offset;
-                long timestamp = shouldCorruptTimestamp ? firstEntry.timestamp - 1 : superLastEntry.timestamp;
+                long offset = shouldCorruptOffset ? this.baseOffset() - 1 : superLastEntry.offset();
+                long timestamp = shouldCorruptTimestamp ? firstEntry.timestamp() - 1 : superLastEntry.timestamp();
                 return new TimestampOffset(timestamp, offset);
             }
             @Override
@@ -193,7 +193,7 @@ public class TimeIndexTest {
     }
 
     private void appendEntries(Integer numEntries) {
-        IntStream.rangeClosed(1, numEntries).forEach(i -> idx.maybeAppend(i * 10, i * 10 + baseOffset));
+        IntStream.rangeClosed(1, numEntries).forEach(i -> idx.maybeAppend(i * 10L, i * 10L + baseOffset));
     }
 
     private File nonExistentTempFile() throws IOException {

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
@@ -100,28 +100,28 @@ public class TransactionIndexTest {
         abortedTransactions.forEach(txn -> assertDoesNotThrow(() -> index.append(txn)));
 
         TxnIndexSearchResult result = index.collectAbortedTxns(0L, 100L);
-        assertEquals(abortedTransactions, result.abortedTransactions);
-        assertFalse(result.isComplete);
+        assertEquals(abortedTransactions, result.abortedTransactions());
+        assertFalse(result.isComplete());
 
         result = index.collectAbortedTxns(0L, 32);
-        assertEquals(abortedTransactions.subList(0, 3), result.abortedTransactions);
-        assertTrue(result.isComplete);
+        assertEquals(abortedTransactions.subList(0, 3), result.abortedTransactions());
+        assertTrue(result.isComplete());
 
         result = index.collectAbortedTxns(0L, 35);
-        assertEquals(abortedTransactions, result.abortedTransactions);
-        assertTrue(result.isComplete);
+        assertEquals(abortedTransactions, result.abortedTransactions());
+        assertTrue(result.isComplete());
 
         result = index.collectAbortedTxns(10, 35);
-        assertEquals(abortedTransactions, result.abortedTransactions);
-        assertTrue(result.isComplete);
+        assertEquals(abortedTransactions, result.abortedTransactions());
+        assertTrue(result.isComplete());
 
         result = index.collectAbortedTxns(11, 35);
-        assertEquals(abortedTransactions.subList(1, 4), result.abortedTransactions);
-        assertTrue(result.isComplete);
+        assertEquals(abortedTransactions.subList(1, 4), result.abortedTransactions());
+        assertTrue(result.isComplete());
 
         result = index.collectAbortedTxns(20, 41);
-        assertEquals(abortedTransactions.subList(2, 4), result.abortedTransactions);
-        assertFalse(result.isComplete);
+        assertEquals(abortedTransactions.subList(2, 4), result.abortedTransactions());
+        assertFalse(result.isComplete());
     }
 
     @Test
@@ -135,13 +135,13 @@ public class TransactionIndexTest {
         abortedTransactions.forEach(txn -> assertDoesNotThrow(() -> index.append(txn)));
 
         index.truncateTo(51);
-        assertEquals(abortedTransactions, index.collectAbortedTxns(0L, 100L).abortedTransactions);
+        assertEquals(abortedTransactions, index.collectAbortedTxns(0L, 100L).abortedTransactions());
 
         index.truncateTo(50);
-        assertEquals(abortedTransactions.subList(0, 3), index.collectAbortedTxns(0L, 100L).abortedTransactions);
+        assertEquals(abortedTransactions.subList(0, 3), index.collectAbortedTxns(0L, 100L).abortedTransactions());
 
         index.reset();
-        assertEquals(List.of(), index.collectAbortedTxns(0L, 100L).abortedTransactions);
+        assertEquals(List.of(), index.collectAbortedTxns(0L, 100L).abortedTransactions());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class TransactionIndexTest {
         index.renameTo(renamed);
         index.append(new AbortedTxn(1L, 5, 15, 16));
 
-        List<AbortedTxn> abortedTxns = index.collectAbortedTxns(0L, 100L).abortedTransactions;
+        List<AbortedTxn> abortedTxns = index.collectAbortedTxns(0L, 100L).abortedTransactions();
         assertEquals(2, abortedTxns.size());
         assertEquals(0, abortedTxns.get(0).firstOffset());
         assertEquals(5, abortedTxns.get(1).firstOffset());

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
@@ -30,19 +30,16 @@ import org.apache.kafka.tiered.storage.actions.CreateTopicAction;
 import org.apache.kafka.tiered.storage.actions.DeleteRecordsAction;
 import org.apache.kafka.tiered.storage.actions.DeleteTopicAction;
 import org.apache.kafka.tiered.storage.actions.EraseBrokerStorageAction;
-import org.apache.kafka.tiered.storage.actions.ExpectBrokerInISRAction;
 import org.apache.kafka.tiered.storage.actions.ExpectEmptyRemoteStorageAction;
 import org.apache.kafka.tiered.storage.actions.ExpectLeaderAction;
 import org.apache.kafka.tiered.storage.actions.ExpectLeaderEpochCheckpointAction;
 import org.apache.kafka.tiered.storage.actions.ExpectListOffsetsAction;
-import org.apache.kafka.tiered.storage.actions.ExpectTopicIdToMatchInRemoteStorageAction;
 import org.apache.kafka.tiered.storage.actions.ExpectUserTopicMappedToMetadataPartitionsAction;
 import org.apache.kafka.tiered.storage.actions.ProduceAction;
 import org.apache.kafka.tiered.storage.actions.ReassignReplicaAction;
 import org.apache.kafka.tiered.storage.actions.ShrinkReplicaAction;
 import org.apache.kafka.tiered.storage.actions.StartBrokerAction;
 import org.apache.kafka.tiered.storage.actions.StopBrokerAction;
-import org.apache.kafka.tiered.storage.actions.UpdateBrokerConfigAction;
 import org.apache.kafka.tiered.storage.actions.UpdateTopicConfigAction;
 import org.apache.kafka.tiered.storage.specs.ConsumableSpec;
 import org.apache.kafka.tiered.storage.specs.DeletableSpec;
@@ -83,16 +80,16 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder createTopic(String topic,
-                                                Integer partitionCount,
-                                                Integer replicationFactor,
-                                                Integer maxBatchCountPerSegment,
+                                                int partitionCount,
+                                                int replicationFactor,
+                                                int maxBatchCountPerSegment,
                                                 Map<Integer, List<Integer>> replicaAssignment,
-                                                Boolean enableRemoteLogStorage) {
+                                                boolean enableRemoteLogStorage) {
         assertTrue(maxBatchCountPerSegment >= 1, "Segments size for topic " + topic + " needs to be >= 1");
         assertTrue(partitionCount >= 1, "Partition count for topic " + topic + " needs to be >= 1");
         assertTrue(replicationFactor >= 1, "Replication factor for topic " + topic + " needs to be >= 1");
         Map<String, String> properties = new HashMap<>();
-        properties.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, enableRemoteLogStorage.toString());
+        properties.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, String.valueOf(enableRemoteLogStorage));
         TopicSpec topicSpec = new TopicSpec(topic, partitionCount, replicationFactor, maxBatchCountPerSegment,
                 replicaAssignment, properties);
         actions.add(new CreateTopicAction(topicSpec));
@@ -100,7 +97,7 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder createPartitions(String topic,
-                                                     Integer partitionCount,
+                                                     int partitionCount,
                                                      Map<Integer, List<Integer>> replicaAssignment) {
         assertTrue(partitionCount >= 1, "Partition count for topic " + topic + " needs to be >= 1");
         ExpandPartitionCountSpec spec = new ExpandPartitionCountSpec(topic, partitionCount, replicaAssignment);
@@ -117,22 +114,13 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder updateBrokerConfig(Integer brokerId,
-                                                       Map<String, String> configsToBeAdded,
-                                                       List<String> configsToBeDeleted) {
-        assertTrue(!configsToBeAdded.isEmpty() || !configsToBeDeleted.isEmpty(),
-                "Broker " + brokerId + " configs shouldn't be empty");
-        actions.add(new UpdateBrokerConfigAction(brokerId, configsToBeAdded, configsToBeDeleted));
-        return this;
-    }
-
     public TieredStorageTestBuilder deleteTopic(List<String> topics) {
         topics.forEach(topic -> actions.add(buildDeleteTopicAction(topic, true)));
         return this;
     }
 
     public TieredStorageTestBuilder produce(String topic,
-                                            Integer partition,
+                                            int partition,
                                             KeyValueSpec... keyValues) {
         assertTrue(partition >= 0, "Partition must be >= 0");
         ProducableSpec spec = getOrCreateProducable(topic, partition);
@@ -144,7 +132,7 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder produceWithTimestamp(String topic,
-                                                         Integer partition,
+                                                         int partition,
                                                          KeyValueSpec... keyValues) {
         assertTrue(partition >= 0, "Partition must be >= 0");
         ProducableSpec spec = getOrCreateProducable(topic, partition);
@@ -156,26 +144,18 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder withBatchSize(String topic,
-                                                  Integer partition,
-                                                  Integer batchSize) {
-        assertTrue(batchSize >= 1, "The size of a batch of produced records must >= 1");
-        getOrCreateProducable(topic, partition).setBatchSize(batchSize);
-        return this;
-    }
-
     public TieredStorageTestBuilder expectEarliestLocalOffsetInLogDirectory(String topic,
-                                                                            Integer partition,
-                                                                            Long earliestLocalOffset) {
+                                                                            int partition,
+                                                                            long earliestLocalOffset) {
         assertTrue(earliestLocalOffset >= 0, "Record offset must be >= 0");
         getOrCreateProducable(topic, partition).setEarliestLocalLogOffset(earliestLocalOffset);
         return this;
     }
 
-    public TieredStorageTestBuilder expectSegmentToBeOffloaded(Integer fromBroker,
+    public TieredStorageTestBuilder expectSegmentToBeOffloaded(int fromBroker,
                                                                String topic,
-                                                               Integer partition,
-                                                               Integer baseOffset,
+                                                               int partition,
+                                                               int baseOffset,
                                                                KeyValueSpec... keyValues) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         List<ProducerRecord<String, String>> records = new ArrayList<>();
@@ -187,16 +167,11 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder expectTopicIdToMatchInRemoteStorage(String topic) {
-        actions.add(new ExpectTopicIdToMatchInRemoteStorageAction(topic));
-        return this;
-    }
-
     public TieredStorageTestBuilder consume(String topic,
-                                            Integer partition,
-                                            Long fetchOffset,
-                                            Integer expectedTotalRecord,
-                                            Integer expectedRecordsFromSecondTier) {
+                                            int partition,
+                                            long fetchOffset,
+                                            int expectedTotalRecord,
+                                            int expectedRecordsFromSecondTier) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         assertTrue(partition >= 0, "Partition must be >= 0");
         assertTrue(fetchOffset >= 0, "Fetch offset must be >=0");
@@ -211,30 +186,23 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder expectLeader(String topic,
-                                                 Integer partition,
-                                                 Integer brokerId,
-                                                 Boolean electLeader) {
+                                                 int partition,
+                                                 int brokerId,
+                                                 boolean electLeader) {
         actions.add(new ExpectLeaderAction(new TopicPartition(topic, partition), brokerId, electLeader));
         return this;
     }
 
-    public TieredStorageTestBuilder expectInIsr(String topic,
-                                                Integer partition,
-                                                Integer brokerId) {
-        actions.add(new ExpectBrokerInISRAction(new TopicPartition(topic, partition), brokerId));
-        return this;
-    }
-
-    public TieredStorageTestBuilder expectFetchFromTieredStorage(Integer fromBroker,
+    public TieredStorageTestBuilder expectFetchFromTieredStorage(int fromBroker,
                                                                  String topic,
-                                                                 Integer partition,
-                                                                 Integer segmentFetchRequestCount) {
+                                                                 int partition,
+                                                                 int segmentFetchRequestCount) {
         return expectFetchFromTieredStorage(fromBroker, topic, partition, new RemoteFetchCount(segmentFetchRequestCount));
     }
 
-    public TieredStorageTestBuilder expectFetchFromTieredStorage(Integer fromBroker,
+    public TieredStorageTestBuilder expectFetchFromTieredStorage(int fromBroker,
                                                                  String topic,
-                                                                 Integer partition,
+                                                                 int partition,
                                                                  RemoteFetchCount remoteFetchRequestCount) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         assertTrue(partition >= 0, "Partition must be >= 0");
@@ -244,11 +212,11 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder expectDeletionInRemoteStorage(Integer fromBroker,
+    public TieredStorageTestBuilder expectDeletionInRemoteStorage(int fromBroker,
                                                                   String topic,
-                                                                  Integer partition,
+                                                                  int partition,
                                                                   LocalTieredStorageEvent.EventType eventType,
-                                                                  Integer eventCount) {
+                                                                  int eventCount) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         deletables.computeIfAbsent(topicPartition, k -> new ArrayList<>())
                 .add(new DeletableSpec(fromBroker, eventType, eventCount));
@@ -260,18 +228,18 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder expectLeaderEpochCheckpoint(Integer brokerId,
+    public TieredStorageTestBuilder expectLeaderEpochCheckpoint(int brokerId,
                                                                 String topic,
-                                                                Integer partition,
-                                                                Integer beginEpoch,
-                                                                Long startOffset) {
+                                                                int partition,
+                                                                int beginEpoch,
+                                                                long startOffset) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         actions.add(new ExpectLeaderEpochCheckpointAction(brokerId, topicPartition, beginEpoch, startOffset));
         return this;
     }
 
     public TieredStorageTestBuilder expectListOffsets(String topic,
-                                                      Integer partition,
+                                                      int partition,
                                                       OffsetSpec offsetSpec,
                                                       EpochEntry epochEntry) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
@@ -279,27 +247,22 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder bounce(Integer brokerId) {
+    public TieredStorageTestBuilder bounce(int brokerId) {
         actions.add(new BounceBrokerAction(brokerId));
         return this;
     }
 
-    public TieredStorageTestBuilder stop(Integer brokerId) {
+    public TieredStorageTestBuilder stop(int brokerId) {
         actions.add(new StopBrokerAction(brokerId));
         return this;
     }
 
-    public TieredStorageTestBuilder start(Integer brokerId) {
+    public TieredStorageTestBuilder start(int brokerId) {
         actions.add(new StartBrokerAction(brokerId));
         return this;
     }
 
-    public TieredStorageTestBuilder eraseBrokerStorage(Integer brokerId) {
-        actions.add(new EraseBrokerStorageAction(brokerId));
-        return this;
-    }
-
-    public TieredStorageTestBuilder eraseBrokerStorage(Integer brokerId,
+    public TieredStorageTestBuilder eraseBrokerStorage(int brokerId,
                                                        FilenameFilter filenameFilter,
                                                        boolean isStopped) {
         actions.add(new EraseBrokerStorageAction(brokerId, filenameFilter, isStopped));
@@ -307,14 +270,14 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder expectEmptyRemoteStorage(String topic,
-                                                             Integer partition) {
+                                                             int partition) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         actions.add(new ExpectEmptyRemoteStorageAction(topicPartition));
         return this;
     }
 
     public TieredStorageTestBuilder shrinkReplica(String topic,
-                                                  Integer partition,
+                                                  int partition,
                                                   List<Integer> replicaIds) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         actions.add(new ShrinkReplicaAction(topicPartition, replicaIds));
@@ -322,7 +285,7 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder reassignReplica(String topic,
-                                                    Integer partition,
+                                                    int partition,
                                                     List<Integer> replicaIds) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         actions.add(new ReassignReplicaAction(topicPartition, replicaIds));
@@ -330,7 +293,7 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder alterLogDir(String topic,
-                                                Integer partition,
+                                                int partition,
                                                 int replicaIds) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         actions.add(new AlterLogDirAction(topicPartition, replicaIds));
@@ -344,8 +307,8 @@ public final class TieredStorageTestBuilder {
     }
 
     public TieredStorageTestBuilder deleteRecords(String topic,
-                                                  Integer partition,
-                                                  Long beforeOffset) {
+                                                  int partition,
+                                                  long beforeOffset) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         actions.add(new DeleteRecordsAction(topicPartition, beforeOffset, buildDeleteSegmentSpecList(topic)));
         return this;
@@ -392,7 +355,7 @@ public final class TieredStorageTestBuilder {
     }
 
     private ProducableSpec getOrCreateProducable(String topic,
-                                                 Integer partition) {
+                                                 int partition) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         return producables.computeIfAbsent(topicPartition,
                 k -> new ProducableSpec(new ArrayList<>(), defaultProducedBatchSize,
@@ -400,7 +363,7 @@ public final class TieredStorageTestBuilder {
     }
 
     private DeleteTopicAction buildDeleteTopicAction(String topic,
-                                                     Boolean shouldDelete) {
+                                                     boolean shouldDelete) {
         return new DeleteTopicAction(topic, buildDeleteSegmentSpecList(topic), shouldDelete);
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
@@ -363,8 +363,8 @@ public final class TieredStorageTestBuilder {
                         offloadables.computeIfAbsent(topicPartition, k -> new ArrayList<>())
                         .stream()
                         .map(spec ->
-                                new OffloadedSegmentSpec(spec.getSourceBrokerId(), topicPartition, spec.getBaseOffset(),
-                                        spec.getRecords()))
+                                new OffloadedSegmentSpec(spec.sourceBrokerId(), topicPartition, spec.baseOffset(),
+                                        spec.records()))
                         .toList();
                 ProduceAction action = new ProduceAction(topicPartition, offloadedSegmentSpecs, recordsToProduce,
                         producableSpec.getBatchSize(), producableSpec.getEarliestLocalLogOffset());
@@ -379,10 +379,10 @@ public final class TieredStorageTestBuilder {
         if (!consumables.isEmpty()) {
             consumables.forEach((topicPartition, consumableSpec) -> {
                 FetchableSpec fetchableSpec = fetchables.computeIfAbsent(topicPartition, k -> new FetchableSpec(0, new RemoteFetchCount(0)));
-                RemoteFetchSpec remoteFetchSpec = new RemoteFetchSpec(fetchableSpec.getSourceBrokerId(), topicPartition,
-                        fetchableSpec.getFetchCount());
-                ConsumeAction action = new ConsumeAction(topicPartition, consumableSpec.getFetchOffset(),
-                        consumableSpec.getExpectedTotalCount(), consumableSpec.getExpectedFromSecondTierCount(),
+                RemoteFetchSpec remoteFetchSpec = new RemoteFetchSpec(fetchableSpec.sourceBrokerId(), topicPartition,
+                        fetchableSpec.fetchCount());
+                ConsumeAction action = new ConsumeAction(topicPartition, consumableSpec.fetchOffset(),
+                        consumableSpec.expectedTotalCount(), consumableSpec.expectedFromSecondTierCount(),
                         remoteFetchSpec);
                 actions.add(action);
             });
@@ -412,11 +412,11 @@ public final class TieredStorageTestBuilder {
                     TopicPartition partition = e.getKey();
                     List<DeletableSpec> deletableSpecs = e.getValue();
                     return deletableSpecs.stream()
-                            .map(spec -> new RemoteDeleteSegmentSpec(spec.getSourceBrokerId(), partition,
-                                    spec.getEventType(), spec.getEventCount()));
+                            .map(spec -> new RemoteDeleteSegmentSpec(spec.sourceBrokerId(), partition,
+                                    spec.eventType(), spec.eventCount()));
                 })
                 .toList();
-        deleteSegmentSpecList.forEach(spec -> deletables.remove(spec.getTopicPartition()));
+        deleteSegmentSpecList.forEach(spec -> deletables.remove(spec.topicPartition()));
         return deleteSegmentSpecList;
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
@@ -93,7 +93,7 @@ public final class TieredStorageTestContext implements AutoCloseable {
     }
 
     private void initClients() {
-        // rediscover the new bootstrap-server port incase of broker restarts
+        // rediscover the new bootstrap-server port in case of broker restarts
         ListenerName listenerName = harness.listenerName();
         Properties commonOverrideProps = new Properties();
         commonOverrideProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, harness.bootstrapServers(listenerName));
@@ -117,35 +117,35 @@ public final class TieredStorageTestContext implements AutoCloseable {
 
     public void createTopic(TopicSpec spec) throws ExecutionException, InterruptedException {
         NewTopic newTopic;
-        if (spec.getAssignment() == null || spec.getAssignment().isEmpty()) {
-            newTopic = new NewTopic(spec.getTopicName(), spec.getPartitionCount(), (short) spec.getReplicationFactor());
+        if (spec.assignment() == null || spec.assignment().isEmpty()) {
+            newTopic = new NewTopic(spec.topicName(), spec.partitionCount(), (short) spec.replicationFactor());
         } else {
-            Map<Integer, List<Integer>> replicasAssignments = spec.getAssignment();
-            newTopic = new NewTopic(spec.getTopicName(), replicasAssignments);
+            Map<Integer, List<Integer>> replicasAssignments = spec.assignment();
+            newTopic = new NewTopic(spec.topicName(), replicasAssignments);
         }
-        newTopic.configs(spec.getProperties());
+        newTopic.configs(spec.properties());
         admin.createTopics(List.of(newTopic)).all().get();
-        TestUtils.waitForAllPartitionsMetadata(harness.brokers(), spec.getTopicName(), spec.getPartitionCount());
+        TestUtils.waitForAllPartitionsMetadata(harness.brokers(), spec.topicName(), spec.partitionCount());
         synchronized (this) {
-            topicSpecs.put(spec.getTopicName(), spec);
+            topicSpecs.put(spec.topicName(), spec);
         }
     }
 
     public void createPartitions(ExpandPartitionCountSpec spec) throws ExecutionException, InterruptedException {
         NewPartitions newPartitions;
-        if (spec.getAssignment() == null || spec.getAssignment().isEmpty()) {
-            newPartitions = NewPartitions.increaseTo(spec.getPartitionCount());
+        if (spec.assignment() == null || spec.assignment().isEmpty()) {
+            newPartitions = NewPartitions.increaseTo(spec.partitionCount());
         } else {
-            Map<Integer, List<Integer>> assignment = spec.getAssignment();
+            Map<Integer, List<Integer>> assignment = spec.assignment();
             List<List<Integer>> newAssignments = assignment.entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
                     .map(Map.Entry::getValue)
                     .toList();
-            newPartitions = NewPartitions.increaseTo(spec.getPartitionCount(), newAssignments);
+            newPartitions = NewPartitions.increaseTo(spec.partitionCount(), newAssignments);
         }
-        Map<String, NewPartitions> partitionsMap = Map.of(spec.getTopicName(), newPartitions);
+        Map<String, NewPartitions> partitionsMap = Map.of(spec.topicName(), newPartitions);
         admin.createPartitions(partitionsMap).all().get();
-        TestUtils.waitForAllPartitionsMetadata(harness.brokers(), spec.getTopicName(), spec.getPartitionCount());
+        TestUtils.waitForAllPartitionsMetadata(harness.brokers(), spec.topicName(), spec.partitionCount());
     }
 
     public void updateTopicConfig(String topic,

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ConsumeAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ConsumeAction.java
@@ -77,7 +77,7 @@ public final class ConsumeAction implements TieredStorageTestAction {
         // The latest event at the time of invocation for the interaction of type "FETCH_SEGMENT" between the
         // given broker and the second-tier storage is retrieved. It can be empty if an interaction of this
         // type has yet to happen.
-        LocalTieredStorageHistory history = context.tieredStorageHistory(remoteFetchSpec.getSourceBrokerId());
+        LocalTieredStorageHistory history = context.tieredStorageHistory(remoteFetchSpec.sourceBrokerId());
         Optional<LocalTieredStorageEvent> latestEventSoFar = history.latestEvent(FETCH_SEGMENT, topicPartition);
         Optional<LocalTieredStorageEvent> latestOffsetIdxEventSoFar = history.latestEvent(FETCH_OFFSET_INDEX, topicPartition);
         Optional<LocalTieredStorageEvent> latestTimeIdxEventSoFar = history.latestEvent(FETCH_TIME_INDEX, topicPartition);
@@ -127,47 +127,27 @@ public final class ConsumeAction implements TieredStorageTestAction {
 
         // (B) Assessment of the interactions between the source broker and the second-tier storage.
         for (LocalTieredStorageEvent.EventType eventType : List.of(FETCH_SEGMENT, FETCH_OFFSET_INDEX, FETCH_TIME_INDEX, FETCH_TRANSACTION_INDEX)) {
-            Optional<LocalTieredStorageEvent> latestEvent;
-            switch (eventType) {
-                case FETCH_SEGMENT:
-                    latestEvent = latestEventSoFar;
-                    break;
-                case FETCH_OFFSET_INDEX:
-                    latestEvent = latestOffsetIdxEventSoFar;
-                    break;
-                case FETCH_TIME_INDEX:
-                    latestEvent = latestTimeIdxEventSoFar;
-                    break;
-                case FETCH_TRANSACTION_INDEX:
-                    latestEvent = latestTxnIdxEventSoFar;
-                    break;
-                default:
-                    latestEvent = Optional.empty();
-            }
+            Optional<LocalTieredStorageEvent> latestEvent = switch (eventType) {
+                case FETCH_SEGMENT -> latestEventSoFar;
+                case FETCH_OFFSET_INDEX -> latestOffsetIdxEventSoFar;
+                case FETCH_TIME_INDEX -> latestTimeIdxEventSoFar;
+                case FETCH_TRANSACTION_INDEX -> latestTxnIdxEventSoFar;
+                default -> Optional.empty();
+            };
 
             List<LocalTieredStorageEvent> events = history.getEvents(eventType, topicPartition);
             List<LocalTieredStorageEvent> eventsInScope = latestEvent
                     .map(e -> events.stream().filter(event -> event.isAfter(e)).toList())
                     .orElse(events);
 
-            RemoteFetchCount remoteFetchCount = remoteFetchSpec.getRemoteFetchCount();
-            RemoteFetchCount.FetchCountAndOp expectedCountAndOp;
-            switch (eventType) {
-                case FETCH_SEGMENT:
-                    expectedCountAndOp = remoteFetchCount.getSegmentFetchCountAndOp();
-                    break;
-                case FETCH_OFFSET_INDEX:
-                    expectedCountAndOp = remoteFetchCount.getOffsetIdxFetchCountAndOp();
-                    break;
-                case FETCH_TIME_INDEX:
-                    expectedCountAndOp = remoteFetchCount.getTimeIdxFetchCountAndOp();
-                    break;
-                case FETCH_TRANSACTION_INDEX:
-                    expectedCountAndOp = remoteFetchCount.getTxnIdxFetchCountAndOp();
-                    break;
-                default:
-                    expectedCountAndOp = new RemoteFetchCount.FetchCountAndOp(-1, RemoteFetchCount.OperationType.EQUALS_TO);
-            }
+            RemoteFetchCount remoteFetchCount = remoteFetchSpec.remoteFetchCount();
+            RemoteFetchCount.FetchCountAndOp expectedCountAndOp = switch (eventType) {
+                case FETCH_SEGMENT -> remoteFetchCount.getSegmentFetchCountAndOp();
+                case FETCH_OFFSET_INDEX -> remoteFetchCount.getOffsetIdxFetchCountAndOp();
+                case FETCH_TIME_INDEX -> remoteFetchCount.getTimeIdxFetchCountAndOp();
+                case FETCH_TRANSACTION_INDEX -> remoteFetchCount.getTxnIdxFetchCountAndOp();
+                default -> new RemoteFetchCount.FetchCountAndOp(-1, RemoteFetchCount.OperationType.EQUALS_TO);
+            };
 
             RemoteFetchCount.OperationType exceptedOperationType = expectedCountAndOp.getOperationType();
             int exceptedCount = expectedCountAndOp.getCount();
@@ -195,8 +175,8 @@ public final class ConsumeAction implements TieredStorageTestAction {
             "Expected %s requests count from broker %d to tiered storage for topic-partition %s to be %s %d, " +
                     "but actual count was %d.",
             eventType,
-            remoteFetchSpec.getSourceBrokerId(),
-            remoteFetchSpec.getTopicPartition(),
+            remoteFetchSpec.sourceBrokerId(),
+            remoteFetchSpec.topicPartition(),
             operationTypeToString(exceptedOperationType),
             exceptedCount,
             actualCount

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/CreateTopicAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/CreateTopicAction.java
@@ -38,11 +38,11 @@ public final class CreateTopicAction implements TieredStorageTestAction {
     public void doExecute(TieredStorageTestContext context) throws ExecutionException, InterruptedException {
         boolean enableRemoteStorage = true;
         Map<String, String> topicConfigs = createTopicConfigForRemoteStorage(
-                enableRemoteStorage, spec.getMaxBatchCountPerSegment());
-        topicConfigs.putAll(spec.getProperties());
+                enableRemoteStorage, spec.maxBatchCountPerSegment());
+        topicConfigs.putAll(spec.properties());
 
-        spec.getProperties().clear();
-        spec.getProperties().putAll(topicConfigs);
+        spec.properties().clear();
+        spec.properties().putAll(topicConfigs);
         context.createTopic(spec);
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/DeleteRecordsAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/DeleteRecordsAction.java
@@ -54,14 +54,14 @@ public final class DeleteRecordsAction implements TieredStorageTestAction {
             throws InterruptedException, ExecutionException, TimeoutException {
         List<LocalTieredStorage> tieredStorages = context.remoteStorageManagers();
         List<LocalTieredStorageCondition> tieredStorageConditions = deleteSegmentSpecs.stream()
-                .filter(spec -> spec.getEventType() == DELETE_SEGMENT)
+                .filter(spec -> spec.eventType() == DELETE_SEGMENT)
                 .map(spec -> expectEvent(
                         tieredStorages,
-                        spec.getEventType(),
-                        spec.getSourceBrokerId(),
-                        spec.getTopicPartition(),
+                        spec.eventType(),
+                        spec.sourceBrokerId(),
+                        spec.topicPartition(),
                         false,
-                        spec.getEventCount()))
+                        spec.eventCount()))
                 .toList();
 
         Map<TopicPartition, RecordsToDelete> recordsToDeleteMap =

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/DeleteTopicAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/DeleteTopicAction.java
@@ -52,14 +52,14 @@ public final class DeleteTopicAction implements TieredStorageTestAction {
             throws ExecutionException, InterruptedException, TimeoutException {
         List<LocalTieredStorage> tieredStorages = context.remoteStorageManagers();
         List<LocalTieredStorageCondition> tieredStorageConditions = deleteSegmentSpecs.stream()
-                .filter(spec -> spec.getEventType() == DELETE_SEGMENT || spec.getEventType() == DELETE_PARTITION)
+                .filter(spec -> spec.eventType() == DELETE_SEGMENT || spec.eventType() == DELETE_PARTITION)
                 .map(spec -> expectEvent(
                         tieredStorages,
-                        spec.getEventType(),
-                        spec.getSourceBrokerId(),
-                        spec.getTopicPartition(),
+                        spec.eventType(),
+                        spec.sourceBrokerId(),
+                        spec.topicPartition(),
                         false,
-                        spec.getEventCount()))
+                        spec.eventCount()))
                 .toList();
         if (shouldDelete) {
             context.deleteTopic(topic);

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ExpectLeaderEpochCheckpointAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ExpectLeaderEpochCheckpointAction.java
@@ -57,8 +57,8 @@ public final class ExpectLeaderEpochCheckpointAction implements TieredStorageTes
                 earliestEntry = leaderEpochCache.earliestEntry().orElse(null);
             }
             earliestEntryOpt.set(earliestEntry);
-            return earliestEntry != null && beginEpoch == earliestEntry.epoch
-                    && startOffset == earliestEntry.startOffset;
+            return earliestEntry != null && beginEpoch == earliestEntry.epoch()
+                    && startOffset == earliestEntry.startOffset();
         }, 2000L, "leader-epoch-checkpoint begin-epoch: " + beginEpoch + " and start-offset: "
                 + startOffset + " doesn't match with actual: " + earliestEntryOpt.get());
     }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ExpectListOffsetsAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ExpectListOffsetsAction.java
@@ -52,10 +52,10 @@ public final class ExpectListOffsetsAction implements TieredStorageTestAction {
                 .all()
                 .get()
                 .get(partition);
-        assertEquals(expected.startOffset, listOffsetsResult.offset());
-        if (expected.epoch != -1) {
+        assertEquals(expected.startOffset(), listOffsetsResult.offset());
+        if (expected.epoch() != -1) {
             assertTrue(listOffsetsResult.leaderEpoch().isPresent());
-            assertEquals(expected.epoch, listOffsetsResult.leaderEpoch().get());
+            assertEquals(expected.epoch(), listOffsetsResult.leaderEpoch().get());
         } else {
             assertFalse(listOffsetsResult.leaderEpoch().isPresent());
         }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ProduceAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ProduceAction.java
@@ -80,9 +80,9 @@ public final class ProduceAction implements TieredStorageTestAction {
                 .map(spec -> expectEvent(
                         tieredStorages,
                         COPY_SEGMENT,
-                        spec.getSourceBrokerId(),
-                        spec.getTopicPartition(),
-                        spec.getBaseOffset(),
+                        spec.sourceBrokerId(),
+                        spec.topicPartition(),
+                        spec.baseOffset(),
                         false))
                 .toList();
 
@@ -109,7 +109,7 @@ public final class ProduceAction implements TieredStorageTestAction {
         TopicSpec topicSpec = context.topicSpec(topicPartition.topic());
         long earliestLocalOffset = expectedEarliestLocalOffset != -1L ? expectedEarliestLocalOffset
                 : startOffset + recordsToProduce.size()
-                - (recordsToProduce.size() % topicSpec.getMaxBatchCountPerSegment()) - 1;
+                - (recordsToProduce.size() % topicSpec.maxBatchCountPerSegment()) - 1;
 
         for (BrokerLocalStorage localStorage : localStorages) {
             // Select brokers which are assigned a replica of the topic-partition
@@ -138,7 +138,7 @@ public final class ProduceAction implements TieredStorageTestAction {
                 tieredStorageRecords.subList((int) (startOffset - beginOffset), tieredStorageRecords.size());
 
         List<ProducerRecord<String, String>> producerRecords = offloadedSegmentSpecs.stream()
-                .flatMap(spec -> spec.getRecords().stream())
+                .flatMap(spec -> spec.records().stream())
                 .toList();
         compareRecords(discoveredRecords, producerRecords, topicPartition);
     }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/AlterLogDirTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/AlterLogDirTest.java
@@ -54,7 +54,7 @@ public final class AlterLogDirTest extends TieredStorageTestHarness {
                 .produce(topicB, p0, new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"),
                         new KeyValueSpec("k2", "v2"))
                 // alter dir within the replica, we only expect one replicaId
-                .alterLogDir(topicB, p0, List.of(broker0).get(0))
+                .alterLogDir(topicB, p0, broker0)
                 // make sure the altered replica can still be elected as the leader
                 .expectLeader(topicB, p0, broker0, true)
                 // produce some more events and verify the earliest local offset

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/BaseDeleteSegmentsTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/BaseDeleteSegmentsTest.java
@@ -35,12 +35,12 @@ public abstract class BaseDeleteSegmentsTest extends TieredStorageTestHarness {
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
+        final int broker0 = 0;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 1;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 1;
+        final int maxBatchCountPerSegment = 1;
         final Map<Integer, List<Integer>> replicaAssignment = null;
         final boolean enableRemoteLogStorage = true;
         final int beginEpoch = 0;

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/BaseReassignReplicaTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/BaseReassignReplicaTest.java
@@ -53,10 +53,10 @@ public abstract class BaseReassignReplicaTest extends TieredStorageTestHarness {
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
         final String topicA = "topicA";
         final String topicB = "topicB";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 1;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 1;
+        final int maxBatchCountPerSegment = 1;
         final Map<Integer, List<Integer>> replicaAssignment = null;
         final boolean enableRemoteLogStorage = true;
         final List<Integer> metadataPartitions = new ArrayList<>();

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsDueToLogStartOffsetBreachTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsDueToLogStartOffsetBreachTest.java
@@ -36,13 +36,13 @@ public final class DeleteSegmentsDueToLogStartOffsetBreachTest extends TieredSto
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 2;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 2;
         final Map<Integer, List<Integer>> replicaAssignment = mkMap(mkEntry(p0, List.of(broker0, broker1)));
         final boolean enableRemoteLogStorage = true;
         final int beginEpoch = 0;

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteTopicTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteTopicTest.java
@@ -36,14 +36,14 @@ public final class DeleteTopicTest extends TieredStorageTestHarness {
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer p1 = 1;
-        final Integer partitionCount = 2;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int p1 = 1;
+        final int partitionCount = 2;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> assignment = mkMap(
                 mkEntry(p0, List.of(broker0, broker1)),

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DisableRemoteLogOnTopicTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DisableRemoteLogOnTopicTest.java
@@ -48,13 +48,13 @@ public final class DisableRemoteLogOnTopicTest extends TieredStorageTestHarness 
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> assignment = mkMap(
                 mkEntry(p0, List.of(broker0, broker1))

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/EnableRemoteLogOnTopicTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/EnableRemoteLogOnTopicTest.java
@@ -36,14 +36,14 @@ public final class EnableRemoteLogOnTopicTest extends TieredStorageTestHarness {
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer p1 = 1;
-        final Integer partitionCount = 2;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int p1 = 1;
+        final int partitionCount = 2;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = false;
         final Map<Integer, List<Integer>> assignment = mkMap(
                 mkEntry(p0, List.of(broker0, broker1)),

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
@@ -39,13 +39,13 @@ public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTes
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> assignment = mkMap(mkEntry(p0, List.of(broker0, broker1)));
         final List<String> checkpointFiles = List.of(

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
@@ -40,14 +40,14 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker = 0;
+        final int broker = 0;
         final String topicA = "topicA";
         final String topicB = "topicB";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 1;
-        final Integer oneBatchPerSegment = 1;
-        final Integer twoBatchPerSegment = 2;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 1;
+        final int oneBatchPerSegment = 1;
+        final int twoBatchPerSegment = 2;
         final Map<Integer, List<Integer>> replicaAssignment = null;
         final boolean enableRemoteLogStorage = true;
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndTxnConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndTxnConsumeFromLeaderTest.java
@@ -61,12 +61,12 @@ public final class OffloadAndTxnConsumeFromLeaderTest extends TieredStorageTestH
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker = 0;
+        final int broker = 0;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 1;
-        final Integer oneBatchPerSegment = 1;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 1;
+        final int oneBatchPerSegment = 1;
         final Map<Integer, List<Integer>> replicaAssignment = null;
         final boolean enableRemoteLogStorage = true;
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/PartitionsExpandTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/PartitionsExpandTest.java
@@ -35,15 +35,15 @@ public final class PartitionsExpandTest extends TieredStorageTestHarness {
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer p1 = 1;
-        final Integer p2 = 2;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int p1 = 1;
+        final int p2 = 2;
+        final int partitionCount = 1;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final List<Integer> p0Assignment = List.of(broker0, broker1);
         final List<Integer> p1Assignment = List.of(broker0, broker1);

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/ReassignReplicaShrinkTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/ReassignReplicaShrinkTest.java
@@ -48,14 +48,14 @@ public final class ReassignReplicaShrinkTest extends TieredStorageTestHarness {
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
-        final Integer broker1 = 1;
+        final int broker0 = 0;
+        final int broker1 = 1;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer p1 = 1;
-        final Integer partitionCount = 2;
-        final Integer replicationFactor = 2;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int p1 = 1;
+        final int partitionCount = 2;
+        final int replicationFactor = 2;
+        final int maxBatchCountPerSegment = 1;
         final boolean enableRemoteLogStorage = true;
         final Map<Integer, List<Integer>> replicaAssignment = mkMap(
                 mkEntry(p0, List.of(broker0, broker1)),

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/RollAndOffloadActiveSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/RollAndOffloadActiveSegmentTest.java
@@ -38,12 +38,12 @@ public class RollAndOffloadActiveSegmentTest extends TieredStorageTestHarness {
 
     @Override
     protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
-        final Integer broker0 = 0;
+        final int broker0 = 0;
         final String topicA = "topicA";
-        final Integer p0 = 0;
-        final Integer partitionCount = 1;
-        final Integer replicationFactor = 1;
-        final Integer maxBatchCountPerSegment = 1;
+        final int p0 = 0;
+        final int partitionCount = 1;
+        final int replicationFactor = 1;
+        final int maxBatchCountPerSegment = 1;
         final Map<Integer, List<Integer>> replicaAssignment = null;
         final boolean enableRemoteLogStorage = true;
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ConsumableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ConsumableSpec.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.tiered.storage.specs;
 
-public record ConsumableSpec(Long fetchOffset, Integer expectedTotalCount, Integer expectedFromSecondTierCount) {
+public record ConsumableSpec(long fetchOffset, int expectedTotalCount, int expectedFromSecondTierCount) {
 
     @Override
     public String toString() {

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ConsumableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ConsumableSpec.java
@@ -16,33 +16,7 @@
  */
 package org.apache.kafka.tiered.storage.specs;
 
-import java.util.Objects;
-
-public final class ConsumableSpec {
-
-    private final Long fetchOffset;
-    private final Integer expectedTotalCount;
-    private final Integer expectedFromSecondTierCount;
-
-    public ConsumableSpec(Long fetchOffset,
-                          Integer expectedTotalCount,
-                          Integer expectedFromSecondTierCount) {
-        this.fetchOffset = fetchOffset;
-        this.expectedTotalCount = expectedTotalCount;
-        this.expectedFromSecondTierCount = expectedFromSecondTierCount;
-    }
-
-    public Long getFetchOffset() {
-        return fetchOffset;
-    }
-
-    public Integer getExpectedTotalCount() {
-        return expectedTotalCount;
-    }
-
-    public Integer getExpectedFromSecondTierCount() {
-        return expectedFromSecondTierCount;
-    }
+public record ConsumableSpec(Long fetchOffset, Integer expectedTotalCount, Integer expectedFromSecondTierCount) {
 
     @Override
     public String toString() {
@@ -53,18 +27,4 @@ public final class ConsumableSpec {
                 '}';
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ConsumableSpec that = (ConsumableSpec) o;
-        return Objects.equals(fetchOffset, that.fetchOffset)
-                && Objects.equals(expectedTotalCount, that.expectedTotalCount)
-                && Objects.equals(expectedFromSecondTierCount, that.expectedFromSecondTierCount);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fetchOffset, expectedTotalCount, expectedFromSecondTierCount);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/DeletableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/DeletableSpec.java
@@ -18,7 +18,7 @@ package org.apache.kafka.tiered.storage.specs;
 
 import org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent;
 
-public record DeletableSpec(Integer sourceBrokerId, LocalTieredStorageEvent.EventType eventType, Integer eventCount) {
+public record DeletableSpec(int sourceBrokerId, LocalTieredStorageEvent.EventType eventType, int eventCount) {
 
     @Override
     public String toString() {

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/DeletableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/DeletableSpec.java
@@ -18,33 +18,7 @@ package org.apache.kafka.tiered.storage.specs;
 
 import org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent;
 
-import java.util.Objects;
-
-public final class DeletableSpec {
-
-    private final Integer sourceBrokerId;
-    private final LocalTieredStorageEvent.EventType eventType;
-    private final Integer eventCount;
-
-    public DeletableSpec(Integer sourceBrokerId,
-                         LocalTieredStorageEvent.EventType eventType,
-                         Integer eventCount) {
-        this.sourceBrokerId = sourceBrokerId;
-        this.eventType = eventType;
-        this.eventCount = eventCount;
-    }
-
-    public Integer getSourceBrokerId() {
-        return sourceBrokerId;
-    }
-
-    public LocalTieredStorageEvent.EventType getEventType() {
-        return eventType;
-    }
-
-    public Integer getEventCount() {
-        return eventCount;
-    }
+public record DeletableSpec(Integer sourceBrokerId, LocalTieredStorageEvent.EventType eventType, Integer eventCount) {
 
     @Override
     public String toString() {
@@ -55,18 +29,4 @@ public final class DeletableSpec {
                 '}';
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DeletableSpec that = (DeletableSpec) o;
-        return Objects.equals(sourceBrokerId, that.sourceBrokerId)
-                && eventType == that.eventType
-                && Objects.equals(eventCount, that.eventCount);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceBrokerId, eventType, eventCount);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ExpandPartitionCountSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ExpandPartitionCountSpec.java
@@ -18,33 +18,8 @@ package org.apache.kafka.tiered.storage.specs;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-public final class ExpandPartitionCountSpec {
-
-    private final String topicName;
-    private final int partitionCount;
-    private final Map<Integer, List<Integer>> assignment;
-
-    public ExpandPartitionCountSpec(String topicName,
-                                    int partitionCount,
-                                    Map<Integer, List<Integer>> assignment) {
-        this.topicName = topicName;
-        this.partitionCount = partitionCount;
-        this.assignment = assignment;
-    }
-
-    public String getTopicName() {
-        return topicName;
-    }
-
-    public int getPartitionCount() {
-        return partitionCount;
-    }
-
-    public Map<Integer, List<Integer>> getAssignment() {
-        return assignment;
-    }
+public record ExpandPartitionCountSpec(String topicName, int partitionCount, Map<Integer, List<Integer>> assignment) {
 
     @Override
     public String toString() {
@@ -52,18 +27,4 @@ public final class ExpandPartitionCountSpec {
                 topicName, partitionCount, assignment);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ExpandPartitionCountSpec that = (ExpandPartitionCountSpec) o;
-        return partitionCount == that.partitionCount
-                && Objects.equals(topicName, that.topicName)
-                && Objects.equals(assignment, that.assignment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(topicName, partitionCount, assignment);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchableSpec.java
@@ -16,26 +16,7 @@
  */
 package org.apache.kafka.tiered.storage.specs;
 
-import java.util.Objects;
-
-public final class FetchableSpec {
-
-    private final Integer sourceBrokerId;
-    private final RemoteFetchCount fetchCount;
-
-    public FetchableSpec(Integer sourceBrokerId,
-                         RemoteFetchCount fetchCount) {
-        this.sourceBrokerId = sourceBrokerId;
-        this.fetchCount = fetchCount;
-    }
-
-    public Integer getSourceBrokerId() {
-        return sourceBrokerId;
-    }
-
-    public RemoteFetchCount getFetchCount() {
-        return fetchCount;
-    }
+public record FetchableSpec(Integer sourceBrokerId, RemoteFetchCount fetchCount) {
 
     @Override
     public String toString() {
@@ -45,16 +26,4 @@ public final class FetchableSpec {
                 '}';
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        FetchableSpec that = (FetchableSpec) o;
-        return Objects.equals(sourceBrokerId, that.sourceBrokerId) && Objects.equals(fetchCount, that.fetchCount);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceBrokerId, fetchCount);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchableSpec.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.tiered.storage.specs;
 
-public record FetchableSpec(Integer sourceBrokerId, RemoteFetchCount fetchCount) {
+public record FetchableSpec(int sourceBrokerId, RemoteFetchCount fetchCount) {
 
     @Override
     public String toString() {

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/OffloadableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/OffloadableSpec.java
@@ -19,33 +19,9 @@ package org.apache.kafka.tiered.storage.specs;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.util.List;
-import java.util.Objects;
 
-public final class OffloadableSpec {
-
-    private final Integer sourceBrokerId;
-    private final Integer baseOffset;
-    private final List<ProducerRecord<String, String>> records;
-
-    public OffloadableSpec(Integer sourceBrokerId,
-                           Integer baseOffset,
-                           List<ProducerRecord<String, String>> records) {
-        this.sourceBrokerId = sourceBrokerId;
-        this.baseOffset = baseOffset;
-        this.records = records;
-    }
-
-    public Integer getSourceBrokerId() {
-        return sourceBrokerId;
-    }
-
-    public Integer getBaseOffset() {
-        return baseOffset;
-    }
-
-    public List<ProducerRecord<String, String>> getRecords() {
-        return records;
-    }
+public record OffloadableSpec(Integer sourceBrokerId, Integer baseOffset,
+                              List<ProducerRecord<String, String>> records) {
 
     @Override
     public String toString() {
@@ -56,18 +32,4 @@ public final class OffloadableSpec {
                 '}';
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        OffloadableSpec that = (OffloadableSpec) o;
-        return Objects.equals(sourceBrokerId, that.sourceBrokerId)
-                && Objects.equals(baseOffset, that.baseOffset)
-                && Objects.equals(records, that.records);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceBrokerId, baseOffset, records);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/OffloadableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/OffloadableSpec.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.util.List;
 
-public record OffloadableSpec(Integer sourceBrokerId, Integer baseOffset,
+public record OffloadableSpec(int sourceBrokerId, int baseOffset,
                               List<ProducerRecord<String, String>> records) {
 
     @Override

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/OffloadedSegmentSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/OffloadedSegmentSpec.java
@@ -20,48 +20,17 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.List;
-import java.util.Objects;
 
-public final class OffloadedSegmentSpec {
-
-    private final int sourceBrokerId;
-    private final TopicPartition topicPartition;
-    private final int baseOffset;
-    private final List<ProducerRecord<String, String>> records;
-
-    /**
-     * Specifies a remote log segment expected to be found in a second-tier storage.
-     *
-     * @param sourceBrokerId The broker which offloaded (uploaded) the segment to the second-tier storage.
-     * @param topicPartition The topic-partition which the remote log segment belongs to.
-     * @param baseOffset The base offset of the remote log segment.
-     * @param records The records *expected* in the remote log segment.
-     */
-    public OffloadedSegmentSpec(int sourceBrokerId,
-                                TopicPartition topicPartition,
-                                int baseOffset,
-                                List<ProducerRecord<String, String>> records) {
-        this.sourceBrokerId = sourceBrokerId;
-        this.topicPartition = topicPartition;
-        this.baseOffset = baseOffset;
-        this.records = records;
-    }
-
-    public int getSourceBrokerId() {
-        return sourceBrokerId;
-    }
-
-    public TopicPartition getTopicPartition() {
-        return topicPartition;
-    }
-
-    public int getBaseOffset() {
-        return baseOffset;
-    }
-
-    public List<ProducerRecord<String, String>> getRecords() {
-        return records;
-    }
+/**
+ * Specifies a remote log segment expected to be found in a second-tier storage.
+ *
+ * @param sourceBrokerId The broker which offloaded (uploaded) the segment to the second-tier storage.
+ * @param topicPartition The topic-partition which the remote log segment belongs to.
+ * @param baseOffset     The base offset of the remote log segment.
+ * @param records        The records *expected* in the remote log segment.
+ */
+public record OffloadedSegmentSpec(int sourceBrokerId, TopicPartition topicPartition, int baseOffset,
+                                   List<ProducerRecord<String, String>> records) {
 
     @Override
     public String toString() {
@@ -69,19 +38,4 @@ public final class OffloadedSegmentSpec {
                 topicPartition, sourceBrokerId, baseOffset, records.size());
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        OffloadedSegmentSpec that = (OffloadedSegmentSpec) o;
-        return sourceBrokerId == that.sourceBrokerId
-                && baseOffset == that.baseOffset
-                && Objects.equals(topicPartition, that.topicPartition)
-                && Objects.equals(records, that.records);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceBrokerId, topicPartition, baseOffset, records);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ProducableSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/ProducableSpec.java
@@ -24,12 +24,12 @@ import java.util.Objects;
 public final class ProducableSpec {
 
     private final List<ProducerRecord<String, String>> records;
-    private Integer batchSize;
-    private Long earliestLocalLogOffset;
+    private int batchSize;
+    private long earliestLocalLogOffset;
 
     public ProducableSpec(List<ProducerRecord<String, String>> records,
-                          Integer batchSize,
-                          Long earliestLocalLogOffset) {
+                          int batchSize,
+                          long earliestLocalLogOffset) {
         this.records = records;
         this.batchSize = batchSize;
         this.earliestLocalLogOffset = earliestLocalLogOffset;
@@ -39,15 +39,15 @@ public final class ProducableSpec {
         return records;
     }
 
-    public Integer getBatchSize() {
+    public int getBatchSize() {
         return batchSize;
     }
 
-    public void setBatchSize(Integer batchSize) {
+    public void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
     }
 
-    public Long getEarliestLocalLogOffset() {
+    public long getEarliestLocalLogOffset() {
         return earliestLocalLogOffset;
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteDeleteSegmentSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteDeleteSegmentSpec.java
@@ -19,51 +19,19 @@ package org.apache.kafka.tiered.storage.specs;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent;
 
-import java.util.Objects;
-
-public final class RemoteDeleteSegmentSpec {
-
-    private final int sourceBrokerId;
-    private final TopicPartition topicPartition;
-    private final LocalTieredStorageEvent.EventType eventType;
-    private final int eventCount;
-
-    /**
-     * Specifies a delete segment/partition event from a second-tier storage. This is used to ensure the
-     * interactions between Kafka and the second-tier storage match expectations.
-     *
-     * @param sourceBrokerId The broker which deletes (a) remote log segments(s) (or) deletes the entire partition from
-     *                       the second-tier storage.
-     * @param topicPartition The topic-partition in which the deletion should happen.
-     * @param eventType      Allowed event types are {@link LocalTieredStorageEvent.EventType#DELETE_PARTITION} and
-     *                       {@link LocalTieredStorageEvent.EventType#DELETE_SEGMENT}
-     * @param eventCount     How many events are expected to interact with the second-tier storage.
-     */
-    public RemoteDeleteSegmentSpec(int sourceBrokerId,
-                                   TopicPartition topicPartition,
-                                   LocalTieredStorageEvent.EventType eventType,
-                                   int eventCount) {
-        this.sourceBrokerId = sourceBrokerId;
-        this.topicPartition = topicPartition;
-        this.eventType = eventType;
-        this.eventCount = eventCount;
-    }
-
-    public int getSourceBrokerId() {
-        return sourceBrokerId;
-    }
-
-    public TopicPartition getTopicPartition() {
-        return topicPartition;
-    }
-
-    public LocalTieredStorageEvent.EventType getEventType() {
-        return eventType;
-    }
-
-    public int getEventCount() {
-        return eventCount;
-    }
+/**
+ * Specifies a delete segment/partition event from a second-tier storage. This is used to ensure the
+ * interactions between Kafka and the second-tier storage match expectations.
+ *
+ * @param sourceBrokerId The broker which deletes (a) remote log segments(s) (or) deletes the entire partition from
+ *                       the second-tier storage.
+ * @param topicPartition The topic-partition in which the deletion should happen.
+ * @param eventType      Allowed event types are {@link LocalTieredStorageEvent.EventType#DELETE_PARTITION} and
+ *                       {@link LocalTieredStorageEvent.EventType#DELETE_SEGMENT}
+ * @param eventCount     How many events are expected to interact with the second-tier storage.
+ */
+public record RemoteDeleteSegmentSpec(int sourceBrokerId, TopicPartition topicPartition,
+                                      LocalTieredStorageEvent.EventType eventType, int eventCount) {
 
     @Override
     public String toString() {
@@ -71,19 +39,4 @@ public final class RemoteDeleteSegmentSpec {
                 sourceBrokerId, topicPartition, eventType, eventCount);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RemoteDeleteSegmentSpec that = (RemoteDeleteSegmentSpec) o;
-        return sourceBrokerId == that.sourceBrokerId
-                && eventCount == that.eventCount
-                && Objects.equals(topicPartition, that.topicPartition)
-                && eventType == that.eventType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceBrokerId, topicPartition, eventType, eventCount);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchCount.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchCount.java
@@ -19,23 +19,13 @@ package org.apache.kafka.tiered.storage.specs;
 import java.util.Objects;
 
 public class RemoteFetchCount {
-    private FetchCountAndOp segmentFetchCountAndOp;
+    private final FetchCountAndOp segmentFetchCountAndOp;
     private FetchCountAndOp offsetIdxFetchCountAndOp = new FetchCountAndOp(-1);
     private FetchCountAndOp timeIdxFetchCountAndOp = new FetchCountAndOp(-1);
     private FetchCountAndOp txnIdxFetchCountAndOp = new FetchCountAndOp(-1);
 
     public RemoteFetchCount(int segmentFetchCountAndOp) {
         this.segmentFetchCountAndOp = new FetchCountAndOp(segmentFetchCountAndOp);
-    }
-
-    public RemoteFetchCount(int segmentFetchCountAndOp,
-                            int offsetIdxFetchCountAndOp,
-                            int timeIdxFetchCountAndOp,
-                            int txnIdxFetchCountAndOp) {
-        this.segmentFetchCountAndOp = new FetchCountAndOp(segmentFetchCountAndOp);
-        this.offsetIdxFetchCountAndOp = new FetchCountAndOp(offsetIdxFetchCountAndOp);
-        this.timeIdxFetchCountAndOp = new FetchCountAndOp(timeIdxFetchCountAndOp);
-        this.txnIdxFetchCountAndOp = new FetchCountAndOp(txnIdxFetchCountAndOp);
     }
 
     public RemoteFetchCount(FetchCountAndOp segmentFetchCountAndOp,
@@ -52,32 +42,16 @@ public class RemoteFetchCount {
         return segmentFetchCountAndOp;
     }
 
-    public void setSegmentFetchCountAndOp(FetchCountAndOp segmentFetchCountAndOp) {
-        this.segmentFetchCountAndOp = segmentFetchCountAndOp;
-    }
-
     public FetchCountAndOp getOffsetIdxFetchCountAndOp() {
         return offsetIdxFetchCountAndOp;
-    }
-
-    public void setOffsetIdxFetchCountAndOp(FetchCountAndOp offsetIdxFetchCountAndOp) {
-        this.offsetIdxFetchCountAndOp = offsetIdxFetchCountAndOp;
     }
 
     public FetchCountAndOp getTimeIdxFetchCountAndOp() {
         return timeIdxFetchCountAndOp;
     }
 
-    public void setTimeIdxFetchCountAndOp(FetchCountAndOp timeIdxFetchCountAndOp) {
-        this.timeIdxFetchCountAndOp = timeIdxFetchCountAndOp;
-    }
-
     public FetchCountAndOp getTxnIdxFetchCountAndOp() {
         return txnIdxFetchCountAndOp;
-    }
-
-    public void setTxnIdxFetchCountAndOp(FetchCountAndOp txnIdxFetchCountAndOp) {
-        this.txnIdxFetchCountAndOp = txnIdxFetchCountAndOp;
     }
 
     @Override

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchSpec.java
@@ -18,41 +18,15 @@ package org.apache.kafka.tiered.storage.specs;
 
 import org.apache.kafka.common.TopicPartition;
 
-import java.util.Objects;
-
-public final class RemoteFetchSpec {
-
-    private final int sourceBrokerId;
-    private final TopicPartition topicPartition;
-    private final RemoteFetchCount remoteFetchCount;
-
-    /**
-     * Specifies a fetch (download) event from a second-tier storage. This is used to ensure the
-     * interactions between Kafka and the second-tier storage match expectations.
-     *
-     * @param sourceBrokerId The broker which fetched (a) remote log segment(s) from the second-tier storage.
-     * @param topicPartition The topic-partition which segment(s) were fetched.
-     * @param remoteFetchCount The number of remote log segment(s) and indexes fetched.
-     */
-    public RemoteFetchSpec(int sourceBrokerId,
-                           TopicPartition topicPartition,
-                           RemoteFetchCount remoteFetchCount) {
-        this.sourceBrokerId = sourceBrokerId;
-        this.topicPartition = topicPartition;
-        this.remoteFetchCount = remoteFetchCount;
-    }
-
-    public int getSourceBrokerId() {
-        return sourceBrokerId;
-    }
-
-    public TopicPartition getTopicPartition() {
-        return topicPartition;
-    }
-
-    public RemoteFetchCount getRemoteFetchCount() {
-        return remoteFetchCount;
-    }
+/**
+ * Specifies a fetch (download) event from a second-tier storage. This is used to ensure the
+ * interactions between Kafka and the second-tier storage match expectations.
+ *
+ * @param sourceBrokerId   The broker which fetched (a) remote log segment(s) from the second-tier storage.
+ * @param topicPartition   The topic-partition which segment(s) were fetched.
+ * @param remoteFetchCount The number of remote log segment(s) and indexes fetched.
+ */
+public record RemoteFetchSpec(int sourceBrokerId, TopicPartition topicPartition, RemoteFetchCount remoteFetchCount) {
 
     @Override
     public String toString() {
@@ -60,18 +34,4 @@ public final class RemoteFetchSpec {
                 sourceBrokerId, topicPartition, remoteFetchCount);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RemoteFetchSpec that = (RemoteFetchSpec) o;
-        return sourceBrokerId == that.sourceBrokerId
-                && Objects.equals(remoteFetchCount, that.remoteFetchCount)
-                && Objects.equals(topicPartition, that.topicPartition);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceBrokerId, topicPartition, remoteFetchCount);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/TopicSpec.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/TopicSpec.java
@@ -18,65 +18,20 @@ package org.apache.kafka.tiered.storage.specs;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-public final class TopicSpec {
-
-    private final String topicName;
-    private final int partitionCount;
-    private final int replicationFactor;
-    private final int maxBatchCountPerSegment;
-    private final Map<Integer, List<Integer>> assignment;
-    private final Map<String, String> properties;
-
-    /**
-     * Specifies a topic-partition with attributes customized for the purpose of tiered-storage tests.
-     *
-     * @param topicName The name of the topic.
-     * @param partitionCount The number of partitions for the topic.
-     * @param replicationFactor The replication factor of the topic.
-     * @param maxBatchCountPerSegment The maximal number of batch in segments of the topic.
-     *                    This allows to obtain a fixed, pre-determined size for the segment, which ease
-     *                    reasoning on the expected states of local and tiered storages.
-     * @param properties Configuration of the topic customized for the purpose of tiered-storage tests.
-     */
-    public TopicSpec(String topicName,
-                     int partitionCount,
-                     int replicationFactor,
-                     int maxBatchCountPerSegment,
-                     Map<Integer, List<Integer>> assignment,
-                     Map<String, String> properties) {
-        this.topicName = topicName;
-        this.partitionCount = partitionCount;
-        this.replicationFactor = replicationFactor;
-        this.maxBatchCountPerSegment = maxBatchCountPerSegment;
-        this.assignment = assignment;
-        this.properties = properties;
-    }
-
-    public String getTopicName() {
-        return topicName;
-    }
-
-    public int getPartitionCount() {
-        return partitionCount;
-    }
-
-    public int getReplicationFactor() {
-        return replicationFactor;
-    }
-
-    public int getMaxBatchCountPerSegment() {
-        return maxBatchCountPerSegment;
-    }
-
-    public Map<Integer, List<Integer>> getAssignment() {
-        return assignment;
-    }
-
-    public Map<String, String> getProperties() {
-        return properties;
-    }
+/**
+ * Specifies a topic-partition with attributes customized for the purpose of tiered-storage tests.
+ *
+ * @param topicName               The name of the topic.
+ * @param partitionCount          The number of partitions for the topic.
+ * @param replicationFactor       The replication factor of the topic.
+ * @param maxBatchCountPerSegment The maximal number of batch in segments of the topic.
+ *                                This allows to obtain a fixed, pre-determined size for the segment, which ease
+ *                                reasoning on the expected states of local and tiered storages.
+ * @param properties              Configuration of the topic customized for the purpose of tiered-storage tests.
+ */
+public record TopicSpec(String topicName, int partitionCount, int replicationFactor, int maxBatchCountPerSegment,
+                        Map<Integer, List<Integer>> assignment, Map<String, String> properties) {
 
     @Override
     public String toString() {
@@ -85,22 +40,4 @@ public final class TopicSpec {
                 topicName, partitionCount, replicationFactor, maxBatchCountPerSegment, assignment, properties);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TopicSpec topicSpec = (TopicSpec) o;
-        return partitionCount == topicSpec.partitionCount
-                && replicationFactor == topicSpec.replicationFactor
-                && maxBatchCountPerSegment == topicSpec.maxBatchCountPerSegment
-                && Objects.equals(topicName, topicSpec.topicName)
-                && Objects.equals(assignment, topicSpec.assignment)
-                && Objects.equals(properties, topicSpec.properties);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(topicName, partitionCount, replicationFactor, maxBatchCountPerSegment, assignment,
-                properties);
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/BrokerLocalStorage.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/BrokerLocalStorage.java
@@ -46,10 +46,10 @@ public final class BrokerLocalStorage {
     private final Time time = Time.SYSTEM;
 
     public BrokerLocalStorage(Integer brokerId,
-                              Set<String> storageDirnames,
+                              Set<String> storageDirNames,
                               Integer storageWaitTimeoutSec) {
         this.brokerId = brokerId;
-        this.brokerStorageDirectories = storageDirnames.stream().map(File::new).collect(Collectors.toSet());
+        this.brokerStorageDirectories = storageDirNames.stream().map(File::new).collect(Collectors.toSet());
         this.storageWaitTimeoutSec = storageWaitTimeoutSec;
     }
 
@@ -220,13 +220,6 @@ public final class BrokerLocalStorage {
                 .toList();
     }
 
-    private static final class OffsetHolder {
-        private final long firstLogFileBaseOffset;
-        private final List<String> partitionFiles;
-
-        public OffsetHolder(long firstLogFileBaseOffset, List<String> partitionFiles) {
-            this.firstLogFileBaseOffset = firstLogFileBaseOffset;
-            this.partitionFiles = partitionFiles;
-        }
+    private record OffsetHolder(long firstLogFileBaseOffset, List<String> partitionFiles) {
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/LocalTieredStorageOutput.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/LocalTieredStorageOutput.java
@@ -92,13 +92,6 @@ public final class LocalTieredStorageOutput<K, V> implements LocalTieredStorageT
         return de.deserialize(currentTopic, Utils.toNullableArray(bytes)).toString();
     }
 
-    private static class Tuple2<T1, T2> {
-        private final T1 t1;
-        private final T2 t2;
-
-        Tuple2(T1 t1, T2 t2) {
-            this.t1 = t1;
-            this.t2 = t2;
-        }
+    private record Tuple2<T1, T2>(T1 t1, T2 t2) {
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/RecordsKeyValueMatcher.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/RecordsKeyValueMatcher.java
@@ -36,9 +36,9 @@ import java.util.Iterator;
 
 /**
  * @param <R1> The type of records used to formulate the expectations.
- * @param <R2></R2> The type of records compared against the expectations.
- * @param <K></K> The type of the record keys.
- * @param <V></V> The type of the record values.
+ * @param <R2> The type of records compared against the expectations.
+ * @param <K> The type of the record keys.
+ * @param <V> The type of the record values.
  */
 public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosingMatcher<Collection<R2>> {
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/RecordsKeyValueMatcher.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/RecordsKeyValueMatcher.java
@@ -34,6 +34,12 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Iterator;
 
+/**
+ * @param <R1> The type of records used to formulate the expectations.
+ * @param <R2></R2> The type of records compared against the expectations.
+ * @param <K></K> The type of the record keys.
+ * @param <V></V> The type of the record values.
+ */
 public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosingMatcher<Collection<R2>> {
 
     private final Collection<R1> expectedRecords;
@@ -43,10 +49,10 @@ public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosi
 
     /**
      * Heterogeneous matcher between alternative types of records:
-     * [[ProducerRecord]], [[ConsumerRecord]] or [[Record]].
+     * {@link ProducerRecord}, {@link ConsumerRecord} or {@link Record}.
      *
      * It is conceptually incorrect to try to match records of different natures.
-     * Only a committed [[Record]] is univoque, whereas a [[ProducerRecord]] or [[ConsumerRecord]] is
+     * Only a committed {@link Record} is univoque, whereas a {@link ProducerRecord} or {@link ConsumerRecord} is
      * a physical representation of a record-to-be or viewed record.
      *
      * This matcher breaches that semantic so that testers can avoid performing manual comparisons on
@@ -55,12 +61,8 @@ public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosi
      *
      * @param expectedRecords The records expected.
      * @param topicPartition The topic-partition which the records belong to.
-     * @param keySerde The [[Serde]] for the keys of the records.
-     * @param valueSerde The [[Serde]] for the values of the records.
-     * @tparam R1 The type of records used to formulate the expectations.
-     * @tparam R2 The type of records compared against the expectations.
-     * @tparam K The type of the record keys.
-     * @tparam V The type of the record values.
+     * @param keySerde The {@link Serde} for the keys of the records.
+     * @param valueSerde The {@link Serde} for the values of the records.
      */
     public RecordsKeyValueMatcher(Collection<R1> expectedRecords,
                                   TopicPartition topicPartition,
@@ -164,12 +166,8 @@ public final class RecordsKeyValueMatcher<R1, R2, K, V> extends TypeSafeDiagnosi
      *
      * @param expectedRecords The records expected.
      * @param topicPartition The topic-partition which the records belong to.
-     * @param keySerde The [[Serde]] for the keys of the records.
-     * @param valueSerde The [[Serde]] for the values of the records.
-     * @tparam R1 The type of records used to formulate the expectations.
-     * @tparam R2 The type of records compared against the expectations.
-     * @tparam K The type of the record keys.
-     * @tparam V The type of the record values.
+     * @param keySerde The {@link Serde} for the keys of the records.
+     * @param valueSerde The {@link Serde} for the values of the records.
      */
     public static <R1, R2, K, V> RecordsKeyValueMatcher<R1, R2, K, V> correspondTo(Collection<R1> expectedRecords,
                                                                                    TopicPartition topicPartition,


### PR DESCRIPTION
Cleanups including:
- Java 17 syntax, record and switch
- assertEquals() order
- javadoc

Reviewers: Andrew Schofield <aschofield@confluent.io>, Jhen-Yung Hsu
 <jhenyunghsu@gmail.com>, Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
