### PR TITLE
MINOR: Add a missing @Test to test case

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -2008,6 +2008,7 @@ public class RecordCollectorTest {
         }
     }
 
+    @Test
     public void shouldCallOldImplementationExceptionHandler() {
         final KafkaException exception = new KafkaException("KABOOM!");
         final StreamsProducer streamProducer = getExceptionalStreamsProducerOnSend(exception);


### PR DESCRIPTION
`shouldCallOldImplementationExceptionHandler` should be a test case, but
somehow misses the `@Test` tag

Reviewers: Ken Huang <s7133700@gmail.com>, TaiJuWu <tjwu1217@gmail.com>,
 Chia-Ping Tsai <chia7712@gmail.com>
