### PR TITLE
HOTFIX: Fix log level in StateChangeLogger#trace

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/logger/StateChangeLogger.java
+++ b/server-common/src/main/java/org/apache/kafka/logger/StateChangeLogger.java
@@ -33,7 +33,7 @@ public class StateChangeLogger {
     }
 
     public void trace(String message) {
-        LOGGER.info("{}{}", logIdent, message);
+        LOGGER.trace("{}{}", logIdent, message);
     }
 
     public void info(String message) {


### PR DESCRIPTION
from: https://github.com/apache/kafka/pull/20637#discussion_r2414668452

Previously, the method used LOGGER.info() instead of LOGGER.trace().
This patch corrects the logging level used in the trace method of
StateChangeLogger.

Reviewers: Manikumar Reddy <manikumar.reddy@gmail.com>, TengYao Chi
 <kitingiao@gmail.com>, Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
