### PR TITLE
MINOR: Change log level for cold snapshot log.

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -593,7 +593,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
             long timeSinceLastSnapshot = time.milliseconds() - shareGroupOffset.writeTimestamp();
             if (timeSinceLastSnapshot >= config.shareCoordinatorColdPartitionSnapshotIntervalMs()) {
                 // We need to force create a snapshot here
-                log.info("Last snapshot for {} is older than allowed interval.", sharePartitionKey);
+                log.debug("Last snapshot for {} is older than allowed interval (last snapshot delta {}).", sharePartitionKey, timeSinceLastSnapshot);
                 records.add(ShareCoordinatorRecordHelpers.newShareSnapshotRecord(
                     sharePartitionKey.groupId(),
                     sharePartitionKey.topicId(),


### PR DESCRIPTION
* We INFO log a message, if a share partition could be cold snapshotted.
* However, this may create noise if we have highly partitioned topic
backing the share partition. This will be further exacerbated by
multiple share groups using that topic.
* To reduce log pollution, this PR changes the level to DEBUG.

Reviewers: ShivsundarR <shr@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
