### PR TITLE
KAFKA-19737: Fix PluginUtils#pluginLocations warning log not being printed

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -205,7 +205,8 @@ public class PluginUtils {
      * Each element may be a directory or a JAR/ZIP archive path.
      * - For a directory, returns its immediate children that are directories, archives, or .class files.
      * - For an archive, returns the archive itself.
-     * - Empty elements are interpreted as the current working directory.
+     * If the comma-separated list contains empty elements (e.g., path1,,path2), they are interpreted as
+     * the current working directory.
      * All returned paths are absolute. Non-existent or invalid elements are ignored unless {@code failFast} is true.
      *
      * @param pluginPath A comma-separated list of plugin roots; may be null

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -205,8 +205,9 @@ public class PluginUtils {
      * Each element may be a directory or a JAR/ZIP archive path.
      * - For a directory, returns its immediate children that are directories, archives, or .class files.
      * - For an archive, returns the archive itself.
-     * If the comma-separated list contains empty elements (e.g., path1,,path2), they are interpreted as
-     * the current working directory.
+     * If the comma-separated list contains empty elements (e.g., path1,,path2), each empty element is
+     * resolved to the current working directory (i.e., {@code Paths.get("").toAbsolutePath()}) and then
+     * processed as a directory.
      * All returned paths are absolute. Non-existent or invalid elements are ignored unless {@code failFast} is true.
      *
      * @param pluginPath A comma-separated list of plugin roots; may be null

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -200,6 +200,19 @@ public class PluginUtils {
         return path.toString().toLowerCase(Locale.ROOT).endsWith(".class");
     }
 
+    /**
+     * Resolve plugin locations from a comma-separated plugin path.
+     * Each element may be a directory or a JAR/ZIP archive path.
+     * - For a directory, returns its immediate children that are directories, archives, or .class files.
+     * - For an archive, returns the archive itself.
+     * - Empty elements are interpreted as the current working directory.
+     * All returned paths are absolute. Non-existent or invalid elements are ignored unless {@code failFast} is true.
+     *
+     * @param pluginPath A comma-separated list of plugin roots; may be null
+     * @param failFast If true, throw a RuntimeException on the first invalid element; otherwise log and continue
+     * @return An ordered set of absolute paths representing plugin locations
+     * @throws RuntimeException When {@code failFast} is true and an invalid element is encountered
+     */
     public static Set<Path> pluginLocations(String pluginPath, boolean failFast) {
         if (pluginPath == null) {
             return Set.of();
@@ -209,7 +222,7 @@ public class PluginUtils {
         for (String path : pluginPathElements) {
             try {
                 Path pluginPathElement = Paths.get(path).toAbsolutePath();
-                if (pluginPath.isEmpty()) {
+                if (path.isEmpty()) {
                     log.warn("Plugin path element is empty, evaluating to {}.", pluginPathElement);
                 }
                 if (!Files.exists(pluginPathElement)) {
@@ -232,14 +245,19 @@ public class PluginUtils {
         return pluginLocations;
     }
 
+    /**
+     * Retrieves a list of paths from the given plugin path element.
+     * This method scans the directory specified by the provided path and collects
+     * all entries that match the {@code PLUGIN_PATH_FILTER} criteria, which includes directories,
+     * archives, or `.class` files.
+     *
+     * @param pluginPathElement the path to the directory to scan for plugin locations
+     * @return a list of paths that match the {@code PLUGIN_PATH_FILTER} criteria
+     * @throws IOException if an I/O error occurs while accessing the directory
+     */
     private static List<Path> pluginLocations(Path pluginPathElement) throws IOException {
         List<Path> locations = new ArrayList<>();
-        try (
-                DirectoryStream<Path> listing = Files.newDirectoryStream(
-                        pluginPathElement,
-                        PLUGIN_PATH_FILTER
-                )
-        ) {
+        try (DirectoryStream<Path> listing = Files.newDirectoryStream(pluginPathElement, PLUGIN_PATH_FILTER)) {
             for (Path dir : listing) {
                 locations.add(dir);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -205,9 +205,10 @@ public class PluginUtils {
      * Each element may be a directory or a JAR/ZIP archive path.
      * - For a directory, returns its immediate children that are directories, archives, or .class files.
      * - For an archive, returns the archive itself.
-     * If the comma-separated list contains empty elements (e.g., path1,,path2), each empty element is
-     * resolved to the current working directory (i.e., {@code Paths.get("").toAbsolutePath()}) and then
+     * Note that if the comma-separated plugin path contains empty elements (e.g., path1,,path2), the empty element
+     * is resolved to the current working directory (i.e., {@code Paths.get("").toAbsolutePath()}) and then
      * processed as a directory.
+     *
      * All returned paths are absolute. Non-existent or invalid elements are ignored unless {@code failFast} is true.
      *
      * @param pluginPath A comma-separated list of plugin roots; may be null

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,13 +42,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PluginUtilsTest {
@@ -600,6 +605,91 @@ public class PluginUtilsTest {
         Map<String, String> expectedAliases = new HashMap<>();
         expectedAliases.put("CollidingConverter", CollidingConverter.class.getName());
         assertEquals(expectedAliases, actualAliases);
+    }
+
+    @Test
+    public void testPluginPathIsNull() {
+        Set<Path> actualPath = PluginUtils.pluginLocations(null, true);
+        assertTrue(actualPath.isEmpty());
+    }
+
+    @Test
+    public void testPluginPathIsDirectory() throws IOException {
+        Path connectorA = Files.createDirectories(pluginPath.resolve("connectorA"));
+        Path connectorB = Files.createDirectories(pluginPath.resolve("connectorB"));
+        Path transformC = Files.createDirectories(pluginPath.resolve("transformC"));
+
+        // not in PLUGIN_PATH_FILTER
+        Files.createFile(pluginPath.resolve("README.txt"));
+
+        Set<Path> actualPluginPath = PluginUtils.pluginLocations(pluginPath.toString(), true);
+
+        Set<Path> expectedPluginPath = new LinkedHashSet<>();
+        expectedPluginPath.add(transformC.toAbsolutePath());
+        expectedPluginPath.add(connectorB.toAbsolutePath());
+        expectedPluginPath.add(connectorA.toAbsolutePath());
+
+        assertEquals(expectedPluginPath, actualPluginPath);
+        actualPluginPath.forEach(p -> assertTrue(p.isAbsolute()));
+    }
+
+    @Test
+    public void testPluginPathIsArchive() throws IOException {
+        Path jarPluginPath = Files.createFile(pluginPath.resolve("converter.jar")).toAbsolutePath();
+        Set<Path> actualPluginPath = PluginUtils.pluginLocations(jarPluginPath.toString(), true);
+        assertEquals(Set.of(jarPluginPath), actualPluginPath);
+    }
+
+    @Test
+    public void testPluginIncludeClassFile() throws IOException {
+        Path pluginPath = this.pluginPath.resolve("plugins-with-class");
+        Files.createDirectories(pluginPath);
+        Path testClass = Files.createFile(pluginPath.resolve("Foo.class"));
+
+        Set<Path> actual = PluginUtils.pluginLocations(pluginPath.toString(), true);
+
+        assertEquals(Set.of(testClass.toAbsolutePath()), actual);
+    }
+
+    @Test
+    public void testPluginPathHaveEmptyElement() throws IOException {
+        Path connectorA = Files.createFile(pluginPath.resolve("connectorA.jar")).toAbsolutePath();
+        Path connectorB = Files.createFile(pluginPath.resolve("connectorB.jar")).toAbsolutePath();
+
+        // have empty element between the commas
+        String pluginPath = connectorA + ",," + connectorB;
+        Set<Path> actualPath = PluginUtils.pluginLocations(pluginPath, true);
+
+        Set<Path> expectedPath = new LinkedHashSet<>();
+        expectedPath.add(connectorA.toAbsolutePath());
+        expectedPath.add(connectorB.toAbsolutePath());
+
+        assertNotEquals(expectedPath, actualPath);
+
+        // need add current path
+        Path cwd = Paths.get("").toAbsolutePath();
+        try (DirectoryStream<Path> listing = Files.newDirectoryStream(cwd,
+                p -> Files.isDirectory(p) || PluginUtils.isArchive(p) || PluginUtils.isClassFile(p))) {
+            for (Path p : listing) {
+                expectedPath.add(p.toAbsolutePath());
+            }
+        }
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void testPluginPathNotExist() {
+        Path missing = pluginPath.resolve("this-path-should-not-exist");
+        assertFalse(Files.exists(missing));
+        Set<Path> actual = PluginUtils.pluginLocations(missing.toString(), false);
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    public void testPluginPathNotExistWithFailFast() {
+        Path missing = pluginPath.resolve("this-path-should-not-exist");
+        assertFalse(Files.exists(missing));
+        assertThrows(RuntimeException.class, () -> PluginUtils.pluginLocations(missing.toString(), true));
     }
 
     public static class CollidingConverter implements Converter, Versioned {


### PR DESCRIPTION
Currently, the warning log is only printed when the `plugin.path` configuration is empty. However, in reality, `plugin.path` is defined as a non-empty value, so this warning log will never be printed. The intended behavior should be to print a warning log only if the `plugin.path` parameter contains an empty string element. Also, add javadoc and unit tests.

