### PR TITLE
KAFKA-19748: fix metrics leak in Kafka Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/OpenIterators.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/OpenIterators.java
@@ -62,7 +62,7 @@ public class OpenIterators {
 
     public void remove(final MeteredIterator iterator) {
         if (openIterators.size() == 1) {
-            streamsMetrics.removeMetric(metricName);
+            streamsMetrics.removeStoreLevelMetric(metricName);
         }
         openIterators.remove(iterator);
         updateOldestStartTimestamp();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -339,6 +339,17 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         metrics.removeMetric(metricName);
     }
 
+    public void removeStoreLevelMetric(final MetricName metricName) {
+        metrics.removeMetric(metricName);
+        storeLevelMetrics.get(
+            storeSensorPrefix(
+                metricName.tags().get("thread-id"),
+                metricName.tags().get("task-id"),
+                metricName.tags().get("scope-state-id")
+            )
+        ).remove(metricName);
+    }
+
     public Map<String, String> taskLevelTagMap(final String threadId, final String taskId) {
         final Map<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put(THREAD_ID_TAG, threadId);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -352,7 +352,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             throw new IllegalStateException("Expected exactly one metric scope tag, but found " + metricsScopeCandidates);
         }
 
-        final Deque<MetricName> metrics = storeLevelMetrics.get(
+        final Deque<MetricName> metricsForStore = storeLevelMetrics.get(
             storeSensorPrefix(
                 metricName.tags().get(THREAD_ID_TAG),
                 metricName.tags().get(TASK_ID_TAG),
@@ -360,8 +360,8 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             )
         );
 
-        if (metrics != null) {
-            metrics.remove(metricName);
+        if (metricsForStore != null) {
+            metricsForStore.remove(metricName);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -356,7 +356,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             storeSensorPrefix(
                 metricName.tags().get("thread-id"),
                 metricName.tags().get("task-id"),
-                metricName.tags(). get(metricsScopeCandidates.get(0))
+                metricName.tags().get(metricsScopeCandidates.get(0))
             )
         ).remove(metricName);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -343,16 +343,20 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public void removeStoreLevelMetric(final MetricName metricName) {
         metrics.removeMetric(metricName);
-        final List<String> tagCandidates = metricName.tags().keySet().stream().filter(tag -> !tag.equals("thread-id") && !tag.equals("task-id")).collect(Collectors.toList());
-        if (tagCandidates.size() != 1) {
+
+        final List<String> metricsScopeCandidates = metricName.tags().keySet().stream()
+            .filter(tag -> !tag.equals("thread-id") && !tag.equals("task-id"))
+            .collect(Collectors.toList());
+        if (metricsScopeCandidates.size() != 1) {
             // should never happen
-            throw new IllegalStateException("Expected exactly one store tag, but found " + tagCandidates);
+            throw new IllegalStateException("Expected exactly one metric scope tag, but found " + metricsScopeCandidates);
         }
+
         storeLevelMetrics.get(
             storeSensorPrefix(
                 metricName.tags().get("thread-id"),
                 metricName.tags().get("task-id"),
-                metricName.tags(). get(tagCandidates.get(0))
+                metricName.tags(). get(metricsScopeCandidates.get(0))
             )
         ).remove(metricName);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -345,20 +345,24 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         metrics.removeMetric(metricName);
 
         final List<String> metricsScopeCandidates = metricName.tags().keySet().stream()
-            .filter(tag -> !tag.equals("thread-id") && !tag.equals("task-id"))
+            .filter(tag -> !tag.equals(THREAD_ID_TAG) && !tag.equals(TASK_ID_TAG))
             .collect(Collectors.toList());
         if (metricsScopeCandidates.size() != 1) {
             // should never happen
             throw new IllegalStateException("Expected exactly one metric scope tag, but found " + metricsScopeCandidates);
         }
 
-        storeLevelMetrics.get(
+        final Deque<MetricName> metrics = storeLevelMetrics.get(
             storeSensorPrefix(
-                metricName.tags().get("thread-id"),
-                metricName.tags().get("task-id"),
+                metricName.tags().get(THREAD_ID_TAG),
+                metricName.tags().get(TASK_ID_TAG),
                 metricName.tags().get(metricsScopeCandidates.get(0))
             )
-        ).remove(metricName);
+        );
+
+        if (metrics != null) {
+            metrics.remove(metricName);
+        }
     }
 
     public Map<String, String> taskLevelTagMap(final String threadId, final String taskId) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -41,12 +41,14 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class StreamsMetricsImpl implements StreamsMetrics {
 
@@ -341,11 +343,16 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public void removeStoreLevelMetric(final MetricName metricName) {
         metrics.removeMetric(metricName);
+        final List<String> tagCandidates = metricName.tags().keySet().stream().filter(tag -> !tag.equals("thread-id") && !tag.equals("task-id")).collect(Collectors.toList());
+        if (tagCandidates.size() != 1) {
+            // should never happen
+            throw new IllegalStateException("Expected exactly one store tag, but found " + tagCandidates);
+        }
         storeLevelMetrics.get(
             storeSensorPrefix(
                 metricName.tags().get("thread-id"),
                 metricName.tags().get("task-id"),
-                metricName.tags().get("scope-state-id")
+                metricName.tags(). get(tagCandidates.get(0))
             )
         ).remove(metricName);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -487,9 +487,11 @@ public class MeteredKeyValueStore<K, V>
         private final long startTimestamp;
         private final Function<byte[], V> valueDeserializer;
 
-        private MeteredKeyValueTimestampedIterator(final KeyValueIterator<Bytes, byte[]> iter,
-                                        final Sensor sensor,
-                                        final Function<byte[], V> valueDeserializer) {
+        private MeteredKeyValueTimestampedIterator(
+            final KeyValueIterator<Bytes, byte[]> iter,
+            final Sensor sensor,
+            final Function<byte[], V> valueDeserializer
+        ) {
             this.iter = iter;
             this.sensor = sensor;
             this.valueDeserializer = valueDeserializer;

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/OpenIteratorsTest.java
@@ -58,11 +58,11 @@ public class OpenIteratorsTest {
         assertThat(gauge.value(null, 0), is(2L));
 
         openIterators.remove(meteredIterator2);
-        verify(streamsMetrics, never()).removeMetric(any());
+        verify(streamsMetrics, never()).removeStoreLevelMetric(any());
         assertThat(gauge.value(null, 0), is(5L));
 
         openIterators.remove(meteredIterator1);
-        verify(streamsMetrics).removeMetric(any());
+        verify(streamsMetrics).removeStoreLevelMetric(any());
         assertThat(gauge.value(null, 0), is(5L));
 
         openIterators.add(meteredIterator3);


### PR DESCRIPTION
This PR fixes a leak in StreamsMetricImpl not removing a
store-level-metric correctly, and thus leaking objects.

Reviewers: Eduwer Camacaro <eduwerc@gmail.com>, Bill Bejeck
 <bbejeck@apache.org>
