### PR TITLE
KAFKA-19679: Fix NoSuchElementException in oldest open iterator metric

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
@@ -36,6 +36,7 @@ public class OpenIteratorsTest {
 
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
 
+    @SuppressWarnings("unchecked")
     @Test
     public void shouldCalculateOldestStartTimestampCorrectly() {
         final OpenIterators openIterators = new OpenIterators(new TaskId(0, 0), "scope", "name", streamsMetrics);

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.MeteredIterator;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
@@ -38,7 +38,7 @@ public class OpenIteratorsTest {
 
     @Test
     public void shouldCalculateOldestStartTimestampCorrectly() {
-        final OpenIterators openIterators = new OpenIterators(new TaskId(1, 1), "2", "3", streamsMetrics);
+        final OpenIterators openIterators = new OpenIterators(new TaskId(0, 0), "scope", "name", streamsMetrics);
 
         final MeteredIterator meteredIterator1 = () -> 5;
         final MeteredIterator meteredIterator2 = () -> 2;

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.internals.metrics;
+
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.MeteredIterator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+public class OpenIteratorsTest {
+
+    private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
+
+    @Test
+    public void shouldCalculateOldestStartTimestampCorrectly() {
+        final OpenIterators openIterators = new OpenIterators(new TaskId(1, 1), "2", "3", streamsMetrics);
+
+        final MeteredIterator meteredIterator1 = () -> 5;
+        final MeteredIterator meteredIterator2 = () -> 2;
+        final MeteredIterator meteredIterator3 = () -> 6;
+
+        openIterators.add(meteredIterator1);
+        final ArgumentCaptor<Gauge<Long>> gaugeCaptor = ArgumentCaptor.forClass(Gauge.class);
+        verify(streamsMetrics).addStoreLevelMutableMetric(any(), any(), any(), any(), any(), any(), gaugeCaptor.capture());
+        final Gauge<Long> gauge = gaugeCaptor.getValue();
+        assertThat(gauge.value(null, 0), is(5L));
+        reset(streamsMetrics);
+
+        openIterators.add(meteredIterator2);
+        verify(streamsMetrics, never()).addStoreLevelMutableMetric(any(), any(), any(), any(), any(), any(), gaugeCaptor.capture());
+        assertThat(gauge.value(null, 0), is(2L));
+
+        openIterators.remove(meteredIterator2);
+        verify(streamsMetrics, never()).removeMetric(any());
+        assertThat(gauge.value(null, 0), is(5L));
+
+        openIterators.remove(meteredIterator1);
+        verify(streamsMetrics).removeMetric(any());
+        assertThat(gauge.value(null, 0), is(5L));
+
+        openIterators.add(meteredIterator3);
+        verify(streamsMetrics).addStoreLevelMutableMetric(any(), any(), any(), any(), any(), any(), gaugeCaptor.capture());
+        assertThat(gaugeCaptor.getValue(), not(gauge));
+        assertThat(gaugeCaptor.getValue().value(null, 0), is(6L));
+    }
+}


### PR DESCRIPTION
Querying the oldest-open-iterator metric can result in a
NoSuchElementException when the last open iterator gets removed, due to
a race condition between the query and the metric update.

To avoid this race condition, this PR caches the metric result, to avoid
accessing the list of open iterator directly.  We don't need to clear
this cache, because the entire metric is removed when the last iterator
gets removed.

Reviewers: Matthias J. Sax <matthias@confluent.io>
