### PR TITLE
KAFKA-19516: Added a request timeout of 120000ms to CreateTopics in ShareFetchAcknolwedgeRequestTest methods

### DIFF
--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.test.ClusterInstance
 import org.apache.kafka.common.utils.ProducerIdAndEpoch
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
 import org.apache.kafka.server.IntegrationTestUtils
-import org.junit.jupiter.api.Assertions.{assertEquals, fail}
+import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, fail}
 
 import java.net.Socket
 import java.util
@@ -121,19 +121,30 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
     topicConfig: Properties = new Properties,
-    createTopicRequestTimeoutMs: Option[Int] = None
   ): Map[TopicIdPartition, Int] = {
     val admin = cluster.admin()
+    var partitionToLeader: scala.collection.immutable.Map[Int, Int] = null
     try {
-      val partitionToLeader = TestUtils.createTopicWithAdmin(
-        admin = admin,
-        topic = topic,
-        brokers = brokers(),
-        controllers = controllerServers(),
-        numPartitions = numPartitions,
-        replicationFactor = replicationFactor,
-        topicConfig = topicConfig,
-        createTopicRequestTimeoutMs = createTopicRequestTimeoutMs
+      TestUtils.waitUntilTrue(
+        condition = () => {
+          try {
+            partitionToLeader = TestUtils.createTopicWithAdmin(
+              admin = admin,
+              topic = topic,
+              brokers = brokers(),
+              controllers = controllerServers(),
+              numPartitions = numPartitions,
+              replicationFactor = replicationFactor,
+              topicConfig = topicConfig
+            )
+            true // Success
+          } catch {
+            case _: Throwable => false // Will retry
+          }
+        },
+        msg = "Failed to create topic with admin within 2 minutes",
+        waitTimeMs = 2 * 60 * 1000, // 2 minutes in milliseconds
+        pause = 40 * 1000 // 40 seconds in milliseconds
       )
       admin
         .describeTopics(TopicCollection.ofTopicNames(List(topic).asJava))

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -120,7 +120,8 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     topic: String,
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
-    topicConfig: Properties = new Properties
+    topicConfig: Properties = new Properties,
+    createTopicRequestTimeoutMs: Option[Int] = None
   ): Map[TopicIdPartition, Int] = {
     val admin = cluster.admin()
     try {
@@ -131,7 +132,8 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
         controllers = controllerServers(),
         numPartitions = numPartitions,
         replicationFactor = replicationFactor,
-        topicConfig = topicConfig
+        topicConfig = topicConfig,
+        createTopicRequestTimeoutMs = createTopicRequestTimeoutMs
       )
       partitionToLeader.map { case (partition, leader) => new TopicIdPartition(getTopicIds.get(topic), new TopicPartition(topic, partition)) -> leader }
     } finally {

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -135,6 +135,12 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
         topicConfig = topicConfig,
         createTopicRequestTimeoutMs = createTopicRequestTimeoutMs
       )
+      admin
+        .describeTopics(TopicCollection.ofTopicNames(List(topic).asJava))
+        .allTopicNames()
+        .get()
+        .get(topic)
+        .topicId()
       partitionToLeader.map { case (partition, leader) => new TopicIdPartition(getTopicIds.get(topic), new TopicPartition(topic, partition)) -> leader }
     } finally {
       admin.close()

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -120,7 +120,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     topic: String,
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
-    topicConfig: Properties = new Properties,
+    topicConfig: Properties = new Properties
   ): Map[TopicIdPartition, Int] = {
     val admin = cluster.admin()
     var partitionToLeader: scala.collection.immutable.Map[Int, Int] = null

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -25,17 +25,19 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.requests.{FindCoordinatorRequest, FindCoordinatorResponse, ShareAcknowledgeRequest, ShareAcknowledgeResponse, ShareFetchRequest, ShareFetchResponse, ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse, ShareRequestMetadata}
 import org.apache.kafka.common.test.ClusterInstance
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
+import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig
+import org.apache.kafka.coordinator.share.ShareCoordinatorConfig
 import org.apache.kafka.server.common.Feature
 import org.apache.kafka.server.IntegrationTestUtils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.{AfterEach, Timeout}
+import org.junit.jupiter.api.AfterEach
 
 import java.net.Socket
 import java.util
 
-@Timeout(1200)
 @ClusterTestDefaults(types = Array(Type.KRAFT), brokers = 1, serverProperties = Array(
-  new ClusterConfigProperty(key = "group.share.persister.class.name", value = "")
+  new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "")
 ))
 class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBaseRequestTest(cluster) {
 
@@ -92,18 +94,18 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         ),
         brokers = 2
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         ),
         brokers = 2
       ),
@@ -113,7 +115,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val metadata: ShareRequestMetadata = new ShareRequestMetadata(MEMBER_ID, ShareRequestMetadata.INITIAL_EPOCH)
 
     // Create a single-partition topic and find a broker which is not the leader
-    val partitionToLeader = createTopicAndReturnLeaders(TOPIC)
+    val partitionToLeader = createTopicAndReturnLeaders(TOPIC, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -147,23 +149,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       )
     )
   )
   def testShareFetchRequestSuccess(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -209,23 +211,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       )
     )
   )
   def testShareFetchRequestSuccessMultiplePartitions(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition1 = new TopicIdPartition(topicId, new TopicPartition(TOPIC, 0))
@@ -305,25 +307,25 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         ),
         brokers = 3
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         ),
         brokers = 3
       ),
     )
   )
   def testShareFetchRequestSuccessMultiplePartitionsMultipleBrokers(): Unit = {
-    val partitionToLeaders = createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    val partitionToLeaders = createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition1 = new TopicIdPartition(topicId, new TopicPartition(TOPIC, 0))
@@ -424,23 +426,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareAcknowledgeRequestSuccessAccept(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -536,25 +538,25 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
           new ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "15000")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1"),
           new ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "15000")
         )
       ),
     )
   )
   def testShareFetchRequestPiggybackedAccept(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -655,23 +657,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareAcknowledgeRequestSuccessRelease(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -764,23 +766,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareFetchRequestPiggybackedRelease(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -877,23 +879,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareAcknowledgeRequestSuccessReject(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -989,23 +991,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareFetchRequestPiggybackedReject(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1106,25 +1108,25 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
           new ClusterConfigProperty(key = "group.share.delivery.count.limit", value = "2") // Setting max delivery count config to 2
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1"),
           new ClusterConfigProperty(key = "group.share.delivery.count.limit", value = "2") // Setting max delivery count config to 2
         )
       ),
     )
   )
   def testShareAcknowledgeRequestMaxDeliveryAttemptExhausted(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1265,17 +1267,17 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
@@ -1285,7 +1287,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val memberId2 = Uuid.randomUuid()
     val memberId3 = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1356,17 +1358,17 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
@@ -1380,7 +1382,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val memberId2 = Uuid.randomUuid()
     val memberId3 = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1458,23 +1460,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareSessionCloseWithShareFetch(): Unit = {
-    createTopicAndReturnLeaders(TOPIC)
+    createTopicAndReturnLeaders(TOPIC, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1565,23 +1567,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareSessionCloseWithShareAcknowledge(): Unit = {
-    createTopicAndReturnLeaders(TOPIC)
+    createTopicAndReturnLeaders(TOPIC, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1681,23 +1683,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareFetchInitialEpochWithAcknowledgements(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1729,23 +1731,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareAcknowledgeInitialRequestError(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1771,23 +1773,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareFetchRequestInvalidShareSessionEpoch(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1842,23 +1844,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
   )
   def testShareAcknowledgeRequestInvalidShareSessionEpoch(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1918,17 +1920,17 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
@@ -1936,7 +1938,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
   def testShareFetchRequestShareSessionNotFound(): Unit = {
     val wrongMemberId = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1990,19 +1992,19 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
           new ClusterConfigProperty(key = "group.share.max.share.sessions", value = "2"),
           new ClusterConfigProperty(key = "group.share.max.size", value = "2")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1"),
           new ClusterConfigProperty(key = "group.share.max.share.sessions", value = "2"),
           new ClusterConfigProperty(key = "group.share.max.size", value = "2")
         )
@@ -2014,7 +2016,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val memberId2 = Uuid.randomUuid()
     val memberId3 = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2074,17 +2076,17 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
@@ -2092,7 +2094,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
   def testShareAcknowledgeRequestShareSessionNotFound(): Unit = {
     val wrongMemberId = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2152,17 +2154,17 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       ),
     )
@@ -2171,7 +2173,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val partition1 = 0
     val partition2 = 1
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition1 = new TopicIdPartition(topicId, new TopicPartition(TOPIC, partition1))
@@ -2251,23 +2253,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       )
     )
   )
   def testShareFetchRequestWithMaxRecordsAndBatchSize(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2313,23 +2315,23 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     Array(
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
         )
       ),
       new ClusterTest(
         serverProperties = Array(
-          new ClusterConfigProperty(key = "offsets.topic.num.partitions", value = "1"),
-          new ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "group.share.persister.class.name", value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-          new ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "1")
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "org.apache.kafka.server.share.persister.DefaultStatePersister"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+          new ClusterConfigProperty(key = ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, value = "1")
         )
       )
     )
   )
   def testShareFetchRequestMultipleBatchesWithMaxRecordsAndBatchSize(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))

--- a/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareFetchAcknowledgeRequestTest.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig
 import org.apache.kafka.coordinator.share.ShareCoordinatorConfig
 import org.apache.kafka.server.common.Feature
 import org.apache.kafka.server.IntegrationTestUtils
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
 import org.junit.jupiter.api.AfterEach
 
 import java.net.Socket
@@ -115,7 +115,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val metadata: ShareRequestMetadata = new ShareRequestMetadata(MEMBER_ID, ShareRequestMetadata.INITIAL_EPOCH)
 
     // Create a single-partition topic and find a broker which is not the leader
-    val partitionToLeader = createTopicAndReturnLeaders(TOPIC, createTopicRequestTimeoutMs = Some(120000))
+    val partitionToLeader = createTopicAndReturnLeaders(TOPIC)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -165,7 +165,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestSuccess(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -227,7 +227,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestSuccessMultiplePartitions(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition1 = new TopicIdPartition(topicId, new TopicPartition(TOPIC, 0))
@@ -325,7 +325,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestSuccessMultiplePartitionsMultipleBrokers(): Unit = {
-    val partitionToLeaders = createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    val partitionToLeaders = createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition1 = new TopicIdPartition(topicId, new TopicPartition(TOPIC, 0))
@@ -442,7 +442,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareAcknowledgeRequestSuccessAccept(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -556,7 +556,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestPiggybackedAccept(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -673,7 +673,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareAcknowledgeRequestSuccessRelease(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -782,7 +782,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestPiggybackedRelease(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -895,7 +895,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareAcknowledgeRequestSuccessReject(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1007,7 +1007,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestPiggybackedReject(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1126,7 +1126,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareAcknowledgeRequestMaxDeliveryAttemptExhausted(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1287,7 +1287,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val memberId2 = Uuid.randomUuid()
     val memberId3 = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1382,7 +1382,12 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val memberId2 = Uuid.randomUuid()
     val memberId3 = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    try {
+      createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
+    } catch {
+      case e: Throwable =>
+        fail(s"Test failed due to exception: ${e.getMessage}", e)
+    }
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1476,7 +1481,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareSessionCloseWithShareFetch(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1583,7 +1588,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareSessionCloseWithShareAcknowledge(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1699,7 +1704,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchInitialEpochWithAcknowledgements(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1747,7 +1752,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareAcknowledgeInitialRequestError(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1789,7 +1794,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestInvalidShareSessionEpoch(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1860,7 +1865,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareAcknowledgeRequestInvalidShareSessionEpoch(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -1938,7 +1943,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
   def testShareFetchRequestShareSessionNotFound(): Unit = {
     val wrongMemberId = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2016,7 +2021,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val memberId2 = Uuid.randomUuid()
     val memberId3 = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2094,7 +2099,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
   def testShareAcknowledgeRequestShareSessionNotFound(): Unit = {
     val wrongMemberId = Uuid.randomUuid()
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2173,7 +2178,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     val partition1 = 0
     val partition2 = 1
 
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition1 = new TopicIdPartition(topicId, new TopicPartition(TOPIC, partition1))
@@ -2269,7 +2274,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestWithMaxRecordsAndBatchSize(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))
@@ -2331,7 +2336,7 @@ class ShareFetchAcknowledgeRequestTest(cluster: ClusterInstance) extends GroupCo
     )
   )
   def testShareFetchRequestMultipleBatchesWithMaxRecordsAndBatchSize(): Unit = {
-    createTopicAndReturnLeaders(TOPIC, numPartitions = 3, createTopicRequestTimeoutMs = Some(120000))
+    createTopicAndReturnLeaders(TOPIC, numPartitions = 3)
     val topicIds = getTopicIds
     val topicId = topicIds.get(TOPIC)
     val topicIdPartition = new TopicIdPartition(topicId, new TopicPartition(TOPIC, PARTITION))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -334,13 +334,19 @@ object TestUtils extends Logging {
     replicationFactor: Int = 1,
     replicaAssignment: collection.Map[Int, Seq[Int]] = Map.empty,
     topicConfig: Properties = new Properties,
+    createTopicRequestTimeoutMs: Option[Int] = None
   ): Uuid = {
     val configsMap = new util.HashMap[String, String]()
     topicConfig.forEach((k, v) => configsMap.put(k.toString, v.toString))
 
+    var createTopicsOptions: CreateTopicsOptions = new CreateTopicsOptions()
+    if (createTopicRequestTimeoutMs.isDefined) {
+      createTopicsOptions = createTopicsOptions.timeoutMs(createTopicRequestTimeoutMs.get)
+    }
+
     val result = if (replicaAssignment.isEmpty) {
       admin.createTopics(util.List.of(new NewTopic(
-        topic, numPartitions, replicationFactor.toShort).configs(configsMap)))
+        topic, numPartitions, replicationFactor.toShort).configs(configsMap)), createTopicsOptions)
     } else {
       val assignment = new util.HashMap[Integer, util.List[Integer]]()
       replicaAssignment.foreachEntry { case (k, v) =>
@@ -349,7 +355,7 @@ object TestUtils extends Logging {
         assignment.put(k.asInstanceOf[Integer], replicas)
       }
       admin.createTopics(util.List.of(new NewTopic(
-        topic, assignment).configs(configsMap)))
+        topic, assignment).configs(configsMap)), createTopicsOptions)
     }
 
     result.topicId(topic).get()
@@ -364,6 +370,7 @@ object TestUtils extends Logging {
     replicationFactor: Int = 1,
     replicaAssignment: collection.Map[Int, Seq[Int]] = Map.empty,
     topicConfig: Properties = new Properties,
+    createTopicRequestTimeoutMs: Option[Int] = None
   ): scala.collection.immutable.Map[Int, Int] = {
     val effectiveNumPartitions = if (replicaAssignment.isEmpty) {
       numPartitions
@@ -386,7 +393,8 @@ object TestUtils extends Logging {
         numPartitions,
         replicationFactor,
         replicaAssignment,
-        topicConfig
+        topicConfig,
+        createTopicRequestTimeoutMs
       )
     } catch {
       case e: ExecutionException =>

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -333,20 +333,14 @@ object TestUtils extends Logging {
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
     replicaAssignment: collection.Map[Int, Seq[Int]] = Map.empty,
-    topicConfig: Properties = new Properties,
-    createTopicRequestTimeoutMs: Option[Int] = None
+    topicConfig: Properties = new Properties
   ): Uuid = {
     val configsMap = new util.HashMap[String, String]()
     topicConfig.forEach((k, v) => configsMap.put(k.toString, v.toString))
 
-    var createTopicsOptions: CreateTopicsOptions = new CreateTopicsOptions()
-    if (createTopicRequestTimeoutMs.isDefined) {
-      createTopicsOptions = createTopicsOptions.timeoutMs(createTopicRequestTimeoutMs.get)
-    }
-
     val result = if (replicaAssignment.isEmpty) {
       admin.createTopics(util.List.of(new NewTopic(
-        topic, numPartitions, replicationFactor.toShort).configs(configsMap)), createTopicsOptions)
+        topic, numPartitions, replicationFactor.toShort).configs(configsMap)))
     } else {
       val assignment = new util.HashMap[Integer, util.List[Integer]]()
       replicaAssignment.foreachEntry { case (k, v) =>
@@ -355,7 +349,7 @@ object TestUtils extends Logging {
         assignment.put(k.asInstanceOf[Integer], replicas)
       }
       admin.createTopics(util.List.of(new NewTopic(
-        topic, assignment).configs(configsMap)), createTopicsOptions)
+        topic, assignment).configs(configsMap)))
     }
 
     result.topicId(topic).get()
@@ -369,8 +363,7 @@ object TestUtils extends Logging {
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
     replicaAssignment: collection.Map[Int, Seq[Int]] = Map.empty,
-    topicConfig: Properties = new Properties,
-    createTopicRequestTimeoutMs: Option[Int] = None
+    topicConfig: Properties = new Properties
   ): scala.collection.immutable.Map[Int, Int] = {
     val effectiveNumPartitions = if (replicaAssignment.isEmpty) {
       numPartitions
@@ -393,8 +386,7 @@ object TestUtils extends Logging {
         numPartitions,
         replicationFactor,
         replicaAssignment,
-        topicConfig,
-        createTopicRequestTimeoutMs
+        topicConfig
       )
     } catch {
       case e: ExecutionException =>

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -333,7 +333,7 @@ object TestUtils extends Logging {
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
     replicaAssignment: collection.Map[Int, Seq[Int]] = Map.empty,
-    topicConfig: Properties = new Properties
+    topicConfig: Properties = new Properties,
   ): Uuid = {
     val configsMap = new util.HashMap[String, String]()
     topicConfig.forEach((k, v) => configsMap.put(k.toString, v.toString))
@@ -363,7 +363,7 @@ object TestUtils extends Logging {
     numPartitions: Int = 1,
     replicationFactor: Int = 1,
     replicaAssignment: collection.Map[Int, Seq[Int]] = Map.empty,
-    topicConfig: Properties = new Properties
+    topicConfig: Properties = new Properties,
   ): scala.collection.immutable.Map[Int, Int] = {
     val effectiveNumPartitions = if (replicaAssignment.isEmpty) {
       numPartitions


### PR DESCRIPTION
This PR works is an aim to resolve the flakiness in the ShareFetchAcknolwedgeRequestTest tests. Recently some flakes were seen on the test and it was reproduced locally as well, with the error -> `Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: createTopics`. This PR tries to resolve that by adding an increased timeout of 120000ms (2 minutes) to the CreateTopics request sent out.