### PR TITLE
MINOR: Bump versions in CI

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -37,7 +37,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
     - name: Pip install

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -14,4 +14,4 @@
 # limitations under the License.
 PyYAML~=6.0
 pytz==2024.2
-requests==2.32.3
+requests==2.32.4

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Note: Ensure the 'requests' version here matches the version in tests/setup.py
 PyYAML~=6.0
 pytz==2024.2
 requests==2.32.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,12 @@ jobs:
     name: Load Test Catalog
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Checkout test-catalog
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: 'test-catalog'
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: ${{ github.sha }}  # this is the default, just being explicit.
@@ -192,7 +192,7 @@ jobs:
     name: JUnit tests Java ${{ matrix.java }}${{ matrix.run-flaky == true && ' (flaky)' || '' }}${{ matrix.run-new == true && ' (new)' || '' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: ${{ needs.configure.outputs.sha }}
@@ -282,7 +282,7 @@ jobs:
       uploaded-test-catalog: ${{ steps.archive-test-catalog.outcome == 'success' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Download Thread Dumps
@@ -334,7 +334,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Test Catalog
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: true  # Needed to commit and push later
           ref: test-catalog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
       # the overall workflow, so we'll continue here without a test catalog.
       - name: Load Test Catalog
         id: load-test-catalog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         continue-on-error: true
         with:
           name: combined-test-catalog
@@ -286,7 +286,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Download Thread Dumps
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: junit-thread-dumps-24-*
           path: thread-dumps
@@ -300,7 +300,7 @@ jobs:
               exit 1;
           fi
       - name: Download JUnit XMLs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: junit-xml-24-*  # Only look at JDK 24 tests for the test catalog
           path: junit-xml
@@ -342,7 +342,7 @@ jobs:
         run: |
           rm -rf test-catalog
       - name: Download Test Catalog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: test-catalog
           path: test-catalog

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -72,7 +72,7 @@ jobs:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Download build scan archive
         id: download-build-scan
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         continue-on-error: true  # Don't want this step to fail the overall workflow
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials:
             false

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -42,7 +42,7 @@ jobs:
     name: Deflake JUnit tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker_build_and_test.yml
+++ b/.github/workflows/docker_build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Setup Docker Compose

--- a/.github/workflows/docker_build_and_test.yml
+++ b/.github/workflows/docker_build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/docker_official_image_build_and_test.yml
+++ b/.github/workflows/docker_official_image_build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Setup Docker Compose

--- a/.github/workflows/docker_official_image_build_and_test.yml
+++ b/.github/workflows/docker_official_image_build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/docker_rc_release.yml
+++ b/.github/workflows/docker_rc_release.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/docker_rc_release.yml
+++ b/.github/workflows/docker_rc_release.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Run Report

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials:
             false

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Load PR Number

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
       - name: Load PR Number
         id: load-pr-number
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - uses: actions/labeler@v5
       with:
         configuration-path: .github/configs/labeler.yml

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         configuration-path: .github/configs/labeler.yml
     - name: check small label

--- a/.github/workflows/prepare_docker_official_image_source.yml
+++ b/.github/workflows/prepare_docker_official_image_source.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/prepare_docker_official_image_source.yml
+++ b/.github/workflows/prepare_docker_official_image_source.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/workflow-requested.yml
+++ b/.github/workflows/workflow-requested.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials:
             false

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -40,6 +40,7 @@ class PyTest(Command):
         sys.exit(errno)
 
 # Note: when changing the version of ducktape, also revise tests/docker/Dockerfile
+# Ensure the 'requests' version here matches the one specified in .github/scripts/requirements.txt
 setup(name="kafkatest",
       version=version,
       description="Apache Kafka System Tests",


### PR DESCRIPTION
**Summary**

This PR bumps several GitHub Actions and dependencies used in CI
workflows to their latest stable versions. This ensures our CI
environment remains consistent, secure, and aligned with upstream
improvements.

**Changes**

- requests: 2.32.3 → 2.32.4
- actions/checkout: v4 → v5
- actions/setup-python: v5 → v6
- actions/setup-java: v4 → v5
- actions/download-artifact: v4 → v5
- actions/labeler: v5 → v6

related: https://github.com/apache/kafka/pull/19940/files#r2328391161

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
