### PR TITLE
KAFKA-19478 [1/N]: Precompute values in ProcessState 

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -329,7 +329,7 @@ public class StickyTaskAssignor implements TaskAssignor {
 
         if (isActive) {
             // update task per process
-            maybeUpdateTasksPerMember(localState.processIdToState.get(member.processId).assignedActiveTasks().size());
+            maybeUpdateTasksPerMember(localState.processIdToState.get(member.processId).activeTaskCount());
         }
     }
 


### PR DESCRIPTION
This is a very mechanical and obvious change that is making most
accessors in ProcessState constant time O(1), instead of linear time
O(n), by computing the collections and aggregations at insertion time,
instead of every time the value is accessed.

Since the accessors are used in deeply nested loops, this reduces the
runtime of our worst case benchmarks by ~14x.

Reviewers: Bill Bejeck <bbejeck@apache.org>
