### PR TITLE
MINOR: describeTopics should pass the timeout to the describeCluster call

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2334,7 +2334,7 @@ public class KafkaAdminClient extends AdminClient {
         }
 
         // First, we need to retrieve the node info.
-        DescribeClusterResult clusterResult = describeCluster();
+        DescribeClusterResult clusterResult = describeCluster(new DescribeClusterOptions().timeoutMs(options.timeoutMs()));
         clusterResult.nodes().whenComplete(
             (nodes, exception) -> {
                 if (exception != null) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -11668,4 +11668,23 @@ public class KafkaAdminClientTest {
             .setAssignmentEpoch(1));
         return data;
     }
+
+    @Test
+    public void testDescribeClusterTimeoutWhenNoBrokerResponds() throws Exception {
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(
+            mockCluster(1, 0),
+            AdminClientConfig.RETRIES_CONFIG, "0",
+            AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "30000")) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+
+            // Not using prepareResponse is equivalent to "no brokers respond".
+            long start = System.currentTimeMillis();
+            ExecutionException exception = assertThrows(ExecutionException.class, () -> env.adminClient().describeCluster(new DescribeClusterOptions().timeoutMs(200)).clusterId().get());
+            // Duration should be greater than or equal to 200 ms but less than 30000 ms.
+            long duration = System.currentTimeMillis() - start;
+
+            assertTrue(exception.getCause() instanceof TimeoutException);
+            assertTrue(duration >= 200L && duration <= 2000L);
+        }
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -11669,7 +11669,7 @@ public class KafkaAdminClientTest {
         return data;
     }
 
-    @Test
+    @Test @Timeout(30)
     public void testDescribeTopicsTimeoutWhenNoBrokerResponds() throws Exception {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(
             mockCluster(1, 0),
@@ -11682,7 +11682,7 @@ public class KafkaAdminClientTest {
             DescribeTopicsResult result = env.adminClient().describeTopics(Collections.singletonList("test-topic"), new DescribeTopicsOptions().timeoutMs(200));
             Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap = result.topicNameValues();
             KafkaFuture<TopicDescription> topicDescription = topicDescriptionMap.get("test-topic");
-            ExecutionException exception = assertThrows(ExecutionException.class, () -> topicDescription.get());
+            ExecutionException exception = assertThrows(ExecutionException.class, topicDescription::get);
             // Duration should be greater than or equal to 200 ms but less than 30000 ms.
             long duration = System.currentTimeMillis() - start;
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -551,7 +551,8 @@ public class KafkaAdminClientTest {
      * Test if admin client can be closed in the callback invoked when
      * an api call completes. If calling {@link Admin#close()} in callback, AdminClient thread hangs
      */
-    @Test @Timeout(10)
+    @Test
+    @Timeout(10)
     public void testCloseAdminClientInCallback() throws InterruptedException {
         MockTime time = new MockTime();
         AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, mockCluster(3, 0));
@@ -11669,7 +11670,8 @@ public class KafkaAdminClientTest {
         return data;
     }
 
-    @Test @Timeout(30)
+    @Test
+    @Timeout(30)
     public void testDescribeTopicsTimeoutWhenNoBrokerResponds() throws Exception {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(
             mockCluster(1, 0),
@@ -11679,7 +11681,7 @@ public class KafkaAdminClientTest {
 
             // Not using prepareResponse is equivalent to "no brokers respond".
             long start = System.currentTimeMillis();
-            DescribeTopicsResult result = env.adminClient().describeTopics(Collections.singletonList("test-topic"), new DescribeTopicsOptions().timeoutMs(200));
+            DescribeTopicsResult result = env.adminClient().describeTopics(List.of("test-topic"), new DescribeTopicsOptions().timeoutMs(200));
             Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap = result.topicNameValues();
             KafkaFuture<TopicDescription> topicDescription = topicDescriptionMap.get("test-topic");
             ExecutionException exception = assertThrows(ExecutionException.class, topicDescription::get);
@@ -11687,7 +11689,7 @@ public class KafkaAdminClientTest {
             long duration = System.currentTimeMillis() - start;
 
             assertInstanceOf(TimeoutException.class, exception.getCause());
-            assertTrue(duration >= 150L && duration < 2000L);
+            assertTrue(duration >= 150L && duration < 30000);
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -11670,7 +11670,7 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testDescribeClusterTimeoutWhenNoBrokerResponds() throws Exception {
+    public void testDescribeTopicsTimeoutWhenNoBrokerResponds() throws Exception {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(
             mockCluster(1, 0),
             AdminClientConfig.RETRIES_CONFIG, "0",
@@ -11679,12 +11679,15 @@ public class KafkaAdminClientTest {
 
             // Not using prepareResponse is equivalent to "no brokers respond".
             long start = System.currentTimeMillis();
-            ExecutionException exception = assertThrows(ExecutionException.class, () -> env.adminClient().describeCluster(new DescribeClusterOptions().timeoutMs(200)).clusterId().get());
+            DescribeTopicsResult result = env.adminClient().describeTopics(Collections.singletonList("test-topic"), new DescribeTopicsOptions().timeoutMs(200));
+            Map<String, KafkaFuture<TopicDescription>> topicDescriptionMap = result.topicNameValues();
+            KafkaFuture<TopicDescription> topicDescription = topicDescriptionMap.get("test-topic");
+            ExecutionException exception = assertThrows(ExecutionException.class, () -> topicDescription.get());
             // Duration should be greater than or equal to 200 ms but less than 30000 ms.
             long duration = System.currentTimeMillis() - start;
 
-            assertTrue(exception.getCause() instanceof TimeoutException);
-            assertTrue(duration >= 200L && duration <= 2000L);
+            assertInstanceOf(TimeoutException.class, exception.getCause());
+            assertTrue(duration >= 150L && duration < 2000L);
         }
     }
 }


### PR DESCRIPTION
This PR ensures that describeTopics correctly propagates its timeoutMs
setting to the underlying describeCluster call. Integration tests were
added to verify that the API now fails with a TimeoutException when
brokers do not respond within the configured timeout.

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
