### PR TITLE
MINOR Rename RecordSnapshotWriter.Builder.setMaxBatchSize to setMaxBatchSizeBytes

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -506,7 +506,7 @@ public class Formatter {
         VoterSet voterSet = initialControllers.toVoterSet(controllerListenerName);
         RecordsSnapshotWriter.Builder builder = new RecordsSnapshotWriter.Builder().
             setLastContainedLogTimestamp(Time.SYSTEM.milliseconds()).
-            setMaxBatchSize(KafkaRaftClient.MAX_BATCH_SIZE_BYTES).
+            setMaxBatchSizeBytes(KafkaRaftClient.MAX_BATCH_SIZE_BYTES).
             setRawSnapshotWriter(FileRawSnapshotWriter.create(
                 clusterMetadataDirectory.toPath(),
                 Snapshots.BOOTSTRAP_SNAPSHOT_ID)).

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3781,7 +3781,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             return new RecordsSnapshotWriter.Builder()
                 .setLastContainedLogTimestamp(lastContainedLogTimestamp)
                 .setTime(time)
-                .setMaxBatchSize(MAX_BATCH_SIZE_BYTES)
+                .setMaxBatchSizeBytes(MAX_BATCH_SIZE_BYTES)
                 .setMemoryPool(memoryPool)
                 .setRawSnapshotWriter(wrappedWriter)
                 .setKraftVersion(partitionState.kraftVersionAtOffset(lastContainedLogOffset))

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -58,7 +58,7 @@ public class BatchAccumulator<T> implements Closeable {
     private final int epoch;
     private final Time time;
     private final int lingerMs;
-    private final int maxBatchSize;
+    private final int maxBatchSizeBytes;
     private final int maxNumberOfBatches;
     private final Compression compression;
     private final MemoryPool memoryPool;
@@ -82,7 +82,7 @@ public class BatchAccumulator<T> implements Closeable {
         int epoch,
         long baseOffset,
         int lingerMs,
-        int maxBatchSize,
+        int maxBatchSizeBytes,
         int maxNumberOfBatches,
         MemoryPool memoryPool,
         Time time,
@@ -91,7 +91,7 @@ public class BatchAccumulator<T> implements Closeable {
     ) {
         this.epoch = epoch;
         this.lingerMs = lingerMs;
-        this.maxBatchSize = maxBatchSize;
+        this.maxBatchSizeBytes = maxBatchSizeBytes;
         this.maxNumberOfBatches = maxNumberOfBatches;
         this.memoryPool = memoryPool;
         this.time = time;
@@ -182,12 +182,12 @@ public class BatchAccumulator<T> implements Closeable {
 
         if (currentBatch != null) {
             OptionalInt bytesNeeded = currentBatch.bytesNeeded(records, serializationCache);
-            if (bytesNeeded.isPresent() && bytesNeeded.getAsInt() > maxBatchSize) {
+            if (bytesNeeded.isPresent() && bytesNeeded.getAsInt() > maxBatchSizeBytes) {
                 throw new RecordBatchTooLargeException(
                     String.format(
                         "The total record(s) size of %d exceeds the maximum allowed batch size of %d",
                         bytesNeeded.getAsInt(),
-                        maxBatchSize
+                        maxBatchSizeBytes
                     )
                 );
             } else if (bytesNeeded.isPresent()) {
@@ -231,7 +231,7 @@ public class BatchAccumulator<T> implements Closeable {
     public long appendControlMessages(MemoryRecordsCreator valueCreator) {
         appendLock.lock();
         try {
-            ByteBuffer buffer = memoryPool.tryAllocate(maxBatchSize);
+            ByteBuffer buffer = memoryPool.tryAllocate(maxBatchSizeBytes);
             if (buffer != null) {
                 try {
                     forceDrain();
@@ -421,7 +421,7 @@ public class BatchAccumulator<T> implements Closeable {
     }
 
     private void startNewBatch() {
-        ByteBuffer buffer = memoryPool.tryAllocate(maxBatchSize);
+        ByteBuffer buffer = memoryPool.tryAllocate(maxBatchSizeBytes);
         if (buffer != null) {
             currentBatch = new BatchBuilder<>(
                 buffer,
@@ -430,7 +430,7 @@ public class BatchAccumulator<T> implements Closeable {
                 nextOffset,
                 time.milliseconds(),
                 epoch,
-                maxBatchSize
+                maxBatchSizeBytes
             );
         }
     }

--- a/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/RecordsSnapshotWriter.java
@@ -44,7 +44,7 @@ public final class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
 
     private RecordsSnapshotWriter(
         RawSnapshotWriter snapshot,
-        int maxBatchSize,
+        int maxBatchSizeBytes,
         MemoryPool memoryPool,
         Time time,
         Compression compression,
@@ -57,7 +57,7 @@ public final class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
             snapshot.snapshotId().epoch(),
             0,
             Integer.MAX_VALUE,
-            maxBatchSize,
+            maxBatchSizeBytes,
             10, // maxNumberOfBatches
             memoryPool,
             time,
@@ -145,7 +145,7 @@ public final class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
         private long lastContainedLogTimestamp = 0;
         private Compression compression = Compression.NONE;
         private Time time = Time.SYSTEM;
-        private int maxBatchSize = 1024;
+        private int maxBatchSizeBytes = 1024;
         private MemoryPool memoryPool = MemoryPool.NONE;
         private KRaftVersion kraftVersion = KRaftVersion.KRAFT_VERSION_1;
         private Optional<VoterSet> voterSet = Optional.empty();
@@ -166,8 +166,8 @@ public final class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
             return this;
         }
 
-        public Builder setMaxBatchSize(int maxBatchSize) {
-            this.maxBatchSize = maxBatchSize;
+        public Builder setMaxBatchSizeBytes(int maxBatchSizeBytes) {
+            this.maxBatchSizeBytes = maxBatchSizeBytes;
             return this;
         }
 
@@ -206,7 +206,7 @@ public final class RecordsSnapshotWriter<T> implements SnapshotWriter<T> {
 
             RecordsSnapshotWriter<T> writer = new RecordsSnapshotWriter<>(
                 rawSnapshotWriter.get(),
-                maxBatchSize,
+                maxBatchSizeBytes,
                 memoryPool,
                 time,
                 compression,

--- a/raft/src/test/java/org/apache/kafka/snapshot/RecordsSnapshotWriterTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/RecordsSnapshotWriterTest.java
@@ -50,13 +50,13 @@ final class RecordsSnapshotWriterTest {
     @Test
     void testBuilderKRaftVersion0() {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(100, 10);
-        int maxBatchSize = 1024;
+        int maxBatchSizeBytes = 1024;
         AtomicReference<ByteBuffer> buffer = new AtomicReference<>(null);
         RecordsSnapshotWriter.Builder builder = new RecordsSnapshotWriter.Builder()
             .setKraftVersion(KRaftVersion.KRAFT_VERSION_0)
             .setVoterSet(Optional.empty())
             .setTime(new MockTime())
-            .setMaxBatchSize(maxBatchSize)
+            .setMaxBatchSizeBytes(maxBatchSizeBytes)
             .setRawSnapshotWriter(
                 new MockRawSnapshotWriter(snapshotId, buffer::set)
             );
@@ -68,7 +68,7 @@ final class RecordsSnapshotWriterTest {
                 new MockRawSnapshotReader(snapshotId, buffer.get()),
                 STRING_SERDE,
                 BufferSupplier.NO_CACHING,
-                maxBatchSize,
+                maxBatchSizeBytes,
                 true,
                 new LogContext()
             )
@@ -100,7 +100,7 @@ final class RecordsSnapshotWriterTest {
     @Test
     void testBuilderKRaftVersion0WithVoterSet() {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(100, 10);
-        int maxBatchSize = 1024;
+        int maxBatchSizeBytes = 1024;
         VoterSet voterSet = VoterSetTest.voterSet(
             new HashMap<>(VoterSetTest.voterMap(IntStream.of(1, 2, 3), true))
         );
@@ -109,7 +109,7 @@ final class RecordsSnapshotWriterTest {
             .setKraftVersion(KRaftVersion.KRAFT_VERSION_0)
             .setVoterSet(Optional.of(voterSet))
             .setTime(new MockTime())
-            .setMaxBatchSize(maxBatchSize)
+            .setMaxBatchSizeBytes(maxBatchSizeBytes)
             .setRawSnapshotWriter(
                 new MockRawSnapshotWriter(snapshotId, buffer::set)
             );
@@ -120,7 +120,7 @@ final class RecordsSnapshotWriterTest {
     @Test
     void testKBuilderRaftVersion1WithVoterSet() {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(100, 10);
-        int maxBatchSize = 1024;
+        int maxBatchSizeBytes = 1024;
         VoterSet voterSet = VoterSetTest.voterSet(
             new HashMap<>(VoterSetTest.voterMap(IntStream.of(1, 2, 3), true))
         );
@@ -129,7 +129,7 @@ final class RecordsSnapshotWriterTest {
             .setKraftVersion(KRaftVersion.KRAFT_VERSION_1)
             .setVoterSet(Optional.of(voterSet))
             .setTime(new MockTime())
-            .setMaxBatchSize(maxBatchSize)
+            .setMaxBatchSizeBytes(maxBatchSizeBytes)
             .setRawSnapshotWriter(
                 new MockRawSnapshotWriter(snapshotId, buffer::set)
             );
@@ -141,7 +141,7 @@ final class RecordsSnapshotWriterTest {
                 new MockRawSnapshotReader(snapshotId, buffer.get()),
                 STRING_SERDE,
                 BufferSupplier.NO_CACHING,
-                maxBatchSize,
+                maxBatchSizeBytes,
                 true,
                 new LogContext()
             )
@@ -181,13 +181,13 @@ final class RecordsSnapshotWriterTest {
     @Test
     void testBuilderKRaftVersion1WithoutVoterSet() {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(100, 10);
-        int maxBatchSize = 1024;
+        int maxBatchSizeBytes = 1024;
         AtomicReference<ByteBuffer> buffer = new AtomicReference<>(null);
         RecordsSnapshotWriter.Builder builder = new RecordsSnapshotWriter.Builder()
             .setKraftVersion(KRaftVersion.KRAFT_VERSION_1)
             .setVoterSet(Optional.empty())
             .setTime(new MockTime())
-            .setMaxBatchSize(maxBatchSize)
+            .setMaxBatchSizeBytes(maxBatchSizeBytes)
             .setRawSnapshotWriter(
                 new MockRawSnapshotWriter(snapshotId, buffer::set)
             );
@@ -199,7 +199,7 @@ final class RecordsSnapshotWriterTest {
                 new MockRawSnapshotReader(snapshotId, buffer.get()),
                 STRING_SERDE,
                 BufferSupplier.NO_CACHING,
-                maxBatchSize,
+                maxBatchSizeBytes,
                 true,
                 new LogContext()
             )


### PR DESCRIPTION
The original name is confusing which could cause engineers to make a
mistake and confuse the `batchSize` with some other unit like number of
records.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
