### PR TITLE
(WIP)KAFKA-9965/KAFKA-13303: RoundRobinPartitioner broken by KIP-480

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -16,58 +16,101 @@
  */
 package org.apache.kafka.clients.producer;
 
-import org.apache.kafka.common.Cluster;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.utils.Utils;
-
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * The "Round-Robin" partitioner
- * 
- * This partitioning strategy can be used when user wants 
- * to distribute the writes to all partitions equally. This
- * is the behaviour regardless of record key hash. 
- *
+ * The "Round-Robin" partitioner - MODIFIED TO WORK PROPERLY WITH STICKY PARTITIONING (KIP-480)
+ * <p>
+ * This partitioning strategy can be used when user wants to distribute the writes to all
+ * partitions equally. This is the behaviour regardless of record key hash.
  */
 public class RoundRobinPartitioner implements Partitioner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoundRobinPartitioner.class);
     private final ConcurrentMap<String, AtomicInteger> topicCounterMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Queue<Integer>> topicPartitionQueueMap = new ConcurrentHashMap<>();
 
-    public void configure(Map<String, ?> configs) {}
+    public void configure(Map<String, ?> configs) {
+    }
 
     /**
      * Compute the partition for the given record.
      *
-     * @param topic The topic name
-     * @param key The key to partition on (or null if no key)
-     * @param keyBytes serialized key to partition on (or null if no key)
-     * @param value The value to partition on or null
+     * @param topic      The topic name
+     * @param key        The key to partition on (or null if no key)
+     * @param keyBytes   serialized key to partition on (or null if no key)
+     * @param value      The value to partition on or null
      * @param valueBytes serialized value to partition on or null
-     * @param cluster The current cluster metadata
+     * @param cluster    The current cluster metadata
      */
     @Override
-    public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
-        int nextValue = nextValue(topic);
-        List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
-        if (!availablePartitions.isEmpty()) {
-            int part = Utils.toPositive(nextValue) % availablePartitions.size();
-            return availablePartitions.get(part).partition();
+    public int partition(
+            String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+        Queue<Integer> partitionQueue = partitionQueueComputeIfAbsent(topic);
+        Integer queuedPartition = partitionQueue.poll();
+        if (queuedPartition != null) {
+            LOGGER.trace("Partition chosen from queue: {}", queuedPartition);
+            return queuedPartition;
         } else {
-            // no partitions are available, give a non-available partition
-            int numPartitions = cluster.partitionsForTopic(topic).size();
-            return Utils.toPositive(nextValue) % numPartitions;
+            List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
+            int numPartitions = partitions.size();
+            int nextValue = nextValue(topic);
+            List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
+            if (!availablePartitions.isEmpty()) {
+                int part = Utils.toPositive(nextValue) % availablePartitions.size();
+                int partition = availablePartitions.get(part).partition();
+                LOGGER.trace("Partition chosen: {}", partition);
+                return partition;
+            } else {
+                // no partitions are available, give a non-available partition
+                return Utils.toPositive(nextValue) % numPartitions;
+            }
         }
     }
 
     private int nextValue(String topic) {
-        AtomicInteger counter = topicCounterMap.computeIfAbsent(topic, k -> new AtomicInteger(0));
+        AtomicInteger counter =
+                topicCounterMap.computeIfAbsent(
+                        topic,
+                        k -> {
+                            return new AtomicInteger(0);
+                        });
         return counter.getAndIncrement();
     }
 
-    public void close() {}
+    private Queue<Integer> partitionQueueComputeIfAbsent(String topic) {
+        return topicPartitionQueueMap.computeIfAbsent(topic, k -> {
+            return new ConcurrentLinkedQueue<>();
+        });
+    }
 
+    public void close() {
+    }
+
+    /**
+     * Notifies the partitioner a new batch is about to be created. When using the sticky partitioner,
+     * this method can change the chosen sticky partition for the new batch.
+     *
+     * @param topic         The topic name
+     * @param cluster       The current cluster metadata
+     * @param prevPartition The partition previously selected for the record that triggered a new
+     *                      batch
+     */
+    @Override
+    public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
+        LOGGER.trace("New batch so enqueuing partition {} for topic {}", prevPartition, topic);
+        Queue<Integer> partitionQueue = partitionQueueComputeIfAbsent(topic);
+        partitionQueue.add(prevPartition);
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -48,12 +48,12 @@ public class RoundRobinPartitioner implements Partitioner {
     /**
      * Compute the partition for the given record.
      *
-     * @param topic      The topic name
-     * @param key        The key to partition on (or null if no key)
-     * @param keyBytes   serialized key to partition on (or null if no key)
-     * @param value      The value to partition on or null
+     * @param topic The topic name
+     * @param key The key to partition on (or null if no key)
+     * @param keyBytes serialized key to partition on (or null if no key)
+     * @param value The value to partition on or null
      * @param valueBytes serialized value to partition on or null
-     * @param cluster    The current cluster metadata
+     * @param cluster The current cluster metadata
      */
     @Override
     public int partition(

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -16,6 +16,13 @@
  */
 package org.apache.kafka.clients.producer;
 
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.utils.Utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -23,12 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.kafka.common.Cluster;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.utils.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The "Round-Robin" partitioner - MODIFIED TO WORK PROPERLY WITH STICKY PARTITIONING (KIP-480)
@@ -107,6 +108,7 @@ public class RoundRobinPartitioner implements Partitioner {
      * @param prevPartition The partition previously selected for the record that triggered a new
      *                      batch
      */
+    @SuppressWarnings("deprecation")
     @Override
     public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
         LOGGER.trace("New batch so enqueuing partition {} for topic {}", prevPartition, topic);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -31,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RoundRobinPartitionerTest {
-    private final static Node[] NODES = new Node[] {
-            new Node(0, "localhost", 99),
-            new Node(1, "localhost", 100),
-            new Node(2, "localhost", 101)
+    private static final Node[] NODES = new Node[] {
+        new Node(0, "localhost", 99),
+        new Node(1, "localhost", 100),
+        new Node(2, "localhost", 101)
     };
 
     @Test
@@ -127,6 +128,7 @@ public class RoundRobinPartitionerTest {
         assertEquals(10, partitionCount.get(2).intValue());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRoundRobinWithAbortForNewBatch() throws Exception {
         final String topicA = "topicA";

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
@@ -53,7 +53,7 @@ public class RoundRobinPartitionerTest {
         int countForPart2 = 0;
         Partitioner partitioner = new RoundRobinPartitioner();
         Cluster cluster = new Cluster("clusterId", asList(NODES[0], NODES[1], NODES[2]), partitions,
-                Collections.<String>emptySet(), Collections.<String>emptySet());
+            Collections.<String>emptySet(), Collections.<String>emptySet());
         for (int i = 1; i <= 100; i++) {
             int part = partitioner.partition("test", null, null, null, null, cluster);
             assertTrue(part == 0 || part == 2, "We should never choose a leader-less node in round robin");

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -32,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RoundRobinPartitionerTest {
-    private static final Node[] NODES = new Node[] {
-        new Node(0, "localhost", 99),
-        new Node(1, "localhost", 100),
-        new Node(2, "localhost", 101)
+    private final static Node[] NODES = new Node[] {
+            new Node(0, "localhost", 99),
+            new Node(1, "localhost", 100),
+            new Node(2, "localhost", 101)
     };
 
     @Test
@@ -53,7 +52,7 @@ public class RoundRobinPartitionerTest {
         int countForPart2 = 0;
         Partitioner partitioner = new RoundRobinPartitioner();
         Cluster cluster = new Cluster("clusterId", asList(NODES[0], NODES[1], NODES[2]), partitions,
-            Collections.emptySet(), Collections.emptySet());
+                Collections.<String>emptySet(), Collections.<String>emptySet());
         for (int i = 1; i <= 100; i++) {
             int part = partitioner.partition("test", null, null, null, null, cluster);
             assertTrue(part == 0 || part == 2, "We should never choose a leader-less node in round robin");
@@ -66,7 +65,7 @@ public class RoundRobinPartitionerTest {
     }
 
     @Test
-    public void testRoundRobinWithKeyBytes() {
+    public void testRoundRobinWithKeyBytes() throws InterruptedException {
         final String topicA = "topicA";
         final String topicB = "topicB";
 
@@ -74,7 +73,7 @@ public class RoundRobinPartitionerTest {
                 new PartitionInfo(topicA, 1, NODES[1], NODES, NODES), new PartitionInfo(topicA, 2, NODES[2], NODES, NODES),
                 new PartitionInfo(topicB, 0, NODES[0], NODES, NODES));
         Cluster testCluster = new Cluster("clusterId", asList(NODES[0], NODES[1], NODES[2]), allPartitions,
-                Collections.emptySet(), Collections.emptySet());
+                Collections.<String>emptySet(), Collections.<String>emptySet());
 
         final Map<Integer, Integer> partitionCount = new HashMap<>();
 
@@ -96,9 +95,9 @@ public class RoundRobinPartitionerTest {
         assertEquals(10, partitionCount.get(1).intValue());
         assertEquals(10, partitionCount.get(2).intValue());
     }
-    
+
     @Test
-    public void testRoundRobinWithNullKeyBytes() {
+    public void testRoundRobinWithNullKeyBytes() throws InterruptedException {
         final String topicA = "topicA";
         final String topicB = "topicB";
 
@@ -106,7 +105,7 @@ public class RoundRobinPartitionerTest {
                 new PartitionInfo(topicA, 1, NODES[1], NODES, NODES), new PartitionInfo(topicA, 2, NODES[2], NODES, NODES),
                 new PartitionInfo(topicB, 0, NODES[0], NODES, NODES));
         Cluster testCluster = new Cluster("clusterId", asList(NODES[0], NODES[1], NODES[2]), allPartitions,
-                Collections.emptySet(), Collections.emptySet());
+                Collections.<String>emptySet(), Collections.<String>emptySet());
 
         final Map<Integer, Integer> partitionCount = new HashMap<>();
 
@@ -126,5 +125,25 @@ public class RoundRobinPartitionerTest {
         assertEquals(10, partitionCount.get(0).intValue());
         assertEquals(10, partitionCount.get(1).intValue());
         assertEquals(10, partitionCount.get(2).intValue());
-    }    
+    }
+
+    @Test
+    public void testRoundRobinWithAbortForNewBatch() throws Exception {
+        final String topicA = "topicA";
+        final String topicB = "topicB";
+
+        Cluster testCluster = new Cluster("clusterId", asList(NODES[0]), Collections.emptyList(),
+                Collections.<String>emptySet(), Collections.<String>emptySet());
+
+        Partitioner partitioner = new RoundRobinPartitioner();
+
+        //abort for new batch - previous partition should be returned on subsequent call
+        //simulate three threads producing to two topics, with race condition in producer
+        partitioner.onNewBatch(topicA, testCluster, 7);
+        partitioner.onNewBatch(topicA, testCluster, 8);
+        partitioner.onNewBatch(topicB, testCluster, 1);
+        assertEquals(7, partitioner.partition(topicA, null, null, null, null, testCluster));
+        assertEquals(8, partitioner.partition(topicA, null, null, null, null, testCluster));
+        assertEquals(1, partitioner.partition(topicB, null, null, null, null, testCluster));
+    }
 }


### PR DESCRIPTION
RoundRobinPartitioner behaviour was broken by sticky partitioning (KIP-480).

This patch addresses the behavioural issue caused by the second call to `partition()` after `onNewBatch()`, in a predictable and thread-safe manner.

Unit tested by simulation of multiple threads producing to two topics with race conditions.