### PR TITLE
KAFKA-19699: improve the documentation of `RecordsToDelete`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/RecordsToDelete.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RecordsToDelete.java
@@ -33,14 +33,16 @@ public class RecordsToDelete {
     /**
      * Delete all the records before the given {@code offset}
      *
-     * @param offset    the offset before which all records will be deleted
+     * @param offset    The offset before which all records will be deleted.
+     *                  Use {@code -1} to truncate to the high watermark.
      */
     public static RecordsToDelete beforeOffset(long offset) {
         return new RecordsToDelete(offset);
     }
 
     /**
-     * The offset before which all records will be deleted
+     * The offset before which all records will be deleted.
+     * Use {@code -1} to truncate to the high watermark.
      */
     public long beforeOffset() {
         return offset;

--- a/clients/src/main/resources/common/message/DeleteRecordsRequest.json
+++ b/clients/src/main/resources/common/message/DeleteRecordsRequest.json
@@ -33,7 +33,7 @@
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "Offset", "type": "int64", "versions": "0+",
-          "about": "The deletion offset." }
+          "about": "The deletion offset. -1 means that records should be truncated to the high watermark." }
       ]}
     ]},
     { "name": "TimeoutMs", "type": "int32", "versions": "0+",


### PR DESCRIPTION
document the behavior of "-1" (HIGH_WATERMARK)

Reviewers: Ken Huang <s7133700@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
