### PR TITLE
MINOR: Reword warning message when internal deprecated properties are used

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -325,12 +325,7 @@ public class WorkerConfig extends AbstractConfig {
         if (!removedProperties.isEmpty()) {
             log.warn(
                     "The worker has been configured with one or more internal converter properties ({}). "
-                            + "Support for these properties was deprecated in version 2.0 and removed in version 3.0, "
-                            + "and specifying them will have no effect. "
-                            + "Instead, an instance of the JsonConverter with schemas.enable "
-                            + "set to false will be used. For more information, please visit "
-                            + "https://kafka.apache.org/documentation/#upgrade and consult the upgrade notes"
-                            + "for the 3.0 release.",
+                     + "These properties have been removed since version 3.0 and an instance of the JsonConverter with schemas.enable set to false will be used instead.",
                     removedProperties);
         }
     }


### PR DESCRIPTION
This is a small typo I noticed while working on Connect

Original warning message

> level=WARN connector_context=The worker has been configured with one
or more internal converter properties ([internal.key.converter,
schemas.enable, internal.value.converter, schemas.enable]). Support for
these properties was deprecated in version 2.0 and removed in version
3.0, and specifying them will have no effect. Instead, an instance of
the JsonConverter with schemas.enable set to false will be used. For
more information, please visit
https://kafka.apache.org/documentation/#upgrade and consult the upgrade
notesfor the 3.0 release.
class=org.apache.kafka.connect.runtime.WorkerConfig line=310

Reviewers: Ken Huang <s7133700@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
