### PR TITLE
MINOR: Refactor on FeaturesPublisher and ScramPublisher

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -145,7 +145,7 @@ class ControllerServer(
 
       metadataCachePublisher = new KRaftMetadataCachePublisher(metadataCache)
 
-      featuresPublisher = new FeaturesPublisher(logContext)
+      featuresPublisher = new FeaturesPublisher(logContext, sharedServer.metadataPublishingFaultHandler)
 
       registrationsPublisher = new ControllerRegistrationsPublisher()
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -224,7 +224,7 @@ class BrokerMetadataPublisher(
       dynamicTopicClusterQuotaPublisher.onMetadataUpdate(delta, newImage)
 
       // Apply SCRAM delta.
-      scramPublisher.onMetadataUpdate(delta, newImage)
+      scramPublisher.onMetadataUpdate(delta, newImage, manifest)
 
       // Apply DelegationToken delta.
       delegationTokenPublisher.onMetadataUpdate(delta, newImage)

--- a/metadata/src/main/java/org/apache/kafka/metadata/publisher/FeaturesPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/publisher/FeaturesPublisher.java
@@ -61,8 +61,8 @@ public class FeaturesPublisher implements MetadataPublisher {
         try {
             if (delta.featuresDelta() != null) {
                 FinalizedFeatures newFinalizedFeatures = new FinalizedFeatures(newImage.features().metadataVersionOrThrow(),
-                        newImage.features().finalizedVersions(),
-                        newImage.provenance().lastContainedOffset()
+                    newImage.features().finalizedVersions(),
+                    newImage.provenance().lastContainedOffset()
                 );
                 if (!newFinalizedFeatures.equals(finalizedFeatures)) {
                     log.info("Loaded new metadata {}.", newFinalizedFeatures);
@@ -70,8 +70,8 @@ public class FeaturesPublisher implements MetadataPublisher {
                 }
             }
         } catch (Throwable t) {
-            String deltaName = "MetadataDelta up to " + newImage.highestOffsetAndEpoch().offset();
-            faultHandler.handleFault("Uncaught exception while publishing features changes from " + deltaName, t);
+            faultHandler.handleFault("Uncaught exception while publishing SCRAM changes from MetadataDelta up to "
+                + newImage.highestOffsetAndEpoch().offset(), t);
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/publisher/FeaturesPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/publisher/FeaturesPublisher.java
@@ -23,6 +23,7 @@ import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.loader.LoaderManifest;
 import org.apache.kafka.image.publisher.MetadataPublisher;
 import org.apache.kafka.server.common.FinalizedFeatures;
+import org.apache.kafka.server.fault.FaultHandler;
 
 import org.slf4j.Logger;
 
@@ -31,12 +32,15 @@ import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 
 public class FeaturesPublisher implements MetadataPublisher {
     private final Logger log;
+    private final FaultHandler faultHandler;
     private volatile FinalizedFeatures finalizedFeatures = FinalizedFeatures.fromKRaftVersion(MINIMUM_VERSION);
 
     public FeaturesPublisher(
-        LogContext logContext
+        LogContext logContext,
+        FaultHandler faultHandler
     ) {
-        log = logContext.logger(FeaturesPublisher.class);
+        this.log = logContext.logger(FeaturesPublisher.class);
+        this.faultHandler = faultHandler;
     }
 
     public FinalizedFeatures features() {
@@ -54,15 +58,20 @@ public class FeaturesPublisher implements MetadataPublisher {
         MetadataImage newImage,
         LoaderManifest manifest
     ) {
-        if (delta.featuresDelta() != null) {
-            FinalizedFeatures newFinalizedFeatures = new FinalizedFeatures(newImage.features().metadataVersionOrThrow(),
-                    newImage.features().finalizedVersions(),
-                    newImage.provenance().lastContainedOffset()
-            );
-            if (!newFinalizedFeatures.equals(finalizedFeatures)) {
-                log.info("Loaded new metadata {}.", newFinalizedFeatures);
-                finalizedFeatures = newFinalizedFeatures;
+        try {
+            if (delta.featuresDelta() != null) {
+                FinalizedFeatures newFinalizedFeatures = new FinalizedFeatures(newImage.features().metadataVersionOrThrow(),
+                        newImage.features().finalizedVersions(),
+                        newImage.provenance().lastContainedOffset()
+                );
+                if (!newFinalizedFeatures.equals(finalizedFeatures)) {
+                    log.info("Loaded new metadata {}.", newFinalizedFeatures);
+                    finalizedFeatures = newFinalizedFeatures;
+                }
             }
+        } catch (Throwable t) {
+            String deltaName = "MetadataDelta up to " + newImage.highestOffsetAndEpoch().offset();
+            faultHandler.handleFault("Uncaught exception while publishing features changes from " + deltaName, t);
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/publisher/ScramPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/publisher/ScramPublisher.java
@@ -44,10 +44,6 @@ public class ScramPublisher implements MetadataPublisher {
 
     @Override
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
-        onMetadataUpdate(delta, newImage);
-    }
-
-    public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage) {
         try {
             // Apply changes to SCRAM credentials.
             ScramDelta scramDelta = delta.scramDelta();

--- a/metadata/src/main/java/org/apache/kafka/metadata/publisher/ScramPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/publisher/ScramPublisher.java
@@ -58,8 +58,8 @@ public class ScramPublisher implements MetadataPublisher {
                 });
             }
         } catch (Throwable t) {
-            String deltaName = "MetadataDelta up to " + newImage.highestOffsetAndEpoch().offset();
-            faultHandler.handleFault("Uncaught exception while publishing SCRAM changes from " + deltaName, t);
+            faultHandler.handleFault("Uncaught exception while publishing SCRAM changes from MetadataDelta up to "
+                + newImage.highestOffsetAndEpoch().offset(), t);
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/publisher/ScramPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/publisher/ScramPublisher.java
@@ -48,7 +48,6 @@ public class ScramPublisher implements MetadataPublisher {
     }
 
     public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage) {
-        String deltaName = "MetadataDelta up to " + newImage.highestOffsetAndEpoch().offset();
         try {
             // Apply changes to SCRAM credentials.
             ScramDelta scramDelta = delta.scramDelta();
@@ -63,6 +62,7 @@ public class ScramPublisher implements MetadataPublisher {
                 });
             }
         } catch (Throwable t) {
+            String deltaName = "MetadataDelta up to " + newImage.highestOffsetAndEpoch().offset();
             faultHandler.handleFault("Uncaught exception while publishing SCRAM changes from " + deltaName, t);
         }
     }


### PR DESCRIPTION
This PR is a follow-up from https://github.com/apache/kafka/pull/20468.
Basically makes two things:
1. Moves the variable to the catch block as it is used only there.
2. Refactor FeaturesPublisher to handle exceptions the same as
ScramPublisher or other publishers :)

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
