### PR TITLE
MINOR: Fix the incorrect package name in metrics and revert the comment

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -833,7 +833,7 @@ private[kafka] class Processor(
   threadName: String,
   connectionDisconnectListeners: Seq[ConnectionDisconnectListener]
 ) extends Runnable with Logging {
-  private val metricsPackage = "kafka.server"
+  private val metricsPackage = "kafka.network"
   private val metricsClassName = "Processor"
   private val metricsGroup = new KafkaMetricsGroup(metricsPackage, metricsClassName)
 

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -1,7 +1,7 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information registryarding copyright ownership.
+ * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at


### PR DESCRIPTION
Fix the incorrect package name in metrics and revert the comment

see:   https://github.com/apache/kafka/pull/20399#discussion_r2415673042
https://github.com/apache/kafka/pull/20399#discussion_r2415633676

Reviewers: Ken Huang <s7133700@gmail.com>, Manikumar Reddy
 <manikumar.reddy@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
