### PR TITLE
KAFKA-19724: Global stream thread should not ignore any exceptions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -471,11 +471,6 @@ public class KafkaStreams implements AutoCloseable {
                 }
                 processStreamThread(thread -> thread.setUncaughtExceptionHandler((t, e) -> { }
                 ));
-
-                if (globalStreamThread != null) {
-                    globalStreamThread.setUncaughtExceptionHandler((t, e) -> { }
-                    );
-                }
             } else {
                 throw new IllegalStateException("Can only set UncaughtExceptionHandler before calling start(). " +
                     "Current state is: " + state);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -239,7 +239,7 @@ public class GlobalStreamThread extends Thread {
         }
 
         /**
-         * @throws IllegalStateException If store gets registered after initialized is already finished
+         * @throws IllegalStateException If a store gets registered after initialized is already finished
          * @throws StreamsException      if the store's change log does not contain the partition
          */
         void initialize() {
@@ -431,9 +431,9 @@ public class GlobalStreamThread extends Thread {
         } catch (final StreamsException fatalException) {
             closeStateConsumer(stateConsumer, false);
             startupException = fatalException;
-        } catch (final Exception fatalException) {
+        } catch (final Throwable throwable) {
             closeStateConsumer(stateConsumer, false);
-            startupException = new StreamsException("Exception caught during initialization of GlobalStreamThread", fatalException);
+            startupException = new StreamsException("Exception caught during initialization of GlobalStreamThread", throwable);
         } finally {
             initializationLatch.countDown();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -431,9 +431,9 @@ public class GlobalStreamThread extends Thread {
         } catch (final StreamsException fatalException) {
             closeStateConsumer(stateConsumer, false);
             startupException = fatalException;
-        } catch (final Throwable throwable) {
+        } catch (final Throwable fatalException) {
             closeStateConsumer(stateConsumer, false);
-            startupException = new StreamsException("Exception caught during initialization of GlobalStreamThread", throwable);
+            startupException = new StreamsException("Exception caught during initialization of GlobalStreamThread", fatalException);
         } finally {
             initializationLatch.countDown();
         }


### PR DESCRIPTION
Kafka Streams does not catch Error types that occur during
`GlobalStreamThread` initiation, and therefore it is not possible to
trace the error (for example, an `ExceptionInInitializerError` occurs
when RocksDB is not found for a global store). This is because errors
are not caught and logged.

The catch block in `GlobalStreamThread#initialize()` has been ensured to
catch `Throwable` instead of `Exception`. Additionally, the empty
`setUncaughtHandler` set operation that prevented this from taking
effect when users employed setUncaughtExceptionHandler has been removed.

Reviewers: Matthias J. Sax <matthias@confluent.io>
