### PR TITLE
MINOR: ignore result of "missing build scan"

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -38,7 +38,7 @@ run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 jobs:
   upload-build-scan:
     # Skip this workflow if the CI run was skipped or cancelled
-    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') && github.event.workflow_run.head_branch != '4.0'
+    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -89,7 +89,7 @@ jobs:
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: Gradle Build Scan / ${{ env.status-context }}
-          state: 'success' # WAR: Always mark as successful, not show as failing, for those branches without the KAFKA-18748 patches.
+          state: 'success' # WAR: Mark as successful, not show as failing, for those branches without the KAFKA-18748 patches
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -89,7 +89,7 @@ jobs:
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: Gradle Build Scan / ${{ env.status-context }}
-          state: 'success' # WAR: Mark as successful, not show as failing, for those branches without the KAFKA-18748 patches
+          state: 'success' # WAR: Always mark as successful, not as failing, for non-trunk branches; real solution to follow in KAFKA-19768
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -89,7 +89,7 @@ jobs:
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: Gradle Build Scan / ${{ env.status-context }}
-          state: 'error'
+          state: 'success' # WAR: Always mark as successful, not show as failing, for those branches without the KAFKA-18748 patches.
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -89,7 +89,7 @@ jobs:
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: Gradle Build Scan / ${{ env.status-context }}
-          state: 'success' # WAR: Always mark as successful, not as failing, for non-trunk branches; real solution to follow in KAFKA-19768
+          state: 'success' # Always mark as successful as a temporary fix; non-trunk branches will miss build scan. Real fix in KAFKA-19768
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}


### PR DESCRIPTION
Always mark the result of "missing build scan" as  successful, not as
failing, for 4.0 and 4.1.

Two reasons causing missing build scan:
- 4.0 does not have the KAFKA-18748 patches.
- The JDK version used by `ci-complete` is inconsistent with other
active branches, causing the build report task to fail.

The real solution will be in
[KAFKA-19768](https://issues.apache.org/jira/browse/KAFKA-19768).

Reviewers: David Arthur <mumrah@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
