### PR TITLE
MINOR: Re-add pageview demo to :streams:examples and remove dependency on :connect:json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
   gradleVersion = versions.gradle
   minClientJavaVersion = 11
   minNonClientJavaVersion = 17
-  modulesNeedingJava11 = [":clients", ":generator", ":streams", ":streams:test-utils", ":streams-scala", ":test-common:test-common-util"]
+  modulesNeedingJava11 = [":clients", ":generator", ":streams", ":streams:test-utils", ":streams:examples", ":streams-scala", ":test-common:test-common-util"]
 
   buildVersionFileName = "kafka-version.properties"
 
@@ -2917,10 +2917,10 @@ project(':streams:examples') {
   }
 
   dependencies {
-    // this dependency should be removed after we unify data API
-    implementation(project(':connect:json'))
     implementation project(':streams')
     implementation libs.slf4jApi
+    implementation libs.jacksonDatabind
+    implementation libs.jacksonAnnotations
 
     testImplementation project(':streams:test-utils')
     testImplementation project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -40,8 +40,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Properties;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Demonstrates how to perform a join between a KStream and a KTable, i.e. an example of a stateful computation,

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -65,11 +65,6 @@ public class PageViewUntypedDemo {
         private final ObjectMapper objectMapper = new ObjectMapper();
 
         @Override
-        public void configure(Map<String, ?> configs, boolean isKey) {
-            // No configuration needed
-        }
-
-        @Override
         public byte[] serialize(String topic, JsonNode data) {
             if (data == null) {
                 return null;
@@ -80,11 +75,6 @@ public class PageViewUntypedDemo {
                 throw new SerializationException("Error serializing JSON message", e);
             }
         }
-
-        @Override
-        public void close() {
-            // No resources to close
-        }
     }
 
     /**
@@ -92,11 +82,6 @@ public class PageViewUntypedDemo {
      */
     public static class JsonNodeDeserializer implements Deserializer<JsonNode> {
         private final ObjectMapper objectMapper = new ObjectMapper();
-
-        @Override
-        public void configure(Map<String, ?> configs, boolean isKey) {
-            // No configuration needed
-        }
 
         @Override
         public JsonNode deserialize(String topic, byte[] data) {
@@ -108,11 +93,6 @@ public class PageViewUntypedDemo {
             } catch (IOException e) {
                 throw new SerializationException("Error deserializing JSON message", e);
             }
-        }
-
-        @Override
-        public void close() {
-            // No resources to close
         }
     }
 

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Properties;
+import java.util.Map;
 
 /**
  * Demonstrates how to perform a join between a KStream and a KTable, i.e. an example of a stateful computation,
@@ -64,15 +65,25 @@ public class PageViewUntypedDemo {
         private final ObjectMapper objectMapper = new ObjectMapper();
 
         @Override
-        public byte[] serialize(String topic, JsonNode data) {
+        public void configure(final Map<String, ?> configs, final boolean isKey) {
+            // No configuration needed
+        }
+
+        @Override
+        public byte[] serialize(final String topic, final JsonNode data) {
             if (data == null) {
                 return null;
             }
             try {
                 return objectMapper.writeValueAsBytes(data);
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 throw new SerializationException("Error serializing JSON message", e);
             }
+        }
+
+        @Override
+        public void close() {
+            // No resources to close
         }
     }
 
@@ -83,15 +94,25 @@ public class PageViewUntypedDemo {
         private final ObjectMapper objectMapper = new ObjectMapper();
 
         @Override
-        public JsonNode deserialize(String topic, byte[] data) {
+        public void configure(final Map<String, ?> configs, final boolean isKey) {
+            // No configuration needed
+        }
+
+        @Override
+        public JsonNode deserialize(final String topic, final byte[] data) {
             if (data == null) {
                 return null;
             }
             try {
                 return objectMapper.readTree(data);
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 throw new SerializationException("Error deserializing JSON message", e);
             }
+        }
+
+        @Override
+        public void close() {
+            // No resources to close
         }
     }
 

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -40,7 +40,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Properties;
 
 /**

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -17,12 +17,11 @@
 package org.apache.kafka.streams.examples.pageview;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.json.JsonDeserializer;
-import org.apache.kafka.connect.json.JsonSerializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -35,10 +34,13 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -56,6 +58,64 @@ import java.util.Properties;
  */
 public class PageViewUntypedDemo {
 
+    /**
+     * Custom JSON serializer for JsonNode objects using Jackson ObjectMapper.
+     */
+    public static class JsonNodeSerializer implements Serializer<JsonNode> {
+        private final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            // No configuration needed
+        }
+
+        @Override
+        public byte[] serialize(String topic, JsonNode data) {
+            if (data == null) {
+                return null;
+            }
+            try {
+                return objectMapper.writeValueAsBytes(data);
+            } catch (IOException e) {
+                throw new SerializationException("Error serializing JSON message", e);
+            }
+        }
+
+        @Override
+        public void close() {
+            // No resources to close
+        }
+    }
+
+    /**
+     * Custom JSON deserializer for JsonNode objects using Jackson ObjectMapper.
+     */
+    public static class JsonNodeDeserializer implements Deserializer<JsonNode> {
+        private final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            // No configuration needed
+        }
+
+        @Override
+        public JsonNode deserialize(String topic, byte[] data) {
+            if (data == null) {
+                return null;
+            }
+            try {
+                return objectMapper.readTree(data);
+            } catch (IOException e) {
+                throw new SerializationException("Error deserializing JSON message", e);
+            }
+        }
+
+        @Override
+        public void close() {
+            // No resources to close
+        }
+    }
+
     public static void main(final String[] args) throws Exception {
         final Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-pageview-untyped");
@@ -68,8 +128,8 @@ public class PageViewUntypedDemo {
 
         final StreamsBuilder builder = new StreamsBuilder();
 
-        final Serializer<JsonNode> jsonSerializer = new JsonSerializer();
-        final Deserializer<JsonNode> jsonDeserializer = new JsonDeserializer();
+        final Serializer<JsonNode> jsonSerializer = new JsonNodeSerializer();
+        final Deserializer<JsonNode> jsonDeserializer = new JsonNodeDeserializer();
         final Serde<JsonNode> jsonSerde = Serdes.serdeFrom(jsonSerializer, jsonDeserializer);
 
         final Consumed<String, JsonNode> consumed = Consumed.with(Serdes.String(), jsonSerde);
@@ -77,15 +137,33 @@ public class PageViewUntypedDemo {
 
         final KTable<String, JsonNode> users = builder.table("streams-userprofile-input", consumed);
 
-        final KTable<String, String> userRegions = users.mapValues(record -> record.get("region").textValue());
+        final KTable<String, String> userRegions = users.mapValues(record -> {
+            if (record != null && record.has("region") && record.get("region") != null) {
+                return record.get("region").textValue();
+            }
+            return "UNKNOWN";
+        });
 
         final Duration duration24Hours = Duration.ofHours(24);
 
         final KStream<JsonNode, JsonNode> regionCount = views
             .leftJoin(userRegions, (view, region) -> {
                 final ObjectNode jNode = JsonNodeFactory.instance.objectNode();
-                return (JsonNode) jNode.put("user", view.get("user").textValue())
-                        .put("page", view.get("page").textValue())
+
+                // Safely extract user field
+                String user = "UNKNOWN";
+                if (view != null && view.has("user") && view.get("user") != null) {
+                    user = view.get("user").textValue();
+                }
+
+                // Safely extract page field
+                String page = "UNKNOWN";
+                if (view != null && view.has("page") && view.get("page") != null) {
+                    page = view.get("page").textValue();
+                }
+
+                return (JsonNode) jNode.put("user", user)
+                        .put("page", page)
                         .put("region", region == null ? "UNKNOWN" : region);
 
             })

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewUntypedDemo.java
@@ -137,33 +137,15 @@ public class PageViewUntypedDemo {
 
         final KTable<String, JsonNode> users = builder.table("streams-userprofile-input", consumed);
 
-        final KTable<String, String> userRegions = users.mapValues(record -> {
-            if (record != null && record.has("region") && record.get("region") != null) {
-                return record.get("region").textValue();
-            }
-            return "UNKNOWN";
-        });
+        final KTable<String, String> userRegions = users.mapValues(record -> record.get("region").textValue());
 
         final Duration duration24Hours = Duration.ofHours(24);
 
         final KStream<JsonNode, JsonNode> regionCount = views
             .leftJoin(userRegions, (view, region) -> {
                 final ObjectNode jNode = JsonNodeFactory.instance.objectNode();
-
-                // Safely extract user field
-                String user = "UNKNOWN";
-                if (view != null && view.has("user") && view.get("user") != null) {
-                    user = view.get("user").textValue();
-                }
-
-                // Safely extract page field
-                String page = "UNKNOWN";
-                if (view != null && view.has("page") && view.get("page") != null) {
-                    page = view.get("page").textValue();
-                }
-
-                return (JsonNode) jNode.put("user", user)
-                        .put("page", page)
+                return (JsonNode) jNode.put("user", view.get("user").textValue())
+                        .put("page", view.get("page").textValue())
                         .put("region", region == null ? "UNKNOWN" : region);
 
             })


### PR DESCRIPTION
With 4.0 release, we remove pageview demo because it depends on
`:connect:json` which requires JDK 17.  This PR removes the connect
dependency and adds a customized serializer and deserializer,  to make
pageview demo works with JDK 11.

Reviewers: Matthias J. Sax <matthias@confluent.io>
