### PR TITLE
KAFKA-19662: Allow resetting offset for unsubscribed topic in kafka-share-groups.sh

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
@@ -381,6 +381,10 @@ public class ShareGroupCommand {
         void resetOffsets() {
             String groupId = opts.options.valueOf(opts.groupOpt);
             try {
+                ShareGroupDescription shareGroupDescription = describeShareGroups(List.of(groupId)).get(groupId);
+                if (!(GroupState.EMPTY.equals(shareGroupDescription.groupState()) || GroupState.DEAD.equals(shareGroupDescription.groupState()))) {
+                    CommandLineUtils.printErrorAndExit(String.format("Share group '%s' is not empty.", groupId));
+                }
                 Map<TopicPartition, OffsetAndMetadata> offsetsToReset = prepareOffsetsToReset(groupId);
                 if (offsetsToReset == null) {
                     return;

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
@@ -381,10 +381,6 @@ public class ShareGroupCommand {
         void resetOffsets() {
             String groupId = opts.options.valueOf(opts.groupOpt);
             try {
-                ShareGroupDescription shareGroupDescription = describeShareGroups(List.of(groupId)).get(groupId);
-                if (!(GroupState.EMPTY.equals(shareGroupDescription.groupState()) || GroupState.DEAD.equals(shareGroupDescription.groupState()))) {
-                    CommandLineUtils.printErrorAndExit(String.format("Share group '%s' is not empty.", groupId));
-                }
                 Map<TopicPartition, OffsetAndMetadata> offsetsToReset = prepareOffsetsToReset(groupId);
                 if (offsetsToReset == null) {
                     return;
@@ -418,18 +414,6 @@ public class ShareGroupCommand {
 
             if (opts.options.has(opts.topicOpt)) {
                 partitionsToReset = offsetsUtils.parseTopicPartitionsToReset(opts.options.valuesOf(opts.topicOpt));
-                Set<String> subscribedTopics = offsetsByTopicPartitions.keySet().stream()
-                    .map(TopicPartition::topic)
-                    .collect(Collectors.toSet());
-                Set<String> resetTopics = partitionsToReset.stream()
-                    .map(TopicPartition::topic)
-                    .collect(Collectors.toSet());
-                if (!subscribedTopics.containsAll(resetTopics)) {
-                    CommandLineUtils
-                        .printErrorAndExit(String.format("Share group '%s' is not subscribed to topic '%s'.",
-                            groupId, resetTopics.stream().filter(topic -> !subscribedTopics.contains(topic)).collect(Collectors.joining(", "))));
-                    return null;
-                }
             } else {
                 partitionsToReset = offsetsByTopicPartitions.keySet();
             }


### PR DESCRIPTION
The `kafka-share-groups.sh` tool checks whether a topic already has a
start-offset in the share group when resetting offsets. This is not
necessary. By removing the check, it is possible to set a start offset
for a topic which has not yet but will be subscribed in the future, thus
initialising the consumption point.

There is still a small piece of outstanding work to do with resetting
the offset for a non-existent group which should also create the group.
A subsequent PR will be used to address that.

Reviewers: Jimmy Wang <48462172+JimmyWang6@users.noreply.github.com>,
 Lan Ding <isDing_L@163.com>, Apoorv Mittal <apoorvmittal10@gmail.com>
