### PR TITLE
[WIP] KAFKA-19656: Ensure share consumer polling does not stall

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -2716,6 +2716,50 @@ public class ShareConsumerTest {
     }
 
     /**
+     * This test is to prove that polling does not stall when there is data on the topic to fetch.
+     */
+    @ClusterTest
+    public void testShareConsumerStallBetweenPoll() throws Exception {
+        // The producer must produce slowly to tickle the scenario.
+        var produceDelay = 500;
+
+        ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
+        try (var producer = createProducer()) {
+            // Start a thread running that produces records at a relative trickle.
+            service.scheduleWithFixedDelay(
+                () -> producer.send(new ProducerRecord<>(tp.topic(), TestUtils.randomBytes(64))),
+                0,
+                produceDelay,
+                TimeUnit.MILLISECONDS
+            );
+
+            // Assign a tolerance for how much time is allowed to pass between Consumer.poll() calls given that there
+            // should be *at least* one record to read every second.
+            var pollDelayTolerance = 2000;
+
+            try (ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer("group1")) {
+                shareConsumer.subscribe(List.of(tp.topic()));
+
+                // This is here to allow the consumer time to settle the group membership/assignment.
+                waitedPoll(shareConsumer, 5000L, 1);
+
+                // Keep track of the last time the poll is invoked to ensure the deltas between invocations don't
+                // exceed the delay threshold defined above.
+                var beforePoll = System.currentTimeMillis();
+                shareConsumer.poll(Duration.ofSeconds(5));
+                shareConsumer.poll(Duration.ofSeconds(5));
+                var afterPoll = System.currentTimeMillis();
+                var pollDelay = afterPoll - beforePoll;
+
+                if (pollDelay > pollDelayTolerance)
+                    fail("Detected a stall of " + pollDelay + " ms between ShareConsumer.poll() invocations despite a Producer producing records every " + produceDelay + " ms");
+            } finally {
+                shutdownExecutorService(service);
+            }
+        }
+    }
+
+    /**
      * Util class to encapsulate state for a consumer/producer
      * being executed by an {@link ExecutorService}.
      */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -786,36 +786,37 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
             final ShareFetchMetricsAggregator shareFetchMetricsAggregator = new ShareFetchMetricsAggregator(metricsManager, partitions);
 
             Map<TopicPartition, Metadata.LeaderIdAndEpoch> partitionsWithUpdatedLeaderInfo = new HashMap<>();
-            for (Map.Entry<TopicIdPartition, ShareFetchResponseData.PartitionData> entry : responseData.entrySet()) {
-                TopicIdPartition tip = entry.getKey();
+            if (!responseData.isEmpty()) {
+                for (Map.Entry<TopicIdPartition, ShareFetchResponseData.PartitionData> entry : responseData.entrySet()) {
+                    TopicIdPartition tip = entry.getKey();
 
-                ShareFetchResponseData.PartitionData partitionData = entry.getValue();
+                    ShareFetchResponseData.PartitionData partitionData = entry.getValue();
 
-                log.debug("ShareFetch for partition {} returned fetch data {}", tip, partitionData);
+                    log.debug("ShareFetch for partition {} returned fetch data {}", tip, partitionData);
 
-                Map<TopicIdPartition, Acknowledgements> nodeAcknowledgementsInFlight = fetchAcknowledgementsInFlight.get(fetchTarget.id());
-                if (nodeAcknowledgementsInFlight != null) {
-                    Acknowledgements acks = nodeAcknowledgementsInFlight.remove(tip);
-                    if (acks != null) {
-                        if (partitionData.acknowledgeErrorCode() != Errors.NONE.code()) {
-                            metricsManager.recordFailedAcknowledgements(acks.size());
+                    Map<TopicIdPartition, Acknowledgements> nodeAcknowledgementsInFlight = fetchAcknowledgementsInFlight.get(fetchTarget.id());
+                    if (nodeAcknowledgementsInFlight != null) {
+                        Acknowledgements acks = nodeAcknowledgementsInFlight.remove(tip);
+                        if (acks != null) {
+                            if (partitionData.acknowledgeErrorCode() != Errors.NONE.code()) {
+                                metricsManager.recordFailedAcknowledgements(acks.size());
+                            }
+                            acks.complete(Errors.forCode(partitionData.acknowledgeErrorCode()).exception());
+                            Map<TopicIdPartition, Acknowledgements> acksMap = Map.of(tip, acks);
+                            maybeSendShareAcknowledgeCommitCallbackEvent(acksMap);
                         }
-                        acks.complete(Errors.forCode(partitionData.acknowledgeErrorCode()).exception());
-                        Map<TopicIdPartition, Acknowledgements> acksMap = Map.of(tip, acks);
-                        maybeSendShareAcknowledgeCommitCallbackEvent(acksMap);
                     }
-                }
 
-                Errors partitionError = Errors.forCode(partitionData.errorCode());
-                if (partitionError == Errors.NOT_LEADER_OR_FOLLOWER || partitionError == Errors.FENCED_LEADER_EPOCH) {
-                    log.debug("For {}, received error {}, with leaderIdAndEpoch {} in ShareFetch", tip, partitionError, partitionData.currentLeader());
-                    if (partitionData.currentLeader().leaderId() != -1 && partitionData.currentLeader().leaderEpoch() != -1) {
-                        partitionsWithUpdatedLeaderInfo.put(tip.topicPartition(), new Metadata.LeaderIdAndEpoch(
-                            Optional.of(partitionData.currentLeader().leaderId()), Optional.of(partitionData.currentLeader().leaderEpoch())));
+                    Errors partitionError = Errors.forCode(partitionData.errorCode());
+                    if (partitionError == Errors.NOT_LEADER_OR_FOLLOWER || partitionError == Errors.FENCED_LEADER_EPOCH) {
+                        log.debug("For {}, received error {}, with leaderIdAndEpoch {} in ShareFetch", tip, partitionError, partitionData.currentLeader());
+                        if (partitionData.currentLeader().leaderId() != -1 && partitionData.currentLeader().leaderEpoch() != -1) {
+                            partitionsWithUpdatedLeaderInfo.put(tip.topicPartition(), new Metadata.LeaderIdAndEpoch(
+                                Optional.of(partitionData.currentLeader().leaderId()), Optional.of(partitionData.currentLeader().leaderEpoch())));
+                        }
                     }
-                }
 
-                ShareCompletedFetch completedFetch = new ShareCompletedFetch(
+                    ShareCompletedFetch completedFetch = new ShareCompletedFetch(
                         logContext,
                         BufferSupplier.create(),
                         fetchTarget.id(),
@@ -823,11 +824,14 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                         partitionData,
                         shareFetchMetricsAggregator,
                         requestVersion);
-                shareFetchBuffer.add(completedFetch);
+                    shareFetchBuffer.add(completedFetch);
 
-                if (!partitionData.acquiredRecords().isEmpty()) {
-                    fetchMoreRecords = false;
+                    if (!partitionData.acquiredRecords().isEmpty()) {
+                        fetchMoreRecords = false;
+                    }
                 }
+            } else {
+                shareFetchBuffer.wakeup();
             }
 
             // Handle any acknowledgements which were not received in the response for this node.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchBuffer.java
@@ -143,7 +143,7 @@ public class ShareFetchBuffer implements AutoCloseable {
      *     <li>The buffer was already non-empty on entry</li>
      *     <li>The buffer was populated during the wait</li>
      *     <li>The remaining time on the {@link Timer timer} elapsed</li>
-     *     <li>The thread was interrupted</li>
+     *     <li>The thread was interrupted or otherwise woken up</li>
      * </ol>
      *
      * @param timer Timer that provides time to wait


### PR DESCRIPTION
In the async consumer, it has been observed that repeated polls
sometimes stall when actually a fetch should be sent to the broker.
Since the design of the share consumer is similar, this PR aims to
ensure that the share consumer is not affected by the same problem.
