### PR TITLE
MINOR: Only Apache Kafka allow to publish build scan

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -92,7 +92,7 @@ jobs:
           state: 'error'
       - name: Publish Scan
         id: publish-build-scan
-        if: ${{ steps.download-build-scan.outcome == 'success' }}
+        if: ${{ github.repository == 'apache/kafka' && steps.download-build-scan.outcome == 'success' }}
         run: |
           set +e
           ./gradlew --info buildScanPublishPrevious > gradle.out
@@ -108,7 +108,7 @@ jobs:
             echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
           fi
       - name: Handle failed publish
-        if: ${{ failure() && steps.publish-build-scan.outcome == 'failure' }}
+        if: ${{ github.repository == 'apache/kafka' && failure() && steps.publish-build-scan.outcome == 'failure' }}
         uses: ./.github/actions/gh-api-update-status
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Original code allow all repo to publish build scan but actually   only
Apache Kafka have the permission to  publish build scan.

With this change the other repos will not publish build scan.
