### PR TITLE
KAFKA-19476: Improve state transition handling in SharePartition

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2054,7 +2054,15 @@ public class SharePartition {
                 // Log in DEBUG to avoid flooding of logs for a faulty client.
                 log.debug("Request failed for updating state, rollback any changed state"
                     + " for the share partition: {}-{}", groupId, topicIdPartition);
-                updatedStates.forEach(state -> state.completeStateTransition(false));
+                updatedStates.forEach(state -> {
+                    state.completeStateTransition(false);
+                    // If state transition fails in write state RPC, we will rollback to the original state if record
+                    // hasn't reached a terminal state. If acquisition lock has expired by that time, the record can
+                    // be stuck in ACQUIRED state unless we run the acquisition lock task again.
+                    if (!state.isTerminalState() && state.acquisitionLockTimeoutTask.hasExpired()) {
+                        state.acquisitionLockTimeoutTask.run();
+                    }
+                });
                 future.completeExceptionally(throwable);
                 return;
             }
@@ -2077,7 +2085,15 @@ public class SharePartition {
                 if (exception != null) {
                     log.debug("Failed to write state to persister for the share partition: {}-{}",
                         groupId, topicIdPartition, exception);
-                    updatedStates.forEach(state -> state.completeStateTransition(false));
+                    updatedStates.forEach(state -> {
+                        state.completeStateTransition(false);
+                        // If state transition fails in write state RPC, we will rollback to the original state if record
+                        // hasn't reached a terminal state. If acquisition lock has expired by that time, the record can
+                        // be stuck in ACQUIRED state unless we run the acquisition lock task again.
+                        if (!state.isTerminalState() && state.acquisitionLockTimeoutTask.hasExpired()) {
+                            state.acquisitionLockTimeoutTask.run();
+                        }
+                    });
                     future.completeExceptionally(exception);
                     return;
                 }
@@ -3023,9 +3039,9 @@ public class SharePartition {
         private InFlightState rollbackState;
         // The timer task for the acquisition lock timeout.
         private AcquisitionLockTimerTask acquisitionLockTimeoutTask;
-        // The boolean determines if the record has achieved a final state of ARCHIVED from which it cannot transition
+        // The boolean determines if the record has achieved a terminal state of ARCHIVED from which it cannot transition
         // to any other state. This could happen because of LSO movement etc.
-        private boolean isMarkedArchived = false;
+        private boolean isTerminalState = false;
 
 
         InFlightState(RecordState state, int deliveryCount, String memberId) {
@@ -3042,6 +3058,10 @@ public class SharePartition {
         // Visible for testing.
         synchronized RecordState state() {
             return state;
+        }
+
+        synchronized boolean isTerminalState() {
+            return isTerminalState;
         }
 
         String memberId() {
@@ -3114,9 +3134,7 @@ public class SharePartition {
 
         // Visible for testing.
         synchronized void archive(String newMemberId) {
-            if (rollbackState != null) {
-                isMarkedArchived = true;
-            }
+            isTerminalState = true;
             state = RecordState.ARCHIVED;
             memberId = newMemberId;
         }
@@ -3133,7 +3151,7 @@ public class SharePartition {
 
         // Visible for testing
         synchronized void completeStateTransition(boolean commit) {
-            if (commit || isMarkedArchived) {
+            if (commit || isTerminalState()) {
                 rollbackState = null;
                 return;
             }
@@ -3141,8 +3159,6 @@ public class SharePartition {
             deliveryCount = rollbackState.deliveryCount;
             memberId = rollbackState.memberId;
             rollbackState = null;
-            if (acquisitionLockTimeoutTask.hasExpired())
-                acquisitionLockTimeoutTask.run();
         }
 
         @Override

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -199,9 +199,9 @@ public class SharePartition {
 
     /**
      * The DeliveryCountOps is used to specify the behavior on the delivery count: increase, decrease,
-     * or do nothing.
+     * or do nothing. Visible for testing.
      */
-    private enum DeliveryCountOps {
+    enum DeliveryCountOps {
         INCREASE,
         DECREASE,
         NO_OP
@@ -3116,7 +3116,8 @@ public class SharePartition {
             };
         }
 
-        private void archive(String newMemberId) {
+        // Visible for testing.
+        void archive(String newMemberId) {
             stateTransitionLock.writeLock().lock();
             try {
                 if (rollbackState != null) {
@@ -3129,7 +3130,8 @@ public class SharePartition {
             }
         }
 
-        private InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
+        // Visible for testing
+        InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
             stateTransitionLock.writeLock().lock();
             try {
                 rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
@@ -3139,7 +3141,8 @@ public class SharePartition {
             }
         }
 
-        private void completeStateTransition(boolean commit) {
+        // Visible for testing
+        void completeStateTransition(boolean commit) {
             stateTransitionLock.writeLock().lock();
             try {
                 if (commit) {

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2834,6 +2834,7 @@ public class SharePartition {
         private final String memberId;
         private final long firstOffset;
         private final long lastOffset;
+        private boolean hasExpired;
 
         AcquisitionLockTimerTask(long delayMs, String memberId, long firstOffset, long lastOffset) {
             super(delayMs);
@@ -2841,10 +2842,15 @@ public class SharePartition {
             this.memberId = memberId;
             this.firstOffset = firstOffset;
             this.lastOffset = lastOffset;
+            this.hasExpired = false;
         }
 
         long expirationMs() {
             return expirationMs;
+        }
+
+        boolean hasExpired() {
+            return hasExpired;
         }
 
         /**
@@ -2854,6 +2860,7 @@ public class SharePartition {
         public void run() {
             sharePartitionMetrics.recordAcquisitionLockTimeoutPerSec(lastOffset - firstOffset + 1);
             releaseAcquisitionLockOnTimeout(memberId, firstOffset, lastOffset);
+            hasExpired = true;
         }
     }
 
@@ -3134,6 +3141,8 @@ public class SharePartition {
             deliveryCount = rollbackState.deliveryCount;
             memberId = rollbackState.memberId;
             rollbackState = null;
+            if (acquisitionLockTimeoutTask.hasExpired())
+                acquisitionLockTimeoutTask.run();
         }
 
         @Override

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2865,7 +2865,7 @@ public class SharePartition {
             return expirationMs;
         }
 
-        boolean hasExpired() {
+        synchronized boolean hasExpired() {
             return hasExpired;
         }
 
@@ -2874,11 +2874,13 @@ public class SharePartition {
          */
         @Override
         public void run() {
-            if (!hasExpired) {
-                sharePartitionMetrics.recordAcquisitionLockTimeoutPerSec(lastOffset - firstOffset + 1);
+            synchronized (this) {
+                if (!hasExpired()) {
+                    sharePartitionMetrics.recordAcquisitionLockTimeoutPerSec(lastOffset - firstOffset + 1);
+                }
+                releaseAcquisitionLockOnTimeout(memberId, firstOffset, lastOffset);
+                hasExpired = true;
             }
-            releaseAcquisitionLockOnTimeout(memberId, firstOffset, lastOffset);
-            hasExpired = true;
         }
     }
 

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -70,7 +70,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -1205,7 +1204,7 @@ public class SharePartition {
 
             // Though such batches can be removed from the cache, but it is better to archive them so
             // that they are never acquired again.
-            boolean anyRecordArchived = archiveRecords(fetchOffset, baseOffset, subMap, RecordState.AVAILABLE, true);
+            boolean anyRecordArchived = archiveRecords(fetchOffset, baseOffset, subMap, RecordState.AVAILABLE);
 
             // If we have transitioned the state of any batch/offset from AVAILABLE to ARCHIVED,
             // then there is a chance that the next fetch offset can change.
@@ -1226,7 +1225,7 @@ public class SharePartition {
     private boolean archiveAvailableRecordsOnLsoMovement(long logStartOffset) {
         lock.writeLock().lock();
         try {
-            return archiveRecords(startOffset, logStartOffset, cachedState, RecordState.AVAILABLE, true);
+            return archiveRecords(startOffset, logStartOffset, cachedState, RecordState.AVAILABLE);
         } finally {
             lock.writeLock().unlock();
         }
@@ -1241,7 +1240,7 @@ public class SharePartition {
      * @param initialState The initial state of the records to be archived.
      * @return A boolean which indicates whether any record is archived or not.
      */
-    private boolean archiveRecords(long startOffset, long endOffset, NavigableMap<Long, InFlightBatch> map, RecordState initialState, boolean clearStateTransitionsList) {
+    private boolean archiveRecords(long startOffset, long endOffset, NavigableMap<Long, InFlightBatch> map, RecordState initialState) {
         lock.writeLock().lock();
         try {
             boolean isAnyOffsetArchived = false, isAnyBatchArchived = false;
@@ -1267,11 +1266,11 @@ public class SharePartition {
                         }
                         inFlightBatch.maybeInitializeOffsetStateUpdate();
                     }
-                    isAnyOffsetArchived = isAnyOffsetArchived || archivePerOffsetBatchRecords(inFlightBatch, startOffset, endOffset - 1, initialState, clearStateTransitionsList);
+                    isAnyOffsetArchived = isAnyOffsetArchived || archivePerOffsetBatchRecords(inFlightBatch, startOffset, endOffset - 1, initialState);
                     continue;
                 }
                 // The in-flight batch is a full match hence change the state of the complete batch.
-                isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch, initialState, clearStateTransitionsList);
+                isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch, initialState);
             }
             return isAnyOffsetArchived || isAnyBatchArchived;
         } finally {
@@ -1282,8 +1281,7 @@ public class SharePartition {
     private boolean archivePerOffsetBatchRecords(InFlightBatch inFlightBatch,
                                                  long startOffsetToArchive,
                                                  long endOffsetToArchive,
-                                                 RecordState initialState,
-                                                 boolean clearStateTransitionsList
+                                                 RecordState initialState
     ) {
         lock.writeLock().lock();
         try {
@@ -1302,9 +1300,6 @@ public class SharePartition {
                 }
 
                 offsetState.getValue().archive(EMPTY_MEMBER_ID);
-                if (clearStateTransitionsList) {
-                    offsetState.getValue().clearStateTransitions();
-                }
                 if (initialState == RecordState.ACQUIRED) {
                     offsetState.getValue().cancelAndClearAcquisitionLockTimeoutTask();
                 }
@@ -1316,16 +1311,13 @@ public class SharePartition {
         }
     }
 
-    private boolean archiveCompleteBatch(InFlightBatch inFlightBatch, RecordState initialState, boolean clearStateTransitionsList) {
+    private boolean archiveCompleteBatch(InFlightBatch inFlightBatch, RecordState initialState) {
         lock.writeLock().lock();
         try {
             log.trace("Archiving complete batch: {} for the share partition: {}-{}", inFlightBatch, groupId, topicIdPartition);
             if (inFlightBatch.batchState() == initialState) {
                 // Change the state of complete batch since the same state exists for the entire inFlight batch.
                 inFlightBatch.archiveBatch(EMPTY_MEMBER_ID);
-                if (clearStateTransitionsList) {
-                    inFlightBatch.batchState.clearStateTransitions();
-                }
                 if (initialState == RecordState.ACQUIRED) {
                     inFlightBatch.batchState.cancelAndClearAcquisitionLockTimeoutTask();
                 }
@@ -2587,7 +2579,7 @@ public class SharePartition {
         for (RecordBatch recordBatch : recordsToArchive) {
             // Archive the offsets/batches in the cached state.
             NavigableMap<Long, InFlightBatch> subMap = fetchSubMap(recordBatch);
-            archiveRecords(recordBatch.baseOffset(), recordBatch.lastOffset() + 1, subMap, RecordState.ACQUIRED, false);
+            archiveRecords(recordBatch.baseOffset(), recordBatch.lastOffset() + 1, subMap, RecordState.ACQUIRED);
         }
         return filterRecordBatchesFromAcquiredRecords(acquiredRecords, recordsToArchive);
     }
@@ -3019,13 +3011,17 @@ public class SharePartition {
         private int deliveryCount;
         // The member id of the client that is fetching/acknowledging the record.
         private String memberId;
-        // The states of the records before the latest transition. In case we need to revert an in-flight state, we use the above
+        // The state of the records before the transition. In case we need to revert an in-flight state, we revert the above
         // attributes of InFlightState to this state, namely - state, deliveryCount and memberId.
-        private LinkedList<InFlightState> stateTransitions = new LinkedList<>();
+        private InFlightState rollbackState;
         // The timer task for the acquisition lock timeout.
         private AcquisitionLockTimerTask acquisitionLockTimeoutTask;
+        // The boolean determines if the record has achieved a final state of ARCHIVED from which it cannot transition
+        // to any other state. This could happen because of LSO movement etc.
+        private boolean isMarkedArchived = false;
         // The lock prevents concurrent state transitions possibly during acknowledgements etc.
         private final ReadWriteLock stateTransitionLock = new ReentrantReadWriteLock();
+
 
         InFlightState(RecordState state, int deliveryCount, String memberId) {
             this(state, deliveryCount, memberId, null);
@@ -3068,12 +3064,12 @@ public class SharePartition {
         boolean hasOngoingStateTransition() {
             stateTransitionLock.readLock().lock();
             try {
-                if (stateTransitions.isEmpty()) {
+                if (rollbackState == null) {
                     // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
                     // been committed.
                     return false;
                 }
-                return stateTransitions.peekLast().state != null;
+                return rollbackState.state != null;
             } finally {
                 stateTransitionLock.readLock().unlock();
             }
@@ -3091,6 +3087,7 @@ public class SharePartition {
          *         helps update chaining.
          */
         private InFlightState tryUpdateState(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
+            stateTransitionLock.writeLock().lock();
             try {
                 if (newState == RecordState.AVAILABLE && ops != DeliveryCountOps.DECREASE && deliveryCount >= maxDeliveryCount) {
                     newState = RecordState.ARCHIVED;
@@ -3103,7 +3100,10 @@ public class SharePartition {
                 return this;
             } catch (IllegalStateException e) {
                 log.error("Failed to update state of the records", e);
+                rollbackState = null;
                 return null;
+            } finally {
+                stateTransitionLock.writeLock().unlock();
             }
         }
 
@@ -3117,19 +3117,23 @@ public class SharePartition {
         }
 
         private void archive(String newMemberId) {
-            state = RecordState.ARCHIVED;
-            memberId = newMemberId;
+            stateTransitionLock.writeLock().lock();
+            try {
+                if (rollbackState != null) {
+                    isMarkedArchived = true;
+                }
+                state = RecordState.ARCHIVED;
+                memberId = newMemberId;
+            } finally {
+                stateTransitionLock.writeLock().unlock();
+            }
         }
 
         private InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
             stateTransitionLock.writeLock().lock();
             try {
-                stateTransitions.add(new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask));
-                InFlightState res = tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
-                if (res == null) {
-                    stateTransitions.pollLast();
-                }
-                return res;
+                rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
+                return tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
             } finally {
                 stateTransitionLock.writeLock().unlock();
             }
@@ -3139,37 +3143,17 @@ public class SharePartition {
             stateTransitionLock.writeLock().lock();
             try {
                 if (commit) {
-                    stateTransitions = new LinkedList<>();
+                    rollbackState = null;
                     return;
                 }
-                if (stateTransitions.isEmpty()) {
-                    // There could be a scenario where an acknowledgement of Release/Accept came for an offset and the persister
-                    // is taking time in returning write state RPC response. Meanwhile, LSO moves forward which causes the
-                    // records to be archived. Now if the write state RPC fails, we would ideally not like to rollback the state
-                    // and keep it archived. In that scenario, we will hit the condition of stateTransitions.isEmpty().
-                    if (state == RecordState.ARCHIVED) {
-                        return;
-                    } else {
-                        throw new IllegalStateException("The state transitions list is empty, nothing to rever to.");
-                    }
+                if (isMarkedArchived) {
+                    rollbackState = null;
+                    return;
                 }
-                InFlightState rollbackState = stateTransitions.pollLast();
                 state = rollbackState.state;
                 deliveryCount = rollbackState.deliveryCount;
                 memberId = rollbackState.memberId;
-            } finally {
-                stateTransitionLock.writeLock().unlock();
-            }
-        }
-
-        /**
-         * This function should be called to remove the history of state transitions list in order to make
-         * the current state as the final state of the InflightState.
-         */
-        private void clearStateTransitions() {
-            stateTransitionLock.writeLock().lock();
-            try {
-                stateTransitions = new LinkedList<>();
+                rollbackState = null;
             } finally {
                 stateTransitionLock.writeLock().unlock();
             }

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -70,6 +70,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -1204,7 +1205,7 @@ public class SharePartition {
 
             // Though such batches can be removed from the cache, but it is better to archive them so
             // that they are never acquired again.
-            boolean anyRecordArchived = archiveRecords(fetchOffset, baseOffset, subMap, RecordState.AVAILABLE);
+            boolean anyRecordArchived = archiveRecords(fetchOffset, baseOffset, subMap, RecordState.AVAILABLE, true);
 
             // If we have transitioned the state of any batch/offset from AVAILABLE to ARCHIVED,
             // then there is a chance that the next fetch offset can change.
@@ -1225,7 +1226,7 @@ public class SharePartition {
     private boolean archiveAvailableRecordsOnLsoMovement(long logStartOffset) {
         lock.writeLock().lock();
         try {
-            return archiveRecords(startOffset, logStartOffset, cachedState, RecordState.AVAILABLE);
+            return archiveRecords(startOffset, logStartOffset, cachedState, RecordState.AVAILABLE, true);
         } finally {
             lock.writeLock().unlock();
         }
@@ -1240,7 +1241,7 @@ public class SharePartition {
      * @param initialState The initial state of the records to be archived.
      * @return A boolean which indicates whether any record is archived or not.
      */
-    private boolean archiveRecords(long startOffset, long endOffset, NavigableMap<Long, InFlightBatch> map, RecordState initialState) {
+    private boolean archiveRecords(long startOffset, long endOffset, NavigableMap<Long, InFlightBatch> map, RecordState initialState, boolean clearStateTransitionsList) {
         lock.writeLock().lock();
         try {
             boolean isAnyOffsetArchived = false, isAnyBatchArchived = false;
@@ -1266,11 +1267,11 @@ public class SharePartition {
                         }
                         inFlightBatch.maybeInitializeOffsetStateUpdate();
                     }
-                    isAnyOffsetArchived = isAnyOffsetArchived || archivePerOffsetBatchRecords(inFlightBatch, startOffset, endOffset - 1, initialState);
+                    isAnyOffsetArchived = isAnyOffsetArchived || archivePerOffsetBatchRecords(inFlightBatch, startOffset, endOffset - 1, initialState, clearStateTransitionsList);
                     continue;
                 }
                 // The in-flight batch is a full match hence change the state of the complete batch.
-                isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch, initialState);
+                isAnyBatchArchived = isAnyBatchArchived || archiveCompleteBatch(inFlightBatch, initialState, clearStateTransitionsList);
             }
             return isAnyOffsetArchived || isAnyBatchArchived;
         } finally {
@@ -1281,7 +1282,8 @@ public class SharePartition {
     private boolean archivePerOffsetBatchRecords(InFlightBatch inFlightBatch,
                                                  long startOffsetToArchive,
                                                  long endOffsetToArchive,
-                                                 RecordState initialState
+                                                 RecordState initialState,
+                                                 boolean clearStateTransitionsList
     ) {
         lock.writeLock().lock();
         try {
@@ -1300,6 +1302,9 @@ public class SharePartition {
                 }
 
                 offsetState.getValue().archive(EMPTY_MEMBER_ID);
+                if (clearStateTransitionsList) {
+                    offsetState.getValue().clearStateTransitions();
+                }
                 if (initialState == RecordState.ACQUIRED) {
                     offsetState.getValue().cancelAndClearAcquisitionLockTimeoutTask();
                 }
@@ -1311,13 +1316,16 @@ public class SharePartition {
         }
     }
 
-    private boolean archiveCompleteBatch(InFlightBatch inFlightBatch, RecordState initialState) {
+    private boolean archiveCompleteBatch(InFlightBatch inFlightBatch, RecordState initialState, boolean clearStateTransitionsList) {
         lock.writeLock().lock();
         try {
             log.trace("Archiving complete batch: {} for the share partition: {}-{}", inFlightBatch, groupId, topicIdPartition);
             if (inFlightBatch.batchState() == initialState) {
                 // Change the state of complete batch since the same state exists for the entire inFlight batch.
                 inFlightBatch.archiveBatch(EMPTY_MEMBER_ID);
+                if (clearStateTransitionsList) {
+                    inFlightBatch.batchState.clearStateTransitions();
+                }
                 if (initialState == RecordState.ACQUIRED) {
                     inFlightBatch.batchState.cancelAndClearAcquisitionLockTimeoutTask();
                 }
@@ -2579,7 +2587,7 @@ public class SharePartition {
         for (RecordBatch recordBatch : recordsToArchive) {
             // Archive the offsets/batches in the cached state.
             NavigableMap<Long, InFlightBatch> subMap = fetchSubMap(recordBatch);
-            archiveRecords(recordBatch.baseOffset(), recordBatch.lastOffset() + 1, subMap, RecordState.ACQUIRED);
+            archiveRecords(recordBatch.baseOffset(), recordBatch.lastOffset() + 1, subMap, RecordState.ACQUIRED, false);
         }
         return filterRecordBatchesFromAcquiredRecords(acquiredRecords, recordsToArchive);
     }
@@ -3011,12 +3019,13 @@ public class SharePartition {
         private int deliveryCount;
         // The member id of the client that is fetching/acknowledging the record.
         private String memberId;
-        // The state of the records before the transition. In case we need to revert an in-flight state, we revert the above
+        // The states of the records before the latest transition. In case we need to revert an in-flight state, we use the above
         // attributes of InFlightState to this state, namely - state, deliveryCount and memberId.
-        private InFlightState rollbackState;
+        private LinkedList<InFlightState> stateTransitions = new LinkedList<>();
         // The timer task for the acquisition lock timeout.
         private AcquisitionLockTimerTask acquisitionLockTimeoutTask;
-
+        // The lock prevents concurrent state transitions possibly during acknowledgements etc.
+        private final ReadWriteLock stateTransitionLock = new ReentrantReadWriteLock();
 
         InFlightState(RecordState state, int deliveryCount, String memberId) {
             this(state, deliveryCount, memberId, null);
@@ -3057,12 +3066,17 @@ public class SharePartition {
 
         // Visible for testing.
         boolean hasOngoingStateTransition() {
-            if (rollbackState == null) {
-                // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
-                // been committed.
-                return false;
+            stateTransitionLock.readLock().lock();
+            try {
+                if (stateTransitions.isEmpty()) {
+                    // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
+                    // been committed.
+                    return false;
+                }
+                return stateTransitions.peekLast().state != null;
+            } finally {
+                stateTransitionLock.readLock().unlock();
             }
-            return rollbackState.state != null;
         }
 
         /**
@@ -3089,7 +3103,6 @@ public class SharePartition {
                 return this;
             } catch (IllegalStateException e) {
                 log.error("Failed to update state of the records", e);
-                rollbackState = null;
                 return null;
             }
         }
@@ -3109,19 +3122,57 @@ public class SharePartition {
         }
 
         private InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
-            rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
-            return tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
+            stateTransitionLock.writeLock().lock();
+            try {
+                stateTransitions.add(new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask));
+                InFlightState res = tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
+                if (res == null) {
+                    stateTransitions.pollLast();
+                }
+                return res;
+            } finally {
+                stateTransitionLock.writeLock().unlock();
+            }
         }
 
         private void completeStateTransition(boolean commit) {
-            if (commit) {
-                rollbackState = null;
-                return;
+            stateTransitionLock.writeLock().lock();
+            try {
+                if (commit) {
+                    stateTransitions = new LinkedList<>();
+                    return;
+                }
+                if (stateTransitions.isEmpty()) {
+                    // There could be a scenario where an acknowledgement of Release/Accept came for an offset and the persister
+                    // is taking time in returning write state RPC response. Meanwhile, LSO moves forward which causes the
+                    // records to be archived. Now if the write state RPC fails, we would ideally not like to rollback the state
+                    // and keep it archived. In that scenario, we will hit the condition of stateTransitions.isEmpty().
+                    if (state == RecordState.ARCHIVED) {
+                        return;
+                    } else {
+                        throw new IllegalStateException("The state transitions list is empty, nothing to rever to.");
+                    }
+                }
+                InFlightState rollbackState = stateTransitions.pollLast();
+                state = rollbackState.state;
+                deliveryCount = rollbackState.deliveryCount;
+                memberId = rollbackState.memberId;
+            } finally {
+                stateTransitionLock.writeLock().unlock();
             }
-            state = rollbackState.state;
-            deliveryCount = rollbackState.deliveryCount;
-            memberId = rollbackState.memberId;
-            rollbackState = null;
+        }
+
+        /**
+         * This function should be called to remove the history of state transitions list in order to make
+         * the current state as the final state of the InflightState.
+         */
+        private void clearStateTransitions() {
+            stateTransitionLock.writeLock().lock();
+            try {
+                stateTransitions = new LinkedList<>();
+            } finally {
+                stateTransitionLock.writeLock().unlock();
+            }
         }
 
         @Override

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2874,7 +2874,9 @@ public class SharePartition {
          */
         @Override
         public void run() {
-            sharePartitionMetrics.recordAcquisitionLockTimeoutPerSec(lastOffset - firstOffset + 1);
+            if (!hasExpired) {
+                sharePartitionMetrics.recordAcquisitionLockTimeoutPerSec(lastOffset - firstOffset + 1);
+            }
             releaseAcquisitionLockOnTimeout(memberId, firstOffset, lastOffset);
             hasExpired = true;
         }

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -3019,8 +3019,6 @@ public class SharePartition {
         // The boolean determines if the record has achieved a final state of ARCHIVED from which it cannot transition
         // to any other state. This could happen because of LSO movement etc.
         private boolean isMarkedArchived = false;
-        // The lock prevents concurrent state transitions possibly during acknowledgements etc.
-        private final ReadWriteLock stateTransitionLock = new ReentrantReadWriteLock();
 
 
         InFlightState(RecordState state, int deliveryCount, String memberId) {
@@ -3035,7 +3033,7 @@ public class SharePartition {
         }
 
         // Visible for testing.
-        RecordState state() {
+        synchronized RecordState state() {
             return state;
         }
 
@@ -3061,18 +3059,13 @@ public class SharePartition {
         }
 
         // Visible for testing.
-        boolean hasOngoingStateTransition() {
-            stateTransitionLock.readLock().lock();
-            try {
-                if (rollbackState == null) {
-                    // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
-                    // been committed.
-                    return false;
-                }
-                return rollbackState.state != null;
-            } finally {
-                stateTransitionLock.readLock().unlock();
+        synchronized boolean hasOngoingStateTransition() {
+            if (rollbackState == null) {
+                // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
+                // been committed.
+                return false;
             }
+            return rollbackState.state != null;
         }
 
         /**
@@ -3086,8 +3079,7 @@ public class SharePartition {
          * @return {@code InFlightState} if update succeeds, null otherwise. Returning state
          *         helps update chaining.
          */
-        private InFlightState tryUpdateState(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
-            stateTransitionLock.writeLock().lock();
+        private synchronized InFlightState tryUpdateState(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
             try {
                 if (newState == RecordState.AVAILABLE && ops != DeliveryCountOps.DECREASE && deliveryCount >= maxDeliveryCount) {
                     newState = RecordState.ARCHIVED;
@@ -3100,10 +3092,7 @@ public class SharePartition {
                 return this;
             } catch (IllegalStateException e) {
                 log.error("Failed to update state of the records", e);
-                rollbackState = null;
                 return null;
-            } finally {
-                stateTransitionLock.writeLock().unlock();
             }
         }
 
@@ -3117,45 +3106,34 @@ public class SharePartition {
         }
 
         // Visible for testing.
-        void archive(String newMemberId) {
-            stateTransitionLock.writeLock().lock();
-            try {
-                if (rollbackState != null) {
-                    isMarkedArchived = true;
-                }
-                state = RecordState.ARCHIVED;
-                memberId = newMemberId;
-            } finally {
-                stateTransitionLock.writeLock().unlock();
+        synchronized void archive(String newMemberId) {
+            if (rollbackState != null) {
+                isMarkedArchived = true;
             }
+            state = RecordState.ARCHIVED;
+            memberId = newMemberId;
         }
 
         // Visible for testing
-        InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
-            stateTransitionLock.writeLock().lock();
-            try {
-                rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
-                return tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
-            } finally {
-                stateTransitionLock.writeLock().unlock();
+        synchronized InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
+            InFlightState currentState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
+            InFlightState updatedState = tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
+            if (updatedState != null) {
+                rollbackState = currentState;
             }
+            return updatedState;
         }
 
         // Visible for testing
-        void completeStateTransition(boolean commit) {
-            stateTransitionLock.writeLock().lock();
-            try {
-                if (commit || isMarkedArchived) {
-                    rollbackState = null;
-                    return;
-                }
-                state = rollbackState.state;
-                deliveryCount = rollbackState.deliveryCount;
-                memberId = rollbackState.memberId;
+        synchronized void completeStateTransition(boolean commit) {
+            if (commit || isMarkedArchived) {
                 rollbackState = null;
-            } finally {
-                stateTransitionLock.writeLock().unlock();
+                return;
             }
+            state = rollbackState.state;
+            deliveryCount = rollbackState.deliveryCount;
+            memberId = rollbackState.memberId;
+            rollbackState = null;
         }
 
         @Override

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -3145,11 +3145,7 @@ public class SharePartition {
         void completeStateTransition(boolean commit) {
             stateTransitionLock.writeLock().lock();
             try {
-                if (commit) {
-                    rollbackState = null;
-                    return;
-                }
-                if (isMarkedArchived) {
+                if (commit || isMarkedArchived) {
                     rollbackState = null;
                     return;
                 }

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -7467,6 +7467,73 @@ public class SharePartitionTest {
         assertEquals(20, sharePartition.nextFetchOffset());
     }
 
+    @Test
+    public void testLsoMovementWithWriteStateRPCFailuresInAck() {
+        Persister persister = Mockito.mock(Persister.class);
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withState(SharePartitionState.ACTIVE)
+            .withPersister(persister)
+            .build();
+
+        fetchAcquiredRecords(sharePartition, memoryRecords(5, 2), 5);
+        fetchAcquiredRecords(sharePartition, memoryRecords(5, 7), 5);
+
+        // Validate that there is no ongoing transition.
+        assertFalse(sharePartition.cachedState().get(2L).batchHasOngoingStateTransition());
+        assertFalse(sharePartition.cachedState().get(7L).batchHasOngoingStateTransition());
+
+        // Return futures which will be completed later, so the batch state has ongoing transition.
+        CompletableFuture<WriteShareGroupStateResult> future1 = new CompletableFuture<>();
+        CompletableFuture<WriteShareGroupStateResult> future2 = new CompletableFuture<>();
+
+        // Mocking the persister write state RPC to return future 1 and future 2 when acknowledgement occurs for
+        // offsets 2-6 and 7-11 respectively.
+        Mockito.when(persister.writeState(Mockito.any())).thenReturn(future1).thenReturn(future2);
+
+        // Acknowledge batch to create ongoing transition.
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(2, 6, List.of(AcknowledgeType.RELEASE.id))));
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(7, 11, List.of(AcknowledgeType.RELEASE.id))));
+
+        // Validate that there is no ongoing transition.
+        assertTrue(sharePartition.cachedState().get(2L).batchHasOngoingStateTransition());
+        assertTrue(sharePartition.cachedState().get(7L).batchHasOngoingStateTransition());
+
+        // LSO is at 9.
+        sharePartition.updateCacheAndOffsets(9);
+
+        // Start offset will be moved.
+        assertEquals(9, sharePartition.nextFetchOffset());
+        assertEquals(9, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(2L).batchState());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(7L).offsetState().get(7L).state());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(7L).offsetState().get(8L).state());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(9L).state());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(10L).state());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(11L).state());
+
+        // Complete future1 exceptionally so acknowledgement for 2-6 offsets will be completed.
+        WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
+                PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
+        future1.complete(writeShareGroupStateResult);
+
+        // The completion of future1 with exception should not impact the cached state since those records have already
+        // been archived.
+        assertEquals(9, sharePartition.nextFetchOffset());
+        assertEquals(9, sharePartition.startOffset());
+        assertEquals(11, sharePartition.endOffset());
+        assertEquals(2, sharePartition.cachedState().size());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(2L).batchState());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(7L).offsetState().get(7L).state());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(7L).offsetState().get(8L).state());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(9L).state());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(10L).state());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(11L).state());
+    }
+
     /**
      * This function produces transactional data of a given no. of records followed by a transactional marker (COMMIT/ABORT).
      */

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -7469,7 +7469,7 @@ public class SharePartitionTest {
     }
 
     @Test
-    public void testLsoMovementWithWriteStateRPCFailuresInAck() {
+    public void testLsoMovementWithWriteStateRPCFailuresInAcknowledgement() {
         Persister persister = Mockito.mock(Persister.class);
         SharePartition sharePartition = SharePartitionBuilder.builder()
             .withState(SharePartitionState.ACTIVE)
@@ -7499,7 +7499,7 @@ public class SharePartitionTest {
         assertTrue(sharePartition.cachedState().get(2L).batchHasOngoingStateTransition());
         assertTrue(sharePartition.cachedState().get(7L).batchHasOngoingStateTransition());
 
-        // LSO is at 9.
+        // Move LSO to 9, so some records/offsets can be marked archived.
         sharePartition.updateCacheAndOffsets(9);
 
         // Start offset will be moved.
@@ -7531,8 +7531,6 @@ public class SharePartitionTest {
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(7L).offsetState().get(7L).state());
         assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(7L).offsetState().get(8L).state());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(9L).state());
-        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(10L).state());
-        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(11L).state());
     }
 
     @Test
@@ -7554,6 +7552,37 @@ public class SharePartitionTest {
                 },
                 () -> {
                     inFlightState.completeStateTransition(false);
+                    return null;
+                }
+            );
+            executorService.invokeAll(callables);
+        } finally {
+            if (!executorService.awaitTermination(30, TimeUnit.MILLISECONDS))
+                executorService.shutdown();
+        }
+        assertEquals(RecordState.ARCHIVED, inFlightState.state());
+        assertEquals("member-2", inFlightState.memberId());
+    }
+
+    @Test
+    public void inFlightStateCommitSuccessAndArchiveStateTransition() throws InterruptedException {
+        InFlightState inFlightState = new InFlightState(RecordState.ACQUIRED, 1, MEMBER_ID);
+
+        inFlightState.startStateTransition(RecordState.ACKNOWLEDGED, SharePartition.DeliveryCountOps.INCREASE, MAX_DELIVERY_COUNT, MEMBER_ID);
+        assertTrue(inFlightState.hasOngoingStateTransition());
+
+        // We have an ongoing state transition from ACQUIRED to ACKNOWLEDGED which is not committed yet. At the same
+        // time when we have a call to completeStateTransition with true commit value, we get a call to ARCHIVE the record.
+        // No matter the order of the 2 calls, we should always be getting the final state as ARCHIVED.
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            List<Callable<Void>> callables = List.of(
+                () -> {
+                    inFlightState.archive("member-2");
+                    return null;
+                },
+                () -> {
+                    inFlightState.completeStateTransition(true);
                     return null;
                 }
             );

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -7566,6 +7566,66 @@ public class SharePartitionTest {
         assertEquals("member-2", inFlightState.memberId());
     }
 
+    @Test
+    public void testAcquisitionLockTimeoutWithWriteStateRPCFailure() throws InterruptedException {
+        Persister persister = Mockito.mock(Persister.class);
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withState(SharePartitionState.ACTIVE)
+            .withDefaultAcquisitionLockTimeoutMs(ACQUISITION_LOCK_TIMEOUT_MS)
+            .withPersister(persister)
+            .build();
+
+        fetchAcquiredRecords(
+            sharePartition.acquire(MEMBER_ID, BATCH_SIZE, MAX_FETCH_RECORDS, 0,
+                fetchPartitionData(memoryRecords(2, 0)), FETCH_ISOLATION_HWM
+            ), 2
+        );
+
+        assertNotNull(sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask());
+        assertEquals(1, sharePartition.timer().size());
+        assertEquals(RecordState.ACQUIRED, sharePartition.cachedState().get(0L).batchState());
+
+        // Return a future which will be completed later, so the batch state has ongoing transition.
+        CompletableFuture<WriteShareGroupStateResult> future = new CompletableFuture<>();
+        Mockito.when(persister.writeState(Mockito.any())).thenReturn(future);
+
+        // Acknowledge batch to create ongoing transition.
+        sharePartition.acknowledge(MEMBER_ID, List.of(new ShareAcknowledgementBatch(0, 1, List.of(AcknowledgeType.RELEASE.id))));
+        // Assert the start offset has not moved and batch has ongoing transition.
+        assertEquals(0L, sharePartition.startOffset());
+        assertEquals(1, sharePartition.cachedState().size());
+        assertTrue(sharePartition.cachedState().get(0L).batchHasOngoingStateTransition());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(0L).batchMemberId());
+
+        // Allowing acquisition lock to expire. This will not cause any change because the record is not in ACQUIRED state.
+        // This will remove the entry of the timer task from timer.
+        mockTimer.advanceClock(DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS);
+        TestUtils.waitForCondition(
+            () -> sharePartition.cachedState().get(0L).batchState() == RecordState.AVAILABLE &&
+                sharePartition.cachedState().get(0L).batchDeliveryCount() == 1 &&
+                sharePartition.timer().size() == 0,
+            DEFAULT_MAX_WAIT_ACQUISITION_LOCK_TIMEOUT_MS,
+            () -> assertionFailedMessage(sharePartition, Map.of(0L, List.of())));
+
+        // Acquisition lock timeout task has run already and is not null.
+        assertNotNull(sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask());
+
+        // Complete future exceptionally so acknowledgement for 0-1 offsets will be completed.
+        WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
+                PartitionFactory.newPartitionErrorData(0, Errors.GROUP_ID_NOT_FOUND.code(), Errors.GROUP_ID_NOT_FOUND.message())))));
+        future.complete(writeShareGroupStateResult);
+
+        // Even though write state RPC has failed, we won't be letting the record stuck in ACQUIRED state with no acquisition
+        // lock timeout task.
+        assertEquals(1, sharePartition.cachedState().size());
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(EMPTY_MEMBER_ID, sharePartition.cachedState().get(0L).batchMemberId());
+        assertNull(sharePartition.cachedState().get(0L).batchAcquisitionLockTimeoutTask());
+    }
+
     /**
      * This function produces transactional data of a given no. of records followed by a transactional marker (COMMIT/ABORT).
      */

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -87,6 +87,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -7532,6 +7533,37 @@ public class SharePartitionTest {
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(9L).state());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(10L).state());
         assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(7L).offsetState().get(11L).state());
+    }
+
+    @Test
+    public void inFlightStateRollbackAndArchiveStateTransition() throws InterruptedException {
+        InFlightState inFlightState = new InFlightState(RecordState.ACQUIRED, 1, MEMBER_ID);
+
+        inFlightState.startStateTransition(RecordState.ACKNOWLEDGED, SharePartition.DeliveryCountOps.INCREASE, MAX_DELIVERY_COUNT, MEMBER_ID);
+        assertTrue(inFlightState.hasOngoingStateTransition());
+
+        // We have an ongoing state transition from ACQUIRED to ACKNOWLEDGED which is not committed yet. At the same
+        // time when we have a call to completeStateTransition with false commit value, we get a call to ARCHIVE the record.
+        // No matter the order of the 2 calls, we should always be getting the final state as ARCHIVED.
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            List<Callable<Void>> callables = List.of(
+                () -> {
+                    inFlightState.archive("member-2");
+                    return null;
+                },
+                () -> {
+                    inFlightState.completeStateTransition(false);
+                    return null;
+                }
+            );
+            executorService.invokeAll(callables);
+        } finally {
+            if (!executorService.awaitTermination(30, TimeUnit.MILLISECONDS))
+                executorService.shutdown();
+        }
+        assertEquals(RecordState.ARCHIVED, inFlightState.state());
+        assertEquals("member-2", inFlightState.memberId());
     }
 
     /**


### PR DESCRIPTION
### About
The way state transition works in SharePartition has a few
problems -
1. In case we arrive at a state which should be treated as final state
of that batch/offset (example - LSO movement which causes offset/batch
to be ARCHIVED permanently), the result of pending write state RPCs for
that offset/batch should not matter for such cases
2. There is no locking available for state transitions which can lead to
inconsistency in case a request to archive record and rollback state
transition request arrive at the same
time.
3. If an acquisition lock timeout occurs while an offset/batch is
undergoing transition followed by write state RPC failure, then we can
land in a scenario where the offset stays in ACQUIRED state with no
acquisition lock timeout task.

### Testing
The code has been tested with new and exiting unit tests and existing
integration tests.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
