### PR TITLE
KAFKA-19524: Fix UnsupportedOperationException in connect-plugin-path

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
@@ -42,7 +42,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -323,8 +322,7 @@ public class ConnectPluginPath {
             rowAliases.add(PluginUtils.prunedName(pluginDesc));
             rows.add(newRow(workspace, pluginDesc.className(), new ArrayList<>(rowAliases), pluginDesc.type(), pluginDesc.version(), true));
             // If a corresponding manifest exists, mark it as loadable by removing it from the map.
-            // TODO: The use of Collections here shall be fixed with KAFKA-19524.
-            nonLoadableManifests.getOrDefault(pluginDesc.className(), Collections.emptySet()).remove(pluginDesc.type());
+            nonLoadableManifests.getOrDefault(pluginDesc.className(), new HashSet<>()).remove(pluginDesc.type());
         });
         nonLoadableManifests.forEach((className, types) -> types.forEach(type -> {
             // All manifests which remain in the map are not loadable

--- a/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
@@ -322,7 +322,8 @@ public class ConnectPluginPath {
             rowAliases.add(PluginUtils.prunedName(pluginDesc));
             rows.add(newRow(workspace, pluginDesc.className(), new ArrayList<>(rowAliases), pluginDesc.type(), pluginDesc.version(), true));
             // If a corresponding manifest exists, mark it as loadable by removing it from the map.
-            nonLoadableManifests.getOrDefault(pluginDesc.className(), new HashSet<>()).remove(pluginDesc.type());
+            var types = nonLoadableManifests.get(pluginDesc.className());
+            if (types != null) types.remove(pluginDesc.type());
         });
         nonLoadableManifests.forEach((className, types) -> types.forEach(type -> {
             // All manifests which remain in the map are not loadable


### PR DESCRIPTION
### Problem
The connect-plugin-path tool crashes with
`UnsupportedOperationException` when processing plugins that have
loadable classes but no ServiceLoader manifest files.

### Root Cause
Line 326 attempts to remove from an immutable `Collections.emptySet()`:
```java
nonLoadableManifests.getOrDefault(pluginDesc.className(),
Collections.emptySet()).remove(pluginDesc.type());
```

### Solution
Replace `Collections.emptySet()` with `new HashSet<>()` to provide a
mutable set.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
