### PR TITLE
MINOR: try new ci-complete logic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProduceRequestResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProduceRequestResult.java
@@ -41,7 +41,7 @@ public class ProduceRequestResult {
     /**
      * Create an instance of this class.
      *
-     * @param topicPartition The topic and partition to which this record set was sent was sent
+     * @param topicPartition The topic and partition to which this record set was sent
      */
     public ProduceRequestResult(TopicPartition topicPartition) {
         this.topicPartition = topicPartition;

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -917,7 +917,7 @@ public class SslTransportLayer implements TransportLayer {
     //      unable to process the server message and an SSLException is thrown:
     //      javax.net.ssl.SSLException: Unrecognized SSL message, plaintext connection?
     //   b) If server closes the connection gracefully during handshake, client may receive close_notify
-    //      and and an SSLException is thrown:
+    //      and an SSLException is thrown:
     //      javax.net.ssl.SSLException: Received close_notify during handshake
     // We want to handle a) as a non-retriable SslAuthenticationException and b) as a retriable IOException.
     // To do this we need to rely on the exception string. Since it is safer to throw a retriable exception


### PR DESCRIPTION
Experiment patch for testing new ci-complete logic, which should skip if on the 4.0 branch.

See https://github.com/apache/kafka/pull/20644.
