### PR TITLE
MINOR: Cleanups in jmh-benchmarks module

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsStickyAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsStickyAssignorBenchmark.java
@@ -44,7 +44,6 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +106,7 @@ public class StreamsStickyAssignorBenchmark {
         taskAssignor = new StickyTaskAssignor();
 
         Map<String, StreamsGroupMember> members = createMembers();
-        this.assignmentConfigs = Collections.singletonMap(
+        this.assignmentConfigs = Map.of(
             "num.standby.replicas",
             Integer.toString(standbyReplicas)
         );
@@ -138,7 +137,7 @@ public class StreamsStickyAssignorBenchmark {
         for (Map.Entry<String, AssignmentMemberSpec> member : groupSpec.members().entrySet()) {
             MemberAssignment memberAssignment = members.getOrDefault(
                 member.getKey(),
-                new MemberAssignment(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap())
+                new MemberAssignment(Map.of(), Map.of(), Map.of())
             );
 
             updatedMemberSpec.put(member.getKey(), new AssignmentMemberSpec(

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
@@ -30,7 +30,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
@@ -405,12 +405,7 @@ public class TestPurgatoryPerformance {
 
     }
 
-    private static class Scheduled implements Delayed {
-        final FakeOperation operation;
-
-        public Scheduled(FakeOperation operation) {
-            this.operation = operation;
-        }
+    private record Scheduled(FakeOperation operation) implements Delayed {
 
         @Override
         public long getDelay(TimeUnit unit) {
@@ -429,12 +424,7 @@ public class TestPurgatoryPerformance {
         }
     }
 
-    private static class FakeOperationKey implements DelayedOperationKey {
-        private final String key;
-
-        public FakeOperationKey(String key) {
-            this.key = key;
-        }
+    private record FakeOperationKey(String key) implements DelayedOperationKey {
 
         @Override
         public String keyLabel() {
@@ -447,11 +437,6 @@ public class TestPurgatoryPerformance {
             if (o == null || getClass() != o.getClass()) return false;
             FakeOperationKey that = (FakeOperationKey) o;
             return Objects.equals(key, that.key);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(key);
         }
     }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/core/TestPurgatoryPerformance.java
@@ -425,18 +425,9 @@ public class TestPurgatoryPerformance {
     }
 
     private record FakeOperationKey(String key) implements DelayedOperationKey {
-
         @Override
         public String keyLabel() {
             return key;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            FakeOperationKey that = (FakeOperationKey) o;
-            return Objects.equals(key, that.key);
         }
     }
 
@@ -454,7 +445,6 @@ public class TestPurgatoryPerformance {
 
         @Override
         public void onExpiration() {
-
         }
 
         @Override


### PR DESCRIPTION
This PR aims at cleaning up the `jmh-benchmarks` module further by
getting rid of some extra code which can be replaced by record

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
