### PR TITLE
MINOR: Add logging when RemoteLogManager#RLMCopyTask task is cancelled.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -917,8 +917,10 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         }
 
         public void copyLogSegmentsToRemote(UnifiedLog log) throws InterruptedException {
-            if (isCancelled())
+            if (isCancelled()) {
+                logger.info("Skipping copying log segments as the current task state is changed, cancelled: {}", isCancelled());
                 return;
+            }
 
             try {
                 maybeUpdateLogStartOffsetOnBecomingLeader(log);


### PR DESCRIPTION
Add logging information when `RemoteLogManager#RLMCopyTask` task is cancelled.