### PR TITLE
MINOR: update kraft dynamic voter set doc

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4114,6 +4114,10 @@ Feature: metadata.version       SupportedMinVersion: 3.3-IV3    SupportedMaxVers
   controllers using the <code>--feature kraft.version=1</code>. (Note that you should not supply
   this flag when formatting brokers -- only when formatting controllers.)<p>
 
+<pre><code class="language-bash">
+  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller.properties
+</code></pre><p>
+
   Note: To migrate from static voter set to dynamic voter set, please refer to the <a href="#kraft_upgrade">Upgrade</a> section.
 
   <h5 class="anchor-heading"><a id="kraft_reconfig_add" class="anchor-link"></a><a href="#kraft_reconfig_add">Add New Controller</a></h5>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4114,11 +4114,6 @@ Feature: metadata.version       SupportedMinVersion: 3.3-IV3    SupportedMaxVers
   controllers using the <code>--feature kraft.version=1</code>. (Note that you should not supply
   this flag when formatting brokers -- only when formatting controllers.)<p>
 
-<pre><code class="language-bash">
-  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller.properties
-  Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. For dynamic controllers support, try using one of --standalone, --initial-controllers, or --no-initial-controllers.
-</code></pre><p>
-
   Note: To migrate from static voter set to dynamic voter set, please refer to the <a href="#kraft_upgrade">Upgrade</a> section.
 
   <h5 class="anchor-heading"><a id="kraft_reconfig_add" class="anchor-link"></a><a href="#kraft_reconfig_add">Add New Controller</a></h5>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4116,11 +4116,10 @@ Feature: metadata.version       SupportedMinVersion: 3.3-IV3    SupportedMaxVers
 
 <pre><code class="language-bash">
   $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller.properties
-  Cannot set kraft.version to 1 unless KIP-853 configuration is present. Try removing the --feature flag for kraft.version.
+  Cannot set kraft.version to 1 unless one of the flags --standalone, --initial-controllers, or --no-initial-controllers is used. For dynamic controllers support, try using one of --standalone, --initial-controllers, or --no-initial-controllers.
 </code></pre><p>
 
-  Note: Currently it is <b>not</b> possible to convert clusters using a static controller quorum to
-  use a dynamic controller quorum. This function will be supported in the future release.
+  Note: To migrate from static voter set to dynamic voter set, please refer to the <a href="#kraft_upgrade">Upgrade</a> section.
 
   <h5 class="anchor-heading"><a id="kraft_reconfig_add" class="anchor-link"></a><a href="#kraft_reconfig_add">Add New Controller</a></h5>
   If a dynamic controller cluster already exists, it can be expanded by first provisioning a new controller using the <a href="#kraft_nodes_observers">kafka-storage.sh tool</a> and starting the controller.


### PR DESCRIPTION
Update the KRaft dynamic voter set documentation. In Kafka 4.1, we
introduced a powerful new feature that enables seamless migration from a
static voter set to a dynamic voter set.

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
