### PR TITLE
KAFKA-19642: Replace dynamicPerBrokerConfigs with dynamicDefaultConfigs

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -219,7 +219,6 @@ object DynamicBrokerConfig {
             logContext
           )
         ) { reader =>
-          val dynamicPerBrokerConfigs = new Properties()
           val dynamicDefaultConfigs = new Properties()
           while (reader.hasNext) {
             val batch = reader.next()
@@ -231,15 +230,15 @@ object DynamicBrokerConfig {
                     if (configRecord.resourceName().isEmpty) {
                       putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
                     } else if (configRecord.resourceName() == config.brokerId.toString) {
-                      putOrRemoveIfNull(dynamicPerBrokerConfigs, configRecord.name(), configRecord.value())
+                      putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
                     }
                   }
               }
             }
           }
           val configHandler = new BrokerConfigHandler(config, quotaManagers)
-          configHandler.processConfigChanges("", dynamicPerBrokerConfigs)
-          configHandler.processConfigChanges(config.brokerId.toString, dynamicPerBrokerConfigs)
+          configHandler.processConfigChanges("", dynamicDefaultConfigs)
+          configHandler.processConfigChanges(config.brokerId.toString, dynamicDefaultConfigs)
         }
       }
     }

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -219,6 +219,7 @@ object DynamicBrokerConfig {
             logContext
           )
         ) { reader =>
+          val dynamicPerBrokerConfigs = new Properties()
           val dynamicDefaultConfigs = new Properties()
           while (reader.hasNext) {
             val batch = reader.next()
@@ -230,7 +231,7 @@ object DynamicBrokerConfig {
                     if (configRecord.resourceName().isEmpty) {
                       putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
                     } else if (configRecord.resourceName() == config.brokerId.toString) {
-                      putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
+                      putOrRemoveIfNull(dynamicPerBrokerConfigs, configRecord.name(), configRecord.value())
                     }
                   }
               }
@@ -238,7 +239,7 @@ object DynamicBrokerConfig {
           }
           val configHandler = new BrokerConfigHandler(config, quotaManagers)
           configHandler.processConfigChanges("", dynamicDefaultConfigs)
-          configHandler.processConfigChanges(config.brokerId.toString, dynamicDefaultConfigs)
+          configHandler.processConfigChanges(config.brokerId.toString, dynamicPerBrokerConfigs)
         }
       }
     }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -1120,7 +1120,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Wait for the metrics reporter to be configured
     val initialReporter = TestNumReplicaFetcherMetricsReporter.waitForReporters(1).head
-    initialReporter.verifyState(reconfigureCount = 1, deleteCount = 0, numFetcher = 2)
+    initialReporter.verifyState(reconfigureCount = 1, numFetcher = 2)
 
     TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
 
@@ -1146,7 +1146,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Verify that the custom MetricsReporter is not reconfigured after restart.
     // If readDynamicBrokerConfigsFromSnapshot works correctly, the reporter should maintain its state.
     val reporterAfterRestart = TestNumReplicaFetcherMetricsReporter.waitForReporters(1).head
-    reporterAfterRestart.verifyState(reconfigureCount = 0, deleteCount = 0, numFetcher = 2)
+    reporterAfterRestart.verifyState(reconfigureCount = 0, numFetcher = 2)
   }
 
   private def awaitInitialPositions(consumer: Consumer[_, _]): Unit = {
@@ -1620,7 +1620,7 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
   }
 
   override def reconfigurableConfigs(): util.Set[String] = {
-    util.Set.of(PollingIntervalProp, ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG)
+    util.Set.of(PollingIntervalProp)
   }
 
   override def validateReconfiguration(configs: util.Map[String, _]): Unit = {
@@ -1671,26 +1671,18 @@ object TestNumReplicaFetcherMetricsReporter {
 
 class TestNumReplicaFetcherMetricsReporter extends MetricsReporter with Reconfigurable with Closeable with ClusterResourceListener {
   import TestNumReplicaFetcherMetricsReporter._
-  @volatile var initializeCount = 0
-  @volatile var contextChangeCount = 0
   @volatile var configureCount = 0
   @volatile var reconfigureCount = 0
-  @volatile var closeCount = 0
-  @volatile var clusterUpdateCount = 0
   @volatile var numFetchers: Int = 1
   testReporters.add(this)
 
   override def contextChange(metricsContext: MetricsContext): Unit = {
-    contextChangeCount += 1
   }
 
   override def init(metrics: util.List[KafkaMetric]): Unit = {
-    assertTrue(contextChangeCount > 0, "contextChange must be called before init")
-    initializeCount += 1
   }
 
   override def configure(configs: util.Map[String, _]): Unit = {
-    configuredBrokers += configs.get(ServerConfigs.BROKER_ID_CONFIG).toString.toInt
     configureCount += 1
     numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
   }
@@ -1702,8 +1694,6 @@ class TestNumReplicaFetcherMetricsReporter extends MetricsReporter with Reconfig
   }
 
   override def onUpdate(clusterResource: ClusterResource): Unit = {
-    assertNotNull(clusterResource.clusterId, "Cluster id not set")
-    clusterUpdateCount += 1
   }
 
   override def reconfigurableConfigs(): util.Set[String] = {
@@ -1722,15 +1712,10 @@ class TestNumReplicaFetcherMetricsReporter extends MetricsReporter with Reconfig
   }
 
   override def close(): Unit = {
-    closeCount += 1
   }
 
-  def verifyState(reconfigureCount: Int, deleteCount: Int, numFetcher: Int = 1): Unit = {
-    assertEquals(1, initializeCount)
-    assertEquals(1, configureCount)
+  def verifyState(reconfigureCount: Int, numFetcher: Int = 1): Unit = {
     assertEquals(reconfigureCount, this.reconfigureCount)
-    assertEquals(deleteCount, closeCount)
-    assertEquals(1, clusterUpdateCount)
     assertEquals(numFetcher, this.numFetchers)
   }
 }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -321,7 +321,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // wait for MetricsReporter
     val reporters = TestMetricsReporter.waitForReporters(servers.size)
     reporters.foreach { reporter =>
-      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000, numFetcher = 2)
+      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000)
       assertFalse(reporter.kafkaMetrics.isEmpty, "No metrics found")
     }
 
@@ -330,7 +330,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     alterConfigsUsingConfigCommand(updatedProps)
     waitForConfig(TestMetricsReporter.PollingIntervalProp, "1000")
     reporters.foreach { reporter =>
-      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000, numFetcher = 2)
+      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000)
     }
 
     // 2. verify update occurring if the value of property changed.
@@ -338,7 +338,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     alterConfigsUsingConfigCommand(updatedProps)
     waitForConfig(TestMetricsReporter.PollingIntervalProp, "2000")
     reporters.foreach { reporter =>
-      reporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 2000, numFetcher = 2)
+      reporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 2000)
     }
   }
 
@@ -947,7 +947,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Add a new metrics reporter
     val newProps = new Properties
     newProps.put(TestMetricsReporter.PollingIntervalProp, "100")
-    newProps.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "1")
     configureMetricsReporters(Seq(classOf[JmxReporter], classOf[TestMetricsReporter]), newProps)
 
     val reporters = TestMetricsReporter.waitForReporters(servers.size + controllerServers.size)
@@ -1100,11 +1099,13 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testServersCanStartWithInvalidStaticConfigsAndValidDynamicConfigs(groupProtocol: String): Unit = {
+    TestNumReplicaFetcherMetricsReporter.testReporters.clear()
+
     // modify snapshot interval config to explicitly take snapshot on a broker with valid dynamic configs
     val props = defaultStaticConfig(numServers)
     props.put(MetadataLogConfig.METADATA_SNAPSHOT_MAX_INTERVAL_MS_CONFIG, "10000")
-    props.put(MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG, classOf[TestMetricsReporter].getName)
-    props.put(TestMetricsReporter.PollingIntervalProp, "1000")
+    props.put(MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG, classOf[TestNumReplicaFetcherMetricsReporter].getName)
+    props.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "1")
 
     val kafkaConfig = KafkaConfig.fromProps(props)
     val newBroker = createBroker(kafkaConfig).asInstanceOf[BrokerServer]
@@ -1114,13 +1115,12 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Add num.replica.fetchers to the cluster-level config.
     val clusterLevelProps = new Properties
-    clusterLevelProps.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "3")
-    reconfigureServers(clusterLevelProps, perBrokerConfig = false,
-      (ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "3"))
+    clusterLevelProps.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "2")
+    reconfigureServers(clusterLevelProps, perBrokerConfig = false, (ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "2"))
 
     // Wait for the metrics reporter to be configured
-    val initialReporter = TestMetricsReporter.waitForReporters(1).head
-    initialReporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 1000, numFetcher = 3)
+    val initialReporter = TestNumReplicaFetcherMetricsReporter.waitForReporters(1).head
+    initialReporter.verifyState(reconfigureCount = 1, deleteCount = 0, numFetcher = 2)
 
     TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
 
@@ -1135,7 +1135,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     newBroker.awaitShutdown()
 
     // Clean up the test reporter
-    TestMetricsReporter.testReporters.clear()
+    TestNumReplicaFetcherMetricsReporter.testReporters.clear()
 
     val invalidStaticConfigs = defaultStaticConfig(newBroker.config.brokerId)
     invalidStaticConfigs.putAll(securityProps(invalidSslConfigs, KEYSTORE_PROPS, listenerPrefix(SecureExternal)))
@@ -1145,8 +1145,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Verify that the custom MetricsReporter is not reconfigured after restart.
     // If readDynamicBrokerConfigsFromSnapshot works correctly, the reporter should maintain its state.
-    val reporterAfterRestart = TestMetricsReporter.waitForReporters(1).head
-    reporterAfterRestart.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000, numFetcher = 3)
+    val reporterAfterRestart = TestNumReplicaFetcherMetricsReporter.waitForReporters(1).head
+    reporterAfterRestart.verifyState(reconfigureCount = 0, deleteCount = 0, numFetcher = 2)
   }
 
   private def awaitInitialPositions(consumer: Consumer[_, _]): Unit = {
@@ -1589,7 +1589,6 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
   @volatile var closeCount = 0
   @volatile var clusterUpdateCount = 0
   @volatile var pollingInterval: Int = -1
-  @volatile var numFetchers: Int = 1
   testReporters.add(this)
 
   override def contextChange(metricsContext: MetricsContext): Unit = {
@@ -1606,7 +1605,6 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
     configuredBrokers += configs.get(ServerConfigs.BROKER_ID_CONFIG).toString.toInt
     configureCount += 1
     pollingInterval = configs.get(PollingIntervalProp).toString.toInt
-    numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
   }
 
   override def metricChange(metric: KafkaMetric): Unit = {
@@ -1629,30 +1627,24 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
     val pollingInterval = configs.get(PollingIntervalProp).toString.toInt
     if (pollingInterval <= 0)
       throw new ConfigException(s"Invalid polling interval $pollingInterval")
-
-    val numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
-    if (numFetchers <= 0)
-      throw new ConfigException(s"Invalid num.replica.fetchers $numFetchers")
   }
 
   override def reconfigure(configs: util.Map[String, _]): Unit = {
     reconfigureCount += 1
     pollingInterval = configs.get(PollingIntervalProp).toString.toInt
-    numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
   }
 
   override def close(): Unit = {
     closeCount += 1
   }
 
-  def verifyState(reconfigureCount: Int, deleteCount: Int, pollingInterval: Int, numFetcher: Int = 1): Unit = {
+  def verifyState(reconfigureCount: Int, deleteCount: Int, pollingInterval: Int): Unit = {
     assertEquals(1, initializeCount)
     assertEquals(1, configureCount)
     assertEquals(reconfigureCount, this.reconfigureCount)
     assertEquals(deleteCount, closeCount)
     assertEquals(1, clusterUpdateCount)
     assertEquals(pollingInterval, this.pollingInterval)
-    assertEquals(numFetcher, this.numFetchers)
   }
 
   def verifyMetricValue(name: String, group: String): Unit = {
@@ -1660,6 +1652,86 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
     assertTrue(matchingMetrics.nonEmpty, "Metric not found")
     val total = matchingMetrics.foldLeft(0.0)((total, metric) => total + metric.metricValue.asInstanceOf[Double])
     assertTrue(total > 0.0, "Invalid metric value " + total + " for name " + name + " , group " + group)
+  }
+}
+
+object TestNumReplicaFetcherMetricsReporter {
+  val testReporters = new ConcurrentLinkedQueue[TestNumReplicaFetcherMetricsReporter]()
+  val configuredBrokers = mutable.Set[Int]()
+
+  def waitForReporters(count: Int): List[TestNumReplicaFetcherMetricsReporter] = {
+    TestUtils.waitUntilTrue(() => testReporters.size == count, msg = "Metrics reporters size not matched. Expected: " + count + ", actual: " + testReporters.size())
+
+    val reporters = testReporters.asScala.toList
+    TestUtils.waitUntilTrue(() => reporters.forall(_.configureCount == 1), msg = "Metrics reporters not configured")
+    reporters
+  }
+}
+
+
+class TestNumReplicaFetcherMetricsReporter extends MetricsReporter with Reconfigurable with Closeable with ClusterResourceListener {
+  import TestNumReplicaFetcherMetricsReporter._
+  @volatile var initializeCount = 0
+  @volatile var contextChangeCount = 0
+  @volatile var configureCount = 0
+  @volatile var reconfigureCount = 0
+  @volatile var closeCount = 0
+  @volatile var clusterUpdateCount = 0
+  @volatile var numFetchers: Int = 1
+  testReporters.add(this)
+
+  override def contextChange(metricsContext: MetricsContext): Unit = {
+    contextChangeCount += 1
+  }
+
+  override def init(metrics: util.List[KafkaMetric]): Unit = {
+    assertTrue(contextChangeCount > 0, "contextChange must be called before init")
+    initializeCount += 1
+  }
+
+  override def configure(configs: util.Map[String, _]): Unit = {
+    configuredBrokers += configs.get(ServerConfigs.BROKER_ID_CONFIG).toString.toInt
+    configureCount += 1
+    numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
+  }
+
+  override def metricChange(metric: KafkaMetric): Unit = {
+  }
+
+  override def metricRemoval(metric: KafkaMetric): Unit = {
+  }
+
+  override def onUpdate(clusterResource: ClusterResource): Unit = {
+    assertNotNull(clusterResource.clusterId, "Cluster id not set")
+    clusterUpdateCount += 1
+  }
+
+  override def reconfigurableConfigs(): util.Set[String] = {
+    util.Set.of(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG)
+  }
+
+  override def validateReconfiguration(configs: util.Map[String, _]): Unit = {
+    val numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
+    if (numFetchers <= 0)
+      throw new ConfigException(s"Invalid num.replica.fetchers $numFetchers")
+  }
+
+  override def reconfigure(configs: util.Map[String, _]): Unit = {
+    reconfigureCount += 1
+    numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
+  }
+
+  override def close(): Unit = {
+    closeCount += 1
+  }
+
+  def verifyState(reconfigureCount: Int, deleteCount: Int, numFetcher: Int = 1): Unit = {
+    assertEquals(1, initializeCount)
+    assertEquals(1, configureCount)
+    assertEquals(reconfigureCount, this.reconfigureCount)
+    assertEquals(deleteCount, closeCount)
+    assertEquals(1, clusterUpdateCount)
+    assertEquals(numFetcher, this.numFetchers)
   }
 }
 

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -1657,7 +1657,6 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
 
 object TestNumReplicaFetcherMetricsReporter {
   val testReporters = new ConcurrentLinkedQueue[TestNumReplicaFetcherMetricsReporter]()
-  val configuredBrokers = mutable.Set[Int]()
 
   def waitForReporters(count: Int): List[TestNumReplicaFetcherMetricsReporter] = {
     TestUtils.waitUntilTrue(() => testReporters.size == count, msg = "Metrics reporters size not matched. Expected: " + count + ", actual: " + testReporters.size())
@@ -1669,15 +1668,12 @@ object TestNumReplicaFetcherMetricsReporter {
 }
 
 
-class TestNumReplicaFetcherMetricsReporter extends MetricsReporter with Reconfigurable with Closeable with ClusterResourceListener {
+class TestNumReplicaFetcherMetricsReporter extends MetricsReporter {
   import TestNumReplicaFetcherMetricsReporter._
   @volatile var configureCount = 0
   @volatile var reconfigureCount = 0
   @volatile var numFetchers: Int = 1
   testReporters.add(this)
-
-  override def contextChange(metricsContext: MetricsContext): Unit = {
-  }
 
   override def init(metrics: util.List[KafkaMetric]): Unit = {
   }
@@ -1691,9 +1687,6 @@ class TestNumReplicaFetcherMetricsReporter extends MetricsReporter with Reconfig
   }
 
   override def metricRemoval(metric: KafkaMetric): Unit = {
-  }
-
-  override def onUpdate(clusterResource: ClusterResource): Unit = {
   }
 
   override def reconfigurableConfigs(): util.Set[String] = {

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -321,7 +321,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // wait for MetricsReporter
     val reporters = TestMetricsReporter.waitForReporters(servers.size)
     reporters.foreach { reporter =>
-      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000)
+      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000, numFetcher = 2)
       assertFalse(reporter.kafkaMetrics.isEmpty, "No metrics found")
     }
 
@@ -330,7 +330,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     alterConfigsUsingConfigCommand(updatedProps)
     waitForConfig(TestMetricsReporter.PollingIntervalProp, "1000")
     reporters.foreach { reporter =>
-      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000)
+      reporter.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000, numFetcher = 2)
     }
 
     // 2. verify update occurring if the value of property changed.
@@ -338,7 +338,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     alterConfigsUsingConfigCommand(updatedProps)
     waitForConfig(TestMetricsReporter.PollingIntervalProp, "2000")
     reporters.foreach { reporter =>
-      reporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 2000)
+      reporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 2000, numFetcher = 2)
     }
   }
 
@@ -947,6 +947,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Add a new metrics reporter
     val newProps = new Properties
     newProps.put(TestMetricsReporter.PollingIntervalProp, "100")
+    newProps.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "1")
     configureMetricsReporters(Seq(classOf[JmxReporter], classOf[TestMetricsReporter]), newProps)
 
     val reporters = TestMetricsReporter.waitForReporters(servers.size + controllerServers.size)
@@ -1102,12 +1103,24 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // modify snapshot interval config to explicitly take snapshot on a broker with valid dynamic configs
     val props = defaultStaticConfig(numServers)
     props.put(MetadataLogConfig.METADATA_SNAPSHOT_MAX_INTERVAL_MS_CONFIG, "10000")
+    props.put(MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG, classOf[TestMetricsReporter].getName)
+    props.put(TestMetricsReporter.PollingIntervalProp, "1000")
 
     val kafkaConfig = KafkaConfig.fromProps(props)
     val newBroker = createBroker(kafkaConfig).asInstanceOf[BrokerServer]
     servers += newBroker
 
     alterSslKeystoreUsingConfigCommand(sslProperties1, listenerPrefix(SecureExternal))
+
+    // Add num.replica.fetchers to the cluster-level config.
+    val clusterLevelProps = new Properties
+    clusterLevelProps.put(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "3")
+    reconfigureServers(clusterLevelProps, perBrokerConfig = false,
+      (ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG, "3"))
+
+    // Wait for the metrics reporter to be configured
+    val initialReporter = TestMetricsReporter.waitForReporters(1).head
+    initialReporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 1000, numFetcher = 3)
 
     TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
 
@@ -1121,11 +1134,19 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     newBroker.shutdown()
     newBroker.awaitShutdown()
 
+    // Clean up the test reporter
+    TestMetricsReporter.testReporters.clear()
+
     val invalidStaticConfigs = defaultStaticConfig(newBroker.config.brokerId)
     invalidStaticConfigs.putAll(securityProps(invalidSslConfigs, KEYSTORE_PROPS, listenerPrefix(SecureExternal)))
     newBroker.config.updateCurrentConfig(KafkaConfig.fromProps(invalidStaticConfigs))
 
     newBroker.startup()
+
+    // Verify that the custom MetricsReporter is not reconfigured after restart.
+    // If readDynamicBrokerConfigsFromSnapshot works correctly, the reporter should maintain its state.
+    val reporterAfterRestart = TestMetricsReporter.waitForReporters(1).head
+    reporterAfterRestart.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 1000, numFetcher = 3)
   }
 
   private def awaitInitialPositions(consumer: Consumer[_, _]): Unit = {
@@ -1568,6 +1589,7 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
   @volatile var closeCount = 0
   @volatile var clusterUpdateCount = 0
   @volatile var pollingInterval: Int = -1
+  @volatile var numFetchers: Int = 1
   testReporters.add(this)
 
   override def contextChange(metricsContext: MetricsContext): Unit = {
@@ -1584,6 +1606,7 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
     configuredBrokers += configs.get(ServerConfigs.BROKER_ID_CONFIG).toString.toInt
     configureCount += 1
     pollingInterval = configs.get(PollingIntervalProp).toString.toInt
+    numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
   }
 
   override def metricChange(metric: KafkaMetric): Unit = {
@@ -1599,31 +1622,37 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
   }
 
   override def reconfigurableConfigs(): util.Set[String] = {
-    util.Set.of(PollingIntervalProp)
+    util.Set.of(PollingIntervalProp, ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG)
   }
 
   override def validateReconfiguration(configs: util.Map[String, _]): Unit = {
     val pollingInterval = configs.get(PollingIntervalProp).toString.toInt
     if (pollingInterval <= 0)
       throw new ConfigException(s"Invalid polling interval $pollingInterval")
+
+    val numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
+    if (numFetchers <= 0)
+      throw new ConfigException(s"Invalid num.replica.fetchers $numFetchers")
   }
 
   override def reconfigure(configs: util.Map[String, _]): Unit = {
     reconfigureCount += 1
     pollingInterval = configs.get(PollingIntervalProp).toString.toInt
+    numFetchers = configs.get(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG).toString.toInt
   }
 
   override def close(): Unit = {
     closeCount += 1
   }
 
-  def verifyState(reconfigureCount: Int, deleteCount: Int, pollingInterval: Int): Unit = {
+  def verifyState(reconfigureCount: Int, deleteCount: Int, pollingInterval: Int, numFetcher: Int = 1): Unit = {
     assertEquals(1, initializeCount)
     assertEquals(1, configureCount)
     assertEquals(reconfigureCount, this.reconfigureCount)
     assertEquals(deleteCount, closeCount)
     assertEquals(1, clusterUpdateCount)
     assertEquals(pollingInterval, this.pollingInterval)
+    assertEquals(numFetcher, this.numFetchers)
   }
 
   def verifyMetricValue(name: String, group: String): Unit = {


### PR DESCRIPTION
- **Changes**: Replace misused dynamicPerBrokerConfigs with
dynamicDefaultConfigs
- **Reasons**: KRaft servers don't handle the cluser-level configs in
starting

from: https://github.com/apache/kafka/pull/18949/files#r2296809389

Reviewers: Jun Rao <junrao@gmail.com>, Jhen-Yung Hsu
<jhenyunghsu@gmail.com>, PoAn Yang <payang@apache.org>, Chia-Ping Tsai
<chia7712@gmail.com>
