### PR TITLE
MINOR: Fix typos in CoordinatorRecordTypeGenerator

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/CoordinatorRecordTypeGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/CoordinatorRecordTypeGenerator.java
@@ -124,11 +124,11 @@ public class CoordinatorRecordTypeGenerator implements TypeClassGenerator {
         for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
             MessageSpec key = entry.getValue().key;
             if (key == null) {
-                throw new RuntimeException("Coordinator record " + entry.getKey() + " has not key.");
+                throw new RuntimeException("Coordinator record " + entry.getKey() + " has no key.");
             }
             MessageSpec value = entry.getValue().value;
             if (value == null) {
-                throw new RuntimeException("Coordinator record " + entry.getKey() + " has not key.");
+                throw new RuntimeException("Coordinator record " + entry.getKey() + " has no value.");
             }
             String name = cleanName(key.name());
             numProcessed++;


### PR DESCRIPTION
This patch fixes a few typos in CoordinatorRecordTypeGenerator.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, TengYao Chi
 <frankvicky@apache.org>, Sean Quah <squah@confluent.io>
