### PR TITLE
Revert "MINOR: Update apacheds to 2.0.0.AM26 (#19565)"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ if ( !versions.scala.contains('-') ) {
 versions += [
   activation: "1.1.1",
   apacheda: "1.0.2",
-  apacheds: "2.0.0.AM26",
+  apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.80",
   caffeine: "3.2.0",


### PR DESCRIPTION
This reverts commit 9a0239a03281e1dd5e132d9d899305ed92dc299c.

The version bump causes build failure on trunk: https://github.com/apache/kafka/pull/19565#issuecomment-3177841140
