### PR TITLE
KAFKA-19494: Undeprecate JoinGroup V0 & V1

### DIFF
--- a/clients/src/main/resources/common/message/JoinGroupRequest.json
+++ b/clients/src/main/resources/common/message/JoinGroupRequest.json
@@ -35,7 +35,6 @@
   //
   // Version 9 is the same as version 8.
   "validVersions": "0-9",
-  "deprecatedVersions": "0-1",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",


### PR DESCRIPTION
We added back support for JoinGroup v0 & v1 in Kafka 4.0.1 and 4.1.0 due to KAFKA-19444. Given that, we should undeprecate these protocol api versions in 3.x.

Reviewers: David Arthur <mumrah@gmail.com>