### PR TITLE
KAFKA-19513: Flaky test: AclControlManagerTest.testDeleteExceedsMaxRecords()

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/AclControlManagerTest.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-@Timeout(value = 40)
+@Timeout(value = 120)
 public class AclControlManagerTest {
     /**
      * Verify that validateNewAcl catches invalid ACLs.


### PR DESCRIPTION
Increase the timeout for AclControlManagerTest to 120 secondes.
Base on the report of this build https://github.com/apache/kafka/actions/runs/16310027994?pr=20164
The test timeout after the original configuration(40s) and the execution time is around 55s.
The test method testDeleteExceedsMaxRecords is recently added in [PR 19974](https://github.com/apache/kafka/pull/19974/files) and has a 10000-time loop.