### PR TITLE
Add `rewrite` support for `RemoveUnusedImports`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,10 @@ jobs:
         # --no-scan:      For public fork PRs, we won't attempt to publish the scan
         run: |
           ./gradlew --build-cache --info $SCAN_ARG check releaseTarGz -x test
+      - name: rewriteDryRun
+        run: ./gradlew rewriteDryRun --build-cache -Dorg.gradle.jvmargs=-Xmx8G
+        # https://docs.openrewrite.org/reference/faq#im-getting-javalangoutofmemoryerror-java-heap-space-when-running-openrewrite
+        timeout-minutes: 90
       - name: Archive check reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ The import order is a part of static check. please call `spotlessApply` to optim
 
     ./gradlew spotlessApply
 
+#### Rewrite
+The build system incorporates [Moderne](https://moderne.io/) rewrite capabilities for automated code transformations.
+
+- **Convention** (e.g., JUnit's naming rules)
+- **Refactor** safely (e.g., rename methods, migrate APIs)
+- **Modernize** (e.g., Java 8 → Java 17 features)
+- **Patterns** (e.g., replace `Vector` with `ArrayList`)
+
+`./gradlew rewriteRun`
+
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.
 You can run spotbugs using:

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,10 @@ plugins {
   id 'org.scoverage' version '8.0.3' apply false
   id 'com.gradleup.shadow' version '8.3.6' apply false
   id 'com.diffplug.spotless' version "6.25.0"
+  id "org.openrewrite.rewrite" version "7.12.1"
 }
+
+apply from: "gradle/.qa/rewrite.gradle"
 
 ext {
   gradleVersion = versions.gradle

--- a/gradle/.qa/rewrite.gradle
+++ b/gradle/.qa/rewrite.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rewrite {
+    //activeRecipe("org.openrewrite.java.RemoveUnusedImports")
+    exportDatatables = true
+    exclusions.add("**.GarbageCollectedMemoryPoolTest.java")
+    exclusions.add("**.MetadataVersionTest.java")
+    failOnDryRunResults = true
+}
+
+dependencies {
+    rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:latest.release"))
+}


### PR DESCRIPTION
enabler for: 

- https://github.com/apache/kafka/pull/20219

### PoC: Add `rewrite` support for `errorprone.refasterrules.FileRulesRecipes`

trying to automate efforts like:

- https://github.com/apache/kafka/pull/20097

refs: 
- https://github.com/opensearch-project/OpenSearch/pull/18791
- https://github.com/diffplug/spotless/pull/2576
- https://github.com/apache/kafka/pull/20214
- https://error-prone.picnic.tech/refasterrules/StringRules/
- https://github.com/apache/kafka/pull/20219
- https://github.com/checkstyle/checkstyle/pull/17545