### PR TITLE
MINOR: changed the condition to only check the test topic to reduce the flakiness of the test.

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -1199,7 +1199,7 @@ public class TopicCommandTest {
 
             String underReplicatedOutput = captureDescribeTopicStandardOut(clusterInstance, buildTopicCommandOptionsWithBootstrap(clusterInstance, "--describe", "--under-replicated-partitions"));
             assertFalse(underReplicatedOutput.contains(String.format("Topic: %s", testTopicName)),
-                    String.format("--under-replicated-partitions shouldn't return anything: '%s'", underReplicatedOutput));
+                    String.format("--under-replicated-partitions shouldn't contain '%s': '%s'", String.format("Topic: %s", testTopicName), underReplicatedOutput));
 
             int maxRetries = 20;
             long pause = 100L;

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -1198,7 +1198,7 @@ public class TopicCommandTest {
                     "Unexpected describe output length: " + simpleDescribeOutputRows.length);
 
             String underReplicatedOutput = captureDescribeTopicStandardOut(clusterInstance, buildTopicCommandOptionsWithBootstrap(clusterInstance, "--describe", "--under-replicated-partitions"));
-            assertEquals("", underReplicatedOutput,
+            assertFalse(underReplicatedOutput.contains(String.format("Topic: %s", testTopicName)),
                     String.format("--under-replicated-partitions shouldn't return anything: '%s'", underReplicatedOutput));
 
             int maxRetries = 20;

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -1192,14 +1192,15 @@ public class TopicCommandTest {
             // describe the topic and test if it's under-replicated
             String simpleDescribeOutput = captureDescribeTopicStandardOut(clusterInstance, buildTopicCommandOptionsWithBootstrap(clusterInstance, "--describe", "--topic", testTopicName));
             String[] simpleDescribeOutputRows = simpleDescribeOutput.split(System.lineSeparator());
-            assertTrue(simpleDescribeOutputRows[0].startsWith(String.format("Topic: %s", testTopicName)),
+            String testTopicNameLogLine = String.format("Topic: %s", testTopicName);
+            assertTrue(simpleDescribeOutputRows[0].startsWith(testTopicNameLogLine),
                     "Unexpected describe output: " + simpleDescribeOutputRows[0]);
             assertEquals(2, simpleDescribeOutputRows.length,
                     "Unexpected describe output length: " + simpleDescribeOutputRows.length);
 
             String underReplicatedOutput = captureDescribeTopicStandardOut(clusterInstance, buildTopicCommandOptionsWithBootstrap(clusterInstance, "--describe", "--under-replicated-partitions"));
-            assertFalse(underReplicatedOutput.contains(String.format("Topic: %s", testTopicName)),
-                    String.format("--under-replicated-partitions shouldn't contain '%s': '%s'", String.format("Topic: %s", testTopicName), underReplicatedOutput));
+            assertFalse(underReplicatedOutput.contains(testTopicNameLogLine),
+                    String.format("--under-replicated-partitions shouldn't contain '%s': '%s'", testTopicNameLogLine, underReplicatedOutput));
 
             int maxRetries = 20;
             long pause = 100L;


### PR DESCRIPTION
MINOR: changed the condition to only check the test topic to reduce the
flakiness of the test.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>


