### PR TITLE
KAFKA-19606: Fix anomaly of requestHandlerAvgIdleMetric in kraft combined mode

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -468,7 +468,7 @@ class BrokerServer(
 
       dataPlaneRequestHandlerPool = new KafkaRequestHandlerPool(config.nodeId,
         socketServer.dataPlaneRequestChannel, dataPlaneRequestProcessor, time,
-        config.numIoThreads, "RequestHandlerAvgIdlePercent")
+        config.numIoThreads, "RequestHandlerAvgIdlePercent", "broker", config.isKRaftCombinedMode)
 
       metadataPublishers.add(new MetadataVersionConfigValidator(config, sharedServer.metadataPublishingFaultHandler))
       brokerMetadataPublisher = new BrokerMetadataPublisher(config,

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -288,7 +288,8 @@ class ControllerServer(
         time,
         config.numIoThreads,
         "RequestHandlerAvgIdlePercent",
-        "controller")
+        "controller",
+        config.isKRaftCombinedMode)
 
       // Set up the metadata cache publisher.
       metadataPublishers.add(metadataCachePublisher)

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -93,7 +93,8 @@ class KafkaRequestHandler(
   val requestChannel: RequestChannel,
   apis: ApiRequestHandler,
   time: Time,
-  nodeName: String = "broker"
+  nodeName: String = "broker",
+  val isCombinedMode: Boolean = false,
 ) extends Runnable with Logging {
   this.logIdent = s"[Kafka Request Handler $id on ${nodeName.capitalize} $brokerId] "
   private val shutdownComplete = new CountDownLatch(1)
@@ -112,7 +113,7 @@ class KafkaRequestHandler(
       val req = requestChannel.receiveRequest(300)
       val endTime = time.nanoseconds
       val idleTime = endTime - startSelectTime
-      aggregateIdleMeter.mark(idleTime / totalHandlerThreads.get)
+      aggregateIdleMeter.mark(idleTime / (totalHandlerThreads.get * (if (isCombinedMode) 2 else 1)))
 
       req match {
         case RequestChannel.ShutdownRequest =>
@@ -199,7 +200,8 @@ class KafkaRequestHandlerPool(
   time: Time,
   numThreads: Int,
   requestHandlerAvgIdleMetricName: String,
-  nodeName: String = "broker"
+  nodeName: String = "broker",
+  isCombinedMode: Boolean = false,
 ) extends Logging {
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
@@ -214,7 +216,7 @@ class KafkaRequestHandlerPool(
   }
 
   def createHandler(id: Int): Unit = synchronized {
-    runnables += new KafkaRequestHandler(id, brokerId, aggregateIdleMeter, threadPoolSize, requestChannel, apis, time, nodeName)
+    runnables += new KafkaRequestHandler(id, brokerId, aggregateIdleMeter, threadPoolSize, requestChannel, apis, time, nodeName, isCombinedMode)
     KafkaThread.daemon("data-plane-kafka-request-handler-" + id, runnables(id)).start()
   }
 
@@ -223,14 +225,15 @@ class KafkaRequestHandlerPool(
     info(s"Resizing request handler thread pool size from $currentSize to $newSize")
     if (newSize > currentSize) {
       for (i <- currentSize until newSize) {
+        threadPoolSize.getAndIncrement()
         createHandler(i)
       }
     } else if (newSize < currentSize) {
       for (i <- 1 to (currentSize - newSize)) {
+        threadPoolSize.getAndDecrement()
         runnables.remove(currentSize - i).stop()
       }
     }
-    threadPoolSize.set(newSize)
   }
 
   def shutdown(): Unit = synchronized {

--- a/core/src/test/scala/kafka/server/KafkaRequestHandlerTest.scala
+++ b/core/src/test/scala/kafka/server/KafkaRequestHandlerTest.scala
@@ -52,6 +52,60 @@ class KafkaRequestHandlerTest {
   val allTopicMetrics: BrokerTopicMetrics = brokerTopicStats.allTopicsStats
 
   @Test
+  def testCombinedModeIdlePercent(): Unit = {
+    val time = Time.SYSTEM
+    val metricsBroker = new RequestChannelMetrics(java.util.Set.of[ApiKeys])
+    val metricsController = new RequestChannelMetrics(java.util.Set.of[ApiKeys])
+    val requestChannelBroker = new RequestChannel(10, time, metricsBroker)
+    val requestChannelController = new RequestChannel(10, time, metricsController)
+    val apiHandler = mock(classOf[ApiRequestHandler])
+
+    // Create both pools with 0 threads so we can wire a shared Meter before handlers are created
+    val brokerPool = new KafkaRequestHandlerPool(
+      0,
+      requestChannelBroker,
+      apiHandler,
+      time,
+      0,
+      "RequestHandlerAvgIdlePercent",
+      isCombinedMode = true
+    )
+
+    val controllerPool = new KafkaRequestHandlerPool(
+      0,
+      requestChannelController,
+      apiHandler,
+      time,
+      0,
+      "RequestHandlerAvgIdlePercent",
+      isCombinedMode = true
+    )
+
+    try {
+      val field = classOf[KafkaRequestHandlerPool].getDeclaredField("aggregateIdleMeter")
+      field.setAccessible(true)
+      val sharedMeter = field.get(brokerPool).asInstanceOf[Meter]
+      field.set(controllerPool, sharedMeter)
+
+      brokerPool.resizeThreadPool(4)
+      controllerPool.resizeThreadPool(4)
+
+      val deadline = System.currentTimeMillis() + 8000
+      var value = 0.0
+      while (System.currentTimeMillis() < deadline && value == 0.0) {
+        Thread.sleep(200)
+        value = sharedMeter.oneMinuteRate()
+      }
+      assertTrue(value >= 0.0 && value <= 1.05, s"idle percent should be within [0,1], got $value")
+    } finally {
+      controllerPool.shutdown()
+      brokerPool.shutdown()
+      metricsBroker.close()
+      metricsController.close()
+    }
+  }
+
+  @Test
   def testCallbackTiming(): Unit = {
     val time = new MockTime()
     val startTime = time.nanoseconds()
@@ -192,6 +246,38 @@ class KafkaRequestHandlerTest {
     // Verify that we do use the request local that we passed in.
     verify(originalRequestLocal, times(1)).bufferSupplier
     assertEquals(1, handledCount)
+  }
+
+  @Test
+  def testResizeThreadPoolUpdatesThreadPoolSize(): Unit = {
+    val time = Time.SYSTEM
+    val metrics = new RequestChannelMetrics(java.util.Set.of[ApiKeys])
+    val requestChannel = new RequestChannel(10, time, metrics)
+    val apiHandler = mock(classOf[ApiRequestHandler])
+
+    // start with 3 threads
+    val pool = new KafkaRequestHandlerPool(
+      0,
+      requestChannel,
+      apiHandler,
+      time,
+      3,
+      "RequestHandlerAvgIdlePercent",
+    )
+    try {
+      assertEquals(3, pool.threadPoolSize.get)
+
+      // grow to 5
+      pool.resizeThreadPool(5)
+      assertEquals(5, pool.threadPoolSize.get)
+
+      // shrink to 2
+      pool.resizeThreadPool(2)
+      assertEquals(2, pool.threadPoolSize.get)
+    } finally {
+      pool.shutdown()
+      metrics.close()
+    }
   }
 
 


### PR DESCRIPTION
JMX metrics RequestHandlerAvgIdlePercent reports a value close to 2 in
combined kraft mode but it's expected to be b/w 0 and 1.

<img width="410" height="330" alt="Screenshot 2025-08-14 at 12 41 42"
src="https://github.com/user-attachments/assets/c6cc26c5-fd40-4765-a8ce-c347d0881280"
/>

This is an issue with kraft combined mode specifically because both
`controller` + `broker` are using the same Meter object in combined
mode, defined in `RequestThreadIdleMeter#requestThreadIdleMeter`, but
the controller and broker are using separate `KafkaRequestHandlerPool`
objects, where each object's `threadPoolSize ==
KafkaConfig.numIoThreads`. This means when calculating idle time, each
pool divides by its own `numIoThreads`value before reporting to the
shared meter and  `Meter` calculates the final result by accumulating
all the values reported by all threads. However, since there are
actually `2 × numIoThreads` total threads contributing to the metric,
the denominator should be doubled to get the correct average.

POC in local environment:  <img width="640" height="220" alt="Screenshot
2025-08-14 at 14 27 32"
src="https://github.com/user-attachments/assets/87019447-251b-4f49-9e00-18948492b74e"
/>

Changes:

1. When creating `dataPlaneRequestHandlerPool`, we pass
`KafkaConfig.isKRaftCombinedMode`; in combined mode the pool adjusts the
idle calculation (dividing by `2 * totalHandlerThreads`), using the
total thread count from both pools as the denominator
2. When resizing threadpool, update the pool size each time a thread is
created/destroyed to ensure the size is up to date
3. add a unit test mocking the combined mode where broker & controller
share the `Meter` and use separate `RequestHandlerPool`
4. add unit test for threadpool resizing

https://issues.apache.org/jira/browse/KAFKA-19606


