### PR TITLE
MINOR: skip ci-complete workflow on 4.0

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -38,7 +38,7 @@ run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 jobs:
   upload-build-scan:
     # Skip this workflow if the CI run was skipped or cancelled
-    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') && github.event.workflow_run.head_branch != '4.0'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Since that 4.0 branch does not include [KAFKA-18748](https://issues.apache.org/jira/browse/KAFKA-18748), it is unable to find the related scan reports, but the ci-complete workflow is still being triggered on the 4.0 branch. Disable this on the 4.0 branch, as its reports can be safely ignored.
 
See https://github.com/apache/kafka/pull/20616#issuecomment-3370876779.