### PR TITLE
KAFKA-19661 [5/N]: Use below-quota as a condition for standby task assignment

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/ProcessState.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/ProcessState.java
@@ -32,7 +32,6 @@ public class ProcessState {
     private int capacity;
     private double load;
     private int taskCount;
-    private int activeTaskCount;
     private final Map<String, Integer> memberToTaskCounts;
     private final Map<String, Set<TaskId>> assignedActiveTasks;
     private final Map<String, Set<TaskId>> assignedStandbyTasks;
@@ -65,10 +64,6 @@ public class ProcessState {
         return memberToTaskCounts;
     }
 
-    public int activeTaskCount() {
-        return activeTaskCount;
-    }
-
     public Set<TaskId> assignedActiveTasks() {
         return assignedActiveTasks.values().stream()
             .flatMap(Set::stream)
@@ -93,7 +88,6 @@ public class ProcessState {
         taskCount += 1;
         assignedTasks.add(taskId);
         if (isActive) {
-            activeTaskCount += 1;
             assignedActiveTasks.putIfAbsent(memberId, new HashSet<>());
             assignedActiveTasks.get(memberId).add(taskId);
         } else {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1092,145 +1092,65 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
-    public void shouldReassignTasksWhenNewNodeJoinsWithExistingActiveAndStandbyAssignments() {
-        // Initial setup: Node 1 has active tasks 0,1 and standby tasks 2,3
-        // Node 2 has active tasks 2,3 and standby tasks 0,1
-        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1",
-            mkMap(mkEntry("test-subtopology", Sets.newSet(0, 1))),
-            mkMap(mkEntry("test-subtopology", Sets.newSet(2, 3))));
+    public void shouldAssignStandbyTaskToPreviousOwnerBasedOnBelowQuotaCondition() {
+        // This test demonstrates the change from "load-balanced" to "below-quota" condition for standby assignment.
+        // We create a scenario where:
+        // - Process1 previously owned standby task 1 and currently has 1 active task (task 0)
+        // - Process2 currently has 1 active task (task 1) 
+        // - Process3 has no previous tasks (least loaded after assignment)
+        // 
+        // Under the old "load-balanced" algorithm: Process1 might not get standby task 1 because 
+        // Process3 could be considered least loaded.
+        //
+        // Under the new "below-quota" algorithm: Process1 gets standby task 1 because 
+        // it previously owned it AND is below quota.
 
+        // Set up previous task assignments:
+        // Process1: active=[0], standby=[1] (previously had both active and standby tasks)
+        // Process2: active=[1] (had the active task that process1 had as standby)
+        // Process3: no previous tasks
+        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1", 
+            mkMap(mkEntry("test-subtopology", Sets.newSet(0))), 
+            mkMap(mkEntry("test-subtopology", Sets.newSet(1))));
         final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2",
-            mkMap(mkEntry("test-subtopology", Sets.newSet(2, 3))),
-            mkMap(mkEntry("test-subtopology", Sets.newSet(0, 1))));
-
-        // Node 3 joins as new client
+            mkMap(mkEntry("test-subtopology", Sets.newSet(1))), 
+            Map.of());
         final AssignmentMemberSpec memberSpec3 = createAssignmentMemberSpec("process3");
 
         final Map<String, AssignmentMemberSpec> members = mkMap(
-            mkEntry("member1", memberSpec1), mkEntry("member2", memberSpec2), mkEntry("member3", memberSpec3));
+            mkEntry("member1", memberSpec1), 
+            mkEntry("member2", memberSpec2), 
+            mkEntry("member3", memberSpec3));
 
+        // We have 2 active tasks + 1 standby replica = 4 total tasks
+        // Quota per process = 4 tasks / 3 processes = 1.33 -> 2 tasks per process
         final GroupAssignment result = assignor.assign(
             new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, "1"))),
-            new TopologyDescriberImpl(4, true, List.of("test-subtopology"))
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
         );
 
-        // Verify all active tasks are assigned
-        final Set<Integer> allAssignedActiveTasks = new HashSet<>();
-        allAssignedActiveTasks.addAll(getAllActiveTaskIds(result, "member1"));
-        allAssignedActiveTasks.addAll(getAllActiveTaskIds(result, "member2"));
-        allAssignedActiveTasks.addAll(getAllActiveTaskIds(result, "member3"));
-        assertEquals(Sets.newSet(0, 1, 2, 3), allAssignedActiveTasks);
-
-        // Verify all standby tasks are assigned
-        final Set<Integer> allAssignedStandbyTasks = new HashSet<>();
-        allAssignedStandbyTasks.addAll(getAllStandbyTaskIds(result, "member1"));
-        allAssignedStandbyTasks.addAll(getAllStandbyTaskIds(result, "member2"));
-        allAssignedStandbyTasks.addAll(getAllStandbyTaskIds(result, "member3"));
-        assertEquals(Sets.newSet(0, 1, 2, 3), allAssignedStandbyTasks);
-
-        // Verify each member has 1-2 active tasks and at most 3 tasks total
-        assertTrue(getAllActiveTaskIds(result, "member1").size() >= 1 && getAllActiveTaskIds(result, "member1").size() <= 2);
-        assertTrue(getAllActiveTaskIds(result, "member1").size() + getAllStandbyTaskIds(result, "member1").size() <= 3);
-
-        assertTrue(getAllActiveTaskIds(result, "member2").size() >= 1 && getAllActiveTaskIds(result, "member2").size() <= 2);
-        assertTrue(getAllActiveTaskIds(result, "member2").size() + getAllStandbyTaskIds(result, "member2").size() <= 3);
-
-        assertTrue(getAllActiveTaskIds(result, "member3").size() >= 1 && getAllActiveTaskIds(result, "member3").size() <= 2);
-        assertTrue(getAllActiveTaskIds(result, "member3").size() + getAllStandbyTaskIds(result, "member3").size() <= 3);
-    }
-
-    @Test
-    public void shouldRangeAssignTasksWhenScalingUp() {
-        // Two clients, the second one is new
-        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1",
-            Map.of("test-subtopology1", Set.of(0, 1), "test-subtopology2", Set.of(0, 1)),
-            Map.of());
-        final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2");
-        final Map<String, AssignmentMemberSpec> members = mkMap(
-            mkEntry("member1", memberSpec1), mkEntry("member2", memberSpec2));
-
-        // Two subtopologies with 2 tasks each (4 tasks total) with standby replicas enabled
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, String.valueOf(1)))),
-            new TopologyDescriberImpl(2, true, Arrays.asList("test-subtopology1", "test-subtopology2"))
-        );
-
-        // Each client should get one task from each subtopology
-        final MemberAssignment testMember1 = result.members().get("member1");
-        assertNotNull(testMember1);
-        assertEquals(1, testMember1.activeTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember1.activeTasks().get("test-subtopology2").size());
+        // Verify that process1 gets the standby task 1 that it previously owned
+        // This should work under the new "below-quota" algorithm since process1 has only 1 active task
+        // which is below the quota of 2 tasks per process
+        final MemberAssignment member1 = result.members().get("member1");
+        assertNotNull(member1);
         
-        final MemberAssignment testMember2 = result.members().get("member2");
-        assertNotNull(testMember2);
-        assertEquals(1, testMember2.activeTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember2.activeTasks().get("test-subtopology2").size());
+        // Member1 should retain its active task 0
+        assertTrue(member1.activeTasks().get("test-subtopology").contains(0));
         
-        // Verify all tasks are assigned exactly once
-        final Set<Integer> allSubtopology1Tasks = new HashSet<>();
-        allSubtopology1Tasks.addAll(testMember1.activeTasks().get("test-subtopology1"));
-        allSubtopology1Tasks.addAll(testMember2.activeTasks().get("test-subtopology1"));
-        assertEquals(Sets.newSet(0, 1), allSubtopology1Tasks);
+        // Member1 should get standby task 1 because it previously owned it and is below quota
+        assertNotNull(member1.standbyTasks().get("test-subtopology"), "Member1 should have standby tasks assigned");
+        assertTrue(member1.standbyTasks().get("test-subtopology").contains(1), 
+            "Member1 should have standby task 1, but has: " + member1.standbyTasks().get("test-subtopology"));
         
-        final Set<Integer> allSubtopology2Tasks = new HashSet<>();
-        allSubtopology2Tasks.addAll(testMember1.activeTasks().get("test-subtopology2"));
-        allSubtopology2Tasks.addAll(testMember2.activeTasks().get("test-subtopology2"));
-        assertEquals(Sets.newSet(0, 1), allSubtopology2Tasks);
-
-        // Each client should get one task from each subtopology
-        assertNotNull(testMember1);
-        assertEquals(1, testMember1.standbyTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember1.standbyTasks().get("test-subtopology2").size());
-
-        assertNotNull(testMember2);
-        assertEquals(1, testMember2.standbyTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember2.standbyTasks().get("test-subtopology2").size());
-    }
-
-    @Test
-    public void shouldRangeAssignTasksWhenStartingEmpty() {
-        // Two clients starting empty (no previous tasks)
-        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1");
-        final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2");
-        final Map<String, AssignmentMemberSpec> members = mkMap(
-            mkEntry("member1", memberSpec1), mkEntry("member2", memberSpec2));
-
-        // Two subtopologies with 2 tasks each (4 tasks total) with standby replicas enabled
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, String.valueOf(1)))),
-            new TopologyDescriberImpl(2, true, Arrays.asList("test-subtopology1", "test-subtopology2"))
-        );
-
-        // Each client should get one task from each subtopology
-        final MemberAssignment testMember1 = result.members().get("member1");
-        assertNotNull(testMember1);
-        assertEquals(1, testMember1.activeTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember1.activeTasks().get("test-subtopology2").size());
-
-        final MemberAssignment testMember2 = result.members().get("member2");
-        assertNotNull(testMember2);
-        assertEquals(1, testMember2.activeTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember2.activeTasks().get("test-subtopology2").size());
-
-        // Verify all tasks are assigned exactly once
-        final Set<Integer> allSubtopology1Tasks = new HashSet<>();
-        allSubtopology1Tasks.addAll(testMember1.activeTasks().get("test-subtopology1"));
-        allSubtopology1Tasks.addAll(testMember2.activeTasks().get("test-subtopology1"));
-        assertEquals(Sets.newSet(0, 1), allSubtopology1Tasks);
-
-        final Set<Integer> allSubtopology2Tasks = new HashSet<>();
-        allSubtopology2Tasks.addAll(testMember1.activeTasks().get("test-subtopology2"));
-        allSubtopology2Tasks.addAll(testMember2.activeTasks().get("test-subtopology2"));
-        assertEquals(Sets.newSet(0, 1), allSubtopology2Tasks);
-
-        // Each client should get one task from each subtopology
-        assertNotNull(testMember1);
-        assertEquals(1, testMember1.standbyTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember1.standbyTasks().get("test-subtopology2").size());
-
-        assertNotNull(testMember2);
-        assertEquals(1, testMember2.standbyTasks().get("test-subtopology1").size());
-        assertEquals(1, testMember2.standbyTasks().get("test-subtopology2").size());
+        // Verify that member1 doesn't have active task 1 (standby can't be same as active)
+        assertFalse(member1.activeTasks().get("test-subtopology").contains(1));
+        
+        // Verify the process1's total task count is at or below quota
+        int member1ActiveCount = member1.activeTasks().get("test-subtopology").size();
+        int member1StandbyCount = member1.standbyTasks().get("test-subtopology").size();
+        int member1TotalTasks = member1ActiveCount + member1StandbyCount;
+        assertTrue(member1TotalTasks <= 2, "Member1 should have <= 2 total tasks (quota), but has " + member1TotalTasks);
     }
 
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1092,6 +1092,148 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
+    public void shouldReassignTasksWhenNewNodeJoinsWithExistingActiveAndStandbyAssignments() {
+        // Initial setup: Node 1 has active tasks 0,1 and standby tasks 2,3
+        // Node 2 has active tasks 2,3 and standby tasks 0,1
+        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1",
+            mkMap(mkEntry("test-subtopology", Sets.newSet(0, 1))),
+            mkMap(mkEntry("test-subtopology", Sets.newSet(2, 3))));
+
+        final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2",
+            mkMap(mkEntry("test-subtopology", Sets.newSet(2, 3))),
+            mkMap(mkEntry("test-subtopology", Sets.newSet(0, 1))));
+
+        // Node 3 joins as new client
+        final AssignmentMemberSpec memberSpec3 = createAssignmentMemberSpec("process3");
+
+        final Map<String, AssignmentMemberSpec> members = mkMap(
+            mkEntry("member1", memberSpec1), mkEntry("member2", memberSpec2), mkEntry("member3", memberSpec3));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, "1"))),
+            new TopologyDescriberImpl(4, true, List.of("test-subtopology"))
+        );
+
+        // Verify all active tasks are assigned
+        final Set<Integer> allAssignedActiveTasks = new HashSet<>();
+        allAssignedActiveTasks.addAll(getAllActiveTaskIds(result, "member1"));
+        allAssignedActiveTasks.addAll(getAllActiveTaskIds(result, "member2"));
+        allAssignedActiveTasks.addAll(getAllActiveTaskIds(result, "member3"));
+        assertEquals(Sets.newSet(0, 1, 2, 3), allAssignedActiveTasks);
+
+        // Verify all standby tasks are assigned
+        final Set<Integer> allAssignedStandbyTasks = new HashSet<>();
+        allAssignedStandbyTasks.addAll(getAllStandbyTaskIds(result, "member1"));
+        allAssignedStandbyTasks.addAll(getAllStandbyTaskIds(result, "member2"));
+        allAssignedStandbyTasks.addAll(getAllStandbyTaskIds(result, "member3"));
+        assertEquals(Sets.newSet(0, 1, 2, 3), allAssignedStandbyTasks);
+
+        // Verify each member has 1-2 active tasks and at most 3 tasks total
+        assertTrue(getAllActiveTaskIds(result, "member1").size() >= 1 && getAllActiveTaskIds(result, "member1").size() <= 2);
+        assertTrue(getAllActiveTaskIds(result, "member1").size() + getAllStandbyTaskIds(result, "member1").size() <= 3);
+
+        assertTrue(getAllActiveTaskIds(result, "member2").size() >= 1 && getAllActiveTaskIds(result, "member2").size() <= 2);
+        assertTrue(getAllActiveTaskIds(result, "member2").size() + getAllStandbyTaskIds(result, "member2").size() <= 3);
+
+        assertTrue(getAllActiveTaskIds(result, "member3").size() >= 1 && getAllActiveTaskIds(result, "member3").size() <= 2);
+        assertTrue(getAllActiveTaskIds(result, "member3").size() + getAllStandbyTaskIds(result, "member3").size() <= 3);
+    }
+
+    @Test
+    public void shouldRangeAssignTasksWhenScalingUp() {
+        // Two clients, the second one is new
+        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1",
+            Map.of("test-subtopology1", Set.of(0, 1), "test-subtopology2", Set.of(0, 1)),
+            Map.of());
+        final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2");
+        final Map<String, AssignmentMemberSpec> members = mkMap(
+            mkEntry("member1", memberSpec1), mkEntry("member2", memberSpec2));
+
+        // Two subtopologies with 2 tasks each (4 tasks total) with standby replicas enabled
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, String.valueOf(1)))),
+            new TopologyDescriberImpl(2, true, Arrays.asList("test-subtopology1", "test-subtopology2"))
+        );
+
+        // Each client should get one task from each subtopology
+        final MemberAssignment testMember1 = result.members().get("member1");
+        assertNotNull(testMember1);
+        assertEquals(1, testMember1.activeTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember1.activeTasks().get("test-subtopology2").size());
+        
+        final MemberAssignment testMember2 = result.members().get("member2");
+        assertNotNull(testMember2);
+        assertEquals(1, testMember2.activeTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember2.activeTasks().get("test-subtopology2").size());
+        
+        // Verify all tasks are assigned exactly once
+        final Set<Integer> allSubtopology1Tasks = new HashSet<>();
+        allSubtopology1Tasks.addAll(testMember1.activeTasks().get("test-subtopology1"));
+        allSubtopology1Tasks.addAll(testMember2.activeTasks().get("test-subtopology1"));
+        assertEquals(Sets.newSet(0, 1), allSubtopology1Tasks);
+        
+        final Set<Integer> allSubtopology2Tasks = new HashSet<>();
+        allSubtopology2Tasks.addAll(testMember1.activeTasks().get("test-subtopology2"));
+        allSubtopology2Tasks.addAll(testMember2.activeTasks().get("test-subtopology2"));
+        assertEquals(Sets.newSet(0, 1), allSubtopology2Tasks);
+
+        // Each client should get one task from each subtopology
+        assertNotNull(testMember1);
+        assertEquals(1, testMember1.standbyTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember1.standbyTasks().get("test-subtopology2").size());
+
+        assertNotNull(testMember2);
+        assertEquals(1, testMember2.standbyTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember2.standbyTasks().get("test-subtopology2").size());
+    }
+
+    @Test
+    public void shouldRangeAssignTasksWhenStartingEmpty() {
+        // Two clients starting empty (no previous tasks)
+        final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1");
+        final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2");
+        final Map<String, AssignmentMemberSpec> members = mkMap(
+            mkEntry("member1", memberSpec1), mkEntry("member2", memberSpec2));
+
+        // Two subtopologies with 2 tasks each (4 tasks total) with standby replicas enabled
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, String.valueOf(1)))),
+            new TopologyDescriberImpl(2, true, Arrays.asList("test-subtopology1", "test-subtopology2"))
+        );
+
+        // Each client should get one task from each subtopology
+        final MemberAssignment testMember1 = result.members().get("member1");
+        assertNotNull(testMember1);
+        assertEquals(1, testMember1.activeTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember1.activeTasks().get("test-subtopology2").size());
+
+        final MemberAssignment testMember2 = result.members().get("member2");
+        assertNotNull(testMember2);
+        assertEquals(1, testMember2.activeTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember2.activeTasks().get("test-subtopology2").size());
+
+        // Verify all tasks are assigned exactly once
+        final Set<Integer> allSubtopology1Tasks = new HashSet<>();
+        allSubtopology1Tasks.addAll(testMember1.activeTasks().get("test-subtopology1"));
+        allSubtopology1Tasks.addAll(testMember2.activeTasks().get("test-subtopology1"));
+        assertEquals(Sets.newSet(0, 1), allSubtopology1Tasks);
+
+        final Set<Integer> allSubtopology2Tasks = new HashSet<>();
+        allSubtopology2Tasks.addAll(testMember1.activeTasks().get("test-subtopology2"));
+        allSubtopology2Tasks.addAll(testMember2.activeTasks().get("test-subtopology2"));
+        assertEquals(Sets.newSet(0, 1), allSubtopology2Tasks);
+
+        // Each client should get one task from each subtopology
+        assertNotNull(testMember1);
+        assertEquals(1, testMember1.standbyTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember1.standbyTasks().get("test-subtopology2").size());
+
+        assertNotNull(testMember2);
+        assertEquals(1, testMember2.standbyTasks().get("test-subtopology1").size());
+        assertEquals(1, testMember2.standbyTasks().get("test-subtopology2").size());
+    }
+
+    @Test
     public void shouldAssignStandbyTaskToPreviousOwnerBasedOnBelowQuotaCondition() {
         // This test demonstrates the change from "load-balanced" to "below-quota" condition for standby assignment.
         // We create a scenario where:


### PR DESCRIPTION
In the original algorithm, standby tasks are assigned to a  process that
previously owned the task only if it is  “load-balanced”, meaning the
process has fewer tasks that  members, or it is the least loaded
process. This is strong  requirement, and will cause standby tasks to
often not get  assigned to process that previously owned it.
Furthermore,  the condition “is the least loaded process” is hard to
evaluate efficiently in this context.

We propose to instead use the same “below-quota” condition  as in active
task assignment.

We compute a quota for active and standby tasks, by definiing numOfTasks
= numberOfActiveTasks+numberOfStandbyTasks and  defining the quota as
numOfTasks/numberOfMembers rounded up.  Whenever a member becomes “full”
(its assigned number of tasks  is equal to numOfTasks) we deduct its
tasks from numOfTasks and  decrement numberOfMembers and recompute the
quota, which means  that the quota may be reduced by one during the
assignment  process, to avoid uneven assignments.

A standby task can be assigned to a process that previously  owned it,
whenever the process has fewer than  numOfMembersOfProcess*quota.

This condition will, again, prioritize standby stickyness,  and can be
evaluated in constant time.

In our worst-performing benchmark, this improves the runtime  by 2.5x on
top of the previous optimizations, but 5x on the  more important
incremental assignment case.

Reviewers: Bill Bejeck <bbejeck@apache.org>
