### PR TITLE
MINOR: Improve skip-record-metadata description

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -638,7 +638,7 @@ object DumpLogSegments {
       " Instead, the value-decoder-class option can be used if a custom RLMM implementation is configured.")
     private val shareStateOpt = parser.accepts("share-group-state-decoder", "If set, log data will be parsed as share group state data from the " +
       "__share_group_state topic.")
-    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Whether to skip printing metadata for each record and control records.")
+    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Whether to skip printing control records, and metadata for each other record.")
     options = parser.parse(args : _*)
 
     def messageParser: MessageParser[_, _] =

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -638,7 +638,7 @@ object DumpLogSegments {
       " Instead, the value-decoder-class option can be used if a custom RLMM implementation is configured.")
     private val shareStateOpt = parser.accepts("share-group-state-decoder", "If set, log data will be parsed as share group state data from the " +
       "__share_group_state topic.")
-    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Whether to skip printing metadata for each record.")
+    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Whether to skip printing metadata for each record and control records.")
     options = parser.parse(args : _*)
 
     def messageParser: MessageParser[_, _] =

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -638,7 +638,7 @@ object DumpLogSegments {
       " Instead, the value-decoder-class option can be used if a custom RLMM implementation is configured.")
     private val shareStateOpt = parser.accepts("share-group-state-decoder", "If set, log data will be parsed as share group state data from the " +
       "__share_group_state topic.")
-    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Whether to skip printing control records, and metadata for each other record.")
+    private val skipRecordMetadataOpt = parser.accepts("skip-record-metadata", "Skip metadata when printing records. This flag also skips control records.")
     options = parser.parse(args : _*)
 
     def messageParser: MessageParser[_, _] =


### PR DESCRIPTION
This flag also skips control records, so the description needs to be updated.