### PR TITLE
MINOR: Makes `LogCleaner.CleanerThread` a `final` class.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
@@ -472,7 +472,6 @@ public class LogCleaner implements BrokerReconfigurable {
         private volatile CleanerStats lastStats = new CleanerStats(Time.SYSTEM);
         private volatile PreCleanStats lastPreCleanStats = new PreCleanStats();
 
-        @SuppressWarnings("this-escape")
         public CleanerThread(int threadId) throws NoSuchAlgorithmException {
             super("kafka-log-cleaner-thread-" + threadId, false);
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
@@ -464,7 +464,7 @@ public class LogCleaner implements BrokerReconfigurable {
      * The cleaner threads do the actual log cleaning. Each thread processes does its cleaning repeatedly by
      * choosing the dirtiest log, cleaning it, and then swapping in the cleaned segments.
      */
-    public class CleanerThread extends ShutdownableThread {
+    public final class CleanerThread extends ShutdownableThread {
         private final Logger logger = new LogContext(logPrefix).logger(CleanerThread.class);
 
         private final Cleaner cleaner;
@@ -483,9 +483,7 @@ public class LogCleaner implements BrokerReconfigurable {
                     config.dedupeBufferLoadFactor,
                     throttler,
                     time,
-                    // Use a lambda instead of method reference to avoid `this` escape
-                    // The lambda captures `this` but doesn't evaluate it until runtime
-                    topicPartition -> checkDone(topicPartition)
+                this::checkDone
             );
 
             if (config.dedupeBufferSize / config.numThreads > Integer.MAX_VALUE) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
@@ -483,7 +483,9 @@ public class LogCleaner implements BrokerReconfigurable {
                     config.dedupeBufferLoadFactor,
                     throttler,
                     time,
-                    this::checkDone
+                    // Use a lambda instead of method reference to avoid `this` escape
+                    // The lambda captures `this` but doesn't evaluate it until runtime
+                    topicPartition -> checkDone(topicPartition)
             );
 
             if (config.dedupeBufferSize / config.numThreads > Integer.MAX_VALUE) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleaner.java
@@ -483,7 +483,7 @@ public class LogCleaner implements BrokerReconfigurable {
                     config.dedupeBufferLoadFactor,
                     throttler,
                     time,
-                this::checkDone
+                    this::checkDone
             );
 
             if (config.dedupeBufferSize / config.numThreads > Integer.MAX_VALUE) {


### PR DESCRIPTION
This inner class is not designed for extension, and making it `final`
improves clarity and maintainability.

The redundant `@SuppressWarnings("this-escape")` is also removed.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
