### PR TITLE
KAFKA-19470 Avoid creating loggers repeatedly to affect the performance of request processing

### DIFF
--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -39,11 +39,15 @@ object Log4jControllerRegistration {
 
 private object Logging {
   private val FatalMarker: Marker = MarkerFactory.getMarker("FATAL")
+  private val loggerCache = new java.util.concurrent.ConcurrentHashMap[String, Logger]()
 }
 
 trait Logging {
 
-  protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(loggerName))
+  protected lazy val logger: Logger = {
+    val name = loggerName
+    Logging.loggerCache.computeIfAbsent(name, _ => Logger(LoggerFactory.getLogger(name)))
+  }
 
   protected var logIdent: String = _
 

--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -17,12 +17,13 @@
 
 package kafka.utils
 
+import com.typesafe.scalalogging.Logger
 import org.apache.kafka.server.logger.LoggingController
-import java.lang.management.ManagementFactory
 
+import java.lang.management.ManagementFactory
 import javax.management.ObjectName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTrue}
 import org.slf4j.LoggerFactory
 
 class LoggingTest extends Logging {
@@ -78,4 +79,21 @@ class LoggingTest extends Logging {
       controller.setLogLevel("kafka", previousLevel)
     }
   }
+
+  @Test
+  def testLoggerSingletonForOneClass(): Unit = {
+    class TestLogging extends Logging {
+      def logger_var: Logger = logger
+      def logger_var2: Logger = Logger(LoggerFactory.getLogger(loggerName))
+    }
+
+    val logging1 = new TestLogging
+    val logging2 = new TestLogging
+    // Using caching, the logger objects of both Logging instances are the same
+    assertEquals(logging1.logger_var, logging2.logger_var)
+
+    // The previous method of obtaining loggers creates loggers for two object instances repeatedly.
+    assertNotEquals(logging1.logger_var2, logging2.logger_var2)
+  }
+
 }


### PR DESCRIPTION
fix the issue mentioned https://issues.apache.org/jira/browse/KAFKA-19470, to avoid the jdk11 + lo4j2 performance issue.
Optimize the trait Logging, introduce a static Map object to cache the same class loggers.


The testing strategy is:
Create two instances, their classes inherit from the trait Logging, these two class instances will have the same variable logger, that is, the StackWalker method will not be called twice

