### PR TITLE
KAFKA-10357: Refactor makeReady to reduce complexity and support upcoming KIP-698 changes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -503,7 +503,6 @@ public class InternalTopicManager {
     }
 
     private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics, final Set<String> tempUnknownTopics) {
-//        final Set<String> tempUnknownTopics = new HashSet<>();
         final Set<String> topicsNotYetCreated = identifyTopicsNotCreated(topics, tempUnknownTopics);
 
         final Set<NewTopic> topicsToCreate = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -473,7 +473,14 @@ public class InternalTopicManager {
         final Set<String> newlyCreatedTopics = new HashSet<>();
 
         while (!topicsNotReady.isEmpty()) {
-            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics);
+            final Set<String> tempUnknownTopics = new HashSet<>();
+            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics, tempUnknownTopics);
+            final boolean noTopicsToCreate = topicsToCreate.isEmpty() && tempUnknownTopics.isEmpty(); // how can we determine that there was a temp unknown topic from here?
+
+            if (noTopicsToCreate) { // Nothing left to do - avoid looping needlessly
+                newlyCreatedTopics.addAll(topicsNotReady);
+                break;
+            }
             if (!topicsToCreate.isEmpty()) {
                 final Set<String> createdTopics = createTopics(topicsToCreate, topicsNotReady, deadlineMs);
                 topicsNotReady.removeAll(createdTopics);
@@ -495,8 +502,8 @@ public class InternalTopicManager {
         return newlyCreatedTopics;
     }
 
-    private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics) {
-        final Set<String> tempUnknownTopics = new HashSet<>();
+    private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics, final Set<String> tempUnknownTopics) {
+//        final Set<String> tempUnknownTopics = new HashSet<>();
         final Set<String> topicsNotYetCreated = identifyTopicsNotCreated(topics, tempUnknownTopics);
 
         final Set<NewTopic> topicsToCreate = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -474,11 +474,16 @@ public class InternalTopicManager {
 
         while (!topicsNotReady.isEmpty()) {
             final Set<String> tempUnknownTopics = new HashSet<>();
-            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics, tempUnknownTopics);
-            final boolean noTopicsToCreate = topicsToCreate.isEmpty() && tempUnknownTopics.isEmpty(); // how can we determine that there was a temp unknown topic from here?
 
-            if (noTopicsToCreate) { // Nothing left to do - avoid looping needlessly
-                newlyCreatedTopics.addAll(topicsNotReady);
+            // Only consider the not-ready subset on each iteration
+            final Map<String, InternalTopicConfig> notReadyTopicsMap = topics.entrySet().stream()
+                    .filter(e -> topicsNotReady.contains(e.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(notReadyTopicsMap, tempUnknownTopics);
+            final boolean noTopicsToCreate = topicsToCreate.isEmpty() && tempUnknownTopics.isEmpty();
+
+            if (noTopicsToCreate) {
+                // Nothing left to create - all remaining topics were already ready
                 break;
             }
             if (!topicsToCreate.isEmpty()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -113,7 +113,7 @@ public class InternalTopicManager {
         }
     }
 
-    static class ValidationResult {
+    public static class ValidationResult {
         private final Set<String> missingTopics = new HashSet<>();
         private final Map<String, List<String>> misconfigurationsForTopics = new HashMap<>();
 
@@ -194,13 +194,18 @@ public class InternalTopicManager {
                         (streamsSide, brokerSide) -> validateCleanupPolicy(validationResult, streamsSide, brokerSide)
                     );
                 }
-
-                maybeThrowTimeoutException(
-                    Arrays.asList(topicDescriptionsStillToValidate, topicConfigsStillToValidate),
-                    deadline,
-                    String.format("Could not validate internal topics within %d milliseconds. " +
-                        "This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs)
-                );
+                
+                maybeThrowTimeout(new TimeoutContext(
+                        new HashSet<String>() {{
+                            addAll(topicDescriptionsStillToValidate);
+                            addAll(topicConfigsStillToValidate);
+                        }},
+                        deadline,
+                        "Validation timeout",
+                        String.format("Could not validate internal topics within %d milliseconds. " +
+                            "This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs),
+                        null
+                    ));
 
                 if (!descriptionsForTopic.isEmpty() || !configsForTopic.isEmpty()) {
                     Utils.sleep(100);
@@ -461,120 +466,119 @@ public class InternalTopicManager {
         // have existed with the expected number of partitions, or some create topic returns fatal errors.
         log.debug("Starting to validate internal topics {} in partition assignor.", topics);
 
-        long currentWallClockMs = time.milliseconds();
+        final long currentWallClockMs = time.milliseconds();
         final long deadlineMs = currentWallClockMs + retryTimeoutMs;
 
-        Set<String> topicsNotReady = new HashSet<>(topics.keySet());
-        final Set<String> newlyCreatedTopics = new HashSet<>();
+        final Set<String> topicsNotReady = new HashSet<>(topics.keySet());
+        final Set<String> newTopics = new HashSet<>();
 
         while (!topicsNotReady.isEmpty()) {
-            final Set<String> tempUnknownTopics = new HashSet<>();
-            topicsNotReady = validateTopics(topicsNotReady, topics, tempUnknownTopics);
-            newlyCreatedTopics.addAll(topicsNotReady);
-
+            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics, topicsNotReady, newTopics);
+            if (!topicsToCreate.isEmpty()) {
+                readyTopics(topicsToCreate, topicsNotReady);
+            }
             if (!topicsNotReady.isEmpty()) {
-                final Set<NewTopic> newTopics = new HashSet<>();
+                maybeThrowTimeout(new TimeoutContext(
+                    Collections.singleton("makeReadyCheck"), // dummy collection just to trigger if `topicsNotReady` is non-empty
+                    deadlineMs,
+                    "MakeReady timeout",
+                    String.format("Could not create topics within %d milliseconds. This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs),
+                    null
+                ));
 
-                for (final String topicName : topicsNotReady) {
-                    if (tempUnknownTopics.contains(topicName)) {
-                        // for the tempUnknownTopics, don't create topic for them
-                        // we'll check again later if remaining retries > 0
-                        continue;
-                    }
-                    final InternalTopicConfig internalTopicConfig = Objects.requireNonNull(topics.get(topicName));
-                    final Map<String, String> topicConfig = internalTopicConfig.properties(defaultTopicConfigs, windowChangeLogAdditionalRetention);
+            }
+        }
+        log.debug("Completed validating internal topics and created {}", newTopics);
 
-                    log.debug("Going to create topic {} with {} partitions and config {}.",
-                        internalTopicConfig.name(),
-                        internalTopicConfig.numberOfPartitions(),
-                        topicConfig);
+        return newTopics;
+    }
 
-                    newTopics.add(
-                        new NewTopic(
+    private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics,
+                                                      final Set<String> topicsNotReady,
+                                                      final Set<String> newTopics) {
+        final Set<String> tempUnknownTopics = new HashSet<>();
+        final Set<String> validatedTopics = validateTopics(topicsNotReady, topics, tempUnknownTopics);
+
+        newTopics.addAll(validatedTopics);
+
+        final Set<NewTopic> validatedTopicObjects = new HashSet<>();
+
+        for (final String topicName : topicsNotReady) {
+            if (tempUnknownTopics.contains(topicName)) {
+                // for the tempUnknownTopics, don't create topic for them
+                // we'll check again later if remaining retries > 0
+                continue;
+            }
+            final InternalTopicConfig internalTopicConfig = Objects.requireNonNull(topics.get(topicName));
+            final Map<String, String> topicConfig = internalTopicConfig.properties(defaultTopicConfigs, windowChangeLogAdditionalRetention);
+
+            log.debug("Going to create topic {} with {} partitions and config {}.",
+                    internalTopicConfig.name(),
+                    internalTopicConfig.numberOfPartitions(),
+                    topicConfig);
+
+            validatedTopicObjects.add(
+                    new NewTopic(
                             internalTopicConfig.name(),
                             internalTopicConfig.numberOfPartitions(),
                             Optional.of(replicationFactor))
                             .configs(topicConfig));
-                }
+        }
+        return validatedTopicObjects;
+    }
 
-                // it's possible that although some topics are not ready yet because they
-                // are temporarily not available, not that they do not exist; in this case
-                // the new topics to create may be empty and hence we can skip here
-                if (!newTopics.isEmpty()) {
-                    final CreateTopicsResult createTopicsResult = adminClient.createTopics(newTopics);
+    private void readyTopics(final Set<NewTopic> topicsToCreate,
+                             final Set<String> topicsNotReady) {
+        final CreateTopicsResult createTopicsResult = adminClient.createTopics(topicsToCreate);
 
-                    for (final Map.Entry<String, KafkaFuture<Void>> createTopicResult : createTopicsResult.values().entrySet()) {
-                        final String topicName = createTopicResult.getKey();
-                        try {
-                            createTopicResult.getValue().get();
-                            topicsNotReady.remove(topicName);
-                        } catch (final InterruptedException fatalException) {
-                            // this should not happen; if it ever happens it indicate a bug
-                            Thread.currentThread().interrupt();
-                            log.error(INTERRUPTED_ERROR_MESSAGE, fatalException);
-                            throw new IllegalStateException(INTERRUPTED_ERROR_MESSAGE, fatalException);
-                        } catch (final ExecutionException executionException) {
-                            final Throwable cause = executionException.getCause();
-                            if (cause instanceof TopicExistsException) {
-                                // This topic didn't exist earlier or its leader not known before; just retain it for next round of validation.
-                                log.info(
-                                        "Could not create topic {}. Topic is probably marked for deletion (number of partitions is unknown).\n"
-                                                +
-                                                "Will retry to create this topic in {} ms (to let broker finish async delete operation first).\n"
-                                                +
-                                                "Error message was: {}", topicName, retryBackOffMs,
-                                        cause.toString());
-                            } else {
-                                log.error("Unexpected error during topic creation for {}.\n" +
-                                        "Error message was: {}", topicName, cause.toString());
+        for (final Map.Entry<String, KafkaFuture<Void>> createTopicResult : createTopicsResult.values().entrySet()) {
+            final String topicName = createTopicResult.getKey();
+            try {
+                createTopicResult.getValue().get();
+                topicsNotReady.remove(topicName);
+            } catch (final InterruptedException fatalException) {
+                // this should not happen; if it ever happens it indicate a bug
+                Thread.currentThread().interrupt();
+                log.error(INTERRUPTED_ERROR_MESSAGE, fatalException);
+                throw new IllegalStateException(INTERRUPTED_ERROR_MESSAGE, fatalException);
+            } catch (final ExecutionException executionException) {
+                final Throwable cause = executionException.getCause();
+                if (cause instanceof TopicExistsException) {
+                    // This topic didn't exist earlier or its leader not known before; just retain it for next round of validation.
+                    log.info(
+                            "Could not create topic {}. Topic is probably marked for deletion (number of partitions is unknown).\n"
+                                    +
+                                    "Will retry to create this topic in {} ms (to let broker finish async delete operation first).\n"
+                                    +
+                                    "Error message was: {}", topicName, retryBackOffMs,
+                            cause.toString());
+                } else {
+                    log.error("Unexpected error during topic creation for {}.\n" +
+                            "Error message was: {}", topicName, cause.toString());
 
-                                if (cause instanceof UnsupportedVersionException) {
-                                    final String errorMessage = cause.getMessage();
-                                    if (errorMessage != null &&
-                                            errorMessage.startsWith("Creating topics with default partitions/replication factor are only supported in CreateTopicRequest version 4+")) {
+                    if (cause instanceof UnsupportedVersionException) {
+                        final String errorMessage = cause.getMessage();
+                        if (errorMessage != null &&
+                                errorMessage.startsWith("Creating topics with default partitions/replication factor are only supported in CreateTopicRequest version 4+")) {
 
-                                        throw new StreamsException(String.format(
-                                                "Could not create topic %s, because brokers don't support configuration replication.factor=-1."
-                                                        + " You can change the replication.factor config or upgrade your brokers to version 2.4 or newer to avoid this error.",
-                                                topicName)
-                                        );
-                                    }
-                                } else if (cause instanceof TimeoutException) {
-                                    log.error("Creating topic {} timed out.\n" +
-                                            "Error message was: {}", topicName, cause.toString());
-                                } else {
-                                    throw new StreamsException(
-                                            String.format("Could not create topic %s.", topicName),
-                                            cause
-                                    );
-                                }
-                            }
+                            throw new StreamsException(String.format(
+                                    "Could not create topic %s, because brokers don't support configuration replication.factor=-1."
+                                            + " You can change the replication.factor config or upgrade your brokers to version 2.4 or newer to avoid this error.",
+                                    topicName)
+                            );
                         }
+                    } else if (cause instanceof TimeoutException) {
+                        log.error("Creating topic {} timed out.\n" +
+                                "Error message was: {}", topicName, cause.toString());
+                    } else {
+                        throw new StreamsException(
+                                String.format("Could not create topic %s.", topicName),
+                                cause
+                        );
                     }
                 }
             }
-
-            if (!topicsNotReady.isEmpty()) {
-                currentWallClockMs = time.milliseconds();
-
-                if (currentWallClockMs >= deadlineMs) {
-                    final String timeoutError = String.format("Could not create topics within %d milliseconds. " +
-                        "This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs);
-                    log.error(timeoutError);
-                    throw new TimeoutException(timeoutError);
-                }
-                log.info(
-                    "Topics {} could not be made ready. Will retry in {} milliseconds. Remaining time in milliseconds: {}",
-                    topicsNotReady,
-                    retryBackOffMs,
-                    deadlineMs - currentWallClockMs
-                );
-                Utils.sleep(retryBackOffMs);
-            }
         }
-        log.debug("Completed validating internal topics and created {}", newlyCreatedTopics);
-
-        return newlyCreatedTopics;
     }
 
     /**
@@ -765,12 +769,18 @@ public class InternalTopicManager {
                 }
             }
 
-            maybeThrowTimeoutExceptionDuringSetup(
+            maybeThrowTimeout(new TimeoutContext(
                 topicStillToCreate,
-                createdTopics,
-                lastErrorsSeenForTopic,
-                deadline
-            );
+                deadline,
+                "Setup timeout",
+                String.format(
+                    "Could not create internal topics within %d milliseconds. This can happen if the " +
+                    "Kafka cluster is temporarily not available or a topic is marked for deletion and the broker " +
+                    "did not complete its deletion within the timeout. The last errors seen per topic are: %s",
+                    retryTimeoutMs, lastErrorsSeenForTopic
+                ),
+                () -> cleanUpCreatedTopics(createdTopics)
+            ));
 
             if (!createResultForTopic.isEmpty()) {
                 Utils.sleep(100);
@@ -825,14 +835,16 @@ public class InternalTopicManager {
                     }
                 }
 
-                maybeThrowTimeoutException(
-                    Collections.singletonList(topicsStillToCleanup),
+                maybeThrowTimeout(new TimeoutContext(
+                    topicsStillToCleanup,
                     deadline,
+                    "Cleanup timeout",
                     String.format("Could not cleanup internal topics within %d milliseconds. This can happen if the " +
-                            "Kafka cluster is temporarily not available or the broker did not complete topic creation " +
-                            "before the cleanup. The following internal topics could not be cleaned up: %s",
-                        retryTimeoutMs, topicsStillToCleanup)
-                );
+                                "Kafka cluster is temporarily not available or the broker did not complete topic creation " +
+                                "before the cleanup. The following internal topics could not be cleaned up: %s",
+                                retryTimeoutMs, topicsStillToCleanup),
+                    null
+                ));
 
                 if (!deleteResultForTopic.isEmpty()) {
                     Utils.sleep(100);
@@ -848,36 +860,39 @@ public class InternalTopicManager {
 
         log.info("Completed cleanup of internal topics {}.", topicsToCleanUp);
     }
-
-    private void maybeThrowTimeoutException(final List<Set<String>> topicStillToProcess,
-                                            final long deadline,
-                                            final String errorMessage) {
-        if (topicStillToProcess.stream().anyMatch(resultSet -> !resultSet.isEmpty())) {
-            final long now = time.milliseconds();
-            if (now >= deadline) {
-                log.error(errorMessage);
-                throw new TimeoutException(errorMessage);
+   
+    private void maybeThrowTimeout(final TimeoutContext context) {
+        if (!context.pendingItems.isEmpty() && time.milliseconds() >= context.deadline) {
+            log.error("{}: {}", context.prefix, context.errorDetails);
+            if (context.onTimeout != null) {
+                context.onTimeout.run();
             }
+            throw new TimeoutException(String.format("%s: %s", context.prefix, context.errorDetails));
         }
     }
 
-    private void maybeThrowTimeoutExceptionDuringSetup(final Set<String> topicStillToProcess,
-                                                       final Set<String> createdTopics,
-                                                       final Map<String, Throwable> lastErrorsSeenForTopic,
-                                                       final long deadline) {
-        if (topicStillToProcess.stream().anyMatch(resultSet -> !resultSet.isEmpty())) {
-            final long now = time.milliseconds();
-            if (now >= deadline) {
-                cleanUpCreatedTopics(createdTopics);
-                final String errorMessage = String.format("Could not create internal topics within %d milliseconds. This can happen if the " +
-                    "Kafka cluster is temporarily not available or a topic is marked for deletion and the broker " +
-                    "did not complete its deletion within the timeout. The last errors seen per topic are: %s",
-                    retryTimeoutMs, lastErrorsSeenForTopic);
-                log.error(errorMessage);
-                throw new TimeoutException(errorMessage);
-            }
+    private static class TimeoutContext {
+        final Collection<?> pendingItems;
+        final long deadline;
+        final String prefix;
+        final String errorDetails;
+        final Runnable onTimeout;
+
+        TimeoutContext(
+            final Collection<?> pendingItems,
+            final long deadline,
+            final String prefix,
+            final String errorDetails,
+            final Runnable onTimeout) {
+            this.pendingItems = pendingItems;
+            this.deadline = deadline;
+            this.prefix = prefix;
+            this.errorDetails = errorDetails;
+            this.onTimeout = onTimeout;
         }
     }
+
+
 
     private void maybeSleep(final List<Set<String>> resultSetsStillToValidate,
                             final long deadline,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -501,7 +501,7 @@ public class InternalTopicManager {
 
         newTopics.addAll(validatedTopics);
 
-        final Set<NewTopic> validatedTopicObjects = new HashSet<>();
+        final Set<NewTopic> topicsToCreate = new HashSet<>();
 
         for (final String topicName : topicsNotReady) {
             if (tempUnknownTopics.contains(topicName)) {
@@ -517,14 +517,14 @@ public class InternalTopicManager {
                     internalTopicConfig.numberOfPartitions(),
                     topicConfig);
 
-            validatedTopicObjects.add(
+            topicsToCreate.add(
                     new NewTopic(
                             internalTopicConfig.name(),
                             internalTopicConfig.numberOfPartitions(),
                             Optional.of(replicationFactor))
                             .configs(topicConfig));
         }
-        return validatedTopicObjects;
+        return topicsToCreate;
     }
 
     private void readyTopics(final Set<NewTopic> topicsToCreate,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -426,9 +426,11 @@ public class InternalTopicManager {
         final Map<String, List<TopicPartitionInfo>> topicPartitionInfo = new HashMap<>();
 
         while (!topicsToDescribe.isEmpty()) {
-            final Map<String, List<TopicPartitionInfo>> existed = getTopicPartitionInfo(topicsToDescribe, null);
+            final Set<String> tempUnknownTopics = new HashSet<>();
+            final Map<String, List<TopicPartitionInfo>> existed = getTopicPartitionInfo(topicsToDescribe, tempUnknownTopics);
             topicPartitionInfo.putAll(existed);
             topicsToDescribe.removeAll(topicPartitionInfo.keySet());
+            topicsToDescribe.addAll(tempUnknownTopics); // keep retrying unknown ones
             if (!topicsToDescribe.isEmpty()) {
                 currentWallClockMs = time.milliseconds();
 
@@ -480,6 +482,11 @@ public class InternalTopicManager {
                     .filter(e -> topicsNotReady.contains(e.getKey()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             final Set<NewTopic> topicsToCreate = computeTopicsToCreate(notReadyTopicsMap, tempUnknownTopics);
+
+            topicsNotReady.retainAll(tempUnknownTopics);
+            topicsNotReady.retainAll(notReadyTopicsMap.keySet());
+            topicsToCreate.forEach(topic -> topicsNotReady.add(topic.name()));
+
             final boolean noTopicsToCreate = topicsToCreate.isEmpty() && tempUnknownTopics.isEmpty();
 
             if (noTopicsToCreate) {
@@ -513,7 +520,8 @@ public class InternalTopicManager {
         final Set<NewTopic> topicsToCreate = new HashSet<>();
         
         for (final String topicName : topicsNotYetCreated) {
-            if (tempUnknownTopics.contains(topicName)) {
+            // Topic already exists or non-deterministic result
+            if (tempUnknownTopics.contains(topicName) || topics.get(topicName) == null) {
                 // for the tempUnknownTopics, don't create topic for them
                 // we'll check again later if remaining retries > 0
                 continue;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -430,7 +430,6 @@ public class InternalTopicManager {
             final Map<String, List<TopicPartitionInfo>> existed = getTopicPartitionInfo(topicsToDescribe, tempUnknownTopics);
             topicPartitionInfo.putAll(existed);
             topicsToDescribe.removeAll(topicPartitionInfo.keySet());
-            topicsToDescribe.addAll(tempUnknownTopics); // keep retrying unknown ones
             if (!topicsToDescribe.isEmpty()) {
                 currentWallClockMs = time.milliseconds();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -470,12 +470,14 @@ public class InternalTopicManager {
         final long deadlineMs = currentWallClockMs + retryTimeoutMs;
 
         final Set<String> topicsNotReady = new HashSet<>(topics.keySet());
-        final Set<String> newTopics = new HashSet<>();
+        final Set<String> newlyCreatedTopics = new HashSet<>();
 
         while (!topicsNotReady.isEmpty()) {
-            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics, topicsNotReady, newTopics);
+            final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics);
             if (!topicsToCreate.isEmpty()) {
-                createTopics(topicsToCreate, topicsNotReady, deadlineMs);
+                final Set<String> createdTopics = createTopics(topicsToCreate, topicsNotReady, deadlineMs);
+                topicsNotReady.removeAll(createdTopics);
+                newlyCreatedTopics.addAll(createdTopics);
             }
             if (!topicsNotReady.isEmpty()) {
                 maybeThrowTimeout(new TimeoutContext(
@@ -488,22 +490,18 @@ public class InternalTopicManager {
 
             }
         }
-        log.debug("Completed validating internal topics and created {}", newTopics);
+        log.debug("Completed validating internal topics and created {}", newlyCreatedTopics);
 
-        return newTopics;
+        return newlyCreatedTopics;
     }
 
-    private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics,
-                                                final Set<String> topicsNotReady,
-                                                final Set<String> newTopics) {
+    private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics) {
         final Set<String> tempUnknownTopics = new HashSet<>();
-        final Set<String> validatedTopics = validateTopics(topicsNotReady, topics, tempUnknownTopics);
-
-        newTopics.addAll(validatedTopics);
+        final Set<String> topicsNotYetCreated = identifyTopicsNotCreated(topics, tempUnknownTopics);
 
         final Set<NewTopic> topicsToCreate = new HashSet<>();
-
-        for (final String topicName : topicsNotReady) {
+        
+        for (final String topicName : topicsNotYetCreated) {
             if (tempUnknownTopics.contains(topicName)) {
                 // for the tempUnknownTopics, don't create topic for them
                 // we'll check again later if remaining retries > 0
@@ -527,16 +525,19 @@ public class InternalTopicManager {
         return topicsToCreate;
     }
 
-    private void createTopics(final Set<NewTopic> topicsToCreate,
-                             final Set<String> topicsNotReady,
-                             final long deadlineMs) {
+    private Set<String> createTopics(final Set<NewTopic> topicsToCreate,
+                                     final Set<String> topicsNotReady,
+                                     final long deadlineMs) {
         final CreateTopicsResult createTopicsResult = adminClient.createTopics(topicsToCreate);
+        final Set<String> createdTopics = new HashSet<>();
 
         for (final Map.Entry<String, KafkaFuture<Void>> createTopicResult : createTopicsResult.values().entrySet()) {
             final String topicName = createTopicResult.getKey();
             try {
                 createTopicResult.getValue().get();
                 topicsNotReady.remove(topicName);
+                createdTopics.add(topicName);
+                
             } catch (final InterruptedException fatalException) {
                 // this should not happen; if it ever happens it indicate a bug
                 Thread.currentThread().interrupt();
@@ -597,9 +598,10 @@ public class InternalTopicManager {
                 );
                 Utils.sleep(retryBackOffMs);
             } else {
-                return;
+                continue;
             }
-        }
+        } 
+        return createdTopics;
     } 
         
 
@@ -672,18 +674,14 @@ public class InternalTopicManager {
     /**
      * Check the existing topics to have correct number of partitions; and return the remaining topics that needs to be created
      */
-    private Set<String> validateTopics(final Set<String> topicsToValidate,
-                                       final Map<String, InternalTopicConfig> topicsMap,
-                                       final Set<String> tempUnknownTopics) {
-        if (!topicsMap.keySet().containsAll(topicsToValidate)) {
-            throw new IllegalStateException("The topics map " + topicsMap.keySet() + " does not contain all the topics " +
-                topicsToValidate + " trying to validate.");
-        }
+    private Set<String> identifyTopicsNotCreated(final Map<String, InternalTopicConfig> topicsMap,
+                                                 final Set<String> tempUnknownTopics) {
 
-        final Map<String, Integer> existedTopicPartition = getNumPartitions(topicsToValidate, tempUnknownTopics);
+        final Set<String> topicsToIdentify = new HashSet<>(topicsMap.keySet());
+        final Map<String, Integer> existedTopicPartition = getNumPartitions(topicsToIdentify, tempUnknownTopics);
 
-        final Set<String> topicsToCreate = new HashSet<>();
-        for (final String topicName : topicsToValidate) {
+        final Set<String> topicsNotCreated = new HashSet<>();
+        for (final String topicName : topicsToIdentify) {
             final Optional<Integer> numberOfPartitions = topicsMap.get(topicName).numberOfPartitions();
             if (numberOfPartitions.isEmpty()) {
                 log.error("Found undefined number of partitions for topic {}", topicName);
@@ -699,11 +697,11 @@ public class InternalTopicManager {
                     throw new StreamsException(errorMsg);
                 }
             } else {
-                topicsToCreate.add(topicName);
+                topicsNotCreated.add(topicName);
             }
         }
 
-        return topicsToCreate;
+        return topicsNotCreated;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -483,9 +483,7 @@ public class InternalTopicManager {
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             final Set<NewTopic> topicsToCreate = computeTopicsToCreate(notReadyTopicsMap, tempUnknownTopics);
 
-            topicsNotReady.retainAll(tempUnknownTopics);
             topicsNotReady.retainAll(notReadyTopicsMap.keySet());
-            topicsToCreate.forEach(topic -> topicsNotReady.add(topic.name()));
 
             final boolean noTopicsToCreate = topicsToCreate.isEmpty() && tempUnknownTopics.isEmpty();
 
@@ -714,6 +712,8 @@ public class InternalTopicManager {
                         topicName, numberOfPartitions.get(), existedTopicPartition.get(topicName));
                     log.error(errorMsg);
                     throw new StreamsException(errorMsg);
+                } else {
+                    topicsMap.remove(topicName);
                 }
             } else {
                 topicsNotCreated.add(topicName);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -475,7 +475,7 @@ public class InternalTopicManager {
         while (!topicsNotReady.isEmpty()) {
             final Set<NewTopic> topicsToCreate = computeTopicsToCreate(topics, topicsNotReady, newTopics);
             if (!topicsToCreate.isEmpty()) {
-                readyTopics(topicsToCreate, topicsNotReady);
+                createTopics(topicsToCreate, topicsNotReady, deadlineMs);
             }
             if (!topicsNotReady.isEmpty()) {
                 maybeThrowTimeout(new TimeoutContext(
@@ -494,8 +494,8 @@ public class InternalTopicManager {
     }
 
     private Set<NewTopic> computeTopicsToCreate(final Map<String, InternalTopicConfig> topics,
-                                                      final Set<String> topicsNotReady,
-                                                      final Set<String> newTopics) {
+                                                final Set<String> topicsNotReady,
+                                                final Set<String> newTopics) {
         final Set<String> tempUnknownTopics = new HashSet<>();
         final Set<String> validatedTopics = validateTopics(topicsNotReady, topics, tempUnknownTopics);
 
@@ -527,8 +527,9 @@ public class InternalTopicManager {
         return topicsToCreate;
     }
 
-    private void readyTopics(final Set<NewTopic> topicsToCreate,
-                             final Set<String> topicsNotReady) {
+    private void createTopics(final Set<NewTopic> topicsToCreate,
+                             final Set<String> topicsNotReady,
+                             final long deadlineMs) {
         final CreateTopicsResult createTopicsResult = adminClient.createTopics(topicsToCreate);
 
         for (final Map.Entry<String, KafkaFuture<Void>> createTopicResult : createTopicsResult.values().entrySet()) {
@@ -578,8 +579,29 @@ public class InternalTopicManager {
                     }
                 }
             }
+
+            if (!topicsNotReady.isEmpty()) {
+                maybeThrowTimeout(new TimeoutContext(
+                        topicsNotReady,
+                        deadlineMs,
+                        "createTopics timeout",
+                        String.format(
+                                "Could not create topics within %d milliseconds. This can happen if the Kafka cluster is temporarily not available.",
+                                retryTimeoutMs),
+                        null));
+                log.info(
+                    "Topics {} could not be made ready. Will retry in {} milliseconds. Remaining time in milliseconds: {}",
+                    topicsNotReady,
+                    retryBackOffMs,
+                    deadlineMs - time.milliseconds()
+                );
+                Utils.sleep(retryBackOffMs);
+            } else {
+                return;
+            }
         }
-    }
+    } 
+        
 
     /**
      * Try to get the partition information for the given topics; return the partition info for topics that already exists.

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -782,16 +782,18 @@ public class InternalTopicManagerTest {
         // let the first describe succeed on topic, and fail on topic2, and then let creation throws topics-existed;
         // it should retry with just topic2 and then let it succeed
         when(admin.describeTopics(Set.of(topic1, topic2)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
-                mkEntry(topic1, topicDescriptionSuccessFuture),
-                mkEntry(topic2, topicDescriptionFailFuture)
-            )));
+                .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
+                        mkEntry(topic1, topicDescriptionSuccessFuture),
+                        mkEntry(topic2, topicDescriptionFailFuture) // first call: missing
+                )))
+                .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
+                        mkEntry(topic1, topicDescriptionSuccessFuture),
+                        mkEntry(topic2, topicDescriptionSuccessFuture) // second call: now exists
+                )));
         when(admin.createTopics(Collections.singleton(new NewTopic(topic2, Optional.of(1), Optional.of((short) 1))
             .configs(mkMap(mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
                                  mkEntry(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime"))))))
             .thenAnswer(answer -> new MockCreateTopicsResult(Collections.singletonMap(topic2, topicCreationFuture)));
-        when(admin.describeTopics(Collections.singleton(topic2)))
-            .thenAnswer(answer -> new MockDescribeTopicsResult(Collections.singletonMap(topic2, topicDescriptionSuccessFuture)));
 
         final InternalTopicConfig topicConfig = new UnwindowedUnversionedChangelogTopicConfig(topic1, Collections.emptyMap());
         topicConfig.setNumberOfPartitions(1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -296,7 +296,7 @@ public class InternalTopicManagerTest {
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionIfTopicExistsDuringSetup() {
+    public void shouldThrowSetupTimeoutExceptionIfTopicExistsDuringSetup() {
         setupTopicInMockAdminClient(topic1, Collections.emptyMap());
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 15
@@ -312,7 +312,7 @@ public class InternalTopicManagerTest {
 
         assertThat(
             exception.getMessage(),
-            is("Could not create internal topics within " +
+            is("Setup timeout: Could not create internal topics within " +
                     (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 2 +
                 " milliseconds. This can happen if the Kafka cluster is temporarily not available or a topic is marked" +
                     " for deletion and the broker did not complete its deletion within the timeout." +
@@ -1024,7 +1024,7 @@ public class InternalTopicManagerTest {
         assertNull(exception.getCause());
         assertThat(
             exception.getMessage(),
-            equalTo("Could not create topics within 50 milliseconds." +
+            equalTo("MakeReady timeout: Could not create topics within 50 milliseconds." +
                 " This can happen if the Kafka cluster is temporarily not available.")
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -864,7 +864,7 @@ public class InternalTopicManagerTest {
             topicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig));
             fail("Should have thrown TimeoutException.");
         } catch (final TimeoutException expected) {
-            assertThat(expected.getMessage(), is("Could not create topics within 50 milliseconds. " +
+            assertThat(expected.getMessage(), is("MakeReady timeout: Could not create topics within 50 milliseconds. " +
                     "This can happen if the Kafka cluster is temporarily not available."));
         }
     }
@@ -995,7 +995,7 @@ public class InternalTopicManagerTest {
         assertNull(exception.getCause());
         assertThat(
             exception.getMessage(),
-            equalTo("Could not create topics within 50 milliseconds." +
+            equalTo("MakeReady timeout: Could not create topics within 50 milliseconds." +
                 " This can happen if the Kafka cluster is temporarily not available.")
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -785,15 +785,14 @@ public class InternalTopicManagerTest {
                 .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
                         mkEntry(topic1, topicDescriptionSuccessFuture),
                         mkEntry(topic2, topicDescriptionFailFuture) // first call: missing
-                )))
-                .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap(
-                        mkEntry(topic1, topicDescriptionSuccessFuture),
-                        mkEntry(topic2, topicDescriptionSuccessFuture) // second call: now exists
                 )));
+
         when(admin.createTopics(Collections.singleton(new NewTopic(topic2, Optional.of(1), Optional.of((short) 1))
             .configs(mkMap(mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
                                  mkEntry(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime"))))))
             .thenAnswer(answer -> new MockCreateTopicsResult(Collections.singletonMap(topic2, topicCreationFuture)));
+        when(admin.describeTopics(Set.of(topic2)))
+                .thenAnswer(answer -> new MockDescribeTopicsResult(Collections.singletonMap(topic2, topicDescriptionSuccessFuture)));
 
         final InternalTopicConfig topicConfig = new UnwindowedUnversionedChangelogTopicConfig(topic1, Collections.emptyMap());
         topicConfig.setNumberOfPartitions(1);


### PR DESCRIPTION
This PR reduces the cyclomatic complexity of the makeReady method by
extracting parts of its logic into smaller, well-named helper methods.
This structural cleanup makes the code easier to understand and
maintain.

These changes are intended to prepare for upcoming work related to
[KIP-698](https://cwiki.apache.org/confluence/display/KAFKA/KIP-698),
which will introduce additional branching logic to makeReady.
Refactoring now ensures that future modifications can be made in a more
modular and testable way.

Reviewer: Matthias J. Sax <matthias@confluent.io>
