### PR TITLE
MINOR: Remove OffsetsForLeaderEpochRequest unused static field

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -36,12 +36,6 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
      */
     public static final int CONSUMER_REPLICA_ID = -1;
 
-    /**
-     * Sentinel replica_id which indicates either a debug consumer or a replica which is using
-     * an old version of the protocol.
-     */
-    public static final int DEBUGGING_REPLICA_ID = -2;
-
     private final OffsetForLeaderEpochRequestData data;
 
     public static class Builder extends AbstractRequest.Builder<OffsetsForLeaderEpochRequest> {


### PR DESCRIPTION
This field was used for replica_id, but after
https://github.com/apache/kafka/commit/51c833e7959bd6ab7fbb043f76933456b40ecae4,
the OffsetsForLeaderEpochRequest directly relies on the internal structs
generated by the automated protocol. Therefore, we can safely remove it.

Reviewers: Lan Ding <isDing_L@163.com>, TengYao Chi
 <frankvicky@apache.org>
