### PR TITLE
KAFKA-12456: Log 'Listeners are not identical across brokers' message at INFO instead of ERROR

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -542,7 +542,7 @@ class ZkMetadataCache(
       aliveNodes.get(brokerId).foreach { listenerMap =>
         val listeners = listenerMap.keySet
         if (!aliveNodes.values.forall(_.keySet == listeners))
-          error(s"Listeners are not identical across brokers: $aliveNodes")
+          info(s"Listeners are not identical across brokers: $aliveNodes")
       }
 
       val topicIds = mutable.Map.empty[String, Uuid]


### PR DESCRIPTION
Lower the log level to INFO instead of ERROR.