### PR TITLE
MINOR: Fix RemoteLogManager.getLeaderEpochEntries comment error

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -764,7 +764,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     }
 
     /**
-     * Returns the leader epoch entries within the range of the given start[exclusive] and end[inclusive] offset.
+     * Returns the leader epoch entries within the range of the given start (inclusive) and end (exclusive) offset.
      * <p>
      * Visible for testing.
      *


### PR DESCRIPTION
The comment on the RemoteLogManager.getLeaderEpochEntries method has a
small error description，it should be start（inclusive）and end（exclusive）.

Reviewers: Ken Huang <s7133700@gmail.com>, Lan Ding <isDing_L@163.com>,
 Chia-Ping Tsai <chia7712@gmail.com>
