### PR TITLE
MINOR: Run CI with Java 24

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -97,6 +97,8 @@ runs:
         -Pkafka.cluster.test.repeat=$TEST_REPEAT \
         -Pkafka.test.verbose=$TEST_VERBOSE \
         -PcommitId=xxxxxxxxxxxxxxxx \
+        -x spotbugsMain \
+        -x spotbugsTest \
         $TEST_TASK
         exitcode="$?"
         echo "exitcode=$exitcode" >> $GITHUB_OUTPUT

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -97,6 +97,8 @@ runs:
         -Pkafka.cluster.test.repeat=$TEST_REPEAT \
         -Pkafka.test.verbose=$TEST_VERBOSE \
         -PcommitId=xxxxxxxxxxxxxxxx \
+        # This build step is invoked by build.yml to run junit tests only,
+        # Spotbugs is being run by that workflow via the "check" task and does not need to also be run here.
         -x spotbugsMain \
         -x spotbugsTest \
         $TEST_TASK

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -83,6 +83,9 @@ runs:
         RUN_FLAKY_TESTS: ${{ inputs.run-flaky-tests }}
         TEST_XML_OUTPUT_DIR: ${{ inputs.test-xml-output }}
         TEST_VERBOSE: ${{ inputs.test-verbose }}
+      # This build step is invoked by build.yml to run junit tests only,
+      # Spotbugs is being run by that workflow via the "check" task and does not need to also be run here,
+      # since that is redundant.
       run: |
         set +e
         ./.github/scripts/thread-dump.sh &
@@ -97,7 +100,7 @@ runs:
         -Pkafka.cluster.test.repeat=$TEST_REPEAT \
         -Pkafka.test.verbose=$TEST_VERBOSE \
         -PcommitId=xxxxxxxxxxxxxxxx \ 
-        -x spotbugsMain \ # This build step is invoked by build.yml to run junit tests only, Spotbugs is being run by that workflow via the "check" task and does not need to also be run here, since that is redundant.
+        -x spotbugsMain \
         -x spotbugsTest \
         $TEST_TASK
         exitcode="$?"

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -99,7 +99,7 @@ runs:
         -Pkafka.test.xml.output.dir=$TEST_XML_OUTPUT_DIR \
         -Pkafka.cluster.test.repeat=$TEST_REPEAT \
         -Pkafka.test.verbose=$TEST_VERBOSE \
-        -PcommitId=xxxxxxxxxxxxxxxx \ 
+        -PcommitId=xxxxxxxxxxxxxxxx \
         -x spotbugsMain \
         -x spotbugsTest \
         $TEST_TASK

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -98,7 +98,8 @@ runs:
         -Pkafka.test.verbose=$TEST_VERBOSE \
         -PcommitId=xxxxxxxxxxxxxxxx \
         # This build step is invoked by build.yml to run junit tests only,
-        # Spotbugs is being run by that workflow via the "check" task and does not need to also be run here.
+        # Spotbugs is being run by that workflow via the "check" task and does not need to also be run here,
+        # since that is redundant.
         -x spotbugsMain \
         -x spotbugsTest \
         $TEST_TASK

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -96,11 +96,8 @@ runs:
         -Pkafka.test.xml.output.dir=$TEST_XML_OUTPUT_DIR \
         -Pkafka.cluster.test.repeat=$TEST_REPEAT \
         -Pkafka.test.verbose=$TEST_VERBOSE \
-        -PcommitId=xxxxxxxxxxxxxxxx \
-        # This build step is invoked by build.yml to run junit tests only,
-        # Spotbugs is being run by that workflow via the "check" task and does not need to also be run here,
-        # since that is redundant.
-        -x spotbugsMain \
+        -PcommitId=xxxxxxxxxxxxxxxx \ 
+        -x spotbugsMain \ # This build step is invoked by build.yml to run junit tests only, Spotbugs is being run by that workflow via the "check" task and does not need to also be run here, since that is redundant.
         -x spotbugsTest \
         $TEST_TASK
         exitcode="$?"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: 23
+          java-version: 17
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         # If we change these, make sure to adjust ci-complete.yml
-        java: [ 23, 17 ]
+        java: [ 24, 17 ]
         run-flaky: [ true, false ]
         run-new: [ true, false ]
         exclude:
@@ -270,7 +270,7 @@ jobs:
           python .github/scripts/junit.py \
            --path build/junit-xml >> $GITHUB_STEP_SUMMARY
 
-  # This job downloads all the JUnit XML files and thread dumps from the JDK 23 test runs.
+  # This job downloads all the JUnit XML files and thread dumps from the JDK 24 test runs.
   # If any test job fails, we will not run this job. Also, if any thread dump artifacts
   # are present, this means there was a timeout in the tests and so we will not proceed
   # with catalog creation.
@@ -288,7 +288,7 @@ jobs:
       - name: Download Thread Dumps
         uses: actions/download-artifact@v4
         with:
-          pattern: junit-thread-dumps-23-*
+          pattern: junit-thread-dumps-24-*
           path: thread-dumps
           merge-multiple: true
       - name: Check For Thread Dump
@@ -302,7 +302,7 @@ jobs:
       - name: Download JUnit XMLs
         uses: actions/download-artifact@v4
         with:
-          pattern: junit-xml-23-*  # Only look at JDK 23 tests for the test catalog
+          pattern: junit-xml-24-*  # Only look at JDK 24 tests for the test catalog
           path: junit-xml
           merge-multiple: true
       - name: Collate Test Catalog

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # Make sure these match build.yml
-        java: [ 23, 17 ]
+        java: [ 24, 17 ]
         run-flaky: [ true, false ]
         run-new: [ true, false ]
         exclude:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-We build and test Apache Kafka with 17 and 23. The `release` parameter in javac is set to `11` for the clients 
+We build and test Apache Kafka with 17 and 24. The `release` parameter in javac is set to `11` for the clients 
 and streams modules, and `17` for the rest, ensuring compatibility with their respective
 minimum Java versions. Similarly, the `release` parameter in scalac is set to `11` for the streams modules and `17`
 for the rest.

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,12 @@ ext {
       "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
     )
 
+  if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_24)) {
+    // Spotbugs is not compatible with Java 24+ until Spotbugs 4.9.4. Disable it until we can upgrade to that version.
+    project.gradle.startParameter.excludedTaskNames.add("spotbugsMain")
+    project.gradle.startParameter.excludedTaskNames.add("spotbugsTest")
+  }
+
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
   maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :
       Math.min(Runtime.runtime.availableProcessors(), 8)

--- a/docs/documentation/compatibility.html
+++ b/docs/documentation/compatibility.html
@@ -30,7 +30,7 @@
                 <th>Kafka Version</th>
                 <th>Java 11</th>
                 <th>Java 17</th>
-                <th>Java 23</th>
+                <th>Java 24</th>
             </tr>
             <tr>
                 <td>Clients</td>

--- a/docs/documentation/compatibility.html
+++ b/docs/documentation/compatibility.html
@@ -30,7 +30,7 @@
                 <th>Kafka Version</th>
                 <th>Java 11</th>
                 <th>Java 17</th>
-                <th>Java 24</th>
+                <th>Java 23</th>
             </tr>
             <tr>
                 <td>Clients</td>


### PR DESCRIPTION
This commit updates CI to test against Java 24 instead of Java 23 which
is EOL.

Due to Spotbugs not having released version 4.9.4 yet, we can't run
Spotbugs on Java 24. Instead, we are choosing to run Spotbugs, and the
rest of the compile and validate build step, on Java 17 for now.

Once 4.9.4 has released, we will switch to using Java 24 for this.

Exclude spotbugs from the run-tests gradle action. Spotbugs is already
being run once in the build by "compile and validate", there is no
reason  to run it again as part of executing tests.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
