### PR TITLE
MINOR: Declare inner RocksDBDualCFRangeIterator class as static

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -404,7 +404,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         }
     }
 
-    private class RocksDBDualCFRangeIterator extends RocksDBDualCFIterator {
+    private static class RocksDBDualCFRangeIterator extends RocksDBDualCFIterator {
         // RocksDB's JNI interface does not expose getters/setters that allow the
         // comparator to be pluggable, and the default is lexicographic, so it's
         // safe to just force lexicographic comparator here for now.


### PR DESCRIPTION
Make inner classes static.

from: https://github.com/apache/kafka/pull/20182#issuecomment-3102893453
Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
<chia7712@gmail.com>
