### PR TITLE
MINOR: Delete the redundant feature upgrade instruction for running KIP-1071 EA

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -213,9 +213,7 @@
         Set <code>unstable.feature.versions.enable=true</code> for controllers and brokers, and
         set <code>unstable.api.versions.enable=true</code> on the brokers as well. In your Kafka Streams application
         configuration, set <code>group.protocol=streams</code>.
-        Upgrade the `streams.version` feature to 1. To do this, run
-	<code>kafka-features.sh --bootstrap-server localhost:9092 upgrade --feature streams.version=1</code>
-	to upgrade, or use Admin#updateFeatures API to update `streams.version`. After the feature is updated, check
+        After the new feature is configured, check
 	<code>kafka-features.sh --bootstrap-server localhost:9092 describe</code>
 	and `streams.version` should now have FinalizedVersionLevel 1.
     </p>


### PR DESCRIPTION
Follow up on https://github.com/apache/kafka/pull/20241.

Delete the instruction that manually set `streams.version=1` for running
Kafka 4.1 since it is already achieved in previous setup steps.

Reviewers: Lucas Brutschy <lucasbru@apache.org>
