### PR TITLE
MINOR: Update ClusterTestExtensions Javadoc example

### DIFF
--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
@@ -79,7 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <pre>
  * class SomeIntegrationTest {
  *   &#64;ClusterTest(brokers = 1, controllers = 1, types = {Type.KRAFT, Type.CO_KRAFT})
- *   def someTest(): Unit = {
+ *   void someTest(ClusterInstance cluster) {
  *     assertTrue(condition)
  *   }
  * }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
@@ -78,14 +78,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <pre>
  * class SomeIntegrationTest {
- *   &#64;ClusterTest(brokers = 1, controllers = 1, clusterType = ClusterType.Both)
+ *   &#64;ClusterTest(brokers = 1, controllers = 1, types = {Type.KRAFT, Type.CO_KRAFT})
  *   def someTest(): Unit = {
  *     assertTrue(condition)
  *   }
  * }
  * </pre>
  *
- * will generate two invocations of "someTest" (since ClusterType.Both was given). For each invocation, the test class
+ * will generate two invocations of "someTest" (since two cluster types were specified). For each invocation, the test class
  * SomeIntegrationTest will be instantiated, lifecycle methods (before/after) will be run, and "someTest" will be invoked.
  *
  * A special system property "kafka.cluster.test.repeat" can be used to cause repeated invocation of the tests.


### PR DESCRIPTION
The previous Javadoc example used the deprecated ClusterType.   It is
now updated to use `types = {Type.KRAFT, Type.CO_KRAFT}`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
