### PR TITLE
KAFKA-19459: List internal topics for the user

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -497,7 +497,7 @@ public class StreamsGroupCommand {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed because the topics do not exist.", Optional.empty());
                                             } else if (e.getCause() instanceof UnsupportedVersionException) {
                                                 printError("Deleting internal topics is not supported by the broker version.\n" +
-                                                    "Topics: (" + String.join(",", internalTopics) + ").\n" +
+                                                    "Internal topics: (" + String.join(",", internalTopics) + ").\n" +
                                                     "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                                             } else {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed due to " + e.getMessage(), Optional.of(e));
@@ -838,11 +838,11 @@ public class StreamsGroupCommand {
                             .filter(topic -> groupIds.stream().anyMatch(groupId -> isInferredInternalTopic(topic, groupId)))
                             .collect(Collectors.toList());
                         printError("Retrieving internal topics is not supported by the broker version.\n" +
-                            "Internal Topics: (" + String.join(",", internalTopics) + ").\n" +
+                            "Internal topics: (" + String.join(",", internalTopics) + ").\n" +
                             "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                     } catch (InterruptedException | ExecutionException ex) {
                         printError("Retrieving internal topics is not supported by the broker version. " +
-                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
+                            "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                     }
                 } else {
                     printError("Retrieving internal topics failed due to " + e.getMessage(), Optional.of(e));

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -496,7 +496,7 @@ public class StreamsGroupCommand {
                                             if (e.getCause() instanceof UnknownTopicOrPartitionException) {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed because the topics do not exist.", Optional.empty());
                                             } else if (e.getCause() instanceof UnsupportedVersionException) {
-                                                printError("Deleting internal topics is not supported by the broker version. \n" +
+                                                printError("Deleting internal topics is not supported by the broker version.\n" +
                                                     "Topics: (" + String.join(",", internalTopics) + ").\n" +
                                                     "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                                             } else {
@@ -831,23 +831,19 @@ public class StreamsGroupCommand {
                 }
             } catch (InterruptedException | ExecutionException e) {
                 if (e.getCause() instanceof UnsupportedVersionException) {
-                    List<String> internalTopics = new ArrayList<>();
                     try {
+                        // Retrieve internal topic list if possible, and add the list of topic names to error message
                         Set<String> allTopics = adminClient.listTopics().names().get();
-                        for (String topic : allTopics) {
-                            for (String groupId : groupIds) {
-                                if (isInferredInternalTopic(topic, groupId)) {
-                                    internalTopics.add(topic);
-                                    break;
-                                }
-                            }
-                        }
-                        System.out.println("Internal Topics: (" + String.join(",", internalTopics) + ").");
+                        List<String> internalTopics = allTopics.stream()
+                            .filter(topic -> groupIds.stream().anyMatch(groupId -> isInferredInternalTopic(topic, groupId)))
+                            .collect(Collectors.toList());
+                        printError("Retrieving internal topics is not supported by the broker version.\n" +
+                            "Internal Topics: (" + String.join(",", internalTopics) + ").\n" +
+                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                     } catch (InterruptedException | ExecutionException ex) {
-                        printError("Retrieving internal topics failed due to " + ex.getMessage(), Optional.of(ex));
+                        printError("Retrieving internal topics is not supported by the broker version. " +
+                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                     }
-                    printError("Retrieving internal topics is not supported by the broker version. " +
-                        "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                 } else {
                     printError("Retrieving internal topics failed due to " + e.getMessage(), Optional.of(e));
                 }

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -1027,7 +1027,6 @@ public class StreamsGroupCommand {
         }
     }
 
-    public record OffsetsInfo(Optional<Long> currentOffset, Optional<Integer> leaderEpoch, Long logEndOffset,
-                              Long lag) {
+    public record OffsetsInfo(Optional<Long> currentOffset, Optional<Integer> leaderEpoch, Long logEndOffset, Long lag) {
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -89,11 +89,11 @@ public class StreamsGroupCommand {
             opts.checkArgs();
             // should have exactly one action
             long numberOfActions = Stream.of(
-                opts.listOpt,
-                opts.describeOpt,
-                opts.resetOffsetsOpt,
-                opts.deleteOpt,
-                opts.deleteOffsetsOpt
+                    opts.listOpt,
+                    opts.describeOpt,
+                    opts.resetOffsetsOpt,
+                    opts.deleteOpt,
+                    opts.deleteOffsetsOpt
             ).filter(opts.options::has).count();
             if (numberOfActions != 1)
                 CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, or --delete-offsets.");
@@ -138,22 +138,22 @@ public class StreamsGroupCommand {
         }
 
         groupAssignmentsToReset.forEach((groupId, assignment) ->
-            assignment.forEach((streamsAssignment, offsetAndMetadata) ->
-                System.out.printf(format,
-                    groupId,
-                    streamsAssignment.topic(),
-                    streamsAssignment.partition(),
-                    offsetAndMetadata.offset())));
+                assignment.forEach((streamsAssignment, offsetAndMetadata) ->
+                        System.out.printf(format,
+                                groupId,
+                                streamsAssignment.topic(),
+                                streamsAssignment.partition(),
+                                offsetAndMetadata.offset())));
         System.out.println();
     }
 
     static Set<GroupState> groupStatesFromString(String input) {
         Set<GroupState> parsedStates =
-            Arrays.stream(input.split(",")).map(s -> GroupState.parse(s.trim())).collect(Collectors.toSet());
+                Arrays.stream(input.split(",")).map(s -> GroupState.parse(s.trim())).collect(Collectors.toSet());
         Set<GroupState> validStates = GroupState.groupStatesForType(GroupType.STREAMS);
         if (!validStates.containsAll(parsedStates)) {
             throw new IllegalArgumentException("Invalid state list '" + input + "'. Valid states are: " +
-                validStates.stream().map(GroupState::toString).collect(Collectors.joining(", ")));
+                    validStates.stream().map(GroupState::toString).collect(Collectors.joining(", ")));
         }
         return parsedStates;
     }
@@ -187,21 +187,21 @@ public class StreamsGroupCommand {
 
         private OffsetsUtils.OffsetsUtilsOptions getOffsetsUtilsOptions(StreamsGroupCommandOptions opts) {
             return
-                new OffsetsUtils.OffsetsUtilsOptions(opts.options.valuesOf(opts.groupOpt),
-                    opts.options.valuesOf(opts.resetToOffsetOpt),
-                    opts.options.valuesOf(opts.resetFromFileOpt),
-                    opts.options.valuesOf(opts.resetToDatetimeOpt),
-                    opts.options.valueOf(opts.resetByDurationOpt),
-                    opts.options.valueOf(opts.resetShiftByOpt),
-                    opts.options.valueOf(opts.timeoutMsOpt));
+                    new OffsetsUtils.OffsetsUtilsOptions(opts.options.valuesOf(opts.groupOpt),
+                            opts.options.valuesOf(opts.resetToOffsetOpt),
+                            opts.options.valuesOf(opts.resetFromFileOpt),
+                            opts.options.valuesOf(opts.resetToDatetimeOpt),
+                            opts.options.valueOf(opts.resetByDurationOpt),
+                            opts.options.valueOf(opts.resetShiftByOpt),
+                            opts.options.valueOf(opts.timeoutMsOpt));
         }
 
         public void listGroups() throws ExecutionException, InterruptedException {
             if (opts.options.has(opts.stateOpt)) {
                 String stateValue = opts.options.valueOf(opts.stateOpt);
                 Set<GroupState> states = (stateValue == null || stateValue.isEmpty())
-                    ? Set.of()
-                    : groupStatesFromString(stateValue);
+                        ? Set.of()
+                        : groupStatesFromString(stateValue);
                 List<GroupListing> listings = listStreamsGroupsInStates(states);
                 printGroupInfo(listings);
             } else
@@ -211,8 +211,8 @@ public class StreamsGroupCommand {
         List<String> listStreamsGroups() {
             try {
                 ListGroupsResult result = adminClient.listGroups(new ListGroupsOptions()
-                    .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
-                    .withTypes(Set.of(GroupType.STREAMS)));
+                        .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+                        .withTypes(Set.of(GroupType.STREAMS)));
                 Collection<GroupListing> listings = result.all().get();
                 return listings.stream().map(GroupListing::groupId).collect(Collectors.toList());
             } catch (InterruptedException | ExecutionException e) {
@@ -222,9 +222,9 @@ public class StreamsGroupCommand {
 
         List<GroupListing> listStreamsGroupsInStates(Set<GroupState> states) throws ExecutionException, InterruptedException {
             ListGroupsResult result = adminClient.listGroups(new ListGroupsOptions()
-                .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
-                .withTypes(Set.of(GroupType.STREAMS))
-                .inGroupStates(states));
+                    .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+                    .withTypes(Set.of(GroupType.STREAMS))
+                    .inGroupStates(states));
             return new ArrayList<>(result.all().get());
         }
 
@@ -244,8 +244,8 @@ public class StreamsGroupCommand {
 
         public void describeGroups() throws ExecutionException, InterruptedException {
             List<String> groupIds = opts.options.has(opts.allGroupsOpt)
-                ? new ArrayList<>(listStreamsGroups())
-                : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
+                    ? new ArrayList<>(listStreamsGroups())
+                    : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
             if (!groupIds.isEmpty()) {
                 for (String groupId : groupIds) {
                     StreamsGroupDescription description = getDescribeGroup(groupId);
@@ -263,8 +263,8 @@ public class StreamsGroupCommand {
 
         StreamsGroupDescription getDescribeGroup(String group) throws ExecutionException, InterruptedException {
             DescribeStreamsGroupsResult result = adminClient.describeStreamsGroups(
-                List.of(group),
-                new DescribeStreamsGroupsOptions().timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue()));
+                    List.of(group),
+                    new DescribeStreamsGroupsOptions().timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue()));
             Map<String, StreamsGroupDescription> descriptionMap = result.all().get();
             return descriptionMap.get(group);
         }
@@ -286,16 +286,16 @@ public class StreamsGroupCommand {
                     System.out.printf(fmt, "GROUP", "MEMBER", "PROCESS", "CLIENT-ID", "ASSIGNMENTS");
                     for (StreamsGroupMemberDescription member : members) {
                         System.out.printf(fmt, description.groupId(), member.memberId(), member.processId(), member.clientId(),
-                            getTasksForPrinting(member.assignment(), Optional.empty()));
+                                getTasksForPrinting(member.assignment(), Optional.empty()));
                     }
                 } else {
                     final int targetAssignmentEpochLen = 25, topologyEpochLen = 15, memberProtocolLen = 15, memberEpochLen = 15;
                     String fmt = "%" + -groupLen + "s %" + -targetAssignmentEpochLen + "s %" + -topologyEpochLen + "s%" + -maxMemberIdLen
-                        + "s %" + -memberProtocolLen + "s %" + -memberEpochLen + "s %" + -maxHostLen + "s %" + -maxClientIdLen + "s %s\n";
+                            + "s %" + -memberProtocolLen + "s %" + -memberEpochLen + "s %" + -maxHostLen + "s %" + -maxClientIdLen + "s %s\n";
                     System.out.printf(fmt, "GROUP", "TARGET-ASSIGNMENT-EPOCH", "TOPOLOGY-EPOCH", "MEMBER", "MEMBER-PROTOCOL", "MEMBER-EPOCH", "PROCESS", "CLIENT-ID", "ASSIGNMENTS");
                     for (StreamsGroupMemberDescription member : members) {
                         System.out.printf(fmt, description.groupId(), description.targetAssignmentEpoch(), description.topologyEpoch(), member.memberId(),
-                            member.isClassic() ? "classic" : "streams", member.memberEpoch(), member.processId(), member.clientId(), getTasksForPrinting(member.assignment(), Optional.of(member.targetAssignment())));
+                                member.isClassic() ? "classic" : "streams", member.memberEpoch(), member.processId(), member.clientId(), getTasksForPrinting(member.assignment(), Optional.of(member.targetAssignment())));
                     }
                 }
             }
@@ -304,8 +304,8 @@ public class StreamsGroupCommand {
         String exportOffsetsToCsv(Map<String, Map<TopicPartition, OffsetAndMetadata>> assignments) {
             boolean isSingleGroupQuery = opts.options.valuesOf(opts.groupOpt).size() == 1;
             ObjectWriter csvWriter = isSingleGroupQuery
-                ? CsvUtils.writerFor(CsvUtils.CsvRecordNoGroup.class)
-                : CsvUtils.writerFor(CsvUtils.CsvRecordWithGroup.class);
+                    ? CsvUtils.writerFor(CsvUtils.CsvRecordNoGroup.class)
+                    : CsvUtils.writerFor(CsvUtils.CsvRecordWithGroup.class);
 
             return assignments.entrySet().stream().flatMap(e -> {
                 String groupId = e.getKey();
@@ -315,8 +315,8 @@ public class StreamsGroupCommand {
                     TopicPartition k = e1.getKey();
                     OffsetAndMetadata v = e1.getValue();
                     Object csvRecord = isSingleGroupQuery
-                        ? new CsvUtils.CsvRecordNoGroup(k.topic(), k.partition(), v.offset())
-                        : new CsvUtils.CsvRecordWithGroup(groupId, k.topic(), k.partition(), v.offset());
+                            ? new CsvUtils.CsvRecordNoGroup(k.topic(), k.partition(), v.offset())
+                            : new CsvUtils.CsvRecordWithGroup(groupId, k.topic(), k.partition(), v.offset());
 
                     try {
                         return csvWriter.writeValueAsString(csvRecord);
@@ -343,11 +343,11 @@ public class StreamsGroupCommand {
         private String getTasksForPrinting(StreamsGroupMemberAssignment assignment, Optional<StreamsGroupMemberAssignment> targetAssignment) {
             StringBuilder builder = new StringBuilder();
             builder.append(prepareTaskType(assignment.activeTasks(), "ACTIVE"))
-                .append(prepareTaskType(assignment.standbyTasks(), "STANDBY"))
-                .append(prepareTaskType(assignment.warmupTasks(), "WARMUP"));
+                    .append(prepareTaskType(assignment.standbyTasks(), "STANDBY"))
+                    .append(prepareTaskType(assignment.warmupTasks(), "WARMUP"));
             targetAssignment.ifPresent(target -> builder.append(prepareTaskType(target.activeTasks(), "TARGET-ACTIVE"))
-                .append(prepareTaskType(target.standbyTasks(), "TARGET-STANDBY"))
-                .append(prepareTaskType(target.warmupTasks(), "TARGET-WARMUP")));
+                    .append(prepareTaskType(target.standbyTasks(), "TARGET-STANDBY"))
+                    .append(prepareTaskType(target.warmupTasks(), "TARGET-WARMUP")));
             return builder.toString();
         }
 
@@ -392,8 +392,8 @@ public class StreamsGroupCommand {
                     System.out.printf(fmt, "GROUP", "TOPIC", "PARTITION", "CURRENT-OFFSET", "LEADER-EPOCH", "LOG-END-OFFSET", "OFFSET-LAG");
                     for (Map.Entry<TopicPartition, OffsetsInfo> offset : offsets.entrySet()) {
                         System.out.printf(fmt, description.groupId(), offset.getKey().topic(), offset.getKey().partition(),
-                            offset.getValue().currentOffset.map(Object::toString).orElse("-"), offset.getValue().leaderEpoch.map(Object::toString).orElse("-"),
-                            offset.getValue().logEndOffset, offset.getValue().lag);
+                                offset.getValue().currentOffset.map(Object::toString).orElse("-"), offset.getValue().leaderEpoch.map(Object::toString).orElse("-"),
+                                offset.getValue().logEndOffset, offset.getValue().lag);
                     }
                 }
             }
@@ -423,11 +423,11 @@ public class StreamsGroupCommand {
                 final Optional<Integer> leaderEpoch = committedOffsets.containsKey(tp.getKey()) ? committedOffsets.get(tp.getKey()).leaderEpoch() : Optional.empty();
                 final long lag = currentOffset.map(current -> latestResult.get(tp.getKey()).offset() - current).orElseGet(() -> latestResult.get(tp.getKey()).offset() - earliestResult.get(tp.getKey()).offset());
                 output.put(tp.getKey(),
-                    new OffsetsInfo(
-                        currentOffset,
-                        leaderEpoch,
-                        latestResult.get(tp.getKey()).offset(),
-                        lag));
+                        new OffsetsInfo(
+                                currentOffset,
+                                leaderEpoch,
+                                latestResult.get(tp.getKey()).offset(),
+                                lag));
             }
             return output;
         }
@@ -435,13 +435,13 @@ public class StreamsGroupCommand {
         Map<TopicPartition, OffsetAndMetadata> getCommittedOffsets(String groupId) {
             try {
                 var sourceTopics = adminClient.describeStreamsGroups(List.of(groupId))
-                    .all().get().get(groupId)
-                    .subtopologies().stream()
-                    .flatMap(subtopology -> subtopology.sourceTopics().stream())
-                    .collect(Collectors.toSet());
+                        .all().get().get(groupId)
+                        .subtopologies().stream()
+                        .flatMap(subtopology -> subtopology.sourceTopics().stream())
+                        .collect(Collectors.toSet());
 
                 var allTopicPartitions = adminClient.listStreamsGroupOffsets(Map.of(groupId, new ListStreamsGroupOffsetsSpec()))
-                    .partitionsToOffsetAndMetadata(groupId).get();
+                        .partitionsToOffsetAndMetadata(groupId).get();
 
                 allTopicPartitions.keySet().removeIf(tp -> !sourceTopics.contains(tp.topic()));
                 return allTopicPartitions;
@@ -453,7 +453,7 @@ public class StreamsGroupCommand {
         private List<TopicPartition> filterExistingGroupTopics(String groupId, List<TopicPartition> topicPartitions) {
             try {
                 var allTopicPartitions = adminClient.listStreamsGroupOffsets(Map.of(groupId, new ListStreamsGroupOffsetsSpec()))
-                    .partitionsToOffsetAndMetadata(groupId).get();
+                        .partitionsToOffsetAndMetadata(groupId).get();
                 boolean allPresent = topicPartitions.stream().allMatch(allTopicPartitions::containsKey);
                 if (!allPresent) {
                     printError("One or more topics are not part of the group '" + groupId + "'.", Optional.empty());
@@ -471,11 +471,11 @@ public class StreamsGroupCommand {
 
             Map<String, Map<TopicPartition, OffsetAndMetadata>> result = new HashMap<>();
             List<String> groupIds = opts.options.has(opts.allGroupsOpt)
-                ? listStreamsGroups()
-                : opts.options.valuesOf(opts.groupOpt);
+                    ? listStreamsGroups()
+                    : opts.options.valuesOf(opts.groupOpt);
             if (!groupIds.isEmpty()) {
                 Map<String, KafkaFuture<StreamsGroupDescription>> streamsGroups = adminClient.describeStreamsGroups(
-                    groupIds
+                        groupIds
                 ).describedGroups();
 
                 streamsGroups.forEach((groupId, groupDescription) -> {
@@ -497,7 +497,7 @@ public class StreamsGroupCommand {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed because the topics do not exist.", Optional.empty());
                                             } else if (e.getCause() instanceof UnsupportedVersionException) {
                                                 printError("Deleting internal topics is not supported by the broker version. \n" +
-                                                        "Topics are:" + String.join(",", internalTopics) + "\n" +
+                                                        "Topics: (" + String.join(",", internalTopics) + ").\n" +
                                                         "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                                             } else {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed due to " + e.getMessage(), Optional.of(e));
@@ -550,14 +550,14 @@ public class StreamsGroupCommand {
 
             // Get the partitions of topics that the user did not explicitly specify the partitions
             DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(
-                topicWithoutPartitions,
-                withTimeoutMs(new DescribeTopicsOptions()));
+                    topicWithoutPartitions,
+                    withTimeoutMs(new DescribeTopicsOptions()));
 
             Iterator<TopicPartition> unspecifiedPartitions = describeTopicsResult.topicNameValues().entrySet().stream().flatMap(e -> {
                 String topic = e.getKey();
                 try {
                     return e.getValue().get().partitions().stream().map(partition ->
-                        new TopicPartition(topic, partition.partition()));
+                            new TopicPartition(topic, partition.partition()));
                 } catch (ExecutionException | InterruptedException err) {
                     partitionLevelResult.put(new TopicPartition(topic, -1), err);
                     return Stream.empty();
@@ -574,9 +574,9 @@ public class StreamsGroupCommand {
         private Map.Entry<Errors, Map<TopicPartition, Throwable>> deleteOffsets(String groupId, Set<TopicPartition> partitions, Map<TopicPartition, Throwable> partitionLevelResult) {
 
             DeleteStreamsGroupOffsetsResult deleteResult = adminClient.deleteStreamsGroupOffsets(
-                groupId,
-                partitions,
-                withTimeoutMs(new DeleteStreamsGroupOffsetsOptions())
+                    groupId,
+                    partitions,
+                    withTimeoutMs(new DeleteStreamsGroupOffsetsOptions())
             );
 
             Errors topLevelException = Errors.NONE;
@@ -610,7 +610,7 @@ public class StreamsGroupCommand {
                 res = deleteOffsets(groupId, topics);
             } else {
                 CommandLineUtils.printUsageAndExit(opts.parser, "Option " + opts.deleteOffsetsOpt +
-                    " requires either" + opts.allInputTopicsOpt + " or " + opts.inputTopicOpt + " to be specified.");
+                        " requires either" + opts.allInputTopicsOpt + " or " + opts.inputTopicOpt + " to be specified.");
                 return null;
             }
 
@@ -646,16 +646,16 @@ public class StreamsGroupCommand {
 
             System.out.printf(format, "TOPIC", "PARTITION", "STATUS");
             partitionLevelResult.entrySet().stream()
-                .sorted(Comparator.comparing(e -> e.getKey().topic() + e.getKey().partition()))
-                .forEach(e -> {
-                    TopicPartition tp = e.getKey();
-                    Throwable error = e.getValue();
-                    System.out.printf(format,
-                        tp.topic(),
-                        tp.partition() >= 0 ? tp.partition() : MISSING_COLUMN_VALUE,
-                        error != null ? "Error: " + error.getMessage() : "Successful"
-                    );
-                });
+                    .sorted(Comparator.comparing(e -> e.getKey().topic() + e.getKey().partition()))
+                    .forEach(e -> {
+                        TopicPartition tp = e.getKey();
+                        Throwable error = e.getValue();
+                        System.out.printf(format,
+                                tp.topic(),
+                                tp.partition() >= 0 ? tp.partition() : MISSING_COLUMN_VALUE,
+                                error != null ? "Error: " + error.getMessage() : "Successful"
+                        );
+                    });
             System.out.println();
             // testing purpose: return the result of the delete operation
             return res;
@@ -663,8 +663,8 @@ public class StreamsGroupCommand {
 
         Map<String, Throwable> deleteGroups() {
             List<String> groupIds = opts.options.has(opts.allGroupsOpt)
-                ? new ArrayList<>(listStreamsGroups())
-                : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
+                    ? new ArrayList<>(listStreamsGroups())
+                    : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
 
             // pre admin call checks
             Map<String, Throwable> failed = preAdminCallChecks(groupIds);
@@ -680,8 +680,8 @@ public class StreamsGroupCommand {
                 }
                 // delete streams groups
                 Map<String, KafkaFuture<Void>> groupsToDelete = adminClient.deleteStreamsGroups(
-                    groupIds,
-                    withTimeoutMs(new DeleteStreamsGroupsOptions())
+                        groupIds,
+                        withTimeoutMs(new DeleteStreamsGroupsOptions())
                 ).deletedGroups();
 
                 groupsToDelete.forEach((g, f) -> {
@@ -774,8 +774,8 @@ public class StreamsGroupCommand {
         List<GroupListing> listDetailedStreamsGroups() {
             try {
                 ListGroupsResult result = adminClient.listGroups(new ListGroupsOptions()
-                    .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
-                    .withTypes(Set.of(GroupType.STREAMS)));
+                        .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+                        .withTypes(Set.of(GroupType.STREAMS)));
                 Collection<GroupListing> listings = result.all().get();
                 return listings.stream().toList();
             } catch (InterruptedException | ExecutionException e) {
@@ -789,14 +789,14 @@ public class StreamsGroupCommand {
             if (!deletedGroupIds.isEmpty()) {
                 if (internalTopicsDeletionFailures.isEmpty()) {
                     List<String> successfulGroups = deletedGroupIds.stream()
-                        .filter(groupIdsWithInternalTopics::contains)
-                        .collect(Collectors.toList());
+                            .filter(groupIdsWithInternalTopics::contains)
+                            .collect(Collectors.toList());
                     System.out.println("Deletion of associated internal topics of the streams groups ('" +
-                        String.join("', '", successfulGroups) + "') was successful.");
+                            String.join("', '", successfulGroups) + "') was successful.");
                 } else {
                     System.out.println("Deletion of some associated internal topics failed:");
                     internalTopicsDeletionFailures.forEach((group, error) ->
-                        System.out.println("* Internal topics of the streams group '" + group + "' could not be deleted due to: " + error));
+                            System.out.println("* Internal topics of the streams group '" + group + "' could not be deleted due to: " + error));
                 }
             }
         }
@@ -809,18 +809,18 @@ public class StreamsGroupCommand {
                 for (StreamsGroupDescription description : descriptionMap.values()) {
 
                     List<String> sourceTopics = description.subtopologies().stream()
-                        .flatMap(subtopology -> subtopology.sourceTopics().stream()).toList();
+                            .flatMap(subtopology -> subtopology.sourceTopics().stream()).toList();
 
                     List<String> internalTopics = description.subtopologies().stream()
-                        .flatMap(subtopology -> Stream.concat(
-                            subtopology.repartitionSourceTopics().keySet().stream(),
-                            subtopology.stateChangelogTopics().keySet().stream()))
-                        .filter(topic -> !sourceTopics.contains(topic))
-                        .collect(Collectors.toList());
+                            .flatMap(subtopology -> Stream.concat(
+                                    subtopology.repartitionSourceTopics().keySet().stream(),
+                                    subtopology.stateChangelogTopics().keySet().stream()))
+                            .filter(topic -> !sourceTopics.contains(topic))
+                            .collect(Collectors.toList());
                     internalTopics.removeIf(topic -> {
                         if (!isInferredInternalTopic(topic, description.groupId())) {
                             printError("The internal topic '" + topic + "' is not inferred as internal " +
-                                "and thus will not be deleted with the group '" + description.groupId() + "'.", Optional.empty());
+                                    "and thus will not be deleted with the group '" + description.groupId() + "'.", Optional.empty());
                             return true;
                         }
                         return false;
@@ -831,8 +831,23 @@ public class StreamsGroupCommand {
                 }
             } catch (InterruptedException | ExecutionException e) {
                 if (e.getCause() instanceof UnsupportedVersionException) {
-                    printError("Retrieving internal topics is not supported by the broker version." +
-                        "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
+                    List<String> internalTopics = new ArrayList<>();
+                    try {
+                        Set<String> allTopics = adminClient.listTopics().names().get();
+                        for (String topic : allTopics) {
+                            for (String groupId : groupIds) {
+                                if (isInferredInternalTopic(topic, groupId)) {
+                                    internalTopics.add(topic);
+                                    break;
+                                }
+                            }
+                        }
+                        System.out.println("Internal Topics: (" + String.join(",", internalTopics) + ").");
+                    } catch (InterruptedException | ExecutionException ex) {
+                        printError("Retrieving internal topics failed due to " + ex.getMessage(), Optional.of(ex));
+                    }
+                    printError("Retrieving internal topics is not supported by the broker version. " +
+                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                 } else {
                     printError("Retrieving internal topics failed due to " + e.getMessage(), Optional.of(e));
                 }
@@ -846,8 +861,8 @@ public class StreamsGroupCommand {
                 Map<TopicPartition, OffsetAndMetadata> preparedOffsets = prepareOffsetsToReset(groupId, partitionsToReset);
                 if (!dryRun) {
                     adminClient.alterStreamsGroupOffsets(
-                        groupId,
-                        preparedOffsets
+                            groupId,
+                            preparedOffsets
                     ).all().get();
                 }
 
@@ -904,7 +919,7 @@ public class StreamsGroupCommand {
             }
 
             CommandLineUtils
-                .printUsageAndExit(opts.parser, String.format("Option '%s' requires one of the following scenarios: %s", opts.resetOffsetsOpt, opts.allResetOffsetScenarioOpts));
+                    .printUsageAndExit(opts.parser, String.format("Option '%s' requires one of the following scenarios: %s", opts.resetOffsetsOpt, opts.allResetOffsetScenarioOpts));
             return null;
         }
 
@@ -914,23 +929,23 @@ public class StreamsGroupCommand {
 
         public static boolean matchesInternalTopicFormat(final String topicName) {
             return topicName.endsWith("-changelog") || topicName.endsWith("-repartition")
-                || topicName.endsWith("-subscription-registration-topic")
-                || topicName.endsWith("-subscription-response-topic")
-                || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic")
-                || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic");
+                    || topicName.endsWith("-subscription-registration-topic")
+                    || topicName.endsWith("-subscription-response-topic")
+                    || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic")
+                    || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic");
         }
 
         List<String> collectAllTopics(String groupId) {
             try {
                 return adminClient.describeStreamsGroups(List.of(groupId))
-                    .all().get().get(groupId)
-                    .subtopologies().stream()
-                    .flatMap(subtopology -> Stream.of(
-                        subtopology.sourceTopics().stream(),
-                        subtopology.repartitionSinkTopics().stream(),
-                        subtopology.repartitionSourceTopics().keySet().stream(),
-                        subtopology.stateChangelogTopics().keySet().stream()
-                    ).flatMap(s -> s)).distinct().collect(Collectors.toList());
+                        .all().get().get(groupId)
+                        .subtopologies().stream()
+                        .flatMap(subtopology -> Stream.of(
+                                subtopology.sourceTopics().stream(),
+                                subtopology.repartitionSinkTopics().stream(),
+                                subtopology.repartitionSourceTopics().keySet().stream(),
+                                subtopology.stateChangelogTopics().keySet().stream()
+                        ).flatMap(s -> s)).distinct().collect(Collectors.toList());
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
             }

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -496,8 +496,8 @@ public class StreamsGroupCommand {
                                             if (e.getCause() instanceof UnknownTopicOrPartitionException) {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed because the topics do not exist.", Optional.empty());
                                             } else if (e.getCause() instanceof UnsupportedVersionException) {
-                                                printError("Deleting internal topics is not supported by the broker version. \n Topics are " +
-                                                        String.join(", ", internalTopics) + "\n" +
+                                                printError("Deleting internal topics is not supported by the broker version. \n" +
+                                                        "Topics are:" + String.join(",", internalTopics) + "\n" +
                                                         "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                                             } else {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed due to " + e.getMessage(), Optional.of(e));
@@ -831,7 +831,7 @@ public class StreamsGroupCommand {
                 }
             } catch (InterruptedException | ExecutionException e) {
                 if (e.getCause() instanceof UnsupportedVersionException) {
-                    printError("Retrieving internal topics is not supported by the broker version. " +
+                    printError("Retrieving internal topics is not supported by the broker version." +
                         "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                 } else {
                     printError("Retrieving internal topics failed due to " + e.getMessage(), Optional.of(e));

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -839,10 +839,10 @@ public class StreamsGroupCommand {
                             .collect(Collectors.toList());
                         printError("Retrieving internal topics is not supported by the broker version.\n" +
                             "Internal topics: (" + String.join(",", internalTopics) + ").\n" +
-                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
+                            "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                     } catch (InterruptedException | ExecutionException ex) {
                         printError("Retrieving internal topics is not supported by the broker version. " +
-                            "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
+                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                     }
                 } else {
                     printError("Retrieving internal topics failed due to " + e.getMessage(), Optional.of(e));

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -89,11 +89,11 @@ public class StreamsGroupCommand {
             opts.checkArgs();
             // should have exactly one action
             long numberOfActions = Stream.of(
-                    opts.listOpt,
-                    opts.describeOpt,
-                    opts.resetOffsetsOpt,
-                    opts.deleteOpt,
-                    opts.deleteOffsetsOpt
+                opts.listOpt,
+                opts.describeOpt,
+                opts.resetOffsetsOpt,
+                opts.deleteOpt,
+                opts.deleteOffsetsOpt
             ).filter(opts.options::has).count();
             if (numberOfActions != 1)
                 CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, or --delete-offsets.");
@@ -138,22 +138,22 @@ public class StreamsGroupCommand {
         }
 
         groupAssignmentsToReset.forEach((groupId, assignment) ->
-                assignment.forEach((streamsAssignment, offsetAndMetadata) ->
-                        System.out.printf(format,
-                                groupId,
-                                streamsAssignment.topic(),
-                                streamsAssignment.partition(),
-                                offsetAndMetadata.offset())));
+            assignment.forEach((streamsAssignment, offsetAndMetadata) ->
+                System.out.printf(format,
+                    groupId,
+                    streamsAssignment.topic(),
+                    streamsAssignment.partition(),
+                    offsetAndMetadata.offset())));
         System.out.println();
     }
 
     static Set<GroupState> groupStatesFromString(String input) {
         Set<GroupState> parsedStates =
-                Arrays.stream(input.split(",")).map(s -> GroupState.parse(s.trim())).collect(Collectors.toSet());
+            Arrays.stream(input.split(",")).map(s -> GroupState.parse(s.trim())).collect(Collectors.toSet());
         Set<GroupState> validStates = GroupState.groupStatesForType(GroupType.STREAMS);
         if (!validStates.containsAll(parsedStates)) {
             throw new IllegalArgumentException("Invalid state list '" + input + "'. Valid states are: " +
-                    validStates.stream().map(GroupState::toString).collect(Collectors.joining(", ")));
+                validStates.stream().map(GroupState::toString).collect(Collectors.joining(", ")));
         }
         return parsedStates;
     }
@@ -187,21 +187,21 @@ public class StreamsGroupCommand {
 
         private OffsetsUtils.OffsetsUtilsOptions getOffsetsUtilsOptions(StreamsGroupCommandOptions opts) {
             return
-                    new OffsetsUtils.OffsetsUtilsOptions(opts.options.valuesOf(opts.groupOpt),
-                            opts.options.valuesOf(opts.resetToOffsetOpt),
-                            opts.options.valuesOf(opts.resetFromFileOpt),
-                            opts.options.valuesOf(opts.resetToDatetimeOpt),
-                            opts.options.valueOf(opts.resetByDurationOpt),
-                            opts.options.valueOf(opts.resetShiftByOpt),
-                            opts.options.valueOf(opts.timeoutMsOpt));
+                new OffsetsUtils.OffsetsUtilsOptions(opts.options.valuesOf(opts.groupOpt),
+                    opts.options.valuesOf(opts.resetToOffsetOpt),
+                    opts.options.valuesOf(opts.resetFromFileOpt),
+                    opts.options.valuesOf(opts.resetToDatetimeOpt),
+                    opts.options.valueOf(opts.resetByDurationOpt),
+                    opts.options.valueOf(opts.resetShiftByOpt),
+                    opts.options.valueOf(opts.timeoutMsOpt));
         }
 
         public void listGroups() throws ExecutionException, InterruptedException {
             if (opts.options.has(opts.stateOpt)) {
                 String stateValue = opts.options.valueOf(opts.stateOpt);
                 Set<GroupState> states = (stateValue == null || stateValue.isEmpty())
-                        ? Set.of()
-                        : groupStatesFromString(stateValue);
+                    ? Set.of()
+                    : groupStatesFromString(stateValue);
                 List<GroupListing> listings = listStreamsGroupsInStates(states);
                 printGroupInfo(listings);
             } else
@@ -211,8 +211,8 @@ public class StreamsGroupCommand {
         List<String> listStreamsGroups() {
             try {
                 ListGroupsResult result = adminClient.listGroups(new ListGroupsOptions()
-                        .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
-                        .withTypes(Set.of(GroupType.STREAMS)));
+                    .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+                    .withTypes(Set.of(GroupType.STREAMS)));
                 Collection<GroupListing> listings = result.all().get();
                 return listings.stream().map(GroupListing::groupId).collect(Collectors.toList());
             } catch (InterruptedException | ExecutionException e) {
@@ -222,9 +222,9 @@ public class StreamsGroupCommand {
 
         List<GroupListing> listStreamsGroupsInStates(Set<GroupState> states) throws ExecutionException, InterruptedException {
             ListGroupsResult result = adminClient.listGroups(new ListGroupsOptions()
-                    .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
-                    .withTypes(Set.of(GroupType.STREAMS))
-                    .inGroupStates(states));
+                .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+                .withTypes(Set.of(GroupType.STREAMS))
+                .inGroupStates(states));
             return new ArrayList<>(result.all().get());
         }
 
@@ -244,8 +244,8 @@ public class StreamsGroupCommand {
 
         public void describeGroups() throws ExecutionException, InterruptedException {
             List<String> groupIds = opts.options.has(opts.allGroupsOpt)
-                    ? new ArrayList<>(listStreamsGroups())
-                    : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
+                ? new ArrayList<>(listStreamsGroups())
+                : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
             if (!groupIds.isEmpty()) {
                 for (String groupId : groupIds) {
                     StreamsGroupDescription description = getDescribeGroup(groupId);
@@ -263,8 +263,8 @@ public class StreamsGroupCommand {
 
         StreamsGroupDescription getDescribeGroup(String group) throws ExecutionException, InterruptedException {
             DescribeStreamsGroupsResult result = adminClient.describeStreamsGroups(
-                    List.of(group),
-                    new DescribeStreamsGroupsOptions().timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue()));
+                List.of(group),
+                new DescribeStreamsGroupsOptions().timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue()));
             Map<String, StreamsGroupDescription> descriptionMap = result.all().get();
             return descriptionMap.get(group);
         }
@@ -286,16 +286,16 @@ public class StreamsGroupCommand {
                     System.out.printf(fmt, "GROUP", "MEMBER", "PROCESS", "CLIENT-ID", "ASSIGNMENTS");
                     for (StreamsGroupMemberDescription member : members) {
                         System.out.printf(fmt, description.groupId(), member.memberId(), member.processId(), member.clientId(),
-                                getTasksForPrinting(member.assignment(), Optional.empty()));
+                            getTasksForPrinting(member.assignment(), Optional.empty()));
                     }
                 } else {
                     final int targetAssignmentEpochLen = 25, topologyEpochLen = 15, memberProtocolLen = 15, memberEpochLen = 15;
                     String fmt = "%" + -groupLen + "s %" + -targetAssignmentEpochLen + "s %" + -topologyEpochLen + "s%" + -maxMemberIdLen
-                            + "s %" + -memberProtocolLen + "s %" + -memberEpochLen + "s %" + -maxHostLen + "s %" + -maxClientIdLen + "s %s\n";
+                        + "s %" + -memberProtocolLen + "s %" + -memberEpochLen + "s %" + -maxHostLen + "s %" + -maxClientIdLen + "s %s\n";
                     System.out.printf(fmt, "GROUP", "TARGET-ASSIGNMENT-EPOCH", "TOPOLOGY-EPOCH", "MEMBER", "MEMBER-PROTOCOL", "MEMBER-EPOCH", "PROCESS", "CLIENT-ID", "ASSIGNMENTS");
                     for (StreamsGroupMemberDescription member : members) {
                         System.out.printf(fmt, description.groupId(), description.targetAssignmentEpoch(), description.topologyEpoch(), member.memberId(),
-                                member.isClassic() ? "classic" : "streams", member.memberEpoch(), member.processId(), member.clientId(), getTasksForPrinting(member.assignment(), Optional.of(member.targetAssignment())));
+                            member.isClassic() ? "classic" : "streams", member.memberEpoch(), member.processId(), member.clientId(), getTasksForPrinting(member.assignment(), Optional.of(member.targetAssignment())));
                     }
                 }
             }
@@ -304,8 +304,8 @@ public class StreamsGroupCommand {
         String exportOffsetsToCsv(Map<String, Map<TopicPartition, OffsetAndMetadata>> assignments) {
             boolean isSingleGroupQuery = opts.options.valuesOf(opts.groupOpt).size() == 1;
             ObjectWriter csvWriter = isSingleGroupQuery
-                    ? CsvUtils.writerFor(CsvUtils.CsvRecordNoGroup.class)
-                    : CsvUtils.writerFor(CsvUtils.CsvRecordWithGroup.class);
+                ? CsvUtils.writerFor(CsvUtils.CsvRecordNoGroup.class)
+                : CsvUtils.writerFor(CsvUtils.CsvRecordWithGroup.class);
 
             return assignments.entrySet().stream().flatMap(e -> {
                 String groupId = e.getKey();
@@ -315,8 +315,8 @@ public class StreamsGroupCommand {
                     TopicPartition k = e1.getKey();
                     OffsetAndMetadata v = e1.getValue();
                     Object csvRecord = isSingleGroupQuery
-                            ? new CsvUtils.CsvRecordNoGroup(k.topic(), k.partition(), v.offset())
-                            : new CsvUtils.CsvRecordWithGroup(groupId, k.topic(), k.partition(), v.offset());
+                        ? new CsvUtils.CsvRecordNoGroup(k.topic(), k.partition(), v.offset())
+                        : new CsvUtils.CsvRecordWithGroup(groupId, k.topic(), k.partition(), v.offset());
 
                     try {
                         return csvWriter.writeValueAsString(csvRecord);
@@ -343,11 +343,11 @@ public class StreamsGroupCommand {
         private String getTasksForPrinting(StreamsGroupMemberAssignment assignment, Optional<StreamsGroupMemberAssignment> targetAssignment) {
             StringBuilder builder = new StringBuilder();
             builder.append(prepareTaskType(assignment.activeTasks(), "ACTIVE"))
-                    .append(prepareTaskType(assignment.standbyTasks(), "STANDBY"))
-                    .append(prepareTaskType(assignment.warmupTasks(), "WARMUP"));
+                .append(prepareTaskType(assignment.standbyTasks(), "STANDBY"))
+                .append(prepareTaskType(assignment.warmupTasks(), "WARMUP"));
             targetAssignment.ifPresent(target -> builder.append(prepareTaskType(target.activeTasks(), "TARGET-ACTIVE"))
-                    .append(prepareTaskType(target.standbyTasks(), "TARGET-STANDBY"))
-                    .append(prepareTaskType(target.warmupTasks(), "TARGET-WARMUP")));
+                .append(prepareTaskType(target.standbyTasks(), "TARGET-STANDBY"))
+                .append(prepareTaskType(target.warmupTasks(), "TARGET-WARMUP")));
             return builder.toString();
         }
 
@@ -392,8 +392,8 @@ public class StreamsGroupCommand {
                     System.out.printf(fmt, "GROUP", "TOPIC", "PARTITION", "CURRENT-OFFSET", "LEADER-EPOCH", "LOG-END-OFFSET", "OFFSET-LAG");
                     for (Map.Entry<TopicPartition, OffsetsInfo> offset : offsets.entrySet()) {
                         System.out.printf(fmt, description.groupId(), offset.getKey().topic(), offset.getKey().partition(),
-                                offset.getValue().currentOffset.map(Object::toString).orElse("-"), offset.getValue().leaderEpoch.map(Object::toString).orElse("-"),
-                                offset.getValue().logEndOffset, offset.getValue().lag);
+                            offset.getValue().currentOffset.map(Object::toString).orElse("-"), offset.getValue().leaderEpoch.map(Object::toString).orElse("-"),
+                            offset.getValue().logEndOffset, offset.getValue().lag);
                     }
                 }
             }
@@ -423,11 +423,11 @@ public class StreamsGroupCommand {
                 final Optional<Integer> leaderEpoch = committedOffsets.containsKey(tp.getKey()) ? committedOffsets.get(tp.getKey()).leaderEpoch() : Optional.empty();
                 final long lag = currentOffset.map(current -> latestResult.get(tp.getKey()).offset() - current).orElseGet(() -> latestResult.get(tp.getKey()).offset() - earliestResult.get(tp.getKey()).offset());
                 output.put(tp.getKey(),
-                        new OffsetsInfo(
-                                currentOffset,
-                                leaderEpoch,
-                                latestResult.get(tp.getKey()).offset(),
-                                lag));
+                    new OffsetsInfo(
+                        currentOffset,
+                        leaderEpoch,
+                        latestResult.get(tp.getKey()).offset(),
+                        lag));
             }
             return output;
         }
@@ -435,13 +435,13 @@ public class StreamsGroupCommand {
         Map<TopicPartition, OffsetAndMetadata> getCommittedOffsets(String groupId) {
             try {
                 var sourceTopics = adminClient.describeStreamsGroups(List.of(groupId))
-                        .all().get().get(groupId)
-                        .subtopologies().stream()
-                        .flatMap(subtopology -> subtopology.sourceTopics().stream())
-                        .collect(Collectors.toSet());
+                    .all().get().get(groupId)
+                    .subtopologies().stream()
+                    .flatMap(subtopology -> subtopology.sourceTopics().stream())
+                    .collect(Collectors.toSet());
 
                 var allTopicPartitions = adminClient.listStreamsGroupOffsets(Map.of(groupId, new ListStreamsGroupOffsetsSpec()))
-                        .partitionsToOffsetAndMetadata(groupId).get();
+                    .partitionsToOffsetAndMetadata(groupId).get();
 
                 allTopicPartitions.keySet().removeIf(tp -> !sourceTopics.contains(tp.topic()));
                 return allTopicPartitions;
@@ -453,7 +453,7 @@ public class StreamsGroupCommand {
         private List<TopicPartition> filterExistingGroupTopics(String groupId, List<TopicPartition> topicPartitions) {
             try {
                 var allTopicPartitions = adminClient.listStreamsGroupOffsets(Map.of(groupId, new ListStreamsGroupOffsetsSpec()))
-                        .partitionsToOffsetAndMetadata(groupId).get();
+                    .partitionsToOffsetAndMetadata(groupId).get();
                 boolean allPresent = topicPartitions.stream().allMatch(allTopicPartitions::containsKey);
                 if (!allPresent) {
                     printError("One or more topics are not part of the group '" + groupId + "'.", Optional.empty());
@@ -471,11 +471,11 @@ public class StreamsGroupCommand {
 
             Map<String, Map<TopicPartition, OffsetAndMetadata>> result = new HashMap<>();
             List<String> groupIds = opts.options.has(opts.allGroupsOpt)
-                    ? listStreamsGroups()
-                    : opts.options.valuesOf(opts.groupOpt);
+                ? listStreamsGroups()
+                : opts.options.valuesOf(opts.groupOpt);
             if (!groupIds.isEmpty()) {
                 Map<String, KafkaFuture<StreamsGroupDescription>> streamsGroups = adminClient.describeStreamsGroups(
-                        groupIds
+                    groupIds
                 ).describedGroups();
 
                 streamsGroups.forEach((groupId, groupDescription) -> {
@@ -497,8 +497,8 @@ public class StreamsGroupCommand {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed because the topics do not exist.", Optional.empty());
                                             } else if (e.getCause() instanceof UnsupportedVersionException) {
                                                 printError("Deleting internal topics is not supported by the broker version. \n" +
-                                                        "Topics: (" + String.join(",", internalTopics) + ").\n" +
-                                                        "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
+                                                    "Topics: (" + String.join(",", internalTopics) + ").\n" +
+                                                    "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                                             } else {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed due to " + e.getMessage(), Optional.of(e));
                                             }
@@ -550,14 +550,14 @@ public class StreamsGroupCommand {
 
             // Get the partitions of topics that the user did not explicitly specify the partitions
             DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(
-                    topicWithoutPartitions,
-                    withTimeoutMs(new DescribeTopicsOptions()));
+                topicWithoutPartitions,
+                withTimeoutMs(new DescribeTopicsOptions()));
 
             Iterator<TopicPartition> unspecifiedPartitions = describeTopicsResult.topicNameValues().entrySet().stream().flatMap(e -> {
                 String topic = e.getKey();
                 try {
                     return e.getValue().get().partitions().stream().map(partition ->
-                            new TopicPartition(topic, partition.partition()));
+                        new TopicPartition(topic, partition.partition()));
                 } catch (ExecutionException | InterruptedException err) {
                     partitionLevelResult.put(new TopicPartition(topic, -1), err);
                     return Stream.empty();
@@ -574,9 +574,9 @@ public class StreamsGroupCommand {
         private Map.Entry<Errors, Map<TopicPartition, Throwable>> deleteOffsets(String groupId, Set<TopicPartition> partitions, Map<TopicPartition, Throwable> partitionLevelResult) {
 
             DeleteStreamsGroupOffsetsResult deleteResult = adminClient.deleteStreamsGroupOffsets(
-                    groupId,
-                    partitions,
-                    withTimeoutMs(new DeleteStreamsGroupOffsetsOptions())
+                groupId,
+                partitions,
+                withTimeoutMs(new DeleteStreamsGroupOffsetsOptions())
             );
 
             Errors topLevelException = Errors.NONE;
@@ -610,7 +610,7 @@ public class StreamsGroupCommand {
                 res = deleteOffsets(groupId, topics);
             } else {
                 CommandLineUtils.printUsageAndExit(opts.parser, "Option " + opts.deleteOffsetsOpt +
-                        " requires either" + opts.allInputTopicsOpt + " or " + opts.inputTopicOpt + " to be specified.");
+                    " requires either" + opts.allInputTopicsOpt + " or " + opts.inputTopicOpt + " to be specified.");
                 return null;
             }
 
@@ -646,16 +646,16 @@ public class StreamsGroupCommand {
 
             System.out.printf(format, "TOPIC", "PARTITION", "STATUS");
             partitionLevelResult.entrySet().stream()
-                    .sorted(Comparator.comparing(e -> e.getKey().topic() + e.getKey().partition()))
-                    .forEach(e -> {
-                        TopicPartition tp = e.getKey();
-                        Throwable error = e.getValue();
-                        System.out.printf(format,
-                                tp.topic(),
-                                tp.partition() >= 0 ? tp.partition() : MISSING_COLUMN_VALUE,
-                                error != null ? "Error: " + error.getMessage() : "Successful"
-                        );
-                    });
+                .sorted(Comparator.comparing(e -> e.getKey().topic() + e.getKey().partition()))
+                .forEach(e -> {
+                    TopicPartition tp = e.getKey();
+                    Throwable error = e.getValue();
+                    System.out.printf(format,
+                        tp.topic(),
+                        tp.partition() >= 0 ? tp.partition() : MISSING_COLUMN_VALUE,
+                        error != null ? "Error: " + error.getMessage() : "Successful"
+                    );
+                });
             System.out.println();
             // testing purpose: return the result of the delete operation
             return res;
@@ -663,8 +663,8 @@ public class StreamsGroupCommand {
 
         Map<String, Throwable> deleteGroups() {
             List<String> groupIds = opts.options.has(opts.allGroupsOpt)
-                    ? new ArrayList<>(listStreamsGroups())
-                    : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
+                ? new ArrayList<>(listStreamsGroups())
+                : new ArrayList<>(opts.options.valuesOf(opts.groupOpt));
 
             // pre admin call checks
             Map<String, Throwable> failed = preAdminCallChecks(groupIds);
@@ -680,8 +680,8 @@ public class StreamsGroupCommand {
                 }
                 // delete streams groups
                 Map<String, KafkaFuture<Void>> groupsToDelete = adminClient.deleteStreamsGroups(
-                        groupIds,
-                        withTimeoutMs(new DeleteStreamsGroupsOptions())
+                    groupIds,
+                    withTimeoutMs(new DeleteStreamsGroupsOptions())
                 ).deletedGroups();
 
                 groupsToDelete.forEach((g, f) -> {
@@ -774,8 +774,8 @@ public class StreamsGroupCommand {
         List<GroupListing> listDetailedStreamsGroups() {
             try {
                 ListGroupsResult result = adminClient.listGroups(new ListGroupsOptions()
-                        .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
-                        .withTypes(Set.of(GroupType.STREAMS)));
+                    .timeoutMs(opts.options.valueOf(opts.timeoutMsOpt).intValue())
+                    .withTypes(Set.of(GroupType.STREAMS)));
                 Collection<GroupListing> listings = result.all().get();
                 return listings.stream().toList();
             } catch (InterruptedException | ExecutionException e) {
@@ -789,14 +789,14 @@ public class StreamsGroupCommand {
             if (!deletedGroupIds.isEmpty()) {
                 if (internalTopicsDeletionFailures.isEmpty()) {
                     List<String> successfulGroups = deletedGroupIds.stream()
-                            .filter(groupIdsWithInternalTopics::contains)
-                            .collect(Collectors.toList());
+                        .filter(groupIdsWithInternalTopics::contains)
+                        .collect(Collectors.toList());
                     System.out.println("Deletion of associated internal topics of the streams groups ('" +
-                            String.join("', '", successfulGroups) + "') was successful.");
+                        String.join("', '", successfulGroups) + "') was successful.");
                 } else {
                     System.out.println("Deletion of some associated internal topics failed:");
                     internalTopicsDeletionFailures.forEach((group, error) ->
-                            System.out.println("* Internal topics of the streams group '" + group + "' could not be deleted due to: " + error));
+                        System.out.println("* Internal topics of the streams group '" + group + "' could not be deleted due to: " + error));
                 }
             }
         }
@@ -809,18 +809,18 @@ public class StreamsGroupCommand {
                 for (StreamsGroupDescription description : descriptionMap.values()) {
 
                     List<String> sourceTopics = description.subtopologies().stream()
-                            .flatMap(subtopology -> subtopology.sourceTopics().stream()).toList();
+                        .flatMap(subtopology -> subtopology.sourceTopics().stream()).toList();
 
                     List<String> internalTopics = description.subtopologies().stream()
-                            .flatMap(subtopology -> Stream.concat(
-                                    subtopology.repartitionSourceTopics().keySet().stream(),
-                                    subtopology.stateChangelogTopics().keySet().stream()))
-                            .filter(topic -> !sourceTopics.contains(topic))
-                            .collect(Collectors.toList());
+                        .flatMap(subtopology -> Stream.concat(
+                            subtopology.repartitionSourceTopics().keySet().stream(),
+                            subtopology.stateChangelogTopics().keySet().stream()))
+                        .filter(topic -> !sourceTopics.contains(topic))
+                        .collect(Collectors.toList());
                     internalTopics.removeIf(topic -> {
                         if (!isInferredInternalTopic(topic, description.groupId())) {
                             printError("The internal topic '" + topic + "' is not inferred as internal " +
-                                    "and thus will not be deleted with the group '" + description.groupId() + "'.", Optional.empty());
+                                "and thus will not be deleted with the group '" + description.groupId() + "'.", Optional.empty());
                             return true;
                         }
                         return false;
@@ -847,7 +847,7 @@ public class StreamsGroupCommand {
                         printError("Retrieving internal topics failed due to " + ex.getMessage(), Optional.of(ex));
                     }
                     printError("Retrieving internal topics is not supported by the broker version. " +
-                            "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
+                        "Use 'kafka-topics.sh' to list and delete the group's internal topics.", Optional.of(e.getCause()));
                 } else {
                     printError("Retrieving internal topics failed due to " + e.getMessage(), Optional.of(e));
                 }
@@ -861,8 +861,8 @@ public class StreamsGroupCommand {
                 Map<TopicPartition, OffsetAndMetadata> preparedOffsets = prepareOffsetsToReset(groupId, partitionsToReset);
                 if (!dryRun) {
                     adminClient.alterStreamsGroupOffsets(
-                            groupId,
-                            preparedOffsets
+                        groupId,
+                        preparedOffsets
                     ).all().get();
                 }
 
@@ -919,7 +919,7 @@ public class StreamsGroupCommand {
             }
 
             CommandLineUtils
-                    .printUsageAndExit(opts.parser, String.format("Option '%s' requires one of the following scenarios: %s", opts.resetOffsetsOpt, opts.allResetOffsetScenarioOpts));
+                .printUsageAndExit(opts.parser, String.format("Option '%s' requires one of the following scenarios: %s", opts.resetOffsetsOpt, opts.allResetOffsetScenarioOpts));
             return null;
         }
 
@@ -929,23 +929,23 @@ public class StreamsGroupCommand {
 
         public static boolean matchesInternalTopicFormat(final String topicName) {
             return topicName.endsWith("-changelog") || topicName.endsWith("-repartition")
-                    || topicName.endsWith("-subscription-registration-topic")
-                    || topicName.endsWith("-subscription-response-topic")
-                    || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic")
-                    || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic");
+                || topicName.endsWith("-subscription-registration-topic")
+                || topicName.endsWith("-subscription-response-topic")
+                || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic")
+                || topicName.matches(".+-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic");
         }
 
         List<String> collectAllTopics(String groupId) {
             try {
                 return adminClient.describeStreamsGroups(List.of(groupId))
-                        .all().get().get(groupId)
-                        .subtopologies().stream()
-                        .flatMap(subtopology -> Stream.of(
-                                subtopology.sourceTopics().stream(),
-                                subtopology.repartitionSinkTopics().stream(),
-                                subtopology.repartitionSourceTopics().keySet().stream(),
-                                subtopology.stateChangelogTopics().keySet().stream()
-                        ).flatMap(s -> s)).distinct().collect(Collectors.toList());
+                    .all().get().get(groupId)
+                    .subtopologies().stream()
+                    .flatMap(subtopology -> Stream.of(
+                        subtopology.sourceTopics().stream(),
+                        subtopology.repartitionSinkTopics().stream(),
+                        subtopology.repartitionSourceTopics().keySet().stream(),
+                        subtopology.stateChangelogTopics().keySet().stream()
+                    ).flatMap(s -> s)).distinct().collect(Collectors.toList());
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
             }
@@ -1027,6 +1027,7 @@ public class StreamsGroupCommand {
         }
     }
 
-    public record OffsetsInfo(Optional<Long> currentOffset, Optional<Integer> leaderEpoch, Long logEndOffset, Long lag) {
+    public record OffsetsInfo(Optional<Long> currentOffset, Optional<Integer> leaderEpoch, Long logEndOffset,
+                              Long lag) {
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -496,8 +496,9 @@ public class StreamsGroupCommand {
                                             if (e.getCause() instanceof UnknownTopicOrPartitionException) {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed because the topics do not exist.", Optional.empty());
                                             } else if (e.getCause() instanceof UnsupportedVersionException) {
-                                                printError("Deleting internal topics is not supported by the broker version. " +
-                                                    "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
+                                                printError("Deleting internal topics is not supported by the broker version. \n Topics are " +
+                                                        String.join(", ", internalTopics) + "\n" +
+                                                        "Use 'kafka-topics.sh' to delete the group's internal topics.", Optional.of(e.getCause()));
                                             } else {
                                                 printError("Deleting internal topics for group '" + groupId + "' failed due to " + e.getMessage(), Optional.of(e));
                                             }

--- a/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
@@ -413,9 +413,18 @@ public class DeleteStreamsGroupTest {
             assertTrue(output.contains("Use 'kafka-topics.sh' to delete the group's internal topics."));
             // Validate the list of internal topics in error message
             assertTrue(output.contains("Internal topics:"));
-            assertTrue(output.contains("aggregated_value-changelog"));
-            assertTrue(output.contains("aggregated_value-repartition"));
-            assertTrue(output.contains("count-repartition"));
+            assertTrue(
+                output.matches("(?s).*" + APP_ID_PREFIX + "-[a-zA-Z0-9]{10}-aggregated_value-changelog.*"),
+                "The internal topic names are not retrieved correctly."
+            );
+            assertTrue(
+                output.matches("(?s).*" + APP_ID_PREFIX + "-[a-zA-Z0-9]{10}-aggregated_value-repartition.*"),
+                "The internal topic names are not retrieved correctly."
+            );
+            assertTrue(
+                output.matches("(?s).*" + APP_ID_PREFIX + "-[a-zA-Z0-9]{10}-count-repartition.*"),
+                "The internal topic names are not retrieved correctly."
+            );
 
             assertEquals(1, result.size());
             assertTrue(result.containsKey(appId));

--- a/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
@@ -405,11 +405,18 @@ public class DeleteStreamsGroupTest {
             updateStreamsGroupProtocol((short) 0);
             final Map<String, Throwable> result = new HashMap<>();
             String output = ToolsTestUtils.grabConsoleOutput(() -> result.putAll(service.deleteGroups()));
+            System.out.println(output);
 
             assertTrue(output.contains("Deletion of requested streams groups ('" + appId + "') was successful."),
                 "The streams group could not be deleted as expected");
             assertTrue(output.contains("Retrieving internal topics is not supported by the broker version. "));
             assertTrue(output.contains("Use 'kafka-topics.sh' to delete the group's internal topics."));
+            // Validate the list of internal topics in error message
+            assertTrue(output.contains("Internal topics:"));
+            assertTrue(output.contains("aggregated_value-changelog"));
+            assertTrue(output.contains("aggregated_value-repartition"));
+            assertTrue(output.contains("count-repartition"));
+
             assertEquals(1, result.size());
             assertTrue(result.containsKey(appId));
             assertNull(result.get(appId), "The streams group could not be deleted as expected");

--- a/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
@@ -409,21 +409,14 @@ public class DeleteStreamsGroupTest {
 
             assertTrue(output.contains("Deletion of requested streams groups ('" + appId + "') was successful."),
                 "The streams group could not be deleted as expected");
-            assertTrue(output.contains("Retrieving internal topics is not supported by the broker version. "));
+            assertTrue(output.contains("Retrieving internal topics is not supported by the broker version."));
             assertTrue(output.contains("Use 'kafka-topics.sh' to delete the group's internal topics."));
             // Validate the list of internal topics in error message
             assertTrue(output.contains("Internal topics:"));
+            System.out.println(output);
             assertTrue(
-                output.matches("(?s).*" + APP_ID_PREFIX + "-[a-zA-Z0-9]{10}-aggregated_value-changelog.*"),
-                "The internal topic names are not retrieved correctly."
-            );
-            assertTrue(
-                output.matches("(?s).*" + APP_ID_PREFIX + "-[a-zA-Z0-9]{10}-aggregated_value-repartition.*"),
-                "The internal topic names are not retrieved correctly."
-            );
-            assertTrue(
-                output.matches("(?s).*" + APP_ID_PREFIX + "-[a-zA-Z0-9]{10}-count-repartition.*"),
-                "The internal topic names are not retrieved correctly."
+                output.matches("(?s).*" + APP_ID_PREFIX + "[a-zA-Z0-9\\-]+-(aggregated_value-changelog|repartition|changelog).*"),
+                "The internal topic name does not match the expected format. Output: " + output
             );
 
             assertEquals(1, result.size());

--- a/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/streams/DeleteStreamsGroupTest.java
@@ -408,8 +408,8 @@ public class DeleteStreamsGroupTest {
 
             assertTrue(output.contains("Deletion of requested streams groups ('" + appId + "') was successful."),
                 "The streams group could not be deleted as expected");
-            assertTrue(output.contains("Retrieving internal topics is not supported by the broker version. " +
-                "Use 'kafka-topics.sh' to list and delete the group's internal topics."));
+            assertTrue(output.contains("Retrieving internal topics is not supported by the broker version. "));
+            assertTrue(output.contains("Use 'kafka-topics.sh' to delete the group's internal topics."));
             assertEquals(1, result.size());
             assertTrue(result.containsKey(appId));
             assertNull(result.get(appId), "The streams group could not be deleted as expected");


### PR DESCRIPTION
For the Kafka Stream group commands, if delete topic requests fail due
to version mismatch, user will have to remove the topics manually by
first retrieving the relevant internal topics.

To assist the user, the internal topic names are now included as part of
the error message, so that the user could delete the internal topics
associated with this application directly.

Reviewers: TengYao Chi <frankvicky@apache.org>, Alieh Saeedi
 <asaeedi@confluent.io>
