### PR TITLE
MINOR: Fix javadoc mistake

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
@@ -239,8 +239,8 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
  * In <code>read_uncommitted</code> isolation level, the share group consumes all non-transactional and transactional
  * records. The consumption is bounded by the high-water mark.
  * <p>
- * In <code>read_committed</code> isolation level (not yet supported), the share group only consumes non-transactional
- * records and committed transactional records. The set of records which are eligible to become in-flight records are
+ * In <code>read_committed</code> isolation level, the share group only consumes non-transactional records and
+ * committed transactional records. The set of records which are eligible to become in-flight records are
  * non-transactional records and committed transactional records only. The consumption is bounded by the last stable
  * offset, so an open transaction blocks the progress of the share group with read_committed isolation level.
  *
@@ -497,7 +497,7 @@ public class KafkaShareConsumer<K, V> implements ShareConsumer<K, V> {
      * <p>This method can only be used if the consumer is using <b>explicit acknowledgement</b>.
      *
      * @param record The record to acknowledge
-     * @param type The acknowledgement type which indicates whether it was processed successfully
+     * @param type The acknowledge type which indicates whether it was processed successfully
      *
      * @throws IllegalStateException if the record is not waiting to be acknowledged, or the consumer is not using
      *                               explicit acknowledgement


### PR DESCRIPTION
Fixes a couple of tiny mistakes in the javadoc for KafkaShareConsumer.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
