### PR TITLE
MINOR: Add 4.1 branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches:
       - 'trunk'
-      - '4.0'
+      - '4.1'
 
   schedule:
     - cron: '0 0 * * 6,0'    # Run on Saturday and Sunday at midnight UTC
@@ -28,7 +28,7 @@ on:
     types: [ opened, synchronize, ready_for_review, reopened ]
     branches:
       - 'trunk'
-      - '4.0'
+      - '4.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Add 4.1 branch to CI per https://github.com/apache/kafka/pull/18215

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
