### PR TITLE
KAFKA-19492 Log detailed message for OffsetOutOfRangeException in deleteRecordsOnLocalLog

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1113,7 +1113,7 @@ class ReplicaManager(val config: KafkaConfig,
                    _: KafkaStorageException) =>
             (topicPartition, LogDeleteRecordsResult(-1L, -1L, Some(e)))
           case e: OffsetOutOfRangeException =>
-            debug("Error processing delete records operation on partition %s. %s".format(topicPartition, e.getMessage))
+            debug("Error processing delete records operation on partition %s".format(topicPartition), e)
             (topicPartition, LogDeleteRecordsResult(-1L, -1L, Some(e)))
           case t: Throwable =>
             error("Error processing delete records operation on partition %s".format(topicPartition), t)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1109,9 +1109,11 @@ class ReplicaManager(val config: KafkaConfig,
         } catch {
           case e@ (_: UnknownTopicOrPartitionException |
                    _: NotLeaderOrFollowerException |
-                   _: OffsetOutOfRangeException |
                    _: PolicyViolationException |
                    _: KafkaStorageException) =>
+            (topicPartition, LogDeleteRecordsResult(-1L, -1L, Some(e)))
+          case e: OffsetOutOfRangeException =>
+            debug("Error processing delete records operation on partition %s. %s".format(topicPartition, e.getMessage))
             (topicPartition, LogDeleteRecordsResult(-1L, -1L, Some(e)))
           case t: Throwable =>
             error("Error processing delete records operation on partition %s".format(topicPartition), t)


### PR DESCRIPTION
Currently, troubleshooting OFFSET_OUT_OF_RANGE errors during record
deletion is challenging because deleteRecordsOnLocalLog suppresses the
detailed messages carried by OffsetOutOfRangeException.

To enhance the diagnostic capabilities of the Kafka Admin Client, we
should log these specific exception details at the debug level. This
ensures that the original context of the failure is preserved for
developers and operators.

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
