### PR TITLE
KAFKA-19551: Remove the handling of FatalExitError in RemoteStorageThreadPool

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.storage.internals.log;
 
-import org.apache.kafka.common.internals.FatalExitError;
-import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
@@ -55,14 +53,8 @@ public final class RemoteStorageThreadPool extends ThreadPoolExecutor {
 
     @Override
     protected void afterExecute(Runnable runnable, Throwable th) {
-        if (th != null) {
-            if (th instanceof FatalExitError) {
-                LOGGER.error("Stopping the server as it encountered a fatal error.");
-                Exit.exit(((FatalExitError) th).statusCode());
-            } else {
-                if (!isShutdown())
-                    LOGGER.error("Error occurred while executing task: {}", runnable, th);
-            }
+        if (th != null && !isShutdown()) {
+            LOGGER.error("Error occurred while executing task: {}", runnable, th);
         }
     }
 


### PR DESCRIPTION
FatalExitError is not thrown after
[KAFKA-19425](https://issues.apache.org/jira/browse/KAFKA-19425). Clean
up the handling of FatalExitError in `RemoteStorageThreadPool`.
