### PR TITLE
KAFKA-19501: Update OpenJDK base image from buster to bullseye

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -55,7 +55,7 @@ image_name="ducker-ak-openjdk:17" bash tests/docker/run_tests.sh
 ```
 bash tests/docker/ducker-ak up -j '<JDK_IMAGE>'; tests/docker/run_tests.sh
 ```
-  You can customize the OpenJDK base image using the `-j` or `--jdk` parameter. The default is `openjdk:17-bullseye`.
+  You can customize the OpenJDK base image using the `-j` or `--jdk` parameter, otherwise a default value will be used.
 * Remove ducker-ak containers
 ```
 bash tests/docker/ducker-ak down -f

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,11 +49,11 @@ TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeT
 ```
 * Run tests with a specific image name
 ```
-image_name="ducker-ak-openjdk:17-buster" bash tests/docker/run_tests.sh
+image_name="ducker-ak-openjdk:17-bullseye" bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```
-bash tests/docker/ducker-ak up -j 'openjdk:17-buster'; tests/docker/run_tests.sh
+bash tests/docker/ducker-ak up -j 'openjdk:17-bullseye'; tests/docker/run_tests.sh
 ```
 * Remove ducker-ak containers
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,11 +49,11 @@ TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeT
 ```
 * Run tests with a specific image name
 ```
-image_name="ducker-ak-openjdk:17-bullseye" bash tests/docker/run_tests.sh
+image_name="ducker-ak-<JDK_IMAGE>" bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```
-bash tests/docker/ducker-ak up -j 'openjdk:17-bullseye'; tests/docker/run_tests.sh
+bash tests/docker/ducker-ak up -j '<JDK_IMAGE>'; tests/docker/run_tests.sh
 ```
 * Remove ducker-ak containers
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,12 +49,13 @@ TC_PATHS="tests/kafkatest/tests/streams/streams_upgrade_test.py::StreamsUpgradeT
 ```
 * Run tests with a specific image name
 ```
-image_name="ducker-ak-<JDK_IMAGE>" bash tests/docker/run_tests.sh
+image_name="ducker-ak-openjdk:17" bash tests/docker/run_tests.sh
 ```
 * Run tests with a different JVM
 ```
 bash tests/docker/ducker-ak up -j '<JDK_IMAGE>'; tests/docker/run_tests.sh
 ```
+  You can customize the OpenJDK base image using the `-j` or `--jdk` parameter. The default is `openjdk:17-bullseye`.
 * Remove ducker-ak containers
 ```
 bash tests/docker/ducker-ak down -f

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The base image of openjdk:17 is typically oraclelinux:8-slim, which doesn't include apt-get. 
-# Therefore, use openjdk:17-bullseye instead.
 ARG jdk_version
 FROM $jdk_version AS build-native-image
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # The base image of openjdk:17 is typically oraclelinux:8-slim, which doesn't include apt-get. 
-# Therefore, use openjdk:17-buster instead.
-ARG jdk_version=openjdk:17-buster
+# Therefore, use openjdk:17-bullseye instead.
+ARG jdk_version=openjdk:17-bullseye
 FROM $jdk_version AS build-native-image
 
 WORKDIR /build

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -15,7 +15,7 @@
 
 # The base image of openjdk:17 is typically oraclelinux:8-slim, which doesn't include apt-get. 
 # Therefore, use openjdk:17-bullseye instead.
-ARG jdk_version=openjdk:17-bullseye
+ARG jdk_version
 FROM $jdk_version AS build-native-image
 
 WORKDIR /build

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -87,7 +87,7 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     By default no port is exposed. See README.md for more detail on this option.
 
     If -j|--jdk is specified, you can customize the OpenJDK base image used for building
-    the ducker container. Defaults to ${default_jdk}. Example: -j openjdk:11-bullseye
+    the ducker container. Defaults to ${default_jdk}. Example: -j openjdk:17-bullseye
 
     If --ipv6 is specified, we will create a Docker network with IPv6 enabled.
     

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,6 +45,8 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
+# The base image of openjdk:17 is typically oraclelinux:8-slim, which doesn't include apt-get. 
+# Therefore, use openjdk:17-bullseye instead.
 default_jdk="openjdk:17-bullseye"
 
 # The default ducker-ak image name.
@@ -70,7 +72,7 @@ help|-h|--help
     Display this help message
 
 up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
-        [-C|--custom-ducktape DIR] [-e|--expose-ports ports] [--ipv6]
+        [-C|--custom-ducktape DIR] [-e|--expose-ports ports] [-j|--jdk JDK_VERSION] [--ipv6]
     Bring up a cluster with the specified amount of nodes (defaults to ${default_num_nodes}).
     The docker image name defaults to ${default_image_name}.  If --force is specified, we will
     attempt to bring up an image even some parameters are not valid.
@@ -83,6 +85,9 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     on the host. The argument can be a single port (like 5005), a port range like (5005-5009)
     or a combination of port/port-range separated by comma (like 2181,9092 or 2181,5005-5008).
     By default no port is exposed. See README.md for more detail on this option.
+
+    If -j|--jdk is specified, you can customize the OpenJDK base image used for building
+    the ducker container. Defaults to ${default_jdk}. Example: -j openjdk:11-bullseye
 
     If --ipv6 is specified, we will create a Docker network with IPv6 enabled.
     

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,7 +45,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-default_jdk="openjdk:17-buster"
+default_jdk="openjdk:17-bullseye"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"

--- a/tools/src/main/java/org/apache/kafka/tools/DelegationTokenCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DelegationTokenCommand.java
@@ -301,7 +301,7 @@ public class DelegationTokenCommand {
             CommandLineUtils.checkInvalidArgs(parser, options, createOpt, Set.of(hmacOpt, renewTimePeriodOpt, expiryTimePeriodOpt));
             CommandLineUtils.checkInvalidArgs(parser, options, renewOpt, Set.of(renewPrincipalsOpt, maxLifeTimeOpt, expiryTimePeriodOpt, ownerPrincipalsOpt));
             CommandLineUtils.checkInvalidArgs(parser, options, expiryOpt, Set.of(renewOpt, maxLifeTimeOpt, renewTimePeriodOpt, ownerPrincipalsOpt));
-            CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set.of(renewTimePeriodOpt, maxLifeTimeOpt, hmacOpt, expiryTimePeriodOpt));
+            CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set.of(renewTimePeriodOpt, maxLifeTimeOpt, hmacOpt, renewTimePeriodOpt, expiryTimePeriodOpt));
         }
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/DelegationTokenCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DelegationTokenCommand.java
@@ -301,7 +301,7 @@ public class DelegationTokenCommand {
             CommandLineUtils.checkInvalidArgs(parser, options, createOpt, Set.of(hmacOpt, renewTimePeriodOpt, expiryTimePeriodOpt));
             CommandLineUtils.checkInvalidArgs(parser, options, renewOpt, Set.of(renewPrincipalsOpt, maxLifeTimeOpt, expiryTimePeriodOpt, ownerPrincipalsOpt));
             CommandLineUtils.checkInvalidArgs(parser, options, expiryOpt, Set.of(renewOpt, maxLifeTimeOpt, renewTimePeriodOpt, ownerPrincipalsOpt));
-            CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set.of(renewTimePeriodOpt, maxLifeTimeOpt, hmacOpt, renewTimePeriodOpt, expiryTimePeriodOpt));
+            CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set.of(renewTimePeriodOpt, maxLifeTimeOpt, hmacOpt, expiryTimePeriodOpt));
         }
     }
 }


### PR DESCRIPTION
The changes update the OpenJDK base image from 17-buster to 17-bullseye:
- Updates tests/docker/Dockerfile to use openjdk:17-bullseye instead of
openjdk:17-buster   - Updates tests/docker/ducker-ak script to use the
new default image   - Updates documentation in tests/README.md with the
new image name examples

Reviewers: Federico Valeri <fedevaleri@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
