### PR TITLE
KAFKA-17207: Recreate config topic in Connect test to prevent thread …

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -867,6 +867,9 @@ public class ConnectWorkerIntegrationTest {
                 "writing a config for connector " + CONNECTOR_NAME + " to the config topic",
                 false
         );
+
+        // Fix for KAFKA-17103: Recreate the config topic to allow producer shutdown and avoid thread leak
+        connect.kafka().createTopic(configTopic);
     }
 
     @Test


### PR DESCRIPTION
## Ticket
- https://issues.apache.org/jira/browse/KAFKA-17207

## Summary
This PR fixes the memory leak in
`ConnectDistributedRequestTimeoutIntegrationTest#testRequestTimeouts`,
where the producer hangs indefinitely after the config topic is deleted.

Root Cause:  The hang occurs inside the Kafka producer's internal
NetworkClient.poll() loop:

https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L645

Selector.poll(...) blocks while trying to reconnect to the broker and
send metadata requests for the deleted config topic. Since the topic is
gone and the MetadataRecoveryStrategy is set to NONE, the metadata
updater continues retrying, and the producer does not timeout or fail
fast. This causes test resources to hang indefinitely.

### Why not fix Kafka core?
While this looks like a Kafka client bug at first, it is technically
consistent with Kafka's design: the system is eventually consistent and
assumes topics may become available again. Therefore, hanging here is
expected behavior unless the producer is explicitly closed or the topic
reappears.

Fixing this behavior in the Kafka producer would require rethinking the
metadata handling policy or tightening timeouts, which is risky and out
of scope for this test.

### Fix:
I restore the deleted topic at the end of the test to allow the producer
to recover and shut down cleanly.

### Tests
- I ran the timeout test manually and verified that I no longer see the
initial error (`[2024-07-26 11:52:50,817] ERROR Executor
java.util.concurrent.ThreadPoolExecutor@7ae97a58[Shutting down, pool
size = 1, active threads = 1, queued tasks = 0, completed tasks = 0] did
not terminate in time (org.apache.kafka.common.utils.ThreadUtils:83)`)
