### PR TITLE
MINOR: new checksum verification in gradlew

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -115,8 +115,6 @@ case "$( uname )" in                #(
 esac
 
 
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
-
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
@@ -173,7 +171,6 @@ fi
 # For Cygwin or MSYS, switch paths to Windows format before running java
 if "$cygwin" || "$msys" ; then
     APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
-    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
 
     JAVACMD=$( cygpath --unix "$JAVACMD" )
 
@@ -223,13 +220,10 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
-#
-# Before gradle 8.14 were not support using an executable JAR for the wrapper.
-# It causes a no main manifest attribute error if developers use the old wrapper.
+
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
-        -classpath "$CLASSPATH" \
-        org.gradle.wrapper.GradleWrapperMain \
+        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/gradlew
+++ b/gradlew
@@ -115,6 +115,8 @@ case "$( uname )" in                #(
 esac
 
 
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
@@ -171,6 +173,7 @@ fi
 # For Cygwin or MSYS, switch paths to Windows format before running java
 if "$cygwin" || "$msys" ; then
     APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
+    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
 
     JAVACMD=$( cygpath --unix "$JAVACMD" )
 
@@ -220,10 +223,13 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
-
+#
+# Before gradle 8.14 were not support using an executable JAR for the wrapper.
+# It causes a no main manifest attribute error if developers use the old wrapper.
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
-        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
+        -classpath "$CLASSPATH" \
+        org.gradle.wrapper.GradleWrapperMain \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/gradlew
+++ b/gradlew
@@ -201,6 +201,7 @@ fi
 
 
 # Loop in case we encounter an error.
+REQUIRED_WRAPPER_JAR_CHECKSUM=$(curl -sSL "https://services.gradle.org/distributions/gradle-9.1.0-wrapper.jar.sha256")
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
     if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v9.1.0/gradle/wrapper/gradle-wrapper.jar"; then
@@ -208,6 +209,24 @@ for attempt in 1 2 3; do
       # Pause for a bit before looping in case the server throttled us.
       sleep 5
       continue
+    fi
+  else
+    # Verify checksum of existing wrapper JAR.
+    # Use sha256sum or shasum, whichever is available.
+    if command -v sha256sum >/dev/null 2>&1; then
+      LOCAL_WRAPPER_JAR_CHECKSUM=$(sha256sum "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+      LOCAL_WRAPPER_JAR_CHECKSUM=$(shasum -a 256 "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" | awk '{print $1}')
+    else
+      # If no checksum tool is found, delete the JAR and re-download.
+      warn "Cannot find sha256sum or shasum to verify wrapper JAR. Deleting and re-downloading."
+      rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
+      continue
+    fi
+
+    # If the local checksum does not match the required checksum, delete the JAR to force re-download.
+    if [ "$LOCAL_WRAPPER_JAR_CHECKSUM" != "$REQUIRED_WRAPPER_JAR_CHECKSUM" ] ; then
+      rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
     fi
   fi
 done

--- a/gradlew
+++ b/gradlew
@@ -224,7 +224,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
 #
-# Before gradle 8.14 were not support using an executable JAR for the wrapper.
+# Before gradle 8.14 didn't support using an executable JAR for the wrapper.
 # It causes a no main manifest attribute error if developers use the old wrapper.
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/gradlew
+++ b/gradlew
@@ -228,6 +228,8 @@ for attempt in 1 2 3; do
     # If the local checksum does not match the required checksum, delete the JAR to force re-download.
     if [ "$LOCAL_WRAPPER_JAR_CHECKSUM" != "$REQUIRED_WRAPPER_JAR_CHECKSUM" ] ; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
+    else
+      break
     fi
   fi
 done

--- a/gradlew
+++ b/gradlew
@@ -220,7 +220,8 @@ for attempt in 1 2 3; do
       LOCAL_WRAPPER_JAR_CHECKSUM=$(shasum -a 256 "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" | awk '{print $1}')
     else
       # If no checksum tool is found, exit with an error.
-      die "ERROR: Cannot find sha256sum or shasum to verify wrapper JAR. Please install one of these tools."
+      warn "Cannot find sha256sum or shasum to verify wrapper JAR."
+      break
     fi
 
     # If the local checksum does not match the required checksum, delete the JAR to force re-download.

--- a/gradlew
+++ b/gradlew
@@ -201,7 +201,7 @@ fi
 
 
 # Loop in case we encounter an error.
-REQUIRED_WRAPPER_JAR_CHECKSUM=$(curl -sSL "https://services.gradle.org/distributions/gradle-9.1.0-wrapper.jar.sha256")
+REQUIRED_WRAPPER_JAR_CHECKSUM="76805e32c009c0cf0dd5d206bddc9fb22ea42e84db904b764f3047de095493f3"
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
     if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v9.1.0/gradle/wrapper/gradle-wrapper.jar"; then
@@ -211,7 +211,8 @@ for attempt in 1 2 3; do
       continue
     fi
   else
-    # Verify checksum of existing wrapper JAR.
+    # Verify checksum of existing wrapper JAR. 
+    # This prevents developers from running into incompatibility issues when using an outdated wrapper JAR after a Gradle upgrade.
     # Use sha256sum or shasum, whichever is available.
     if command -v sha256sum >/dev/null 2>&1; then
       LOCAL_WRAPPER_JAR_CHECKSUM=$(sha256sum "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" | awk '{print $1}')

--- a/gradlew
+++ b/gradlew
@@ -219,10 +219,8 @@ for attempt in 1 2 3; do
     elif command -v shasum >/dev/null 2>&1; then
       LOCAL_WRAPPER_JAR_CHECKSUM=$(shasum -a 256 "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" | awk '{print $1}')
     else
-      # If no checksum tool is found, delete the JAR and re-download.
-      warn "Cannot find sha256sum or shasum to verify wrapper JAR. Deleting and re-downloading."
-      rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
-      continue
+      # If no checksum tool is found, exit with an error.
+      die "ERROR: Cannot find sha256sum or shasum to verify wrapper JAR. Please install one of these tools."
     fi
 
     # If the local checksum does not match the required checksum, delete the JAR to force re-download.

--- a/gradlew
+++ b/gradlew
@@ -224,7 +224,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
 #
-# Before gradle 8.14 didn't support using an executable JAR for the wrapper.
+# Before gradle 8.14 were not support using an executable JAR for the wrapper.
 # It causes a no main manifest attribute error if developers use the old wrapper.
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/gradlew
+++ b/gradlew
@@ -219,7 +219,7 @@ for attempt in 1 2 3; do
     elif command -v shasum >/dev/null 2>&1; then
       LOCAL_WRAPPER_JAR_CHECKSUM=$(shasum -a 256 "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" | awk '{print $1}')
     else
-      # If no checksum tool is found, exit with an error.
+      # If no checksum tool is found, this verification is skipped .
       warn "Cannot find sha256sum or shasum to verify wrapper JAR."
       break
     fi

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -42,11 +42,12 @@ task bootstrapWrapper() {
         // fetch the jar.
         def wrapperBaseUrl = "https://raw.githubusercontent.com/gradle/gradle/v$versions.gradle/gradle/wrapper"
         def wrapperJarUrl = wrapperBaseUrl + "/gradle-wrapper.jar"
-        def wrapperJarChecksumUrl = "https://services.gradle.org/distributions/gradle-$versions.gradle-wrapper.jar.sha256"
+        // IMPORTANT: This checksum **must** be updated whenever the Gradle version changes.
+        String wrapperChecksum = "76805e32c009c0cf0dd5d206bddc9fb22ea42e84db904b764f3047de095493f3"
 
         def bootstrapString = """
       # Loop in case we encounter an error.
-      REQUIRED_WRAPPER_JAR_CHECKSUM=\$(curl -sSL "$wrapperJarChecksumUrl")
+      REQUIRED_WRAPPER_JAR_CHECKSUM="$wrapperChecksum"
       for attempt in 1 2 3; do
         if [ ! -e "$wrapperJarPath" ]; then
           if ! curl -s -S --retry 3 -L -o "$wrapperJarPath" "$wrapperJarUrl"; then
@@ -56,7 +57,8 @@ task bootstrapWrapper() {
             continue
           fi
         else
-          # Verify checksum of existing wrapper JAR.
+          # Verify checksum of existing wrapper JAR. 
+          # This prevents developers from running into incompatibility issues when using an outdated wrapper JAR after a Gradle upgrade.
           # Use sha256sum or shasum, whichever is available.
           if command -v sha256sum >/dev/null 2>&1; then
             LOCAL_WRAPPER_JAR_CHECKSUM=\$(sha256sum "$wrapperJarPath" | awk '{print \$1}')

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -74,6 +74,8 @@ task bootstrapWrapper() {
           # If the local checksum does not match the required checksum, delete the JAR to force re-download.
           if [ "\$LOCAL_WRAPPER_JAR_CHECKSUM" != "\$REQUIRED_WRAPPER_JAR_CHECKSUM" ] ; then
             rm -f "$wrapperJarPath"
+          else
+            break
           fi
         fi
       done

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -39,10 +39,9 @@ task bootstrapWrapper() {
         // github.com servers deprecated TLSv1/TLSv1.1 support some time ago, so older versions
         // of curl (built against OpenSSL library that doesn't support TLSv1.2) would fail to
         // fetch the jar.
-        def wrapperBaseUrl = "https://raw.githubusercontent.com/gradle/gradle/v$versions.gradle/gradle/wrapper"
-        def wrapperJarUrl = wrapperBaseUrl + "/gradle-wrapper.jar"
         // IMPORTANT: This checksum **must** be updated whenever the Gradle version changes.
         String wrapperChecksum = "76805e32c009c0cf0dd5d206bddc9fb22ea42e84db904b764f3047de095493f3"
+        def wrapperJarUrl = "https://raw.githubusercontent.com/gradle/gradle/v$versions.gradle/gradle/wrapper/gradle-wrapper.jar"
 
         def bootstrapString = """
       # Loop in case we encounter an error.

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -65,7 +65,8 @@ task bootstrapWrapper() {
             LOCAL_WRAPPER_JAR_CHECKSUM=\$(shasum -a 256 "$wrapperJarPath" | awk '{print \$1}')
           else
             # If no checksum tool is found, exit with an error.
-            die "ERROR: Cannot find sha256sum or shasum to verify wrapper JAR. Please install one of these tools."
+            warn "Cannot find sha256sum or shasum to verify wrapper JAR."
+            break
           fi
 
           # If the local checksum does not match the required checksum, delete the JAR to force re-download.

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -42,9 +42,11 @@ task bootstrapWrapper() {
         // fetch the jar.
         def wrapperBaseUrl = "https://raw.githubusercontent.com/gradle/gradle/v$versions.gradle/gradle/wrapper"
         def wrapperJarUrl = wrapperBaseUrl + "/gradle-wrapper.jar"
+        def wrapperJarChecksumUrl = "https://services.gradle.org/distributions/gradle-$versions.gradle-wrapper.jar.sha256"
 
         def bootstrapString = """
       # Loop in case we encounter an error.
+      REQUIRED_WRAPPER_JAR_CHECKSUM=\$(curl -sSL "$wrapperJarChecksumUrl")
       for attempt in 1 2 3; do
         if [ ! -e "$wrapperJarPath" ]; then
           if ! curl -s -S --retry 3 -L -o "$wrapperJarPath" "$wrapperJarUrl"; then
@@ -52,6 +54,24 @@ task bootstrapWrapper() {
             # Pause for a bit before looping in case the server throttled us.
             sleep 5
             continue
+          fi
+        else
+          # Verify checksum of existing wrapper JAR.
+          # Use sha256sum or shasum, whichever is available.
+          if command -v sha256sum >/dev/null 2>&1; then
+            LOCAL_WRAPPER_JAR_CHECKSUM=\$(sha256sum "$wrapperJarPath" | awk '{print \$1}')
+          elif command -v shasum >/dev/null 2>&1; then
+            LOCAL_WRAPPER_JAR_CHECKSUM=\$(shasum -a 256 "$wrapperJarPath" | awk '{print \$1}')
+          else
+            # If no checksum tool is found, delete the JAR and re-download.
+            warn "Cannot find sha256sum or shasum to verify wrapper JAR. Deleting and re-downloading."
+            rm -f "$wrapperJarPath"
+            continue
+          fi
+
+          # If the local checksum does not match the required checksum, delete the JAR to force re-download.
+          if [ "\$LOCAL_WRAPPER_JAR_CHECKSUM" != "\$REQUIRED_WRAPPER_JAR_CHECKSUM" ] ; then
+            rm -f "$wrapperJarPath"
           fi
         fi
       done

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -64,7 +64,7 @@ task bootstrapWrapper() {
           elif command -v shasum >/dev/null 2>&1; then
             LOCAL_WRAPPER_JAR_CHECKSUM=\$(shasum -a 256 "$wrapperJarPath" | awk '{print \$1}')
           else
-            # If no checksum tool is found, exit with an error.
+            # If no checksum tool is found, this verification is skipped .
             warn "Cannot find sha256sum or shasum to verify wrapper JAR."
             break
           fi

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -65,10 +65,8 @@ task bootstrapWrapper() {
           elif command -v shasum >/dev/null 2>&1; then
             LOCAL_WRAPPER_JAR_CHECKSUM=\$(shasum -a 256 "$wrapperJarPath" | awk '{print \$1}')
           else
-            # If no checksum tool is found, delete the JAR and re-download.
-            warn "Cannot find sha256sum or shasum to verify wrapper JAR. Deleting and re-downloading."
-            rm -f "$wrapperJarPath"
-            continue
+            # If no checksum tool is found, exit with an error.
+            die "ERROR: Cannot find sha256sum or shasum to verify wrapper JAR. Please install one of these tools."
           fi
 
           # If the local checksum does not match the required checksum, delete the JAR to force re-download.


### PR DESCRIPTION
According to the
[discussion](https://github.com/apache/kafka/pull/19513#discussion_r2412531614)
in #19513 , add a new checksum verification process to determine whether
a new  wrapper JAR needs to be downloaded.

This prevents developers  from running into incompatibility issues when
using an outdated wrapper  JAR after a Gradle upgrade.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
