### PR TITLE
MINOR: Fix typo

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminBootstrapAddresses.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminBootstrapAddresses.java
@@ -95,7 +95,7 @@ public final class AdminBootstrapAddresses {
     public String toString() {
         StringBuilder bld = new StringBuilder();
         bld.append("AdminBootstrapAddresses");
-        bld.append("(usingBoostrapControllers=").append(usingBootstrapControllers);
+        bld.append("(usingBootstrapControllers=").append(usingBootstrapControllers);
         bld.append(", addresses=[");
         String prefix = "";
         for (InetSocketAddress address : addresses) {


### PR DESCRIPTION
Fix the typo in `AdminBootstrapAddresses`.

Reviewers: TengYao Chi <frankvicky@apache.org>, Ken Huang
 <s7133700@gmail.com>
