### PR TITLE
MINOR: Cleanups in storage module

### DIFF
--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
@@ -206,7 +206,7 @@ public final class TieredStorageTestBuilder {
                                                                  RemoteFetchCount remoteFetchRequestCount) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         assertTrue(partition >= 0, "Partition must be >= 0");
-        assertTrue(remoteFetchRequestCount.getSegmentFetchCountAndOp().getCount() >= 0, "Expected fetch count from tiered storage must be >= 0");
+        assertTrue(remoteFetchRequestCount.getSegmentFetchCountAndOp().count() >= 0, "Expected fetch count from tiered storage must be >= 0");
         assertFalse(fetchables.containsKey(topicPartition), "Consume already in progress for " + topicPartition);
         fetchables.put(topicPartition, new FetchableSpec(fromBroker, remoteFetchRequestCount));
         return this;

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ConsumeAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/ConsumeAction.java
@@ -25,6 +25,7 @@ import org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent;
 import org.apache.kafka.server.log.remote.storage.LocalTieredStorageHistory;
 import org.apache.kafka.tiered.storage.TieredStorageTestAction;
 import org.apache.kafka.tiered.storage.TieredStorageTestContext;
+import org.apache.kafka.tiered.storage.specs.FetchCountAndOp;
 import org.apache.kafka.tiered.storage.specs.RemoteFetchCount;
 import org.apache.kafka.tiered.storage.specs.RemoteFetchSpec;
 
@@ -141,16 +142,16 @@ public final class ConsumeAction implements TieredStorageTestAction {
                     .orElse(events);
 
             RemoteFetchCount remoteFetchCount = remoteFetchSpec.remoteFetchCount();
-            RemoteFetchCount.FetchCountAndOp expectedCountAndOp = switch (eventType) {
+            FetchCountAndOp expectedCountAndOp = switch (eventType) {
                 case FETCH_SEGMENT -> remoteFetchCount.getSegmentFetchCountAndOp();
                 case FETCH_OFFSET_INDEX -> remoteFetchCount.getOffsetIdxFetchCountAndOp();
                 case FETCH_TIME_INDEX -> remoteFetchCount.getTimeIdxFetchCountAndOp();
                 case FETCH_TRANSACTION_INDEX -> remoteFetchCount.getTxnIdxFetchCountAndOp();
-                default -> new RemoteFetchCount.FetchCountAndOp(-1, RemoteFetchCount.OperationType.EQUALS_TO);
+                default -> new FetchCountAndOp(-1, RemoteFetchCount.OperationType.EQUALS_TO);
             };
 
-            RemoteFetchCount.OperationType exceptedOperationType = expectedCountAndOp.getOperationType();
-            int exceptedCount = expectedCountAndOp.getCount();
+            RemoteFetchCount.OperationType exceptedOperationType = expectedCountAndOp.operationType();
+            int exceptedCount = expectedCountAndOp.count();
             int actualCount = eventsInScope.size();
             String message = errorMessage(eventType, actualCount, exceptedOperationType, exceptedCount);
             if (exceptedCount != -1) {

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndTxnConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndTxnConsumeFromLeaderTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.apache.kafka.tiered.storage.TieredStorageTestBuilder;
 import org.apache.kafka.tiered.storage.TieredStorageTestHarness;
+import org.apache.kafka.tiered.storage.specs.FetchCountAndOp;
 import org.apache.kafka.tiered.storage.specs.KeyValueSpec;
 import org.apache.kafka.tiered.storage.specs.RemoteFetchCount;
 
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.kafka.tiered.storage.specs.RemoteFetchCount.FetchCountAndOp;
 import static org.apache.kafka.tiered.storage.specs.RemoteFetchCount.OperationType.LESS_THAN_OR_EQUALS_TO;
 
 /**

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchCountAndOp.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/FetchCountAndOp.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tiered.storage.specs;
+
+public record FetchCountAndOp(
+    int count,
+    RemoteFetchCount.OperationType operationType
+) {
+    public FetchCountAndOp(int count) {
+        this(count, RemoteFetchCount.OperationType.EQUALS_TO);
+    }
+
+    @Override
+    public String toString() {
+        return "FetchCountAndOp{" +
+            "count=" + count +
+            ", operationType=" + operationType +
+            '}';
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchCount.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/specs/RemoteFetchCount.java
@@ -85,35 +85,4 @@ public class RemoteFetchCount {
         GREATER_THAN_OR_EQUALS_TO,
         LESS_THAN_OR_EQUALS_TO
     }
-
-    public static class FetchCountAndOp {
-        private final int count;
-        private final OperationType operationType;
-
-        public FetchCountAndOp(int count) {
-            this.count = count;
-            this.operationType = OperationType.EQUALS_TO;
-        }
-
-        public FetchCountAndOp(int count, OperationType operationType) {
-            this.count = count;
-            this.operationType = operationType;
-        }
-
-        public int getCount() {
-            return count;
-        }
-
-        public OperationType getOperationType() {
-            return operationType;
-        }
-
-        @Override
-        public String toString() {
-            return "FetchCountAndOp{" +
-                    "count=" + count +
-                    ", operationType=" + operationType +
-                    '}';
-        }
-    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/LocalTieredStorageOutput.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/LocalTieredStorageOutput.java
@@ -25,6 +25,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.SEGMENT;
 
@@ -67,15 +68,15 @@ public final class LocalTieredStorageOutput<K, V> implements LocalTieredStorageT
             if (records.isEmpty()) {
                 output += row(segFilename, -1, "");
             } else {
-                List<Tuple2<Long, String>> offsetKeyValues = records
+                List<Map.Entry<Long, String>> offsetKeyValues = records
                         .stream()
-                        .map(record -> new Tuple2<>(record.offset(),
+                        .map(record -> Map.entry(record.offset(),
                                 "(" + des(keyDe, record.key()) + ", " + des(valueDe, record.value()) + ")"))
                         .toList();
-                output += row(segFilename, offsetKeyValues.get(0).t1, offsetKeyValues.get(0).t2);
+                output += row(segFilename, offsetKeyValues.get(0).getKey(), offsetKeyValues.get(0).getValue());
                 if (offsetKeyValues.size() > 1) {
                     offsetKeyValues.subList(1, records.size()).forEach(offsetKeyValue ->
-                            output += row("", offsetKeyValue.t1, offsetKeyValue.t2));
+                            output += row("", offsetKeyValue.getKey(), offsetKeyValue.getValue()));
                 }
             }
             output += row();
@@ -90,8 +91,5 @@ public final class LocalTieredStorageOutput<K, V> implements LocalTieredStorageT
 
     private String des(Deserializer<?> de, ByteBuffer bytes) {
         return de.deserialize(currentTopic, Utils.toNullableArray(bytes)).toString();
-    }
-
-    private record Tuple2<T1, T2>(T1 t1, T2 t2) {
     }
 }


### PR DESCRIPTION
Cleanups including:

- Rewrite `FetchCountAndOp`  as a record class
- Replace `Tuple` by `Map.Entry`

Reviewers: TengYao Chi <frankvicky@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>
