### PR TITLE
KAFKA-17302: ReplicaFetcher changes for fetching from tiered offset

### DIFF
--- a/core/src/main/java/kafka/server/TierStateMachine.java
+++ b/core/src/main/java/kafka/server/TierStateMachine.java
@@ -21,7 +21,7 @@ import kafka.cluster.Partition;
 
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.message.FetchResponseData.PartitionData;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.protocol.Errors;
@@ -85,21 +85,19 @@ public class TierStateMachine {
     /**
      * Start the tier state machine for the provided topic partition.
      *
-     * @param topicPartition the topic partition
-     * @param currentFetchState the current PartitionFetchState which will
-     *                          be used to derive the return value
-     * @param fetchPartitionData the data from the fetch response that returned the offset moved to tiered storage error
-     *
-     * @return the new PartitionFetchState after the successful start of the
-     *         tier state machine
+     * @param topicPartition          the topic partition for which the tier state machine is to be started
+     * @param topicId                 the optional unique identifier of the topic
+     * @param currentLeaderEpoch      the current leader epoch of the partition
+     * @param epochAndStartingOffset  the offset on the leader's local log from which to start replicating logs
+     * @param leaderLogStartOffset    the starting offset in the leader's log
+     * @return the new PartitionFetchState after the successful start of the tier state machine
+     * @throws Exception if an error occurs during the process, such as issues with remote storage
      */
     PartitionFetchState start(TopicPartition topicPartition,
-                              PartitionFetchState currentFetchState,
-                              PartitionData fetchPartitionData) throws Exception {
-        OffsetAndEpoch epochAndLeaderLocalStartOffset = leader.fetchEarliestLocalOffset(topicPartition, currentFetchState.currentLeaderEpoch());
-        int epoch = epochAndLeaderLocalStartOffset.epoch();
-        long leaderLocalStartOffset = epochAndLeaderLocalStartOffset.offset();
-
+                              Optional<Uuid> topicId,
+                              int currentLeaderEpoch,
+                              OffsetAndEpoch epochAndStartingOffset,
+                              long leaderLogStartOffset) throws Exception {
         long offsetToFetch;
         replicaMgr.brokerTopicStats().topicStats(topicPartition.topic()).buildRemoteLogAuxStateRequestRate().mark();
         replicaMgr.brokerTopicStats().allTopicsStats().buildRemoteLogAuxStateRequestRate().mark();
@@ -112,21 +110,20 @@ public class TierStateMachine {
         }
 
         try {
-            offsetToFetch = buildRemoteLogAuxState(topicPartition, currentFetchState.currentLeaderEpoch(), leaderLocalStartOffset, epoch, fetchPartitionData.logStartOffset(), unifiedLog);
+            offsetToFetch = buildRemoteLogAuxState(topicPartition, currentLeaderEpoch, epochAndStartingOffset.offset(), epochAndStartingOffset.epoch(), leaderLogStartOffset, unifiedLog);
         } catch (RemoteStorageException e) {
             replicaMgr.brokerTopicStats().topicStats(topicPartition.topic()).failedBuildRemoteLogAuxStateRate().mark();
             replicaMgr.brokerTopicStats().allTopicsStats().failedBuildRemoteLogAuxStateRate().mark();
             throw e;
         }
 
-        OffsetAndEpoch fetchLatestOffsetResult = leader.fetchLatestOffset(topicPartition, currentFetchState.currentLeaderEpoch());
+        OffsetAndEpoch fetchLatestOffsetResult = leader.fetchLatestOffset(topicPartition, currentLeaderEpoch);
         long leaderEndOffset = fetchLatestOffsetResult.offset();
 
         long initialLag = leaderEndOffset - offsetToFetch;
 
-        return new PartitionFetchState(currentFetchState.topicId(), offsetToFetch, Optional.of(initialLag), currentFetchState.currentLeaderEpoch(),
+        return new PartitionFetchState(topicId, offsetToFetch, Optional.of(initialLag), currentLeaderEpoch,
                 ReplicaState.FETCHING, unifiedLog.latestEpoch());
-
     }
 
     private OffsetForLeaderEpochResponseData.EpochEndOffset fetchEarlierEpochEndOffset(Integer epoch,
@@ -182,12 +179,12 @@ public class TierStateMachine {
      * fetching records from the leader. The return value is the next offset to fetch from the leader, which is the
      * next offset following the end offset of the remote log portion.
      */
-    private Long buildRemoteLogAuxState(TopicPartition topicPartition,
-                                        Integer currentLeaderEpoch,
-                                        Long leaderLocalLogStartOffset,
-                                        Integer epochForLeaderLocalLogStartOffset,
-                                        Long leaderLogStartOffset,
-                                        UnifiedLog unifiedLog) throws IOException, RemoteStorageException {
+    protected Long buildRemoteLogAuxState(TopicPartition topicPartition,
+                                          Integer currentLeaderEpoch,
+                                          Long leaderLocalLogStartOffset,
+                                          Integer epochForLeaderLocalLogStartOffset,
+                                          Long leaderLogStartOffset,
+                                          UnifiedLog unifiedLog) throws IOException, RemoteStorageException {
 
         if (!unifiedLog.remoteLogEnabled()) {
             // If the tiered storage is not enabled throw an exception back so that it will retry until the tiered storage

--- a/core/src/main/java/kafka/server/TierStateMachine.java
+++ b/core/src/main/java/kafka/server/TierStateMachine.java
@@ -85,18 +85,18 @@ public class TierStateMachine {
     /**
      * Start the tier state machine for the provided topic partition.
      *
-     * @param topicPartition          the topic partition for which the tier state machine is to be started
-     * @param topicId                 the optional unique identifier of the topic
-     * @param currentLeaderEpoch      the current leader epoch of the partition
-     * @param epochAndStartingOffset  the offset on the leader's local log from which to start replicating logs
-     * @param leaderLogStartOffset    the starting offset in the leader's log
+     * @param topicPartition            the topic partition for which the tier state machine is to be started
+     * @param topicId                   the optional unique identifier of the topic
+     * @param currentLeaderEpoch        the current leader epoch of the partition
+     * @param fetchStartOffsetAndEpoch  the offset on the leader's local log from which to start replicating logs
+     * @param leaderLogStartOffset      the starting offset in the leader's log
      * @return the new PartitionFetchState after the successful start of the tier state machine
      * @throws Exception if an error occurs during the process, such as issues with remote storage
      */
     PartitionFetchState start(TopicPartition topicPartition,
                               Optional<Uuid> topicId,
                               int currentLeaderEpoch,
-                              OffsetAndEpoch epochAndStartingOffset,
+                              OffsetAndEpoch fetchStartOffsetAndEpoch,
                               long leaderLogStartOffset) throws Exception {
         long offsetToFetch;
         replicaMgr.brokerTopicStats().topicStats(topicPartition.topic()).buildRemoteLogAuxStateRequestRate().mark();
@@ -110,7 +110,7 @@ public class TierStateMachine {
         }
 
         try {
-            offsetToFetch = buildRemoteLogAuxState(topicPartition, currentLeaderEpoch, epochAndStartingOffset.offset(), epochAndStartingOffset.epoch(), leaderLogStartOffset, unifiedLog);
+            offsetToFetch = buildRemoteLogAuxState(topicPartition, currentLeaderEpoch, fetchStartOffsetAndEpoch.offset(), fetchStartOffsetAndEpoch.epoch(), leaderLogStartOffset, unifiedLog);
         } catch (RemoteStorageException e) {
             replicaMgr.brokerTopicStats().topicStats(topicPartition.topic()).failedBuildRemoteLogAuxStateRate().mark();
             replicaMgr.brokerTopicStats().allTopicsStats().failedBuildRemoteLogAuxStateRate().mark();
@@ -124,6 +124,7 @@ public class TierStateMachine {
 
         return new PartitionFetchState(topicId, offsetToFetch, Optional.of(initialLag), currentLeaderEpoch,
                 ReplicaState.FETCHING, unifiedLog.latestEpoch());
+
     }
 
     private OffsetForLeaderEpochResponseData.EpochEndOffset fetchEarlierEpochEndOffset(Integer epoch,
@@ -179,12 +180,12 @@ public class TierStateMachine {
      * fetching records from the leader. The return value is the next offset to fetch from the leader, which is the
      * next offset following the end offset of the remote log portion.
      */
-    protected Long buildRemoteLogAuxState(TopicPartition topicPartition,
-                                          Integer currentLeaderEpoch,
-                                          Long leaderLocalLogStartOffset,
-                                          Integer epochForLeaderLocalLogStartOffset,
-                                          Long leaderLogStartOffset,
-                                          UnifiedLog unifiedLog) throws IOException, RemoteStorageException {
+    private Long buildRemoteLogAuxState(TopicPartition topicPartition,
+                                        Integer currentLeaderEpoch,
+                                        Long leaderLocalLogStartOffset,
+                                        Integer epochForLeaderLocalLogStartOffset,
+                                        Long leaderLogStartOffset,
+                                        UnifiedLog unifiedLog) throws IOException, RemoteStorageException {
 
         if (!unifiedLog.remoteLogEnabled()) {
             // If the tiered storage is not enabled throw an exception back so that it will retry until the tiered storage

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -671,7 +671,13 @@ abstract class AbstractFetcherThread(name: String,
      */
     val offsetAndEpoch = leader.fetchLatestOffset(topicPartition, currentLeaderEpoch)
     val leaderEndOffset = offsetAndEpoch.offset
-    if (leaderEndOffset < replicaEndOffset) {
+    val fetchFromLastTieredOffset = shouldFetchFromLastTieredOffset(topicPartition, leaderEndOffset, replicaEndOffset)
+
+    if (fetchFromLastTieredOffset) {
+      val leaderStartOffset = leader.fetchEarliestOffset(topicPartition, currentLeaderEpoch)
+      val epochAndStartingOffset = earliestPendingUploadOffset(topicPartition, currentLeaderEpoch, leaderStartOffset)
+      fetchTierStateMachine.start(topicPartition, topicId.asJava, currentLeaderEpoch, epochAndStartingOffset, leaderStartOffset.offset())
+    } else if (leaderEndOffset < replicaEndOffset) {
       warn(s"Reset fetch offset for partition $topicPartition from $replicaEndOffset to current " +
         s"leader's latest offset $leaderEndOffset")
       truncate(topicPartition, OffsetTruncationState(leaderEndOffset, truncationCompleted = true))
@@ -781,7 +787,15 @@ abstract class AbstractFetcherThread(name: String,
                                                 leaderEpochInRequest: Optional[Integer],
                                                 fetchPartitionData: PartitionData): Boolean = {
     try {
-      val newFetchState = fetchTierStateMachine.start(topicPartition, fetchState, fetchPartitionData)
+      val fetchFromLastTieredOffset = shouldFetchFromLastTieredOffset(topicPartition, fetchState)
+      val epochAndLogStartOffset = leader.fetchEarliestOffset(topicPartition, fetchState.currentLeaderEpoch())
+      val epochAndStartingOffset = if (fetchFromLastTieredOffset) {
+        earliestPendingUploadOffset(topicPartition, fetchState.currentLeaderEpoch(), epochAndLogStartOffset)
+      } else {
+        leader.fetchEarliestLocalOffset(topicPartition, fetchState.currentLeaderEpoch())
+      }
+      val newFetchState = fetchTierStateMachine.start(topicPartition, fetchState.topicId(), fetchState.currentLeaderEpoch(),
+        epochAndStartingOffset, epochAndLogStartOffset.offset())
 
       // TODO: use fetchTierStateMachine.maybeAdvanceState when implementing async tiering logic in KAFKA-13560
 
@@ -803,6 +817,29 @@ abstract class AbstractFetcherThread(name: String,
         error(s"Error building remote log auxiliary state for $topicPartition", e)
         false
     }
+  }
+
+  /**
+   * Determines the earliest offset for pending uploads, taking into account
+   * both local and remote storage conditions.
+   */
+  private def earliestPendingUploadOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int, leaderLogStartOffset: OffsetAndEpoch): OffsetAndEpoch = {
+    val earliestPendingUploadOffset = leader.fetchEarliestPendingUploadOffset(topicPartition, currentLeaderEpoch)
+    if (earliestPendingUploadOffset.offset == -1L) {
+      val leaderLocalStartOffset = leader.fetchEarliestLocalOffset(topicPartition, currentLeaderEpoch)
+      if (leaderLocalStartOffset.offset == leaderLogStartOffset.offset) {
+        return leaderLocalStartOffset
+      }
+      throw new OffsetNotAvailableException("Segments are uploaded to remote storage, but the leader does not have the information about the uploaded segments")
+    }
+    earliestPendingUploadOffset
+  }
+
+  private def shouldFetchFromLastTieredOffset(topicPartition: TopicPartition, fetchState: PartitionFetchState): Boolean = {
+    val leaderEndOffset = leader.fetchLatestOffset(topicPartition, fetchState.currentLeaderEpoch())
+    val replicaEndOffset = logEndOffset(topicPartition)
+
+    shouldFetchFromLastTieredOffset(topicPartition, leaderEndOffset.offset(), replicaEndOffset)
   }
 
   private def delayPartitions(partitions: Iterable[TopicPartition], delay: Long): Unit = {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -674,9 +674,9 @@ abstract class AbstractFetcherThread(name: String,
     val fetchFromLastTieredOffset = shouldFetchFromLastTieredOffset(topicPartition, leaderEndOffset, replicaEndOffset)
 
     if (fetchFromLastTieredOffset) {
-      val leaderStartOffset = leader.fetchEarliestOffset(topicPartition, currentLeaderEpoch)
-      val epochAndStartingOffset = earliestPendingUploadOffset(topicPartition, currentLeaderEpoch, leaderStartOffset)
-      fetchTierStateMachine.start(topicPartition, topicId.asJava, currentLeaderEpoch, epochAndStartingOffset, leaderStartOffset.offset())
+      val leaderStartOffsetAndEpoch = leader.fetchEarliestOffset(topicPartition, currentLeaderEpoch)
+      val earliestPendingUploadOffsetAndEpoch = fetchEarliestPendingUploadOffset(topicPartition, currentLeaderEpoch, leaderStartOffsetAndEpoch)
+      fetchTierStateMachine.start(topicPartition, topicId.toJava, currentLeaderEpoch, earliestPendingUploadOffsetAndEpoch, leaderStartOffsetAndEpoch.offset())
     } else if (leaderEndOffset < replicaEndOffset) {
       warn(s"Reset fetch offset for partition $topicPartition from $replicaEndOffset to current " +
         s"leader's latest offset $leaderEndOffset")
@@ -787,15 +787,15 @@ abstract class AbstractFetcherThread(name: String,
                                                 leaderEpochInRequest: Optional[Integer],
                                                 fetchPartitionData: PartitionData): Boolean = {
     try {
-      val fetchFromLastTieredOffset = shouldFetchFromLastTieredOffset(topicPartition, fetchState)
-      val epochAndLogStartOffset = leader.fetchEarliestOffset(topicPartition, fetchState.currentLeaderEpoch())
-      val epochAndStartingOffset = if (fetchFromLastTieredOffset) {
-        earliestPendingUploadOffset(topicPartition, fetchState.currentLeaderEpoch(), epochAndLogStartOffset)
+      val isLastTieredOffsetFetchEnabled = shouldFetchFromLastTieredOffset(topicPartition, fetchState)
+      val leaderLogStartOffsetAndEpoch = leader.fetchEarliestOffset(topicPartition, fetchState.currentLeaderEpoch())
+      val fetchOffsetAndEpoch = if (isLastTieredOffsetFetchEnabled) {
+        fetchEarliestPendingUploadOffset(topicPartition, fetchState.currentLeaderEpoch(), leaderLogStartOffsetAndEpoch)
       } else {
         leader.fetchEarliestLocalOffset(topicPartition, fetchState.currentLeaderEpoch())
       }
       val newFetchState = fetchTierStateMachine.start(topicPartition, fetchState.topicId(), fetchState.currentLeaderEpoch(),
-        epochAndStartingOffset, epochAndLogStartOffset.offset())
+        fetchOffsetAndEpoch, leaderLogStartOffsetAndEpoch.offset())
 
       // TODO: use fetchTierStateMachine.maybeAdvanceState when implementing async tiering logic in KAFKA-13560
 
@@ -823,14 +823,14 @@ abstract class AbstractFetcherThread(name: String,
    * Determines the earliest offset for pending uploads, taking into account
    * both local and remote storage conditions.
    */
-  private def earliestPendingUploadOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int, leaderLogStartOffset: OffsetAndEpoch): OffsetAndEpoch = {
+  private def fetchEarliestPendingUploadOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int, leaderLogStartOffsetAndEpoch: OffsetAndEpoch): OffsetAndEpoch = {
     val earliestPendingUploadOffset = leader.fetchEarliestPendingUploadOffset(topicPartition, currentLeaderEpoch)
     if (earliestPendingUploadOffset.offset == -1L) {
       val leaderLocalStartOffset = leader.fetchEarliestLocalOffset(topicPartition, currentLeaderEpoch)
-      if (leaderLocalStartOffset.offset == leaderLogStartOffset.offset) {
+      if (leaderLocalStartOffset.offset == leaderLogStartOffsetAndEpoch.offset) {
         return leaderLocalStartOffset
       }
-      throw new OffsetNotAvailableException("Segments are uploaded to remote storage, but the leader does not have the information about the uploaded segments")
+      throw new OffsetNotAvailableException("Segments are uploaded to remote storage, but the leader does not know the earliest pending upload offset.")
     }
     earliestPendingUploadOffset
   }

--- a/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
@@ -144,10 +144,10 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
     } else {
       val highestRemoteOffset = log.highestOffsetInRemoteStorage()
       val logStartOffset = fetchEarliestOffset(topicPartition, currentLeaderEpoch)
+      val localLogStartOffset = fetchEarliestLocalOffset(topicPartition, currentLeaderEpoch)
 
       highestRemoteOffset match {
         case -1L =>
-          val localLogStartOffset = fetchEarliestLocalOffset(topicPartition, currentLeaderEpoch)
           if (localLogStartOffset.offset() == logStartOffset.offset()) {
             // No segments have been uploaded yet
             logStartOffset
@@ -156,7 +156,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
             new OffsetAndEpoch(-1L, -1)
           }
         case _ =>
-          val earliestPendingUploadOffset = Math.max(highestRemoteOffset + 1, logStartOffset.offset())
+          val earliestPendingUploadOffset = Math.max(highestRemoteOffset + 1, Math.max(logStartOffset.offset(), localLogStartOffset.offset()))
           val epoch = log.leaderEpochCache.epochForOffset(earliestPendingUploadOffset)
           new OffsetAndEpoch(earliestPendingUploadOffset, epoch.orElse(0))
       }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -18,7 +18,6 @@ package kafka.server
 
 import com.yammer.metrics.core.Gauge
 import kafka.utils.TestUtils
-import org.apache.kafka.common.message.FetchResponseData.PartitionData
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.metrics.Metrics
@@ -323,7 +322,8 @@ class AbstractFetcherManagerTest {
   }
 
   private class MockResizeFetcherTierStateMachine extends TierStateMachine(null, null, false) {
-    override def start(topicPartition: TopicPartition, currentFetchState: PartitionFetchState, fetchPartitionData: PartitionData): PartitionFetchState = {
+
+    override def start(topicPartition: TopicPartition, topicId: Optional[Uuid], currentLeaderEpoch: Int, epochAndStartingOffset: OffsetAndEpoch, leaderLogStartOffset: Long): PartitionFetchState = {
       throw new UnsupportedOperationException("Materializing tier state is not supported in this test.")
     }
   }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -322,8 +322,7 @@ class AbstractFetcherManagerTest {
   }
 
   private class MockResizeFetcherTierStateMachine extends TierStateMachine(null, null, false) {
-
-    override def start(topicPartition: TopicPartition, topicId: Optional[Uuid], currentLeaderEpoch: Int, epochAndStartingOffset: OffsetAndEpoch, leaderLogStartOffset: Long): PartitionFetchState = {
+    override def start(topicPartition: TopicPartition, topicId: Optional[Uuid], currentLeaderEpoch: Int, fetchStartOffsetAndEpoch: OffsetAndEpoch, leaderLogStartOffset: Long): PartitionFetchState = {
       throw new UnsupportedOperationException("Materializing tier state is not supported in this test.")
     }
   }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -1748,27 +1748,27 @@ class AbstractFetcherThreadTest {
    * All Local Segments Retained
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
+   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
    *   and all local log segments are retained.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Leader LogStartOffset: **0**
-   * - Leader LocalLogStartOffset: **0** (all segments retained locally)
-   * - Replica Start offset Strategy: **TieredOffset**
+   *  - TieredStorage: **Enabled**
+   *  - Leader LogStartOffset: **0**
+   *  - Leader LocalLogStartOffset: **0** (all segments retained locally)
+   *  - Should replica from the last tiered offset: **True**
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 0
-   * - Some segments are uploaded to tiered storage (with earliestPendingUploadOffset = 150)
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader log contains record batches starting from offset 0
+   *  - Some segments are uploaded to tiered storage (with earliestPendingUploadOffset = 150)
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower adapts to tiered storage configuration:
+   *  - Follower adapts to tiered storage configuration:
    *    - LogStartOffset remains 0
    *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
    *    - LogEndOffset advances to 200 after fetching all records
-   * 2. HighWatermark aligns with the leader (199)
-   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   *  - HighWatermark aligns with the leader (199)
+   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
    */
   @Test
   @Disabled
@@ -1819,29 +1819,29 @@ class AbstractFetcherThreadTest {
    * and All Local Segments Deleted
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
+   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
    *   but local segments below a certain offset have been deleted.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **0**
-   * - Leader LocalLogStartOffset: **100** (segments below offset 100 deleted locally)
-   * - EarliestPendingUploadOffset: **150**
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **0**
+   *  - Leader LocalLogStartOffset: **100** (segments below offset 100 deleted locally)
+   *  - EarliestPendingUploadOffset: **150**
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
-   * - Some segments are pending upload to tiered storage (from offset 150)
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
+   *  - Some segments are pending upload to tiered storage (from offset 150)
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower adapts to tiered storage configuration:
+   *  - Follower adapts to tiered storage configuration:
    *    - LogStartOffset initializes to 0 (matching leader's logical start)
    *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
    *    - LogEndOffset advances to 200 after fetching all records
-   * 2. HighWatermark aligns with the leader (199)
-   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   * 4. The follower correctly handles the gap between LogStartOffset (0) and LocalLogStartOffset (150)
+   *  - HighWatermark aligns with the leader (199)
+   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   *  - The follower correctly handles the gap between LogStartOffset (0) and LocalLogStartOffset (150)
    */
   @Test
   def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroAllLocalSegmentsDeleted(): Unit = {
@@ -1891,29 +1891,29 @@ class AbstractFetcherThreadTest {
    * and All Local Segments Retained
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
+   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
    *   and all local log segments from the start offset are retained.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **10** (non-zero)
-   * - Leader LocalLogStartOffset: **10** (equal to LogStartOffset, all segments retained)
-   * - EarliestPendingUploadOffset: **150**
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **10** (non-zero)
+   *  - Leader LocalLogStartOffset: **10** (equal to LogStartOffset, all segments retained)
+   *  - EarliestPendingUploadOffset: **150**
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 10 (non-zero start)
-   * - Some segments are pending upload to tiered storage (from offset 150)
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader log contains record batches starting from offset 10 (non-zero start)
+   *  - Some segments are pending upload to tiered storage (from offset 150)
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower adapts to tiered storage configuration:
+   *  - Follower adapts to tiered storage configuration:
    *    - LogStartOffset initializes to 10 (matching leader's logical start)
    *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
    *    - LogEndOffset advances to 200 after fetching all records
-   * 2. HighWatermark aligns with the leader (199)
-   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   * 4. The follower correctly handles the gap between LogStartOffset (10) and LocalLogStartOffset (150)
+   *  - HighWatermark aligns with the leader (199)
+   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   *  - The follower correctly handles the gap between LogStartOffset (10) and LocalLogStartOffset (150)
    *    when segments in that range exist in tiered storage
    */
   @Test
@@ -1963,29 +1963,29 @@ class AbstractFetcherThreadTest {
    * and All Local Segments Deleted
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
+   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
    *   and local segments between log start offset and a higher offset have been deleted.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **10** (non-zero)
-   * - Leader LocalLogStartOffset: **100** (segments between 10 and 100 deleted locally)
-   * - EarliestPendingUploadOffset: **150**
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **10** (non-zero)
+   *  - Leader LocalLogStartOffset: **100** (segments between 10 and 100 deleted locally)
+   *  - EarliestPendingUploadOffset: **150**
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
-   * - Some segments are pending upload to tiered storage (from offset 150)
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
+   *  - Some segments are pending upload to tiered storage (from offset 150)
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower adapts to tiered storage configuration:
+   *  - Follower adapts to tiered storage configuration:
    *    - LogStartOffset initializes to 10 (matching leader's logical start)
    *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
    *    - LogEndOffset advances to 200 after fetching all records
-   * 2. HighWatermark aligns with the leader (199)
-   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   * 4. The follower correctly handles two gaps:
+   *  - HighWatermark aligns with the leader (199)
+   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   *  - The follower correctly handles two gaps:
    *    - Between LogStartOffset (10) and leader's LocalLogStartOffset (100)
    *    - Between leader's LocalLogStartOffset (100) and EarliestPendingUploadOffset (150)
    */
@@ -2036,32 +2036,32 @@ class AbstractFetcherThreadTest {
    * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset - All Leader Segments Deleted Locally
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset and all leader's segments
+   *  - Validate follower behavior when starting from the last tiered offset and all leader's segments
    *   have been uploaded to tiered storage and deleted locally (complete local emptiness).
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **Parameterized (0 or 10)**
-   * - Leader LocalLogStartOffset: **151** (equals LogEndOffset)
-   * - EarliestPendingUploadOffset: **151** (all segments uploaded)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **Parameterized (0 or 10)**
+   *  - Leader LocalLogStartOffset: **151** (equals LogEndOffset)
+   *  - EarliestPendingUploadOffset: **151** (all segments uploaded)
    *
    * Scenario:
-   * - The leader has historical record batches (at offsets 100 and 150)
-   * - All segments have been uploaded to tiered storage and deleted locally
-   * - LocalLogStartOffset equals LogEndOffset (151), indicating empty local storage
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
-   * - The test is parameterized to run with LogStartOffset values of 0 and 10
+   *  - The leader has historical record batches (at offsets 100 and 150)
+   *  - All segments have been uploaded to tiered storage and deleted locally
+   *  - LocalLogStartOffset equals LogEndOffset (151), indicating empty local storage
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The test is parameterized to run with LogStartOffset values of 0 and 10
    *
    * Expected Outcomes:
-   * 1. Follower properly adapts to leader's empty local state:
+   *  - Follower properly adapts to leader's empty local state:
    *    - LogStartOffset initializes to match leader's (0 or 10)
    *    - LocalLogStartOffset and LogEndOffset both set to 151 (matching leader)
    *    - HighWatermark sets to 151 (matching leader)
-   * 2. No record batches are fetched (log size remains 0)
-   * 3. Follower remains in FETCHING state but doesn't receive any data
-   * 4. Subsequent fetch operations don't change the follower's state
-   * 5. Follower correctly handles the gap between LogStartOffset and LocalLogStartOffset
+   *  - No record batches are fetched (log size remains 0)
+   *  - Follower remains in FETCHING state but doesn't receive any data
+   *  - Subsequent fetch operations don't change the follower's state
+   *  - Follower correctly handles the gap between LogStartOffset and LocalLogStartOffset
    *    when all segments are in tiered storage only
    */
   @ParameterizedTest
@@ -2114,33 +2114,33 @@ class AbstractFetcherThreadTest {
    * Test: Empty Follower Fetch with Tiered Storage Disabled, fetch from Last Tiered Offset enabled, and Leader LogStartOffset Zero
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled,
+   *  - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled,
    *   and the leader's log starts at offset zero.
    *
    * Conditions:
-   * - TieredStorage: **Disabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **0**
-   * - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
-   * - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
+   *  - TieredStorage: **Disabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **0**
+   *  - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
+   *  - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 0
-   * - Tiered storage is disabled, so all segments are local
-   * - The follower starts with an empty log but enabled with data replication from the last tiered offset
-   * - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
+   *  - The leader log contains record batches starting from offset 0
+   *  - Tiered storage is disabled, so all segments are local
+   *  - The follower starts with an empty log but enabled with data replication from the last tiered offset
+   *  - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
    *   standard fetch
    *
    * Expected Outcomes:
-   * 1. Follower adapts to non-tiered environment despite fetch from last tiered offset enabled:
+   *  - Follower adapts to non-tiered environment despite fetch from last tiered offset enabled:
    *    - LogStartOffset initializes to 0 (matching leader's start)
    *    - LocalLogStartOffset equals LogStartOffset (0)
    *    - LogEndOffset advances to 200 after fetching all records
-   * 2. HighWatermark aligns with the leader (199)
-   * 3. All segments are fetched sequentially from the beginning:
+   *  - HighWatermark aligns with the leader (199)
+   *  - All segments are fetched sequentially from the beginning:
    *    - First fetch: 1 record batch, logEndOffset = 1
    *    - After additional fetches: 3 record batches, logEndOffset = 200
-   * 4. Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
+   *  - Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
    *    pattern when tiered storage is disabled
    */
   @Test
@@ -2189,33 +2189,33 @@ class AbstractFetcherThreadTest {
    * Test: Empty Follower Fetch with Tiered Storage Disabled, fetch from Last Tiered Offset enabled, and Leader LogStartOffset Non-Zero
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled
+   *  - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled
    *   and the leader's log starts at a non-zero offset.
    *
    * Conditions:
-   * - TieredStorage: **Disabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **10** (non-zero)
-   * - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
-   * - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
+   *  - TieredStorage: **Disabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **10** (non-zero)
+   *  - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
+   *  - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 10 (non-zero)
-   * - Tiered storage is disabled, so all segments are local
-   * - The follower starts with an empty log but enabled with data replication from the last tiered offset
-   * - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
+   *  - The leader log contains record batches starting from offset 10 (non-zero)
+   *  - Tiered storage is disabled, so all segments are local
+   *  - The follower starts with an empty log but enabled with data replication from the last tiered offset
+   *  - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
    *   standard fetch
    *
    * Expected Outcomes:
-   * 1. Follower adapts to non-tiered environment despite tiered strategy:
+   *  - Follower adapts to non-tiered environment despite tiered strategy:
    *    - LogStartOffset initializes to 10 (matching leader's start)
    *    - LogEndOffset initially sets to 10, then advances as records are fetched
    *    - After all fetches, LogEndOffset reaches 200
-   * 2. HighWatermark aligns with the leader (199)
-   * 3. All segments are fetched sequentially from the leader's start offset:
+   *  - HighWatermark aligns with the leader (199)
+   *  - All segments are fetched sequentially from the leader's start offset:
    *    - First fetch: logEndOffset = 10, but no records fetched yet
    *    - After additional fetches: 3 record batches, logEndOffset = 200
-   * 4. Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
+   *  - Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
    *    pattern when tiered storage is disabled, properly handling non-zero start offsets
    */
   @Test
@@ -2263,32 +2263,32 @@ class AbstractFetcherThreadTest {
    * No Segments Uploaded
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
    *   when the leader's log starts at a non-zero offset but no segments have been uploaded to tiered storage.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **10** (non-zero)
-   * - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
-   * - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **10** (non-zero)
+   *  - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
+   *  - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 10 (non-zero)
-   * - Tiered storage is enabled, but no segments have been uploaded or are pending upload
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
-   * - With no segments in tiered storage, follower should replicate from leader's start offset
+   *  - The leader log contains record batches starting from offset 10 (non-zero)
+   *  - Tiered storage is enabled, but no segments have been uploaded or are pending upload
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - With no segments in tiered storage, follower should replicate from leader's start offset
    *
    * Expected Outcomes:
-   * 1. Follower properly initializes with leader's state:
+   *  - Follower properly initializes with leader's state:
    *    - LogStartOffset initializes to 10 (matching leader's start)
    *    - LocalLogStartOffset equals LogStartOffset (10)
    *    - LogEndOffset initially sets to 10, then advances as records are fetched
-   * 2. HighWatermark initially set to 10, then aligned with leader (199) after fetching
-   * 3. All segments are fetched sequentially from the leader's start offset:
+   *  - HighWatermark initially set to 10, then aligned with leader (199) after fetching
+   *  - All segments are fetched sequentially from the leader's start offset:
    *    - First fetch: logEndOffset = 10, but no records fetched yet
    *    - After additional fetches: 3 record batches, logEndOffset = 200
-   * 4. When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
+   *  - When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
    *    correctly falls back to fetching all segments from the logical start offset
    */
   @Test
@@ -2340,32 +2340,32 @@ class AbstractFetcherThreadTest {
    * No Segments Uploaded
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
    *   when the leader's log starts at offset zero and no segments have been uploaded to tiered storage.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **0**
-   * - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
-   * - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **0**
+   *  - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
+   *  - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
    *
    * Scenario:
-   * - The leader log contains record batches starting from offset 0
-   * - Tiered storage is enabled, but no segments have been uploaded or are pending upload
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
-   * - With no segments in tiered storage, follower should replicate from leader's start offset (0)
+   *  - The leader log contains record batches starting from offset 0
+   *  - Tiered storage is enabled, but no segments have been uploaded or are pending upload
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - With no segments in tiered storage, follower should replicate from leader's start offset (0)
    *
    * Expected Outcomes:
-   * 1. Follower properly initializes with leader's state:
+   *  - Follower properly initializes with leader's state:
    *    - LogStartOffset initializes to 0 (matching leader's start)
    *    - LocalLogStartOffset equals LogStartOffset (0)
    *    - First fetch returns 1 record batch, setting logEndOffset to 1
-   * 2. HighWatermark immediately aligned with leader (199) after first fetch
-   * 3. All segments are fetched sequentially from the leader's start offset:
+   *  - HighWatermark immediately aligned with leader (199) after first fetch
+   *  - All segments are fetched sequentially from the leader's start offset:
    *    - First fetch: 1 record batch, logEndOffset = 1
    *    - After additional fetches: 3 record batches, logEndOffset = 200
-   * 4. When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
+   *  - When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
    *    correctly falls back to traditional fetch behavior from offset 0
    */
   @Test
@@ -2418,34 +2418,34 @@ class AbstractFetcherThreadTest {
    * Segments Uploaded and a newly elected Leader
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *   when the leader is newly elected and has local segments that start after the logical log start offset,
-   *   but doesn't yet have information about tiered segments.
+   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *    when the leader is newly elected and has local segments that start after the logical log start offset,
+   *    but doesn't yet have information about tiered segments.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **10** (non-zero)
-   * - Leader LocalLogStartOffset: **100** (greater than LogStartOffset, indicating tiered segments should exist)
-   * - EarliestPendingUploadOffset: **-1** (leader doesn't know about tiered segments yet)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **10** (non-zero)
+   *  - Leader LocalLogStartOffset: **100** (greater than LogStartOffset, indicating tiered segments should exist)
+   *  - EarliestPendingUploadOffset: **-1** (leader doesn't know about tiered segments yet)
    *
    * Scenario:
-   * - The leader's local log contains record batches starting from offset 100
-   * - The leader's logical log starts at offset 10 (implying offsets 10-99 should be in tiered storage)
-   * - However, leader reports earliestPendingUploadOffset as -1, indicating it's not aware of tiered segments
-   * - This represents a newly elected leader that hasn't completed initialization of tiered storage state
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader's local log contains record batches starting from offset 100
+   *  - The leader's logical log starts at offset 10 (implying offsets 10-99 should be in tiered storage)
+   *  - However, leader reports earliestPendingUploadOffset as -1, indicating it's not aware of tiered segments
+   *  - This represents a newly elected leader that hasn't completed initialization of tiered storage state
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower detects the inconsistent state and responds properly:
+   *  - Follower detects the inconsistent state and responds properly:
    *    - Remains in FETCHING state but doesn't fetch any records
    *    - Fetch offset remains at 0 (unchanged)
    *    - Sets a delay before retry to allow leader to complete initialization
-   * 2. Follower's state remains unchanged:
+   *  - Follower's state remains unchanged:
    *    - LogEndOffset remains at 0
    *    - No records are fetched until leader initializes properly
-   * 3. The fetch will be retried after some delay, allowing leader time to initialize
-   * 4. This graceful handling prevents replication issues during leader transition
+   *  - The fetch will be retried after some delay, allowing leader time to initialize
+   *  - This graceful handling prevents replication issues during leader transition
    */
   @Test
   def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroSegmentsUploadedNewlyElectedLeader(): Unit = {
@@ -2499,36 +2499,36 @@ class AbstractFetcherThreadTest {
    * Slow Local Segment Deletion
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
    *   when the leader's logical log start offset is higher than its local log start offset due to
    *   a lag in local segment deletion after tiering.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **110** (non-zero)
-   * - Leader LocalLogStartOffset: **100** (less than LogStartOffset, indicating slow local segment deletion)
-   * - EarliestPendingUploadOffset: **150** (segments up to this offset are already tiered)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **110** (non-zero)
+   *  - Leader LocalLogStartOffset: **100** (less than LogStartOffset, indicating slow local segment deletion)
+   *  - EarliestPendingUploadOffset: **150** (segments up to this offset are already tiered)
    *
    * Scenario:
-   * - The leader's local log contains record batches starting from offset 100
-   * - The leader's logical log starts at offset 110 (implying offsets 100-109 are deleted logically but not physically)
-   * - Segments up to offset 150 have been uploaded to tiered storage
-   * - This represents a leader where segment deletion is lagging behind the logical truncation point
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader's local log contains record batches starting from offset 100
+   *  - The leader's logical log starts at offset 110 (implying offsets 100-109 are deleted logically but not physically)
+   *  - Segments up to offset 150 have been uploaded to tiered storage
+   *  - This represents a leader where segment deletion is lagging behind the logical truncation point
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower initializes based on tiered offsets:
+   *  - Follower initializes based on tiered offsets:
    *    - LocalLogStartOffset initializes to 150 (earliestPendingUploadOffset)
    *    - LogEndOffset initially set to 150 as well
    *    - No records fetched in first call
-   * 2. After additional fetch operations:
+   *  - After additional fetch operations:
    *    - LogStartOffset is properly set to 110 (matching leader's logical start)
    *    - LocalLogStartOffset remains at 150 (based on tiered storage boundary)
    *    - LogEndOffset advances to 200 after fetching all records
-   * 3. Follower correctly fetches only the non-tiered segments (150-199)
-   * 4. Follower properly ignores leader's locally retained but logically deleted segments (100-109)
-   * 5. HighWatermark aligns with leader (199)
+   *  - Follower correctly fetches only the non-tiered segments (150-199)
+   *  - Follower properly ignores leader's locally retained but logically deleted segments (100-109)
+   *  - HighWatermark aligns with leader (199)
    */
   @Test
   def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroSlowLocalSegmentDeletion(): Unit = {
@@ -2579,37 +2579,37 @@ class AbstractFetcherThreadTest {
    * Than Leader LogStartOffset
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
    *   when the leader's earliest pending upload offset is less than its log start offset
    *   (a scenario that can occur after log truncation).
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **100** (non-zero)
-   * - Leader LocalLogStartOffset: **100** (equals LogStartOffset)
-   * - EarliestPendingUploadOffset: **50** (less than LogStartOffset, indicating truncation)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **100** (non-zero)
+   *  - Leader LocalLogStartOffset: **100** (equals LogStartOffset)
+   *  - EarliestPendingUploadOffset: **50** (less than LogStartOffset, indicating truncation)
    *
    * Scenario:
-   * - The leader's local log contains record batches starting from offset 100
-   * - The leader reports earliestPendingUploadOffset as 50, which is less than its LogStartOffset of 100
-   * - This represents a case where segments that were pending upload were truncated
-   *   or where offsets were adjusted after a leader change
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader's local log contains record batches starting from offset 100
+   *  - The leader reports earliestPendingUploadOffset as 50, which is less than its LogStartOffset of 100
+   *  - This represents a case where segments that were pending upload were truncated
+   *    or where offsets were adjusted after a leader change
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower initialization prioritizes leader's log start offset:
+   *  - Follower initialization prioritizes leader's log start offset:
    *    - LocalLogStartOffset initializes to 100 (leader's LogStartOffset)
    *    - LogEndOffset initially set to 100 as well
    *    - No records fetched in first call
-   * 2. After additional fetch operations:
+   *  - After additional fetch operations:
    *    - LogStartOffset remains at 100 (matching leader's logical start)
    *    - LocalLogStartOffset remains at 100
    *    - LogEndOffset advances to 200 after fetching all records
-   * 3. Follower correctly ignores the anomalous earliestPendingUploadOffset (50)
+   *  - Follower correctly ignores the anomalous earliestPendingUploadOffset (50)
    *    and uses the leader's LogStartOffset (100) as the fetch starting point
-   * 4. All 3 record batches are fetched from the leader (100, 150, 199)
-   * 5. HighWatermark aligns with leader (199)
+   *  - All 3 record batches are fetched from the leader (100, 150, 199)
+   *  - HighWatermark aligns with leader (199)
    */
   @Test
   def testEmptyFollowerFetchLastTieredOffsetEarliestOffsetToUploadLessThanLeaderLogStartOffset(): Unit = {
@@ -2657,36 +2657,36 @@ class AbstractFetcherThreadTest {
    * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Retryable Remote Storage Exception
    *
    * Purpose:
-   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
    *   when there's a temporary failure accessing the remote tiered storage.
    *
    * Conditions:
-   * - TieredStorage: **Enabled**
-   * - Replica Start offset Strategy: **TieredOffset**
-   * - Leader LogStartOffset: **0**
-   * - Leader LocalLogStartOffset: **0** (equals LogStartOffset)
-   * - EarliestPendingUploadOffset: **150**
-   * - Remote Storage: **Temporarily unavailable** (throws RetriableRemoteStorageException)
+   *  - TieredStorage: **Enabled**
+   *  - Should replica from the last tiered offset: **True**
+   *  - Leader LogStartOffset: **0**
+   *  - Leader LocalLogStartOffset: **0** (equals LogStartOffset)
+   *  - EarliestPendingUploadOffset: **150**
+   *  - Remote Storage: **Temporarily unavailable** (throws RetriableRemoteStorageException)
    *
    * Scenario:
-   * - The leader's local log contains record batches starting from offset 0
-   * - The leader reports earliestPendingUploadOffset as 150, indicating tiered storage is being used
-   * - When attempting to build the remote log state, a RetriableRemoteStorageException is thrown
-   * - This represents a temporary failure in accessing the remote storage service
-   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *  - The leader's local log contains record batches starting from offset 0
+   *  - The leader reports earliestPendingUploadOffset as 150, indicating tiered storage is being used
+   *  - When attempting to build the remote log state, a RetriableRemoteStorageException is thrown
+   *  - This represents a temporary failure in accessing the remote storage service
+   *  - The follower starts with an empty log and starts data replication from the last tiered offset
    *
    * Expected Outcomes:
-   * 1. Follower correctly handles the temporary remote storage failure:
+   *  - Follower correctly handles the temporary remote storage failure:
    *    - The partition is NOT marked as failed (since the error is retryable)
    *    - Remains in FETCHING state
    *    - Fetch offset remains unchanged at 0
-   * 2. Follower schedules a retry:
+   *  - Follower schedules a retry:
    *    - Sets a delay before the next fetch attempt
    *    - Preserves the fetchOffset and other state for retry
-   * 3. Follower's log state remains unchanged during the error:
+   *  - Follower's log state remains unchanged during the error:
    *    - LogEndOffset remains at 0
    *    - No records are fetched until remote storage is accessible
-   * 4. The leader epoch tracking is maintained (lastFetchedEpoch = 0)
+   *  - The leader epoch tracking is maintained (lastFetchedEpoch = 0)
    */
   @Test
   @Disabled

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -26,15 +26,17 @@ import org.apache.kafka.common.requests.FetchRequest
 import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
-import org.apache.kafka.storage.internals.log.LogAppendInfo
+import org.apache.kafka.storage.internals.log.{LogAppendInfo, UnifiedLog}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{BeforeEach, Disabled, Test}
 import kafka.server.FetcherThreadTestUtils.{initialFetchState, mkBatch}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
+import org.apache.kafka.server.log.remote.storage.RetriableRemoteStorageException
 import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import java.lang
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable.ArrayBuffer
@@ -1739,5 +1741,1008 @@ class AbstractFetcherThreadTest {
     assertEquals(151, replicaState.localLogStartOffset)
     assertEquals(151, replicaState.logEndOffset)
     assertEquals(151, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset = 0, and
+   * All Local Segments Retained
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
+   *   and all local log segments are retained.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **0** (all segments retained locally)
+   * - Replica Start offset Strategy: **TieredOffset**
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 0
+   * - Some segments are uploaded to tiered storage (with earliestPendingUploadOffset = 150)
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower adapts to tiered storage configuration:
+   *    - LogStartOffset remains 0
+   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 2. HighWatermark aligns with the leader (199)
+   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   */
+  @Test
+  @Disabled
+  // KIP extension required for LSO = LLSO
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroAllLocalSegmentsRetained(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 0
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from the Last Tiered Offset, Leader LogStartOffset = 0,
+   * and All Local Segments Deleted
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
+   *   but local segments below a certain offset have been deleted.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **100** (segments below offset 100 deleted locally)
+   * - EarliestPendingUploadOffset: **150**
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
+   * - Some segments are pending upload to tiered storage (from offset 150)
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower adapts to tiered storage configuration:
+   *    - LogStartOffset initializes to 0 (matching leader's logical start)
+   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 2. HighWatermark aligns with the leader (199)
+   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   * 4. The follower correctly handles the gap between LogStartOffset (0) and LocalLogStartOffset (150)
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroAllLocalSegmentsDeleted(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 100
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    leaderState.logStartOffset = 0
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
+   * and All Local Segments Retained
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
+   *   and all local log segments from the start offset are retained.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **10** (non-zero)
+   * - Leader LocalLogStartOffset: **10** (equal to LogStartOffset, all segments retained)
+   * - EarliestPendingUploadOffset: **150**
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 10 (non-zero start)
+   * - Some segments are pending upload to tiered storage (from offset 150)
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower adapts to tiered storage configuration:
+   *    - LogStartOffset initializes to 10 (matching leader's logical start)
+   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 2. HighWatermark aligns with the leader (199)
+   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   * 4. The follower correctly handles the gap between LogStartOffset (10) and LocalLogStartOffset (150)
+   *    when segments in that range exist in tiered storage
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroAllLocalSegmentsRetained(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
+   * and All Local Segments Deleted
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
+   *   and local segments between log start offset and a higher offset have been deleted.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **10** (non-zero)
+   * - Leader LocalLogStartOffset: **100** (segments between 10 and 100 deleted locally)
+   * - EarliestPendingUploadOffset: **150**
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
+   * - Some segments are pending upload to tiered storage (from offset 150)
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower adapts to tiered storage configuration:
+   *    - LogStartOffset initializes to 10 (matching leader's logical start)
+   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 2. HighWatermark aligns with the leader (199)
+   * 3. Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
+   * 4. The follower correctly handles two gaps:
+   *    - Between LogStartOffset (10) and leader's LocalLogStartOffset (100)
+   *    - Between leader's LocalLogStartOffset (100) and EarliestPendingUploadOffset (150)
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroAllLocalSegmentsDeleted(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 100
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset - All Leader Segments Deleted Locally
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset and all leader's segments
+   *   have been uploaded to tiered storage and deleted locally (complete local emptiness).
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **Parameterized (0 or 10)**
+   * - Leader LocalLogStartOffset: **151** (equals LogEndOffset)
+   * - EarliestPendingUploadOffset: **151** (all segments uploaded)
+   *
+   * Scenario:
+   * - The leader has historical record batches (at offsets 100 and 150)
+   * - All segments have been uploaded to tiered storage and deleted locally
+   * - LocalLogStartOffset equals LogEndOffset (151), indicating empty local storage
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   * - The test is parameterized to run with LogStartOffset values of 0 and 10
+   *
+   * Expected Outcomes:
+   * 1. Follower properly adapts to leader's empty local state:
+   *    - LogStartOffset initializes to match leader's (0 or 10)
+   *    - LocalLogStartOffset and LogEndOffset both set to 151 (matching leader)
+   *    - HighWatermark sets to 151 (matching leader)
+   * 2. No record batches are fetched (log size remains 0)
+   * 3. Follower remains in FETCHING state but doesn't receive any data
+   * 4. Subsequent fetch operations don't change the follower's state
+   * 5. Follower correctly handles the gap between LogStartOffset and LocalLogStartOffset
+   *    when all segments are in tiered storage only
+   */
+  @ParameterizedTest
+  @ValueSource(longs = Array(0, 10))
+  def testEmptyFollowerFetchLastTieredOffsetAllLeaderSegmentsDeletedLocally(offsetToStartLog : Long): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 100
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 151L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 151
+    )
+    leaderState.logStartOffset = offsetToStartLog
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    // Replica log is truncated and fetch offset updated
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(151, replicaState.localLogStartOffset)
+    assertEquals(151, replicaState.logEndOffset)
+    assertEquals(151, replicaState.highWatermark)
+
+    // Call once again to see if new data is received
+    fetcher.doWork()
+    // No metadata update expected
+    assertEquals(0, replicaState.log.size)
+    assertEquals(offsetToStartLog, replicaState.logStartOffset)
+    assertEquals(151, replicaState.localLogStartOffset)
+    assertEquals(151, replicaState.logEndOffset)
+    assertEquals(151, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with Tiered Storage Disabled, fetch from Last Tiered Offset enabled, and Leader LogStartOffset Zero
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled,
+   *   and the leader's log starts at offset zero.
+   *
+   * Conditions:
+   * - TieredStorage: **Disabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
+   * - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 0
+   * - Tiered storage is disabled, so all segments are local
+   * - The follower starts with an empty log but enabled with data replication from the last tiered offset
+   * - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
+   *   standard fetch
+   *
+   * Expected Outcomes:
+   * 1. Follower adapts to non-tiered environment despite fetch from last tiered offset enabled:
+   *    - LogStartOffset initializes to 0 (matching leader's start)
+   *    - LocalLogStartOffset equals LogStartOffset (0)
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 2. HighWatermark aligns with the leader (199)
+   * 3. All segments are fetched sequentially from the beginning:
+   *    - First fetch: 1 record batch, logEndOffset = 1
+   *    - After additional fetches: 3 record batches, logEndOffset = 200
+   * 4. Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
+   *    pattern when tiered storage is disabled
+   */
+  @Test
+  def testEmptyFollowerFetchTieredStorageDisabledTieredOffsetStrategyLeaderLogStartOffsetZero(): Unit = {
+    val rlmEnabled = false
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 0
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(1, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(1, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with Tiered Storage Disabled, fetch from Last Tiered Offset enabled, and Leader LogStartOffset Non-Zero
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled
+   *   and the leader's log starts at a non-zero offset.
+   *
+   * Conditions:
+   * - TieredStorage: **Disabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **10** (non-zero)
+   * - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
+   * - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 10 (non-zero)
+   * - Tiered storage is disabled, so all segments are local
+   * - The follower starts with an empty log but enabled with data replication from the last tiered offset
+   * - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
+   *   standard fetch
+   *
+   * Expected Outcomes:
+   * 1. Follower adapts to non-tiered environment despite tiered strategy:
+   *    - LogStartOffset initializes to 10 (matching leader's start)
+   *    - LogEndOffset initially sets to 10, then advances as records are fetched
+   *    - After all fetches, LogEndOffset reaches 200
+   * 2. HighWatermark aligns with the leader (199)
+   * 3. All segments are fetched sequentially from the leader's start offset:
+   *    - First fetch: logEndOffset = 10, but no records fetched yet
+   *    - After additional fetches: 3 record batches, logEndOffset = 200
+   * 4. Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
+   *    pattern when tiered storage is disabled, properly handling non-zero start offsets
+   */
+  @Test
+  def testEmptyFollowerFetchTieredStorageDisabledTieredOffsetStrategyLeaderLogStartOffsetNonZero(): Unit = {
+    val rlmEnabled = false
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
+   * No Segments Uploaded
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *   when the leader's log starts at a non-zero offset but no segments have been uploaded to tiered storage.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **10** (non-zero)
+   * - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
+   * - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 10 (non-zero)
+   * - Tiered storage is enabled, but no segments have been uploaded or are pending upload
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   * - With no segments in tiered storage, follower should replicate from leader's start offset
+   *
+   * Expected Outcomes:
+   * 1. Follower properly initializes with leader's state:
+   *    - LogStartOffset initializes to 10 (matching leader's start)
+   *    - LocalLogStartOffset equals LogStartOffset (10)
+   *    - LogEndOffset initially sets to 10, then advances as records are fetched
+   * 2. HighWatermark initially set to 10, then aligned with leader (199) after fetching
+   * 3. All segments are fetched sequentially from the leader's start offset:
+   *    - First fetch: logEndOffset = 10, but no records fetched yet
+   *    - After additional fetches: 3 record batches, logEndOffset = 200
+   * 4. When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
+   *    correctly falls back to fetching all segments from the logical start offset
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroNoSegmentsUploaded(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      // Leader has not uploaded any log segments, hence the offset is -1
+      earliestPendingUploadOffset = -1
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(10, replicaState.highWatermark)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Zero,
+   * No Segments Uploaded
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *   when the leader's log starts at offset zero and no segments have been uploaded to tiered storage.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
+   * - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
+   *
+   * Scenario:
+   * - The leader log contains record batches starting from offset 0
+   * - Tiered storage is enabled, but no segments have been uploaded or are pending upload
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   * - With no segments in tiered storage, follower should replicate from leader's start offset (0)
+   *
+   * Expected Outcomes:
+   * 1. Follower properly initializes with leader's state:
+   *    - LogStartOffset initializes to 0 (matching leader's start)
+   *    - LocalLogStartOffset equals LogStartOffset (0)
+   *    - First fetch returns 1 record batch, setting logEndOffset to 1
+   * 2. HighWatermark immediately aligned with leader (199) after first fetch
+   * 3. All segments are fetched sequentially from the leader's start offset:
+   *    - First fetch: 1 record batch, logEndOffset = 1
+   *    - After additional fetches: 3 record batches, logEndOffset = 200
+   * 4. When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
+   *    correctly falls back to traditional fetch behavior from offset 0
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroNoSegmentsUploaded(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 0
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      // Leader has not uploaded any log segments, hence the offset is -1
+      earliestPendingUploadOffset = -1
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(1, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(1, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
+   * Segments Uploaded and a newly elected Leader
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *   when the leader is newly elected and has local segments that start after the logical log start offset,
+   *   but doesn't yet have information about tiered segments.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **10** (non-zero)
+   * - Leader LocalLogStartOffset: **100** (greater than LogStartOffset, indicating tiered segments should exist)
+   * - EarliestPendingUploadOffset: **-1** (leader doesn't know about tiered segments yet)
+   *
+   * Scenario:
+   * - The leader's local log contains record batches starting from offset 100
+   * - The leader's logical log starts at offset 10 (implying offsets 10-99 should be in tiered storage)
+   * - However, leader reports earliestPendingUploadOffset as -1, indicating it's not aware of tiered segments
+   * - This represents a newly elected leader that hasn't completed initialization of tiered storage state
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower detects the inconsistent state and responds properly:
+   *    - Remains in FETCHING state but doesn't fetch any records
+   *    - Fetch offset remains at 0 (unchanged)
+   *    - Sets a delay before retry to allow leader to complete initialization
+   * 2. Follower's state remains unchanged:
+   *    - LogEndOffset remains at 0
+   *    - No records are fetched until leader initializes properly
+   * 3. The fetch will be retried after some delay, allowing leader time to initialize
+   * 4. This graceful handling prevents replication issues during leader transition
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroSegmentsUploadedNewlyElectedLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 100
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      // Leader has not uploaded any log segments, hence the offset is -1
+      earliestPendingUploadOffset = -1
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+
+    fetcher.doWork()
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    // Fetch offset remains unchanged
+    assertEquals(0, fetchStateOpt.get.fetchOffset)
+    // Lag remains unchanged
+    assertTrue(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    // Fetch will be retried after some delay
+    assertTrue(fetchStateOpt.get.delay.isPresent)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+
+    // LogEndOffset is unchanged
+    assertEquals(0, replicaState.logEndOffset)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
+   * Slow Local Segment Deletion
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *   when the leader's logical log start offset is higher than its local log start offset due to
+   *   a lag in local segment deletion after tiering.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **110** (non-zero)
+   * - Leader LocalLogStartOffset: **100** (less than LogStartOffset, indicating slow local segment deletion)
+   * - EarliestPendingUploadOffset: **150** (segments up to this offset are already tiered)
+   *
+   * Scenario:
+   * - The leader's local log contains record batches starting from offset 100
+   * - The leader's logical log starts at offset 110 (implying offsets 100-109 are deleted logically but not physically)
+   * - Segments up to offset 150 have been uploaded to tiered storage
+   * - This represents a leader where segment deletion is lagging behind the logical truncation point
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower initializes based on tiered offsets:
+   *    - LocalLogStartOffset initializes to 150 (earliestPendingUploadOffset)
+   *    - LogEndOffset initially set to 150 as well
+   *    - No records fetched in first call
+   * 2. After additional fetch operations:
+   *    - LogStartOffset is properly set to 110 (matching leader's logical start)
+   *    - LocalLogStartOffset remains at 150 (based on tiered storage boundary)
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 3. Follower correctly fetches only the non-tiered segments (150-199)
+   * 4. Follower properly ignores leader's locally retained but logically deleted segments (100-109)
+   * 5. HighWatermark aligns with leader (199)
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroSlowLocalSegmentDeletion(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 100
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    // LogStartOffset > LocalLogStartOffset
+    leaderState.logStartOffset = 110
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(110, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Earliest Offset To Upload Less
+   * Than Leader LogStartOffset
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *   when the leader's earliest pending upload offset is less than its log start offset
+   *   (a scenario that can occur after log truncation).
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **100** (non-zero)
+   * - Leader LocalLogStartOffset: **100** (equals LogStartOffset)
+   * - EarliestPendingUploadOffset: **50** (less than LogStartOffset, indicating truncation)
+   *
+   * Scenario:
+   * - The leader's local log contains record batches starting from offset 100
+   * - The leader reports earliestPendingUploadOffset as 50, which is less than its LogStartOffset of 100
+   * - This represents a case where segments that were pending upload were truncated
+   *   or where offsets were adjusted after a leader change
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower initialization prioritizes leader's log start offset:
+   *    - LocalLogStartOffset initializes to 100 (leader's LogStartOffset)
+   *    - LogEndOffset initially set to 100 as well
+   *    - No records fetched in first call
+   * 2. After additional fetch operations:
+   *    - LogStartOffset remains at 100 (matching leader's logical start)
+   *    - LocalLogStartOffset remains at 100
+   *    - LogEndOffset advances to 200 after fetching all records
+   * 3. Follower correctly ignores the anomalous earliestPendingUploadOffset (50)
+   *    and uses the leader's LogStartOffset (100) as the fetch starting point
+   * 4. All 3 record batches are fetched from the leader (100, 150, 199)
+   * 5. HighWatermark aligns with leader (199)
+   */
+  @Test
+  def testEmptyFollowerFetchLastTieredOffsetEarliestOffsetToUploadLessThanLeaderLogStartOffset(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 100
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 50
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(100, replicaState.localLogStartOffset)
+    assertEquals(100, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(100, replicaState.logStartOffset)
+    assertEquals(100, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  /**
+   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Retryable Remote Storage Exception
+   *
+   * Purpose:
+   * - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
+   *   when there's a temporary failure accessing the remote tiered storage.
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - Replica Start offset Strategy: **TieredOffset**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **0** (equals LogStartOffset)
+   * - EarliestPendingUploadOffset: **150**
+   * - Remote Storage: **Temporarily unavailable** (throws RetriableRemoteStorageException)
+   *
+   * Scenario:
+   * - The leader's local log contains record batches starting from offset 0
+   * - The leader reports earliestPendingUploadOffset as 150, indicating tiered storage is being used
+   * - When attempting to build the remote log state, a RetriableRemoteStorageException is thrown
+   * - This represents a temporary failure in accessing the remote storage service
+   * - The follower starts with an empty log and starts data replication from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower correctly handles the temporary remote storage failure:
+   *    - The partition is NOT marked as failed (since the error is retryable)
+   *    - Remains in FETCHING state
+   *    - Fetch offset remains unchanged at 0
+   * 2. Follower schedules a retry:
+   *    - Sets a delay before the next fetch attempt
+   *    - Preserves the fetchOffset and other state for retry
+   * 3. Follower's log state remains unchanged during the error:
+   *    - LogEndOffset remains at 0
+   *    - No records are fetched until remote storage is accessible
+   * 4. The leader epoch tracking is maintained (lastFetchedEpoch = 0)
+   */
+  @Test
+  @Disabled
+  // KIP extension required for LSO = LLSO
+  def testEmptyFollowerFetchLastTieredOffsetRetryableRemoteStorageException(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint) {
+      override def buildRemoteLogAuxState(topicPartition: TopicPartition,
+                                          currentLeaderEpoch: Integer,
+                                          leaderLocalLogStartOffset: lang.Long,
+                                          epochForLeaderLocalLogStartOffset: Integer,
+                                          leaderLogStartOffset: lang.Long,
+                                          unifiedLog: UnifiedLog): lang.Long = {
+        throw new RetriableRemoteStorageException("Retryable exception")
+      }
+    }
+    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 0
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    // Should not be marked as failed
+    assertFalse(failedPartitions.contains(partition))
+
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    // Fetch offset remains unchanged
+    assertEquals(0, fetchStateOpt.get.fetchOffset)
+    // Lag remains unchanged
+    assertTrue(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    // Fetch will be retried after some delay
+    assertTrue(fetchStateOpt.get.delay.isPresent)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+
+    // LogEndOffset is unchanged
+    assertEquals(0, replicaState.logEndOffset)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -1742,6 +1742,35 @@ class AbstractFetcherThreadTest {
     assertEquals(151, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Empty Leader Log
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when fetching from last tiered offset with an empty leader log
+   * - Test scenario: Leader has no data and no segments uploaded
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty**
+   * - earliestPendingUploadOffset: **-1** (no upload information available)
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **0**
+   *
+   * Scenario:
+   * - The leader log is completely empty with no records
+   * - No segments have been uploaded to remote storage
+   * - The follower attempts to fetch from the last tiered offset
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. All offsets remain at 0:
+   *    - logStartOffset = 0
+   *    - localLogStartOffset = 0
+   *    - logEndOffset = 0
+   *    - highWatermark = 0
+   * 3. No data is fetched (log size = 0)
+   */
   @Test
   def testLastTieredOffsetWithEmptyLeaderLog(): Unit = {
     val rlmEnabled = true
@@ -1772,6 +1801,36 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with No Segments Uploaded
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has local data but no segments uploaded to remote storage
+   * - Test scenario: Leader has 3 record batches locally, but upload to tiered storage hasn't started yet
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **3 batches** at offsets 0, 150, 199
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **0**
+   * - earliestPendingUploadOffset: **-1** (no segments uploaded yet)
+   *
+   * Scenario:
+   * - The leader has local data (3 record batches)
+   * - No segments have been uploaded to remote storage yet (earliestPendingUploadOffset = -1)
+   * - The follower starts from offset 0 and fetches the local data
+   * - Since there's no gap between logStartOffset and where local log starts, fetching proceeds normally
+   *
+   * Expected Outcomes:
+   * 1. Follower successfully fetches from offset 0
+   * 2. After 3 doWork() calls, all 3 batches are fetched:
+   *    - log size = 3
+   *    - logStartOffset = 0
+   *    - localLogStartOffset = 0
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithNoSegmentsUploaded(): Unit = {
     val rlmEnabled = true
@@ -1813,6 +1872,36 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Partial Upload on New Leader (Gap Scenario)
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when new leader doesn't know upload state and there's a gap
+   * - Test scenario: Gap between logStartOffset (0) and where local log actually starts (10)
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **10** (local log starts at offset 10, creating a gap)
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know about previous uploads)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - A new leader takes over that has local log starting at offset 10
+   * - The logStartOffset is 0, but local log doesn't have data before offset 10
+   * - This creates a gap: logStartOffset (0) != where local log starts (10)
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Follower cannot safely determine where to fetch from
+   *
+   * Expected Outcomes:
+   * 1. Follower does NOT fetch immediately (gap scenario with unknown upload state)
+   * 2. Fetch state shows delayed retry:
+   *    - fetchOffset = 0 (unchanged)
+   *    - lag is empty
+   *    - delay is present (will retry after delay)
+   * 3. LogEndOffset remains 0
+   */
   @Test
   def testLastTieredOffsetWithPartialUploadOnNewLeader(): Unit = {
     val rlmEnabled = true
@@ -1856,6 +1945,41 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.logEndOffset)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Slow Partial Upload
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when upload to tiered storage is in progress but slow
+   * - Test scenario: Upload has just started, with earliestPendingUploadOffset matching local log start
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **10** (local log starts at offset 10)
+   * - earliestPendingUploadOffset: **10** (upload just started at offset 10)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader has uploaded segments before offset 10 to remote storage
+   * - Local log starts at offset 10 (earlier segments are in remote storage)
+   * - Upload is in progress with earliestPendingUploadOffset = 10 (slow upload - no progress yet)
+   * - Follower uses lastTieredOffset logic to determine fetch start point
+   * - Since earliestPendingUploadOffset is provided, follower can safely fetch from offset 10
+   *
+   * Expected Outcomes:
+   * 1. Follower starts fetching from offset 10 (lastTieredOffset logic)
+   * 2. First doWork() call:
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - fetchOffset = 10
+   * 3. After 3 additional doWork() calls, all data from offset 10 onwards is fetched:
+   *    - log size = 3
+   *    - logStartOffset = 0
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithSlowPartialUpload(): Unit = {
     val rlmEnabled = true
@@ -1899,6 +2023,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Fast Partial Upload
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when upload to tiered storage has made significant progress
+   * - Test scenario: Upload has progressed to offset 150, follower fetches only remaining data
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **10** (local log starts at offset 10)
+   * - earliestPendingUploadOffset: **150** (upload has progressed to offset 150 - fast upload)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader has uploaded segments up to offset 150 to remote storage
+   * - Local log starts at offset 10, but segments from 10-149 are uploaded
+   * - earliestPendingUploadOffset = 150 indicates upload has made significant progress
+   * - Follower uses lastTieredOffset logic to start from offset 150
+   * - Only remaining batches (150, 199) need to be fetched locally
+   *
+   * Expected Outcomes:
+   * 1. Follower starts fetching from offset 150 (lastTieredOffset logic)
+   * 2. First doWork() call:
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 150
+   *    - fetchOffset = 150
+   * 3. After 2 additional doWork() calls, only remaining batches are fetched:
+   *    - log size = 2 (only batches at 150 and 199)
+   *    - logStartOffset = 0
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithFastPartialUpload(): Unit = {
     val rlmEnabled = true
@@ -1942,6 +2101,39 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Full Upload Completed
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when all segments have been uploaded to remote storage
+   * - Test scenario: Leader has completed uploading all data, no local data remains to be fetched
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **10** (local log starts at offset 10)
+   * - earliestPendingUploadOffset: **200** (all segments uploaded - matches logEndOffset)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader has uploaded all segments to remote storage
+   * - earliestPendingUploadOffset = 200 indicates upload has completed up to logEndOffset
+   * - Local log starts at offset 10, but all data from 10-199 is already uploaded
+   * - Follower uses lastTieredOffset logic to determine it should start from offset 200
+   * - Since logEndOffset = earliestPendingUploadOffset = 200, there's no local data to fetch
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. Follower starts at offset 200 (end of uploaded data):
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - fetchOffset = 200
+   * 3. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   *    - logStartOffset = 0
+   *    - highWatermark = 200
+   */
   @Test
   def testLastTieredOffsetWithFullUploadCompleted(): Unit = {
     val rlmEnabled = true
@@ -1978,6 +2170,40 @@ class AbstractFetcherThreadTest {
     assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Inactive Leader and Full Upload on New Leader
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when new leader has empty log with all segments uploaded
+   * - Test scenario: New leader doesn't know upload state, creating a gap scenario
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (inactive leader - no local data)
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **200** (all local segments uploaded/deleted)
+   * - Leader LogEndOffset: **200**
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know about previous uploads)
+   *
+   * Scenario:
+   * - New leader takes over with empty local log
+   * - All data (0-199) has been uploaded to remote storage and deleted locally
+   * - logStartOffset = 0, but localLogStartOffset = 200 (creating a gap)
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Follower cannot safely determine where to fetch from due to gap and unknown upload state
+   *
+   * Expected Outcomes:
+   * 1. Follower does NOT fetch immediately (gap scenario with unknown upload state)
+   * 2. Fetch state shows delayed retry:
+   *    - fetchOffset = 0 (unchanged)
+   *    - lag is empty
+   *    - delay is present (will retry after delay)
+   *    - state = FETCHING
+   *    - currentLeaderEpoch = 0
+   *    - lastFetchedEpoch = 0
+   * 3. LogEndOffset remains 0 (no progress until upload state known)
+   */
   @Test
   def testLastTieredOffsetWithInactiveLeaderFullUploadOnNewLeader(): Unit = {
     val rlmEnabled = true
@@ -2019,6 +2245,40 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.logEndOffset)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Inactive Leader and Full Upload Completed
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has empty log with known full upload
+   * - Test scenario: Leader has empty log but knows all data is uploaded (earliestPendingUploadOffset = 200)
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (inactive leader - no local data)
+   * - Leader LogStartOffset: **0**
+   * - Leader LocalLogStartOffset: **200** (all local segments uploaded/deleted)
+   * - Leader LogEndOffset: **200**
+   * - earliestPendingUploadOffset: **200** (full upload completed - leader knows upload state)
+   *
+   * Scenario:
+   * - Leader has empty local log (all data uploaded and deleted locally)
+   * - All data (0-199) has been uploaded to remote storage
+   * - earliestPendingUploadOffset = 200 indicates leader knows about the completed upload
+   * - Follower uses lastTieredOffset logic to start from offset 200
+   * - Since all data is uploaded, no local fetching is needed
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. Follower adjusts to upload endpoint:
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - fetchOffset = 200
+   *    - highWatermark = 200
+   * 3. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   *    - logStartOffset = 0
+   */
   @Test
   def testLastTieredOffsetWithInactiveLeaderFullUpload(): Unit = {
     val rlmEnabled = true
@@ -2053,6 +2313,44 @@ class AbstractFetcherThreadTest {
     assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Empty Leader Log, Non-Zero LSO on New Leader
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has empty log with non-zero logStartOffset
+   * - Test scenario: Leader has no data with non-zero start offset, new leader scenario
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (no data)
+   * - Leader LogStartOffset: **10** (non-zero - segments 0-9 previously deleted)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no gap)
+   * - Leader LogEndOffset: **10**
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know upload state)
+   *
+   * Scenario:
+   * - Leader has empty log with logStartOffset = 10 (segments 0-9 were previously deleted/uploaded)
+   * - No gap exists (logStartOffset = localLogStartOffset = 10)
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Since there's no gap, follower can safely fetch from logStartOffset
+   * - Leader log is empty (logEndOffset = logStartOffset = 10), so no data to fetch
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to logStartOffset:
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - highWatermark = 10
+   *    - fetchOffset = 10
+   * 3. Second doWork() call confirms stable state:
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - highWatermark = 10
+   * 4. No batches are fetched (log is empty):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetWithEmptyLeaderLogNonZeroLSOOnNewLeader(): Unit = {
     val rlmEnabled = true
@@ -2094,6 +2392,44 @@ class AbstractFetcherThreadTest {
     assertEquals(10, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Empty Leader Log and Stale Upload Offset
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has empty log with stale upload offset
+   * - Test scenario: Stale upload offset is ignored in favor of logStartOffset
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (no data)
+   * - Leader LogStartOffset: **10** (non-zero - segments 0-9 previously deleted)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no gap)
+   * - Leader LogEndOffset: **10**
+   * - earliestPendingUploadOffset: **5** (stale - before logStartOffset of 10)
+   *
+   * Scenario:
+   * - Leader has empty log with logStartOffset = 10 (segments 0-9 previously deleted/uploaded)
+   * - earliestPendingUploadOffset = 5 is stale (before logStartOffset of 10)
+   * - Despite stale upload offset, presence of upload offset indicates leader knows about tiered storage
+   * - Follower ignores stale value and uses logStartOffset (10) to determine fetch point
+   * - Since logEndOffset = logStartOffset = 10, log is empty and no data to fetch
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to logStartOffset:
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - highWatermark = 10
+   *    - fetchOffset = 10
+   * 3. Second doWork() call confirms stable state:
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - highWatermark = 10
+   * 4. No batches are fetched (log is empty):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetWithEmptyLeaderLogStaleUploadOffset(): Unit = {
     val rlmEnabled = true
@@ -2135,6 +2471,39 @@ class AbstractFetcherThreadTest {
     assertEquals(10, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Non-Zero LSO on New Leader
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has non-zero logStartOffset without upload info
+   * - Test scenario: New leader with data but no upload information
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no deletions)
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know upload state)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 with local data available
+   * - No gap exists (logStartOffset = localLogStartOffset = 10)
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Since there's no gap, follower can safely fetch from logStartOffset
+   * - Follower calculates lag correctly as difference between logEndOffset and fetchOffset
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. Follower starts at logStartOffset:
+   *    - fetchOffset = 10
+   *    - lag is calculated correctly (190 = 200 - 10)
+   *    - state = FETCHING
+   *    - currentLeaderEpoch = 0
+   *    - lastFetchedEpoch = 0
+   * 3. LogEndOffset updates to logStartOffset:
+   *    - logEndOffset = 10
+   */
   @Test
   def testLastTieredOffsetWithNonZeroLSOOnNewLeader(): Unit = {
     val rlmEnabled = true
@@ -2172,6 +2541,42 @@ class AbstractFetcherThreadTest {
     assertEquals(10, replicaState.logEndOffset)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Non-Zero LSO and Stale Upload Offset
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has stale upload offset with non-zero LSO
+   * - Test scenario: Stale upload offset is ignored, follower fetches from logStartOffset
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no deletions)
+   * - earliestPendingUploadOffset: **5** (stale - before logStartOffset of 10)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 with local data available
+   * - earliestPendingUploadOffset = 5 is stale (before logStartOffset of 10)
+   * - Despite stale upload offset, presence of upload offset indicates leader knows about tiered storage
+   * - Follower ignores stale value and uses logStartOffset (10) to determine fetch point
+   * - Since logStartOffset = localLogStartOffset = 10 (no gap), follower can fetch from offset 10
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to logStartOffset:
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - highWatermark = 10
+   *    - fetchOffset = 10
+   * 3. After 3 additional doWork() calls, all 3 batches are fetched:
+   *    - log size = 3
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithNonZeroLSOStaleUploadOffset(): Unit = {
     val rlmEnabled = true
@@ -2214,6 +2619,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Slow Upload and No Local Deletion
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when upload is in progress (slow) with no local deletions
+   * - Test scenario: Upload has just started, follower fetches from upload point
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no deletions)
+   * - earliestPendingUploadOffset: **10** (slow upload - just started at offset 10)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 with local data available
+   * - Upload has just started with earliestPendingUploadOffset = 10 (slow upload - no progress yet)
+   * - Follower uses lastTieredOffset logic to determine fetch point
+   * - Since earliestPendingUploadOffset is provided, follower can safely fetch from offset 10
+   * - No segments have been uploaded yet (upload just starting)
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload point:
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - fetchOffset = 10
+   * 3. After 3 additional doWork() calls, all 3 batches are fetched:
+   *    - log size = 3
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithSlowUploadNoLocalDeletion(): Unit = {
     val rlmEnabled = true
@@ -2242,7 +2682,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(10, replicaState.localLogStartOffset)
     assertEquals(10, replicaState.logEndOffset)
@@ -2257,6 +2696,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Fast Upload and No Local Deletion
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when upload has made significant progress (fast)
+   * - Test scenario: Upload has progressed significantly, follower fetches only remaining data
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no deletions)
+   * - earliestPendingUploadOffset: **150** (fast upload - significant progress to offset 150)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 with local data available
+   * - Upload has progressed to offset 150 (fast upload - batch at offset 10 already uploaded)
+   * - Follower uses lastTieredOffset logic to start from earliestPendingUploadOffset
+   * - Only remaining batches (150, 199) need to be fetched locally
+   * - Batch at offset 10 is already uploaded to remote storage
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload point:
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 150
+   *    - fetchOffset = 150
+   * 3. After 2 additional doWork() calls, only remaining batches are fetched:
+   *    - log size = 2 (only batches at 150 and 199)
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithFastUploadNoLocalDeletion(): Unit = {
     val rlmEnabled = true
@@ -2285,7 +2759,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(150, replicaState.localLogStartOffset)
     assertEquals(150, replicaState.logEndOffset)
@@ -2300,6 +2773,42 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Full Upload and No Local Deletions
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when all segments are uploaded and no local deletions occurred
+   * - Test scenario: Leader log starts at non-zero offset with full upload completed
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **10** (no local deletions - same as logStartOffset)
+   * - earliestPendingUploadOffset: **200** (full upload completed - all data uploaded)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 (non-zero)
+   * - No local deletions have occurred (logStartOffset = localLogStartOffset = 10)
+   * - All segments have been uploaded to remote storage (earliestPendingUploadOffset = 200)
+   * - Follower uses lastTieredOffset logic to start from offset 200
+   * - Since all data is uploaded, no local fetching is needed
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts offsets to upload endpoint:
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - fetchOffset = 200
+   * 3. Second doWork() call updates logStartOffset:
+   *    - logStartOffset = 10 (leader's logStartOffset)
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   * 4. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetWithFullUploadNoLocalDeletion(): Unit = {
     val rlmEnabled = true
@@ -2328,7 +2837,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(200, replicaState.localLogStartOffset)
     assertEquals(200, replicaState.logEndOffset)
@@ -2342,6 +2850,36 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Partial Upload on New Leader (Non-Zero LSO, Gap Scenario)
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when new leader doesn't know upload state with non-zero log start
+   * - Test scenario: Gap between logStartOffset (10) and where local log actually starts (100)
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10**
+   * - Leader LocalLogStartOffset: **100** (local log starts at offset 100, creating a gap)
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know about previous uploads)
+   * - Leader has 3 batches at offsets 100, 150, 199
+   *
+   * Scenario:
+   * - A new leader takes over that has local log starting at offset 100
+   * - The logStartOffset is 10, but local log doesn't have data before offset 100
+   * - This creates a gap: logStartOffset (10) != where local log starts (100)
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Follower cannot safely determine where to fetch from
+   *
+   * Expected Outcomes:
+   * 1. Follower does NOT fetch immediately (gap scenario with unknown upload state)
+   * 2. Fetch state shows delayed retry:
+   *    - fetchOffset = 0 (unchanged)
+   *    - lag is empty
+   *    - delay is present (will retry after delay)
+   * 3. LogEndOffset remains 0
+   */
   @Test
   def testLastTieredOffsetWithPartialUploadOnNewLeaderNonZeroLSO(): Unit = {
     val rlmEnabled = true
@@ -2383,6 +2921,40 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.logEndOffset)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Partial Upload and Stale Upload Offset
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when earliestPendingUploadOffset is stale (before logStartOffset)
+   * - Test scenario: Upload offset is stale but local log starts at offset 100, follower can still fetch
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10**
+   * - Leader LocalLogStartOffset: **100** (local log starts at offset 100)
+   * - earliestPendingUploadOffset: **5** (stale - before logStartOffset of 10)
+   * - Leader has 3 batches at offsets 100, 150, 199
+   *
+   * Scenario:
+   * - Leader has earliestPendingUploadOffset = 5, which is stale (before logStartOffset of 10)
+   * - Despite stale upload offset, local log is available starting at offset 100
+   * - Follower ignores the stale upload offset and uses localLogStartOffset (100) to start fetching
+   * - The presence of a (even stale) upload offset indicates the leader knows about tiered storage
+   *
+   * Expected Outcomes:
+   * 1. Follower successfully fetches from offset 100 (ignores stale upload offset)
+   * 2. First doWork() call:
+   *    - localLogStartOffset = 100
+   *    - logEndOffset = 100
+   *    - fetchOffset = 100
+   * 3. After 3 additional doWork() calls, all 3 batches from offset 100 onwards are fetched:
+   *    - log size = 3
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 100
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithPartialUploadAndStaleUploadOffset(): Unit = {
     val rlmEnabled = true
@@ -2425,6 +2997,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Slow Upload and Non-Zero LSO
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when upload is slow with non-zero logStartOffset and local deletions
+   * - Test scenario: Upload just started at local log start point
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **100** (local deletions - local log starts at offset 100)
+   * - earliestPendingUploadOffset: **100** (slow upload - just started at offset 100)
+   * - Leader has 3 batches at offsets 100, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 (segments 0-9 previously deleted)
+   * - Local log starts at offset 100 due to local deletions (segments 10-99 deleted locally)
+   * - Upload has just started with earliestPendingUploadOffset = 100 (slow upload - no progress yet)
+   * - Follower uses lastTieredOffset logic to start from earliestPendingUploadOffset
+   * - All local data (100-199) needs to be fetched
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload point:
+   *    - localLogStartOffset = 100
+   *    - logEndOffset = 100
+   *    - fetchOffset = 100
+   * 3. After 3 additional doWork() calls, all 3 batches are fetched:
+   *    - log size = 3
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 100
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithSlowUploadNonZeroLSO(): Unit = {
     val rlmEnabled = true
@@ -2453,7 +3060,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(100, replicaState.localLogStartOffset)
     assertEquals(100, replicaState.logEndOffset)
@@ -2468,6 +3074,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Fast Upload and Non-Zero LSO
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when upload has made significant progress with non-zero LSO
+   * - Test scenario: Fast upload progress with non-zero logStartOffset
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **100** (local deletions - local log starts at offset 100)
+   * - earliestPendingUploadOffset: **150** (fast upload - progressed to offset 150)
+   * - Leader has 3 batches at offsets 100, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 (segments 0-9 previously deleted)
+   * - Local log starts at offset 100 due to local deletions (segments 10-99 deleted locally)
+   * - Upload has progressed to offset 150 (fast upload - batch at offset 100 already uploaded)
+   * - Follower uses lastTieredOffset logic to start from earliestPendingUploadOffset
+   * - Only remaining batches (150, 199) need to be fetched locally
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload point:
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 150
+   *    - fetchOffset = 150
+   * 3. After 2 additional doWork() calls, only remaining batches are fetched:
+   *    - log size = 2 (only batches at 150 and 199)
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetWithFastUploadNonZeroLSO(): Unit = {
     val rlmEnabled = true
@@ -2496,7 +3137,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(150, replicaState.localLogStartOffset)
     assertEquals(150, replicaState.logEndOffset)
@@ -2511,6 +3151,42 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Full Upload and Non-Zero Local Start Offset
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when full upload is completed with local deletions
+   * - Test scenario: Leader has non-zero logStartOffset with local log starting at higher offset
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **100** (local deletions - local log starts at offset 100)
+   * - earliestPendingUploadOffset: **200** (full upload completed - all data uploaded)
+   * - Leader has 3 batches at offsets 100, 150, 199
+   *
+   * Scenario:
+   * - Leader log starts at offset 10 (non-zero)
+   * - Local log starts at offset 100 due to local deletions (segments 10-99 deleted locally but in remote)
+   * - All segments have been uploaded to remote storage (earliestPendingUploadOffset = 200)
+   * - Follower uses lastTieredOffset logic to start from offset 200
+   * - Since all data is uploaded (even the locally deleted segments 10-99), no local fetching needed
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts offsets to upload endpoint:
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - fetchOffset = 200
+   * 3. Second doWork() call updates logStartOffset:
+   *    - logStartOffset = 10 (leader's logStartOffset)
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   * 4. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetWithFullUploadNonZeroLSO(): Unit = {
     val rlmEnabled = true
@@ -2539,7 +3215,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(200, replicaState.localLogStartOffset)
     assertEquals(200, replicaState.logEndOffset)
@@ -2553,6 +3228,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Inactive Leader, Full Upload, Non-Zero LSO on New Leader
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when new leader has empty log with non-zero logStartOffset
+   * - Test scenario: New leader doesn't know upload state with gap scenario
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (inactive leader - no local data)
+   * - Leader LogStartOffset: **10** (non-zero - segments 0-9 previously deleted)
+   * - Leader LocalLogStartOffset: **200** (all local segments uploaded/deleted)
+   * - Leader LogEndOffset: **200**
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know about previous uploads)
+   *
+   * Scenario:
+   * - New leader takes over with empty local log
+   * - logStartOffset = 10 (segments 0-9 were previously deleted)
+   * - All remaining data (10-199) has been uploaded to remote storage and deleted locally
+   * - localLogStartOffset = 200 (creating a gap: 10 != 200)
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Follower cannot safely determine where to fetch from due to gap and unknown upload state
+   *
+   * Expected Outcomes:
+   * 1. Follower does NOT fetch immediately (gap scenario with unknown upload state)
+   * 2. Fetch state shows delayed retry:
+   *    - fetchOffset = 0 (unchanged)
+   *    - lag is empty
+   *    - delay is present (will retry after delay)
+   *    - state = FETCHING
+   *    - currentLeaderEpoch = 0
+   *    - lastFetchedEpoch = 0
+   * 3. LogEndOffset remains 0 (no progress until upload state known)
+   */
   @Test
   def testLastTieredOffsetWithInactiveLeaderFullUploadNonZeroLSOOnNewLeader(): Unit = {
     val rlmEnabled = true
@@ -2592,6 +3302,43 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.logEndOffset)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Inactive Leader, Stale Upload Offset, Non-Zero LSO
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has empty log with stale upload offset
+   * - Test scenario: Leader has stale upload offset but follower can still determine fetch point
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (inactive leader - no local data)
+   * - Leader LogStartOffset: **10** (non-zero - segments 0-9 previously deleted)
+   * - Leader LocalLogStartOffset: **200** (all local segments uploaded/deleted)
+   * - Leader LogEndOffset: **200**
+   * - earliestPendingUploadOffset: **5** (stale - before logStartOffset of 10)
+   *
+   * Scenario:
+   * - Leader has empty local log (all data uploaded and deleted locally)
+   * - earliestPendingUploadOffset = 5 is stale (before logStartOffset of 10)
+   * - Despite stale upload offset, presence of upload offset indicates leader knows about tiered storage
+   * - Follower ignores stale value and uses localLogStartOffset (200) to determine fetch point
+   * - Since localLogStartOffset = logEndOffset = 200, all data is uploaded
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to localLogStartOffset:
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - highWatermark = 200
+   * 3. Second doWork() call updates logStartOffset:
+   *    - logStartOffset = 10 (leader's logStartOffset)
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   * 4. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetWithInactiveLeaderStaleUploadNonZeroLSO(): Unit = {
     val rlmEnabled = true
@@ -2632,6 +3379,44 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Inactive Leader, Full Upload, Non-Zero LSO
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when leader has empty log with known full upload and non-zero LSO
+   * - Test scenario: Leader has empty log but knows all data is uploaded with non-zero logStartOffset
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader log: **Empty** (inactive leader - no local data)
+   * - Leader LogStartOffset: **10** (non-zero - segments 0-9 previously deleted)
+   * - Leader LocalLogStartOffset: **200** (all local segments uploaded/deleted)
+   * - Leader LogEndOffset: **200**
+   * - earliestPendingUploadOffset: **200** (full upload completed - leader knows upload state)
+   *
+   * Scenario:
+   * - Leader has empty local log (all data uploaded and deleted locally)
+   * - logStartOffset = 10 (segments 0-9 were previously deleted)
+   * - All remaining data (10-199) has been uploaded to remote storage
+   * - earliestPendingUploadOffset = 200 indicates leader knows about the completed upload
+   * - Follower uses lastTieredOffset logic to start from offset 200
+   * - Since all data is uploaded, no local fetching is needed
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload endpoint:
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - fetchOffset = 200
+   * 3. Second doWork() call updates logStartOffset:
+   *    - logStartOffset = 10 (leader's logStartOffset)
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   * 4. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetWithInactiveLeaderFullUploadNonZeroLSO(): Unit = {
     val rlmEnabled = true
@@ -2659,7 +3444,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(200, replicaState.localLogStartOffset)
     assertEquals(200, replicaState.logEndOffset)
@@ -2673,6 +3457,39 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Stale Local Log Offset on New Leader
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when local log offset is stale (before logStartOffset)
+   * - Test scenario: New leader with stale local log offset creates gap scenario
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **5** (stale - before logStartOffset, creating inconsistency)
+   * - earliestPendingUploadOffset: **-1** (new leader doesn't know upload state)
+   * - Leader has 3 batches at offsets 5, 10, 199
+   *
+   * Scenario:
+   * - Leader has local log starting at offset 5 (before logStartOffset of 10)
+   * - This creates a stale/inconsistent state where localLogStartOffset < logStartOffset
+   * - New leader doesn't have upload information (earliestPendingUploadOffset = -1)
+   * - Follower cannot safely determine where to fetch from due to gap and unknown upload state
+   * - This is an unusual scenario where local log offset hasn't been updated properly
+   *
+   * Expected Outcomes:
+   * 1. Follower does NOT fetch immediately (gap scenario with unknown upload state)
+   * 2. Fetch state shows delayed retry:
+   *    - fetchOffset = 0 (unchanged)
+   *    - lag is empty
+   *    - delay is present (will retry after delay)
+   *    - state = FETCHING
+   *    - currentLeaderEpoch = 0
+   *    - lastFetchedEpoch = 0
+   * 3. LogEndOffset remains 0 (no progress until upload state known)
+   */
   @Test
   def testLastTieredOffsetStaleLocalLogOffsetNewLeader(): Unit = {
     val rlmEnabled = true
@@ -2714,6 +3531,41 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.logEndOffset)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Stale Local Log Offset and Slow Upload
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when local log offset is stale but upload info is available
+   * - Test scenario: Stale local log offset with known upload state allows fetching
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **5** (stale - before logStartOffset)
+   * - earliestPendingUploadOffset: **10** (slow upload - just started at offset 10)
+   * - Leader has 3 batches at offsets 5, 10, 199
+   *
+   * Scenario:
+   * - Leader has stale local log offset (5 < 10)
+   * - Upload has just started with earliestPendingUploadOffset = 10 (slow upload)
+   * - Despite stale local log offset, presence of upload offset indicates leader knows about tiered storage
+   * - Follower uses earliestPendingUploadOffset (10) to determine fetch point
+   * - Follower can safely fetch from offset 10 onwards
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload point:
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 10
+   *    - fetchOffset = 10
+   * 3. After 2 additional doWork() calls, 2 batches are fetched:
+   *    - log size = 2 (batches at 10 and 199)
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 10
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetStaleLocalLogOffsetSlowUpload():Unit = {
     val rlmEnabled = true
@@ -2742,7 +3594,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(10, replicaState.localLogStartOffset)
     assertEquals(10, replicaState.logEndOffset)
@@ -2756,6 +3607,41 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Stale Local Log Offset and Fast Upload
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when local log offset is stale with significant upload progress
+   * - Test scenario: Stale local log offset with fast upload allows fetching from upload point
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **5** (stale - before logStartOffset)
+   * - earliestPendingUploadOffset: **150** (fast upload - progressed to offset 150)
+   * - Leader has 4 batches at offsets 5, 10, 150, 199
+   *
+   * Scenario:
+   * - Leader has stale local log offset (5 < 10)
+   * - Upload has progressed to offset 150 (fast upload - batches at 5 and 10 already uploaded)
+   * - Despite stale local log offset, presence of upload offset indicates leader knows about tiered storage
+   * - Follower uses earliestPendingUploadOffset (150) to determine fetch point
+   * - Only remaining batches (150, 199) need to be fetched locally
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload point:
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 150
+   *    - fetchOffset = 150
+   * 3. After 2 additional doWork() calls, only remaining batches are fetched:
+   *    - log size = 2 (only batches at 150 and 199)
+   *    - logStartOffset = 10
+   *    - localLogStartOffset = 150
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   */
   @Test
   def testLastTieredOffsetStaleLocalLogOffsetFastUpload(): Unit = {
     val rlmEnabled = true
@@ -2785,7 +3671,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(150, replicaState.localLogStartOffset)
     assertEquals(150, replicaState.logEndOffset)
@@ -2799,6 +3684,42 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Stale Local Log Offset and Full Upload
+   *
+   * Purpose:
+   * - Validate follower fetch behavior when local log offset is stale with full upload completed
+   * - Test scenario: Stale local log offset with all data uploaded to remote storage
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **5** (stale - before logStartOffset)
+   * - earliestPendingUploadOffset: **200** (full upload completed - all data uploaded to remote)
+   * - Leader has 3 batches at offsets 5, 10, 199
+   *
+   * Scenario:
+   * - Leader has stale local log offset (5 < 10)
+   * - All data has been uploaded to remote storage (earliestPendingUploadOffset = 200)
+   * - Despite stale local log offset, presence of upload offset indicates leader knows about tiered storage
+   * - Follower uses earliestPendingUploadOffset (200) to determine fetch point
+   * - Since all data is uploaded (logEndOffset = earliestPendingUploadOffset = 200), no local fetching needed
+   *
+   * Expected Outcomes:
+   * 1. Follower fetch state transitions to FETCHING
+   * 2. First doWork() call adjusts to upload endpoint (200, not logStartOffset):
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - fetchOffset = 200
+   * 3. Second doWork() call updates logStartOffset:
+   *    - logStartOffset = 10 (leader's logStartOffset)
+   *    - localLogStartOffset = 200
+   *    - logEndOffset = 200
+   *    - highWatermark = 199
+   * 4. No batches are fetched (all data already uploaded):
+   *    - log size = 0
+   */
   @Test
   def testLastTieredOffsetStaleLocalLogOffsetFullUpload(): Unit = {
     val rlmEnabled = true
@@ -2827,7 +3748,6 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    // TODO: confirm log start offset
     assertEquals(0, replicaState.logStartOffset)
     assertEquals(200, replicaState.localLogStartOffset)
     assertEquals(200, replicaState.logEndOffset)
@@ -2841,6 +3761,42 @@ class AbstractFetcherThreadTest {
     assertEquals(199, replicaState.highWatermark)
   }
 
+  /**
+   * Test: Last Tiered Offset Fetch with Retriable Remote Storage Exception
+   *
+   * Purpose:
+   * - Validate follower error handling when tier state machine throws retriable remote storage exception
+   * - Test scenario: Retriable exception during tier state machine start should trigger retry, not failure
+   *
+   * Conditions:
+   * - TieredStorage: **Enabled**
+   * - fetchFromLastTieredOffset: **true**
+   * - Leader LogStartOffset: **10** (leader log starts at offset 10)
+   * - Leader LocalLogStartOffset: **10** (same as logStartOffset - no deletions)
+   * - earliestPendingUploadOffset: **150** (fast upload - progressed to offset 150)
+   * - Leader has 3 batches at offsets 10, 150, 199
+   * - Mock tier state machine throws RetriableRemoteStorageException during start()
+   *
+   * Scenario:
+   * - Follower attempts to fetch from last tiered offset
+   * - Tier state machine start() throws RetriableRemoteStorageException (simulating temporary remote storage issue)
+   * - Exception is retriable, so follower should enter delayed retry mode, NOT mark partition as failed
+   * - Follower will retry the operation after a delay
+   * - This tests proper error handling for transient remote storage failures
+   *
+   * Expected Outcomes:
+   * 1. Partition is NOT marked as failed:
+   *    - assertFalse(failedPartitions.contains(partition))
+   * 2. Follower enters delayed retry mode:
+   *    - fetchOffset = 0 (unchanged - no progress made)
+   *    - lag is empty (not calculated due to error)
+   *    - delay is present (will retry after delay)
+   *    - state = FETCHING (stays in FETCHING state)
+   *    - currentLeaderEpoch = 0
+   *    - lastFetchedEpoch = 0
+   * 3. LogEndOffset remains unchanged:
+   *    - logEndOffset = 0 (no progress until retry succeeds)
+   */
   @Test
   def testLastTieredOffsetRetryableRemoteStorageException(): Unit = {
     val rlmEnabled = true

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -26,9 +26,9 @@ import org.apache.kafka.common.requests.FetchRequest
 import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
-import org.apache.kafka.storage.internals.log.{LogAppendInfo, UnifiedLog}
+import org.apache.kafka.storage.internals.log.LogAppendInfo
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Disabled, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 import kafka.server.FetcherThreadTestUtils.{initialFetchState, mkBatch}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.server.log.remote.storage.RetriableRemoteStorageException
@@ -36,7 +36,6 @@ import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-import java.lang
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable.ArrayBuffer
@@ -1743,58 +1742,23 @@ class AbstractFetcherThreadTest {
     assertEquals(151, replicaState.highWatermark)
   }
 
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset = 0, and
-   * All Local Segments Retained
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
-   *   and all local log segments are retained.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Leader LogStartOffset: **0**
-   *  - Leader LocalLogStartOffset: **0** (all segments retained locally)
-   *  - Should replica from the last tiered offset: **True**
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 0
-   *  - Some segments are uploaded to tiered storage (with earliestPendingUploadOffset = 150)
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower adapts to tiered storage configuration:
-   *    - LogStartOffset remains 0
-   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - HighWatermark aligns with the leader (199)
-   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   */
   @Test
-  @Disabled
-  // KIP extension required for LSO = LLSO
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroAllLocalSegmentsRetained(): Unit = {
+  def testLastTieredOffsetWithEmptyLeaderLog(): Unit = {
     val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
 
     val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 0
-      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
+    // Empty Logs
+    val leaderLog = Seq()
     val leaderState = PartitionState(
       leaderLog,
       leaderEpoch = 0,
-      highWatermark = 199L,
+      highWatermark = 0L,
       rlmEnabled = rlmEnabled,
-      earliestPendingUploadOffset = 150
+      earliestPendingUploadOffset = -1
     )
     fetcher.mockLeader.setLeaderState(partition, leaderState)
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
@@ -1802,680 +1766,78 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(150, replicaState.logEndOffset)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 2) fetcher.doWork()
-    assertEquals(2, replicaState.log.size)
     assertEquals(0, replicaState.logStartOffset)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(0, replicaState.logEndOffset)
+    assertEquals(0, replicaState.highWatermark)
   }
 
-  /**
-   * Test: Empty Follower Fetch with data replication starting from the Last Tiered Offset, Leader LogStartOffset = 0,
-   * and All Local Segments Deleted
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at offset zero,
-   *   but local segments below a certain offset have been deleted.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **0**
-   *  - Leader LocalLogStartOffset: **100** (segments below offset 100 deleted locally)
-   *  - EarliestPendingUploadOffset: **150**
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
-   *  - Some segments are pending upload to tiered storage (from offset 150)
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower adapts to tiered storage configuration:
-   *    - LogStartOffset initializes to 0 (matching leader's logical start)
-   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - HighWatermark aligns with the leader (199)
-   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   *  - The follower correctly handles the gap between LogStartOffset (0) and LocalLogStartOffset (150)
-   */
   @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroAllLocalSegmentsDeleted(): Unit = {
+  def testLastTieredOffsetWithNoSegmentsUploaded(): Unit = {
     val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
 
     val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
     val leaderLog = Seq(
-      // LocalLogStartOffset = 100
-      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      // LogStartOffset = LocalLogStartOffset = 0
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
       mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
       mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
     )
-
     val leaderState = PartitionState(
       leaderLog,
       leaderEpoch = 0,
       highWatermark = 199L,
       rlmEnabled = rlmEnabled,
-      earliestPendingUploadOffset = 150
+      earliestPendingUploadOffset = -1
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(1, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(1, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll, so calling 'n' number of times to get the desired result
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(0, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithPartialUploadOnNewLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
     )
     leaderState.logStartOffset = 0
     fetcher.mockLeader.setLeaderState(partition, leaderState)
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(0, replicaState.log.size)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(150, replicaState.logEndOffset)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 2) fetcher.doWork()
-    assertEquals(2, replicaState.log.size)
-    assertEquals(0, replicaState.logStartOffset)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
-   * and All Local Segments Retained
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
-   *   and all local log segments from the start offset are retained.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **10** (non-zero)
-   *  - Leader LocalLogStartOffset: **10** (equal to LogStartOffset, all segments retained)
-   *  - EarliestPendingUploadOffset: **150**
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 10 (non-zero start)
-   *  - Some segments are pending upload to tiered storage (from offset 150)
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower adapts to tiered storage configuration:
-   *    - LogStartOffset initializes to 10 (matching leader's logical start)
-   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - HighWatermark aligns with the leader (199)
-   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   *  - The follower correctly handles the gap between LogStartOffset (10) and LocalLogStartOffset (150)
-   *    when segments in that range exist in tiered storage
-   */
-  @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroAllLocalSegmentsRetained(): Unit = {
-    val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 10
-      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled,
-      earliestPendingUploadOffset = 150
-    )
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(0, replicaState.log.size)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(150, replicaState.logEndOffset)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 2) fetcher.doWork()
-    assertEquals(2, replicaState.log.size)
-    assertEquals(10, replicaState.logStartOffset)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
-   * and All Local Segments Deleted
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset, the leader's log starts at a non-zero offset,
-   *   and local segments between log start offset and a higher offset have been deleted.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **10** (non-zero)
-   *  - Leader LocalLogStartOffset: **100** (segments between 10 and 100 deleted locally)
-   *  - EarliestPendingUploadOffset: **150**
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 100, with local segments below 100 deleted
-   *  - Some segments are pending upload to tiered storage (from offset 150)
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower adapts to tiered storage configuration:
-   *    - LogStartOffset initializes to 10 (matching leader's logical start)
-   *    - LocalLogStartOffset updates to 150 (matching the earliest pending upload offset)
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - HighWatermark aligns with the leader (199)
-   *  - Only segments after LocalLogStartOffset (150) are fetched, resulting in 2 record batches
-   *  - The follower correctly handles two gaps:
-   *    - Between LogStartOffset (10) and leader's LocalLogStartOffset (100)
-   *    - Between leader's LocalLogStartOffset (100) and EarliestPendingUploadOffset (150)
-   */
-  @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroAllLocalSegmentsDeleted(): Unit = {
-    val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LocalLogStartOffset = 100
-      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled,
-      earliestPendingUploadOffset = 150
-    )
-    leaderState.logStartOffset = 10
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(0, replicaState.log.size)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(150, replicaState.logEndOffset)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 2) fetcher.doWork()
-    assertEquals(2, replicaState.log.size)
-    assertEquals(10, replicaState.logStartOffset)
-    assertEquals(150, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset - All Leader Segments Deleted Locally
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset and all leader's segments
-   *   have been uploaded to tiered storage and deleted locally (complete local emptiness).
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **Parameterized (0 or 10)**
-   *  - Leader LocalLogStartOffset: **151** (equals LogEndOffset)
-   *  - EarliestPendingUploadOffset: **151** (all segments uploaded)
-   *
-   * Scenario:
-   *  - The leader has historical record batches (at offsets 100 and 150)
-   *  - All segments have been uploaded to tiered storage and deleted locally
-   *  - LocalLogStartOffset equals LogEndOffset (151), indicating empty local storage
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *  - The test is parameterized to run with LogStartOffset values of 0 and 10
-   *
-   * Expected Outcomes:
-   *  - Follower properly adapts to leader's empty local state:
-   *    - LogStartOffset initializes to match leader's (0 or 10)
-   *    - LocalLogStartOffset and LogEndOffset both set to 151 (matching leader)
-   *    - HighWatermark sets to 151 (matching leader)
-   *  - No record batches are fetched (log size remains 0)
-   *  - Follower remains in FETCHING state but doesn't receive any data
-   *  - Subsequent fetch operations don't change the follower's state
-   *  - Follower correctly handles the gap between LogStartOffset and LocalLogStartOffset
-   *    when all segments are in tiered storage only
-   */
-  @ParameterizedTest
-  @ValueSource(longs = Array(0, 10))
-  def testEmptyFollowerFetchLastTieredOffsetAllLeaderSegmentsDeletedLocally(offsetToStartLog : Long): Unit = {
-    val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LocalLogStartOffset = 100
-      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 151L,
-      rlmEnabled = rlmEnabled,
-      earliestPendingUploadOffset = 151
-    )
-    leaderState.logStartOffset = offsetToStartLog
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    // Replica log is truncated and fetch offset updated
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(0, replicaState.log.size)
-    assertEquals(151, replicaState.localLogStartOffset)
-    assertEquals(151, replicaState.logEndOffset)
-    assertEquals(151, replicaState.highWatermark)
-
-    // Call once again to see if new data is received
-    fetcher.doWork()
-    // No metadata update expected
-    assertEquals(0, replicaState.log.size)
-    assertEquals(offsetToStartLog, replicaState.logStartOffset)
-    assertEquals(151, replicaState.localLogStartOffset)
-    assertEquals(151, replicaState.logEndOffset)
-    assertEquals(151, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with Tiered Storage Disabled, fetch from Last Tiered Offset enabled, and Leader LogStartOffset Zero
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled,
-   *   and the leader's log starts at offset zero.
-   *
-   * Conditions:
-   *  - TieredStorage: **Disabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **0**
-   *  - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
-   *  - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 0
-   *  - Tiered storage is disabled, so all segments are local
-   *  - The follower starts with an empty log but enabled with data replication from the last tiered offset
-   *  - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
-   *   standard fetch
-   *
-   * Expected Outcomes:
-   *  - Follower adapts to non-tiered environment despite fetch from last tiered offset enabled:
-   *    - LogStartOffset initializes to 0 (matching leader's start)
-   *    - LocalLogStartOffset equals LogStartOffset (0)
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - HighWatermark aligns with the leader (199)
-   *  - All segments are fetched sequentially from the beginning:
-   *    - First fetch: 1 record batch, logEndOffset = 1
-   *    - After additional fetches: 3 record batches, logEndOffset = 200
-   *  - Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
-   *    pattern when tiered storage is disabled
-   */
-  @Test
-  def testEmptyFollowerFetchTieredStorageDisabledTieredOffsetStrategyLeaderLogStartOffsetZero(): Unit = {
-    val rlmEnabled = false
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 0
-      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled
-    )
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(1, replicaState.log.size)
-    assertEquals(0, replicaState.logStartOffset)
-    assertEquals(0, replicaState.localLogStartOffset)
-    assertEquals(1, replicaState.logEndOffset)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 2) fetcher.doWork()
-    assertEquals(3, replicaState.log.size)
-    assertEquals(0, replicaState.logStartOffset)
-    assertEquals(0, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with Tiered Storage Disabled, fetch from Last Tiered Offset enabled, and Leader LogStartOffset Non-Zero
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset but tiered storage is disabled
-   *   and the leader's log starts at a non-zero offset.
-   *
-   * Conditions:
-   *  - TieredStorage: **Disabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **10** (non-zero)
-   *  - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
-   *  - EarliestPendingUploadOffset: **N/A** (tiered storage disabled)
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 10 (non-zero)
-   *  - Tiered storage is disabled, so all segments are local
-   *  - The follower starts with an empty log but enabled with data replication from the last tiered offset
-   *  - Even though fetch from last tiered offset is enabled, with tiered storage disabled it should follow like
-   *   standard fetch
-   *
-   * Expected Outcomes:
-   *  - Follower adapts to non-tiered environment despite tiered strategy:
-   *    - LogStartOffset initializes to 10 (matching leader's start)
-   *    - LogEndOffset initially sets to 10, then advances as records are fetched
-   *    - After all fetches, LogEndOffset reaches 200
-   *  - HighWatermark aligns with the leader (199)
-   *  - All segments are fetched sequentially from the leader's start offset:
-   *    - First fetch: logEndOffset = 10, but no records fetched yet
-   *    - After additional fetches: 3 record batches, logEndOffset = 200
-   *  - Even with fetch from last tiered offset enabled, follower behavior matches traditional fetch
-   *    pattern when tiered storage is disabled, properly handling non-zero start offsets
-   */
-  @Test
-  def testEmptyFollowerFetchTieredStorageDisabledTieredOffsetStrategyLeaderLogStartOffsetNonZero(): Unit = {
-    val rlmEnabled = false
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 10
-      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled
-    )
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(0, replicaState.log.size)
-    assertEquals(10, replicaState.logStartOffset)
-    assertEquals(10, replicaState.logEndOffset)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 3) fetcher.doWork()
-    assertEquals(3, replicaState.log.size)
-    assertEquals(10, replicaState.logStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
-   * No Segments Uploaded
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *   when the leader's log starts at a non-zero offset but no segments have been uploaded to tiered storage.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **10** (non-zero)
-   *  - Leader LocalLogStartOffset: **10** (equals LogStartOffset, all segments retained)
-   *  - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 10 (non-zero)
-   *  - Tiered storage is enabled, but no segments have been uploaded or are pending upload
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *  - With no segments in tiered storage, follower should replicate from leader's start offset
-   *
-   * Expected Outcomes:
-   *  - Follower properly initializes with leader's state:
-   *    - LogStartOffset initializes to 10 (matching leader's start)
-   *    - LocalLogStartOffset equals LogStartOffset (10)
-   *    - LogEndOffset initially sets to 10, then advances as records are fetched
-   *  - HighWatermark initially set to 10, then aligned with leader (199) after fetching
-   *  - All segments are fetched sequentially from the leader's start offset:
-   *    - First fetch: logEndOffset = 10, but no records fetched yet
-   *    - After additional fetches: 3 record batches, logEndOffset = 200
-   *  - When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
-   *    correctly falls back to fetching all segments from the logical start offset
-   */
-  @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroNoSegmentsUploaded(): Unit = {
-    val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 10
-      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled,
-      // Leader has not uploaded any log segments, hence the offset is -1
-      earliestPendingUploadOffset = -1
-    )
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(0, replicaState.log.size)
-    assertEquals(10, replicaState.localLogStartOffset)
-    assertEquals(10, replicaState.logEndOffset)
-    assertEquals(10, replicaState.highWatermark)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 3) fetcher.doWork()
-    assertEquals(3, replicaState.log.size)
-    assertEquals(10, replicaState.logStartOffset)
-    assertEquals(10, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Zero,
-   * No Segments Uploaded
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *   when the leader's log starts at offset zero and no segments have been uploaded to tiered storage.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **0**
-   *  - Leader LocalLogStartOffset: **0** (equals LogStartOffset, all segments retained)
-   *  - EarliestPendingUploadOffset: **-1** (no segments uploaded or pending upload)
-   *
-   * Scenario:
-   *  - The leader log contains record batches starting from offset 0
-   *  - Tiered storage is enabled, but no segments have been uploaded or are pending upload
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *  - With no segments in tiered storage, follower should replicate from leader's start offset (0)
-   *
-   * Expected Outcomes:
-   *  - Follower properly initializes with leader's state:
-   *    - LogStartOffset initializes to 0 (matching leader's start)
-   *    - LocalLogStartOffset equals LogStartOffset (0)
-   *    - First fetch returns 1 record batch, setting logEndOffset to 1
-   *  - HighWatermark immediately aligned with leader (199) after first fetch
-   *  - All segments are fetched sequentially from the leader's start offset:
-   *    - First fetch: 1 record batch, logEndOffset = 1
-   *    - After additional fetches: 3 record batches, logEndOffset = 200
-   *  - When tiered storage is enabled but no segments are uploaded, and fetch from tiered offset enabled, it
-   *    correctly falls back to traditional fetch behavior from offset 0
-   */
-  @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetZeroNoSegmentsUploaded(): Unit = {
-    val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 0
-      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled,
-      // Leader has not uploaded any log segments, hence the offset is -1
-      earliestPendingUploadOffset = -1
-    )
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    fetcher.doWork()
-    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(1, replicaState.log.size)
-    assertEquals(0, replicaState.logStartOffset)
-    assertEquals(0, replicaState.localLogStartOffset)
-    assertEquals(1, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-
-    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
-    for (_ <- 1 to 2) fetcher.doWork()
-    assertEquals(3, replicaState.log.size)
-    assertEquals(0, replicaState.logStartOffset)
-    assertEquals(0, replicaState.localLogStartOffset)
-    assertEquals(200, replicaState.logEndOffset)
-    assertEquals(199, replicaState.highWatermark)
-  }
-
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
-   * Segments Uploaded and a newly elected Leader
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *    when the leader is newly elected and has local segments that start after the logical log start offset,
-   *    but doesn't yet have information about tiered segments.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **10** (non-zero)
-   *  - Leader LocalLogStartOffset: **100** (greater than LogStartOffset, indicating tiered segments should exist)
-   *  - EarliestPendingUploadOffset: **-1** (leader doesn't know about tiered segments yet)
-   *
-   * Scenario:
-   *  - The leader's local log contains record batches starting from offset 100
-   *  - The leader's logical log starts at offset 10 (implying offsets 10-99 should be in tiered storage)
-   *  - However, leader reports earliestPendingUploadOffset as -1, indicating it's not aware of tiered segments
-   *  - This represents a newly elected leader that hasn't completed initialization of tiered storage state
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower detects the inconsistent state and responds properly:
-   *    - Remains in FETCHING state but doesn't fetch any records
-   *    - Fetch offset remains at 0 (unchanged)
-   *    - Sets a delay before retry to allow leader to complete initialization
-   *  - Follower's state remains unchanged:
-   *    - LogEndOffset remains at 0
-   *    - No records are fetched until leader initializes properly
-   *  - The fetch will be retried after some delay, allowing leader time to initialize
-   *  - This graceful handling prevents replication issues during leader transition
-   */
-  @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroSegmentsUploadedNewlyElectedLeader(): Unit = {
-    val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
-
-    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
-    val leaderLog = Seq(
-      // LocalLogStartOffset = 100
-      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
-      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
-      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
-    )
-
-    val leaderState = PartitionState(
-      leaderLog,
-      leaderEpoch = 0,
-      highWatermark = 199L,
-      rlmEnabled = rlmEnabled,
-      // Leader has not uploaded any log segments, hence the offset is -1
-      earliestPendingUploadOffset = -1
-    )
-    leaderState.logStartOffset = 10
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
 
     fetcher.doWork()
     val fetchStateOpt = fetcher.fetchState(partition)
@@ -2494,59 +1856,64 @@ class AbstractFetcherThreadTest {
     assertEquals(0, replicaState.logEndOffset)
   }
 
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Leader LogStartOffset Non-Zero,
-   * Slow Local Segment Deletion
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *   when the leader's logical log start offset is higher than its local log start offset due to
-   *   a lag in local segment deletion after tiering.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **110** (non-zero)
-   *  - Leader LocalLogStartOffset: **100** (less than LogStartOffset, indicating slow local segment deletion)
-   *  - EarliestPendingUploadOffset: **150** (segments up to this offset are already tiered)
-   *
-   * Scenario:
-   *  - The leader's local log contains record batches starting from offset 100
-   *  - The leader's logical log starts at offset 110 (implying offsets 100-109 are deleted logically but not physically)
-   *  - Segments up to offset 150 have been uploaded to tiered storage
-   *  - This represents a leader where segment deletion is lagging behind the logical truncation point
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower initializes based on tiered offsets:
-   *    - LocalLogStartOffset initializes to 150 (earliestPendingUploadOffset)
-   *    - LogEndOffset initially set to 150 as well
-   *    - No records fetched in first call
-   *  - After additional fetch operations:
-   *    - LogStartOffset is properly set to 110 (matching leader's logical start)
-   *    - LocalLogStartOffset remains at 150 (based on tiered storage boundary)
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - Follower correctly fetches only the non-tiered segments (150-199)
-   *  - Follower properly ignores leader's locally retained but logically deleted segments (100-109)
-   *  - HighWatermark aligns with leader (199)
-   */
   @Test
-  def testEmptyFollowerFetchLastTieredOffsetLeaderLogStartOffsetNonZeroSlowLocalSegmentDeletion(): Unit = {
+  def testLastTieredOffsetWithSlowPartialUpload(): Unit = {
     val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
 
     val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
     val leaderLog = Seq(
-      // LocalLogStartOffset = 100
-      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      // LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
       mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
       mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
     )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 10
+    )
+    leaderState.logStartOffset = 0
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
 
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(Some(10), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithFastPartialUpload(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
     val leaderState = PartitionState(
       leaderLog,
       leaderEpoch = 0,
@@ -2554,86 +1921,278 @@ class AbstractFetcherThreadTest {
       rlmEnabled = rlmEnabled,
       earliestPendingUploadOffset = 150
     )
-    // LogStartOffset > LocalLogStartOffset
-    leaderState.logStartOffset = 110
+    leaderState.logStartOffset = 0
     fetcher.mockLeader.setLeaderState(partition, leaderState)
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
 
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
     assertEquals(150, replicaState.localLogStartOffset)
     assertEquals(150, replicaState.logEndOffset)
+    assertEquals(Some(150), fetcher.fetchState(partition).map(_.fetchOffset()))
 
     // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
     for (_ <- 1 to 2) fetcher.doWork()
     assertEquals(2, replicaState.log.size)
-    assertEquals(110, replicaState.logStartOffset)
+    assertEquals(0, replicaState.logStartOffset)
     assertEquals(150, replicaState.localLogStartOffset)
     assertEquals(200, replicaState.logEndOffset)
     assertEquals(199, replicaState.highWatermark)
   }
 
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Earliest Offset To Upload Less
-   * Than Leader LogStartOffset
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *   when the leader's earliest pending upload offset is less than its log start offset
-   *   (a scenario that can occur after log truncation).
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **100** (non-zero)
-   *  - Leader LocalLogStartOffset: **100** (equals LogStartOffset)
-   *  - EarliestPendingUploadOffset: **50** (less than LogStartOffset, indicating truncation)
-   *
-   * Scenario:
-   *  - The leader's local log contains record batches starting from offset 100
-   *  - The leader reports earliestPendingUploadOffset as 50, which is less than its LogStartOffset of 100
-   *  - This represents a case where segments that were pending upload were truncated
-   *    or where offsets were adjusted after a leader change
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower initialization prioritizes leader's log start offset:
-   *    - LocalLogStartOffset initializes to 100 (leader's LogStartOffset)
-   *    - LogEndOffset initially set to 100 as well
-   *    - No records fetched in first call
-   *  - After additional fetch operations:
-   *    - LogStartOffset remains at 100 (matching leader's logical start)
-   *    - LocalLogStartOffset remains at 100
-   *    - LogEndOffset advances to 200 after fetching all records
-   *  - Follower correctly ignores the anomalous earliestPendingUploadOffset (50)
-   *    and uses the leader's LogStartOffset (100) as the fetch starting point
-   *  - All 3 record batches are fetched from the leader (100, 150, 199)
-   *  - HighWatermark aligns with leader (199)
-   */
   @Test
-  def testEmptyFollowerFetchLastTieredOffsetEarliestOffsetToUploadLessThanLeaderLogStartOffset(): Unit = {
+  def testLastTieredOffsetWithFullUploadCompleted(): Unit = {
     val rlmEnabled = true
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
 
     val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
     val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 100
-      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      // LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
       mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
       mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
     )
-
     val leaderState = PartitionState(
       leaderLog,
       leaderEpoch = 0,
       highWatermark = 199L,
       rlmEnabled = rlmEnabled,
-      earliestPendingUploadOffset = 50
+      earliestPendingUploadOffset = 200
+    )
+    leaderState.logStartOffset = 0
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(200, replicaState.highWatermark)
+    assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
+  }
+
+  @Test
+  def testLastTieredOffsetWithInactiveLeaderFullUploadOnNewLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
+    )
+    leaderState.logStartOffset = 0
+    leaderState.localLogStartOffset = 200
+    leaderState.logEndOffset = 200
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    // Fetch offset remains unchanged
+    assertEquals(0, fetchStateOpt.get.fetchOffset)
+    // Lag remains unchanged
+    assertTrue(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    // Fetch will be retried after some delay
+    assertTrue(fetchStateOpt.get.delay.isPresent)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+
+    // LogEndOffset is unchanged
+    assertEquals(0, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testLastTieredOffsetWithInactiveLeaderFullUpload(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 200
+    )
+    leaderState.logStartOffset = 0
+    leaderState.localLogStartOffset = 200
+    leaderState.logEndOffset = 200
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(200, replicaState.highWatermark)
+    assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
+  }
+
+  @Test
+  def testLastTieredOffsetWithEmptyLeaderLogNonZeroLSOOnNewLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 10L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
+    )
+    leaderState.logStartOffset = 10
+    leaderState.localLogStartOffset = 10
+    leaderState.logEndOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(10, replicaState.highWatermark)
+    assertEquals(Some(10), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(10, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithEmptyLeaderLogStaleUploadOffset(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 10L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 5
+    )
+    leaderState.logStartOffset = 10
+    leaderState.localLogStartOffset = 10
+    leaderState.logEndOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(10, replicaState.highWatermark)
+    assertEquals(Some(10), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(10, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithNonZeroLSOOnNewLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    assertEquals(10, fetchStateOpt.get.fetchOffset)
+    assertFalse(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(190, fetchStateOpt.get.lag().get())
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+    assertEquals(10, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testLastTieredOffsetWithNonZeroLSOStaleUploadOffset(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 5
     )
     fetcher.mockLeader.setLeaderState(partition, leaderState)
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
@@ -2641,77 +2200,667 @@ class AbstractFetcherThreadTest {
     fetcher.doWork()
     assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
     assertEquals(0, replicaState.log.size)
-    assertEquals(100, replicaState.localLogStartOffset)
-    assertEquals(100, replicaState.logEndOffset)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(10, replicaState.highWatermark)
+    assertEquals(Some(10), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithSlowUploadNoLocalDeletion(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 10
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(Some(10), fetcher.fetchState(partition).map(_.fetchOffset()))
 
     // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
     for (_ <- 1 to 3) fetcher.doWork()
     assertEquals(3, replicaState.log.size)
-    assertEquals(100, replicaState.logStartOffset)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithFastUploadNoLocalDeletion(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+    assertEquals(Some(150), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithFullUploadNoLocalDeletion(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 200
+    )
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithPartialUploadOnNewLeaderNonZeroLSO(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    assertEquals(0, fetchStateOpt.get.fetchOffset)
+    assertTrue(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    // Fetch will be retried after some delay
+    assertTrue(fetchStateOpt.get.delay.isPresent)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+
+    // LogEndOffset is unchanged
+    assertEquals(0, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testLastTieredOffsetWithPartialUploadAndStaleUploadOffset(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 5
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(100, replicaState.localLogStartOffset)
+    assertEquals(100, replicaState.logEndOffset)
+    assertEquals(100, replicaState.highWatermark)
+    assertEquals(Some(100), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
     assertEquals(100, replicaState.localLogStartOffset)
     assertEquals(200, replicaState.logEndOffset)
     assertEquals(199, replicaState.highWatermark)
   }
 
-  /**
-   * Test: Empty Follower Fetch with data replication starting from Last Tiered Offset, Retryable Remote Storage Exception
-   *
-   * Purpose:
-   *  - Validate follower behavior when starting from the last tiered offset with tiered storage enabled,
-   *   when there's a temporary failure accessing the remote tiered storage.
-   *
-   * Conditions:
-   *  - TieredStorage: **Enabled**
-   *  - Should replica from the last tiered offset: **True**
-   *  - Leader LogStartOffset: **0**
-   *  - Leader LocalLogStartOffset: **0** (equals LogStartOffset)
-   *  - EarliestPendingUploadOffset: **150**
-   *  - Remote Storage: **Temporarily unavailable** (throws RetriableRemoteStorageException)
-   *
-   * Scenario:
-   *  - The leader's local log contains record batches starting from offset 0
-   *  - The leader reports earliestPendingUploadOffset as 150, indicating tiered storage is being used
-   *  - When attempting to build the remote log state, a RetriableRemoteStorageException is thrown
-   *  - This represents a temporary failure in accessing the remote storage service
-   *  - The follower starts with an empty log and starts data replication from the last tiered offset
-   *
-   * Expected Outcomes:
-   *  - Follower correctly handles the temporary remote storage failure:
-   *    - The partition is NOT marked as failed (since the error is retryable)
-   *    - Remains in FETCHING state
-   *    - Fetch offset remains unchanged at 0
-   *  - Follower schedules a retry:
-   *    - Sets a delay before the next fetch attempt
-   *    - Preserves the fetchOffset and other state for retry
-   *  - Follower's log state remains unchanged during the error:
-   *    - LogEndOffset remains at 0
-   *    - No records are fetched until remote storage is accessible
-   *  - The leader epoch tracking is maintained (lastFetchedEpoch = 0)
-   */
   @Test
-  @Disabled
-  // KIP extension required for LSO = LLSO
-  def testEmptyFollowerFetchLastTieredOffsetRetryableRemoteStorageException(): Unit = {
+  def testLastTieredOffsetWithSlowUploadNonZeroLSO(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 100
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(100, replicaState.localLogStartOffset)
+    assertEquals(100, replicaState.logEndOffset)
+    assertEquals(Some(100), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 3) fetcher.doWork()
+    assertEquals(3, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(100, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithFastUploadNonZeroLSO(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+    assertEquals(Some(150), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithFullUploadNonZeroLSO(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 100, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 200
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithInactiveLeaderFullUploadNonZeroLSOOnNewLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
+    )
+    leaderState.logStartOffset = 10
+    leaderState.localLogStartOffset = 200
+    leaderState.logEndOffset = 200
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    assertEquals(0, fetchStateOpt.get.fetchOffset)
+    assertTrue(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    // Fetch will be retried after some delay
+    assertTrue(fetchStateOpt.get.delay.isPresent)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+
+    // LogEndOffset is unchanged
+    assertEquals(0, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testLastTieredOffsetWithInactiveLeaderStaleUploadNonZeroLSO(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 5
+    )
+    leaderState.logStartOffset = 10
+    leaderState.localLogStartOffset = 200
+    leaderState.logEndOffset = 200
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(200, replicaState.highWatermark)
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetWithInactiveLeaderFullUploadNonZeroLSO(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    // Empty logs
+    val leaderLog = Seq()
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 200
+    )
+    leaderState.logStartOffset = 10
+    leaderState.localLogStartOffset = 200
+    leaderState.logEndOffset = 200
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetStaleLocalLogOffsetNewLeader(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = -1
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    val fetchStateOpt = fetcher.fetchState(partition)
+    assertTrue(fetchStateOpt.nonEmpty)
+    assertEquals(ReplicaState.FETCHING, fetchStateOpt.get.state)
+    assertEquals(0, fetchStateOpt.get.fetchOffset)
+    assertTrue(fetchStateOpt.get.lag.isEmpty)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    assertEquals(0, fetchStateOpt.get.currentLeaderEpoch)
+    // Fetch will be retried after some delay
+    assertTrue(fetchStateOpt.get.delay.isPresent)
+    assertEquals(Optional.of(0), fetchStateOpt.get.lastFetchedEpoch)
+
+    // LogEndOffset is unchanged
+    assertEquals(0, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testLastTieredOffsetStaleLocalLogOffsetSlowUpload():Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 10
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(10, replicaState.logEndOffset)
+    assertEquals(Some(10), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(10, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetStaleLocalLogOffsetFastUpload(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("e".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("f".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 150
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(150, replicaState.logEndOffset)
+    assertEquals(Some(150), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    for (_ <- 1 to 2) fetcher.doWork()
+    assertEquals(2, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(150, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetStaleLocalLogOffsetFullUpload(): Unit = {
+    val rlmEnabled = true
+    val partition = new TopicPartition("topic", 0);
+    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version)
+    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
+    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
+
+    val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
+      mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
+    )
+    val leaderState = PartitionState(
+      leaderLog,
+      leaderEpoch = 0,
+      highWatermark = 199L,
+      rlmEnabled = rlmEnabled,
+      earliestPendingUploadOffset = 200
+    )
+    leaderState.logStartOffset = 10
+    fetcher.mockLeader.setLeaderState(partition, leaderState)
+    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
+
+    fetcher.doWork()
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(0, replicaState.log.size)
+    // TODO: confirm log start offset
+    assertEquals(0, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(Some(200), fetcher.fetchState(partition).map(_.fetchOffset()))
+
+    fetcher.doWork()
+    assertEquals(0, replicaState.log.size)
+    assertEquals(10, replicaState.logStartOffset)
+    assertEquals(200, replicaState.localLogStartOffset)
+    assertEquals(200, replicaState.logEndOffset)
+    assertEquals(199, replicaState.highWatermark)
+  }
+
+  @Test
+  def testLastTieredOffsetRetryableRemoteStorageException(): Unit = {
     val rlmEnabled = true
     val partition = new TopicPartition("topic", 0)
     val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
     val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint) {
-      override def buildRemoteLogAuxState(topicPartition: TopicPartition,
-                                          currentLeaderEpoch: Integer,
-                                          leaderLocalLogStartOffset: lang.Long,
-                                          epochForLeaderLocalLogStartOffset: Integer,
-                                          leaderLogStartOffset: lang.Long,
-                                          unifiedLog: UnifiedLog): lang.Long = {
+      override def start(topicPartition: TopicPartition,
+                         topicId: Optional[Uuid],
+                         currentLeaderEpoch: Int,
+                         epochAndStartingOffset: OffsetAndEpoch,
+                         leaderLogStartOffset: Long): PartitionFetchState = {
         throw new RetriableRemoteStorageException("Retryable exception")
       }
     }
     val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, fetchFromLastTieredOffset = true)
 
     val replicaState = emptyReplicaState(rlmEnabled, partition, fetcher)
-
     val leaderLog = Seq(
-      // LogStartOffset = LocalLogStartOffset = 0
-      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
+      // LogStartOffset = LocalLogStartOffset = 10
+      mkBatch(baseOffset = 10, leaderEpoch = 0, new SimpleRecord("c".getBytes)),
       mkBatch(baseOffset = 150, leaderEpoch = 0, new SimpleRecord("d".getBytes)),
       mkBatch(baseOffset = 199, leaderEpoch = 0, new SimpleRecord("e".getBytes))
     )

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -2850,7 +2850,7 @@ class AbstractFetcherThreadTest {
       override def start(topicPartition: TopicPartition,
                          topicId: Optional[Uuid],
                          currentLeaderEpoch: Int,
-                         epochAndStartingOffset: OffsetAndEpoch,
+                         fetchStartOffsetAndEpoch: OffsetAndEpoch,
                          leaderLogStartOffset: Long): PartitionFetchState = {
         throw new RetriableRemoteStorageException("Retryable exception")
       }

--- a/core/src/test/scala/unit/kafka/server/MockLeaderEndPoint.scala
+++ b/core/src/test/scala/unit/kafka/server/MockLeaderEndPoint.scala
@@ -140,7 +140,9 @@ class MockLeaderEndPoint(sourceBroker: BrokerEndPoint = new BrokerEndPoint(1, "l
     checkLeaderEpochAndThrow(leaderEpoch, leaderState)
     leaderState.earliestPendingUploadOffset match {
       case -1L => new OffsetAndEpoch(-1L, -1)
-      case _ => new OffsetAndEpoch(math.max(leaderState.earliestPendingUploadOffset, leaderState.logStartOffset), leaderState.leaderEpoch)
+      case _ => new OffsetAndEpoch(
+        math.max(leaderState.earliestPendingUploadOffset, math.max(leaderState.localLogStartOffset, leaderState.logStartOffset)),
+        leaderState.leaderEpoch)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/MockTierStateMachine.scala
+++ b/core/src/test/scala/unit/kafka/server/MockTierStateMachine.scala
@@ -17,11 +17,11 @@
 
 package kafka.server
 
-import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.message.FetchResponseData
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.server.LeaderEndPoint
 import org.apache.kafka.server.PartitionFetchState
 import org.apache.kafka.server.ReplicaState
+import org.apache.kafka.server.common.OffsetAndEpoch
 
 import java.util.Optional
 
@@ -30,15 +30,17 @@ class MockTierStateMachine(leader: LeaderEndPoint) extends TierStateMachine(lead
   var fetcher: MockFetcherThread = _
 
   override def start(topicPartition: TopicPartition,
-                     currentFetchState: PartitionFetchState,
-                     fetchPartitionData: FetchResponseData.PartitionData): PartitionFetchState = {
-    val leaderEndOffset = leader.fetchLatestOffset(topicPartition, currentFetchState.currentLeaderEpoch).offset
-    val offsetToFetch = leader.fetchEarliestLocalOffset(topicPartition, currentFetchState.currentLeaderEpoch).offset
+                     topicId: Optional[Uuid],
+                     currentLeaderEpoch: Int,
+                     epochAndStartingOffset: OffsetAndEpoch,
+                     leaderLogStartOffset: Long): PartitionFetchState = {
+    val leaderEndOffset = leader.fetchLatestOffset(topicPartition, currentLeaderEpoch).offset
+    val offsetToFetch = epochAndStartingOffset.offset
     val initialLag = leaderEndOffset - offsetToFetch
     fetcher.truncateFullyAndStartAt(topicPartition, offsetToFetch)
-    new PartitionFetchState(currentFetchState.topicId, offsetToFetch, Optional.of(initialLag),
-      currentFetchState.currentLeaderEpoch, Optional.empty(), ReplicaState.FETCHING,
-      Optional.of(currentFetchState.currentLeaderEpoch)
+    new PartitionFetchState(topicId, offsetToFetch, Optional.of(initialLag),
+      currentLeaderEpoch, Optional.empty(), ReplicaState.FETCHING,
+      Optional.of(currentLeaderEpoch)
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/MockTierStateMachine.scala
+++ b/core/src/test/scala/unit/kafka/server/MockTierStateMachine.scala
@@ -32,10 +32,10 @@ class MockTierStateMachine(leader: LeaderEndPoint) extends TierStateMachine(lead
   override def start(topicPartition: TopicPartition,
                      topicId: Optional[Uuid],
                      currentLeaderEpoch: Int,
-                     epochAndStartingOffset: OffsetAndEpoch,
+                     fetchStartOffsetAndEpoch: OffsetAndEpoch,
                      leaderLogStartOffset: Long): PartitionFetchState = {
     val leaderEndOffset = leader.fetchLatestOffset(topicPartition, currentLeaderEpoch).offset
-    val offsetToFetch = epochAndStartingOffset.offset
+    val offsetToFetch = fetchStartOffsetAndEpoch.offset
     val initialLag = leaderEndOffset - offsetToFetch
     fetcher.truncateFullyAndStartAt(topicPartition, offsetToFetch)
     new PartitionFetchState(topicId, offsetToFetch, Optional.of(initialLag),

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -18,7 +18,6 @@ package kafka.server
 
 import kafka.cluster.Partition
 import kafka.log.LogManager
-
 import kafka.server.QuotaFactory.UNBOUNDED_QUOTA
 import kafka.server.epoch.util.MockBlockingSender
 import kafka.utils.TestUtils

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -18,6 +18,7 @@ package kafka.server
 
 import kafka.cluster.Partition
 import kafka.log.LogManager
+
 import kafka.server.QuotaFactory.UNBOUNDED_QUOTA
 import kafka.server.epoch.util.MockBlockingSender
 import kafka.utils.TestUtils

--- a/core/src/test/scala/unit/kafka/server/TierStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TierStateMachineTest.scala
@@ -18,16 +18,17 @@
 package kafka.server
 
 import org.apache.kafka.common.errors.FencedLeaderEpochException
-import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
 import org.junit.jupiter.api.Assertions._
 import kafka.server.FetcherThreadTestUtils.{initialFetchState, mkBatch}
+import org.apache.kafka.server.common.OffsetAndEpoch
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import java.util.Optional
 import scala.collection.Map
 
 class TierStateMachineTest {
@@ -164,10 +165,12 @@ class TierStateMachineTest {
     val mockLeaderEndpoint = new MockLeaderEndPoint(truncateOnFetch = truncateOnFetch, version = version)
     val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint) {
       override def start(topicPartition: TopicPartition,
-                         currentFetchState: PartitionFetchState,
-                         fetchPartitionData: FetchResponseData.PartitionData): PartitionFetchState = {
+                         topicId: Optional[Uuid],
+                         currentLeaderEpoch: Int,
+                         epochAndStartingOffset: OffsetAndEpoch,
+                         leaderLogStartOffset: Long): PartitionFetchState = {
         isErrorHandled = true
-        throw new FencedLeaderEpochException(s"Epoch ${currentFetchState.currentLeaderEpoch} is fenced")
+        throw new FencedLeaderEpochException(s"Epoch ${currentLeaderEpoch} is fenced")
       }
     }
     val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine, failedPartitions = failedPartitions)

--- a/core/src/test/scala/unit/kafka/server/TierStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TierStateMachineTest.scala
@@ -167,7 +167,7 @@ class TierStateMachineTest {
       override def start(topicPartition: TopicPartition,
                          topicId: Optional[Uuid],
                          currentLeaderEpoch: Int,
-                         epochAndStartingOffset: OffsetAndEpoch,
+                         fetchStartOffsetAndEpoch: OffsetAndEpoch,
                          leaderLogStartOffset: Long): PartitionFetchState = {
         isErrorHandled = true
         throw new FencedLeaderEpochException(s"Epoch ${currentLeaderEpoch} is fenced")


### PR DESCRIPTION
In this PR, we are adding the ReplicaFetcher changes to support fetching
from the last tiered offset.

- We are modifying the TierStateMachine's start method signature to take
any offset on the leader's local log from which to start replicating
leader's logs. Previously, the start method used to build remote log
auxiliary state until the leader's local start offset. Going forward, it
will build the auxiliary state until the supplied offset.
- When the ReplicaFetcher runs into an OOR or OMTS error, and it should
fetch from last tiered offset, it will determine the offset until which
remote log aux state should be built (last tiered offset) and use it to
start the TierStateMachine.

Test scenarios to cover:
https://docs.google.com/spreadsheets/d/1SPp4_otQP_4VH_F6Ta5rVhLPQhUnRxXnZu3hDWf07B4/edit?gid=1256210467#gid=1256210467

Reviewers: Kamal Chandraprakash <kamal.chandraprakash@gmail.com>
