### PR TITLE
KAFKA-19625: Consistency of command-line arguments for verifiable producer/consumer

### DIFF
--- a/tests/kafkatest/services/verifiable_client.py
+++ b/tests/kafkatest/services/verifiable_client.py
@@ -75,7 +75,7 @@ Command line arguments:
  * `--max-messages <n>`
  * `--assignment-strategy <s>`
  * `--consumer.config <config-file>` - (DEPRECATED) consumer config properties (typically empty). This option will be removed in a future version. Use --command-config instead.
- * `--command-config <config-file>` - consumer config properties
+ * `--command-config <config-file>` - command config properties
 
 Environment variables:
  * `LOG_DIR` - log output directory. Typically not needed if logs are written to stderr.
@@ -99,7 +99,7 @@ Command line arguments:
  * `--max-messages <n>`
  * `--throughput <msgs/s>`
  * `--producer.config <config-file>` - producer config properties (typically empty). This option will be removed in a future version. Use --command-config instead.
- * `--command-config <config-file>` - producer config properties
+ * `--command-config <config-file>` - command config properties
 
 Environment variables:
  * `LOG_DIR` - log output directory. Typically not needed if logs are written to stderr.

--- a/tests/kafkatest/services/verifiable_client.py
+++ b/tests/kafkatest/services/verifiable_client.py
@@ -74,7 +74,8 @@ Command line arguments:
  * `--enable-autocommit`
  * `--max-messages <n>`
  * `--assignment-strategy <s>`
- * `--consumer.config <config-file>` - consumer config properties (typically empty)
+ * `--consumer.config <config-file>` - (DEPRECATED) consumer config properties (typically empty). This option will be removed in a future version. Use --command-config instead.
+ * `--command.config <config-file>` - consumer config properties
 
 Environment variables:
  * `LOG_DIR` - log output directory. Typically not needed if logs are written to stderr.
@@ -97,7 +98,8 @@ Command line arguments:
  * `--broker-list <brokers>`
  * `--max-messages <n>`
  * `--throughput <msgs/s>`
- * `--producer.config <config-file>` - producer config properties (typically empty)
+ * `--producer.config <config-file>` - producer config properties (typically empty). This option will be removed in a future version. Use --command-config instead.
+ * `--command.config <config-file>` - producer config properties
 
 Environment variables:
  * `LOG_DIR` - log output directory. Typically not needed if logs are written to stderr.

--- a/tests/kafkatest/services/verifiable_client.py
+++ b/tests/kafkatest/services/verifiable_client.py
@@ -75,7 +75,7 @@ Command line arguments:
  * `--max-messages <n>`
  * `--assignment-strategy <s>`
  * `--consumer.config <config-file>` - (DEPRECATED) consumer config properties (typically empty). This option will be removed in a future version. Use --command-config instead.
- * `--command.config <config-file>` - consumer config properties
+ * `--command-config <config-file>` - consumer config properties
 
 Environment variables:
  * `LOG_DIR` - log output directory. Typically not needed if logs are written to stderr.
@@ -99,7 +99,7 @@ Command line arguments:
  * `--max-messages <n>`
  * `--throughput <msgs/s>`
  * `--producer.config <config-file>` - producer config properties (typically empty). This option will be removed in a future version. Use --command-config instead.
- * `--command.config <config-file>` - producer config properties
+ * `--command-config <config-file>` - producer config properties
 
 Environment variables:
  * `LOG_DIR` - log output directory. Typically not needed if logs are written to stderr.

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -424,7 +424,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
 
-        cmd += " --consumer.config %s" % VerifiableConsumer.CONFIG_FILE
+        cmd += " --command.config %s" % VerifiableConsumer.CONFIG_FILE
         cmd += " 2>> %s | tee -a %s &" % (VerifiableConsumer.STDOUT_CAPTURE, VerifiableConsumer.STDOUT_CAPTURE)
         return cmd
 

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -424,7 +424,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
 
-        cmd += " --command.config %s" % VerifiableConsumer.CONFIG_FILE
+        cmd += " --command-config %s" % VerifiableConsumer.CONFIG_FILE
         cmd += " 2>> %s | tee -a %s &" % (VerifiableConsumer.STDOUT_CAPTURE, VerifiableConsumer.STDOUT_CAPTURE)
         return cmd
 

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -249,7 +249,7 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.repeating_keys is not None:
             cmd += " --repeating-keys %s " % str(self.repeating_keys)
 
-        cmd += " --producer.config %s" % VerifiableProducer.CONFIG_FILE
+        cmd += " --command.config %s" % VerifiableProducer.CONFIG_FILE
 
         cmd += " 2>> %s | tee -a %s &" % (VerifiableProducer.STDOUT_CAPTURE, VerifiableProducer.STDOUT_CAPTURE)
         return cmd

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -249,7 +249,7 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.repeating_keys is not None:
             cmd += " --repeating-keys %s " % str(self.repeating_keys)
 
-        cmd += " --command.config %s" % VerifiableProducer.CONFIG_FILE
+        cmd += " --command-config %s" % VerifiableProducer.CONFIG_FILE
 
         cmd += " 2>> %s | tee -a %s &" % (VerifiableProducer.STDOUT_CAPTURE, VerifiableProducer.STDOUT_CAPTURE)
         return cmd

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -611,7 +611,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .action(store())
                 .required(false)
                 .type(String.class)
-                .metavar("CONFIG_FILE")
+                .metavar("CONFIG-FILE")
                 .help("(DEPRECATED) Consumer config properties file (config options shared with command line parameters will be overridden)." +
                         "This option will be removed in a future version. Use --command-config instead.");
 
@@ -621,7 +621,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(String.class)
                 .metavar("CONFIG-FILE")
                 .dest("commandConfigFile")
-                .help("Consumer config properties file.");
+                .help("Config properties file.");
 
         return parser;
     }
@@ -631,11 +631,12 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
         boolean useAutoCommit = res.getBoolean("useAutoCommit");
         String configFile = res.getString("consumer.config");
-        String commandConfigFile = res.getString("command-config");
+        String commandConfigFile = res.getString("commandConfigFile");
         String brokerHostAndPort = res.getString("bootstrapServer");
 
         Properties consumerProps = new Properties();
         if (configFile != null && commandConfigFile != null) {
+            System.out.println("Option --consumer.config has been deprecated and will be removed in a future version. Use --command-config instead.");
             throw new ArgumentParserException("Options --consumer.config and --command-config are mutually exclusive.", parser);
         }
         if (configFile != null) {
@@ -645,7 +646,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 throw new ArgumentParserException(e.getMessage(), parser);
             }
         }
-        if (res.getString(commandConfigFile) != null) {
+        if (commandConfigFile != null) {
             try {
                 consumerProps.putAll(Utils.loadProps(res.getString(commandConfigFile)));
             } catch (IOException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -636,10 +636,10 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
         Properties consumerProps = new Properties();
         if (configFile != null && commandConfigFile != null) {
-            System.out.println("Option --consumer.config has been deprecated and will be removed in a future version. Use --command-config instead.");
             throw new ArgumentParserException("Options --consumer.config and --command-config are mutually exclusive.", parser);
         }
         if (configFile != null) {
+            System.out.println("Option --consumer.config has been deprecated and will be removed in a future version. Use --command-config instead.");
             try {
                 consumerProps.putAll(Utils.loadProps(configFile));
             } catch (IOException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -621,7 +621,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(String.class)
                 .metavar("CONFIG-FILE")
                 .dest("commandConfigFile")
-                .help("Config properties file (config options shared with command line parameters will be overridden)");
+                .help("Config properties file (config options shared with command line parameters will be overridden).");
 
         return parser;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -597,7 +597,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .setDefault("earliest")
                 .type(String.class)
                 .dest("resetPolicy")
-                .help("Set reset policy (must be either 'earliest', 'latest', or 'none'");
+                .help("Set reset policy (must be either 'earliest', 'latest', or 'none')");
 
         parser.addArgument("--assignment-strategy")
                 .action(store())
@@ -612,8 +612,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .required(false)
                 .type(String.class)
                 .metavar("CONFIG-FILE")
-                .help("(DEPRECATED) Consumer config properties file (config options shared with command line parameters will be overridden)." +
-                        "This option will be removed in a future version. Use --command-config instead.");
+                .help("(DEPRECATED) Consumer config properties file" +
+                        "This option will be removed in a future version. Use --command-config instead");
 
         parser.addArgument("--command-config")
                 .action(store())
@@ -621,7 +621,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(String.class)
                 .metavar("CONFIG-FILE")
                 .dest("commandConfigFile")
-                .help("Config properties file.");
+                .help("Config properties file (config options shared with command line parameters will be overridden)");
 
         return parser;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -607,7 +607,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .dest("assignmentStrategy")
                 .help(String.format("Set assignment strategy (e.g. %s); only used if the group protocol is %s", RoundRobinAssignor.class.getName(), GroupProtocol.CLASSIC.name()));
 
-        parser.addArgument("--consumer.config")
+        parser.addArgument("--command-config")
                 .action(store())
                 .required(false)
                 .type(String.class)
@@ -621,7 +621,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         Namespace res = parser.parseArgs(args);
 
         boolean useAutoCommit = res.getBoolean("useAutoCommit");
-        String configFile = res.getString("consumer.config");
+        String configFile = res.getString("command-config");
         String brokerHostAndPort = res.getString("bootstrapServer");
 
         Properties consumerProps = new Properties();

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -607,12 +607,21 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .dest("assignmentStrategy")
                 .help(String.format("Set assignment strategy (e.g. %s); only used if the group protocol is %s", RoundRobinAssignor.class.getName(), GroupProtocol.CLASSIC.name()));
 
-        parser.addArgument("--command-config")
+        parser.addArgument("--consumer.config")
                 .action(store())
                 .required(false)
                 .type(String.class)
                 .metavar("CONFIG_FILE")
-                .help("Consumer config properties file (config options shared with command line parameters will be overridden).");
+                .help("(DEPRECATED) Consumer config properties file (config options shared with command line parameters will be overridden)." +
+                        "This option will be removed in a future version. Use --command-config instead.");
+
+        parser.addArgument("--command-config")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .metavar("CONFIG-FILE")
+                .dest("commandConfigFile")
+                .help("Consumer config properties file.");
 
         return parser;
     }
@@ -621,13 +630,24 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         Namespace res = parser.parseArgs(args);
 
         boolean useAutoCommit = res.getBoolean("useAutoCommit");
-        String configFile = res.getString("command-config");
+        String configFile = res.getString("consumer.config");
+        String commandConfigFile = res.getString("command-config");
         String brokerHostAndPort = res.getString("bootstrapServer");
 
         Properties consumerProps = new Properties();
+        if (configFile != null && commandConfigFile != null) {
+            throw new ArgumentParserException("Options --consumer.config and --command-config are mutually exclusive.", parser);
+        }
         if (configFile != null) {
             try {
                 consumerProps.putAll(Utils.loadProps(configFile));
+            } catch (IOException e) {
+                throw new ArgumentParserException(e.getMessage(), parser);
+            }
+        }
+        if (res.getString(commandConfigFile) != null) {
+            try {
+                consumerProps.putAll(Utils.loadProps(res.getString(commandConfigFile)));
             } catch (IOException e) {
                 throw new ArgumentParserException(e.getMessage(), parser);
             }

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -161,7 +161,7 @@ public class VerifiableProducer implements AutoCloseable {
                 .action(store())
                 .required(false)
                 .type(String.class)
-                .metavar("CONFIG_FILE")
+                .metavar("CONFIG-FILE")
                 .help("(DEPRECATED) Producer config properties file. " +
                         "This option will be removed in a future version. Use --command-config instead.");
 
@@ -196,7 +196,7 @@ public class VerifiableProducer implements AutoCloseable {
             .type(String.class)
             .metavar("CONFIG-FILE")
             .dest("commandConfigFile")
-            .help("Producer config properties file.");
+            .help("Config properties file.");
 
         return parser;
     }
@@ -251,11 +251,12 @@ public class VerifiableProducer implements AutoCloseable {
         // No producer retries
         producerProps.put(ProducerConfig.RETRIES_CONFIG, "0");
         if (configFile != null && commandConfigFile != null) {
+            System.out.println("Option --producer.config has been deprecated and will be removed in a future version. Use --command-config instead.");
             throw new ArgumentParserException("Options --producer.config and --command-config are mutually exclusive.", parser);
         }
 
         if (configFile != null) {
-            System.out.println("Option --producer-config has been deprecated and will be removed in a future version. Use --command-config instead.");
+            System.out.println("Option --producer.config has been deprecated and will be removed in a future version. Use --command-config instead.");
             try {
                 producerProps.putAll(loadProps(configFile));
             } catch (IOException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -251,7 +251,6 @@ public class VerifiableProducer implements AutoCloseable {
         // No producer retries
         producerProps.put(ProducerConfig.RETRIES_CONFIG, "0");
         if (configFile != null && commandConfigFile != null) {
-            System.out.println("Option --producer.config has been deprecated and will be removed in a future version. Use --command-config instead.");
             throw new ArgumentParserException("Options --producer.config and --command-config are mutually exclusive.", parser);
         }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -157,12 +157,13 @@ public class VerifiableProducer implements AutoCloseable {
                 .metavar("ACKS")
                 .help("Acks required on each produced message. See Kafka docs on acks for details.");
 
-        parser.addArgument("--command-config")
+        parser.addArgument("--producer.config")
                 .action(store())
                 .required(false)
                 .type(String.class)
                 .metavar("CONFIG_FILE")
-                .help("Producer config properties file.");
+                .help("(DEPRECATED) Producer config properties file. " +
+                        "This option will be removed in a future version. Use --command-config instead.");
 
         parser.addArgument("--message-create-time")
                 .action(store())
@@ -188,6 +189,14 @@ public class VerifiableProducer implements AutoCloseable {
             .metavar("REPEATING-KEYS")
             .dest("repeatingKeys")
             .help("If specified, each produced record will have a key starting at 0 increment by 1 up to the number specified (exclusive), then the key is set to 0 again");
+
+        parser.addArgument("--command-config")
+            .action(store())
+            .required(false)
+            .type(String.class)
+            .metavar("CONFIG-FILE")
+            .dest("commandConfigFile")
+            .help("Producer config properties file.");
 
         return parser;
     }
@@ -216,7 +225,8 @@ public class VerifiableProducer implements AutoCloseable {
         int maxMessages = res.getInt("maxMessages");
         String topic = res.getString("topic");
         int throughput = res.getInt("throughput");
-        String configFile = res.getString("command-config");
+        String configFile = res.getString("producer.config");
+        String commandConfigFile = res.getString("commandConfigFile");
         Integer valuePrefix = res.getInt("valuePrefix");
         Long createTime = res.getLong("createTime");
         Integer repeatingKeys = res.getInt("repeatingKeys");
@@ -240,14 +250,25 @@ public class VerifiableProducer implements AutoCloseable {
         producerProps.put(ProducerConfig.ACKS_CONFIG, Integer.toString(res.getInt("acks")));
         // No producer retries
         producerProps.put(ProducerConfig.RETRIES_CONFIG, "0");
+        if (configFile != null && commandConfigFile != null) {
+            throw new ArgumentParserException("Options --producer.config and --command-config are mutually exclusive.", parser);
+        }
+
         if (configFile != null) {
+            System.out.println("Option --producer-config has been deprecated and will be removed in a future version. Use --command-config instead.");
             try {
                 producerProps.putAll(loadProps(configFile));
             } catch (IOException e) {
                 throw new ArgumentParserException(e.getMessage(), parser);
             }
         }
-
+        if (commandConfigFile != null) {
+            try {
+                producerProps.putAll(loadProps(commandConfigFile));
+            } catch (IOException e) {
+                throw new ArgumentParserException(e.getMessage(), parser);
+            }
+        }
         StringSerializer serializer = new StringSerializer();
         KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps, serializer, serializer);
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -196,7 +196,7 @@ public class VerifiableProducer implements AutoCloseable {
             .type(String.class)
             .metavar("CONFIG-FILE")
             .dest("commandConfigFile")
-            .help("Config properties file.");
+            .help("Config properties file (config options shared with command line parameters will be overridden)");
 
         return parser;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -157,7 +157,7 @@ public class VerifiableProducer implements AutoCloseable {
                 .metavar("ACKS")
                 .help("Acks required on each produced message. See Kafka docs on acks for details.");
 
-        parser.addArgument("--producer.config")
+        parser.addArgument("--command-config")
                 .action(store())
                 .required(false)
                 .type(String.class)
@@ -216,7 +216,7 @@ public class VerifiableProducer implements AutoCloseable {
         int maxMessages = res.getInt("maxMessages");
         String topic = res.getString("topic");
         int throughput = res.getInt("throughput");
-        String configFile = res.getString("producer.config");
+        String configFile = res.getString("command-config");
         Integer valuePrefix = res.getInt("valuePrefix");
         Long createTime = res.getLong("createTime");
         Integer repeatingKeys = res.getInt("repeatingKeys");

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -196,7 +196,7 @@ public class VerifiableProducer implements AutoCloseable {
             .type(String.class)
             .metavar("CONFIG-FILE")
             .dest("commandConfigFile")
-            .help("Config properties file (config options shared with command line parameters will be overridden)");
+            .help("Config properties file (config options shared with command line parameters will be overridden).");
 
         return parser;
     }


### PR DESCRIPTION
As described in
[jira](https://issues.apache.org/jira/browse/KAFKA-19625), this PR
implements replace `consumer.config` and `producer.config` with
`command-config` for kafka-verifiable-producer.sh and
kafka-verifiable-consumer.sh.

Reviewers: Andrew Schofield <aschofield@confluent.io>
