### PR TITLE
KAFKA-12281: Deprecate BrokerNotFoundException

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/BrokerNotFoundException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/BrokerNotFoundException.java
@@ -23,6 +23,7 @@ package org.apache.kafka.streams.errors;
  * @see org.apache.kafka.streams.StreamsConfig
  */
 @SuppressWarnings("unused")
+@Deprecated(since = "4.2", forRemoval = true)
 public class BrokerNotFoundException extends StreamsException {
 
     private static final long serialVersionUID = 1L;

--- a/streams/src/main/java/org/apache/kafka/streams/errors/BrokerNotFoundException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/BrokerNotFoundException.java
@@ -17,14 +17,14 @@
 package org.apache.kafka.streams.errors;
 
 /**
- * @deprecated since 4.2 and should not be used any longer.
  * Indicates that none of the specified {@link org.apache.kafka.streams.StreamsConfig#BOOTSTRAP_SERVERS_CONFIG brokers}
  * could be found.
  *
  * @see org.apache.kafka.streams.StreamsConfig
+ * @deprecated since 4.2 and should not be used any longer.
  */
 @SuppressWarnings("unused")
-@Deprecated(since = "4.2", forRemoval = true)
+@Deprecated
 public class BrokerNotFoundException extends StreamsException {
 
     private static final long serialVersionUID = 1L;

--- a/streams/src/main/java/org/apache/kafka/streams/errors/BrokerNotFoundException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/BrokerNotFoundException.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.errors;
 
 /**
+ * @deprecated since 4.2 and should not be used any longer.
  * Indicates that none of the specified {@link org.apache.kafka.streams.StreamsConfig#BOOTSTRAP_SERVERS_CONFIG brokers}
  * could be found.
  *


### PR DESCRIPTION
Implements KIP-1195.

BrokerNotFoundException exception is unused since 2.8  Marking it
deprecated so that it can be removed in next major release.

Reviewers: Matthias J. Sax <matthias@confluent.io>
