### PR TITLE
Minor: fix AdjustStreamThreadCountTest

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
@@ -272,8 +272,8 @@ public class AdjustStreamThreadCountTest {
             stateTransitionHistory.clear();
 
             final CountDownLatch latch = new CountDownLatch(2);
-            final Thread one = adjustCountHelperThread(kafkaStreams, 2, latch);
-            final Thread two = adjustCountHelperThread(kafkaStreams, 3, latch);
+            final Thread one = adjustCountHelperThread(kafkaStreams, 1, latch);
+            final Thread two = adjustCountHelperThread(kafkaStreams, 1, latch);
             Set<ThreadMetadata> threadMetadata = null;
 
             AssertionError testError = null;
@@ -281,9 +281,10 @@ public class AdjustStreamThreadCountTest {
                 two.start();
                 one.start();
 
-                assertTrue(latch.await(90, TimeUnit.SECONDS));
+                assertTrue(latch.await(30, TimeUnit.SECONDS));
                 one.join();
                 two.join();
+
                 waitForCondition(
                     () -> kafkaStreams.metadataForLocalThreads().size() == oldThreadCount &&
                         kafkaStreams.state() == KafkaStreams.State.RUNNING,

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
@@ -103,7 +103,7 @@ public class AdjustStreamThreadCountTest {
     private static StreamsBuilder builder;
     private static Properties properties;
     private static String appId = "";
-    public static final Duration DEFAULT_DURATION = Duration.ofSeconds(30);
+    public static final Duration DEFAULT_DURATION = Duration.ofSeconds(60);
 
     @BeforeEach
     public void setup(final TestInfo testInfo) {
@@ -272,8 +272,8 @@ public class AdjustStreamThreadCountTest {
             stateTransitionHistory.clear();
 
             final CountDownLatch latch = new CountDownLatch(2);
-            final Thread one = adjustCountHelperThread(kafkaStreams, 4, latch);
-            final Thread two = adjustCountHelperThread(kafkaStreams, 6, latch);
+            final Thread one = adjustCountHelperThread(kafkaStreams, 2, latch);
+            final Thread two = adjustCountHelperThread(kafkaStreams, 3, latch);
             Set<ThreadMetadata> threadMetadata = null;
 
             AssertionError testError = null;
@@ -281,7 +281,7 @@ public class AdjustStreamThreadCountTest {
                 two.start();
                 one.start();
 
-                assertTrue(latch.await(30, TimeUnit.SECONDS));
+                assertTrue(latch.await(90, TimeUnit.SECONDS));
                 one.join();
                 two.join();
                 waitForCondition(
@@ -290,7 +290,7 @@ public class AdjustStreamThreadCountTest {
                     DEFAULT_DURATION.toMillis(),
                     "Kafka Streams did not stabilize at the expected thread count and RUNNING state."
                 );
-                
+
                 threadMetadata = kafkaStreams.metadataForLocalThreads();
                 assertThat(threadMetadata.size(), equalTo(oldThreadCount));
             } catch (final AssertionError e) {


### PR DESCRIPTION
AdjustStreamThreadCountTest becomes flaky since this [upgrade](https://issues.apache.org/jira/browse/KAFKA-12506). The root cause is the timeout is not enough, for every remove and create the kafka stream thread, it takes around 10s. Should takes more on CI. I reduce the times of remove & create kafka streams and add longer timeout.
