### PR TITLE
KAFKA-19527: improve the docs of LogDirDescription for remote storage

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
@@ -67,6 +67,7 @@ public class LogDirDescription {
     /**
      * The total size of the volume this log directory is on or empty if the broker did not return a value.
      * For volumes larger than Long.MAX_VALUE, Long.MAX_VALUE is returned.
+     * This value does not include the size of data stored in remote storage.
      */
     public OptionalLong totalBytes() {
         return totalBytes;
@@ -75,6 +76,7 @@ public class LogDirDescription {
     /**
      * The usable size on the volume this log directory is on or empty if the broker did not return a value.
      * For usable sizes larger than Long.MAX_VALUE, Long.MAX_VALUE is returned.
+     * This value does not include the size of data stored in remote storage.
      */
     public OptionalLong usableBytes() {
         return usableBytes;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ReplicaInfo.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ReplicaInfo.java
@@ -33,6 +33,7 @@ public class ReplicaInfo {
 
     /**
      * The total size of the log segments in this replica in bytes.
+     * This value does not include the size of data stored in remote storage.
      */
     public long size() {
         return size;

--- a/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
@@ -51,10 +51,10 @@
             "about": "True if this log is created by AlterReplicaLogDirsRequest and will replace the current log of the replica in the future." }]}
       ]},
       { "name": "TotalBytes", "type": "int64", "versions": "4+", "ignorable": true, "default": "-1",
-        "about": "The total size in bytes of the volume the log directory is in."
+        "about": "The total size in bytes of the volume the log directory is in. This value does not include the size of data stored in remote storage."
       },
       { "name": "UsableBytes", "type": "int64", "versions": "4+", "ignorable": true, "default": "-1",
-        "about": "The usable size in bytes of the volume the log directory is in."
+        "about": "The usable size in bytes of the volume the log directory is in. This value does not include the size of data stored in remote storage."
       }
     ]}
   ]


### PR DESCRIPTION
Clarifies that the fields `LogDirDescription#totalBytes`,
`LogDirDescription#usableBytes`, and `ReplicaInfo#size` do not include
the size of remote storage by updating their corresponding docs.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
