### PR TITLE
KAFKA-19489; Extra validation when formatting a node

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -135,8 +135,10 @@ object StorageTool extends Logging {
       featureNamesAndLevels(_).foreachEntry {
         (k, v) => formatter.setFeatureLevel(k, v)
       })
+    val initialControllers = namespace.getString("initial_controllers")
+    val isStandalone = namespace.getBoolean("standalone")
     if (!config.quorumConfig.voters().isEmpty &&
-      (namespace.getString("initial_controllers") != null || namespace.getBoolean("standalone"))) {
+      (Option(initialControllers).isDefined || isStandalone)) {
       throw new TerseFailure("You cannot specify " +
         QuorumConfig.QUORUM_VOTERS_CONFIG + " and format the node " +
         "with --initial-controllers or --standalone. " +
@@ -144,9 +146,9 @@ object StorageTool extends Logging {
         QuorumConfig.QUORUM_VOTERS_CONFIG + " and specify " +
         QuorumConfig.QUORUM_BOOTSTRAP_SERVERS_CONFIG + " instead.")
     }
-    Option(namespace.getString("initial_controllers")).
+    Option(initialControllers).
       foreach(v => formatter.setInitialControllers(DynamicVoters.parse(v)))
-    if (namespace.getBoolean("standalone")) {
+    if (isStandalone) {
       formatter.setInitialControllers(createStandaloneDynamicVoters(config))
     }
     if (namespace.getBoolean("no_initial_controllers")) {

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -135,6 +135,15 @@ object StorageTool extends Logging {
       featureNamesAndLevels(_).foreachEntry {
         (k, v) => formatter.setFeatureLevel(k, v)
       })
+    if (!config.quorumConfig.voters().isEmpty &&
+      (namespace.getString("initial_controllers") != null || namespace.getBoolean("standalone"))) {
+      throw new TerseFailure("You cannot specify " +
+        QuorumConfig.QUORUM_VOTERS_CONFIG + " and format the node " +
+        "with --initial-controllers or --standalone. " +
+        "If you want to use dynamic quorum, please remove " +
+        QuorumConfig.QUORUM_VOTERS_CONFIG + " and specify " +
+        QuorumConfig.QUORUM_BOOTSTRAP_SERVERS_CONFIG + " instead.")
+    }
     Option(namespace.getString("initial_controllers")).
       foreach(v => formatter.setInitialControllers(DynamicVoters.parse(v)))
     if (namespace.getBoolean("standalone")) {

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -375,9 +375,10 @@ Found problem:
   def testFormatWithStandaloneFlagOnBrokerFails(): Unit = {
     val availableDirs = Seq(TestUtils.tempDir())
     val properties = new Properties()
-    properties.putAll(defaultStaticQuorumProperties)
-    properties.remove("controller.quorum.voters")
-    properties.put("controller.quorum.bootstrap.servers", "localhost:9093")
+    properties.setProperty("process.roles", "broker")
+    properties.setProperty("node.id", "0")
+    properties.setProperty("controller.listener.names", "CONTROLLER")
+    properties.setProperty("controller.quorum.bootstrap.servers", "localhost:9093")
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     val stream = new ByteArrayOutputStream()
     val arguments = ListBuffer[String]("--release-version", "3.9-IV0", "--standalone")
@@ -387,7 +388,7 @@ Found problem:
   }
 
   @Test
-  def testFormatWithStandaloneFailsWithVotersConfig(): Unit = {
+  def testFormatWithStandaloneFailsWithStaticVotersConfig(): Unit = {
     val availableDirs = Seq(TestUtils.tempDir())
     val properties = new Properties()
     properties.putAll(defaultDynamicQuorumProperties)
@@ -405,7 +406,7 @@ Found problem:
   }
 
   @Test
-  def testFormatWithInitialControllersFailsWithVotersConfig(): Unit = {
+  def testFormatWithInitialControllersFailsWithStaticVotersConfig(): Unit = {
     val availableDirs = Seq(TestUtils.tempDir())
     val properties = new Properties()
     properties.putAll(defaultDynamicQuorumProperties)

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -376,12 +376,56 @@ Found problem:
     val availableDirs = Seq(TestUtils.tempDir())
     val properties = new Properties()
     properties.putAll(defaultStaticQuorumProperties)
+    properties.remove("controller.quorum.voters")
+    properties.put("controller.quorum.bootstrap.servers", "localhost:9093")
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     val stream = new ByteArrayOutputStream()
     val arguments = ListBuffer[String]("--release-version", "3.9-IV0", "--standalone")
     assertEquals("You can only use --standalone on a controller.",
       assertThrows(classOf[TerseFailure],
         () => runFormatCommand(stream, properties, arguments.toSeq)).getMessage)
+  }
+
+  @Test
+  def testFormatWithStandaloneAndInitialControllersFailsWithVotersConfig(): Unit = {
+    val availableDirs = Seq(TestUtils.tempDir())
+    val properties = new Properties()
+    properties.putAll(defaultDynamicQuorumProperties)
+    properties.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "0@localhost:8020")
+    properties.setProperty("log.dirs", availableDirs.mkString(","))
+    val stream = new ByteArrayOutputStream()
+    val args1 = ListBuffer[String]("--release-version", "3.9-IV0", "--standalone")
+    assertEquals("You cannot specify controller.quorum.voters and " +
+      "format the node with --initial-controllers or --standalone. If you " +
+      "want to use dynamic quorum, please remove controller.quorum.voters and " +
+      "specify controller.quorum.bootstrap.servers instead.",
+      assertThrows(classOf[TerseFailure],
+        () => runFormatCommand(stream, properties, args1.toSeq)).getMessage
+    )
+    val args2 = ListBuffer[String](
+      "--release-version", "3.9-IV0",
+      "--initial-controllers",
+      "0@localhost:8020:K90IZ-0DRNazJ49kCZ1EMQ,"
+    )
+    assertEquals("You cannot specify controller.quorum.voters and " +
+      "format the node with --initial-controllers or --standalone. If you " +
+      "want to use dynamic quorum, please remove controller.quorum.voters and " +
+      "specify controller.quorum.bootstrap.servers instead.",
+      assertThrows(classOf[TerseFailure],
+        () => runFormatCommand(stream, properties, args2.toSeq)).getMessage
+    )
+  }
+
+  @Test
+  def testFormatWithNoInitialControllersPassesWithVotersConfig(): Unit = {
+    val availableDirs = Seq(TestUtils.tempDir())
+    val properties = new Properties()
+    properties.putAll(defaultDynamicQuorumProperties)
+    properties.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "0@localhost:8020")
+    properties.setProperty("log.dirs", availableDirs.mkString(","))
+    val stream = new ByteArrayOutputStream()
+    val arguments = ListBuffer[String]("--release-version", "3.9-IV0", "--no-initial-controllers")
+    assertEquals(0, runFormatCommand(stream, properties, arguments.toSeq))
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -387,22 +387,32 @@ Found problem:
   }
 
   @Test
-  def testFormatWithStandaloneAndInitialControllersFailsWithVotersConfig(): Unit = {
+  def testFormatWithStandaloneFailsWithVotersConfig(): Unit = {
     val availableDirs = Seq(TestUtils.tempDir())
     val properties = new Properties()
     properties.putAll(defaultDynamicQuorumProperties)
     properties.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "0@localhost:8020")
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     val stream = new ByteArrayOutputStream()
-    val args1 = ListBuffer[String]("--release-version", "3.9-IV0", "--standalone")
+    val arguments = ListBuffer[String]("--release-version", "3.9-IV0", "--standalone")
     assertEquals("You cannot specify controller.quorum.voters and " +
       "format the node with --initial-controllers or --standalone. If you " +
       "want to use dynamic quorum, please remove controller.quorum.voters and " +
       "specify controller.quorum.bootstrap.servers instead.",
       assertThrows(classOf[TerseFailure],
-        () => runFormatCommand(stream, properties, args1.toSeq)).getMessage
+        () => runFormatCommand(stream, properties, arguments.toSeq)).getMessage
     )
-    val args2 = ListBuffer[String](
+  }
+
+  @Test
+  def testFormatWithInitialControllersFailsWithVotersConfig(): Unit = {
+    val availableDirs = Seq(TestUtils.tempDir())
+    val properties = new Properties()
+    properties.putAll(defaultDynamicQuorumProperties)
+    properties.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "0@localhost:8020")
+    properties.setProperty("log.dirs", availableDirs.mkString(","))
+    val stream = new ByteArrayOutputStream()
+    val arguments = ListBuffer[String](
       "--release-version", "3.9-IV0",
       "--initial-controllers",
       "0@localhost:8020:K90IZ-0DRNazJ49kCZ1EMQ,"
@@ -412,7 +422,7 @@ Found problem:
       "want to use dynamic quorum, please remove controller.quorum.voters and " +
       "specify controller.quorum.bootstrap.servers instead.",
       assertThrows(classOf[TerseFailure],
-        () => runFormatCommand(stream, properties, args2.toSeq)).getMessage
+        () => runFormatCommand(stream, properties, arguments.toSeq)).getMessage
     )
   }
 

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4021,17 +4021,17 @@ In the replica description 0@controller-0:1234:3Db5QLSqSZieL3rJBUUegA, 0 is the 
   <h4 class="anchor-heading"><a id="kraft_reconfig" class="anchor-link"></a><a href="#kraft_reconfig">Controller membership changes</a></h4>
 
   <h5 class="anchor-heading"><a id="static_versus_dynamic_kraft_quorums" class="anchor-link"></a><a href="#static_versus_dynamic_kraft_quorums">Static versus Dynamic KRaft Quorums</a></h5>
-  There are two ways to run KRaft: the old way using static controller quorums, and the new way
-  using KIP-853 dynamic controller quorums.<p>
+  There are two ways to run KRaft: using KIP-853 dynamic controller quorums, or the old way
+  using static controller quorums.<p>
 
-  When using a static quorum, the configuration file for each broker and controller must specify
-  the IDs, hostnames, and ports of all controllers in <code>controller.quorum.voters</code>.<p>
-
-  In contrast, when using a dynamic quorum, <code>controller.quorum.bootstrap.servers</code>
-  is set instead and <code>controller.quorum.voters</code> must not be set. This configuration key need not
+  When using a dynamic quorum, <code>controller.quorum.voters</code> must not be set
+  and <code>controller.quorum.bootstrap.servers</code> is set instead. This configuration key need not
   contain all the controllers, but it should contain as many as possible so that all the servers
   can locate the quorum. In other words, its function is much like the
   <code>bootstrap.servers</code> configuration used by Kafka clients.<p>
+
+  When using a static quorum, the configuration file for each broker and controller must specify
+  the IDs, hostnames, and ports of all controllers in <code>controller.quorum.voters</code>.<p>
 
   If you are not sure whether you are using static or dynamic quorums, you can determine this by
   running something like the following:<p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4027,8 +4027,8 @@ In the replica description 0@controller-0:1234:3Db5QLSqSZieL3rJBUUegA, 0 is the 
   When using a static quorum, the configuration file for each broker and controller must specify
   the IDs, hostnames, and ports of all controllers in <code>controller.quorum.voters</code>.<p>
 
-  In contrast, when using a dynamic quorum, you should set
-  <code>controller.quorum.bootstrap.servers</code> instead. This configuration key need not
+  In contrast, when using a dynamic quorum, <code>controller.quorum.bootstrap.servers</code>
+  is set instead and <code>controller.quorum.voters</code> must not be set. This configuration key need not
   contain all the controllers, but it should contain as many as possible so that all the servers
   can locate the quorum. In other words, its function is much like the
   <code>bootstrap.servers</code> configuration used by Kafka clients.<p>

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumConfig.java
@@ -57,6 +57,9 @@ public class QuorumConfig {
     public static final String QUORUM_VOTERS_CONFIG = QUORUM_PREFIX + "voters";
     public static final String QUORUM_VOTERS_DOC = "Map of id/endpoint information for " +
         "the set of voters in a comma-separated list of <code>{id}@{host}:{port}</code> entries. " +
+        "This is the old way of defining membership for controller quorums and should NOT be " +
+        "set if using dynamic quorums. Instead, controller.quorum.bootstrap.servers should be set," +
+        "and the voter set is determined by the --standalone or --initial-controllers flags when formatting." +
         "For example: <code>1@localhost:9092,2@localhost:9093,3@localhost:9094</code>";
     public static final List<String> DEFAULT_QUORUM_VOTERS = List.of();
 


### PR DESCRIPTION
This PR adds a check to the storage tool's format command which throws a
TerseFailure when the controller.quorum.voters config is defined and the
node is formatted with the --standalone flag or the
--initial-controllers flag.

Without this check, it is possible to have two voter sets. For example,
in a three node setup, the two nodes that formatted with
--no-initial-controllers could form quorum with each other since they
have the static voter set, and the --standalone node would ignore the
config and read the voter set of itself from its log, forming its own
quorum of 1.

Reviewers: José Armando García Sancio <jsancio@apache.org>, TaiJuWu
 <tjwu1217@gmail.com>, Alyssa Huang <ahuang@confluent.io>
