### PR TITLE
MINOR: Prevent error message swallow in persister.

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
@@ -437,6 +437,10 @@ public class PersisterStateManager {
 
             FindCoordinatorResponseData.Coordinator coordinatorData = coordinators.get(0);
             Errors error = Errors.forCode(coordinatorData.errorCode());
+            String errMessage = coordinatorData.errorMessage();
+            if (errMessage == null || errMessage.isEmpty()) {
+                errMessage = error.message();
+            }
 
             switch (error) {
                 case NONE:
@@ -455,7 +459,7 @@ public class PersisterStateManager {
                 case COORDINATOR_LOAD_IN_PROGRESS:
                 case NOT_COORDINATOR:
                 case UNKNOWN_TOPIC_OR_PARTITION:
-                    log.debug("Received retriable error in find coordinator for {} using key {}: {}", name(), partitionKey(), error.message());
+                    log.debug("Received retriable error in find coordinator for {} using key {}: {}", name(), partitionKey(), errMessage);
                     if (!findCoordBackoff.canAttempt()) {
                         log.error("Exhausted max retries to find coordinator for {} using key {} without success.", name(), partitionKey());
                         findCoordinatorErrorResponse(error, new Exception("Exhausted max retries to find coordinator without success."));
@@ -467,7 +471,7 @@ public class PersisterStateManager {
 
                 default:
                     log.error("Unable to find coordinator for {} using key {}.", name(), partitionKey());
-                    findCoordinatorErrorResponse(error, null);
+                    findCoordinatorErrorResponse(error, new Exception(errMessage));
             }
         }
 
@@ -567,6 +571,11 @@ public class PersisterStateManager {
 
                     if (partitionStateData.isPresent()) {
                         Errors error = Errors.forCode(partitionStateData.get().errorCode());
+                        String errorMessage = partitionStateData.get().errorMessage();
+                        if (errorMessage == null || errorMessage.isEmpty()) {
+                            errorMessage = error.message();
+                        }
+
                         switch (error) {
                             case NONE:
                                 initializeStateBackoff.resetAttempts();
@@ -583,7 +592,7 @@ public class PersisterStateManager {
                             case COORDINATOR_LOAD_IN_PROGRESS:
                             case NOT_COORDINATOR:
                             case UNKNOWN_TOPIC_OR_PARTITION:
-                                log.debug("Received retriable error in initialize state RPC for key {}: {}", partitionKey(), error.message());
+                                log.debug("Received retriable error in initialize state RPC for key {}: {}", partitionKey(), errorMessage);
                                 if (!initializeStateBackoff.canAttempt()) {
                                     log.error("Exhausted max retries for initialize state RPC for key {} without success.", partitionKey());
                                     requestErrorResponse(error, new Exception("Exhausted max retries to complete initialize state RPC without success."));
@@ -594,7 +603,7 @@ public class PersisterStateManager {
                                 return;
 
                             default:
-                                log.error("Unable to perform initialize state RPC for key {}: {}", partitionKey(), error.message());
+                                log.error("Unable to perform initialize state RPC for key {}: {}", partitionKey(), errorMessage);
                                 requestErrorResponse(error, null);
                                 return;
                         }
@@ -726,6 +735,11 @@ public class PersisterStateManager {
 
                     if (partitionStateData.isPresent()) {
                         Errors error = Errors.forCode(partitionStateData.get().errorCode());
+                        String errorMessage = partitionStateData.get().errorMessage();
+                        if (errorMessage == null || errorMessage.isEmpty()) {
+                            errorMessage = error.message();
+                        }
+
                         switch (error) {
                             case NONE:
                                 writeStateBackoff.resetAttempts();
@@ -742,7 +756,7 @@ public class PersisterStateManager {
                             case COORDINATOR_LOAD_IN_PROGRESS:
                             case NOT_COORDINATOR:
                             case UNKNOWN_TOPIC_OR_PARTITION:
-                                log.debug("Received retriable error in write state RPC for key {}: {}", partitionKey(), error.message());
+                                log.debug("Received retriable error in write state RPC for key {}: {}", partitionKey(), errorMessage);
                                 if (!writeStateBackoff.canAttempt()) {
                                     log.error("Exhausted max retries for write state RPC for key {} without success.", partitionKey());
                                     requestErrorResponse(error, new Exception("Exhausted max retries to complete write state RPC without success."));
@@ -753,7 +767,7 @@ public class PersisterStateManager {
                                 return;
 
                             default:
-                                log.error("Unable to perform write state RPC for key {}: {}", partitionKey(), error.message());
+                                log.error("Unable to perform write state RPC for key {}: {}", partitionKey(), errorMessage);
                                 requestErrorResponse(error, null);
                                 return;
                         }
@@ -869,6 +883,11 @@ public class PersisterStateManager {
 
                     if (partitionStateData.isPresent()) {
                         Errors error = Errors.forCode(partitionStateData.get().errorCode());
+                        String errorMessage = partitionStateData.get().errorMessage();
+                        if (errorMessage == null || errorMessage.isEmpty()) {
+                            errorMessage = error.message();
+                        }
+
                         switch (error) {
                             case NONE:
                                 readStateBackoff.resetAttempts();
@@ -885,7 +904,7 @@ public class PersisterStateManager {
                             case COORDINATOR_LOAD_IN_PROGRESS:
                             case NOT_COORDINATOR:
                             case UNKNOWN_TOPIC_OR_PARTITION:
-                                log.debug("Received retriable error in read state RPC for key {}: {}", partitionKey(), error.message());
+                                log.debug("Received retriable error in read state RPC for key {}: {}", partitionKey(), errorMessage);
                                 if (!readStateBackoff.canAttempt()) {
                                     log.error("Exhausted max retries for read state RPC for key {} without success.", partitionKey());
                                     requestErrorResponse(error, new Exception("Exhausted max retries to complete read state RPC without success."));
@@ -896,7 +915,7 @@ public class PersisterStateManager {
                                 return;
 
                             default:
-                                log.error("Unable to perform read state RPC for key {}: {}", partitionKey(), error.message());
+                                log.error("Unable to perform read state RPC for key {}: {}", partitionKey(), errorMessage);
                                 requestErrorResponse(error, null);
                                 return;
                         }
@@ -1012,6 +1031,11 @@ public class PersisterStateManager {
 
                     if (partitionStateData.isPresent()) {
                         Errors error = Errors.forCode(partitionStateData.get().errorCode());
+                        String errorMessage = partitionStateData.get().errorMessage();
+                        if (errorMessage == null || errorMessage.isEmpty()) {
+                            errorMessage = error.message();
+                        }
+
                         switch (error) {
                             case NONE:
                                 readStateSummaryBackoff.resetAttempts();
@@ -1028,7 +1052,7 @@ public class PersisterStateManager {
                             case COORDINATOR_LOAD_IN_PROGRESS:
                             case NOT_COORDINATOR:
                             case UNKNOWN_TOPIC_OR_PARTITION:
-                                log.debug("Received retriable error in read state summary RPC for key {}: {}", partitionKey(), error.message());
+                                log.debug("Received retriable error in read state summary RPC for key {}: {}", partitionKey(), errorMessage);
                                 if (!readStateSummaryBackoff.canAttempt()) {
                                     log.error("Exhausted max retries for read state summary RPC for key {} without success.", partitionKey());
                                     requestErrorResponse(error, new Exception("Exhausted max retries to complete read state summary RPC without success."));
@@ -1039,7 +1063,7 @@ public class PersisterStateManager {
                                 return;
 
                             default:
-                                log.error("Unable to perform read state summary RPC for key {}: {}", partitionKey(), error.message());
+                                log.error("Unable to perform read state summary RPC for key {}: {}", partitionKey(), errorMessage);
                                 requestErrorResponse(error, null);
                                 return;
                         }
@@ -1152,6 +1176,11 @@ public class PersisterStateManager {
 
                     if (partitionStateData.isPresent()) {
                         Errors error = Errors.forCode(partitionStateData.get().errorCode());
+                        String errorMessage = partitionStateData.get().errorMessage();
+                        if (errorMessage == null || errorMessage.isEmpty()) {
+                            errorMessage = error.message();
+                        }
+
                         switch (error) {
                             case NONE:
                                 deleteStateBackoff.resetAttempts();
@@ -1168,7 +1197,7 @@ public class PersisterStateManager {
                             case COORDINATOR_LOAD_IN_PROGRESS:
                             case NOT_COORDINATOR:
                             case UNKNOWN_TOPIC_OR_PARTITION:
-                                log.debug("Received retriable error in delete state RPC for key {}: {}", partitionKey(), error.message());
+                                log.debug("Received retriable error in delete state RPC for key {}: {}", partitionKey(), errorMessage);
                                 if (!deleteStateBackoff.canAttempt()) {
                                     log.error("Exhausted max retries for delete state RPC for key {} without success.", partitionKey());
                                     requestErrorResponse(error, new Exception("Exhausted max retries to complete delete state RPC without success."));
@@ -1179,7 +1208,7 @@ public class PersisterStateManager {
                                 return;
 
                             default:
-                                log.error("Unable to perform delete state RPC for key {}: {}", partitionKey(), error.message());
+                                log.error("Unable to perform delete state RPC for key {}: {}", partitionKey(), errorMessage);
                                 requestErrorResponse(error, null);
                                 return;
                         }

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
@@ -604,7 +604,7 @@ public class PersisterStateManager {
 
                             default:
                                 log.error("Unable to perform initialize state RPC for key {}: {}", partitionKey(), errorMessage);
-                                requestErrorResponse(error, null);
+                                requestErrorResponse(error, new Exception(errorMessage));
                                 return;
                         }
                     }
@@ -768,7 +768,7 @@ public class PersisterStateManager {
 
                             default:
                                 log.error("Unable to perform write state RPC for key {}: {}", partitionKey(), errorMessage);
-                                requestErrorResponse(error, null);
+                                requestErrorResponse(error, new Exception(errorMessage));
                                 return;
                         }
                     }
@@ -916,7 +916,7 @@ public class PersisterStateManager {
 
                             default:
                                 log.error("Unable to perform read state RPC for key {}: {}", partitionKey(), errorMessage);
-                                requestErrorResponse(error, null);
+                                requestErrorResponse(error, new Exception(errorMessage));
                                 return;
                         }
                     }
@@ -1064,7 +1064,7 @@ public class PersisterStateManager {
 
                             default:
                                 log.error("Unable to perform read state summary RPC for key {}: {}", partitionKey(), errorMessage);
-                                requestErrorResponse(error, null);
+                                requestErrorResponse(error, new Exception(errorMessage));
                                 return;
                         }
                     }
@@ -1209,7 +1209,7 @@ public class PersisterStateManager {
 
                             default:
                                 log.error("Unable to perform delete state RPC for key {}: {}", partitionKey(), errorMessage);
-                                requestErrorResponse(error, null);
+                                requestErrorResponse(error, new Exception(errorMessage));
                                 return;
                         }
                     }

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
@@ -437,9 +437,9 @@ public class PersisterStateManager {
 
             FindCoordinatorResponseData.Coordinator coordinatorData = coordinators.get(0);
             Errors error = Errors.forCode(coordinatorData.errorCode());
-            String errMessage = coordinatorData.errorMessage();
-            if (errMessage == null || errMessage.isEmpty()) {
-                errMessage = error.message();
+            String errorMessage = coordinatorData.errorMessage();
+            if (errorMessage == null || errorMessage.isEmpty()) {
+                errorMessage = error.message();
             }
 
             switch (error) {
@@ -459,7 +459,7 @@ public class PersisterStateManager {
                 case COORDINATOR_LOAD_IN_PROGRESS:
                 case NOT_COORDINATOR:
                 case UNKNOWN_TOPIC_OR_PARTITION:
-                    log.debug("Received retriable error in find coordinator for {} using key {}: {}", name(), partitionKey(), errMessage);
+                    log.debug("Received retriable error in find coordinator for {} using key {}: {}", name(), partitionKey(), errorMessage);
                     if (!findCoordBackoff.canAttempt()) {
                         log.error("Exhausted max retries to find coordinator for {} using key {} without success.", name(), partitionKey());
                         findCoordinatorErrorResponse(error, new Exception("Exhausted max retries to find coordinator without success."));
@@ -471,7 +471,7 @@ public class PersisterStateManager {
 
                 default:
                     log.error("Unable to find coordinator for {} using key {}.", name(), partitionKey());
-                    findCoordinatorErrorResponse(error, new Exception(errMessage));
+                    findCoordinatorErrorResponse(error, new Exception(errorMessage));
             }
         }
 


### PR DESCRIPTION
* The persister receives the response from the share coordinator and
performs various actions based on the response error code.
* There was an issue in handling the error code and error message. We
were creating an Error object from the error code in the response but
not looking at the error message in the response.
* In some cases where a standard code has a custom associated message -
this will not provide complete information in the logs.
* In this PR, we rectify the situation by first checking the error
message in response and if empty, getting the standard message from
Errors object.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Apoorv Mittal
 <apoorvmittal10@gmail.com>
