### PR TITLE
KAFKA-19563: improve the add controller doc

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4123,6 +4123,9 @@ Feature: metadata.version       SupportedMinVersion: 3.3-IV3    SupportedMaxVers
   When using controller endpoints use the --bootstrap-controller flag:
   <pre><code class="language-bash">$ bin/kafka-metadata-quorum.sh --command-config config/controller.properties --bootstrap-controller localhost:9093 add-controller</code></pre>
 
+  <p>Note that if there are any configs needed to be passed to the Admin Client, like the authentication configuration,
+    please also include in the "controller.properties".</p>
+
   <h5 class="anchor-heading"><a id="kraft_reconfig_remove" class="anchor-link"></a><a href="#kraft_reconfig_remove">Remove Controller</a></h5>
   If the dynamic controller cluster already exists, it can be shrunk using the <code>bin/kafka-metadata-quorum.sh remove-controller</code> command. Until KIP-996: Pre-vote has been implemented and released, it is recommended to shutdown the controller that will be removed before running the remove-controller command.
 


### PR DESCRIPTION
JIRA: [KAFKA-19563](https://issues.apache.org/jira/browse/KAFKA-19563)
Improve the add-controller doc to notify users they have to add the
configs to be passed to admin client into the controller.properties
before the improvement is done.
```
--command-config COMMAND_CONFIG
      Property file containing configs to be passed to Admin Client.
For  add-controller,  the file is used to specify the controller
properties as well.
```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
