### PR TITLE
KAFKA-19676: EpochState should override close to avoid throwing IOException

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/EpochState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/EpochState.java
@@ -59,4 +59,9 @@ public interface EpochState extends Closeable {
      * User-friendly description of the state
      */
     String name();
+
+    @Override
+    default void close() {
+        // intentionally left blank
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/EpochState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/EpochState.java
@@ -60,9 +60,10 @@ public interface EpochState extends Closeable {
      */
     String name();
 
+    /**
+     * Since all subclasses implement the Closeable interface while none throw any IOException,
+     * this implementation is provided to eliminate the need for exception handling in the close operation.
+     */
     @Override
-    default void close() {
-        // Since all subclasses implement the Closeable interface while none throw any IOException,
-        // this default implementation is provided to eliminate the need for exception handling in the close operation.
-    }
+    void close();
 }

--- a/raft/src/main/java/org/apache/kafka/raft/EpochState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/EpochState.java
@@ -62,6 +62,7 @@ public interface EpochState extends Closeable {
 
     @Override
     default void close() {
-        // intentionally left blank
+        // Since all subclasses implement the Closeable interface while none throw any IOException,
+        // this default implementation is provided to eliminate the need for exception handling in the close operation.
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -736,12 +736,7 @@ public class QuorumState {
 
     private void memoryTransitionTo(EpochState newState) {
         if (state != null) {
-            try {
-                state.close();
-            } catch (IOException e) {
-                throw new UncheckedIOException(
-                    "Failed to transition from " + state.name() + " to " + newState.name(), e);
-            }
+            state.close();
         }
 
         EpochState from = state;

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -27,8 +27,6 @@ import org.apache.kafka.server.common.OffsetAndEpoch;
 
 import org.slf4j.Logger;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;


### PR DESCRIPTION
Jira: [KAFKA-19676](https://issues.apache.org/jira/browse/KAFKA-19676)
All subclasses of EpochState do not throw an IOException when closing,
so catching it is unnecessary. We could override close to remove the
IOException declaration.

Reviewers: Jhen-Yung Hsu <jhenyunghsu@gmail.com>, TaiJuWu
 <tjwu1217@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
