### PR TITLE
MINOR: Refactor snapshottableSize method for better readability and simplicity

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
@@ -293,9 +293,7 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
     }
 
     int snapshottableSize(long epoch) {
-        if (epoch == LATEST_EPOCH) {
-            return baseSize();
-        } else {
+        if (epoch != LATEST_EPOCH) {
             Iterator<Snapshot> iterator = snapshotRegistry.iterator(epoch);
             while (iterator.hasNext()) {
                 Snapshot snapshot = iterator.next();
@@ -304,8 +302,8 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
                     return tier.size;
                 }
             }
-            return baseSize();
         }
+        return baseSize();
     }
 
     T snapshottableGet(Object key, long epoch) {


### PR DESCRIPTION
### Motivation
The `snapshottableSize(long epoch)` method previously contained unnecessary nested conditions and multiple redundant `return baseSize();` statements. This refactor aims to simplify the method's control flow and improve code readability.

### Changes
- Changed the condition from `epoch == LATEST_EPOCH` to `epoch != LATEST_EPOCH` to avoid unnecessary else block usage.
- Consolidated the redundant `return baseSize();` statements into a single return at the end of the method.
- Ensured the iterator logic executes only when necessary, resulting in clearer control flow.

### Before
```java
int snapshottableSize(long epoch) {
    if (epoch == LATEST_EPOCH) {
        return baseSize();
    } else {
        Iterator<Snapshot> iterator = snapshotRegistry.iterator(epoch);
        while(iterator.hasNext()) {
            Snapshot snapshot = iterator.next();
            HashTier<T> tier = snapshot.getDelta(SnapshottableHashTable.this);
            if (tier != null) {
                return tier.size;
            }
        }
        return baseSize();
    }
}
```

### After
```java
int snapshottableSize(long epoch) {
    if (epoch != LATEST_EPOCH) {
        Iterator<Snapshot> iterator = snapshotRegistry.iterator(epoch);
        while(iterator.hasNext()) {
            Snapshot snapshot = iterator.next();
            HashTier<T> tier = snapshot.getDelta(SnapshottableHashTable.this);
            if (tier != null) {
                return tier.size;
            }
        }
    }
    return baseSize();
}
```

---

Please let me know if any further adjustments are needed.  
Thank you for your review!