### PR TITLE
MINOR: Fix typo in GetOffsetShell

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -263,7 +263,7 @@ public class GetOffsetShell {
         }
     }
 
-    // visible for tseting
+    // Visible for testing
     static OffsetSpec parseOffsetSpec(String listOffsetsTimestamp) throws TerseException {
         switch (listOffsetsTimestamp) {
             case "earliest":


### PR DESCRIPTION
Fix typo in GetOffsetShell : `visible for tseting` -> `Visible for
testing`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
