### PR TITLE
MINOR: Improve RLMM doc

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -329,7 +329,22 @@
   <h3 class="anchor-heading"><a id="tieredstorageconfigs" class="anchor-link"></a><a href="#tieredstorageconfigs">3.11 Tiered Storage Configs</a></h3>
   Below is the Tiered Storage configuration.
   <!--#include virtual="generated/remote_log_manager_config.html" -->
+
+  <h4 class="anchor-heading"><a id="rlmmconfigs" class="anchor-link"></a><a href="#rlmmconfigs">3.11.1 RLMM Configs</a></h4>
+  <p>Below is the configuration for <code>TopicBasedRemoteLogMetadataManager</code>, which is the default implementation of <code>RemoteLogMetadataManager</code>.</p>
+  <p>All configurations here should start with the prefix defined by <code>remote.log.metadata.manager.impl.prefix</code>, for example, <code>rlmm.config.remote.log.metadata.consume.wait.ms</code>.</p>
   <!--#include virtual="generated/remote_log_metadata_manager_config.html" -->
+
+  <p>The implementation of <code>TopicBasedRemoteLogMetadataManager</code> needs to create admin, producer, and consumer clients for the internal topic <code>__remote_log_metadata</code>.</p>
+  <p>Additional configurations can be provided for different types of clients using the following configuration properties: </p>
+  <pre><code class="language-text"># Configs for admin, producer, and consumer clients
+&lt;rlmm.prefix&gt;.remote.log.metadata.common.client.&lt;kafka.property&gt; = &lt;value&gt;
+
+# Configs only for producer client
+&lt;rlmm.prefix&gt;.remote.log.metadata.producer.&lt;kafka.property&gt; = &lt;value&gt;
+
+# Configs only for consumer client
+&lt;rlmm.prefix&gt;.remote.log.metadata.consumer.&lt;kafka.property&gt; = &lt;value&gt;</code></pre>
 
   <h3 class="anchor-heading">
     <a id="config_providers" class="anchor-link"></a>


### PR DESCRIPTION
Improve RLMM doc:
1. Distinguish RLMM configs from other tiered storage configs, all RLMM configs need to start with a specific prefix, but the original documentation miss description.
2. Added description of additional configs for client, which is required when configuring authentication information. This can confuse users, for example: Aiven-Open/tiered-storage-for-apache-kafka#681

Reviewers: Luke Chen <showuon@gmail.com>, TengYao Chi <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
