### PR TITLE
MINOR: Fix race conditions in KafkaStreams when topic is missing.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
@@ -1098,7 +1098,9 @@ public class StreamsMembershipManager implements RequestManager {
 
         final SortedSet<TopicPartition> partitionsToRevoke = topicPartitionsForActiveTasks(activeTasksToRevoke);
         log.debug("Marking partitions pending for revocation: {}", partitionsToRevoke);
-        subscriptionState.markPendingRevocation(partitionsToRevoke);
+        // If topic is missing and it is in reconciliation state,
+        // Subscription State already may not have TopicPartition for revoked tasks.
+        subscriptionState.markPendingRevocationIfPresentTopicPartitions(partitionsToRevoke);
 
         CompletableFuture<Void> tasksRevoked = new CompletableFuture<>();
         CompletableFuture<Void> onTasksRevokedCallbackExecuted = requestOnTasksRevokedCallbackInvocation(activeTasksToRevoke);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -909,6 +909,12 @@ public class SubscriptionState {
         tps.forEach(tp -> assignedState(tp).markPendingRevocation());
     }
 
+    public synchronized void markPendingRevocationIfPresentTopicPartitions(Set<TopicPartition> tps) {
+        tps.stream()
+           .filter(tp -> this.assignment.stateValue(tp) != null)
+           .forEach(tp -> assignedState(tp).markPendingRevocation());
+    }
+
     // Visible for testing
     synchronized void markPendingOnAssignedCallback(Collection<TopicPartition> tps,
                                                     boolean pendingOnAssignedCallback) {


### PR DESCRIPTION
### Background
There is race condition in `ConsumerNetworkThread` for `Kafka Streams` with `new_protocol`.
So it make [HandlingSourceTopicDeletionIntegrationTest#shouldThrowErrorAfterSourceTopicDeleted](https://github.com/apache/kafka/blob/bf0e6ba700510fae9f08784fe239b33875446f56/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java#L78-L79) be flaky.
Please refer to details in attached sequence diagram. 
<img width="1208" height="805" alt="image" src="https://github.com/user-attachments/assets/e62ef7df-5ca8-448d-a1c9-f48d6734f25f" />

CC. @mjsax

### Result
- Fixes flaky test `HandlingSourceTopicDeletionIntegrationTest#shouldThrowErrorAfterSourceTopicDeleted`. 

### Related
- https://issues.apache.org/jira/browse/KAFKA-19511
- https://issues.apache.org/jira/browse/KAFKA-19521
- #20183 

