### PR TITLE
MINOR: Add a description document for batchLength

### DIFF
--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -60,13 +60,13 @@ records: [Record]</code></pre>
     <p> Note that when compression is enabled, the compressed record data is serialized directly following the count of the number of records. </p>
 
     <p>batchLength represents the number of bytes from the current position (immediately after the batchLength field) to the end of the batch. 
-        In other words, the total size of a record batch on disk is batchLength + 12 bytes, which includes the 8-byte baseOffset and the 4-byte batchLength field itself.</p>
+    In other words, the total size of a record batch on disk is batchLength + 12 bytes, which includes the 8-byte baseOffset and the 4-byte batchLength field itself.</p>
     
     <p>The CRC covers the data from the attributes to the end of the batch (i.e. all the bytes that follow the CRC). It is located after the magic byte, which
     means that clients must parse the magic byte before deciding how to interpret the bytes between the batch length and the magic byte. The partition leader
     epoch field is not included in the CRC computation to avoid the need to recompute the CRC when this field is assigned for every batch that is received by
     the broker. The CRC-32C (Castagnoli) polynomial is used for the computation.</p>
-    
+
     <p>On compaction, we preserve the first and last offset/sequence numbers from the original batch when the log is cleaned. This is required in order to be able to restore the
     producer's state when the log is reloaded. If we did not retain the last sequence number, for example, then after a partition leader failure, the producer might see an OutOfSequence error. The base sequence number must
     be preserved for duplicate checking (the broker checks incoming Produce requests for duplicates by verifying that the first and last sequence numbers of the incoming batch match the last from that producer). As a result,

--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -59,11 +59,14 @@ recordsCount: int32
 records: [Record]</code></pre>
     <p> Note that when compression is enabled, the compressed record data is serialized directly following the count of the number of records. </p>
 
+    <p>batchLength represents the number of bytes from the current position (immediately after the batchLength field) to the end of the batch. 
+        In other words, the total size of a record batch on disk is batchLength + 12 bytes, which includes the 8-byte baseOffset and the 4-byte batchLength field itself.</p>
+    
     <p>The CRC covers the data from the attributes to the end of the batch (i.e. all the bytes that follow the CRC). It is located after the magic byte, which
     means that clients must parse the magic byte before deciding how to interpret the bytes between the batch length and the magic byte. The partition leader
     epoch field is not included in the CRC computation to avoid the need to recompute the CRC when this field is assigned for every batch that is received by
     the broker. The CRC-32C (Castagnoli) polynomial is used for the computation.</p>
-
+    
     <p>On compaction, we preserve the first and last offset/sequence numbers from the original batch when the log is cleaned. This is required in order to be able to restore the
     producer's state when the log is reloaded. If we did not retain the last sequence number, for example, then after a partition leader failure, the producer might see an OutOfSequence error. The base sequence number must
     be preserved for duplicate checking (the broker checks incoming Produce requests for duplicates by verifying that the first and last sequence numbers of the incoming batch match the last from that producer). As a result,


### PR DESCRIPTION
Add documentation for Batch Format to explain the meaning of
batchLength.

This is the preview image after the change:

![image](https://github.com/user-attachments/assets/85023c48-64e6-4a33-898f-df84f6864e58)

Reviewers: Ken Huang <s7133700@gmail.com>, Jhen-Yung Hsu
 <jhenyunghsu@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
