### PR TITLE
MINOR: Update apacheds to 2.0.0.AM25

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ if ( !versions.scala.contains('-') ) {
 versions += [
   activation: "1.1.1",
   apacheda: "1.0.2",
-  apacheds: "2.0.0-M24",
+  apacheds: "2.0.0.AM25",
   argparse4j: "0.7.0",
   bcpkix: "1.80",
   caffeine: "3.2.0",


### PR DESCRIPTION
Dependencies such as api-ldap-client-api and mina-core used by the current version of apacheds have several critical CVEs: CVE-2018-1337, CVE-2024-52046 and CVE-2019-0231. 2.0.0.AM25 is the latest compatible release (2.0.0.AM26 removes classes used by core tests).