### PR TITLE
MINOR: Fix duplicate 'to' in ExactlyOnceMessageProcessor javadoc

### DIFF
--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -323,7 +323,7 @@ class AbstractFetcherThreadTest {
     val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
     val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine)
 
-    // This test is contrived because it shouldn't be possible to to see unknown leader epoch
+    // This test is contrived because it shouldn't be possible to see unknown leader epoch
     // in the Fetching state as the leader must validate the follower's epoch when it checks
     // the truncation offset.
 

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -227,7 +227,7 @@ public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebal
     /**
      * When we get a generic {@code KafkaException} while processing records, we retry up to {@code MAX_RETRIES} times.
      * If we exceed this threshold, we log an error and move on to the next batch of records.
-     * In a real world application you may want to to send these records to a dead letter topic (DLT) for further processing.
+     * In a real world application you may want to send these records to a dead letter topic (DLT) for further processing.
      * 
      * @param retries Current number of retries
      * @param consumer Consumer instance


### PR DESCRIPTION
## Description
Fixed a simple typo in javadoc comment where "to to" appeared instead of
"to".

_No functional changes_

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
