### PR TITLE
KAFKA-19472 A BufferOverflowException is thrown by RemoteLogManager when FetchApiVersion <= 2

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1649,7 +1649,7 @@ public class RemoteLogManager implements Closeable {
             firstBatch.writeTo(buffer);
 
             if (bufferSize > updatedFetchSize) {
-                buffer = buffer.position(updatedFetchSize);
+                buffer.position(updatedFetchSize);
             }
 
             remainingBytes -= firstBatchSize;

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1647,6 +1647,7 @@ public class RemoteLogManager implements Closeable {
             int remainingBytes = bufferSize;
 
             firstBatch.writeTo(buffer);
+            
 
             if (bufferSize > updatedFetchSize) {
                 buffer.position(updatedFetchSize);

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1641,10 +1641,17 @@ public class RemoteLogManager implements Closeable {
             int updatedFetchSize =
                     remoteStorageFetchInfo.minOneMessage && firstBatchSize > maxBytes ? firstBatchSize : maxBytes;
 
-            ByteBuffer buffer = ByteBuffer.allocate(updatedFetchSize);
-            int remainingBytes = updatedFetchSize;
+            int bufferSize = Math.max(firstBatchSize, updatedFetchSize);
+
+            ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+            int remainingBytes = bufferSize;
 
             firstBatch.writeTo(buffer);
+
+            if (bufferSize > updatedFetchSize) {
+                buffer = buffer.position(updatedFetchSize);
+            }
+
             remainingBytes -= firstBatchSize;
 
             if (remainingBytes > 0) {

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2977,9 +2977,9 @@ public class RemoteLogManagerTest {
         }
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testReadForFirstBatchMoreThanMaxFetchBytes(boolean minOneMessage) throws RemoteStorageException, IOException {
+    @ParameterizedTest(name = "testReadForFirstBatchMoreThanMaxFetchBytes minOneMessage={0} hardMaxBytesLimit={1}")
+    @CsvSource(value = {"true, true", "true, false", "false, true", "false, false"})
+    public void testReadForFirstBatchMoreThanMaxFetchBytes(boolean minOneMessage, boolean hardMaxBytesLimit) throws RemoteStorageException, IOException {
         FileInputStream fileInputStream = mock(FileInputStream.class);
         ClassLoaderAwareRemoteStorageManager rsmManager = mock(ClassLoaderAwareRemoteStorageManager.class);
         RemoteLogSegmentMetadata segmentMetadata = mock(RemoteLogSegmentMetadata.class);
@@ -3001,7 +3001,7 @@ public class RemoteLogManagerTest {
         );
 
         RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(
-                0, minOneMessage, tp, partitionData, FetchIsolation.HIGH_WATERMARK, false
+                0, minOneMessage, tp, partitionData, FetchIsolation.HIGH_WATERMARK, hardMaxBytesLimit
         );
 
         try (RemoteLogManager remoteLogManager = new RemoteLogManager(
@@ -3048,9 +3048,13 @@ public class RemoteLogManagerTest {
                 // Verify that the byte buffer has capacity equal to the size of the first batch
                 assertEquals(recordBatchSizeInBytes, capture.getValue().capacity());
             } else {
-                // Verify that the first batch is never written to the buffer
-                verify(firstBatch, never()).writeTo(any(ByteBuffer.class));
-                assertEquals(MemoryRecords.EMPTY, fetchDataInfo.records);
+                if (!hardMaxBytesLimit) {
+                    // Verify that the first batch is never written to the buffer
+                    verify(firstBatch, never()).writeTo(any(ByteBuffer.class));
+                    assertEquals(MemoryRecords.EMPTY, fetchDataInfo.records);
+                } else {
+                    assertEquals(recordBatchSizeInBytes, capture.getValue().capacity());
+                }
             }
         }
     }


### PR DESCRIPTION
Fix A BufferOverflowException is thrown by RemoteLogManager when FetchApiVersion <= 2

@satishd 
