### PR TITLE
MINOR: Add test coverage for StorageTool format command feature validation

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -256,6 +256,7 @@ public class Formatter {
         releaseVersion = calculateEffectiveReleaseVersion();
         featureLevels = calculateEffectiveFeatureLevels();
         this.bootstrapMetadata = calculateBootstrapMetadata();
+        printStream.println("Bootstrap metadata: " + bootstrapMetadata);
         doFormat(bootstrapMetadata);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -256,7 +256,6 @@ public class Formatter {
         releaseVersion = calculateEffectiveReleaseVersion();
         featureLevels = calculateEffectiveFeatureLevels();
         this.bootstrapMetadata = calculateBootstrapMetadata();
-        printStream.println("Bootstrap metadata: " + bootstrapMetadata);
         doFormat(bootstrapMetadata);
     }
 
@@ -416,6 +415,7 @@ public class Formatter {
         if (ensemble.emptyLogDirs().isEmpty()) {
             printStream.println("All of the log directories are already formatted.");
         } else {
+            printStream.println("Bootstrap metadata: " + bootstrapMetadata);
             Map<String, DirectoryType> directoryTypes = new HashMap<>();
             for (String emptyLogDir : ensemble.emptyLogDirs()) {
                 DirectoryType directoryType = DirectoryType.calculate(emptyLogDir,

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -188,7 +188,7 @@ public class FormatterTest {
             FormatterContext formatter2 = testEnv.newFormatter();
             formatter2.formatter.setIgnoreFormatted(true);
             formatter2.formatter.run();
-            assertTrue(formatter2.output().trim().contains("\nAll of the log directories are already formatted."));
+            assertTrue(formatter2.output().trim().contains("All of the log directories are already formatted."));
         }
     }
 
@@ -212,8 +212,7 @@ public class FormatterTest {
                 .setIgnoreFormatted(true)
                 .setInitialControllers(DynamicVoters.parse("1@localhost:8020:" + newDirectoryId))
                 .run();
-            assertEquals("Bootstrap metadata: " + formatter2.formatter.bootstrapMetadata() +
-                    "\nAll of the log directories are already formatted.",
+            assertEquals("All of the log directories are already formatted.",
                 formatter2.output().trim());
             assertMetadataDirectoryId(testEnv, Uuid.fromString(originalDirectoryId));
         }

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -89,7 +89,7 @@ public class FormatterTest {
             Formatter formatter = new Formatter().
                 setNodeId(DEFAULT_NODE_ID).
                 setClusterId(DEFAULT_CLUSTER_ID.toString());
-            directories.forEach(d -> formatter.addDirectory(d));
+            directories.forEach(formatter::addDirectory);
             formatter.setMetadataLogDirectory(directories.get(0));
             return new FormatterContext(formatter);
         }
@@ -170,7 +170,7 @@ public class FormatterTest {
             String expectedPrefix = "Error while writing meta.properties file";
             assertEquals(expectedPrefix,
                 assertThrows(FormatterException.class,
-                    () -> formatter1.formatter.run()).
+                    formatter1.formatter::run).
                         getMessage().substring(0, expectedPrefix.length()));
         }
     }
@@ -188,9 +188,7 @@ public class FormatterTest {
             FormatterContext formatter2 = testEnv.newFormatter();
             formatter2.formatter.setIgnoreFormatted(true);
             formatter2.formatter.run();
-            assertEquals("Bootstrap metadata: " + formatter2.formatter.bootstrapMetadata() +
-                    "\nAll of the log directories are already formatted.",
-                formatter2.output().trim());
+            assertTrue(formatter2.output().trim().contains("\nAll of the log directories are already formatted."));
         }
     }
 
@@ -278,7 +276,7 @@ public class FormatterTest {
             FormatterContext formatter1 = testEnv.newFormatter();
             formatter1.formatter.setReleaseVersion(MetadataVersion.latestTesting());
             assertEquals("metadata.version " + MetadataVersion.latestTesting() + " is not yet stable.",
-                assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage());
+                assertThrows(FormatterException.class, formatter1.formatter::run).getMessage());
         }
     }
 
@@ -325,7 +323,7 @@ public class FormatterTest {
                     "saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\"]"));
             assertEquals("SCRAM is only supported in metadata.version 3.5-IV2 or later.",
                 assertThrows(FormatterException.class,
-                    () -> formatter1.formatter.run()).getMessage());
+                    formatter1.formatter::run).getMessage());
         }
     }
 
@@ -414,7 +412,7 @@ public class FormatterTest {
                     "are: eligible.leader.replicas.version, group.version, kraft.version, " +
                     "share.version, streams.version, test.feature.version, transaction.version",
                 assertThrows(FormatterException.class,
-                    () -> formatter1.formatter.run()).
+                    formatter1.formatter::run).
                         getMessage());
         }
     }
@@ -468,7 +466,7 @@ public class FormatterTest {
                 "Cannot set kraft.version to 0 if one of the flags --standalone, --initial-controllers, or " +
                 "--no-initial-controllers is used. For dynamic controllers support, try removing the " +
                 "--feature flag for kraft.version.",
-                assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage()
+                assertThrows(FormatterException.class, formatter1.formatter::run).getMessage()
             );
         }
     }
@@ -484,7 +482,7 @@ public class FormatterTest {
                 "Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or " +
                 "--no-initial-controllers is used. For dynamic controllers support, try using one of " +
                 "--standalone, --initial-controllers, or --no-initial-controllers.",
-                assertThrows(FormatterException.class, () -> formatter1.formatter.run()).getMessage()
+                assertThrows(FormatterException.class, formatter1.formatter::run).getMessage()
             );
         }
     }
@@ -501,7 +499,7 @@ public class FormatterTest {
             assertEquals("kraft.version could not be set to 1 because it depends on " +
                 "metadata.version level 21",
                     assertThrows(IllegalArgumentException.class,
-                        () -> formatter1.formatter.run()).getMessage());
+                        formatter1.formatter::run).getMessage());
         }
     }
 
@@ -523,12 +521,12 @@ public class FormatterTest {
             formatter1.formatter.setInitialControllers(DynamicVoters.
                 parse("1@localhost:8020:4znU-ou9Taa06bmEJxsjnw"));
             if (metadataVersion.isAtLeast(MetadataVersion.IBP_4_0_IV1)) {
-                assertDoesNotThrow(() -> formatter1.formatter.run());
+                assertDoesNotThrow(formatter1.formatter::run);
             } else {
                 assertEquals("eligible.leader.replicas.version could not be set to 1 because it depends on " +
                     "metadata.version level 23",
                     assertThrows(IllegalArgumentException.class,
-                        () -> formatter1.formatter.run()).getMessage());
+                        formatter1.formatter::run).getMessage());
             }
         }
     }

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -180,14 +180,16 @@ public class FormatterTest {
         try (TestEnv testEnv = new TestEnv(1)) {
             FormatterContext formatter1 = testEnv.newFormatter();
             formatter1.formatter.run();
-            assertEquals("Formatting metadata directory " + testEnv.directory(0) +
-                " with metadata.version " + MetadataVersion.latestProduction() + ".",
-                    formatter1.output().trim());
+            assertEquals("Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata() +
+                    "\nFormatting metadata directory " + testEnv.directory(0) +
+                    " with metadata.version " + MetadataVersion.latestProduction() + ".",
+                formatter1.output().trim());
 
             FormatterContext formatter2 = testEnv.newFormatter();
             formatter2.formatter.setIgnoreFormatted(true);
             formatter2.formatter.run();
-            assertEquals("All of the log directories are already formatted.",
+            assertEquals("Bootstrap metadata: " + formatter2.formatter.bootstrapMetadata() +
+                    "\nAll of the log directories are already formatted.",
                 formatter2.output().trim());
         }
     }
@@ -201,7 +203,8 @@ public class FormatterTest {
             formatter1.formatter
                 .setInitialControllers(DynamicVoters.parse("1@localhost:8020:" + originalDirectoryId))
                 .run();
-            assertEquals("Formatting dynamic metadata voter directory " + testEnv.directory(0) +
+            assertEquals("Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata() +
+                    "\nFormatting dynamic metadata voter directory " + testEnv.directory(0) +
                     " with metadata.version " + MetadataVersion.latestProduction() + ".",
                 formatter1.output().trim());
             assertMetadataDirectoryId(testEnv, Uuid.fromString(originalDirectoryId));
@@ -211,7 +214,8 @@ public class FormatterTest {
                 .setIgnoreFormatted(true)
                 .setInitialControllers(DynamicVoters.parse("1@localhost:8020:" + newDirectoryId))
                 .run();
-            assertEquals("All of the log directories are already formatted.",
+            assertEquals("Bootstrap metadata: " + formatter2.formatter.bootstrapMetadata() +
+                    "\nAll of the log directories are already formatted.",
                 formatter2.output().trim());
             assertMetadataDirectoryId(testEnv, Uuid.fromString(originalDirectoryId));
         }
@@ -244,9 +248,10 @@ public class FormatterTest {
             FormatterContext formatter2 = testEnv.newFormatter();
             formatter2.formatter.setIgnoreFormatted(true);
             formatter2.formatter.run();
-            assertEquals("Formatting data directory " + testEnv.directory(1) + " with metadata.version " +
-                MetadataVersion.latestProduction() + ".",
-                    formatter2.output().trim());
+            assertEquals("Bootstrap metadata: " + formatter2.formatter.bootstrapMetadata() +
+                    "\nFormatting data directory " + testEnv.directory(1) + " with metadata.version " +
+                    MetadataVersion.latestProduction() + ".",
+                formatter2.output().trim());
         }
     }
 
@@ -256,9 +261,10 @@ public class FormatterTest {
             FormatterContext formatter1 = testEnv.newFormatter();
             formatter1.formatter.setReleaseVersion(MetadataVersion.IBP_3_5_IV0);
             formatter1.formatter.run();
-            assertEquals("Formatting metadata directory " + testEnv.directory(0) +
-                " with metadata.version " + MetadataVersion.IBP_3_5_IV0 + ".",
-                    formatter1.output().trim());
+            assertEquals("Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata() +
+                    "\nFormatting metadata directory " + testEnv.directory(0) +
+                    " with metadata.version " + MetadataVersion.IBP_3_5_IV0 + ".",
+                formatter1.output().trim());
             BootstrapMetadata bootstrapMetadata =
                 new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.IBP_3_5_IV0, bootstrapMetadata.metadataVersion());
@@ -283,9 +289,10 @@ public class FormatterTest {
             formatter1.formatter.setReleaseVersion(MetadataVersion.latestTesting());
             formatter1.formatter.setUnstableFeatureVersionsEnabled(true);
             formatter1.formatter.run();
-            assertEquals("Formatting metadata directory " + testEnv.directory(0) +
-                " with metadata.version " + MetadataVersion.latestTesting() + ".",
-                    formatter1.output().trim());
+            assertEquals("Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata() +
+                    "\nFormatting metadata directory " + testEnv.directory(0) +
+                    " with metadata.version " + MetadataVersion.latestTesting() + ".",
+                formatter1.output().trim());
             BootstrapMetadata bootstrapMetadata =
                     new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.latestTesting(), bootstrapMetadata.metadataVersion());
@@ -333,9 +340,10 @@ public class FormatterTest {
                 "SCRAM-SHA-512=[name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\"," +
                     "saltedpassword=\"mT0yyUUxnlJaC99HXgRTSYlbuqa4FSGtJCJfTMvjYCE=\"]"));
             formatter1.formatter.run();
-            assertEquals("Formatting metadata directory " + testEnv.directory(0) +
-                " with metadata.version " + MetadataVersion.IBP_3_8_IV0 + ".",
-                    formatter1.output().trim());
+            assertEquals("Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata() +
+                    "\nFormatting metadata directory " + testEnv.directory(0) +
+                    " with metadata.version " + MetadataVersion.IBP_3_8_IV0 + ".",
+                formatter1.output().trim());
             BootstrapMetadata bootstrapMetadata =
                 new BootstrapDirectory(testEnv.directory(0)).read();
             assertEquals(MetadataVersion.IBP_3_8_IV0, bootstrapMetadata.metadataVersion());
@@ -425,6 +433,7 @@ public class FormatterTest {
             formatter1.formatter.run();
             assertEquals((short) 1, formatter1.formatter.featureLevels.getOrDefault("kraft.version", (short) 0));
             assertEquals(List.of(
+                "Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata(),
                 String.format("Formatting data directory %s with %s %s.",
                     testEnv.directory(1),
                     MetadataVersion.FEATURE_NAME,
@@ -539,6 +548,7 @@ public class FormatterTest {
             formatter1.formatter.run();
             assertEquals((short) 1, formatter1.formatter.featureLevels.getOrDefault("kraft.version", (short) 0));
             assertEquals(List.of(
+                    "Bootstrap metadata: " + formatter1.formatter.bootstrapMetadata(),
                     String.format("Formatting data directory %s with %s %s.",
                         testEnv.directory(1),
                         MetadataVersion.FEATURE_NAME,


### PR DESCRIPTION
### Summary
Adds comprehensive test coverage for the StorageTool format command
feature validation, including tests for valid feature overrides, invalid
feature detection, and multiple feature specifications. Also adds debug
output to help with troubleshooting format operations.

### Changes Made

#### Test Coverage Improvements
- **`testFormatWithReleaseVersionAndFeatureOverride()`**: Tests that
feature overrides work correctly when specified with `--feature` flag

- **`testFormatWithInvalidFeatureThrowsError()`**: Tests error handling
for unsupported features

- **`testFormatWithMultipleFeatures()`**: Tests multiple feature
specifications in a single format command

#### Debug Output Enhancement
- **Formatter.java**: Added debug output to print bootstrap metadata
during format operations
  - Helps with troubleshooting format issues by showing the complete
bootstrap metadata being written
  - Improves visibility into what features and configurations are being
applied

#### Test Updates
- **FormatterTest.java**: Updated existing tests to account for the new
debug output\

### Related
- KIP-1022: [Formatting and Updating Features
](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1022%3A+Formatting+and+Updating+Features)

Reviewers: Kevin Wu <kevin.wu2412@gmail.com>, Justine Olshan
 <jolshan@confluent.io>
