### PR TITLE
MINOR: Update Kafka Streams API broker compatibility table for 4.1

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -1851,8 +1851,8 @@
         <tbody>
           <tr>
             <td>Kafka Streams API (rows)</td>
-            <td>2.1.x and<br>2.2.x and<br>2.3.x and<br>2.4.x and<br>2.5.x and<br>2.6.x and<br>2.7.x and<br>2.8.x and<br>3.0.x and<br>3.1.x and<br>3.2.x and<br>3.3.x and<br>3.4.x and<br>3.5.x and<br>3.6.x and<br>3.7.x and<br>3.8.x and<br>3.9.x</td>
-            <td>4.0.x</td>
+            <td>2.1.x and<br>2.2.x and<br>2.3.x and<br>2.4.x and<br>2.5.x and<br>2.6.x and<br>2.7.x and<br>2.8.x and<br>3.0.x and<br>3.1.x and<br>3.2.x and<br>3.3.x and<br>3.4.x and<br>3.5.x and<br>3.6.x and<br>3.7.x and<br>3.8.x and<br>3.9.x and<br>4.0.x</td>
+            <td>4.1.x</td>
           </tr>
           <tr>
             <td>2.4.x and<br>2.5.x</td>
@@ -1860,7 +1860,7 @@
             <td>compatible</td>
           </tr>
           <tr>
-            <td>2.6.x and<br>2.7.x and<br>2.8.x and<br>3.0.x and<br>3.1.x and<br>3.2.x and<br>3.3.x and<br>3.4.x and<br>3.5.x and<br>3.6.x and<br>3.7.x and<br>3.8.x and<br>3.9.x and<br>4.0.x</td>
+            <td>2.6.x and<br>2.7.x and<br>2.8.x and<br>3.0.x and<br>3.1.x and<br>3.2.x and<br>3.3.x and<br>3.4.x and<br>3.5.x and<br>3.6.x and<br>3.7.x and<br>3.8.x and<br>3.9.x and<br>4.0.x and<br>4.1.x</td>
             <td>compatible; enabling exactly-once v2 requires broker version 2.5.x or higher</td>
             <td>compatible</td>
           </tr>


### PR DESCRIPTION
Update the Kafka Streams API broker compatibility table for version 4.1.

Reviewers: Matthias J. Sax <matthias@confluent.io>
