### PR TITLE
MINOR: Remove unnecessary checks in `TopicDelta`

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -211,10 +211,7 @@ public final class TopicDelta {
 
             try {
                 PartitionRegistration prevPartition = image.partitions().get(entry.getKey());
-                if (
-                        prevPartition == null ||
-                        prevPartition.directory(brokerId) != entry.getValue().directory(brokerId)
-                ) {
+                if (prevPartition == null || prevPartition.directory(brokerId) != entry.getValue().directory(brokerId)) {
                     directoryIds.put(
                         new TopicIdPartition(id(), new TopicPartition(name(), entry.getKey())),
                         entry.getValue().directory(brokerId)

--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -213,7 +213,6 @@ public final class TopicDelta {
                 PartitionRegistration prevPartition = image.partitions().get(entry.getKey());
                 if (
                         prevPartition == null ||
-                        prevPartition.directories == null ||
                         prevPartition.directory(brokerId) != entry.getValue().directory(brokerId)
                 ) {
                     directoryIds.put(


### PR DESCRIPTION
field `directories` has already been validated in the constructor,so
there’s no need to check for null.

https://github.com/apache/kafka/blob/7d2ad185206cd4c7089fceb07f9a3f2c016f38d6/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java#L221

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, TengYao Chi
 <frankvicky@apache.org>, Yung <yungyung7654321@gmail.com>, Ken Huang
 <s7133700@gmail.com>
