### PR TITLE
MINOR: Remove broken link in CoordinatorMetricsShard javadoc

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorMetricsShard.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorMetricsShard.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.TopicPartition;
 /**
  * A CoordinatorMetricsShard is mapped to a single CoordinatorShard. The metrics shard records sensors that have been
  * defined in {@link CoordinatorMetrics}. Coordinator specific gauges and related methods are exposed in the
- * implementation of CoordinatorMetricsShard (i.e. {@link GroupCoordinatorMetricsShard}).
+ * implementation of CoordinatorMetricsShard (such as GroupCoordinatorMetricsShard and ShareCoordinatorMetricsShard).
  *
  * For sensors, each shard individually records the observed values.
  */


### PR DESCRIPTION
CoordinatorMetricsShard was split into a separate module in
(https://github.com/apache/kafka/pull/16883), causing the link in the
javadoc to become invalid.

So, remove broken link in CoordinatorMetricsShard javadoc.

Reviewers: TengYao Chi <kitingiao@gmail.com>, Sanskar Jhajharia
 <sjhajharia@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
