### PR TITLE
MINOR: renamed testAsyncConsumerClassicConsumerSubscribeInvalidTopicCanUnsubscribe to align test case

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerSubscriptionTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerSubscriptionTest.java
@@ -576,7 +576,7 @@ public class PlaintextConsumerSubscriptionTest {
     }
 
     @ClusterTest
-    public void testAsyncConsumerClassicConsumerSubscribeInvalidTopicCanUnsubscribe() throws InterruptedException {
+    public void testAsyncConsumerSubscribeInvalidTopicCanUnsubscribe() throws InterruptedException {
         testSubscribeInvalidTopicCanUnsubscribe(GroupProtocol.CONSUMER);
     }
 


### PR DESCRIPTION
Simple test method rename.

Reviewers: TengYao Chi <frankvicky@apache.org>
