### PR TITLE
KAFKA-19503: Deprecate MX4j support

### DIFF
--- a/core/src/main/scala/kafka/utils/Mx4jLoader.scala
+++ b/core/src/main/scala/kafka/utils/Mx4jLoader.scala
@@ -30,12 +30,14 @@ import javax.management.ObjectName
  *
  * This is a Scala port of org.apache.cassandra.utils.Mx4jTool written by Ran Tavory for CASSANDRA-1068
  * */
+@deprecated
 object Mx4jLoader extends Logging {
 
   def maybeLoad(): Boolean = {
     val props = new VerifiableProperties(System.getProperties)
     if (!props.getBoolean("kafka_mx4jenable", default = false))
       return false
+    warn("MX4j is deprecated and will be removed in the next major release")
     val address = props.getString("mx4jaddress", "0.0.0.0")
     val port = props.getInt("mx4jport", 8082)
     try {

--- a/core/src/main/scala/kafka/utils/Mx4jLoader.scala
+++ b/core/src/main/scala/kafka/utils/Mx4jLoader.scala
@@ -37,7 +37,7 @@ object Mx4jLoader extends Logging {
     val props = new VerifiableProperties(System.getProperties)
     if (!props.getBoolean("kafka_mx4jenable", default = false))
       return false
-    warn("MX4j is deprecated and will be removed in the next major release")
+    warn("MX4j is deprecated and will be removed in Kafka 5.0")
     val address = props.getString("mx4jaddress", "0.0.0.0")
     val port = props.getInt("mx4jport", 8082)
     try {

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -35,7 +35,7 @@
         For further details, please refer to <a href="https://cwiki.apache.org/confluence/x/1gq9F">KIP-1157</a>.
     </li>
     <li>
-        The support for MX4J library, enabled through <code>kafka_mx4jenable</code> system property, was deprecated and will be removed in the next  major release.
+        The support for MX4J library, enabled through <code>kafka_mx4jenable</code> system property, was deprecated and will be removed in the next major release.
     </li>
 </ul>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -34,8 +34,10 @@
     <li>The <code>KafkaPrincipalBuilder</code> now extends <code>KafkaPrincipalSerde</code>. Force developer to implement <code>KafkaPrincipalSerde</code> interface for custom <code>KafkaPrincipalBuilder</code>.
         For further details, please refer to <a href="https://cwiki.apache.org/confluence/x/1gq9F">KIP-1157</a>.
     </li>
+    <li>
+        The support for MX4J library, enabled through <code>kafka_mx4jenable</code> system property, was deprecated and will be removed in the next  major release.
+    </li>
 </ul>
-
 
 <h4><a id="upgrade_4_1_0" href="#upgrade_4_1_0">Upgrading to 4.1.0</a></h4>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -35,7 +35,7 @@
         For further details, please refer to <a href="https://cwiki.apache.org/confluence/x/1gq9F">KIP-1157</a>.
     </li>
     <li>
-        The support for MX4J library, enabled through <code>kafka_mx4jenable</code> system property, was deprecated and will be removed in the next major release.
+        The support for MX4J library, enabled through <code>kafka_mx4jenable</code> system property, was deprecated and will be removed in Kafka 5.0.
     </li>
 </ul>
 


### PR DESCRIPTION
This feature adds maintenance burden and potential security concerns
while providing no apparent value to the Kafka community. See
[KIP-1193](https://cwiki.apache.org/confluence/x/dAxJFg) for more
details.

Reviewers: TengYao Chi <frankvicky@apache.org>, Ken Huang
 <s7133700@gmail.com>
