### PR TITLE
MINOR Metrics: use String.intern() to reduce duplicate metric names and tags

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/TelemetryMetricNamingConvention.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/TelemetryMetricNamingConvention.java
@@ -19,12 +19,11 @@ package org.apache.kafka.common.telemetry.internals;
 import org.apache.kafka.common.MetricName;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * This class encapsulates naming and mapping conventions defined as part of
@@ -37,6 +36,7 @@ public class TelemetryMetricNamingConvention {
 
     // remove metrics as it is redundant for telemetry metrics naming convention
     private static final Pattern GROUP_PATTERN = Pattern.compile("\\.(metrics)");
+    private static final Pattern DASH_PATTERN = Pattern.compile("-");
 
     public static MetricNamingStrategy<MetricName> getClientTelemetryMetricNamingStrategy(String prefix) {
         Objects.requireNonNull(prefix, "prefix cannot be null");
@@ -46,14 +46,17 @@ public class TelemetryMetricNamingConvention {
             public MetricKey metricKey(MetricName metricName) {
                 Objects.requireNonNull(metricName, "metric name cannot be null");
 
-                return new MetricKey(fullMetricName(prefix, metricName.group(), metricName.name()),
+                return new MetricKey(
+                    fullMetricName(prefix, metricName.group(), metricName.name()).intern(),
                     Collections.unmodifiableMap(cleanTags(metricName.tags())));
             }
 
             @Override
             public MetricKey derivedMetricKey(MetricKey key, String derivedComponent) {
                 Objects.requireNonNull(derivedComponent, "derived component cannot be null");
-                return new MetricKey(key.name() + NAME_JOINER + derivedComponent, key.tags());
+                return new MetricKey(
+                    (key.name() + NAME_JOINER + derivedComponent).intern(),
+                    key.tags());
             }
         };
     }
@@ -111,14 +114,16 @@ public class TelemetryMetricNamingConvention {
      * @return the new map with keys replaced by snake_case representations.
      */
     private static Map<String, String> cleanTags(Map<String, String> raw) {
-        return raw.entrySet()
-            .stream()
-            .collect(Collectors.toMap(s -> clean(s.getKey(), TAG_JOINER), Entry::getValue));
+        Map<String, String> result = new HashMap<>();
+        raw.forEach((k, v) -> {
+            result.put(clean(k, TAG_JOINER).intern(), v.intern());
+        });
+        return result;
     }
 
     private static String clean(String raw, String joiner) {
         Objects.requireNonNull(raw, "metric data cannot be null");
         String lowerCase = raw.toLowerCase(Locale.ROOT);
-        return lowerCase.replaceAll("-", joiner);
+        return DASH_PATTERN.matcher(lowerCase).replaceAll(joiner);
     }
 }


### PR DESCRIPTION
While diagnosing an out of memory condition, our profiler alerted us
that tens of megabytes of our heap was used to store redundant String
objects.

In particular, the strings `thread_id`, `rocksdb_state_id`, `task_id`,
and `org.apache.kafka.consumer.fetch.manager.preferred.read.replica`
alone take 12MB. All of these objects are strongly held by MetricKey or
MetricName instances.

Interning a string is a somewhat expensive operation, however, metric
names are generally created once at initialization and then not again
dynamically (excepting some per-connection tracking)

Example showing a quarter million copies of `thread_id`:  <img
width="1596" height="1008" alt="image"
src="https://github.com/user-attachments/assets/d14ac423-ceac-4410-94e2-c21a61ba8584"
/>


