### PR TITLE
MINOR : Add unit tests for verifying --formatter-property in console tools.

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
@@ -355,13 +355,63 @@ public class ConsoleConsumerOptionsTest {
     }
 
     @Test
-    public void testCustomPropertyShouldBePassedToConfigureMethod() throws Exception {
+    public void testCustomPropertyShouldBePassedToConfigureMethodDeprecated() throws Exception {
         String[] args = new String[]{
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
             "--property", "print.key=true",
             "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
             "--property", "key.deserializer.my-props=abc"
+        };
+
+        ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
+
+        assertInstanceOf(DefaultMessageFormatter.class, config.formatter());
+        assertTrue(config.formatterArgs().containsKey("key.deserializer.my-props"));
+        DefaultMessageFormatter formatter = (DefaultMessageFormatter) config.formatter();
+        assertTrue(formatter.keyDeserializer().isPresent());
+        assertInstanceOf(MockDeserializer.class, formatter.keyDeserializer().get());
+        MockDeserializer keyDeserializer = (MockDeserializer) formatter.keyDeserializer().get();
+        assertEquals(1, keyDeserializer.configs.size());
+        assertEquals("abc", keyDeserializer.configs.get("my-props"));
+        assertTrue(keyDeserializer.isKey);
+    }
+
+    @Test
+    public void testCustomPropertyShouldBePassedToConfigureMethod() throws Exception {
+        String[] args = new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--formatter-property", "print.key=true",
+            "--formatter-property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+            "--formatter-property", "key.deserializer.my-props=abc"
+        };
+
+        ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
+
+        assertInstanceOf(DefaultMessageFormatter.class, config.formatter());
+        assertTrue(config.formatterArgs().containsKey("key.deserializer.my-props"));
+        DefaultMessageFormatter formatter = (DefaultMessageFormatter) config.formatter();
+        assertTrue(formatter.keyDeserializer().isPresent());
+        assertInstanceOf(MockDeserializer.class, formatter.keyDeserializer().get());
+        MockDeserializer keyDeserializer = (MockDeserializer) formatter.keyDeserializer().get();
+        assertEquals(1, keyDeserializer.configs.size());
+        assertEquals("abc", keyDeserializer.configs.get("my-props"));
+        assertTrue(keyDeserializer.isKey);
+    }
+
+    @Test
+    public void testCustomConfigShouldBePassedToConfigureMethodDeprecated() throws Exception {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("key.deserializer.my-props", "abc");
+        configs.put("print.key", "false");
+        File propsFile = ToolsTestUtils.tempPropertiesFile(configs);
+        String[] args = new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--property", "print.key=true",
+            "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+            "--formatter-config", propsFile.getAbsolutePath()
         };
 
         ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
@@ -386,8 +436,8 @@ public class ConsoleConsumerOptionsTest {
         String[] args = new String[]{
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
-            "--property", "print.key=true",
-            "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+            "--formatter-property", "print.key=true",
+            "--formatter-property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
             "--formatter-config", propsFile.getAbsolutePath()
         };
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
@@ -151,13 +151,34 @@ public class ConsoleConsumerOptionsTest {
     }
 
     @Test
-    public void shouldParseValidSimpleConsumerValidConfigWithStringOffset() throws Exception {
+    public void shouldParseValidSimpleConsumerValidConfigWithStringOffsetDeprecated() throws Exception {
         String[] args = new String[]{
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
             "--partition", "0",
             "--offset", "LatEst",
             "--property", "print.value=false"
+        };
+
+        ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
+
+        assertEquals("localhost:9092", config.bootstrapServer());
+        assertEquals("test", config.topicArg().orElse(""));
+        assertTrue(config.partitionArg().isPresent());
+        assertEquals(0, config.partitionArg().getAsInt());
+        assertEquals(-1, config.offsetArg());
+        assertFalse(config.fromBeginning());
+        assertFalse(((DefaultMessageFormatter) config.formatter()).printValue());
+    }
+
+    @Test
+    public void shouldParseValidSimpleConsumerValidConfigWithStringOffset() throws Exception {
+        String[] args = new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--partition", "0",
+            "--offset", "LatEst",
+            "--formatter-property", "print.value=false"
         };
 
         ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
@@ -222,13 +222,63 @@ public class ConsoleShareConsumerOptionsTest {
     }
 
     @Test
-    public void testCustomPropertyShouldBePassedToConfigureMethod() throws Exception {
+    public void testCustomPropertyShouldBePassedToConfigureMethodDeprecated() throws Exception {
         String[] args = new String[]{
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
             "--property", "print.key=true",
             "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
             "--property", "key.deserializer.my-props=abc"
+        };
+
+        ConsoleShareConsumerOptions config = new ConsoleShareConsumerOptions(args);
+
+        assertInstanceOf(DefaultMessageFormatter.class, config.formatter());
+        assertTrue(config.formatterArgs().containsKey("key.deserializer.my-props"));
+        DefaultMessageFormatter formatter = (DefaultMessageFormatter) config.formatter();
+        assertTrue(formatter.keyDeserializer().isPresent());
+        assertInstanceOf(MockDeserializer.class, formatter.keyDeserializer().get());
+        MockDeserializer keyDeserializer = (MockDeserializer) formatter.keyDeserializer().get();
+        assertEquals(1, keyDeserializer.configs.size());
+        assertEquals("abc", keyDeserializer.configs.get("my-props"));
+        assertTrue(keyDeserializer.isKey);
+    }
+
+    @Test
+    public void testCustomPropertyShouldBePassedToConfigureMethod() throws Exception {
+        String[] args = new String[]{
+                "--bootstrap-server", "localhost:9092",
+                "--topic", "test",
+                "--formatter-property", "print.key=true",
+                "--formatter-property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+                "--formatter-property", "key.deserializer.my-props=abc"
+        };
+
+        ConsoleShareConsumerOptions config = new ConsoleShareConsumerOptions(args);
+
+        assertInstanceOf(DefaultMessageFormatter.class, config.formatter());
+        assertTrue(config.formatterArgs().containsKey("key.deserializer.my-props"));
+        DefaultMessageFormatter formatter = (DefaultMessageFormatter) config.formatter();
+        assertTrue(formatter.keyDeserializer().isPresent());
+        assertInstanceOf(MockDeserializer.class, formatter.keyDeserializer().get());
+        MockDeserializer keyDeserializer = (MockDeserializer) formatter.keyDeserializer().get();
+        assertEquals(1, keyDeserializer.configs.size());
+        assertEquals("abc", keyDeserializer.configs.get("my-props"));
+        assertTrue(keyDeserializer.isKey);
+    }
+
+    @Test
+    public void testCustomConfigShouldBePassedToConfigureMethodDeprecated() throws Exception {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("key.deserializer.my-props", "abc");
+        configs.put("print.key", "false");
+        File propsFile = ToolsTestUtils.tempPropertiesFile(configs);
+        String[] args = new String[]{
+                "--bootstrap-server", "localhost:9092",
+                "--topic", "test",
+                "--property", "print.key=true",
+                "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+                "--formatter-config", propsFile.getAbsolutePath()
         };
 
         ConsoleShareConsumerOptions config = new ConsoleShareConsumerOptions(args);
@@ -253,8 +303,8 @@ public class ConsoleShareConsumerOptionsTest {
         String[] args = new String[]{
             "--bootstrap-server", "localhost:9092",
             "--topic", "test",
-            "--property", "print.key=true",
-            "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+            "--formatter-property", "print.key=true",
+            "--formatter-property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
             "--formatter-config", propsFile.getAbsolutePath()
         };
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleShareConsumerOptionsTest.java
@@ -247,11 +247,11 @@ public class ConsoleShareConsumerOptionsTest {
     @Test
     public void testCustomPropertyShouldBePassedToConfigureMethod() throws Exception {
         String[] args = new String[]{
-                "--bootstrap-server", "localhost:9092",
-                "--topic", "test",
-                "--formatter-property", "print.key=true",
-                "--formatter-property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
-                "--formatter-property", "key.deserializer.my-props=abc"
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--formatter-property", "print.key=true",
+            "--formatter-property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+            "--formatter-property", "key.deserializer.my-props=abc"
         };
 
         ConsoleShareConsumerOptions config = new ConsoleShareConsumerOptions(args);
@@ -274,11 +274,11 @@ public class ConsoleShareConsumerOptionsTest {
         configs.put("print.key", "false");
         File propsFile = ToolsTestUtils.tempPropertiesFile(configs);
         String[] args = new String[]{
-                "--bootstrap-server", "localhost:9092",
-                "--topic", "test",
-                "--property", "print.key=true",
-                "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
-                "--formatter-config", propsFile.getAbsolutePath()
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--property", "print.key=true",
+            "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+            "--formatter-config", propsFile.getAbsolutePath()
         };
 
         ConsoleShareConsumerOptions config = new ConsoleShareConsumerOptions(args);


### PR DESCRIPTION
*What*
In the implementation of KIP-1147 for console tools -
https://github.com/apache/kafka/pull/20479/files#diff-85b87c675a4b933e8e0e05c654d35d60e9cfd36cebe3331af825191b2cc688ee,
we missed adding unit tests for verifying the new
"`--formatter-property`" option.
Thanks to @Yunyung for pointing this out.

PR adds unit tests to both `ConsoleConsumerOptionsTest` and
`ConsoleShareConsumerOptionsTest` to verify the same.

Reviewers: Jhen-Yung Hsu <jhenyunghsu@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
