### PR TITLE
MINOR: Remove fetchQuotaMetrics and copyQuotaMetrics on close

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaMetrics.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaMetrics.java
@@ -24,7 +24,7 @@ import org.apache.kafka.server.quota.SensorAccess;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class RLMQuotaMetrics {
+public class RLMQuotaMetrics implements AutoCloseable {
 
     private final SensorAccess sensorAccess;
     private final Metrics metrics;
@@ -50,5 +50,10 @@ public class RLMQuotaMetrics {
             s.add(metrics.metricName(name + "-max", group,
                 String.format(descriptionFormat, "maximum")), new Max());
         });
+    }
+
+    @Override
+    public void close() {
+        this.metrics.removeSensor(name);
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -2054,6 +2054,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 Utils.closeQuietly(indexCache, "RemoteIndexCache");
                 Utils.closeQuietly(remoteLogMetadataManagerPlugin, "remoteLogMetadataManagerPlugin");
                 Utils.closeQuietly(remoteStorageManagerPlugin, "remoteStorageManagerPlugin");
+                Utils.closeQuietly(fetchQuotaMetrics, "fetchQuotaMetrics");
+                Utils.closeQuietly(copyQuotaMetrics, "copyQuotaMetrics");
                 closed = true;
             }
         }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -314,6 +314,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         metricsGroup.removeMetric(REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC);
         metricsGroup.removeMetric(REMOTE_LOG_READER_FETCH_RATE_AND_TIME_METRIC);
         remoteStorageReaderThreadPool.removeMetrics();
+        Utils.closeQuietly(fetchQuotaMetrics, "fetchQuotaMetrics");
+        Utils.closeQuietly(copyQuotaMetrics, "copyQuotaMetrics");
     }
 
     // Visible for testing
@@ -2044,19 +2046,18 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 followerThreadPool.close();
                 try {
                     shutdownAndAwaitTermination(remoteStorageReaderThreadPool, "RemoteStorageReaderThreadPool", 10, TimeUnit.SECONDS);
+
+                    leaderCopyRLMTasks.clear();
+                    leaderExpirationRLMTasks.clear();
+                    followerRLMTasks.clear();
+
+                    Utils.closeQuietly(indexCache, "RemoteIndexCache");
+                    Utils.closeQuietly(remoteLogMetadataManagerPlugin, "remoteLogMetadataManagerPlugin");
+                    Utils.closeQuietly(remoteStorageManagerPlugin, "remoteStorageManagerPlugin");
+                    closed = true;
                 } finally {
                     removeMetrics();
                 }
-                leaderCopyRLMTasks.clear();
-                leaderExpirationRLMTasks.clear();
-                followerRLMTasks.clear();
-
-                Utils.closeQuietly(indexCache, "RemoteIndexCache");
-                Utils.closeQuietly(remoteLogMetadataManagerPlugin, "remoteLogMetadataManagerPlugin");
-                Utils.closeQuietly(remoteStorageManagerPlugin, "remoteStorageManagerPlugin");
-                Utils.closeQuietly(fetchQuotaMetrics, "fetchQuotaMetrics");
-                Utils.closeQuietly(copyQuotaMetrics, "copyQuotaMetrics");
-                closed = true;
             }
         }
     }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaMetricsTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaMetricsTest.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RLMQuotaMetricsTest {
     private final MockTime time = new MockTime();
@@ -48,5 +50,23 @@ public class RLMQuotaMetricsTest {
         // If the sensor has been removed, we should get a new one.
         Sensor newSensor = rlmQuotaMetrics.sensor();
         assertNotEquals(sensor, newSensor);
+    }
+
+    @Test
+    public void testClose() {
+        RLMQuotaMetrics quotaMetrics = new RLMQuotaMetrics(metrics, "metric", "group", "format", 5);
+
+        // Register the sensor
+        quotaMetrics.sensor();
+        var avg = metrics.metricName("metric" + "-avg", "group", String.format("format", "average"));
+
+        // Verify that metrics are created
+        assertNotNull(metrics.metric(avg));
+
+        // Close the quotaMetrics instance
+        quotaMetrics.close();
+
+        // After closing, the metrics should be removed
+        assertNull(metrics.metric(avg));
     }
 }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaMetricsTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaMetricsTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class RLMQuotaMetricsTest {
     private final MockTime time = new MockTime();


### PR DESCRIPTION
- Changes: Remove  fetchQuotaMetrics and copyQuotaMetrics in RemoteLogManager on close

from: https://github.com/apache/kafka/pull/20342#discussion_r2290612736

Reviewers: Kamal Chandraprakash <kamal.chandraprakash@gmail.com>
