### PR TITLE
MINOR: Fix TestLinearWriteSpeed class

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
@@ -81,13 +81,13 @@ public class TestLinearWriteSpeed {
             .describedAs("num_bytes")
             .ofType(Integer.class);
 
-        OptionSpec<Integer> messageSizeOpt = parser.accepts("message-size", "REQUIRED: The size of each message in the message set.")
+        OptionSpec<Integer> messageSizeOpt = parser.accepts("message-size", "The size of each message in the message set.")
             .withRequiredArg()
             .describedAs("num_bytes")
             .ofType(Integer.class)
             .defaultsTo(1024);
 
-        OptionSpec<Integer> filesOpt = parser.accepts("files", "REQUIRED: The number of logs or files.")
+        OptionSpec<Integer> filesOpt = parser.accepts("files", "The number of logs or files.")
             .withRequiredArg()
             .describedAs("num_files")
             .ofType(Integer.class)
@@ -126,7 +126,7 @@ public class TestLinearWriteSpeed {
         OptionSpec<Void> channelOpt = parser.accepts("channel", "Do writes to file channels.");
         OptionSpec<Void> logOpt = parser.accepts("log", "Do writes to kafka logs.");
         OptionSet options = parser.parse(args);
-        CommandLineUtils.checkRequiredArgs(parser, options, bytesOpt, sizeOpt, filesOpt);
+        CommandLineUtils.checkRequiredArgs(parser, options, bytesOpt, sizeOpt);
 
         long bytesToWrite = options.valueOf(bytesOpt);
         int bufferSize = options.valueOf(sizeOpt);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
@@ -126,16 +126,6 @@ public class TestLinearWriteSpeed {
         OptionSpec<Void> mmapOpt = parser.accepts("mmap", "Do writes to memory-mapped files.");
         OptionSpec<Void> channelOpt = parser.accepts("channel", "Do writes to file channels.");
         OptionSpec<Void> logOpt = parser.accepts("log", "Do writes to kafka logs.");
-        OptionSpec<Integer> runsOpt = parser.accepts("runs", "How many times to repeat the evaluation.")
-            .withRequiredArg()
-            .describedAs("count")
-            .ofType(Integer.class)
-            .defaultsTo(1);
-        OptionSpec<Integer> warmupOpt = parser.accepts("warmup", "How many initial runs to discard from summary.")
-            .withRequiredArg()
-            .describedAs("count")
-            .ofType(Integer.class)
-            .defaultsTo(0);
         OptionSet options = parser.parse(args);
         CommandLineUtils.checkRequiredArgs(parser, options, bytesOpt, sizeOpt, filesOpt);
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
@@ -143,9 +143,7 @@ public class TestLinearWriteSpeed {
         int compressionLevel = options.valueOf(compressionLevelOpt);
 
         setupCompression(compressionType, compressionBuilder, compressionLevel);
-        final Compression compression = compressionBuilder.build();
-
-        System.out.printf("Using compression=%s level=%d%n", compressionType.name, compressionLevel);
+        Compression compression = compressionBuilder.build();
 
         ThreadLocalRandom.current().nextBytes(buffer.array());
         int numMessages = bufferSize / (messageSize + Records.LOG_OVERHEAD);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
@@ -141,7 +141,7 @@ public class TestLinearWriteSpeed {
         Compression.Builder<? extends Compression> compressionBuilder = Compression.of(compressionType);
         Integer compressionLevel = options.valueOf(compressionLevelOpt);
 
-        setupCompression(compressionType, compressionBuilder, compressionLevel);
+        if (compressionLevel != null) setupCompression(compressionType, compressionBuilder, compressionLevel);
         Compression compression = compressionBuilder.build();
 
         ThreadLocalRandom.current().nextBytes(buffer.array());
@@ -225,16 +225,13 @@ public class TestLinearWriteSpeed {
                                          Integer compressionLevel) {
         switch (compressionType) {
             case GZIP:
-                ((GzipCompression.Builder) compressionBuilder)
-                    .level(compressionLevel != null ? compressionLevel : CompressionType.GZIP.defaultLevel());
+                ((GzipCompression.Builder) compressionBuilder).level(compressionLevel);
                 break;
             case LZ4:
-                ((Lz4Compression.Builder) compressionBuilder)
-                    .level(compressionLevel != null ? compressionLevel : CompressionType.LZ4.defaultLevel());
+                ((Lz4Compression.Builder) compressionBuilder).level(compressionLevel);
                 break;
             case ZSTD:
-                ((ZstdCompression.Builder) compressionBuilder)
-                    .level(compressionLevel != null ? compressionLevel : CompressionType.ZSTD.defaultLevel());
+                ((ZstdCompression.Builder) compressionBuilder).level(compressionLevel);
                 break;
             default:
                 break;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
@@ -126,6 +126,16 @@ public class TestLinearWriteSpeed {
         OptionSpec<Void> mmapOpt = parser.accepts("mmap", "Do writes to memory-mapped files.");
         OptionSpec<Void> channelOpt = parser.accepts("channel", "Do writes to file channels.");
         OptionSpec<Void> logOpt = parser.accepts("log", "Do writes to kafka logs.");
+        OptionSpec<Integer> runsOpt = parser.accepts("runs", "How many times to repeat the evaluation.")
+            .withRequiredArg()
+            .describedAs("count")
+            .ofType(Integer.class)
+            .defaultsTo(1);
+        OptionSpec<Integer> warmupOpt = parser.accepts("warmup", "How many initial runs to discard from summary.")
+            .withRequiredArg()
+            .describedAs("count")
+            .ofType(Integer.class)
+            .defaultsTo(0);
         OptionSet options = parser.parse(args);
         CommandLineUtils.checkRequiredArgs(parser, options, bytesOpt, sizeOpt, filesOpt);
 
@@ -143,6 +153,9 @@ public class TestLinearWriteSpeed {
         int compressionLevel = options.valueOf(compressionLevelOpt);
 
         setupCompression(compressionType, compressionBuilder, compressionLevel);
+        final Compression compression = compressionBuilder.build();
+
+        System.out.printf("Using compression=%s level=%d%n", compressionType.name, compressionLevel);
 
         ThreadLocalRandom.current().nextBytes(buffer.array());
         int numMessages = bufferSize / (messageSize + Records.LOG_OVERHEAD);
@@ -153,7 +166,7 @@ public class TestLinearWriteSpeed {
             recordsList.add(new SimpleRecord(createTime, null, new byte[messageSize]));
         }
 
-        MemoryRecords messageSet = MemoryRecords.withRecords(Compression.NONE, recordsList.toArray(new SimpleRecord[0]));
+        MemoryRecords messageSet = MemoryRecords.withRecords(compression, recordsList.toArray(new SimpleRecord[0]));
         Writable[] writables = new Writable[numFiles];
         KafkaScheduler scheduler = new KafkaScheduler(1);
         scheduler.startup();

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/log/TestLinearWriteSpeed.java
@@ -120,8 +120,7 @@ public class TestLinearWriteSpeed {
         OptionSpec<Integer> compressionLevelOpt = parser.accepts("level", "The compression level to use")
             .withRequiredArg()
             .describedAs("level")
-            .ofType(Integer.class)
-            .defaultsTo(0);
+            .ofType(Integer.class);
 
         OptionSpec<Void> mmapOpt = parser.accepts("mmap", "Do writes to memory-mapped files.");
         OptionSpec<Void> channelOpt = parser.accepts("channel", "Do writes to file channels.");
@@ -140,7 +139,7 @@ public class TestLinearWriteSpeed {
         long flushInterval = options.valueOf(flushIntervalOpt);
         CompressionType compressionType = CompressionType.forName(options.valueOf(compressionCodecOpt));
         Compression.Builder<? extends Compression> compressionBuilder = Compression.of(compressionType);
-        int compressionLevel = options.valueOf(compressionLevelOpt);
+        Integer compressionLevel = options.valueOf(compressionLevelOpt);
 
         setupCompression(compressionType, compressionBuilder, compressionLevel);
         Compression compression = compressionBuilder.build();
@@ -223,16 +222,19 @@ public class TestLinearWriteSpeed {
 
     private static void setupCompression(CompressionType compressionType,
                                          Compression.Builder<? extends Compression> compressionBuilder,
-                                         int compressionLevel) {
+                                         Integer compressionLevel) {
         switch (compressionType) {
             case GZIP:
-                ((GzipCompression.Builder) compressionBuilder).level(compressionLevel);
+                ((GzipCompression.Builder) compressionBuilder)
+                    .level(compressionLevel != null ? compressionLevel : CompressionType.GZIP.defaultLevel());
                 break;
             case LZ4:
-                ((Lz4Compression.Builder) compressionBuilder).level(compressionLevel);
+                ((Lz4Compression.Builder) compressionBuilder)
+                    .level(compressionLevel != null ? compressionLevel : CompressionType.LZ4.defaultLevel());
                 break;
             case ZSTD:
-                ((ZstdCompression.Builder) compressionBuilder).level(compressionLevel);
+                ((ZstdCompression.Builder) compressionBuilder)
+                    .level(compressionLevel != null ? compressionLevel : CompressionType.ZSTD.defaultLevel());
                 break;
             default:
                 break;


### PR DESCRIPTION
This PR fixes a problem related to `TestLinearWriteSpeed`.  During my
work on KIP-780, I discovered that benchmarks for `TestLinearWriteSpeed`
do not account for compression algorithms. It always uses
`Compression.NONE` when creating records. The problem was introduced in
this PR [1].

[1] - https://github.com/apache/kafka/pull/17736

Reviewers: Ken Huang <s7133700@gmail.com>, Mickael Maison
 <mickael.maison@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
