### PR TITLE
KAFKA-15307: Kafka Streams configuration docs outdated

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -297,13 +297,13 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           </tr>
           <tr class="row-even"><td>commit.interval.ms</td>
             <td>Low</td>
-            <td colspan="2">The frequency in milliseconds with which to save the position (offsets in source topics) of tasks.</td>
+            <td colspan="2">The frequency in milliseconds with which to save the position (offsets in source topics) of tasks. Note that if exactly-once processing is enabled, then the default changes to <code class="docutils literal"><span class="pre">100</span></code></td>
             <td><code class="docutils literal"><span class="pre">30000</span></code> (30 seconds)</td>
           </tr>
           <tr class="row-odd"><td>default.deserialization.exception.handler (Deprecated. Use deserialization.exception.handler instead.)</td>
             <td>Medium</td>
             <td colspan="2">Exception handling class that implements the <code class="docutils literal"><span class="pre">DeserializationExceptionHandler</span></code> interface.</td>
-            <td><code class="docutils literal"><span class="pre">LogAndContinueExceptionHandler</span></code></td>
+            <td><code class="docutils literal"><span class="pre">LogAndFailExceptionHandler</span></code></td>
           </tr>
           <tr class="row-even"><td>default.key.serde</td>
             <td>Medium</td>
@@ -328,11 +328,10 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
               set by the user or all serdes must be passed in explicitly (see also default.key.serde).</td>
             <td><code class="docutils literal"><span class="pre">null</span></code></td>
           </tr>
-          <tr class="row-even"><td>default.dsl.store</td>
+          <tr class="row-even"><td>default.dsl.store (Deprecated. Use dsl.store.suppliers.class instead.)</td>
             <td>Low</td>
             <td colspan="2">
-              [DEPRECATED] The default state store type used by DSL operators. Deprecated in
-              favor of <code>dsl.store.suppliers.class</code>
+              The default state store type used by DSL operators.
               </td>
             <td><code class="docutils literal"><span class="pre">"ROCKS_DB"</span></code></td>
           </tr>
@@ -492,54 +491,60 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
               The default of <code>-1</code> (meaning: use broker default replication factor) requires broker version 2.4 or newer.</td>
             <td><code class="docutils literal"><span class="pre">-1</span></code></td>
           </tr>
-          <tr class="row-odd"><td>retry.backoff.ms</td>
+          <tr class="row-odd"><td>repartition.purge.interval.ms</td>
+            <td>Low</td>
+            <td colspan="2">The frequency in milliseconds with which to delete fully consumed records from repartition topics. Purging will occur after at least this value since the last purge, but may be delayed until later.
+              (Note, unlike <code class="docutils literal"><span class="pre">commit.interval.ms</span></code>, the default for this value remains unchanged when <code class="docutils literal"><span class="pre">processing.guarantee</span></code> is set to <code class="docutils literal"><span class="pre">exactly_once_v2</span></code>)</td>
+            <td><code class="docutils literal"><span class="pre">30000</span></code> (30 seconds)</td>
+          </tr>
+          <tr class="row-even"><td>retry.backoff.ms</td>
             <td>Low</td>
             <td colspan="2">The amount of time in milliseconds, before a request is retried.</td>
             <td><code class="docutils literal"><span class="pre">100</span></code></td>
           </tr>
-          <tr class="row-even"><td>rocksdb.config.setter</td>
+          <tr class="row-odd"><td>rocksdb.config.setter</td>
             <td>Medium</td>
             <td colspan="2">The RocksDB configuration.</td>
             <td><code class="docutils literal"><span class="pre">null</span></code></td>
           </tr>
-          <tr class="row-odd"><td>state.cleanup.delay.ms</td>
+          <tr class="row-even"><td>state.cleanup.delay.ms</td>
             <td>Low</td>
             <td colspan="2">The amount of time in milliseconds to wait before deleting state when a partition has migrated.</td>
             <td><code class="docutils literal"><span class="pre">600000</span></code></td> (10 minutes)</td>
           </tr>
-          <tr class="row-even"><td>state.dir</td>
+          <tr class="row-odd"><td>state.dir</td>
             <td>High</td>
             <td colspan="2">Directory location for state stores.</td>
             <td><code class="docutils literal"><span class="pre">/${java.io.tmpdir}/kafka-streams</span></code></td>
           </tr>
-          <tr class="row-odd"><td>task.assignor.class</td>
+          <tr class="row-even"><td>task.assignor.class</td>
             <td>Medium</td>
             <td colspan="2">A task assignor class or class name implementing the <code>TaskAssignor</code> interface.</td>
             <td>The high-availability task assignor.</td>
           </tr>
-          <tr class="row-even"><td>task.timeout.ms</td>
+          <tr class="row-odd"><td>task.timeout.ms</td>
             <td>Medium</td>
             <td colspan="2">The maximum amount of time in milliseconds a task might stall due to internal errors and retries until an error is raised. For a timeout of <code>0 ms</code>, a task would raise an error for the first internal error. For any timeout larger than <code>0 ms</code>, a task will retry at least once before an error is raised.</td>
             <td><code class="docutils literal"><span class="pre">300000</span></code></td> (5 minutes)</td>
           </tr>
-          <tr class="row-odd"><td>topology.optimization</td>
+          <tr class="row-even"><td>topology.optimization</td>
             <td>Medium</td>
             <td colspan="2">A configuration telling Kafka Streams if it should optimize the topology and what optimizations to apply. Acceptable values are: <code>StreamsConfig.NO_OPTIMIZATION</code> (<code>none</code>), <code>StreamsConfig.OPTIMIZE</code> (<code>all</code>) or a comma separated list of specific optimizations: <code>StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS</code> (<code>reuse.ktable.source.topics</code>), <code>StreamsConfig.MERGE_REPARTITION_TOPICS</code> (<code>merge.repartition.topics</code>),
               <code>StreamsConfig.SINGLE_STORE_SELF_JOIN</code> (<code>single.store.self.join</code>). </td>
             <td><code class="docutils literal"><span class="pre">"NO_OPTIMIZATION"</span></code></td>
           </tr>
-          <tr class="row-even"><td>upgrade.from</td>
+          <tr class="row-odd"><td>upgrade.from</td>
             <td>Medium</td>
             <td colspan="2">The version you are upgrading from during a rolling upgrade.
               See <a class="reference internal" href="#streams-developer-guide-upgrade-from"><span class="std std-ref">Upgrade From</span></a></td>
             <td><code class="docutils literal"><span class="pre">null</span></code></td>
           </tr>
-          <tr class="row-odd"><td>windowstore.changelog.additional.retention.ms</td>
+          <tr class="row-even"><td>windowstore.changelog.additional.retention.ms</td>
             <td>Low</td>
             <td colspan="2">Added to a windows maintainMs to ensure data is not deleted from the log prematurely. Allows for clock drift.</td>
             <td><code class="docutils literal"><span class="pre">86400000</span></code></td> (1 day)</td>
           </tr>
-          <tr class="row-even"><td>window.size.ms</td>
+          <tr class="row-odd"><td>window.size.ms</td>
             <td>Low</td>
             <td colspan="2">Sets window size for the deserializer in order to calculate window end times.</td>
             <td><code class="docutils literal"><span class="pre">null</span></code></td>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -297,8 +297,8 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           </tr>
           <tr class="row-even"><td>commit.interval.ms</td>
             <td>Low</td>
-            <td colspan="2">The frequency in milliseconds with which to save the position (offsets in source topics) of tasks. Note that if exactly-once processing is enabled, then the default changes to <code class="docutils literal"><span class="pre">100</span></code></td>
-            <td><code class="docutils literal"><span class="pre">30000</span></code> (30 seconds)</td>
+            <td colspan="2">The frequency in milliseconds with which to save the position (offsets in source topics) of tasks.</td>
+            <td><code class="docutils literal"><span class="pre">30000</span></code> (30 seconds) (at-least-once) / <code class="docutils literal"><span class="pre">100</span></code> (exactly-once)</td>
           </tr>
           <tr class="row-odd"><td>default.deserialization.exception.handler (Deprecated. Use deserialization.exception.handler instead.)</td>
             <td>Medium</td>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -493,8 +493,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           </tr>
           <tr class="row-odd"><td>repartition.purge.interval.ms</td>
             <td>Low</td>
-            <td colspan="2">The frequency in milliseconds with which to delete fully consumed records from repartition topics. Purging will occur after at least this value since the last purge, but may be delayed until later.
-              (Note, unlike <code class="docutils literal"><span class="pre">commit.interval.ms</span></code>, the default for this value remains unchanged when <code class="docutils literal"><span class="pre">processing.guarantee</span></code> is set to <code class="docutils literal"><span class="pre">exactly_once_v2</span></code>)</td>
+            <td colspan="2">The frequency in milliseconds with which to delete fully consumed records from repartition topics. Purging will occur after at least this value since the last purge, but may be delayed until later.</td>
             <td><code class="docutils literal"><span class="pre">30000</span></code> (30 seconds)</td>
           </tr>
           <tr class="row-even"><td>retry.backoff.ms</td>


### PR DESCRIPTION
Updated Kafka Streams configuration documentation to stay latest with
version 4.0.0.

Reviewers: Matthias J. Sax <matthias@confluent.io>
