### PR TITLE
KAFKA-19659: Wrong generic type for UnregisterBrokerOptions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/UnregisterBrokerOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/UnregisterBrokerOptions.java
@@ -20,5 +20,5 @@ package org.apache.kafka.clients.admin;
 /**
  * Options for {@link Admin#unregisterBroker(int, UnregisterBrokerOptions)}.
  */
-public class UnregisterBrokerOptions extends AbstractOptions<UpdateFeaturesOptions> {
+public class UnregisterBrokerOptions extends AbstractOptions<UnregisterBrokerOptions> {
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -9952,9 +9952,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().setNodeApiVersions(
                     NodeApiVersions.create(ApiKeys.UNREGISTER_BROKER.id, (short) 0, (short) 0));
 
-            UnregisterBrokerOptions options = new UnregisterBrokerOptions();
-            options.timeoutMs = 10;
-            UnregisterBrokerResult result = env.adminClient().unregisterBroker(nodeId, options);
+            UnregisterBrokerResult result = env.adminClient().unregisterBroker(nodeId, new UnregisterBrokerOptions().timeoutMs(10));
 
             // Validate response
             assertNotNull(result.all());


### PR DESCRIPTION
Fix wrong generic type for UnregisterBrokerOptions

Reviewers: Andrew Schofield <aschofield@confluent.io>
