### PR TITLE
MINOR: `gradle-versions-plugin` version update: 0.52.0 -->> 0.53.0 (some issues with Gradle 9+ are solved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Alternatively, use the `allDeps` or `allDepInsight` tasks for recursively iterat
 These take the same arguments as the builtin variants.
 
 ### Determining if any dependencies could be updated ###
-    ./gradlew dependencyUpdates
+    ./gradlew dependencyUpdates --no-parallel
 
 ### Common build options ###
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.52.0'
+  id 'com.github.ben-manes.versions' version '0.53.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'


### PR DESCRIPTION
Extends from: #19513

Note: in Gradle 9+ we have to add a switch like this:
```
./gradlew dependencyUpdates --no-parallel
```
Related link:
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.53.0

FYI @chia7712

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
