### PR TITLE
KAFKA-18265: Move inflight batch and state classes from SharePartition (2/N)

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/share/fetch/DeliveryCountOps.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/DeliveryCountOps.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch;
+
+/**
+ * The DeliveryCountOps is used to specify the behavior on the delivery count: increase, decrease,
+ * or do nothing.
+ */
+public enum DeliveryCountOps {
+    INCREASE, DECREASE, NO_OP
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/InFlightBatch.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/InFlightBatch.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.share.metrics.SharePartitionMetrics;
+import org.apache.kafka.server.util.timer.Timer;
+
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * The InFlightBatch maintains the in-memory state of the fetched records i.e. in-flight records.
+ */
+public class InFlightBatch {
+    // The timer is used to schedule the acquisition lock timeout task for the batch.
+    private final Timer timer;
+    // The time is used to get the current time in milliseconds.
+    private final Time time;
+    // The offset of the first record in the batch that is fetched from the log.
+    private final long firstOffset;
+    // The last offset of the batch that is fetched from the log.
+    private final long lastOffset;
+    // The acquisition lock timeout handler is used to release the acquired records when the acquisition
+    // lock timeout is reached.
+    private final AcquisitionLockTimeoutHandler timeoutHandler;
+    // The share partition metrics are used to track the metrics related to the share partition.
+    private final SharePartitionMetrics sharePartitionMetrics;
+
+    // The batch state of the fetched records. If the offset state map is empty then batchState
+    // determines the state of the complete batch else individual offset determines the state of
+    // the respective records.
+    private InFlightState batchState;
+
+    // The offset state map is used to track the state of the records per offset. However, the
+    // offset state map is only required when the state of the offsets within same batch are
+    // different. The states can be different when explicit offset acknowledgment is done which
+    // is different from the batch state.
+    private NavigableMap<Long, InFlightState> offsetState;
+
+    public InFlightBatch(
+        Timer timer,
+        Time time,
+        String memberId,
+        long firstOffset,
+        long lastOffset,
+        RecordState state,
+        int deliveryCount,
+        AcquisitionLockTimerTask acquisitionLockTimeoutTask,
+        AcquisitionLockTimeoutHandler timeoutHandler,
+        SharePartitionMetrics sharePartitionMetrics
+    ) {
+        this.timer = timer;
+        this.time = time;
+        this.firstOffset = firstOffset;
+        this.lastOffset = lastOffset;
+        this.timeoutHandler = timeoutHandler;
+        this.sharePartitionMetrics = sharePartitionMetrics;
+        this.batchState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
+    }
+
+    /**
+     * @return the first offset of the batch.
+     */
+    public long firstOffset() {
+        return firstOffset;
+    }
+
+    /**
+     * @return the last offset of the batch.
+     */
+    public long lastOffset() {
+        return lastOffset;
+    }
+
+    /**
+     * @return the state of the batch.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public RecordState batchState() {
+        return inFlightState().state();
+    }
+
+    /**
+     * @return the member id of the batch.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public String batchMemberId() {
+        return inFlightState().memberId();
+    }
+
+    /**
+     * @return the delivery count of the batch.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public int batchDeliveryCount() {
+        return inFlightState().deliveryCount();
+    }
+
+    /**
+     * @return the acquisition lock timeout task for the batch.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public AcquisitionLockTimerTask batchAcquisitionLockTimeoutTask() {
+        return inFlightState().acquisitionLockTimeoutTask();
+    }
+
+    /**
+     * @return the offset state map which maintains the state of the records per offset.
+     */
+    public NavigableMap<Long, InFlightState> offsetState() {
+        return offsetState;
+    }
+
+    /**
+     * Cancel the acquisition lock timeout task and clear the reference to it.
+     * This method is used to cancel the acquisition lock timeout task if it exists
+     * and clear the reference to it.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public void cancelAndClearAcquisitionLockTimeoutTask() {
+        inFlightState().cancelAndClearAcquisitionLockTimeoutTask();
+    }
+
+    /**
+     * @return true if the batch has an ongoing state transition, false otherwise.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public boolean batchHasOngoingStateTransition() {
+        return inFlightState().hasOngoingStateTransition();
+    }
+
+    /**
+     * Archive the batch state. This is used to mark the batch as archived and no further updates
+     * are allowed to the batch state.
+     * @param newMemberId The new member id for the records.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public void archiveBatch(String newMemberId) {
+        inFlightState().archive(newMemberId);
+    }
+
+    /**
+     * Try to update the batch state. The state of the batch can only be updated if the new state is allowed
+     * to be transitioned from old state. The delivery count is not changed if the state update is unsuccessful.
+     *
+     * @param newState The new state of the records.
+     * @param ops      The behavior on the delivery count.
+     * @param maxDeliveryCount The maximum delivery count for the records.
+     * @param newMemberId The new member id for the records.
+     * @return {@code InFlightState} if update succeeds, null otherwise. Returning state helps update chaining.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public InFlightState tryUpdateBatchState(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
+        return inFlightState().tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
+    }
+
+    /**
+     * Start a state transition for the batch. This is used to mark the batch as in-flight and
+     * no further updates are allowed to the batch state.
+     *
+     * @param newState The new state of the records.
+     * @param ops      The behavior on the delivery count.
+     * @param maxDeliveryCount The maximum delivery count for the records.
+     * @param newMemberId The new member id for the records.
+     * @return {@code InFlightState} if update succeeds, null otherwise. Returning state helps update chaining.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public InFlightState startBatchStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount,
+        String newMemberId
+    ) {
+        return inFlightState().startStateTransition(newState, ops, maxDeliveryCount, newMemberId);
+    }
+
+    /**
+     * Initialize the offset state map if it is not already initialized. This is used to maintain the state of the
+     * records per offset when the state of the offsets within same batch are different.
+     */
+    public void maybeInitializeOffsetStateUpdate() {
+        if (offsetState == null) {
+            offsetState = new ConcurrentSkipListMap<>();
+            // The offset state map is not initialized hence initialize the state of the offsets
+            // from the first offset to the last offset. Mark the batch inflightState to null as
+            // the state of the records is maintained in the offset state map now.
+            for (long offset = this.firstOffset; offset <= this.lastOffset; offset++) {
+                if (batchState.acquisitionLockTimeoutTask() != null) {
+                    // The acquisition lock timeout task is already scheduled for the batch, hence we need to schedule
+                    // the acquisition lock timeout task for the offset as well.
+                    long delayMs = batchState.acquisitionLockTimeoutTask().expirationMs() - time.hiResClockMs();
+                    AcquisitionLockTimerTask timerTask = acquisitionLockTimerTask(batchState.memberId(), offset, offset, delayMs);
+                    offsetState.put(offset, new InFlightState(batchState.state(), batchState.deliveryCount(), batchState.memberId(), timerTask));
+                    timer.add(timerTask);
+                } else {
+                    offsetState.put(offset, new InFlightState(batchState.state(), batchState.deliveryCount(), batchState.memberId()));
+                }
+            }
+            // Cancel the acquisition lock timeout task for the batch as the offset state is maintained.
+            if (batchState.acquisitionLockTimeoutTask() != null) {
+                batchState.cancelAndClearAcquisitionLockTimeoutTask();
+            }
+            batchState = null;
+        }
+    }
+
+    /**
+     * Update the acquisition lock timeout task for the batch. This is used to update the acquisition lock timeout
+     * task for the batch when the acquisition lock timeout is changed.
+     *
+     * @param acquisitionLockTimeoutTask The new acquisition lock timeout task for the batch.
+     * @throws IllegalStateException if the offset state is maintained and the batch state is not available.
+     */
+    public void updateAcquisitionLockTimeout(AcquisitionLockTimerTask acquisitionLockTimeoutTask) {
+        inFlightState().updateAcquisitionLockTimeoutTask(acquisitionLockTimeoutTask);
+    }
+
+    private InFlightState inFlightState() {
+        if (batchState == null) {
+            throw new IllegalStateException("The batch state is not available as the offset state is maintained");
+        }
+        return batchState;
+    }
+
+    private AcquisitionLockTimerTask acquisitionLockTimerTask(
+        String memberId,
+        long firstOffset,
+        long lastOffset,
+        long delayMs
+    ) {
+        return new AcquisitionLockTimerTask(time, delayMs, memberId, firstOffset, lastOffset, timeoutHandler, sharePartitionMetrics);
+    }
+
+    @Override
+    public String toString() {
+        return "InFlightBatch(" +
+            "firstOffset=" + firstOffset +
+            ", lastOffset=" + lastOffset +
+            ", inFlightState=" + batchState +
+            ", offsetState=" + ((offsetState == null) ? "null" : offsetState) +
+            ")";
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/InFlightState.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/InFlightState.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * The InFlightState is used to track the state and delivery count of a record that has been
+ * fetched from the leader. The state of the record is used to determine if the record should
+ * be re-deliver or if it can be acknowledged or archived.
+ */
+public class InFlightState {
+
+    private static final Logger log = LoggerFactory.getLogger(InFlightState.class);
+
+    // The state of the fetch batch records.
+    private RecordState state;
+    // The number of times the records has been delivered to the client.
+    private int deliveryCount;
+    // The member id of the client that is fetching/acknowledging the record.
+    private String memberId;
+    // The state of the records before the transition. In case we need to revert an in-flight state, we revert the above
+    // attributes of InFlightState to this state, namely - state, deliveryCount and memberId.
+    private InFlightState rollbackState;
+    // The timer task for the acquisition lock timeout.
+    private AcquisitionLockTimerTask acquisitionLockTimeoutTask;
+
+    // Visible for testing.
+    public InFlightState(RecordState state, int deliveryCount, String memberId) {
+        this(state, deliveryCount, memberId, null);
+    }
+
+    InFlightState(RecordState state, int deliveryCount, String memberId, AcquisitionLockTimerTask acquisitionLockTimeoutTask) {
+        this.state = state;
+        this.deliveryCount = deliveryCount;
+        this.memberId = memberId;
+        this.acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
+    }
+
+    /**
+     * @return The current state of the record.
+     */
+    public RecordState state() {
+        return state;
+    }
+
+    /**
+     * @return The number of times the record has been delivered.
+     */
+    public int deliveryCount() {
+        return deliveryCount;
+    }
+
+    /**
+     * @return The member id of the client that is fetching/acknowledging the record.
+     */
+    public String memberId() {
+        return memberId;
+    }
+
+    /**
+     * @return The timer task for the acquisition lock timeout.
+     */
+    public AcquisitionLockTimerTask acquisitionLockTimeoutTask() {
+        return acquisitionLockTimeoutTask;
+    }
+
+    /**
+     * Update the acquisition lock timeout task. This method is used to set the acquisition lock
+     * timeout task for the record. If there is already an acquisition lock timeout task set,
+     * it throws an IllegalArgumentException.
+     *
+     * @param acquisitionLockTimeoutTask The new acquisition lock timeout task to set.
+     * @throws IllegalArgumentException if there is already an acquisition lock timeout task set.
+     */
+    public void updateAcquisitionLockTimeoutTask(AcquisitionLockTimerTask acquisitionLockTimeoutTask) throws IllegalArgumentException {
+        if (this.acquisitionLockTimeoutTask != null) {
+            throw new IllegalArgumentException("Existing acquisition lock timeout exists, cannot override.");
+        }
+        this.acquisitionLockTimeoutTask = acquisitionLockTimeoutTask;
+    }
+
+    /**
+     * Cancel the acquisition lock timeout task and clear the reference to it.
+     * This method is used to cancel the acquisition lock timeout task if it exists
+     * and clear the reference to it.
+     */
+    public void cancelAndClearAcquisitionLockTimeoutTask() {
+        acquisitionLockTimeoutTask.cancel();
+        acquisitionLockTimeoutTask = null;
+    }
+
+    /**
+     * Check if there is an ongoing state transition for the records.
+     * This method checks if the rollbackState is not null, which indicates that
+     * there has been a state transition that has not been committed yet.
+     *
+     * @return true if there is an ongoing state transition, false otherwise.
+     */
+    public boolean hasOngoingStateTransition() {
+        if (rollbackState == null) {
+            // This case could occur when the batch/offset hasn't transitioned even once or the state transitions have
+            // been committed.
+            return false;
+        }
+        return rollbackState.state != null;
+    }
+
+    /**
+     * Try to update the state of the records. The state of the records can only be updated if the
+     * new state is allowed to be transitioned from old state. The delivery count is not changed
+     * if the state update is unsuccessful.
+     *
+     * @param newState The new state of the records.
+     * @param ops      The behavior on the delivery count.
+     * @param maxDeliveryCount The maximum delivery count for the record.
+     * @param newMemberId The member id of the client that is fetching/acknowledging the record.
+     *
+     * @return {@code InFlightState} if update succeeds, null otherwise. Returning state
+     *         helps update chaining.
+     */
+    public InFlightState tryUpdateState(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
+        try {
+            if (newState == RecordState.AVAILABLE && ops != DeliveryCountOps.DECREASE && deliveryCount >= maxDeliveryCount) {
+                newState = RecordState.ARCHIVED;
+            }
+            state = state.validateTransition(newState);
+            if (newState != RecordState.ARCHIVED) {
+                deliveryCount = updatedDeliveryCount(ops);
+            }
+            memberId = newMemberId;
+            return this;
+        } catch (IllegalStateException e) {
+            log.error("Failed to update state of the records", e);
+            rollbackState = null;
+            return null;
+        }
+    }
+
+    /**
+     * Archive the record by setting its state to ARCHIVED, clearing the memberId and
+     * cancelling the acquisition lock timeout task.
+     * This method is used to archive the record when it is no longer needed.
+     */
+    public void archive(String newMemberId) {
+        state = RecordState.ARCHIVED;
+        memberId = newMemberId;
+    }
+
+    /**
+     * Start a state transition for the records. This method is used to start a state transition
+     * for the records. It creates a copy of the current state and sets it as the rollback state.
+     * If the state transition is successful, it returns the updated state.
+     *
+     * @param newState The new state of the records.
+     * @param ops      The behavior on the delivery count.
+     * @param maxDeliveryCount The maximum delivery count for the record.
+     * @param newMemberId The member id of the client that is fetching/acknowledging the record.
+     *
+     * @return {@code InFlightState} if update succeeds, null otherwise. Returning state
+     *         helps update chaining.
+     */
+    public InFlightState startStateTransition(RecordState newState, DeliveryCountOps ops, int maxDeliveryCount, String newMemberId) {
+        rollbackState = new InFlightState(state, deliveryCount, memberId, acquisitionLockTimeoutTask);
+        return tryUpdateState(newState, ops, maxDeliveryCount, newMemberId);
+    }
+
+    /**
+     * Complete the state transition for the records. If the commit is true or the state is terminal,
+     * it cancels the acquisition lock timeout task and clears the rollback state.
+     * If the commit is false and the state is not terminal, it rolls back the state transition.
+     *
+     * @param commit If true, commits the state transition, otherwise rolls back.
+     */
+    public void completeStateTransition(boolean commit) {
+        if (commit) {
+            rollbackState = null;
+            return;
+        }
+        state = rollbackState.state;
+        deliveryCount = rollbackState.deliveryCount;
+        memberId = rollbackState.memberId;
+        rollbackState = null;
+    }
+
+    private int updatedDeliveryCount(DeliveryCountOps ops) {
+        return switch (ops) {
+            case INCREASE -> deliveryCount + 1;
+            case DECREASE -> deliveryCount - 1;
+            // do nothing
+            case NO_OP -> deliveryCount;
+        };
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(state, deliveryCount, memberId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InFlightState that = (InFlightState) o;
+        return state == that.state && deliveryCount == that.deliveryCount && memberId.equals(that.memberId);
+    }
+
+    @Override
+    public String toString() {
+        return "InFlightState(" +
+            "state=" + state.toString() +
+            ", deliveryCount=" + deliveryCount +
+            ", memberId=" + memberId +
+            ")";
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch;
+
+import java.util.Objects;
+
+/**
+ * The RecordState is used to track the state of a record that has been fetched from the leader.
+ * The state of the records determines if the records should be re-delivered, move the next fetch
+ * offset, or be state persisted to disk.
+ */
+public enum RecordState {
+    AVAILABLE((byte) 0),
+    ACQUIRED((byte) 1),
+    ACKNOWLEDGED((byte) 2),
+    ARCHIVED((byte) 4);
+
+    public final byte id;
+
+    RecordState(byte id) {
+        this.id = id;
+    }
+
+    /**
+     * Validates that the <code>newState</code> is one of the valid transition from the current
+     * {@code RecordState}.
+     *
+     * @param newState State into which requesting to transition; must be non-<code>null</code>
+     *
+     * @return {@code RecordState} <code>newState</code> if validation succeeds. Returning
+     *         <code>newState</code> helps state assignment chaining.
+     *
+     * @throws IllegalStateException if the state transition validation fails.
+     */
+    public RecordState validateTransition(RecordState newState) throws IllegalStateException {
+        Objects.requireNonNull(newState, "newState cannot be null");
+        if (this == newState) {
+            throw new IllegalStateException("The state transition is invalid as the new state is"
+                + "the same as the current state");
+        }
+
+        if (this == ACKNOWLEDGED || this == ARCHIVED) {
+            throw new IllegalStateException("The state transition is invalid from the current state: " + this);
+        }
+
+        if (this == AVAILABLE && newState != ACQUIRED) {
+            throw new IllegalStateException("The state can only be transitioned to ACQUIRED from AVAILABLE");
+        }
+
+        // Either the transition is from Available -> Acquired or from Acquired -> Available/
+        // Acknowledged/Archived.
+        return newState;
+    }
+
+    public static RecordState forId(byte id) {
+        return switch (id) {
+            case 0 -> AVAILABLE;
+            case 1 -> ACQUIRED;
+            case 2 -> ACKNOWLEDGED;
+            case 4 -> ARCHIVED;
+            default -> throw new IllegalArgumentException("Unknown record state id: " + id);
+        };
+    }
+
+    public byte id() {
+        return this.id;
+    }
+}

--- a/server/src/test/java/org/apache/kafka/server/share/fetch/RecordStateTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/fetch/RecordStateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RecordStateTest {
+
+    @Test
+    public void testRecordStateValidateTransition() {
+        // Null check.
+        assertThrows(NullPointerException.class, () -> RecordState.AVAILABLE.validateTransition(null));
+        // Same state transition check.
+        assertThrows(IllegalStateException.class, () -> RecordState.AVAILABLE.validateTransition(RecordState.AVAILABLE));
+        assertThrows(IllegalStateException.class, () -> RecordState.ACQUIRED.validateTransition(RecordState.ACQUIRED));
+        assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.ACKNOWLEDGED));
+        assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.ARCHIVED));
+        // Invalid state transition to any other state from Acknowledged state.
+        assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.AVAILABLE));
+        assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.ACQUIRED));
+        assertThrows(IllegalStateException.class, () -> RecordState.ACKNOWLEDGED.validateTransition(RecordState.ARCHIVED));
+        // Invalid state transition to any other state from Archived state.
+        assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.AVAILABLE));
+        assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.ACKNOWLEDGED));
+        assertThrows(IllegalStateException.class, () -> RecordState.ARCHIVED.validateTransition(RecordState.ARCHIVED));
+        // Invalid state transition to any other state from Available state other than Acquired.
+        assertThrows(IllegalStateException.class, () -> RecordState.AVAILABLE.validateTransition(RecordState.ACKNOWLEDGED));
+        assertThrows(IllegalStateException.class, () -> RecordState.AVAILABLE.validateTransition(RecordState.ARCHIVED));
+
+        // Successful transition from Available to Acquired.
+        assertEquals(RecordState.ACQUIRED, RecordState.AVAILABLE.validateTransition(RecordState.ACQUIRED));
+        // Successful transition from Acquired to any state.
+        assertEquals(RecordState.AVAILABLE, RecordState.ACQUIRED.validateTransition(RecordState.AVAILABLE));
+        assertEquals(RecordState.ACKNOWLEDGED, RecordState.ACQUIRED.validateTransition(RecordState.ACKNOWLEDGED));
+        assertEquals(RecordState.ARCHIVED, RecordState.ACQUIRED.validateTransition(RecordState.ARCHIVED));
+    }
+
+    @Test
+    public void testRecordStateForId() {
+        assertEquals(RecordState.AVAILABLE, RecordState.forId((byte) 0));
+        assertEquals(RecordState.ACQUIRED, RecordState.forId((byte) 1));
+        assertEquals(RecordState.ACKNOWLEDGED, RecordState.forId((byte) 2));
+        assertEquals(RecordState.ARCHIVED, RecordState.forId((byte) 4));
+        // Invalid check.
+        assertThrows(IllegalArgumentException.class, () -> RecordState.forId((byte) 5));
+    }
+}


### PR DESCRIPTION
Another refactor PR to move in-flight batch and state out of
SharePartition. This PR concludes the refactoring and subsequent PRs for
this ticket will involve code cleanups and better lock handling. However
the intent is to keep PRs small so they can be reviewed easily.

Reviewers: Andrew Schofield <aschofield@confluent.io>
