### PR TITLE
MINOR : Fix parantheses in console_consumer.py and console_share_consumer.py

### DIFF
--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -179,7 +179,7 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
             # This will be added in the properties file instead
             cmd += " --timeout-ms %s" % self.consumer_timeout_ms
 
-        formatter_property_arg = "--formatter-property" if version.supports_formatter_property else "--property"
+        formatter_property_arg = "--formatter-property" if version.supports_formatter_property() else "--property"
         if self.print_timestamp:
             cmd += " %s print.timestamp=true" % formatter_property_arg
 

--- a/tests/kafkatest/services/console_share_consumer.py
+++ b/tests/kafkatest/services/console_share_consumer.py
@@ -167,7 +167,7 @@ class ConsoleShareConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadSer
             # This will be added in the properties file instead
             cmd += " --timeout-ms %s" % self.share_consumer_timeout_ms
 
-        formatter_property_arg = "--formatter-property" if version.supports_formatter_property else "--property"
+        formatter_property_arg = "--formatter-property" if version.supports_formatter_property() else "--property"
         if self.print_timestamp:
             cmd += " %s print.timestamp=true" % formatter_property_arg
 


### PR DESCRIPTION
*What*
We were missing a parantheses when we invoked a method
`supports_formatter_property()`. This would mean we would get the object
not call the function.
PR fixes this by including parantheses and invoking the actual function.
