### PR TITLE
KAFKA-19573: Update num.recovery.threads.per.data.dir configs

### DIFF
--- a/config/broker.properties
+++ b/config/broker.properties
@@ -76,7 +76,7 @@ num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
 # This value is recommended to be increased for installations with data dirs located in RAID array.
-num.recovery.threads.per.data.dir=1
+num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################
 # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"

--- a/config/broker.properties
+++ b/config/broker.properties
@@ -75,7 +75,7 @@ log.dirs=/tmp/kraft-broker-logs
 num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
-# This value is recommended to be increased for installations with data dirs located in RAID array.
+# This value is recommended to be increased based on the installation resources.
 num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################

--- a/config/controller.properties
+++ b/config/controller.properties
@@ -75,7 +75,7 @@ log.dirs=/tmp/kraft-controller-logs
 num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
-# This value is recommended to be increased for installations with data dirs located in RAID array.
+# This value is recommended to be increased based on the installation resources.
 num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################

--- a/config/controller.properties
+++ b/config/controller.properties
@@ -76,7 +76,7 @@ num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
 # This value is recommended to be increased for installations with data dirs located in RAID array.
-num.recovery.threads.per.data.dir=1
+num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################
 # The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"

--- a/config/server.properties
+++ b/config/server.properties
@@ -78,7 +78,7 @@ log.dirs=/tmp/kraft-combined-logs
 num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
-# This value is recommended to be increased for installations with data dirs located in RAID array.
+# This value is recommended to be increased based on the installation resources.
 num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################

--- a/config/server.properties
+++ b/config/server.properties
@@ -79,7 +79,7 @@ num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
 # This value is recommended to be increased for installations with data dirs located in RAID array.
-num.recovery.threads.per.data.dir=1
+num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################
 # The replication factor for the group metadata internal topics "__consumer_offsets", "__share_group_state" and "__transaction_state"

--- a/docker/server.properties
+++ b/docker/server.properties
@@ -87,7 +87,7 @@ log.dirs=/tmp/kraft-combined-logs
 num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
-# This value is recommended to be increased for installations with data dirs located in RAID array.
+# This value is recommended to be increased based on the installation resources.
 num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################

--- a/docker/server.properties
+++ b/docker/server.properties
@@ -88,7 +88,7 @@ num.partitions=1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
 # This value is recommended to be increased for installations with data dirs located in RAID array.
-num.recovery.threads.per.data.dir=1
+num.recovery.threads.per.data.dir=2
 
 ############################# Internal Topic Settings  #############################
 # The replication factor for the group metadata internal topics "__consumer_offsets", "__share_group_state" and "__transaction_state"


### PR DESCRIPTION
The default value of `num.recovery.threads.per.data.dir` is now 2 according to KIP-1030. We should update config files which are still setting 1.

Reviewers: Luke Chen <showuon@gmail.com>
