### PR TITLE
MINOR: Expose internal topic creation errors to the user

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -65,7 +65,6 @@ trait AutoTopicCreationManager {
 
 }
 
-  time: Time
 /**
  * Thread-safe cache that stores topic creation errors with per-entry expiration.
  * - Expiration: maintained by a min-heap (priority queue) on expiration time

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -56,7 +56,8 @@ trait AutoTopicCreationManager {
   ): Unit
 
   def getTopicCreationErrors(
-    topicNames: Set[String]
+    topicNames: Set[String],
+    errorCacheTtlMs: Long
   ): Map[String, String]
 
   def close(): Unit = {}
@@ -81,8 +82,6 @@ class DefaultAutoTopicCreationManager(
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
   private val topicCreationErrorCache = new ConcurrentHashMap[String, CachedTopicCreationError]()
-  // Use session timeout for better semantic alignment with client lifecycle
-  private val errorCacheTtlMs = config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs.toLong
 
   /**
    * Initiate auto topic creation for the given topics.
@@ -120,7 +119,8 @@ class DefaultAutoTopicCreationManager(
   }
 
   override def getTopicCreationErrors(
-    topicNames: Set[String]
+    topicNames: Set[String],
+    errorCacheTtlMs: Long
   ): Map[String, String] = {
     val currentTime = time.milliseconds()
     val errors = mutable.Map.empty[String, String]

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -74,7 +74,7 @@ private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
 
   private case class Entry(topicName: String, errorMessage: String, expirationTimeMs: Long)
 
-  private val byTopic = new java.util.HashMap[String, Entry]()
+  private val byTopic = new ConcurrentHashMap[String, Entry]()
   private val expiryQueue = new java.util.PriorityQueue[Entry](11, new java.util.Comparator[Entry] {
     override def compare(a: Entry, b: Entry): Int = java.lang.Long.compare(a.expirationTimeMs, b.expirationTimeMs)
   })
@@ -89,10 +89,20 @@ private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
         expiryQueue.remove(existing)
       }
 
-      val expirationTimeMs = time.milliseconds() + ttlMs
+      val currentTimeMs = time.milliseconds()
+      val expirationTimeMs = currentTimeMs + ttlMs
       val entry = Entry(topicName, errorMessage, expirationTimeMs)
       byTopic.put(topicName, entry)
       expiryQueue.add(entry)
+
+      // Clean up expired entries
+      while (!expiryQueue.isEmpty && expiryQueue.peek().expirationTimeMs <= currentTimeMs) {
+        val expired = expiryQueue.poll()
+        val current = byTopic.get(expired.topicName)
+        if (current != null && (current eq expired)) {
+          byTopic.remove(expired.topicName)
+        }
+      }
 
       // Enforce capacity by removing entries with earliest expiration time first
       while (byTopic.size() > maxSize && !expiryQueue.isEmpty) {
@@ -110,35 +120,14 @@ private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
   }
 
   def getErrorsForTopics(topicNames: Set[String], currentTimeMs: Long): Map[String, String] = {
-    lock.lock()
-    try {
-      cleanupExpired(currentTimeMs)
-      val result = mutable.Map.empty[String, String]
-      topicNames.foreach { topicName =>
-        val entry = byTopic.get(topicName)
-        if (entry != null) {
-          result.put(topicName, entry.errorMessage)
-        }
+    val result = mutable.Map.empty[String, String]
+    topicNames.foreach { topicName =>
+      val entry = byTopic.get(topicName)
+      if (entry != null && entry.expirationTimeMs > currentTimeMs) {
+        result.put(topicName, entry.errorMessage)
       }
-      result.toMap
-    } finally {
-      lock.unlock()
     }
-  }
-
-  private def cleanupExpired(currentTimeMs: Long): Unit = {
-    lock.lock()
-    try {
-      while (!expiryQueue.isEmpty && expiryQueue.peek().expirationTimeMs <= currentTimeMs) {
-        val expired = expiryQueue.poll()
-        val current = byTopic.get(expired.topicName)
-        if (current != null && (current eq expired)) {
-          byTopic.remove(expired.topicName)
-        }
-      }
-    } finally {
-      lock.unlock()
-    }
+    result.toMap
   }
 
   private[server] def clear(): Unit = {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -126,7 +126,7 @@ private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
     }
   }
 
-  private[server] def cleanupExpired(currentTimeMs: Long): Unit = {
+  private def cleanupExpired(currentTimeMs: Long): Unit = {
     lock.lock()
     try {
       while (!expiryQueue.isEmpty && expiryQueue.peek().expirationTimeMs <= currentTimeMs) {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -41,6 +41,7 @@ import org.apache.kafka.common.utils.Time
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
+import scala.util.control.Breaks._
 
 trait AutoTopicCreationManager {
 
@@ -71,6 +72,7 @@ case class CachedTopicCreationError(
   val timestamp: Long = time.milliseconds()
 }
 
+
 class DefaultAutoTopicCreationManager(
   config: KafkaConfig,
   channelManager: NodeToControllerChannelManager,
@@ -81,7 +83,20 @@ class DefaultAutoTopicCreationManager(
 ) extends AutoTopicCreationManager with Logging {
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
-  private val topicCreationErrorCache = new ConcurrentHashMap[String, CachedTopicCreationError]()
+  
+  // Use MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG as the size limit for the error cache
+  // This provides a reasonable bound (default 1000) to prevent unbounded growth
+  private val maxCacheSize = config.maxIncrementalFetchSessionCacheSlots
+  info(s"AutoTopicCreationManager initialized with error cache size limit: $maxCacheSize")
+  
+  // LRU cache with size limit to prevent unbounded memory growth
+  private val topicCreationErrorCache = Collections.synchronizedMap(
+    new java.util.LinkedHashMap[String, CachedTopicCreationError](16, 0.75f, false) {
+      override def removeEldestEntry(eldest: java.util.Map.Entry[String, CachedTopicCreationError]): Boolean = {
+        size() > maxCacheSize
+      }
+    }
+  )
 
   /**
    * Initiate auto topic creation for the given topics.
@@ -114,7 +129,7 @@ class DefaultAutoTopicCreationManager(
     requestContext: RequestContext
   ): Unit = {
     if (topics.nonEmpty) {
-      sendCreateTopicRequest(topics, Some(requestContext))
+      sendCreateTopicRequestWithErrorCaching(topics, Some(requestContext))
     }
   }
 
@@ -122,28 +137,49 @@ class DefaultAutoTopicCreationManager(
     topicNames: Set[String],
     errorCacheTtlMs: Long
   ): Map[String, String] = {
-    val currentTime = time.milliseconds()
-    val errors = mutable.Map.empty[String, String]
-    val expiredKeys = mutable.Set.empty[String]
+    // Proactively expire old entries using the provided TTL
+    expireOldEntries(errorCacheTtlMs)
     
-    // Check requested topics and collect expired keys
+    val errors = mutable.Map.empty[String, String]
+    
+    // Check requested topics  
     topicNames.foreach { topicName =>
       Option(topicCreationErrorCache.get(topicName)) match {
-        case Some(cachedError) if (currentTime - cachedError.timestamp) <= errorCacheTtlMs =>
-          errors.put(topicName, cachedError.errorMessage)
-        case Some(_) =>
-          expiredKeys += topicName
+        case Some(error) =>
+          errors.put(topicName, error.errorMessage)
         case None =>
       }
     }
     
-    // Remove expired entries
-    expiredKeys.foreach { key =>
-      topicCreationErrorCache.remove(key)
-      debug(s"Removed expired topic creation error cache entry for $key")
-    }
-    
     errors.toMap
+  }
+
+  /**
+   * Remove expired entries from the cache using the provided TTL.
+   * Since we use LinkedHashMap with insertion order, we only need to check 
+   * entries from the beginning until we find a non-expired entry.
+   */
+  private def expireOldEntries(ttlMs: Long): Unit = {
+    val currentTime = time.milliseconds()
+    
+    // Iterate and remove expired entries
+    val iterator = topicCreationErrorCache.entrySet().iterator()
+    
+    breakable {
+      while (iterator.hasNext) {
+        val entry = iterator.next()
+        val cachedError = entry.getValue
+        
+        if (currentTime - cachedError.timestamp > ttlMs) {
+          iterator.remove()
+          debug(s"Removed expired topic creation error cache entry for ${entry.getKey}")
+        } else {
+          // Since entries are in insertion order, if this entry is not expired,
+          // all following entries are also not expired
+          break()
+        }
+      }
+    }
   }
 
   private def sendCreateTopicRequest(
@@ -170,18 +206,11 @@ class DefaultAutoTopicCreationManager(
         if (response.authenticationException() != null) {
           val authException = response.authenticationException()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception: ${authException.getMessage}")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage)
         } else if (response.versionMismatch() != null) {
           val versionException = response.versionMismatch()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage)
         } else {
-          response.responseBody() match {
-            case createTopicsResponse: CreateTopicsResponse =>
-              cacheTopicCreationErrorsFromResponse(createTopicsResponse)
-            case _ =>
-              debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
-          }
+          debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }
       }
     }
@@ -307,6 +336,80 @@ class DefaultAutoTopicCreationManager(
     (creatableTopics, uncreatableTopics)
   }
 
+  private def sendCreateTopicRequestWithErrorCaching(
+    creatableTopics: Map[String, CreatableTopic],
+    requestContext: Option[RequestContext]
+  ): Seq[MetadataResponseTopic] = {
+    val topicsToCreate = new CreateTopicsRequestData.CreatableTopicCollection(creatableTopics.size)
+    topicsToCreate.addAll(creatableTopics.values.asJavaCollection)
+
+    val createTopicsRequest = new CreateTopicsRequest.Builder(
+      new CreateTopicsRequestData()
+        .setTimeoutMs(config.requestTimeoutMs)
+        .setTopics(topicsToCreate)
+    )
+
+    val requestCompletionHandler = new ControllerRequestCompletionHandler {
+      override def onTimeout(): Unit = {
+        clearInflightRequests(creatableTopics)
+        debug(s"Auto topic creation timed out for ${creatableTopics.keys}.")
+      }
+
+      override def onComplete(response: ClientResponse): Unit = {
+        clearInflightRequests(creatableTopics)
+        if (response.authenticationException() != null) {
+          val authException = response.authenticationException()
+          warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception: ${authException.getMessage}")
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage)
+        } else if (response.versionMismatch() != null) {
+          val versionException = response.versionMismatch()
+          warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage)
+        } else {
+          response.responseBody() match {
+            case createTopicsResponse: CreateTopicsResponse =>
+              cacheTopicCreationErrorsFromResponse(createTopicsResponse)
+            case _ =>
+              debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
+          }
+        }
+      }
+    }
+
+    val request = requestContext.map { context =>
+      val requestVersion =
+        channelManager.controllerApiVersions.toScala match {
+          case None =>
+            // We will rely on the Metadata request to be retried in the case
+            // that the latest version is not usable by the controller.
+            ApiKeys.CREATE_TOPICS.latestVersion()
+          case Some(nodeApiVersions) =>
+            nodeApiVersions.latestUsableVersion(ApiKeys.CREATE_TOPICS)
+        }
+
+      // Borrow client information such as client id and correlation id from the original request,
+      // in order to correlate the create request with the original metadata request.
+      val requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS,
+        requestVersion,
+        context.clientId,
+        context.correlationId)
+      ForwardingManager.buildEnvelopeRequest(context,
+        createTopicsRequest.build(requestVersion).serializeWithHeader(requestHeader))
+    }.getOrElse(createTopicsRequest)
+
+    channelManager.sendRequest(request, requestCompletionHandler)
+
+    val creatableTopicResponses = creatableTopics.keySet.toSeq.map { topic =>
+      new MetadataResponseTopic()
+        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code)
+        .setName(topic)
+        .setIsInternal(Topic.isInternal(topic))
+    }
+
+    info(s"Sent auto-creation request for ${creatableTopics.keys} to the active controller.")
+    creatableTopicResponses
+  }
+
   private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String): Unit = {
     topicNames.foreach { topicName =>
       topicCreationErrorCache.put(topicName, CachedTopicCreationError(errorMessage, time))
@@ -325,7 +428,6 @@ class DefaultAutoTopicCreationManager(
         )
         debug(s"Cached topic creation error for ${topicResult.name()}: $errorMessage")
       }
-      
     }
   }
 

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
 import java.util.{Collections, Properties}
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.utils.Logging
@@ -40,7 +41,6 @@ import org.apache.kafka.common.utils.Time
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.control.Breaks._
 
 trait AutoTopicCreationManager {
 
@@ -52,23 +52,104 @@ trait AutoTopicCreationManager {
 
   def createStreamsInternalTopics(
     topics: Map[String, CreatableTopic],
-    requestContext: RequestContext
+    requestContext: RequestContext,
+    expirationTimeMs: Long
   ): Unit
 
-  def getTopicCreationErrors(
+  def getStreamsInternalTopicCreationErrors(
     topicNames: Set[String],
-    errorCacheTtlMs: Long
+    currentTimeMs: Long
   ): Map[String, String]
 
   def close(): Unit = {}
 
 }
 
-case class CachedTopicCreationError(
-  errorMessage: String,
   time: Time
-) {
-  val timestamp: Long = time.milliseconds()
+/**
+ * Thread-safe cache that stores topic creation errors with per-entry expiration.
+ * - Expiration: maintained by a min-heap (priority queue) on expiration time
+ * - Capacity: enforced by insertion-order removal (keeps the most recently inserted entries)
+ */
+class ExpiringErrorCache(maxSize: Int) {
+
+  private case class Entry(topicName: String, errorMessage: String, expirationTimeMs: Long)
+
+  private val byTopic = new java.util.HashMap[String, Entry]()
+  private val expiryQueue = new java.util.PriorityQueue[Entry](11, new java.util.Comparator[Entry] {
+    override def compare(a: Entry, b: Entry): Int = java.lang.Long.compare(a.expirationTimeMs, b.expirationTimeMs)
+  })
+  private val lock = new ReentrantLock()
+
+  def put(topicName: String, errorMessage: String, expirationTimeMs: Long): Unit = {
+    lock.lock()
+    try {
+      val existing = byTopic.get(topicName)
+      if (existing != null) {
+        // Remove old instance from structures
+        expiryQueue.remove(existing)
+      }
+
+      val entry = Entry(topicName, errorMessage, expirationTimeMs)
+      byTopic.put(topicName, entry)
+      expiryQueue.add(entry)
+
+      // Enforce capacity by removing entries with earliest expiration time first
+      while (byTopic.size() > maxSize && !expiryQueue.isEmpty) {
+        val evicted = expiryQueue.poll()
+        if (evicted != null) {
+          val current = byTopic.get(evicted.topicName)
+          if (current != null && (current eq evicted)) {
+            byTopic.remove(evicted.topicName)
+          }
+        }
+      }
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  def getErrorsForTopics(topicNames: Set[String], currentTimeMs: Long): Map[String, String] = {
+    lock.lock()
+    try {
+      cleanupExpired(currentTimeMs)
+      val result = mutable.Map.empty[String, String]
+      topicNames.foreach { topicName =>
+        val entry = byTopic.get(topicName)
+        if (entry != null) {
+          result.put(topicName, entry.errorMessage)
+        }
+      }
+      result.toMap
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  def cleanupExpired(currentTimeMs: Long): Unit = {
+    lock.lock()
+    try {
+      while (!expiryQueue.isEmpty && expiryQueue.peek().expirationTimeMs <= currentTimeMs) {
+        val expired = expiryQueue.poll()
+        val current = byTopic.get(expired.topicName)
+        if (current != null && (current eq expired)) {
+          byTopic.remove(expired.topicName)
+        }
+      }
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  def clear(): Unit = {
+    lock.lock()
+    try {
+      byTopic.clear()
+      expiryQueue.clear()
+    } finally {
+      lock.unlock()
+    }
+  }
 }
 
 
@@ -78,24 +159,14 @@ class DefaultAutoTopicCreationManager(
   groupCoordinator: GroupCoordinator,
   txnCoordinator: TransactionCoordinator,
   shareCoordinator: ShareCoordinator,
-  time: Time
+  time: Time,
+  cacheCapacity: Int = 1000
 ) extends AutoTopicCreationManager with Logging {
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
-  
-  // Use MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG as the size limit for the error cache
-  // This provides a reasonable bound (default 1000) to prevent unbounded growth
-  private val maxCacheSize = config.maxIncrementalFetchSessionCacheSlots
-  info(s"AutoTopicCreationManager initialized with error cache size limit: $maxCacheSize")
-  
-  // LRU cache with size limit to prevent unbounded memory growth
-  private val topicCreationErrorCache = Collections.synchronizedMap(
-    new java.util.LinkedHashMap[String, CachedTopicCreationError](16, 0.75f, false) {
-      override def removeEldestEntry(eldest: java.util.Map.Entry[String, CachedTopicCreationError]): Boolean = {
-        size() > maxCacheSize
-      }
-    }
-  )
+
+  // Hardcoded default capacity; can be overridden in tests via constructor param
+  private val topicCreationErrorCache = new ExpiringErrorCache(cacheCapacity)
 
   /**
    * Initiate auto topic creation for the given topics.
@@ -125,60 +196,19 @@ class DefaultAutoTopicCreationManager(
 
   override def createStreamsInternalTopics(
     topics: Map[String, CreatableTopic],
-    requestContext: RequestContext
+    requestContext: RequestContext,
+    expirationTimeMs: Long
   ): Unit = {
     if (topics.nonEmpty) {
-      sendCreateTopicRequestWithErrorCaching(topics, Some(requestContext))
+      sendCreateTopicRequestWithErrorCaching(topics, Some(requestContext), expirationTimeMs)
     }
   }
 
-  override def getTopicCreationErrors(
+  override def getStreamsInternalTopicCreationErrors(
     topicNames: Set[String],
-    errorCacheTtlMs: Long
+    currentTimeMs: Long
   ): Map[String, String] = {
-    // Proactively expire old entries using the provided TTL
-    expireOldEntries(errorCacheTtlMs)
-    
-    val errors = mutable.Map.empty[String, String]
-    
-    // Check requested topics  
-    topicNames.foreach { topicName =>
-      Option(topicCreationErrorCache.get(topicName)) match {
-        case Some(error) =>
-          errors.put(topicName, error.errorMessage)
-        case None =>
-      }
-    }
-    
-    errors.toMap
-  }
-
-  /**
-   * Remove expired entries from the cache using the provided TTL.
-   * Since we use LinkedHashMap with insertion order, we only need to check 
-   * entries from the beginning until we find a non-expired entry.
-   */
-  private def expireOldEntries(ttlMs: Long): Unit = {
-    val currentTime = time.milliseconds()
-    
-    // Iterate and remove expired entries
-    val iterator = topicCreationErrorCache.entrySet().iterator()
-    
-    breakable {
-      while (iterator.hasNext) {
-        val entry = iterator.next()
-        val cachedError = entry.getValue
-        
-        if (currentTime - cachedError.timestamp > ttlMs) {
-          iterator.remove()
-          debug(s"Removed expired topic creation error cache entry for ${entry.getKey}")
-        } else {
-          // Since entries are in insertion order, if this entry is not expired,
-          // all following entries are also not expired
-          break()
-        }
-      }
-    }
+    topicCreationErrorCache.getErrorsForTopics(topicNames, currentTimeMs)
   }
 
   private def sendCreateTopicRequest(
@@ -209,6 +239,19 @@ class DefaultAutoTopicCreationManager(
           val versionException = response.versionMismatch()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
         } else {
+          if (response.hasResponse) {
+            response.responseBody() match {
+              case createTopicsResponse: CreateTopicsResponse =>
+                createTopicsResponse.data().topics().forEach(topicResult => {
+                  val error = Errors.forCode(topicResult.errorCode)
+                  if (error != Errors.NONE) {
+                    warn(s"Auto topic creation failed for ${topicResult.name} with error '${error.name}': ${topicResult.errorMessage}")
+                  }
+                })
+              case other =>
+                warn(s"Auto topic creation request received unexpected response type: ${other.getClass.getSimpleName}")
+            }
+          }
           debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }
       }
@@ -337,7 +380,8 @@ class DefaultAutoTopicCreationManager(
 
   private def sendCreateTopicRequestWithErrorCaching(
     creatableTopics: Map[String, CreatableTopic],
-    requestContext: Option[RequestContext]
+    requestContext: Option[RequestContext],
+    expirationTimeMs: Long
   ): Seq[MetadataResponseTopic] = {
     val topicsToCreate = new CreateTopicsRequestData.CreatableTopicCollection(creatableTopics.size)
     topicsToCreate.addAll(creatableTopics.values.asJavaCollection)
@@ -352,6 +396,7 @@ class DefaultAutoTopicCreationManager(
       override def onTimeout(): Unit = {
         clearInflightRequests(creatableTopics)
         debug(s"Auto topic creation timed out for ${creatableTopics.keys}.")
+        cacheTopicCreationErrors(creatableTopics.keys.toSet, "Auto topic creation timed out.", expirationTimeMs)
       }
 
       override def onComplete(response: ClientResponse): Unit = {
@@ -359,15 +404,15 @@ class DefaultAutoTopicCreationManager(
         if (response.authenticationException() != null) {
           val authException = response.authenticationException()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception: ${authException.getMessage}")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage)
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage, expirationTimeMs)
         } else if (response.versionMismatch() != null) {
           val versionException = response.versionMismatch()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage)
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage, expirationTimeMs)
         } else {
           response.responseBody() match {
             case createTopicsResponse: CreateTopicsResponse =>
-              cacheTopicCreationErrorsFromResponse(createTopicsResponse)
+              cacheTopicCreationErrorsFromResponse(createTopicsResponse, expirationTimeMs)
             case _ =>
               debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
           }
@@ -405,26 +450,22 @@ class DefaultAutoTopicCreationManager(
         .setIsInternal(Topic.isInternal(topic))
     }
 
-    info(s"Sent auto-creation request for ${creatableTopics.keys} to the active controller.")
     creatableTopicResponses
   }
 
-  private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String): Unit = {
+  private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String, expirationTimeMs: Long): Unit = {
     topicNames.foreach { topicName =>
-      topicCreationErrorCache.put(topicName, CachedTopicCreationError(errorMessage, time))
+      topicCreationErrorCache.put(topicName, errorMessage, expirationTimeMs)
     }
   }
 
-  private def cacheTopicCreationErrorsFromResponse(response: CreateTopicsResponse): Unit = {
+  private def cacheTopicCreationErrorsFromResponse(response: CreateTopicsResponse, expirationTimeMs: Long): Unit = {
     response.data().topics().forEach { topicResult =>
       if (topicResult.errorCode() != Errors.NONE.code()) {
         val errorMessage = Option(topicResult.errorMessage())
           .filter(_.nonEmpty)
           .getOrElse(Errors.forCode(topicResult.errorCode()).message())
-        topicCreationErrorCache.put(
-          topicResult.name(),
-          CachedTopicCreationError(errorMessage, time)
-        )
+        topicCreationErrorCache.put(topicResult.name(), errorMessage, expirationTimeMs)
         debug(s"Cached topic creation error for ${topicResult.name()}: $errorMessage")
       }
     }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -53,7 +53,7 @@ trait AutoTopicCreationManager {
   def createStreamsInternalTopics(
     topics: Map[String, CreatableTopic],
     requestContext: RequestContext,
-    expirationTimeMs: Long
+    timeoutMs: Long
   ): Unit
 
   def getStreamsInternalTopicCreationErrors(
@@ -70,7 +70,7 @@ trait AutoTopicCreationManager {
  * - Expiration: maintained by a min-heap (priority queue) on expiration time
  * - Capacity: enforced by insertion-order removal (keeps the most recently inserted entries)
  */
-class ExpiringErrorCache(maxSize: Int) {
+private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
 
   private case class Entry(topicName: String, errorMessage: String, expirationTimeMs: Long)
 
@@ -80,7 +80,7 @@ class ExpiringErrorCache(maxSize: Int) {
   })
   private val lock = new ReentrantLock()
 
-  def put(topicName: String, errorMessage: String, expirationTimeMs: Long): Unit = {
+  def put(topicName: String, errorMessage: String, ttlMs: Long): Unit = {
     lock.lock()
     try {
       val existing = byTopic.get(topicName)
@@ -89,6 +89,7 @@ class ExpiringErrorCache(maxSize: Int) {
         expiryQueue.remove(existing)
       }
 
+      val expirationTimeMs = time.milliseconds() + ttlMs
       val entry = Entry(topicName, errorMessage, expirationTimeMs)
       byTopic.put(topicName, entry)
       expiryQueue.add(entry)
@@ -125,7 +126,7 @@ class ExpiringErrorCache(maxSize: Int) {
     }
   }
 
-  def cleanupExpired(currentTimeMs: Long): Unit = {
+  private[server] def cleanupExpired(currentTimeMs: Long): Unit = {
     lock.lock()
     try {
       while (!expiryQueue.isEmpty && expiryQueue.peek().expirationTimeMs <= currentTimeMs) {
@@ -140,7 +141,7 @@ class ExpiringErrorCache(maxSize: Int) {
     }
   }
 
-  def clear(): Unit = {
+  private[server] def clear(): Unit = {
     lock.lock()
     try {
       byTopic.clear()
@@ -159,13 +160,13 @@ class DefaultAutoTopicCreationManager(
   txnCoordinator: TransactionCoordinator,
   shareCoordinator: ShareCoordinator,
   time: Time,
-  cacheCapacity: Int = 1000
+  topicErrorCacheCapacity: Int = 1000
 ) extends AutoTopicCreationManager with Logging {
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
 
   // Hardcoded default capacity; can be overridden in tests via constructor param
-  private val topicCreationErrorCache = new ExpiringErrorCache(cacheCapacity)
+  private val topicCreationErrorCache = new ExpiringErrorCache(topicErrorCacheCapacity, time)
 
   /**
    * Initiate auto topic creation for the given topics.
@@ -196,10 +197,10 @@ class DefaultAutoTopicCreationManager(
   override def createStreamsInternalTopics(
     topics: Map[String, CreatableTopic],
     requestContext: RequestContext,
-    expirationTimeMs: Long
+    timeoutMs: Long
   ): Unit = {
     if (topics.nonEmpty) {
-      sendCreateTopicRequestWithErrorCaching(topics, Some(requestContext), expirationTimeMs)
+      sendCreateTopicRequestWithErrorCaching(topics, Some(requestContext), timeoutMs)
     }
   }
 
@@ -232,11 +233,9 @@ class DefaultAutoTopicCreationManager(
       override def onComplete(response: ClientResponse): Unit = {
         clearInflightRequests(creatableTopics)
         if (response.authenticationException() != null) {
-          val authException = response.authenticationException()
-          warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception: ${authException.getMessage}")
+          warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception")
         } else if (response.versionMismatch() != null) {
-          val versionException = response.versionMismatch()
-          warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
+          warn(s"Auto topic creation failed for ${creatableTopics.keys} with invalid version exception")
         } else {
           if (response.hasResponse) {
             response.responseBody() match {
@@ -380,7 +379,7 @@ class DefaultAutoTopicCreationManager(
   private def sendCreateTopicRequestWithErrorCaching(
     creatableTopics: Map[String, CreatableTopic],
     requestContext: Option[RequestContext],
-    expirationTimeMs: Long
+    timeoutMs: Long
   ): Seq[MetadataResponseTopic] = {
     val topicsToCreate = new CreateTopicsRequestData.CreatableTopicCollection(creatableTopics.size)
     topicsToCreate.addAll(creatableTopics.values.asJavaCollection)
@@ -395,7 +394,7 @@ class DefaultAutoTopicCreationManager(
       override def onTimeout(): Unit = {
         clearInflightRequests(creatableTopics)
         debug(s"Auto topic creation timed out for ${creatableTopics.keys}.")
-        cacheTopicCreationErrors(creatableTopics.keys.toSet, "Auto topic creation timed out.", expirationTimeMs)
+        cacheTopicCreationErrors(creatableTopics.keys.toSet, "Auto topic creation timed out.", timeoutMs)
       }
 
       override def onComplete(response: ClientResponse): Unit = {
@@ -403,15 +402,15 @@ class DefaultAutoTopicCreationManager(
         if (response.authenticationException() != null) {
           val authException = response.authenticationException()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception: ${authException.getMessage}")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage, expirationTimeMs)
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage, timeoutMs)
         } else if (response.versionMismatch() != null) {
           val versionException = response.versionMismatch()
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage, expirationTimeMs)
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage, timeoutMs)
         } else {
           response.responseBody() match {
             case createTopicsResponse: CreateTopicsResponse =>
-              cacheTopicCreationErrorsFromResponse(createTopicsResponse, expirationTimeMs)
+              cacheTopicCreationErrorsFromResponse(createTopicsResponse, timeoutMs)
             case _ =>
               debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
           }
@@ -452,19 +451,19 @@ class DefaultAutoTopicCreationManager(
     creatableTopicResponses
   }
 
-  private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String, expirationTimeMs: Long): Unit = {
+  private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String, ttlMs: Long): Unit = {
     topicNames.foreach { topicName =>
-      topicCreationErrorCache.put(topicName, errorMessage, expirationTimeMs)
+      topicCreationErrorCache.put(topicName, errorMessage, ttlMs)
     }
   }
 
-  private def cacheTopicCreationErrorsFromResponse(response: CreateTopicsResponse, expirationTimeMs: Long): Unit = {
+  private def cacheTopicCreationErrorsFromResponse(response: CreateTopicsResponse, ttlMs: Long): Unit = {
     response.data().topics().forEach { topicResult =>
       if (topicResult.errorCode() != Errors.NONE.code()) {
         val errorMessage = Option(topicResult.errorMessage())
           .filter(_.nonEmpty)
           .getOrElse(Errors.forCode(topicResult.errorCode()).message())
-        topicCreationErrorCache.put(topicResult.name(), errorMessage, expirationTimeMs)
+        topicCreationErrorCache.put(topicResult.name(), errorMessage, ttlMs)
         debug(s"Cached topic creation error for ${topicResult.name()}: $errorMessage")
       }
     }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{Collections, Properties}
-import scala.concurrent.duration._
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
@@ -37,6 +36,7 @@ import org.apache.kafka.coordinator.share.ShareCoordinator
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.quota.ControllerMutationQuota
+import org.apache.kafka.common.utils.Time
 
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
@@ -65,21 +65,24 @@ trait AutoTopicCreationManager {
 
 case class CachedTopicCreationError(
   errorMessage: String,
-  timestamp: Long
-)
+  time: Time
+) {
+  val timestamp: Long = time.milliseconds()
+}
 
 class DefaultAutoTopicCreationManager(
   config: KafkaConfig,
   channelManager: NodeToControllerChannelManager,
   groupCoordinator: GroupCoordinator,
   txnCoordinator: TransactionCoordinator,
-  shareCoordinator: ShareCoordinator
+  shareCoordinator: ShareCoordinator,
+  time: Time
 ) extends AutoTopicCreationManager with Logging {
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
   private val topicCreationErrorCache = new ConcurrentHashMap[String, CachedTopicCreationError]()
-  private val errorCacheTtlMs = config.requestTimeoutMs.toLong * 3 // 3x request timeout
-  private val maxCacheSize = 1000
+  // Use session timeout instead of request timeout for better semantic alignment with client lifecycle
+  private val errorCacheTtlMs = config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs.toLong
 
   /**
    * Initiate auto topic creation for the given topics.
@@ -119,7 +122,7 @@ class DefaultAutoTopicCreationManager(
   override def getTopicCreationErrors(
     topicNames: Set[String]
   ): Map[String, String] = {
-    val currentTime = System.currentTimeMillis()
+    val currentTime = time.milliseconds()
     val errors = mutable.Map.empty[String, String]
     val expiredKeys = mutable.Set.empty[String]
     
@@ -138,18 +141,6 @@ class DefaultAutoTopicCreationManager(
     expiredKeys.foreach { key =>
       topicCreationErrorCache.remove(key)
       debug(s"Removed expired topic creation error cache entry for $key")
-    }
-    
-    // If cache is too large, remove oldest entries
-    if (topicCreationErrorCache.size() > maxCacheSize) {
-      val entriesToRemove = topicCreationErrorCache.size() - maxCacheSize
-      val oldestEntries = topicCreationErrorCache.entrySet().asScala
-        .toSeq.sortBy(_.getValue.timestamp).take(entriesToRemove)
-      oldestEntries.foreach { entry =>
-        topicCreationErrorCache.remove(entry.getKey)
-        debug(s"Removed oldest topic creation error cache entry for ${entry.getKey} due to cache size limit")
-      }
-      debug(s"Removed $entriesToRemove oldest entries from topic creation error cache due to size limit")
     }
     
     errors.toMap
@@ -177,11 +168,13 @@ class DefaultAutoTopicCreationManager(
       override def onComplete(response: ClientResponse): Unit = {
         clearInflightRequests(creatableTopics)
         if (response.authenticationException() != null) {
-          warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, "Authentication failed")
+          val authException = response.authenticationException()
+          warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception: ${authException.getMessage}")
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, authException.getMessage)
         } else if (response.versionMismatch() != null) {
-          warn(s"Auto topic creation failed for ${creatableTopics.keys} with invalid version exception")
-          cacheTopicCreationErrors(creatableTopics.keys.toSet, "Version mismatch")
+          val versionException = response.versionMismatch()
+          warn(s"Auto topic creation failed for ${creatableTopics.keys} with version mismatch exception: ${versionException.getMessage}")
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, versionException.getMessage)
         } else {
           response.responseBody() match {
             case createTopicsResponse: CreateTopicsResponse =>
@@ -315,14 +308,12 @@ class DefaultAutoTopicCreationManager(
   }
 
   private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String): Unit = {
-    val timestamp = System.currentTimeMillis()
     topicNames.foreach { topicName =>
-      topicCreationErrorCache.put(topicName, CachedTopicCreationError(errorMessage, timestamp))
+      topicCreationErrorCache.put(topicName, CachedTopicCreationError(errorMessage, time))
     }
   }
 
   private def cacheTopicCreationErrorsFromResponse(response: CreateTopicsResponse): Unit = {
-    val timestamp = System.currentTimeMillis()
     response.data().topics().forEach { topicResult =>
       if (topicResult.errorCode() != Errors.NONE.code()) {
         val errorMessage = Option(topicResult.errorMessage())
@@ -330,10 +321,11 @@ class DefaultAutoTopicCreationManager(
           .getOrElse(Errors.forCode(topicResult.errorCode()).message())
         topicCreationErrorCache.put(
           topicResult.name(),
-          CachedTopicCreationError(errorMessage, timestamp)
+          CachedTopicCreationError(errorMessage, time)
         )
         debug(s"Cached topic creation error for ${topicResult.name()}: $errorMessage")
       }
+      
     }
   }
 

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -81,7 +81,7 @@ class DefaultAutoTopicCreationManager(
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
   private val topicCreationErrorCache = new ConcurrentHashMap[String, CachedTopicCreationError]()
-  // Use session timeout instead of request timeout for better semantic alignment with client lifecycle
+  // Use session timeout for better semantic alignment with client lifecycle
   private val errorCacheTtlMs = config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs.toLong
 
   /**

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -68,7 +68,8 @@ trait AutoTopicCreationManager {
 /**
  * Thread-safe cache that stores topic creation errors with per-entry expiration.
  * - Expiration: maintained by a min-heap (priority queue) on expiration time
- * - Capacity: enforced by insertion-order removal (keeps the most recently inserted entries)
+ * - Capacity: enforced by evicting entries with earliest expiration time (not LRU)
+ * - Updates: old entries remain in queue but are ignored via reference equality check
  */
 private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
 

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -23,7 +23,6 @@ import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.errors.InvalidTopicException
-import org.apache.kafka.common.requests.CreateTopicsResponse
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
 import org.apache.kafka.common.message.CreateTopicsRequestData

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -78,7 +78,7 @@ class DefaultAutoTopicCreationManager(
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
   private val topicCreationErrorCache = new ConcurrentHashMap[String, CachedTopicCreationError]()
-  private val errorCacheTtlMs = 5.minutes.toMillis
+  private val errorCacheTtlMs = config.requestTimeoutMs.toLong * 3 // 3x request timeout
   private val maxCacheSize = 1000
 
   /**

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -83,35 +83,19 @@ private[server] class ExpiringErrorCache(maxSize: Int, time: Time) {
   def put(topicName: String, errorMessage: String, ttlMs: Long): Unit = {
     lock.lock()
     try {
-      val existing = byTopic.get(topicName)
-      if (existing != null) {
-        // Remove old instance from structures
-        expiryQueue.remove(existing)
-      }
-
       val currentTimeMs = time.milliseconds()
       val expirationTimeMs = currentTimeMs + ttlMs
       val entry = Entry(topicName, errorMessage, expirationTimeMs)
       byTopic.put(topicName, entry)
       expiryQueue.add(entry)
 
-      // Clean up expired entries
-      while (!expiryQueue.isEmpty && expiryQueue.peek().expirationTimeMs <= currentTimeMs) {
-        val expired = expiryQueue.poll()
-        val current = byTopic.get(expired.topicName)
-        if (current != null && (current eq expired)) {
-          byTopic.remove(expired.topicName)
-        }
-      }
-
-      // Enforce capacity by removing entries with earliest expiration time first
-      while (byTopic.size() > maxSize && !expiryQueue.isEmpty) {
+      // Clean up expired entries and enforce capacity
+      while (!expiryQueue.isEmpty && 
+             (expiryQueue.peek().expirationTimeMs <= currentTimeMs || byTopic.size() > maxSize)) {
         val evicted = expiryQueue.poll()
-        if (evicted != null) {
-          val current = byTopic.get(evicted.topicName)
-          if (current != null && (current eq evicted)) {
-            byTopic.remove(evicted.topicName)
-          }
+        val current = byTopic.get(evicted.topicName)
+        if (current != null && (current eq evicted)) {
+          byTopic.remove(evicted.topicName)
         }
       }
     } finally {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -19,10 +19,12 @@ package kafka.server
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{Collections, Properties}
+import scala.concurrent.duration._
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.errors.InvalidTopicException
+import org.apache.kafka.common.requests.CreateTopicsResponse
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, SHARE_GROUP_STATE_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
 import org.apache.kafka.common.message.CreateTopicsRequestData
@@ -53,7 +55,18 @@ trait AutoTopicCreationManager {
     requestContext: RequestContext
   ): Unit
 
+  def getTopicCreationErrors(
+    topicNames: Set[String]
+  ): Map[String, String]
+
+  def close(): Unit = {}
+
 }
+
+case class CachedTopicCreationError(
+  errorMessage: String,
+  timestamp: Long
+)
 
 class DefaultAutoTopicCreationManager(
   config: KafkaConfig,
@@ -64,6 +77,9 @@ class DefaultAutoTopicCreationManager(
 ) extends AutoTopicCreationManager with Logging {
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
+  private val topicCreationErrorCache = new ConcurrentHashMap[String, CachedTopicCreationError]()
+  private val errorCacheTtlMs = 5.minutes.toMillis
+  private val maxCacheSize = 1000
 
   /**
    * Initiate auto topic creation for the given topics.
@@ -100,6 +116,45 @@ class DefaultAutoTopicCreationManager(
     }
   }
 
+  override def getTopicCreationErrors(
+    topicNames: Set[String]
+  ): Map[String, String] = {
+    val currentTime = System.currentTimeMillis()
+    val errors = mutable.Map.empty[String, String]
+    val expiredKeys = mutable.Set.empty[String]
+    
+    // Check requested topics and collect expired keys
+    topicNames.foreach { topicName =>
+      Option(topicCreationErrorCache.get(topicName)) match {
+        case Some(cachedError) if (currentTime - cachedError.timestamp) <= errorCacheTtlMs =>
+          errors.put(topicName, cachedError.errorMessage)
+        case Some(_) =>
+          expiredKeys += topicName
+        case None =>
+      }
+    }
+    
+    // Remove expired entries
+    expiredKeys.foreach { key =>
+      topicCreationErrorCache.remove(key)
+      debug(s"Removed expired topic creation error cache entry for $key")
+    }
+    
+    // If cache is too large, remove oldest entries
+    if (topicCreationErrorCache.size() > maxCacheSize) {
+      val entriesToRemove = topicCreationErrorCache.size() - maxCacheSize
+      val oldestEntries = topicCreationErrorCache.entrySet().asScala
+        .toSeq.sortBy(_.getValue.timestamp).take(entriesToRemove)
+      oldestEntries.foreach { entry =>
+        topicCreationErrorCache.remove(entry.getKey)
+        debug(s"Removed oldest topic creation error cache entry for ${entry.getKey} due to cache size limit")
+      }
+      debug(s"Removed $entriesToRemove oldest entries from topic creation error cache due to size limit")
+    }
+    
+    errors.toMap
+  }
+
   private def sendCreateTopicRequest(
     creatableTopics: Map[String, CreatableTopic],
     requestContext: Option[RequestContext]
@@ -123,23 +178,17 @@ class DefaultAutoTopicCreationManager(
         clearInflightRequests(creatableTopics)
         if (response.authenticationException() != null) {
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with authentication exception")
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, "Authentication failed")
         } else if (response.versionMismatch() != null) {
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with invalid version exception")
+          cacheTopicCreationErrors(creatableTopics.keys.toSet, "Version mismatch")
         } else {
-          if (response.hasResponse) {
-            response.responseBody() match {
-              case createTopicsResponse: CreateTopicsResponse =>
-                createTopicsResponse.data().topics().forEach(topicResult => {
-                  val error = Errors.forCode(topicResult.errorCode)
-                  if (error != Errors.NONE) {
-                    warn(s"Auto topic creation failed for ${topicResult.name} with error '${error.name}': ${topicResult.errorMessage}")
-                  }
-                })
-              case other =>
-                warn(s"Auto topic creation request received unexpected response type: ${other.getClass.getSimpleName}")
-            }
+          response.responseBody() match {
+            case createTopicsResponse: CreateTopicsResponse =>
+              cacheTopicCreationErrorsFromResponse(createTopicsResponse)
+            case _ =>
+              debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
           }
-          debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }
       }
     }
@@ -263,5 +312,32 @@ class DefaultAutoTopicCreationManager(
     }
 
     (creatableTopics, uncreatableTopics)
+  }
+
+  private def cacheTopicCreationErrors(topicNames: Set[String], errorMessage: String): Unit = {
+    val timestamp = System.currentTimeMillis()
+    topicNames.foreach { topicName =>
+      topicCreationErrorCache.put(topicName, CachedTopicCreationError(errorMessage, timestamp))
+    }
+  }
+
+  private def cacheTopicCreationErrorsFromResponse(response: CreateTopicsResponse): Unit = {
+    val timestamp = System.currentTimeMillis()
+    response.data().topics().forEach { topicResult =>
+      if (topicResult.errorCode() != Errors.NONE.code()) {
+        val errorMessage = Option(topicResult.errorMessage())
+          .filter(_.nonEmpty)
+          .getOrElse(Errors.forCode(topicResult.errorCode()).message())
+        topicCreationErrorCache.put(
+          topicResult.name(),
+          CachedTopicCreationError(errorMessage, timestamp)
+        )
+        debug(s"Cached topic creation error for ${topicResult.name()}: $errorMessage")
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    topicCreationErrorCache.clear()
   }
 }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -781,6 +781,9 @@ class BrokerServer(
       if (shareCoordinator != null)
         CoreUtils.swallow(shareCoordinator.shutdown(), this)
 
+      if (autoTopicCreationManager != null)
+        CoreUtils.swallow(autoTopicCreationManager.close(), this)
+
       if (assignmentsManager != null)
         CoreUtils.swallow(assignmentsManager.close(), this)
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -387,7 +387,7 @@ class BrokerServer(
 
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
         config, clientToControllerChannelManager, groupCoordinator,
-        transactionCoordinator, shareCoordinator)
+        transactionCoordinator, shareCoordinator, time)
 
       dynamicConfigHandlers = Map[ConfigType, ConfigHandler](
         ConfigType.TOPIC -> new TopicConfigHandler(replicaManager, config, quotaManagers),

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2888,13 +2888,13 @@ class KafkaApis(val requestChannel: RequestChannel,
                 )
               }
             } else {
-              // Compute group-specific expiration time for freshly cached errors
-              val sessionTimeoutMs = Option(groupConfigManager.groupConfig(streamsGroupHeartbeatRequest.data.groupId).orElse(null))
-                .map(_.streamsSessionTimeoutMs().toLong)
-                .getOrElse(config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs().toLong)
-              val expirationTimeMs = time.milliseconds() + sessionTimeoutMs
+              // Compute group-specific timeout for caching errors (2 * heartbeat interval)
+              val heartbeatIntervalMs = Option(groupConfigManager.groupConfig(streamsGroupHeartbeatRequest.data.groupId).orElse(null))
+                .map(_.streamsHeartbeatIntervalMs().toLong)
+                .getOrElse(config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs().toLong)
+              val timeoutMs = heartbeatIntervalMs * 2
 
-              autoTopicCreationManager.createStreamsInternalTopics(topicsToCreate, requestContext, expirationTimeMs)
+              autoTopicCreationManager.createStreamsInternalTopics(topicsToCreate, requestContext, timeoutMs)
               
               // Check for cached topic creation errors only if there's already a MISSING_INTERNAL_TOPICS status
               val hasMissingInternalTopicsStatus = responseData.status() != null && 
@@ -2908,8 +2908,9 @@ class KafkaApis(val requestChannel: RequestChannel,
                     responseData.status().stream().filter(x => x.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code()).findFirst()
                   val creationErrorDetails = cachedErrors.map { case (topic, error) => s"$topic ($error)" }.mkString(", ")
                   if (missingInternalTopicStatus.isPresent) {
+                    val existingDetail = Option(missingInternalTopicStatus.get().statusDetail()).getOrElse("")
                     missingInternalTopicStatus.get().setStatusDetail(
-                      missingInternalTopicStatus.get().statusDetail() + s"; Creation failed: $creationErrorDetails."
+                      existingDetail + s"; Creation failed: $creationErrorDetails."
                     )
                   }
                 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2888,19 +2888,21 @@ class KafkaApis(val requestChannel: RequestChannel,
                 )
               }
             } else {
-              autoTopicCreationManager.createStreamsInternalTopics(topicsToCreate, requestContext);
+              // Compute group-specific expiration time for freshly cached errors
+              val sessionTimeoutMs = Option(groupConfigManager.groupConfig(streamsGroupHeartbeatRequest.data.groupId).orElse(null))
+                .map(_.streamsSessionTimeoutMs().toLong)
+                .getOrElse(config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs().toLong)
+              val expirationTimeMs = time.milliseconds() + sessionTimeoutMs
+
+              autoTopicCreationManager.createStreamsInternalTopics(topicsToCreate, requestContext, expirationTimeMs)
               
               // Check for cached topic creation errors only if there's already a MISSING_INTERNAL_TOPICS status
               val hasMissingInternalTopicsStatus = responseData.status() != null && 
                 responseData.status().stream().anyMatch(s => s.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code())
               
               if (hasMissingInternalTopicsStatus) {
-                // Calculate group-specific error cache TTL
-                val errorCacheTtlMs = Option(groupConfigManager.groupConfig(streamsGroupHeartbeatRequest.data.groupId).orElse(null))
-                  .map(_.streamsSessionTimeoutMs().toLong)
-                  .getOrElse(config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs().toLong)
-                
-                val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(topicsToCreate.keys.toSet, errorCacheTtlMs)
+                val currentTimeMs = time.milliseconds()
+                val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(topicsToCreate.keys.toSet, currentTimeMs)
                 if (cachedErrors.nonEmpty) {
                   val missingInternalTopicStatus =
                     responseData.status().stream().filter(x => x.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code()).findFirst()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2895,7 +2895,12 @@ class KafkaApis(val requestChannel: RequestChannel,
                 responseData.status().stream().anyMatch(s => s.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code())
               
               if (hasMissingInternalTopicsStatus) {
-                val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(topicsToCreate.keys.toSet)
+                // Calculate group-specific error cache TTL
+                val errorCacheTtlMs = Option(groupConfigManager.groupConfig(streamsGroupHeartbeatRequest.data.groupId).orElse(null))
+                  .map(_.streamsSessionTimeoutMs().toLong)
+                  .getOrElse(config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs().toLong)
+                
+                val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(topicsToCreate.keys.toSet, errorCacheTtlMs)
                 if (cachedErrors.nonEmpty) {
                   val missingInternalTopicStatus =
                     responseData.status().stream().filter(x => x.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code()).findFirst()
@@ -2909,7 +2914,6 @@ class KafkaApis(val requestChannel: RequestChannel,
               }
             }
           }
-
           requestHelper.sendMaybeThrottle(request, new StreamsGroupHeartbeatResponse(responseData))
         }
       }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2889,6 +2889,24 @@ class KafkaApis(val requestChannel: RequestChannel,
               }
             } else {
               autoTopicCreationManager.createStreamsInternalTopics(topicsToCreate, requestContext);
+              
+              // Check for cached topic creation errors only if there's already a MISSING_INTERNAL_TOPICS status
+              val hasMissingInternalTopicsStatus = responseData.status() != null && 
+                responseData.status().stream().anyMatch(s => s.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code())
+              
+              if (hasMissingInternalTopicsStatus) {
+                val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(topicsToCreate.keys.toSet)
+                if (cachedErrors.nonEmpty) {
+                  val missingInternalTopicStatus =
+                    responseData.status().stream().filter(x => x.statusCode() == StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code()).findFirst()
+                  val creationErrorDetails = cachedErrors.map { case (topic, error) => s"$topic ($error)" }.mkString(", ")
+                  if (missingInternalTopicStatus.isPresent) {
+                    missingInternalTopicStatus.get().setStatusDetail(
+                      missingInternalTopicStatus.get().statusDetail() + s"; Creation failed: $creationErrorDetails."
+                    )
+                  }
+                }
+              }
             }
           }
 

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -508,12 +508,10 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator,
       shareCoordinator,
       mockTime)
-    
-    // 测试getTopicCreationErrors在没有缓存时返回空
+
     val initialResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"))
     assertTrue(initialResult.isEmpty)
-    
-    // 让时间前进，再次查询确保仍然为空
+
     mockTime.sleep(config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs + 1000)
     val laterResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"))
     assertTrue(laterResult.isEmpty)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -380,7 +380,8 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      topicErrorCacheCapacity = testCacheCapacity)
 
     val topics = Map(
       "test-topic-1" -> new CreatableTopic().setName("test-topic-1").setNumPartitions(1).setReplicationFactor(1)
@@ -408,7 +409,7 @@ class AutoTopicCreationManagerTest {
       0, 0, false, null, null, createTopicsResponse)
 
     // Trigger the completion handler
-    argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+    argumentCaptor.getValue.onComplete(clientResponse)
 
     // Verify that the error was cached
     val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("test-topic-1"), mockTime.milliseconds())
@@ -425,7 +426,8 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      topicErrorCacheCapacity = testCacheCapacity)
 
     val topics = Map(
       "success-topic" -> new CreatableTopic().setName("success-topic").setNumPartitions(1).setReplicationFactor(1),
@@ -458,7 +460,7 @@ class AutoTopicCreationManagerTest {
     val clientResponse = new ClientResponse(header, null, null,
       0, 0, false, null, null, createTopicsResponse)
 
-    argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+    argumentCaptor.getValue.onComplete(clientResponse)
 
     // Only the failed topic should be cached
     val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("success-topic", "failed-topic", "nonexistent-topic"), mockTime.milliseconds())
@@ -475,7 +477,8 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      topicErrorCacheCapacity = testCacheCapacity)
 
 
     // First cache an error by simulating topic creation failure
@@ -505,7 +508,7 @@ class AutoTopicCreationManagerTest {
       0, 0, false, null, null, createTopicsResponse)
 
     // Cache the error at T0
-    argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+    argumentCaptor.getValue.onComplete(clientResponse)
 
     // Verify error is cached and accessible within TTL
     val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("test-topic"), mockTime.milliseconds())
@@ -521,28 +524,16 @@ class AutoTopicCreationManagerTest {
   }
 
   @Test
-  def testErrorCacheLRUEviction(): Unit = {
-    // Create a config with a small cache size for testing
-    val props = TestUtils.createBrokerConfig(1)
-    props.setProperty(ServerConfigs.REQUEST_TIMEOUT_MS_CONFIG, requestTimeout.toString)
-    props.setProperty(ServerConfigs.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG, "3") // Small cache size for testing
-    
-    props.setProperty(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, internalTopicPartitions.toString)
-    props.setProperty(TransactionLogConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_CONFIG, internalTopicPartitions.toString)
-    props.setProperty(ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG , internalTopicPartitions.toString)
-    
-    props.setProperty(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
-    props.setProperty(TransactionLogConfig.TRANSACTIONS_TOPIC_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
-    props.setProperty(ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
-    
-    val smallCacheConfig = KafkaConfig.fromProps(props)
-    
-    // Verify the configuration was properly set
-    assertEquals(3, smallCacheConfig.maxIncrementalFetchSessionCacheSlots, "Cache size configuration should be 3")
-    
-    // Replace the test class's config with our smallCacheConfig
-    // so that initializeRequestContext will use the correct config
-    config = smallCacheConfig
+  def testErrorCacheExpirationBasedEviction(): Unit = {
+    // Create manager with small cache size for testing
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator,
+      mockTime,
+      topicErrorCacheCapacity = 3)
     
     val requestContext = initializeRequestContextWithUserPrincipal()
     
@@ -575,7 +566,7 @@ class AutoTopicCreationManagerTest {
       val clientResponse = new ClientResponse(header, null, null,
         0, 0, false, null, null, createTopicsResponse)
       
-      argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+      argumentCaptor.getValue.onComplete(clientResponse)
       
       // Advance time slightly between additions to ensure different timestamps
       mockTime.sleep(10)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
 import org.apache.kafka.common.utils.{SecurityUtils, Utils}
+import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.coordinator.group.{GroupCoordinator, GroupCoordinatorConfig}
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorConfig}
 import org.apache.kafka.metadata.MetadataCache
@@ -42,11 +43,11 @@ import org.apache.kafka.server.config.ServerConfigs
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.quota.ControllerMutationQuota
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.never
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
+import org.mockito.Mockito.never
 
 import scala.collection.{Map, Seq}
 
@@ -60,6 +61,7 @@ class AutoTopicCreationManagerTest {
   private val transactionCoordinator = Mockito.mock(classOf[TransactionCoordinator])
   private val shareCoordinator = Mockito.mock(classOf[ShareCoordinator])
   private var autoTopicCreationManager: AutoTopicCreationManager = _
+  private val mockTime = new MockTime(0L, 0L)
 
   private val internalTopicPartitions = 2
   private val internalTopicReplicationFactor: Short = 2
@@ -76,6 +78,8 @@ class AutoTopicCreationManagerTest {
     props.setProperty(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
     props.setProperty(TransactionLogConfig.TRANSACTIONS_TOPIC_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
     props.setProperty(ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
+    // Set a short group max session timeout for testing TTL (1 second)
+    props.setProperty(GroupCoordinatorConfig.GROUP_MAX_SESSION_TIMEOUT_MS_CONFIG, "1000")
 
     config = KafkaConfig.fromProps(props)
     val aliveBrokers = util.List.of(new Node(0, "host0", 0), new Node(1, "host1", 1))
@@ -115,7 +119,8 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
     topicsCollection.add(getNewTopic(topicName, numPartitions, replicationFactor))
@@ -231,7 +236,8 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
 
@@ -267,13 +273,52 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
 
     Mockito.verify(brokerToController, never()).sendRequest(
       any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
       any(classOf[ControllerRequestCompletionHandler]))
+  }
+
+  @Test
+  def testCreateStreamsInternalTopicsWithDefaultConfig(): Unit = {
+    val topics = Map(
+      "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)
+    )
+    val requestContext = initializeRequestContextWithUserPrincipal()
+
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator,
+      mockTime)
+
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+
+    val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
+    Mockito.verify(brokerToController).sendRequest(
+      argumentCaptor.capture(),
+      any(classOf[ControllerRequestCompletionHandler]))
+
+    val capturedRequest = argumentCaptor.getValue.asInstanceOf[EnvelopeRequest.Builder].build(ApiKeys.ENVELOPE.latestVersion())
+
+    val requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion(), "clientId", 0)
+    val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
+    topicsCollection.add(getNewTopic("stream-topic-1", config.numPartitions, config.defaultReplicationFactor.toShort))
+    val requestBody = new CreateTopicsRequest.Builder(
+      new CreateTopicsRequestData()
+        .setTopics(topicsCollection)
+        .setTimeoutMs(requestTimeout))
+      .build(ApiKeys.CREATE_TOPICS.latestVersion())
+    val forwardedRequestBuffer = capturedRequest.requestData().duplicate()
+    assertEquals(requestHeader, RequestHeader.parse(forwardedRequestBuffer))
+    assertEquals(requestBody.data(), CreateTopicsRequest.parse(new ByteBufferAccessor(forwardedRequestBuffer),
+      ApiKeys.CREATE_TOPICS.latestVersion()).data())
   }
 
   @Test
@@ -288,7 +333,8 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
 
@@ -319,7 +365,8 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     val createTopicApiVersion = new ApiVersionsResponseData.ApiVersion()
       .setApiKey(ApiKeys.CREATE_TOPICS.id)
@@ -364,7 +411,8 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     val topics = Map(
       "test-topic-1" -> new CreatableTopic().setName("test-topic-1").setNumPartitions(1).setReplicationFactor(1)
@@ -408,7 +456,8 @@ class AutoTopicCreationManagerTest {
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
 
     val topics = Map(
       "success-topic" -> new CreatableTopic().setName("success-topic").setNumPartitions(1).setReplicationFactor(1),
@@ -450,82 +499,23 @@ class AutoTopicCreationManagerTest {
     assertEquals("Policy violation", cachedErrors("failed-topic"))
   }
 
-  @Test
-  def testLazyCleanupOfExpiredCacheEntries(): Unit = {
-    // Test will verify that expired entries are cleaned up when accessed
-    // We'll simulate the passage of time by directly manipulating the cache
-    
+  @Test 
+  def testErrorCacheTTL(): Unit = {
     autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
       brokerToController,
       groupCoordinator,
       transactionCoordinator,
-      shareCoordinator)
+      shareCoordinator,
+      mockTime)
     
-    // Manually add an expired entry to the cache using reflection
-    val cacheField = classOf[DefaultAutoTopicCreationManager].getDeclaredField("topicCreationErrorCache")
-    cacheField.setAccessible(true)
-    val cache = cacheField.get(autoTopicCreationManager).asInstanceOf[java.util.concurrent.ConcurrentHashMap[String, CachedTopicCreationError]]
+    // 测试getTopicCreationErrors在没有缓存时返回空
+    val initialResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"))
+    assertTrue(initialResult.isEmpty)
     
-    // Add an entry with old timestamp (expired) - use 2 minutes which is > 3*requestTimeout (3*100ms = 300ms)
-    val expiredTimestamp = System.currentTimeMillis() - (2 * 60 * 1000) // 2 minutes ago
-    cache.put("expired-topic", CachedTopicCreationError("Some error", expiredTimestamp))
-    
-    // Add an entry with fresh timestamp (not expired)
-    val freshTimestamp = System.currentTimeMillis()
-    cache.put("fresh-topic", CachedTopicCreationError("Another error", freshTimestamp))
-    
-    // Query both topics - expired should be removed, fresh should remain
-    val result = autoTopicCreationManager.getTopicCreationErrors(Set("expired-topic", "fresh-topic"))
-    
-    // Only the fresh entry should remain
-    assertEquals(1, result.size)
-    assertTrue(result.contains("fresh-topic"))
-    assertFalse(result.contains("expired-topic"))
-    assertEquals("Another error", result("fresh-topic"))
-    
-    // Verify the expired entry was actually removed from the cache
-    assertFalse(cache.containsKey("expired-topic"))
-    assertTrue(cache.containsKey("fresh-topic"))
-  }
-
-  @Test
-  def testCacheSizeLimitCleanup(): Unit = {
-    // Test will verify that when cache exceeds size limit, oldest entries are removed
-    
-    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
-      config,
-      brokerToController,
-      groupCoordinator,
-      transactionCoordinator,
-      shareCoordinator)
-    
-    // Manually add entries to the cache using reflection
-    val cacheField = classOf[DefaultAutoTopicCreationManager].getDeclaredField("topicCreationErrorCache")
-    cacheField.setAccessible(true)
-    val cache = cacheField.get(autoTopicCreationManager).asInstanceOf[java.util.concurrent.ConcurrentHashMap[String, CachedTopicCreationError]]
-    
-    // Add entries with different timestamps to simulate creation order
-    val baseTime = System.currentTimeMillis()
-    cache.put("oldest-topic", CachedTopicCreationError("Error 1", baseTime - 3000)) // 3 seconds ago
-    cache.put("middle-topic", CachedTopicCreationError("Error 2", baseTime - 2000)) // 2 seconds ago
-    cache.put("newest-topic", CachedTopicCreationError("Error 3", baseTime - 1000)) // 1 second ago
-    
-    // Fill cache beyond the limit (1000) by adding many entries
-    for (i <- 1 to 1002) {
-      cache.put(s"topic-$i", CachedTopicCreationError(s"Error $i", baseTime))
-    }
-    
-    // Now query some topics to trigger cleanup
-    val result = autoTopicCreationManager.getTopicCreationErrors(Set("oldest-topic", "middle-topic", "newest-topic"))
-    
-    // All should still be found since they were queried before cleanup
-    assertEquals(3, result.size)
-    assertTrue(result.contains("oldest-topic"))
-    assertTrue(result.contains("middle-topic"))  
-    assertTrue(result.contains("newest-topic"))
-    
-    // Cache should be limited to maxCacheSize (1000) after cleanup
-    assertTrue(cache.size() <= 1000)
+    // 让时间前进，再次查询确保仍然为空
+    mockTime.sleep(config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs + 1000)
+    val laterResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"))
+    assertTrue(laterResult.isEmpty)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -511,12 +511,122 @@ class AutoTopicCreationManagerTest {
       shareCoordinator,
       mockTime)
 
-    val defaultTtlMs = config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs()
-    val initialResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"), defaultTtlMs)
-    assertTrue(initialResult.isEmpty)
 
-    mockTime.sleep(config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs + 1000)
-    val laterResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"), defaultTtlMs)
-    assertTrue(laterResult.isEmpty)
+    // First cache an error by simulating topic creation failure
+    val topics = Map(
+      "test-topic" -> new CreatableTopic().setName("test-topic").setNumPartitions(1).setReplicationFactor(1)
+    )
+    val requestContext = initializeRequestContextWithUserPrincipal()
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+
+    val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    Mockito.verify(brokerToController).sendRequest(
+      any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
+      argumentCaptor.capture())
+
+    // Simulate a CreateTopicsResponse with error
+    val createTopicsResponseData = new org.apache.kafka.common.message.CreateTopicsResponseData()
+    val topicResult = new org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult()
+      .setName("test-topic")
+      .setErrorCode(Errors.INVALID_REPLICATION_FACTOR.code())
+      .setErrorMessage("Invalid replication factor")
+    createTopicsResponseData.topics().add(topicResult)
+
+    val createTopicsResponse = new CreateTopicsResponse(createTopicsResponseData)
+    val header = new RequestHeader(ApiKeys.CREATE_TOPICS, 0, "client", 1)
+    val clientResponse = new ClientResponse(header, null, null,
+      0, 0, false, null, null, createTopicsResponse)
+
+    // Cache the error at T0
+    argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+
+    val shortTtlMs = 1000L // Use 1 second TTL for faster testing
+    
+    // Verify error is cached and accessible within TTL
+    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic"), shortTtlMs)
+    assertEquals(1, cachedErrors.size)
+    assertEquals("Invalid replication factor", cachedErrors("test-topic"))
+
+    // Advance time beyond TTL
+    mockTime.sleep(shortTtlMs + 100) // T0 + 1.1 seconds
+
+    // Verify error is now expired and proactively cleaned up
+    val expiredErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic"), shortTtlMs)
+    assertTrue(expiredErrors.isEmpty, "Expired errors should be proactively cleaned up")
+  }
+
+  @Test
+  def testErrorCacheLRUEviction(): Unit = {
+    // Create a config with a small cache size for testing
+    val props = TestUtils.createBrokerConfig(1)
+    props.setProperty(ServerConfigs.REQUEST_TIMEOUT_MS_CONFIG, requestTimeout.toString)
+    props.setProperty(ServerConfigs.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG, "3") // Small cache size for testing
+    
+    props.setProperty(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, internalTopicPartitions.toString)
+    props.setProperty(TransactionLogConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_CONFIG, internalTopicPartitions.toString)
+    props.setProperty(ShareCoordinatorConfig.STATE_TOPIC_REPLICATION_FACTOR_CONFIG , internalTopicPartitions.toString)
+    
+    props.setProperty(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
+    props.setProperty(TransactionLogConfig.TRANSACTIONS_TOPIC_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
+    props.setProperty(ShareCoordinatorConfig.STATE_TOPIC_NUM_PARTITIONS_CONFIG, internalTopicReplicationFactor.toString)
+    
+    val smallCacheConfig = KafkaConfig.fromProps(props)
+    
+    // Verify the configuration was properly set
+    assertEquals(3, smallCacheConfig.maxIncrementalFetchSessionCacheSlots, "Cache size configuration should be 3")
+    
+    // Replace the test class's config with our smallCacheConfig
+    // so that initializeRequestContext will use the correct config
+    config = smallCacheConfig
+    
+    val requestContext = initializeRequestContextWithUserPrincipal()
+    
+    // Create 5 topics to exceed the cache size of 3
+    val topicNames = (1 to 5).map(i => s"test-topic-$i")
+    
+    // Add errors for all 5 topics to the cache
+    topicNames.zipWithIndex.foreach { case (topicName, idx) =>
+      val topics = Map(
+        topicName -> new CreatableTopic().setName(topicName).setNumPartitions(1).setReplicationFactor(1)
+      )
+      
+      autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+      
+      val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+      Mockito.verify(brokerToController, Mockito.atLeastOnce()).sendRequest(
+        any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
+        argumentCaptor.capture())
+      
+      // Simulate error response for this topic
+      val createTopicsResponseData = new org.apache.kafka.common.message.CreateTopicsResponseData()
+      val topicResult = new org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult()
+        .setName(topicName)
+        .setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code())
+        .setErrorMessage(s"Topic '$topicName' already exists.")
+      createTopicsResponseData.topics().add(topicResult)
+      
+      val createTopicsResponse = new CreateTopicsResponse(createTopicsResponseData)
+      val header = new RequestHeader(ApiKeys.CREATE_TOPICS, 0, "client", 1)
+      val clientResponse = new ClientResponse(header, null, null,
+        0, 0, false, null, null, createTopicsResponse)
+      
+      argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+      
+      // Advance time slightly between additions to ensure different timestamps
+      mockTime.sleep(10)
+      
+    }
+    
+    // With cache size of 3, topics 1 and 2 should have been evicted
+    val longTtlMs = 60000L // Use a long TTL to ensure entries aren't expired by time
+    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(topicNames.toSet, longTtlMs)
+    
+    // Only the last 3 topics should be in the cache (topics 3, 4, 5)
+    assertEquals(3, cachedErrors.size, "Cache should contain only the most recent 3 entries")
+    assertTrue(cachedErrors.contains("test-topic-3"), "test-topic-3 should be in cache")
+    assertTrue(cachedErrors.contains("test-topic-4"), "test-topic-4 should be in cache")
+    assertTrue(cachedErrors.contains("test-topic-5"), "test-topic-5 should be in cache")
+    assertTrue(!cachedErrors.contains("test-topic-1"), "test-topic-1 should have been evicted")
+    assertTrue(!cachedErrors.contains("test-topic-2"), "test-topic-2 should have been evicted")
   }
 }

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -467,8 +467,8 @@ class AutoTopicCreationManagerTest {
     cacheField.setAccessible(true)
     val cache = cacheField.get(autoTopicCreationManager).asInstanceOf[java.util.concurrent.ConcurrentHashMap[String, CachedTopicCreationError]]
     
-    // Add an entry with old timestamp (expired)
-    val expiredTimestamp = System.currentTimeMillis() - (6 * 60 * 1000) // 6 minutes ago
+    // Add an entry with old timestamp (expired) - use 2 minutes which is > 3*requestTimeout (3*100ms = 300ms)
+    val expiredTimestamp = System.currentTimeMillis() - (2 * 60 * 1000) // 2 minutes ago
     cache.put("expired-topic", CachedTopicCreationError("Some error", expiredTimestamp))
     
     // Add an entry with fresh timestamp (not expired)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -443,7 +443,8 @@ class AutoTopicCreationManagerTest {
     argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
 
     // Verify that the error was cached
-    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic-1"))
+    val defaultTtlMs = config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs()
+    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic-1"), defaultTtlMs)
     assertEquals(1, cachedErrors.size)
     assertTrue(cachedErrors.contains("test-topic-1"))
     assertEquals("Topic 'test-topic-1' already exists.", cachedErrors("test-topic-1"))
@@ -493,7 +494,8 @@ class AutoTopicCreationManagerTest {
     argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
 
     // Only the failed topic should be cached
-    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("success-topic", "failed-topic", "nonexistent-topic"))
+    val defaultTtlMs = config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs()
+    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("success-topic", "failed-topic", "nonexistent-topic"), defaultTtlMs)
     assertEquals(1, cachedErrors.size)
     assertTrue(cachedErrors.contains("failed-topic"))
     assertEquals("Policy violation", cachedErrors("failed-topic"))
@@ -509,11 +511,12 @@ class AutoTopicCreationManagerTest {
       shareCoordinator,
       mockTime)
 
-    val initialResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"))
+    val defaultTtlMs = config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs()
+    val initialResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"), defaultTtlMs)
     assertTrue(initialResult.isEmpty)
 
     mockTime.sleep(config.groupCoordinatorConfig.classicGroupMaxSessionTimeoutMs + 1000)
-    val laterResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"))
+    val laterResult = autoTopicCreationManager.getTopicCreationErrors(Set("nonexistent-topic"), defaultTtlMs)
     assertTrue(laterResult.isEmpty)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -284,44 +284,6 @@ class AutoTopicCreationManagerTest {
   }
 
   @Test
-  def testCreateStreamsInternalTopicsWithDefaultConfig(): Unit = {
-    val topics = Map(
-      "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)
-    )
-    val requestContext = initializeRequestContextWithUserPrincipal()
-
-    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
-      config,
-      brokerToController,
-      groupCoordinator,
-      transactionCoordinator,
-      shareCoordinator,
-      mockTime)
-
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
-
-    val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
-    Mockito.verify(brokerToController).sendRequest(
-      argumentCaptor.capture(),
-      any(classOf[ControllerRequestCompletionHandler]))
-
-    val capturedRequest = argumentCaptor.getValue.asInstanceOf[EnvelopeRequest.Builder].build(ApiKeys.ENVELOPE.latestVersion())
-
-    val requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion(), "clientId", 0)
-    val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
-    topicsCollection.add(getNewTopic("stream-topic-1", config.numPartitions, config.defaultReplicationFactor.toShort))
-    val requestBody = new CreateTopicsRequest.Builder(
-      new CreateTopicsRequestData()
-        .setTopics(topicsCollection)
-        .setTimeoutMs(requestTimeout))
-      .build(ApiKeys.CREATE_TOPICS.latestVersion())
-    val forwardedRequestBuffer = capturedRequest.requestData().duplicate()
-    assertEquals(requestHeader, RequestHeader.parse(forwardedRequestBuffer))
-    assertEquals(requestBody.data(), CreateTopicsRequest.parse(new ByteBufferAccessor(forwardedRequestBuffer),
-      ApiKeys.CREATE_TOPICS.latestVersion()).data())
-  }
-
-  @Test
   def testCreateStreamsInternalTopicsPassesPrincipal(): Unit = {
     val topics = Map(
       "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -42,7 +42,7 @@ import org.apache.kafka.server.config.ServerConfigs
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.quota.ControllerMutationQuota
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.never
@@ -355,5 +355,177 @@ class AutoTopicCreationManagerTest {
       .setName(topicName)
       .setNumPartitions(numPartitions)
       .setReplicationFactor(replicationFactor)
+  }
+
+  @Test
+  def testTopicCreationErrorCaching(): Unit = {
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator)
+
+    val topics = Map(
+      "test-topic-1" -> new CreatableTopic().setName("test-topic-1").setNumPartitions(1).setReplicationFactor(1)
+    )
+    val requestContext = initializeRequestContextWithUserPrincipal()
+
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+
+    val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    Mockito.verify(brokerToController).sendRequest(
+      any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
+      argumentCaptor.capture())
+
+    // Simulate a CreateTopicsResponse with errors
+    val createTopicsResponseData = new org.apache.kafka.common.message.CreateTopicsResponseData()
+    val topicResult = new org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult()
+      .setName("test-topic-1")
+      .setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code())
+      .setErrorMessage("Topic 'test-topic-1' already exists.")
+    createTopicsResponseData.topics().add(topicResult)
+
+    val createTopicsResponse = new CreateTopicsResponse(createTopicsResponseData)
+    val header = new RequestHeader(ApiKeys.CREATE_TOPICS, 0, "client", 1)
+    val clientResponse = new ClientResponse(header, null, null,
+      0, 0, false, null, null, createTopicsResponse)
+
+    // Trigger the completion handler
+    argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+
+    // Verify that the error was cached
+    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic-1"))
+    assertEquals(1, cachedErrors.size)
+    assertTrue(cachedErrors.contains("test-topic-1"))
+    assertEquals("Topic 'test-topic-1' already exists.", cachedErrors("test-topic-1"))
+  }
+
+  @Test
+  def testGetTopicCreationErrorsWithMultipleTopics(): Unit = {
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator)
+
+    val topics = Map(
+      "success-topic" -> new CreatableTopic().setName("success-topic").setNumPartitions(1).setReplicationFactor(1),
+      "failed-topic" -> new CreatableTopic().setName("failed-topic").setNumPartitions(1).setReplicationFactor(1)
+    )
+    val requestContext = initializeRequestContextWithUserPrincipal()
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+
+    val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    Mockito.verify(brokerToController).sendRequest(
+      any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
+      argumentCaptor.capture())
+
+    // Simulate mixed response - one success, one failure
+    val createTopicsResponseData = new org.apache.kafka.common.message.CreateTopicsResponseData()
+    createTopicsResponseData.topics().add(
+      new org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult()
+        .setName("success-topic")
+        .setErrorCode(Errors.NONE.code())
+    )
+    createTopicsResponseData.topics().add(
+      new org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult()
+        .setName("failed-topic")
+        .setErrorCode(Errors.POLICY_VIOLATION.code())
+        .setErrorMessage("Policy violation")
+    )
+
+    val createTopicsResponse = new CreateTopicsResponse(createTopicsResponseData)
+    val header = new RequestHeader(ApiKeys.CREATE_TOPICS, 0, "client", 1)
+    val clientResponse = new ClientResponse(header, null, null,
+      0, 0, false, null, null, createTopicsResponse)
+
+    argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
+
+    // Only the failed topic should be cached
+    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("success-topic", "failed-topic", "nonexistent-topic"))
+    assertEquals(1, cachedErrors.size)
+    assertTrue(cachedErrors.contains("failed-topic"))
+    assertEquals("Policy violation", cachedErrors("failed-topic"))
+  }
+
+  @Test
+  def testLazyCleanupOfExpiredCacheEntries(): Unit = {
+    // Test will verify that expired entries are cleaned up when accessed
+    // We'll simulate the passage of time by directly manipulating the cache
+    
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator)
+    
+    // Manually add an expired entry to the cache using reflection
+    val cacheField = classOf[DefaultAutoTopicCreationManager].getDeclaredField("topicCreationErrorCache")
+    cacheField.setAccessible(true)
+    val cache = cacheField.get(autoTopicCreationManager).asInstanceOf[java.util.concurrent.ConcurrentHashMap[String, CachedTopicCreationError]]
+    
+    // Add an entry with old timestamp (expired)
+    val expiredTimestamp = System.currentTimeMillis() - (6 * 60 * 1000) // 6 minutes ago
+    cache.put("expired-topic", CachedTopicCreationError("Some error", expiredTimestamp))
+    
+    // Add an entry with fresh timestamp (not expired)
+    val freshTimestamp = System.currentTimeMillis()
+    cache.put("fresh-topic", CachedTopicCreationError("Another error", freshTimestamp))
+    
+    // Query both topics - expired should be removed, fresh should remain
+    val result = autoTopicCreationManager.getTopicCreationErrors(Set("expired-topic", "fresh-topic"))
+    
+    // Only the fresh entry should remain
+    assertEquals(1, result.size)
+    assertTrue(result.contains("fresh-topic"))
+    assertFalse(result.contains("expired-topic"))
+    assertEquals("Another error", result("fresh-topic"))
+    
+    // Verify the expired entry was actually removed from the cache
+    assertFalse(cache.containsKey("expired-topic"))
+    assertTrue(cache.containsKey("fresh-topic"))
+  }
+
+  @Test
+  def testCacheSizeLimitCleanup(): Unit = {
+    // Test will verify that when cache exceeds size limit, oldest entries are removed
+    
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator)
+    
+    // Manually add entries to the cache using reflection
+    val cacheField = classOf[DefaultAutoTopicCreationManager].getDeclaredField("topicCreationErrorCache")
+    cacheField.setAccessible(true)
+    val cache = cacheField.get(autoTopicCreationManager).asInstanceOf[java.util.concurrent.ConcurrentHashMap[String, CachedTopicCreationError]]
+    
+    // Add entries with different timestamps to simulate creation order
+    val baseTime = System.currentTimeMillis()
+    cache.put("oldest-topic", CachedTopicCreationError("Error 1", baseTime - 3000)) // 3 seconds ago
+    cache.put("middle-topic", CachedTopicCreationError("Error 2", baseTime - 2000)) // 2 seconds ago
+    cache.put("newest-topic", CachedTopicCreationError("Error 3", baseTime - 1000)) // 1 second ago
+    
+    // Fill cache beyond the limit (1000) by adding many entries
+    for (i <- 1 to 1002) {
+      cache.put(s"topic-$i", CachedTopicCreationError(s"Error $i", baseTime))
+    }
+    
+    // Now query some topics to trigger cleanup
+    val result = autoTopicCreationManager.getTopicCreationErrors(Set("oldest-topic", "middle-topic", "newest-topic"))
+    
+    // All should still be found since they were queried before cleanup
+    assertEquals(3, result.size)
+    assertTrue(result.contains("oldest-topic"))
+    assertTrue(result.contains("middle-topic"))  
+    assertTrue(result.contains("newest-topic"))
+    
+    // Cache should be limited to maxCacheSize (1000) after cleanup
+    assertTrue(cache.size() <= 1000)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -122,7 +122,7 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator,
       shareCoordinator,
       mockTime,
-      cacheCapacity = testCacheCapacity)
+      topicErrorCacheCapacity = testCacheCapacity)
 
     val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
     topicsCollection.add(getNewTopic(topicName, numPartitions, replicationFactor))
@@ -240,9 +240,9 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator,
       shareCoordinator,
       mockTime,
-      cacheCapacity = testCacheCapacity)
+      topicErrorCacheCapacity = testCacheCapacity)
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs() * 2)
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
     Mockito.verify(brokerToController).sendRequest(
@@ -278,9 +278,9 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator,
       shareCoordinator,
       mockTime,
-      cacheCapacity = testCacheCapacity)
+      topicErrorCacheCapacity = testCacheCapacity)
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs() * 2)
 
     Mockito.verify(brokerToController, never()).sendRequest(
       any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
@@ -301,9 +301,9 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator,
       shareCoordinator,
       mockTime,
-      cacheCapacity = testCacheCapacity)
+      topicErrorCacheCapacity = testCacheCapacity)
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs() * 2)
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
     Mockito.verify(brokerToController).sendRequest(
@@ -334,7 +334,7 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator,
       shareCoordinator,
       mockTime,
-      cacheCapacity = testCacheCapacity)
+      topicErrorCacheCapacity = testCacheCapacity)
 
     val createTopicApiVersion = new ApiVersionsResponseData.ApiVersion()
       .setApiKey(ApiKeys.CREATE_TOPICS.id)
@@ -387,7 +387,7 @@ class AutoTopicCreationManagerTest {
     )
     val requestContext = initializeRequestContextWithUserPrincipal()
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs() * 2)
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(
@@ -432,7 +432,7 @@ class AutoTopicCreationManagerTest {
       "failed-topic" -> new CreatableTopic().setName("failed-topic").setNumPartitions(1).setReplicationFactor(1)
     )
     val requestContext = initializeRequestContextWithUserPrincipal()
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs() * 2)
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(
@@ -484,7 +484,7 @@ class AutoTopicCreationManagerTest {
     )
     val requestContext = initializeRequestContextWithUserPrincipal()
     val shortTtlMs = 1000L // Use 1 second TTL for faster testing
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + shortTtlMs)
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, shortTtlMs)
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(
@@ -555,7 +555,7 @@ class AutoTopicCreationManagerTest {
         topicName -> new CreatableTopic().setName(topicName).setNumPartitions(1).setReplicationFactor(1)
       )
       
-      autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
+      autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, config.groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs() * 2)
       
       val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
       Mockito.verify(brokerToController, Mockito.atLeastOnce()).sendRequest(

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -54,6 +54,7 @@ import scala.collection.{Map, Seq}
 class AutoTopicCreationManagerTest {
 
   private val requestTimeout = 100
+  private val testCacheCapacity = 3
   private var config: KafkaConfig = _
   private val metadataCache = Mockito.mock(classOf[MetadataCache])
   private val brokerToController = Mockito.mock(classOf[NodeToControllerChannelManager])
@@ -120,7 +121,8 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      cacheCapacity = testCacheCapacity)
 
     val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
     topicsCollection.add(getNewTopic(topicName, numPartitions, replicationFactor))
@@ -237,9 +239,10 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      cacheCapacity = testCacheCapacity)
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
     Mockito.verify(brokerToController).sendRequest(
@@ -274,9 +277,10 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      cacheCapacity = testCacheCapacity)
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
 
     Mockito.verify(brokerToController, never()).sendRequest(
       any(classOf[AbstractRequest.Builder[_ <: AbstractRequest]]),
@@ -296,9 +300,10 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      cacheCapacity = testCacheCapacity)
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
     Mockito.verify(brokerToController).sendRequest(
@@ -328,7 +333,8 @@ class AutoTopicCreationManagerTest {
       groupCoordinator,
       transactionCoordinator,
       shareCoordinator,
-      mockTime)
+      mockTime,
+      cacheCapacity = testCacheCapacity)
 
     val createTopicApiVersion = new ApiVersionsResponseData.ApiVersion()
       .setApiKey(ApiKeys.CREATE_TOPICS.id)
@@ -381,7 +387,7 @@ class AutoTopicCreationManagerTest {
     )
     val requestContext = initializeRequestContextWithUserPrincipal()
 
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(
@@ -405,8 +411,7 @@ class AutoTopicCreationManagerTest {
     argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
 
     // Verify that the error was cached
-    val defaultTtlMs = config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs()
-    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic-1"), defaultTtlMs)
+    val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("test-topic-1"), mockTime.milliseconds())
     assertEquals(1, cachedErrors.size)
     assertTrue(cachedErrors.contains("test-topic-1"))
     assertEquals("Topic 'test-topic-1' already exists.", cachedErrors("test-topic-1"))
@@ -427,7 +432,7 @@ class AutoTopicCreationManagerTest {
       "failed-topic" -> new CreatableTopic().setName("failed-topic").setNumPartitions(1).setReplicationFactor(1)
     )
     val requestContext = initializeRequestContextWithUserPrincipal()
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(
@@ -456,8 +461,7 @@ class AutoTopicCreationManagerTest {
     argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
 
     // Only the failed topic should be cached
-    val defaultTtlMs = config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs()
-    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("success-topic", "failed-topic", "nonexistent-topic"), defaultTtlMs)
+    val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("success-topic", "failed-topic", "nonexistent-topic"), mockTime.milliseconds())
     assertEquals(1, cachedErrors.size)
     assertTrue(cachedErrors.contains("failed-topic"))
     assertEquals("Policy violation", cachedErrors("failed-topic"))
@@ -479,7 +483,8 @@ class AutoTopicCreationManagerTest {
       "test-topic" -> new CreatableTopic().setName("test-topic").setNumPartitions(1).setReplicationFactor(1)
     )
     val requestContext = initializeRequestContextWithUserPrincipal()
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+    val shortTtlMs = 1000L // Use 1 second TTL for faster testing
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + shortTtlMs)
 
     val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(
@@ -502,10 +507,8 @@ class AutoTopicCreationManagerTest {
     // Cache the error at T0
     argumentCaptor.getValue.asInstanceOf[ControllerRequestCompletionHandler].onComplete(clientResponse)
 
-    val shortTtlMs = 1000L // Use 1 second TTL for faster testing
-    
     // Verify error is cached and accessible within TTL
-    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic"), shortTtlMs)
+    val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("test-topic"), mockTime.milliseconds())
     assertEquals(1, cachedErrors.size)
     assertEquals("Invalid replication factor", cachedErrors("test-topic"))
 
@@ -513,7 +516,7 @@ class AutoTopicCreationManagerTest {
     mockTime.sleep(shortTtlMs + 100) // T0 + 1.1 seconds
 
     // Verify error is now expired and proactively cleaned up
-    val expiredErrors = autoTopicCreationManager.getTopicCreationErrors(Set("test-topic"), shortTtlMs)
+    val expiredErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(Set("test-topic"), mockTime.milliseconds())
     assertTrue(expiredErrors.isEmpty, "Expired errors should be proactively cleaned up")
   }
 
@@ -552,7 +555,7 @@ class AutoTopicCreationManagerTest {
         topicName -> new CreatableTopic().setName(topicName).setNumPartitions(1).setReplicationFactor(1)
       )
       
-      autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+      autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext, mockTime.milliseconds() + config.groupCoordinatorConfig.streamsGroupSessionTimeoutMs())
       
       val argumentCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
       Mockito.verify(brokerToController, Mockito.atLeastOnce()).sendRequest(
@@ -580,8 +583,7 @@ class AutoTopicCreationManagerTest {
     }
     
     // With cache size of 3, topics 1 and 2 should have been evicted
-    val longTtlMs = 60000L // Use a long TTL to ensure entries aren't expired by time
-    val cachedErrors = autoTopicCreationManager.getTopicCreationErrors(topicNames.toSet, longTtlMs)
+    val cachedErrors = autoTopicCreationManager.getStreamsInternalTopicCreationErrors(topicNames.toSet, mockTime.milliseconds())
     
     // Only the last 3 topics should be in the cache (topics 3, 4, 5)
     assertEquals(3, cachedErrors.size, "Cache should contain only the most recent 3 entries")

--- a/core/src/test/scala/unit/kafka/server/ExpiringErrorCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ExpiringErrorCacheTest.scala
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import org.apache.kafka.server.util.MockTime
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{BeforeEach, Test}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Random
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+class ExpiringErrorCacheTest {
+
+  private var mockTime: MockTime = _
+  private var cache: ExpiringErrorCache = _
+  
+  @BeforeEach
+  def setUp(): Unit = {
+    mockTime = new MockTime()
+  }
+
+  // Basic Functionality Tests
+  
+  @Test
+  def testPutAndGet(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic2", "error2", 2000L)
+    
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2"), mockTime.milliseconds())
+    assertEquals(2, errors.size)
+    assertEquals("error1", errors("topic1"))
+    assertEquals("error2", errors("topic2"))
+  }
+  
+  @Test
+  def testGetNonExistentTopic(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2"), mockTime.milliseconds())
+    assertEquals(1, errors.size)
+    assertEquals("error1", errors("topic1"))
+    assertFalse(errors.contains("topic2"))
+  }
+  
+  @Test
+  def testUpdateExistingEntry(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    assertEquals("error1", cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds())("topic1"))
+    
+    // Update with new error
+    cache.put("topic1", "error2", 2000L)
+    assertEquals("error2", cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds())("topic1"))
+  }
+  
+  @Test
+  def testGetMultipleTopics(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic2", "error2", 1000L)
+    cache.put("topic3", "error3", 1000L)
+    
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic3", "topic4"), mockTime.milliseconds())
+    assertEquals(2, errors.size)
+    assertEquals("error1", errors("topic1"))
+    assertEquals("error3", errors("topic3"))
+    assertFalse(errors.contains("topic2"))
+    assertFalse(errors.contains("topic4"))
+  }
+
+  // Expiration Tests
+  
+  @Test
+  def testExpiredEntryNotReturned(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    
+    // Entry should be available before expiration
+    assertEquals(1, cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds()).size)
+    
+    // Advance time past expiration
+    mockTime.sleep(1001L)
+    
+    // Entry should not be returned after expiration
+    assertTrue(cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds()).isEmpty)
+  }
+  
+  @Test
+  def testExpiredEntriesCleanedOnPut(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    // Add entries with different TTLs
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic2", "error2", 2000L)
+    
+    // Advance time to expire topic1 but not topic2
+    mockTime.sleep(1500L)
+    
+    // Add a new entry - this should trigger cleanup
+    cache.put("topic3", "error3", 1000L)
+    
+    // Verify only non-expired entries remain
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2", "topic3"), mockTime.milliseconds())
+    assertEquals(2, errors.size)
+    assertFalse(errors.contains("topic1"))
+    assertEquals("error2", errors("topic2"))
+    assertEquals("error3", errors("topic3"))
+  }
+  
+  @Test
+  def testMixedExpiredAndValidEntries(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 500L)
+    cache.put("topic2", "error2", 1000L)
+    cache.put("topic3", "error3", 1500L)
+    
+    // Advance time to expire only topic1
+    mockTime.sleep(600L)
+    
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2", "topic3"), mockTime.milliseconds())
+    assertEquals(2, errors.size)
+    assertFalse(errors.contains("topic1"))
+    assertTrue(errors.contains("topic2"))
+    assertTrue(errors.contains("topic3"))
+  }
+
+  // Capacity Enforcement Tests
+  
+  @Test
+  def testCapacityEnforcement(): Unit = {
+    cache = new ExpiringErrorCache(3, mockTime)
+    
+    // Add 5 entries, exceeding capacity of 3
+    for (i <- 1 to 5) {
+      cache.put(s"topic$i", s"error$i", 1000L)
+      // Small time advance between entries to ensure different insertion order
+      mockTime.sleep(10L)
+    }
+    
+    val errors = cache.getErrorsForTopics((1 to 5).map(i => s"topic$i").toSet, mockTime.milliseconds())
+    assertEquals(3, errors.size)
+    
+    // The cache evicts by earliest expiration time
+    // Since all have same TTL, earliest inserted (topic1, topic2) should be evicted
+    assertFalse(errors.contains("topic1"))
+    assertFalse(errors.contains("topic2"))
+    assertTrue(errors.contains("topic3"))
+    assertTrue(errors.contains("topic4"))
+    assertTrue(errors.contains("topic5"))
+  }
+  
+  @Test
+  def testEvictionOrder(): Unit = {
+    cache = new ExpiringErrorCache(3, mockTime)
+    
+    // Add entries with different TTLs
+    cache.put("topic1", "error1", 3000L) // Expires at 3000
+    mockTime.sleep(100L)
+    cache.put("topic2", "error2", 1000L) // Expires at 1100
+    mockTime.sleep(100L)
+    cache.put("topic3", "error3", 2000L) // Expires at 2200
+    mockTime.sleep(100L)
+    cache.put("topic4", "error4", 500L)  // Expires at 800
+    
+    // With capacity 3, topic4 (earliest expiration) should be evicted
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2", "topic3", "topic4"), mockTime.milliseconds())
+    assertEquals(3, errors.size)
+    assertTrue(errors.contains("topic1"))
+    assertTrue(errors.contains("topic2"))
+    assertTrue(errors.contains("topic3"))
+    assertFalse(errors.contains("topic4"))
+  }
+  
+  @Test
+  def testCapacityWithDifferentTTLs(): Unit = {
+    cache = new ExpiringErrorCache(2, mockTime)
+    
+    cache.put("topic1", "error1", 5000L) // Long TTL
+    cache.put("topic2", "error2", 100L)  // Short TTL
+    cache.put("topic3", "error3", 3000L) // Medium TTL
+    
+    // topic2 has earliest expiration, so it should be evicted
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2", "topic3"), mockTime.milliseconds())
+    assertEquals(2, errors.size)
+    assertTrue(errors.contains("topic1"))
+    assertFalse(errors.contains("topic2"))
+    assertTrue(errors.contains("topic3"))
+  }
+
+  // Update and Stale Entry Tests
+  
+  @Test
+  def testUpdateDoesNotLeaveStaleEntries(): Unit = {
+    cache = new ExpiringErrorCache(3, mockTime)
+    
+    // Fill cache to capacity
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic2", "error2", 1000L)
+    cache.put("topic3", "error3", 1000L)
+    
+    // Update topic2 with longer TTL
+    cache.put("topic2", "error2_updated", 5000L)
+    
+    // Add new entry to trigger eviction
+    cache.put("topic4", "error4", 1000L)
+    
+    // Should evict topic1 or topic3 (earliest expiration), not the updated topic2
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2", "topic3", "topic4"), mockTime.milliseconds())
+    assertEquals(3, errors.size)
+    assertTrue(errors.contains("topic2"))
+    assertEquals("error2_updated", errors("topic2"))
+  }
+  
+  @Test
+  def testStaleEntriesInQueueHandledCorrectly(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    // Add and update same topic multiple times
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic1", "error2", 2000L)
+    cache.put("topic1", "error3", 3000L)
+    
+    // Only latest value should be returned
+    val errors = cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds())
+    assertEquals(1, errors.size)
+    assertEquals("error3", errors("topic1"))
+    
+    // Advance time to expire first two entries
+    mockTime.sleep(2500L)
+    
+    // Force cleanup by adding new entry
+    cache.put("topic2", "error_new", 1000L)
+    
+    // topic1 should still be available with latest value
+    val errorsAfterCleanup = cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds())
+    assertEquals(1, errorsAfterCleanup.size)
+    assertEquals("error3", errorsAfterCleanup("topic1"))
+  }
+
+  // Edge Cases
+  
+  @Test
+  def testEmptyCache(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2"), mockTime.milliseconds())
+    assertTrue(errors.isEmpty)
+  }
+  
+  @Test
+  def testSingleEntryCache(): Unit = {
+    cache = new ExpiringErrorCache(1, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic2", "error2", 1000L)
+    
+    // Only most recent should remain
+    val errors = cache.getErrorsForTopics(Set("topic1", "topic2"), mockTime.milliseconds())
+    assertEquals(1, errors.size)
+    assertFalse(errors.contains("topic1"))
+    assertTrue(errors.contains("topic2"))
+  }
+  
+  @Test
+  def testZeroTTL(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 0L)
+    
+    // Entry expires immediately
+    assertTrue(cache.getErrorsForTopics(Set("topic1"), mockTime.milliseconds()).isEmpty)
+  }
+  
+  @Test
+  def testClearOperation(): Unit = {
+    cache = new ExpiringErrorCache(10, mockTime)
+    
+    cache.put("topic1", "error1", 1000L)
+    cache.put("topic2", "error2", 1000L)
+    
+    assertEquals(2, cache.getErrorsForTopics(Set("topic1", "topic2"), mockTime.milliseconds()).size)
+    
+    cache.clear()
+    
+    assertTrue(cache.getErrorsForTopics(Set("topic1", "topic2"), mockTime.milliseconds()).isEmpty)
+  }
+
+  // Concurrent Access Tests
+  
+  @Test
+  def testConcurrentPutOperations(): Unit = {
+    cache = new ExpiringErrorCache(100, mockTime)
+    val numThreads = 10
+    val numTopicsPerThread = 20
+    val latch = new CountDownLatch(numThreads)
+    
+    (1 to numThreads).foreach { threadId =>
+      Future {
+        try {
+          for (i <- 1 to numTopicsPerThread) {
+            cache.put(s"topic_${threadId}_$i", s"error_${threadId}_$i", 1000L)
+          }
+        } finally {
+          latch.countDown()
+        }
+      }
+    }
+    
+    assertTrue(latch.await(5, TimeUnit.SECONDS))
+    
+    // Verify all entries were added
+    val allTopics = (1 to numThreads).flatMap { threadId =>
+      (1 to numTopicsPerThread).map(i => s"topic_${threadId}_$i")
+    }.toSet
+    
+    val errors = cache.getErrorsForTopics(allTopics, mockTime.milliseconds())
+    assertEquals(100, errors.size) // Limited by cache capacity
+  }
+  
+  @Test
+  def testConcurrentPutAndGet(): Unit = {
+    cache = new ExpiringErrorCache(100, mockTime)
+    val numOperations = 1000
+    val random = new Random()
+    val topics = (1 to 50).map(i => s"topic$i").toArray
+    
+    val futures = (1 to numOperations).map { _ =>
+      Future {
+        if (random.nextBoolean()) {
+          // Put operation
+          val topic = topics(random.nextInt(topics.length))
+          cache.put(topic, s"error_${random.nextInt()}", 1000L)
+        } else {
+          // Get operation
+          val topicsToGet = Set(topics(random.nextInt(topics.length)))
+          cache.getErrorsForTopics(topicsToGet, mockTime.milliseconds())
+        }
+      }
+    }
+    
+    // Wait for all operations to complete
+    Future.sequence(futures).map(_ => ())
+  }
+  
+  @Test
+  def testConcurrentUpdates(): Unit = {
+    cache = new ExpiringErrorCache(50, mockTime)
+    val numThreads = 10
+    val numUpdatesPerThread = 100
+    val sharedTopics = (1 to 10).map(i => s"shared_topic$i").toArray
+    val latch = new CountDownLatch(numThreads)
+    
+    (1 to numThreads).foreach { threadId =>
+      Future {
+        try {
+          val random = new Random()
+          for (i <- 1 to numUpdatesPerThread) {
+            val topic = sharedTopics(random.nextInt(sharedTopics.length))
+            cache.put(topic, s"error_thread${threadId}_update$i", 1000L)
+          }
+        } finally {
+          latch.countDown()
+        }
+      }
+    }
+    
+    assertTrue(latch.await(5, TimeUnit.SECONDS))
+    
+    // Verify all shared topics have some value
+    val errors = cache.getErrorsForTopics(sharedTopics.toSet, mockTime.milliseconds())
+    sharedTopics.foreach { topic =>
+      assertTrue(errors.contains(topic), s"Topic $topic should have a value")
+      assertTrue(errors(topic).startsWith("error_thread"), s"Value should be from one of the threads")
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -10890,7 +10890,7 @@ class KafkaApisTest extends Logging {
     future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics.asJava))
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(streamsGroupHeartbeatResponse, response.data)
-    verify(autoTopicCreationManager).createStreamsInternalTopics(missingTopics, requestChannelRequest.context)
+    verify(autoTopicCreationManager).createStreamsInternalTopics(any(), any(), anyLong())
   }
 
   @Test
@@ -10969,10 +10969,10 @@ class KafkaApisTest extends Logging {
 
     // Mock AutoTopicCreationManager to return cached errors
     val mockAutoTopicCreationManager = mock(classOf[AutoTopicCreationManager])
-    when(mockAutoTopicCreationManager.getTopicCreationErrors(ArgumentMatchers.eq(Set("test-topic")), any()))
+    when(mockAutoTopicCreationManager.getStreamsInternalTopicCreationErrors(ArgumentMatchers.eq(Set("test-topic")), any()))
       .thenReturn(Map("test-topic" -> "INVALID_REPLICATION_FACTOR"))
     // Mock the createStreamsInternalTopics method to do nothing (simulate topic creation attempt)
-    doNothing().when(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any())
+    doNothing().when(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any(), anyLong())
 
     kafkaApis = createKafkaApis(autoTopicCreationManager = Some(mockAutoTopicCreationManager))
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
@@ -11001,8 +11001,8 @@ class KafkaApisTest extends Logging {
     assertTrue(status.statusDetail().contains("Creation failed: test-topic (INVALID_REPLICATION_FACTOR)"))
     
     // Verify that createStreamsInternalTopics was called
-    verify(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any())
-    verify(mockAutoTopicCreationManager).getTopicCreationErrors(ArgumentMatchers.eq(Set("test-topic")), any())
+    verify(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any(), anyLong())
+    verify(mockAutoTopicCreationManager).getStreamsInternalTopicCreationErrors(ArgumentMatchers.eq(Set("test-topic")), any())
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -10969,7 +10969,7 @@ class KafkaApisTest extends Logging {
 
     // Mock AutoTopicCreationManager to return cached errors
     val mockAutoTopicCreationManager = mock(classOf[AutoTopicCreationManager])
-    when(mockAutoTopicCreationManager.getTopicCreationErrors(Set("test-topic")))
+    when(mockAutoTopicCreationManager.getTopicCreationErrors(ArgumentMatchers.eq(Set("test-topic")), any()))
       .thenReturn(Map("test-topic" -> "INVALID_REPLICATION_FACTOR"))
     // Mock the createStreamsInternalTopics method to do nothing (simulate topic creation attempt)
     doNothing().when(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any())
@@ -11002,7 +11002,7 @@ class KafkaApisTest extends Logging {
     
     // Verify that createStreamsInternalTopics was called
     verify(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any())
-    verify(mockAutoTopicCreationManager).getTopicCreationErrors(Set("test-topic"))
+    verify(mockAutoTopicCreationManager).getTopicCreationErrors(ArgumentMatchers.eq(Set("test-topic")), any())
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -169,7 +169,8 @@ class KafkaApisTest extends Logging {
     authorizer: Option[Authorizer] = None,
     configRepository: ConfigRepository = new MockConfigRepository(),
     overrideProperties: Map[String, String] = Map.empty,
-    featureVersions: Seq[FeatureVersion] = Seq.empty
+    featureVersions: Seq[FeatureVersion] = Seq.empty,
+    autoTopicCreationManager: Option[AutoTopicCreationManager] = None
   ): KafkaApis = {
 
     val properties = TestUtils.createBrokerConfig(brokerId)
@@ -195,7 +196,7 @@ class KafkaApisTest extends Logging {
       groupCoordinator = groupCoordinator,
       txnCoordinator = txnCoordinator,
       shareCoordinator = shareCoordinator,
-      autoTopicCreationManager = autoTopicCreationManager,
+      autoTopicCreationManager = autoTopicCreationManager.getOrElse(this.autoTopicCreationManager),
       brokerId = brokerId,
       config = config,
       configRepository = configRepository,
@@ -10947,6 +10948,59 @@ class KafkaApisTest extends Logging {
       ),
       response.data.status()
     )
+  }
+
+  @Test
+  def testStreamsGroupHeartbeatRequestWithCachedTopicCreationErrors(): Unit = {
+    val features = mock(classOf[FinalizedFeatures])
+    when(features.finalizedFeatures()).thenReturn(util.Map.of(StreamsVersion.FEATURE_NAME, 1.toShort))
+
+    metadataCache = mock(classOf[KRaftMetadataCache])
+    when(metadataCache.features()).thenReturn(features)
+
+    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequestData().setGroupId("group")
+    val requestChannelRequest = buildRequest(new StreamsGroupHeartbeatRequest.Builder(streamsGroupHeartbeatRequest, true).build())
+
+    val future = new CompletableFuture[StreamsGroupHeartbeatResult]()
+    when(groupCoordinator.streamsGroupHeartbeat(
+      requestChannelRequest.context,
+      streamsGroupHeartbeatRequest
+    )).thenReturn(future)
+
+    // Mock AutoTopicCreationManager to return cached errors
+    val mockAutoTopicCreationManager = mock(classOf[AutoTopicCreationManager])
+    when(mockAutoTopicCreationManager.getTopicCreationErrors(Set("test-topic")))
+      .thenReturn(Map("test-topic" -> "INVALID_REPLICATION_FACTOR"))
+
+    kafkaApis = createKafkaApis(autoTopicCreationManager = Some(mockAutoTopicCreationManager))
+    kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)
+
+    // Group coordinator returns MISSING_INTERNAL_TOPICS status and topics to create
+    val missingTopics = util.Map.of("test-topic", new CreatableTopic())
+    val streamsGroupHeartbeatResponse = new StreamsGroupHeartbeatResponseData()
+      .setMemberId("member")
+      .setStatus(util.List.of(
+        new StreamsGroupHeartbeatResponseData.Status()
+          .setStatusCode(StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code())
+          .setStatusDetail("Internal topics are missing: [test-topic]")
+      ))
+
+    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics))
+    val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
+    
+    assertEquals(Errors.NONE.code, response.data.errorCode())
+    assertEquals(null, response.data.errorMessage())
+    
+    // Verify that the cached error was appended to the existing status detail
+    assertEquals(1, response.data.status().size())
+    val status = response.data.status().get(0)
+    assertEquals(StreamsGroupHeartbeatResponse.Status.MISSING_INTERNAL_TOPICS.code(), status.statusCode())
+    assertTrue(status.statusDetail().contains("Internal topics are missing: [test-topic]"))
+    assertTrue(status.statusDetail().contains("Creation failed: test-topic (INVALID_REPLICATION_FACTOR)"))
+    
+    // Verify that createStreamsInternalTopics was called
+    verify(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any())
+    verify(mockAutoTopicCreationManager).getTopicCreationErrors(Set("test-topic"))
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -10971,6 +10971,8 @@ class KafkaApisTest extends Logging {
     val mockAutoTopicCreationManager = mock(classOf[AutoTopicCreationManager])
     when(mockAutoTopicCreationManager.getTopicCreationErrors(Set("test-topic")))
       .thenReturn(Map("test-topic" -> "INVALID_REPLICATION_FACTOR"))
+    // Mock the createStreamsInternalTopics method to do nothing (simulate topic creation attempt)
+    doNothing().when(mockAutoTopicCreationManager).createStreamsInternalTopics(any(), any())
 
     kafkaApis = createKafkaApis(autoTopicCreationManager = Some(mockAutoTopicCreationManager))
     kafkaApis.handle(requestChannelRequest, RequestLocal.noCaching)


### PR DESCRIPTION
This PR introduces an ExpiringErrorCache that temporarily stores topic
creation errors, allowing the system to provide detailed failure reasons
in subsequent heartbeat responses.

Key Designs:

Time-based expiration: Errors are cached with a TTL based on the streams
group heartbeat interval (2x heartbeat interval). This ensures errors
remain available for at least one retry cycle while preventing unbounded
growth.    2. Priority queue for efficient expiry: Uses a min-heap to
track entries by expiration time, enabling efficient cleanup of expired
entries during cache operations.    3. Capacity enforcement: Limits
cache size to prevent memory issues under high error rates. When
capacity is exceeded, oldest entries are evicted first.    4. Reference
equality checks: Uses eq for object identity comparison when cleaning up
stale entries, avoiding expensive value comparisons while correctly
handling entry updates.

Reviewers: Lucas Brutschy <lucasbru@apache.org>
