### PR TITLE
KAFKA-19533: Correct the docs of 'messages' for `kafka-consumer-perf-test.sh` and `kafka-share-consumer-perf-test.sh

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
@@ -299,7 +299,7 @@ public class ConsumerPerformance {
                 .describedAs("milliseconds")
                 .ofType(Long.class)
                 .defaultsTo(10_000L);
-            numMessagesOpt = parser.accepts("messages", "REQUIRED: The number of messages to send or consume")
+            numMessagesOpt = parser.accepts("messages", "REQUIRED: The number of messages to consume.")
                 .withRequiredArg()
                 .describedAs("count")
                 .ofType(Long.class);

--- a/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ShareConsumerPerformance.java
@@ -335,7 +335,7 @@ public class ShareConsumerPerformance {
                     .describedAs("milliseconds")
                     .ofType(Long.class)
                     .defaultsTo(10_000L);
-            numMessagesOpt = parser.accepts("messages", "REQUIRED: The number of messages to send or consume")
+            numMessagesOpt = parser.accepts("messages", "REQUIRED: The number of messages to consume.")
                     .withRequiredArg()
                     .describedAs("count")
                     .ofType(Long.class);


### PR DESCRIPTION
The descrption "REQUIRED: The number of messages to send or consume" is
not correct, since those tools do NOT send any records.

Reviewers: TengYao Chi <frankvicky@apache.org>
