### PR TITLE
MINOR: Fix an off-by-one issue in ValuesTest

### DIFF
--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Values.Parser;
 import org.apache.kafka.connect.errors.DataException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Values.Parser;
 import org.apache.kafka.connect.errors.DataException;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -30,7 +29,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -903,7 +901,7 @@ public class ValuesTest {
 
         // ISO8601 strings - accept a string matching pattern "yyyy-MM-dd"
         LocalDateTime localTimeTruncated = localTime.truncatedTo(ChronoUnit.DAYS);
-        java.util.Date d3 = Values.convertToDate(Date.SCHEMA, LocalDate.ofEpochDay(days).format(DateTimeFormatter.ISO_LOCAL_DATE));
+        java.util.Date d3 = Values.convertToDate(Date.SCHEMA, localTime.format(DateTimeFormatter.ISO_LOCAL_DATE));
         LocalDateTime date3 = LocalDateTime.ofInstant(Instant.ofEpochMilli(d3.getTime()), ZoneId.systemDefault());
         assertEquals(localTimeTruncated, date3);
 


### PR DESCRIPTION
This test case ensures that the parser can convert ISO8601 correctly.
However, when the local time falls on a different day than the UTC time,
there will be an off-by-one issue.

I changed the test to convert the local time and then compare it with
the expected local time. This should fix the off-by-one issue.

[Reference
link](https://github.com/apache/kafka/pull/18611#discussion_r2318146619)

Reviewers: Andrew Schofield <aschofield@confluent.io>
