### PR TITLE
MINOR: Add plugin.path config non-empty check in connect-plugin-path.sh

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -209,9 +209,6 @@ public class PluginUtils {
         for (String path : pluginPathElements) {
             try {
                 Path pluginPathElement = Paths.get(path).toAbsolutePath();
-                if (pluginPath.isEmpty()) {
-                    log.warn("Plugin path element is empty, evaluating to {}.", pluginPathElement);
-                }
                 if (!Files.exists(pluginPathElement)) {
                     throw new FileNotFoundException(pluginPathElement.toString());
                 }

--- a/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.tools;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.WorkerConfig;
@@ -85,7 +86,7 @@ public class ConnectPluginPath {
         } catch (ArgumentParserException e) {
             parser.handleError(e);
             return 1;
-        } catch (TerseException e) {
+        } catch (TerseException | ConfigException e) {
             err.println(e.getMessage());
             return 2;
         } catch (Throwable e) {
@@ -199,17 +200,17 @@ public class ConnectPluginPath {
         return pluginLocations;
     }
 
-    private static void validatePluginPath(String pluginPath, String configName) throws TerseException {
+    private static void validatePluginPath(String pluginPath, String configName) throws ConfigException {
         String trimmed = pluginPath.trim();
         if (trimmed.isEmpty()) {
-            throw new TerseException("'" + configName + "' must not be empty.");
+            throw new ConfigException("'" + configName + "' must not be empty.");
         }
 
         String[] pluginPathElements = COMMA_WITH_WHITESPACE.split(trimmed, -1);
 
         for (String path : pluginPathElements) {
             if (path.isEmpty()) {
-                throw new TerseException("'" + configName + "' values must not be empty.");
+                throw new ConfigException("'" + configName + "' values must not be empty.");
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,6 +68,8 @@ public class ConnectPluginPath {
         "pluginLocation" // last because it is least important and most repetitive
     };
     public static final String NO_ALIAS = "N/A";
+
+    private static final Pattern COMMA_WITH_WHITESPACE = Pattern.compile("\\s*,\\s*");
 
     public static void main(String[] args) {
         Exit.exit(mainNoExit(args, System.out, System.err));
@@ -162,6 +165,9 @@ public class ConnectPluginPath {
         if (rawLocations.isEmpty() && rawPluginPaths.isEmpty() && rawWorkerConfigs.isEmpty()) {
             throw new ArgumentParserException("Must specify at least one --plugin-location, --plugin-path, or --worker-config", parser);
         }
+        for (String pluginPath : rawPluginPaths) {
+            validatePluginPath(pluginPath, "--plugin-path");
+        }
         Set<Path> pluginLocations = new LinkedHashSet<>();
         for (String rawWorkerConfig : rawWorkerConfigs) {
             Properties properties;
@@ -172,6 +178,7 @@ public class ConnectPluginPath {
             }
             String pluginPath = properties.getProperty(WorkerConfig.PLUGIN_PATH_CONFIG);
             if (pluginPath != null) {
+                validatePluginPath(pluginPath, WorkerConfig.PLUGIN_PATH_CONFIG);
                 rawPluginPaths.add(pluginPath);
             }
         }
@@ -190,6 +197,21 @@ public class ConnectPluginPath {
             pluginLocations.add(pluginLocation);
         }
         return pluginLocations;
+    }
+
+    private static void validatePluginPath(String pluginPath, String configName) throws TerseException {
+        String trimmed = pluginPath.trim();
+        if (trimmed.isEmpty()) {
+            throw new TerseException("'" + configName + "' must not be empty.");
+        }
+
+        String[] pluginPathElements = COMMA_WITH_WHITESPACE.split(trimmed, -1);
+
+        for (String path : pluginPathElements) {
+            if (path.isEmpty()) {
+                throw new TerseException("'" + configName + "' values must not be empty.");
+            }
+        }
     }
 
     enum Command {

--- a/tools/src/test/java/org/apache/kafka/tools/ConnectPluginPathTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConnectPluginPathTest.java
@@ -341,7 +341,7 @@ public class ConnectPluginPathTest {
                 ""
         );
         assertNotEquals(0, res.returnCode);
-        assertTrue("'--plugin-path' must not be empty.\n".equals(res.err));
+        assertEquals("'--plugin-path' must not be empty.\n", res.err);
     }
 
     @Test
@@ -352,7 +352,7 @@ public class ConnectPluginPathTest {
                 "location-a,,location-b"
         );
         assertNotEquals(0, res.returnCode);
-        assertTrue("'--plugin-path' values must not be empty.\n".equals(res.err));
+        assertEquals("'--plugin-path' values must not be empty.\n", res.err);
     }
 
     @Test
@@ -370,7 +370,7 @@ public class ConnectPluginPathTest {
                 configPath.toString()
         );
         assertNotEquals(0, res.returnCode);
-        assertTrue("'plugin.path' must not be empty.\n".equals(res.err));
+        assertEquals("'plugin.path' must not be empty.\n", res.err);
     }
 
     @Test
@@ -388,7 +388,7 @@ public class ConnectPluginPathTest {
                 configPath.toString()
         );
         assertNotEquals(0, res.returnCode);
-        assertTrue("'plugin.path' values must not be empty.\n".equals(res.err));
+        assertEquals("'plugin.path' values must not be empty.\n", res.err);
     }
 
     private static Map<String, List<String[]>> assertListSuccess(CommandResult result) {

--- a/tools/src/test/java/org/apache/kafka/tools/ConnectPluginPathTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConnectPluginPathTest.java
@@ -333,6 +333,63 @@ public class ConnectPluginPathTest {
         assertBadPackagingPluginsStatus(table, false);
     }
 
+    @Test
+    public void testListEmptyPluginPathArg() {
+        CommandResult res = runCommand(
+                "list",
+                "--plugin-path",
+                ""
+        );
+        assertNotEquals(0, res.returnCode);
+        assertTrue("'--plugin-path' must not be empty.\n".equals(res.err));
+    }
+
+    @Test
+    public void testListEmptyPluginPathElementArg() {
+        CommandResult res = runCommand(
+                "list",
+                "--plugin-path",
+                "location-a,,location-b"
+        );
+        assertNotEquals(0, res.returnCode);
+        assertTrue("'--plugin-path' values must not be empty.\n".equals(res.err));
+    }
+
+    @Test
+    public void testListEmptyPluginPathInWorkerConfig() {
+        Path configPath = workspace.resolve("worker-empty.properties");
+        try {
+            Files.writeString(configPath, "plugin.path=", StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            fail("Failed to create test worker config: " + e.getMessage());
+        }
+
+        CommandResult res = runCommand(
+                "list",
+                "--worker-config",
+                configPath.toString()
+        );
+        assertNotEquals(0, res.returnCode);
+        assertTrue("'plugin.path' must not be empty.\n".equals(res.err));
+    }
+
+    @Test
+    public void testListEmptyPluginPathElementInWorkerConfig() {
+        Path configPath = workspace.resolve("worker-empty-element.properties");
+        try {
+            Files.writeString(configPath, "plugin.path=location-a,,location-b", StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            fail("Failed to create test worker config: " + e.getMessage());
+        }
+
+        CommandResult res = runCommand(
+                "list",
+                "--worker-config",
+                configPath.toString()
+        );
+        assertNotEquals(0, res.returnCode);
+        assertTrue("'plugin.path' values must not be empty.\n".equals(res.err));
+    }
 
     private static Map<String, List<String[]>> assertListSuccess(CommandResult result) {
         assertEquals(0, result.returnCode);


### PR DESCRIPTION
[KAFKA-19112](https://github.com/apache/kafka/pull/20334) defines the
`plugin.path` config as non-empty. This PR add validation for
`plugin.path` related config in the `connect-plugin-path.sh` tool to
satisfy the same non-empty semantics, addressing the issue [mentioned
here](https://github.com/apache/kafka/pull/20334/files#r2395222944).

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
