### PR TITLE
MINOR: Fix the handling source topic deletion integration test

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
@@ -42,10 +42,13 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 public class HandlingSourceTopicDeletionIntegrationTest {
@@ -124,12 +127,15 @@ public class HandlingSourceTopicDeletionIntegrationTest {
 
         CLUSTER.deleteTopic(INPUT_TOPIC);
 
-        TestUtils.waitForCondition(
-            () -> kafkaStreams1.state() == State.ERROR && kafkaStreams2.state() == State.ERROR,
-            TIMEOUT,
-            () -> "Kafka Streams clients did not reach state ERROR"
-        );
+        if (!useNewProtocol) {
+            TestUtils.waitForCondition(
+                    () -> kafkaStreams1.state() == State.ERROR && kafkaStreams2.state() == State.ERROR,
+                    TIMEOUT,
+                    () -> "Kafka Streams clients did not reach state ERROR"
+            );
 
+        }
+        TimeUnit.SECONDS.sleep(5);
         assertThat(calledUncaughtExceptionHandler1.get(), is(true));
         assertThat(calledUncaughtExceptionHandler2.get(), is(true));
     }


### PR DESCRIPTION
Fix an integration test error:
 
In the old version, the `HandlingSouceTopicDeleteIntegrationTest` expects state change to `ERROR` in both old and new protocols, but in the new protocol, we should expects `MissingSourceTopicException`. 
