### PR TITLE
MINOR: Enhanced exception handling for metadata acquisition

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1268,46 +1268,51 @@ public class NetworkClient implements KafkaClient {
 
         @Override
         public void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException) {
-            maybeFatalException.ifPresent(metadata::fatalError);
-            metadata.failedUpdate(now);
-            inProgress = null;
+            try {
+                maybeFatalException.ifPresent(metadata::fatalError);
+                metadata.failedUpdate(now);
+            } finally {
+                inProgress = null;
+            }
         }
 
         @Override
         public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
-            // If any partition has leader with missing listeners, log up to ten of these partitions
-            // for diagnosing broker configuration issues.
-            // This could be a transient issue if listeners were added dynamically to brokers.
-            List<TopicPartition> missingListenerPartitions = response.topicMetadata().stream().flatMap(topicMetadata ->
-                topicMetadata.partitionMetadata().stream()
-                    .filter(partitionMetadata -> partitionMetadata.error == Errors.LISTENER_NOT_FOUND)
-                    .map(partitionMetadata -> new TopicPartition(topicMetadata.topic(), partitionMetadata.partition())))
-                .collect(Collectors.toList());
-            if (!missingListenerPartitions.isEmpty()) {
-                int count = missingListenerPartitions.size();
-                log.warn("{} partitions have leader brokers without a matching listener, including {}",
-                        count, missingListenerPartitions.subList(0, Math.min(10, count)));
+            try {
+                // If any partition has leader with missing listeners, log up to ten of these partitions
+                // for diagnosing broker configuration issues.
+                // This could be a transient issue if listeners were added dynamically to brokers.
+                List<TopicPartition> missingListenerPartitions = response.topicMetadata().stream().flatMap(topicMetadata ->
+                                topicMetadata.partitionMetadata().stream()
+                                        .filter(partitionMetadata -> partitionMetadata.error == Errors.LISTENER_NOT_FOUND)
+                                        .map(partitionMetadata -> new TopicPartition(topicMetadata.topic(), partitionMetadata.partition())))
+                        .collect(Collectors.toList());
+                if (!missingListenerPartitions.isEmpty()) {
+                    int count = missingListenerPartitions.size();
+                    log.warn("{} partitions have leader brokers without a matching listener, including {}",
+                            count, missingListenerPartitions.subList(0, Math.min(10, count)));
+                }
+
+                // Check if any topic's metadata failed to get updated
+                Map<String, Errors> errors = response.errors();
+                if (!errors.isEmpty())
+                    log.warn("The metadata response from the cluster reported a recoverable issue with correlation id {} : {}", requestHeader.correlationId(), errors);
+
+                if (metadataRecoveryStrategy == MetadataRecoveryStrategy.REBOOTSTRAP && response.topLevelError() == Errors.REBOOTSTRAP_REQUIRED) {
+                    log.info("Rebootstrap requested by server.");
+                    initiateRebootstrap();
+                } else if (response.brokers().isEmpty()) {
+                    // When talking to the startup phase of a broker, it is possible to receive an empty metadata set, which
+                    // we should retry later.
+                    log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
+                    this.metadata.failedUpdate(now);
+                } else {
+                    this.metadata.update(inProgress.requestVersion, response, inProgress.isPartialUpdate, now);
+                    metadataAttemptStartMs = Optional.empty();
+                }
+            } finally {
+                inProgress = null;
             }
-
-            // Check if any topic's metadata failed to get updated
-            Map<String, Errors> errors = response.errors();
-            if (!errors.isEmpty())
-                log.warn("The metadata response from the cluster reported a recoverable issue with correlation id {} : {}", requestHeader.correlationId(), errors);
-
-            if (metadataRecoveryStrategy == MetadataRecoveryStrategy.REBOOTSTRAP && response.topLevelError() == Errors.REBOOTSTRAP_REQUIRED) {
-                log.info("Rebootstrap requested by server.");
-                initiateRebootstrap();
-            } else if (response.brokers().isEmpty()) {
-                // When talking to the startup phase of a broker, it is possible to receive an empty metadata set, which
-                // we should retry later.
-                log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
-                this.metadata.failedUpdate(now);
-            } else {
-                this.metadata.update(inProgress.requestVersion, response, inProgress.isPartialUpdate, now);
-                metadataAttemptStartMs = Optional.empty();
-            }
-
-            inProgress = null;
         }
 
         @Override


### PR DESCRIPTION
Hi community, currently, the client sets
org.apache.kafka.clients.NetworkClient.DefaultMetadataUpdater#inProgress
when retrieving metadata. In the event of a successful or failed
response, inProgress is set to null.    <img width="669" height="953"
alt="image"
src="https://github.com/user-attachments/assets/0f68db84-8f02-40c8-a499-31a78ff0458f"
/>

The problem we encountered was:    An exception was thrown while
processing the MetadataResponse, causing inProgress to not be updated.
Metadata requests could not be initiated again, and metadata remained
unupdated.      <img width="702" height="234" alt="image"
src="https://github.com/user-attachments/assets/4a0ad909-cee3-4c0f-9c04-2b0d76506fd5"
/>

Why did the update fail?    maybeUpdate(long now) always returns a
default timeout, meaning no new MetadataRequest would be sent until the
previous one was complete.
