### PR TITLE
MINOR: fix e2e docs for test that cannot be run directly

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -33,7 +33,7 @@ TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py" bash tests/docker/run_
 ```
 * Run multiple test files
 ```
-TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py tests/kafkatest/services/console_consumer.py" bash tests/docker/run_tests.sh
+TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py tests/kafkatest/sanity_checks/test_console_consumer.py" bash tests/docker/run_tests.sh
 ```
 * Run a specific test class
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,7 @@ TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py::PluggableConsumerTest.
 ```
 * Run a specific test method with specific parameters
 ```
-TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeTest.test_metadata_upgrade" _DUCKTAPE_OPTIONS='--parameters '\''{"from_version":"0.10.1.1","to_version":"2.6.0-SNAPSHOT"}'\' bash tests/docker/run_tests.sh
+TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeTest.test_rolling_upgrade_with_2_bounces" _DUCKTAPE_OPTIONS='--parameters '\''{"from_version":"2.4.1","metadata_quorum":"COMBINED_KRAFT"}'\' bash tests/docker/run_tests.sh
 ```
 * Run tests with a specific image name
 ```


### PR DESCRIPTION
`tests/kafkatest/services/console_consumer.py` cannot be run directly.
The correct way is to run
`tests/kafkatest/sanity_checks/test_console_consumer.py`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
