### PR TITLE
MINOR: typo in javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableEvent.java
@@ -45,7 +45,7 @@ public interface CompletableEvent<T> {
      *         (if applicable) is passed to {@link CompletableFuture#complete(Object)}. In the case where the generic
      *         bound type is specified as {@link Void}, {@code null} is provided.</li>
      *     <li>
-     *         Error: when the the event logic generates an error, the error is passed to
+     *         Error: when the event logic generates an error, the error is passed to
      *         {@link CompletableFuture#completeExceptionally(Throwable)}.
      *     </li>
      *     <li>

--- a/release/templates.py
+++ b/release/templates.py
@@ -70,7 +70,7 @@ If any of these are missing, see https://cwiki.apache.org/confluence/display/KAF
 Some of these may be used from these previous settings loaded from {prefs_file}:
 {prefs}
 
-Do you have all of of these setup?"""
+Do you have all of these setup?"""
 
 
 def release_announcement_email(release_version, contributors):

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -236,7 +236,7 @@ public class KafkaStreams implements AutoCloseable {
      *   </li>
      *   <li>
      *     REBALANCING state will transit to RUNNING if all of its threads are in RUNNING state
-     *     (Note: a thread transits to RUNNING state, if all active tasks got restored are are ready for processing.
+     *     (Note: a thread transits to RUNNING state, if all active tasks got restored are ready for processing.
      *     Standby tasks are not considered.)
      *   </li>
      *   <li>

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1849,7 +1849,7 @@ public class StreamsConfig extends AbstractConfig {
 
             if (segmentSize < batchSize) {
                 throw new IllegalArgumentException(String.format(
-                    "Specified topic segment size %d is is smaller than the configured producer batch size %d, this will cause produced batch not able to be appended to the topic",
+                    "Specified topic segment size %d is smaller than the configured producer batch size %d, this will cause produced batch not able to be appended to the topic",
                     segmentSize,
                     batchSize
                 ));

--- a/tests/kafkatest/services/security/kafka_acls.py
+++ b/tests/kafkatest/services/security/kafka_acls.py
@@ -29,7 +29,7 @@ class ACLs:
         :param additional_cluster_operations_to_grant may be set to ['Alter', 'Create'] if the cluster is secured since these are required
                to create SCRAM credentials and topics, respectively
         :param security_protocol set it to explicitly determine whether we use client or broker credentials, otherwise
-                we use the the client security protocol unless inter-broker security protocol is PLAINTEXT, in which case we use PLAINTEXT.
+                we use the client security protocol unless inter-broker security protocol is PLAINTEXT, in which case we use PLAINTEXT.
                 Then we use the broker's credentials if the selected security protocol matches the inter-broker security protocol,
                 otherwise we use the client's credentials.
         """
@@ -51,7 +51,7 @@ class ACLs:
         :param additional_cluster_operations_to_remove may be set to ['Alter', 'Create'] if the cluster is secured since these are required
                to create SCRAM credentials and topics, respectively
         :param security_protocol set it to explicitly determine whether we use client or broker credentials, otherwise
-                we use the the client security protocol unless inter-broker security protocol is PLAINTEXT, in which case we use PLAINTEXT.
+                we use the client security protocol unless inter-broker security protocol is PLAINTEXT, in which case we use PLAINTEXT.
                 Then we use the broker's credentials if the selected security protocol matches the inter-broker security protocol,
                 otherwise we use the client's credentials.
         """

--- a/tools/src/test/java/org/apache/kafka/tools/JmxToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/JmxToolTest.java
@@ -55,7 +55,7 @@ public class JmxToolTest {
     public static void beforeAll() throws Exception {
         int port = findRandomOpenPortOnAllLocalInterfaces();
         jmxUrl = format("service:jmx:rmi:///jndi/rmi://:%d/jmxrmi", port);
-        // explicitly set the hostname returned to the the clients in the remote stub object
+        // explicitly set the hostname returned to the clients in the remote stub object
         // when connecting to a multi-homed machine using RMI, the wrong address may be returned
         // by the RMI registry to the client, causing the connection to the RMI server to timeout
         System.setProperty("java.rmi.server.hostname", "localhost");


### PR DESCRIPTION
This PR fixes a typo in the Javadoc. 