### PR TITLE
fix(windows): replace deprecated wmic command on Windows 11

### DIFF
--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -14,6 +14,8 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
+set KAFKA_OPTS=-Duser.language=en -Duser.country=US
+
 IF [%1] EQU [] (
 	echo USAGE: %0 server.properties
 	EXIT /B 1
@@ -24,9 +26,8 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
     set KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=%~dp0../../config/log4j2.yaml
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
-    rem detect OS architecture
-    wmic os get osarchitecture | find /i "32-bit" >nul 2>&1
-    IF NOT ERRORLEVEL 1 (
+    rem detect OS architecture using environment variable
+    IF /I "%PROCESSOR_ARCHITECTURE%"=="x86" (
         rem 32-bit OS
         set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
     ) ELSE (


### PR DESCRIPTION
### Summary
This PR fixes an issue on Windows systems where the wmic command used to detect OS architecture is deprecated and may cause failures in Kafka startup scripts. It replaces the wmic command with a check on the environment variable %PROCESSOR_ARCHITECTURE% to determine whether the OS is 32-bit or 64-bit.

Additionally, this PR sets the KAFKA_OPTS environment variable to force the Java runtime to use the English (US) locale (-Duser.language=en -Duser.country=US) during Kafka startup on Windows. This ensures consistent locale behavior, which can help prevent locale-related issues in logs and error messages.

**Changes**

- Removed deprecated wmic command and replaced it with environment variable detection.
- Added set KAFKA_OPTS=-Duser.language=en -Duser.country=US in the Windows startup batch script.
- Updated comments to reflect the changes.

**Motivation**

- wmic is deprecated and may not be available on future Windows releases.
- Using %PROCESSOR_ARCHITECTURE% is a more reliable and lightweight way to detect OS bitness.
- Explicitly setting locale properties improves Kafka’s behavior on non-English or multi-lingual Windows systems.

**Testing**

- Confirmed Kafka launches successfully


**Notes**
This change only affects Kafka when started using the Windows batch scripts.

