### PR TITLE
MINOR: Fix typo for the headers.separator cli option

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
@@ -111,7 +111,7 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                             " print.value=true|false\n" +
                             " key.separator=<key.separator>\n" +
                             " line.separator=<line.separator>\n" +
-                            " headers.separator=<line.separator>\n" +
+                            " headers.separator=<headers.separator>\n" +
                             " null.literal=<null.literal>\n" +
                             " key.deserializer=<key.deserializer>\n" +
                             " value.deserializer=<value.deserializer>\n" +

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
@@ -83,7 +83,7 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                                 " print.value=true|false\n" +
                                 " key.separator=<key.separator>\n" +
                                 " line.separator=<line.separator>\n" +
-                                " headers.separator=<line.separator>\n" +
+                                " headers.separator=<headers.separator>\n" +
                                 " null.literal=<null.literal>\n" +
                                 " key.deserializer=<key.deserializer>\n" +
                                 " value.deserializer=<value.deserializer>\n" +


### PR DESCRIPTION
[MINOR] Fix typo for the headers.separator cli option. Should be
`headers.separator=<headers.separator>` instead of
`headers.separator=<line.separator>`

Reviewers: Kuan-Po Tseng <brandboat@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
