### PR TITLE
MINOR: Remove default config in creating internal stream topic

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -95,18 +95,6 @@ class DefaultAutoTopicCreationManager(
     topics: Map[String, CreatableTopic],
     requestContext: RequestContext
   ): Unit = {
-
-    for ((_, creatableTopic) <- topics) {
-      if (creatableTopic.numPartitions() == -1) {
-        creatableTopic
-          .setNumPartitions(config.numPartitions)
-      }
-      if (creatableTopic.replicationFactor() == -1) {
-        creatableTopic
-          .setReplicationFactor(config.defaultReplicationFactor.shortValue)
-      }
-    }
-
     if (topics.nonEmpty) {
       sendCreateTopicRequest(topics, Some(requestContext))
     }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -96,6 +96,7 @@ class DefaultAutoTopicCreationManager(
     requestContext: RequestContext
   ): Unit = {
 
+    // Add default configs to CreatableTopic request to remain consistent with AutoTopicCreationManager#createTopics
     for ((_, creatableTopic) <- topics) {
       if (creatableTopic.numPartitions() == -1) {
         creatableTopic

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -95,6 +95,18 @@ class DefaultAutoTopicCreationManager(
     topics: Map[String, CreatableTopic],
     requestContext: RequestContext
   ): Unit = {
+
+    for ((_, creatableTopic) <- topics) {
+      if (creatableTopic.numPartitions() == -1) {
+        creatableTopic
+          .setNumPartitions(config.numPartitions)
+      }
+      if (creatableTopic.replicationFactor() == -1) {
+        creatableTopic
+          .setReplicationFactor(config.defaultReplicationFactor.shortValue)
+      }
+    }
+
     if (topics.nonEmpty) {
       sendCreateTopicRequest(topics, Some(requestContext))
     }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -96,7 +96,6 @@ class DefaultAutoTopicCreationManager(
     requestContext: RequestContext
   ): Unit = {
 
-    // Add default configs to CreatableTopic request to remain consistent with AutoTopicCreationManager#createTopics
     for ((_, creatableTopic) <- topics) {
       if (creatableTopic.numPartitions() == -1) {
         creatableTopic

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -277,43 +277,6 @@ class AutoTopicCreationManagerTest {
   }
 
   @Test
-  def testCreateStreamsInternalTopicsWithDefaultConfig(): Unit = {
-    val topics = Map(
-      "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)
-    )
-    val requestContext = initializeRequestContextWithUserPrincipal()
-
-    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
-      config,
-      brokerToController,
-      groupCoordinator,
-      transactionCoordinator,
-      shareCoordinator)
-
-    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
-
-    val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
-    Mockito.verify(brokerToController).sendRequest(
-      argumentCaptor.capture(),
-      any(classOf[ControllerRequestCompletionHandler]))
-
-    val capturedRequest = argumentCaptor.getValue.asInstanceOf[EnvelopeRequest.Builder].build(ApiKeys.ENVELOPE.latestVersion())
-
-    val requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion(), "clientId", 0)
-    val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
-    topicsCollection.add(getNewTopic("stream-topic-1", config.numPartitions, config.defaultReplicationFactor.toShort))
-    val requestBody = new CreateTopicsRequest.Builder(
-      new CreateTopicsRequestData()
-        .setTopics(topicsCollection)
-        .setTimeoutMs(requestTimeout))
-      .build(ApiKeys.CREATE_TOPICS.latestVersion())
-    val forwardedRequestBuffer = capturedRequest.requestData().duplicate()
-    assertEquals(requestHeader, RequestHeader.parse(forwardedRequestBuffer))
-    assertEquals(requestBody.data(), CreateTopicsRequest.parse(new ByteBufferAccessor(forwardedRequestBuffer),
-      ApiKeys.CREATE_TOPICS.latestVersion()).data())
-  }
-
-  @Test
   def testCreateStreamsInternalTopicsPassesPrincipal(): Unit = {
     val topics = Map(
       "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -277,6 +277,43 @@ class AutoTopicCreationManagerTest {
   }
 
   @Test
+  def testCreateStreamsInternalTopicsWithDefaultConfig(): Unit = {
+    val topics = Map(
+      "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)
+    )
+    val requestContext = initializeRequestContextWithUserPrincipal()
+
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      brokerToController,
+      groupCoordinator,
+      transactionCoordinator,
+      shareCoordinator)
+
+    autoTopicCreationManager.createStreamsInternalTopics(topics, requestContext)
+
+    val argumentCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_ <: AbstractRequest]])
+    Mockito.verify(brokerToController).sendRequest(
+      argumentCaptor.capture(),
+      any(classOf[ControllerRequestCompletionHandler]))
+
+    val capturedRequest = argumentCaptor.getValue.asInstanceOf[EnvelopeRequest.Builder].build(ApiKeys.ENVELOPE.latestVersion())
+
+    val requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion(), "clientId", 0)
+    val topicsCollection = new CreateTopicsRequestData.CreatableTopicCollection
+    topicsCollection.add(getNewTopic("stream-topic-1", config.numPartitions, config.defaultReplicationFactor.toShort))
+    val requestBody = new CreateTopicsRequest.Builder(
+      new CreateTopicsRequestData()
+        .setTopics(topicsCollection)
+        .setTimeoutMs(requestTimeout))
+      .build(ApiKeys.CREATE_TOPICS.latestVersion())
+    val forwardedRequestBuffer = capturedRequest.requestData().duplicate()
+    assertEquals(requestHeader, RequestHeader.parse(forwardedRequestBuffer))
+    assertEquals(requestBody.data(), CreateTopicsRequest.parse(new ByteBufferAccessor(forwardedRequestBuffer),
+      ApiKeys.CREATE_TOPICS.latestVersion()).data())
+  }
+
+  @Test
   def testCreateStreamsInternalTopicsPassesPrincipal(): Unit = {
     val topics = Map(
       "stream-topic-1" -> new CreatableTopic().setName("stream-topic-1").setNumPartitions(-1).setReplicationFactor(-1)


### PR DESCRIPTION
Cleanup default configs in
AutoTopicCreationManager#createStreamsInternalTopics.   The streams
protocol would like to be consistent with the kafka streams using the
classic protocol - which would create the internal topics using
CreateTopic and therefore use the controller config.

Reviewers: Lucas Brutschy <lucasbru@apache.org>
