### PR TITLE
KAFKA-19495: update native image config for native images

### DIFF
--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -1024,6 +1024,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever"
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator"
+},
+{
   "name":"org.apache.kafka.common.security.plain.PlainLoginModule",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -1066,6 +1072,18 @@
 {
   "name":"org.apache.kafka.metadata.authorizer.StandardAuthorizer",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.server.logger.LoggingController",
+  "queryAllPublicConstructors":true
+},
+{
+  "name":"org.apache.kafka.server.logger.LoggingControllerMBean",
+  "queryAllPublicMethods":true
+},
+{
+  "name":"org.apache.kafka.server.share.persister.DefaultStatePersister",
+  "methods":[{"name":"<init>","parameterTypes":["org.apache.kafka.server.share.persister.PersisterStateManager"] }]
 },
 {
   "name":"org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler$Content",


### PR DESCRIPTION
We failed the native image build and test workflow
[here](https://github.com/apache/kafka/actions/runs/16211393417/job/45772104969).
The failed messages are:
```
Exception in thread "main" java.lang.ExceptionInInitializerError at
org.apache.kafka.server.config.AbstractKafkaConfig.<clinit>(AbstractKafkaConfig.java:56)
at
java.base@21.0.2/java.lang.Class.ensureInitialized(DynamicHub.java:601)
at kafka.tools.StorageTool$.$anonfun$execute$1(StorageTool.scala:79) at
scala.Option.flatMap(Option.scala:283) at
kafka.tools.StorageTool$.execute(StorageTool.scala:79) at
kafka.tools.StorageTool$.main(StorageTool.scala:46) at
kafka.docker.KafkaDockerWrapper$.main(KafkaDockerWrapper.scala:57) at
kafka.docker.KafkaDockerWrapper.main(KafkaDockerWrapper.scala) at
java.base@21.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
Caused by: org.apache.kafka.common.config.ConfigException: Invalid value
org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever for
configuration sasl.oauthbearer.jwt.retriever.class: Class
org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever could
not be found. at
org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:778)
at
org.apache.kafka.common.config.ConfigDef$ConfigKey.<init>(ConfigDef.java:1271)
at org.apache.kafka.common.config.ConfigDef.define(ConfigDef.java:155)
at org.apache.kafka.common.config.ConfigDef.define(ConfigDef.java:198)
at org.apache.kafka.common.config.ConfigDef.define(ConfigDef.java:237)
at org.apache.kafka.common.config.ConfigDef.define(ConfigDef.java:399)
at org.apache.kafka.common.config.ConfigDef.define(ConfigDef.java:412)
at
org.apache.kafka.common.config.internals.BrokerSecurityConfigs.<clinit>(BrokerSecurityConfigs.java:197)
... 9 more
```
After investigation, I found we have to update the native image configs
to support the new code change as described
[here](https://github.com/apache/kafka/blob/trunk/docker/native/README.md#native-image-reachability-metadata).
This PR fixes this issue and verified that the same workflow for native
image passed
[here](https://github.com/apache/kafka/actions/runs/16215454627/job/45783738496).

The PR for v4.1.0 is https://github.com/apache/kafka/pull/20151 .

Reviewers: TengYao Chi <frankvicky@apache.org>
