### PR TITLE
KAFKA-19537 StreamsGroupCommand should return exit code

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.util.CommandLineUtils;
 import org.apache.kafka.tools.OffsetsUtils;
@@ -81,8 +82,14 @@ import joptsimple.OptionException;
 public class StreamsGroupCommand {
 
     static final String MISSING_COLUMN_VALUE = "-";
+    private static final int EXIT_CODE_SUCCESS = 0;
+    private static final int EXIT_CODE_ERROR = 1;
 
     public static void main(String[] args) {
+        Exit.exit(mainNoExit(args));
+    }
+
+    static int mainNoExit(String[] args) {
         StreamsGroupCommandOptions opts = new StreamsGroupCommandOptions(args);
         try {
             opts.checkArgs();
@@ -97,13 +104,14 @@ public class StreamsGroupCommand {
             if (numberOfActions != 1)
                 CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, or --delete-offsets.");
 
-            run(opts);
+            return run(opts);
         } catch (OptionException e) {
             CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage());
+            return EXIT_CODE_ERROR;
         }
     }
 
-    public static void run(StreamsGroupCommandOptions opts) {
+    static int run(StreamsGroupCommandOptions opts) {
         try (StreamsGroupService streamsGroupService = new StreamsGroupService(opts, Map.of())) {
             if (opts.options.has(opts.listOpt)) {
                 streamsGroupService.listGroups();
@@ -117,16 +125,26 @@ public class StreamsGroupCommand {
                 } else
                     printOffsetsToReset(offsetsToReset);
             } else if (opts.options.has(opts.deleteOpt)) {
-                streamsGroupService.deleteGroups();
+                Map<String, Throwable> result = streamsGroupService.deleteGroups();
+                if (result.values().stream().anyMatch(java.util.Objects::nonNull)) {
+                    return EXIT_CODE_ERROR;
+                }
             } else if (opts.options.has(opts.deleteOffsetsOpt)) {
-                streamsGroupService.deleteOffsets();
+                Map.Entry<Errors, Map<TopicPartition, Throwable>> res = streamsGroupService.deleteOffsets();
+                boolean hasErrors = res.getKey() != Errors.NONE || res.getValue().values().stream().anyMatch(java.util.Objects::nonNull);
+                if (hasErrors) {
+                    return EXIT_CODE_ERROR;
+                }
             } else {
                 throw new IllegalArgumentException("Unknown action!");
             }
+            return EXIT_CODE_SUCCESS;
         } catch (IllegalArgumentException e) {
             CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage());
+            return EXIT_CODE_ERROR;
         } catch (Throwable e) {
             printError("Executing streams group command failed due to " + e.getMessage(), Optional.of(e));
+            return EXIT_CODE_ERROR;
         }
     }
 


### PR DESCRIPTION
The newly added `StreamsGroupCommand.java` tool, does not return a popper error code, what might break scripts which use `bin/kafka-streams-group.sh` as they cannot do proper error handling.

Similar to existing [`StreamsResetter.java`](https://github.com/apache/kafka/blob/trunk/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java) we should return a proper error code.