### PR TITLE
KAFKA-19580: Upgrade to spotbugs 4.9.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: 17
+          java-version: 24
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -72,12 +72,6 @@ ext {
       "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
     )
 
-  if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_24)) {
-    // Spotbugs is not compatible with Java 24+ until Spotbugs 4.9.4. Disable it until we can upgrade to that version.
-    project.gradle.startParameter.excludedTaskNames.add("spotbugsMain")
-    project.gradle.startParameter.excludedTaskNames.add("spotbugsTest")
-  }
-
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
   maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :
       Math.min(Runtime.runtime.availableProcessors(), 8)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -123,10 +123,7 @@ versions += [
   scoverage: "2.0.11",
   slf4j: "1.7.36",
   snappy: "1.1.10.7",
-  // While Spotbugs 4.9.3 exists at the time of writing,
-  // Spotbugs 4.9.1 is the latest version not affected by https://github.com/spotbugs/spotbugs/pull/3311,
-  // which breaks the build, so we're sticking with that version until 4.9.4 is released.
-  spotbugs: "4.9.1",
+  spotbugs: "4.9.4",
   mockOAuth2Server: "2.2.1",
   zinc: "1.9.2",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -725,7 +725,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.1.
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
         <Or>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -551,7 +551,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.1.
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
         <Or>
@@ -586,7 +586,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.1.
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
         <Or>
@@ -617,12 +617,16 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="kafka.coordinator.transaction.TransactionStateManager"/>
             <Class name="kafka.log.LogManager"/>
             <Class name="kafka.server.ReplicaManager"/>
+            <Class name="org.apache.kafka.streams.state.internals.AbstractDualSchemaRocksDBSegmentedBytesStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemorySessionStore"/>
+            <Class name="org.apache.kafka.streams.state.internals.InMemoryWindowStore"/>
         </Or>
         <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
     </Match>
 
     <Match>
-        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.1.
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
         <Or>
@@ -687,12 +691,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="kafka.server.ReplicaManager"/>
             <Class name="org.apache.kafka.trogdor.coordinator.NodeManager$NodeHeartbeat"/>
             <Class name="org.apache.kafka.connect.runtime.distributed.DistributedHerder$RebalanceListener"/>
+            <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
         </Or>
         <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
     </Match>
 
     <Match>
-        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.1.
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
         <Or>
@@ -717,6 +722,17 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.connect.runtime.SourceConnectorConfig"/>
         </Or>
         <Bug pattern="HSM_HIDING_METHOD"/>
+    </Match>
+
+    <Match>
+        <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.1.
+        These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
+         -->
+        <Or>
+            <Class name="org.apache.kafka.common.security.ssl.SslFactory$SslEngineValidator"/>
+            <Class name="org.apache.kafka.server.authorizer.Authorizer"/>
+        </Or>
+        <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
     </Match>
 
 </FindBugsFilter>


### PR DESCRIPTION
Use Java 24 for the spotbugs checks, now that Spotbugs works  on Java
24.

Added some more warning exclusions for warnings that are new to 4.9.4.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
