### PR TITLE
MINOR: Refactor CLI tools to use CommandLineUtils#maybePrintHelpOrVersion

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/JmxTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/JmxTool.java
@@ -66,14 +66,7 @@ public class JmxTool {
     public static void main(String[] args) {
         try {
             JmxToolOptions options = new JmxToolOptions(args);
-            if (CommandLineUtils.isPrintHelpNeeded(options)) {
-                CommandLineUtils.printUsageAndExit(options.parser, "Dump JMX values to standard output.");
-                return;
-            }
-            if (CommandLineUtils.isPrintVersionNeeded(options)) {
-                CommandLineUtils.printVersionAndExit();
-                return;
-            }
+            CommandLineUtils.maybePrintHelpOrVersion(options, "Dump JMX values to standard output.");
 
             Optional<String[]> attributesInclude = options.attributesInclude();
             Optional<DateFormat> dateFormat = options.dateFormat();

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -300,12 +300,8 @@ public class ReplicaVerificationTool {
                 .ofType(Long.class)
                 .defaultsTo(30_000L);
             options = parser.parse(args);
-            if (args.length == 0 || options.has(helpOpt)) {
-                CommandLineUtils.printUsageAndExit(parser, "Validate that all replicas for a set of topics have the same data.");
-            }
-            if (options.has(versionOpt)) {
-                CommandLineUtils.printVersionAndExit();
-            }
+
+            CommandLineUtils.maybePrintHelpOrVersion(this, "Validate that all replicas for a set of topics have the same data.");
             CommandLineUtils.checkRequiredArgs(parser, options, brokerListOpt);
         }
 

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -647,12 +647,7 @@ public class StreamsResetter {
 
             try {
                 options = parser.parse(args);
-                if (CommandLineUtils.isPrintHelpNeeded(this)) {
-                    CommandLineUtils.printUsageAndExit(parser, USAGE);
-                }
-                if (CommandLineUtils.isPrintVersionNeeded(this)) {
-                    CommandLineUtils.printVersionAndExit();
-                }
+                CommandLineUtils.maybePrintHelpOrVersion(this, USAGE);
                 CommandLineUtils.checkInvalidArgs(parser, options, toOffsetOption, toDatetimeOption, byDurationOption, toEarliestOption, toLatestOption, fromFileOption, shiftByOption);
                 CommandLineUtils.checkInvalidArgs(parser, options, toDatetimeOption, toOffsetOption, byDurationOption, toEarliestOption, toLatestOption, fromFileOption, shiftByOption);
                 CommandLineUtils.checkInvalidArgs(parser, options, byDurationOption, toOffsetOption, toDatetimeOption, toEarliestOption, toLatestOption, fromFileOption, shiftByOption);


### PR DESCRIPTION
Refactor help and version handling in command-line tools by replacing
duplicate code with `CommandLineUtils#maybePrintHelpOrVersion`.

Reviewers: TengYao Chi <kitingiao@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Chia-Ping
 Tsai <chia7712@gmail.com>
