### PR TITLE
MINOR: Tighten up argument descriptions for console CLI tools

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
@@ -254,12 +254,12 @@ public class ConsoleProducer {
                     .withRequiredArg()
                     .describedAs("config file")
                     .ofType(String.class);
-            producerPropertyOpt = parser.accepts("producer-property", "(DEPRECATED) A mechanism to pass user-defined properties in the form key=value to the producer." +
+            producerPropertyOpt = parser.accepts("producer-property", "(DEPRECATED) Producer config properties in the form key=value. " +
                             "This option will be removed in a future version. Use --command-property instead.")
                     .withRequiredArg()
                     .describedAs("producer_prop")
                     .ofType(String.class);
-            commandPropertyOpt = parser.accepts("command-property", "A mechanism to pass user-defined properties in the form key=value to the producer.")
+            commandPropertyOpt = parser.accepts("command-property", "Producer config properties in the form key=value.")
                     .withRequiredArg()
                     .describedAs("producer_prop")
                     .ofType(String.class);

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptions.java
@@ -71,7 +71,7 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
     @SuppressWarnings("deprecation")
     public ConsoleConsumerOptions(String[] args) throws IOException {
         super(args);
-        topicOpt = parser.accepts("topic", "The topic to consume on.")
+        topicOpt = parser.accepts("topic", "The topic to consume from.")
                 .withRequiredArg()
                 .describedAs("topic")
                 .ofType(String.class);
@@ -91,12 +91,12 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                 .ofType(String.class)
                 .defaultsTo("latest");
         @Deprecated(since = "4.2", forRemoval = true)
-        OptionSpec<String> consumerPropertyOpt = parser.accepts("consumer-property", "(DEPRECATED) A mechanism to pass user-defined properties in the form key=value to the consumer. " +
+        OptionSpec<String> consumerPropertyOpt = parser.accepts("consumer-property", "(DEPRECATED) Consumer config properties in the form key=value. " +
                         "This option will be removed in a future version. Use --command-property instead.")
                 .withRequiredArg()
                 .describedAs("consumer_prop")
                 .ofType(String.class);
-        OptionSpec<String> commandPropertyOpt = parser.accepts("command-property", "A mechanism to pass user-defined properties in the form key=value to the consumer.")
+        OptionSpec<String> commandPropertyOpt = parser.accepts("command-property", "Consumer config properties in the form key=value.")
                 .withRequiredArg()
                 .describedAs("consumer_prop")
                 .ofType(String.class);
@@ -126,7 +126,7 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                             " print.value=true|false\n" +
                             " key.separator=<key.separator>\n" +
                             " line.separator=<line.separator>\n" +
-                            " headers.separator=<line.separator>\n" +
+                            " headers.separator=<headers.separator>\n" +
                             " null.literal=<null.literal>\n" +
                             " key.deserializer=<key.deserializer>\n" +
                             " value.deserializer=<value.deserializer>\n" +
@@ -176,11 +176,11 @@ public final class ConsoleConsumerOptions extends CommandDefaultOptions {
                 .withRequiredArg()
                 .describedAs("server to connect to")
                 .ofType(String.class);
-        keyDeserializerOpt = parser.accepts("key-deserializer")
+        keyDeserializerOpt = parser.accepts("key-deserializer", "The name of the class to use for deserializing keys.")
                 .withRequiredArg()
-                .describedAs("deserializer for key")
+                .describedAs("deserializer for keys")
                 .ofType(String.class);
-        valueDeserializerOpt = parser.accepts("value-deserializer")
+        valueDeserializerOpt = parser.accepts("value-deserializer", "The name of the class to use for deserializing values.")
                 .withRequiredArg()
                 .describedAs("deserializer for values")
                 .ofType(String.class);

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptions.java
@@ -62,12 +62,12 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                 .describedAs("topic")
                 .ofType(String.class);
         @Deprecated(since = "4.2", forRemoval = true)
-        OptionSpec<String> consumerPropertyOpt = parser.accepts("consumer-property", "(DEPRECATED) A mechanism to pass user-defined properties in the form key=value to the consumer. " +
+        OptionSpec<String> consumerPropertyOpt = parser.accepts("consumer-property", "(DEPRECATED) Consumer config properties in the form key=value. " +
                         "This option will be removed in a future version. Use --command-property instead.")
                 .withRequiredArg()
                 .describedAs("consumer_prop")
                 .ofType(String.class);
-        OptionSpec<String> commandPropertyOpt = parser.accepts("command-property", "A mechanism to pass user-defined properties in the form key=value to the consumer.")
+        OptionSpec<String> commandPropertyOpt = parser.accepts("command-property", "Consumer config properties in the form key=value.")
                 .withRequiredArg()
                 .describedAs("consumer_prop")
                 .ofType(String.class);
@@ -98,7 +98,7 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                                 " print.value=true|false\n" +
                                 " key.separator=<key.separator>\n" +
                                 " line.separator=<line.separator>\n" +
-                                " headers.separator=<line.separator>\n" +
+                                " headers.separator=<headers.separator>\n" +
                                 " null.literal=<null.literal>\n" +
                                 " key.deserializer=<key.deserializer>\n" +
                                 " value.deserializer=<value.deserializer>\n" +
@@ -151,7 +151,7 @@ public final class ConsoleShareConsumerOptions extends CommandDefaultOptions {
                 .ofType(String.class);
         keyDeserializerOpt = parser.accepts("key-deserializer", "The name of the class to use for deserializing keys.")
                 .withRequiredArg()
-                .describedAs("deserializer for key")
+                .describedAs("deserializer for keys")
                 .ofType(String.class);
         valueDeserializerOpt = parser.accepts("value-deserializer", "The name of the class to use for deserializing values.")
                 .withRequiredArg()


### PR DESCRIPTION
Small improvements to the argument descriptions in the usage messages
for the console producer/consumer tools.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
