### PR TITLE
KAFKA-19511: Fix flaky test HandlingSourceTopicDeletionIntegrationTest.shouldThrowErrorAfterSourceTopicDeleted

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.test.TestUtils;
+import org.apache.kafka.test.TestCondition;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -41,6 +42,7 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.hamcrest.CoreMatchers.is;
@@ -95,36 +97,40 @@ public class HandlingSourceTopicDeletionIntegrationTest {
         streamsConfiguration.put(StreamsConfig.METADATA_MAX_AGE_CONFIG, 2000);
 
         final Topology topology = builder.build();
-        final KafkaStreams kafkaStreams1 = new KafkaStreams(topology, streamsConfiguration);
         final AtomicBoolean calledUncaughtExceptionHandler1 = new AtomicBoolean(false);
-        kafkaStreams1.setUncaughtExceptionHandler(exception -> {
-            calledUncaughtExceptionHandler1.set(true);
-            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
-        });
-        kafkaStreams1.start();
-        final KafkaStreams kafkaStreams2 = new KafkaStreams(topology, streamsConfiguration);
         final AtomicBoolean calledUncaughtExceptionHandler2 = new AtomicBoolean(false);
-        kafkaStreams2.setUncaughtExceptionHandler(exception -> {
-            calledUncaughtExceptionHandler2.set(true);
-            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
-        });
-        kafkaStreams2.start();
 
-        TestUtils.waitForCondition(
-            () -> kafkaStreams1.state() == State.RUNNING && kafkaStreams2.state() == State.RUNNING,
-            TIMEOUT,
-            () -> "Kafka Streams clients did not reach state RUNNING"
-        );
+        try (final KafkaStreams kafkaStreams1 = new KafkaStreams(topology, streamsConfiguration);
+             final KafkaStreams kafkaStreams2 = new KafkaStreams(topology, streamsConfiguration)) {
+            
+            kafkaStreams1.setUncaughtExceptionHandler(exception -> {
+                calledUncaughtExceptionHandler1.set(true);
+                return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+            });
+            kafkaStreams1.start();
 
-        CLUSTER.deleteTopic(INPUT_TOPIC);
+            kafkaStreams2.setUncaughtExceptionHandler(exception -> {
+                calledUncaughtExceptionHandler2.set(true);
+                return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+            });
+            kafkaStreams2.start();
 
-        TestUtils.waitForCondition(
-            () -> kafkaStreams1.state() == State.ERROR && kafkaStreams2.state() == State.ERROR,
-            TIMEOUT,
-            () -> "Kafka Streams clients did not reach state ERROR"
-        );
+            TestUtils.waitForCondition(
+                () -> kafkaStreams1.state() == State.RUNNING && kafkaStreams2.state() == State.RUNNING,
+                TIMEOUT,
+                () -> "Kafka Streams clients did not reach state RUNNING"
+            );
 
-        assertThat(calledUncaughtExceptionHandler1.get(), is(true));
-        assertThat(calledUncaughtExceptionHandler2.get(), is(true));
+            CLUSTER.deleteTopic(INPUT_TOPIC);
+
+            TestUtils.waitForCondition(
+                () -> kafkaStreams1.state() == State.ERROR && kafkaStreams2.state() == State.ERROR,
+                TIMEOUT,
+                () -> "Kafka Streams clients did not reach state ERROR"
+            );
+
+            assertThat(calledUncaughtExceptionHandler1.get(), is(true));
+            assertThat(calledUncaughtExceptionHandler2.get(), is(true));
+        }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
@@ -52,7 +52,7 @@ public class HandlingSourceTopicDeletionIntegrationTest {
 
     private static final int NUM_BROKERS = 1;
     private static final int NUM_THREADS = 2;
-    private static final long TIMEOUT = 60000;
+    private static final long TIMEOUT = 300000;
     private static final String INPUT_TOPIC = "inputTopic";
     private static final String OUTPUT_TOPIC = "outputTopic";
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -28,7 +27,6 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.test.TestUtils;
-import org.apache.kafka.test.TestCondition;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -39,10 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
-import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.hamcrest.CoreMatchers.is;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
@@ -34,9 +34,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -52,7 +51,7 @@ public class HandlingSourceTopicDeletionIntegrationTest {
 
     private static final int NUM_BROKERS = 1;
     private static final int NUM_THREADS = 2;
-    private static final long TIMEOUT = 300000;
+    private static final long TIMEOUT = 60000;
     private static final String INPUT_TOPIC = "inputTopic";
     private static final String OUTPUT_TOPIC = "outputTopic";
 
@@ -78,9 +77,8 @@ public class HandlingSourceTopicDeletionIntegrationTest {
         CLUSTER.deleteTopics(INPUT_TOPIC, OUTPUT_TOPIC);
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void shouldThrowErrorAfterSourceTopicDeleted(final boolean useNewProtocol, final TestInfo testName) throws InterruptedException {
+    @Test
+    public void shouldThrowErrorAfterSourceTopicDeleted(final TestInfo testName) throws InterruptedException {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.stream(INPUT_TOPIC, Consumed.with(Serdes.Integer(), Serdes.String()))
             .to(OUTPUT_TOPIC, Produced.with(Serdes.Integer(), Serdes.String()));
@@ -91,14 +89,10 @@ public class HandlingSourceTopicDeletionIntegrationTest {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
-        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
         streamsConfiguration.put(StreamsConfig.METADATA_MAX_AGE_CONFIG, 2000);
-        
-        if (useNewProtocol) {
-            streamsConfiguration.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.name().toLowerCase(Locale.getDefault()));
-        }
 
         final Topology topology = builder.build();
         final KafkaStreams kafkaStreams1 = new KafkaStreams(topology, streamsConfiguration);


### PR DESCRIPTION
Temporarily fix it by disable the new protocol, will take a deeper look
at it in the consumer protocol.

Reviewers: Matthias J. Sax <matthias@confluent.io>
