### PR TITLE
MINOR: Add doc for external schemas in JSONConverter

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -357,11 +357,6 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
             } else if (!jsonValue.isObject() || jsonValue.size() != 2 || !jsonValue.has(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME) || !jsonValue.has(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME)) {
                 throw new DataException("JsonConverter with schemas.enable requires \"schema\" and \"payload\" fields and may not contain additional fields." +
                     " If you are trying to deserialize plain JSON data, set schemas.enable=false in your converter configuration.");
-            } else {
-                ObjectNode envelope = JSON_NODE_FACTORY.objectNode();
-                envelope.set(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME, jsonValue.get(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME));
-                envelope.set(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME, jsonValue);
-                jsonValue = envelope;
             }
         } else {
             // The deserialized data should either be an envelope object containing the schema and the payload or the schema

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -224,7 +224,7 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
     private JsonConverterConfig config;
     private Cache<Schema, ObjectNode> fromConnectSchemaCache;
     private Cache<JsonNode, Schema> toConnectSchemaCache;
-    private Schema schema = null;     // if a schema is provided in config, this schema will be used for all messages
+    private Schema schema = null;     // if a schema is provided in config, this schema will be used for all messages for sink connector
 
     private final JsonSerializer serializer;
     private final JsonDeserializer deserializer;
@@ -357,6 +357,11 @@ public class JsonConverter implements Converter, HeaderConverter, Versioned {
             } else if (!jsonValue.isObject() || jsonValue.size() != 2 || !jsonValue.has(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME) || !jsonValue.has(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME)) {
                 throw new DataException("JsonConverter with schemas.enable requires \"schema\" and \"payload\" fields and may not contain additional fields." +
                     " If you are trying to deserialize plain JSON data, set schemas.enable=false in your converter configuration.");
+            } else {
+                ObjectNode envelope = JSON_NODE_FACTORY.objectNode();
+                envelope.set(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME, jsonValue.get(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME));
+                envelope.set(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME, jsonValue);
+                jsonValue = envelope;
             }
         } else {
             // The deserialized data should either be an envelope object containing the schema and the payload or the schema

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -38,7 +38,8 @@ public final class JsonConverterConfig extends ConverterConfig {
 
     public static final String SCHEMA_CONTENT_CONFIG = "schema.content";
     public static final String SCHEMA_CONTENT_DEFAULT = null;
-    private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages. Otherwise, the schema will be included in the content of each message.";
+    private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages. Otherwise, the schema will be included in the content of each message. " 
+        + " This configuration applies only to the sink connector and has no effect on the source connector.";
     private static final String SCHEMA_CONTENT_DISPLAY = "Schema Content";
 
     public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.size";

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -38,8 +38,8 @@ public final class JsonConverterConfig extends ConverterConfig {
 
     public static final String SCHEMA_CONTENT_CONFIG = "schema.content";
     public static final String SCHEMA_CONTENT_DEFAULT = null;
-    private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages. Otherwise, the schema will be included in the content of each message. " 
-        + " This configuration applies only 'schemas.enable' is true, and it exclusively affects the sink connector.";
+    private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages, and the schemas within each of the message will be ignored." 
+        + "Otherwise, the schema will be included in the content of each message. This configuration applies only 'schemas.enable' is true, and it exclusively affects the sink connector.";
     private static final String SCHEMA_CONTENT_DISPLAY = "Schema Content";
 
     public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.size";

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -39,7 +39,7 @@ public final class JsonConverterConfig extends ConverterConfig {
     public static final String SCHEMA_CONTENT_CONFIG = "schema.content";
     public static final String SCHEMA_CONTENT_DEFAULT = null;
     private static final String SCHEMA_CONTENT_DOC = "When set, this is used as the schema for all messages. Otherwise, the schema will be included in the content of each message. " 
-        + " This configuration applies only to the sink connector and has no effect on the source connector.";
+        + " This configuration applies only 'schemas.enable' is true, and it exclusively affects the sink connector.";
     private static final String SCHEMA_CONTENT_DISPLAY = "Schema Content";
 
     public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.size";


### PR DESCRIPTION
This is a follow-up to #19449, which do the following things:

1. Add document to explain `schema.content` only work for sink connector
when  `schemas.enable` set to true.
2. Handle the case that while jsonValue contains the `schema` and
`payload` fields, we should use the corresponding value.

Reviewers: Priyanka K U <priyanka.ku@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
