### PR TITLE
KAFKA-19605; Fix the busy loop occurring in kraft client observers

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -159,11 +159,6 @@ public class FollowerState implements EpochState {
         return updateVoterSetPeriodTimer.isExpired();
     }
 
-    public long remainingUpdateVoterSetPeriodMs(long currentTimeMs) {
-        updateVoterSetPeriodTimer.update(currentTimeMs);
-        return updateVoterSetPeriodTimer.remainingMs();
-    }
-
     public void resetUpdateVoterSetPeriod(long currentTimeMs) {
         updateVoterSetPeriodTimer.update(currentTimeMs);
         updateVoterSetPeriodTimer.reset(updateVoterPeriodMs());

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3315,10 +3315,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         return Math.min(
             backoffMs,
-            Math.min(
-                state.remainingFetchTimeMs(currentTimeMs),
-                state.remainingUpdateVoterSetPeriodMs(currentTimeMs)
-            )
+            state.remainingFetchTimeMs(currentTimeMs)
         );
     }
 
@@ -3334,13 +3331,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
     private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
         GracefulShutdown shutdown = this.shutdown.get();
-        final long backoffMs;
-        final var shouldSendAddOrRemoveVoterRequest = shouldSendAddOrRemoveVoterRequest();
         if (shutdown != null) {
             // If we are an observer, then we can shutdown immediately. We want to
             // skip potentially sending any add or remove voter RPCs.
-            backoffMs = 0;
-        } else if (shouldSendAddOrRemoveVoterRequest &&
+            return 0;
+        } else if (shouldSendAddOrRemoveVoterRequest() &&
             state.hasUpdateVoterSetPeriodExpired(currentTimeMs)
         ) {
             final var localReplicaKey = quorum.localReplicaKeyOrThrow();
@@ -3360,19 +3355,13 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             } else {
                 sendResult = maybeSendAddVoterRequest(state, currentTimeMs);
             }
-            backoffMs = sendResult.timeToWaitMs();
             if (sendResult.requestSent()) {
                 state.resetUpdateVoterSetPeriod(currentTimeMs);
             }
+            return sendResult.timeToWaitMs();
         } else {
-            backoffMs = maybeSendFetchToBestNode(state, currentTimeMs);
+            return maybeSendFetchToBestNode(state, currentTimeMs);
         }
-        return Math.min(
-            backoffMs,
-            shouldSendAddOrRemoveVoterRequest ?
-                state.remainingUpdateVoterSetPeriodMs(currentTimeMs) :
-                Integer.MAX_VALUE
-        );
     }
 
     private long maybeSendFetchToBestNode(FollowerState state, long currentTimeMs) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3322,13 +3322,14 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private boolean shouldSendAddOrRemoveVoterRequest(FollowerState state, long currentTimeMs) {
+    private boolean shouldSendAddOrRemoveVoterRequest() {
         /* When the cluster supports reconfiguration, only replicas that can become a voter
          * and are configured to auto join should attempt to automatically join the voter
          * set for the configured topic partition.
          */
-        return partitionState.lastKraftVersion().isReconfigSupported() && canBecomeVoter &&
-            quorumConfig.autoJoin() && state.hasUpdateVoterSetPeriodExpired(currentTimeMs);
+        return partitionState.lastKraftVersion().isReconfigSupported() &&
+            canBecomeVoter &&
+            quorumConfig.autoJoin();
     }
 
     private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
@@ -3338,7 +3339,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             // If we are an observer, then we can shutdown immediately. We want to
             // skip potentially sending any add or remove voter RPCs.
             backoffMs = 0;
-        } else if (shouldSendAddOrRemoveVoterRequest(state, currentTimeMs)) {
+        } else if (shouldSendAddOrRemoveVoterRequest() &&
+            state.hasUpdateVoterSetPeriodExpired(currentTimeMs)
+        ) {
             final var localReplicaKey = quorum.localReplicaKeyOrThrow();
             final var voters = partitionState.lastVoterSet();
             final RequestSendResult sendResult;
@@ -3363,7 +3366,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         } else {
             backoffMs = maybeSendFetchToBestNode(state, currentTimeMs);
         }
-        if (canBecomeVoter) {
+        if (shouldSendAddOrRemoveVoterRequest()) {
             return Math.min(
                 backoffMs,
                 state.remainingUpdateVoterSetPeriodMs(currentTimeMs)

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3363,10 +3363,14 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         } else {
             backoffMs = maybeSendFetchToBestNode(state, currentTimeMs);
         }
-        return Math.min(
-            backoffMs,
-            state.remainingUpdateVoterSetPeriodMs(currentTimeMs)
-        );
+        if (canBecomeVoter) {
+            return Math.min(
+                backoffMs,
+                state.remainingUpdateVoterSetPeriodMs(currentTimeMs)
+            );
+        } else {
+            return backoffMs;
+        }
     }
 
     private long maybeSendFetchToBestNode(FollowerState state, long currentTimeMs) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3335,11 +3335,12 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
         GracefulShutdown shutdown = this.shutdown.get();
         final long backoffMs;
+        final var shouldSendAddOrRemoveVoterRequest = shouldSendAddOrRemoveVoterRequest();
         if (shutdown != null) {
             // If we are an observer, then we can shutdown immediately. We want to
             // skip potentially sending any add or remove voter RPCs.
             backoffMs = 0;
-        } else if (shouldSendAddOrRemoveVoterRequest() &&
+        } else if (shouldSendAddOrRemoveVoterRequest &&
             state.hasUpdateVoterSetPeriodExpired(currentTimeMs)
         ) {
             final var localReplicaKey = quorum.localReplicaKeyOrThrow();
@@ -3366,14 +3367,12 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         } else {
             backoffMs = maybeSendFetchToBestNode(state, currentTimeMs);
         }
-        if (shouldSendAddOrRemoveVoterRequest()) {
-            return Math.min(
-                backoffMs,
-                state.remainingUpdateVoterSetPeriodMs(currentTimeMs)
-            );
-        } else {
-            return backoffMs;
-        }
+        return Math.min(
+            backoffMs,
+            shouldSendAddOrRemoveVoterRequest ?
+                state.remainingUpdateVoterSetPeriodMs(currentTimeMs) :
+                Integer.MAX_VALUE
+        );
     }
 
     private long maybeSendFetchToBestNode(FollowerState state, long currentTimeMs) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3319,14 +3319,13 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private boolean shouldSendAddOrRemoveVoterRequest() {
+    private boolean shouldSendAddOrRemoveVoterRequest(FollowerState state, long currentTimeMs) {
         /* When the cluster supports reconfiguration, only replicas that can become a voter
          * and are configured to auto join should attempt to automatically join the voter
          * set for the configured topic partition.
          */
-        return partitionState.lastKraftVersion().isReconfigSupported() &&
-            canBecomeVoter &&
-            quorumConfig.autoJoin();
+        return partitionState.lastKraftVersion().isReconfigSupported() && canBecomeVoter &&
+            quorumConfig.autoJoin() && state.hasUpdateVoterSetPeriodExpired(currentTimeMs);
     }
 
     private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
@@ -3335,9 +3334,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             // If we are an observer, then we can shutdown immediately. We want to
             // skip potentially sending any add or remove voter RPCs.
             return 0;
-        } else if (shouldSendAddOrRemoveVoterRequest() &&
-            state.hasUpdateVoterSetPeriodExpired(currentTimeMs)
-        ) {
+        } else if (shouldSendAddOrRemoveVoterRequest(state, currentTimeMs)) {
             final var localReplicaKey = quorum.localReplicaKeyOrThrow();
             final var voters = partitionState.lastVoterSet();
             final RequestSendResult sendResult;


### PR DESCRIPTION
The broker observer should not read update voter set timer value when
polling to determine its backoff, since brokers cannot auto-join the
KRaft voter set. If auto-join or kraft.version=1 is not supported,
controller observers should not read this timer either when polling.

The updateVoterSetPeriodMs timer is not something that should be
considered when calculating the backoff returned by polling, since this
timer does not represent the same thing as the fetchTimeMs timer.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, José Armando García
 Sancio <jsancio@apache.org>, Alyssa Huang <ahuang@confluent.io>,
 Kuan-Po Tseng <brandboat@gmail.com>
