### PR TITLE
MINOR: Use lambda expressions instead of ImmutableValue for Gauges

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -18,7 +18,6 @@ package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
-import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 
 import org.slf4j.Logger;
@@ -96,9 +95,9 @@ public class AppInfoParser {
 
     private static void registerMetrics(Metrics metrics, AppInfo appInfo) {
         if (metrics != null) {
-            metrics.addMetric(metricName(metrics, "version"), new ImmutableValue<>(appInfo.getVersion()));
-            metrics.addMetric(metricName(metrics, "commit-id"), new ImmutableValue<>(appInfo.getCommitId()));
-            metrics.addMetric(metricName(metrics, "start-time-ms"), new ImmutableValue<>(appInfo.getStartTimeMs()));
+            metrics.addMetric(metricName(metrics, "version"), (Gauge<String>) (config, now) -> appInfo.getVersion());
+            metrics.addMetric(metricName(metrics, "commit-id"), (Gauge<String>) (config, now) -> appInfo.getCommitId());
+            metrics.addMetric(metricName(metrics, "start-time-ms"), (Gauge<Long>) (config, now) -> appInfo.getStartTimeMs());
         }
     }
 
@@ -142,18 +141,5 @@ public class AppInfoParser {
             return startTimeMs;
         }
 
-    }
-
-    static class ImmutableValue<T> implements Gauge<T> {
-        private final T value;
-
-        public ImmutableValue(T value) {
-            this.value = value;
-        }
-
-        @Override
-        public T value(MetricConfig config, long now) {
-            return value;
-        }
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
-import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 
@@ -186,35 +185,35 @@ public class PushHttpMetricsReporterTest {
         KafkaMetric metric1 = new KafkaMetric(
                 new Object(),
                 new MetricName("name1", "group1", "desc1", Map.of("key1", "value1")),
-                new ImmutableValue<>(1.0),
+                (Gauge<Double>)(config, now) -> 1.0,
                 null,
                 time
         );
         KafkaMetric newMetric1 = new KafkaMetric(
                 new Object(),
                 new MetricName("name1", "group1", "desc1", Map.of("key1", "value1")),
-                new ImmutableValue<>(-1.0),
+                (Gauge<Double>)(config, now) -> -1.0,
                 null,
                 time
         );
         KafkaMetric metric2 = new KafkaMetric(
                 new Object(),
                 new MetricName("name2", "group2", "desc2", Map.of("key2", "value2")),
-                new ImmutableValue<>(2.0),
+                (Gauge<Double>)(config, now) -> 2.0,
                 null,
                 time
         );
         KafkaMetric metric3 = new KafkaMetric(
                 new Object(),
                 new MetricName("name3", "group3", "desc3", Map.of("key3", "value3")),
-                new ImmutableValue<>(3.0),
+                (Gauge<Double>)(config, now) -> 3.0,
                 null,
                 time
         );
         KafkaMetric metric4 = new KafkaMetric(
             new Object(),
             new MetricName("name4", "group4", "desc4", Map.of("key4", "value4")),
-            new ImmutableValue<>("value4"),
+            (Gauge<String>)(config, now) -> "value4",
             null,
             time
         );
@@ -332,18 +331,5 @@ public class PushHttpMetricsReporterTest {
         verify(httpOut).write(httpPayloadCaptor.capture());
         verify(httpOut).flush();
         verify(httpOut).close();
-    }
-
-    static class ImmutableValue<T> implements Gauge<T> {
-        private final T value;
-
-        public ImmutableValue(T value) {
-            this.value = value;
-        }
-
-        @Override
-        public T value(MetricConfig config, long now) {
-            return value;
-        }
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/PushHttpMetricsReporterTest.java
@@ -185,35 +185,35 @@ public class PushHttpMetricsReporterTest {
         KafkaMetric metric1 = new KafkaMetric(
                 new Object(),
                 new MetricName("name1", "group1", "desc1", Map.of("key1", "value1")),
-                (Gauge<Double>)(config, now) -> 1.0,
+                (Gauge<Double>) (config, now) -> 1.0,
                 null,
                 time
         );
         KafkaMetric newMetric1 = new KafkaMetric(
                 new Object(),
                 new MetricName("name1", "group1", "desc1", Map.of("key1", "value1")),
-                (Gauge<Double>)(config, now) -> -1.0,
+                (Gauge<Double>) (config, now) -> -1.0,
                 null,
                 time
         );
         KafkaMetric metric2 = new KafkaMetric(
                 new Object(),
                 new MetricName("name2", "group2", "desc2", Map.of("key2", "value2")),
-                (Gauge<Double>)(config, now) -> 2.0,
+                (Gauge<Double>) (config, now) -> 2.0,
                 null,
                 time
         );
         KafkaMetric metric3 = new KafkaMetric(
                 new Object(),
                 new MetricName("name3", "group3", "desc3", Map.of("key3", "value3")),
-                (Gauge<Double>)(config, now) -> 3.0,
+                (Gauge<Double>) (config, now) -> 3.0,
                 null,
                 time
         );
         KafkaMetric metric4 = new KafkaMetric(
             new Object(),
             new MetricName("name4", "group4", "desc4", Map.of("key4", "value4")),
-            (Gauge<String>)(config, now) -> "value4",
+            (Gauge<String>) (config, now) -> "value4",
             null,
             time
         );


### PR DESCRIPTION
Refactor metric gauges instantiation to use lambda expressions instead
of ImmutableValue.

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
