### PR TITLE
MINOR: Prevent unnecessary test runs - KAFKA-19042 follow-up

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.concurrent.ExecutionException
 
 @Timeout(600)
-class PlaintextConsumerTest extends BaseConsumerTest {
+class PlaintextConsumerTest extends AbstractConsumerTest {
 
   @Flaky("KAFKA-18031")
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource
 
 import java.util.concurrent.ExecutionException
 
-@Timeout(600)
+@Timeout(60)
 class PlaintextConsumerTest extends AbstractConsumerTest {
 
   @Flaky("KAFKA-18031")


### PR DESCRIPTION
PlaintextConsumerTest should extend AbstractConsumerTest instead
BaseConsumerTest. Otherwise, those tests will be executed on both
`clients-integration-tests` and `core` (see
https://github.com/apache/kafka/pull/20081/files#r2190749592).

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
