### PR TITLE
KAFKA-19520: Bump Commons-Lang for CVE-2025-48924

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -212,7 +212,7 @@ commons-cli-1.4
 commons-collections-3.2.2
 commons-digester-2.1
 commons-io-2.14.0
-commons-lang3-3.12.0
+commons-lang3-3.18.0
 commons-logging-1.3.5
 commons-validator-1.7
 error_prone_annotations-2.10.0

--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,7 @@ allprojects {
           libs.reload4j,
           // Workaround before `commons-validator` has new release. See KAFKA-19359.
           libs.commonsBeanutils,
+          libs.commonsLang
         )
       }
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -92,6 +92,7 @@ versions += [
   commonsCli: "1.4",
   commonsIo: "2.14.0", // ZooKeeper dependency. Do not use, this is going away.
   commonsBeanutils: "1.11.0",
+  commonsLang: "3.18.0",
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.10.2",
@@ -184,6 +185,7 @@ libs += [
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsIo: "commons-io:commons-io:$versions.commonsIo",
   commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
+  commonsLang: "org.apache.commons:commons-lang3:$versions.commonsLang",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",


### PR DESCRIPTION
Bump Commons-Lang for CVE-2025-48924.