### PR TITLE
KAFKA-19776: Fix log values for previous leader id and epoch

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -855,6 +855,8 @@ class Partition(val topicPartition: TopicPartition,
       val isNewLeaderEpoch = partitionRegistration.leaderEpoch > leaderEpoch
       // The leader should be updated before updateAssignmentAndIsr where we clear the ISR. Or it is possible to meet
       // the under min isr condition during the makeFollower process and emits the wrong metric.
+      val prevLeaderReplicaIdOpt = leaderReplicaIdOpt
+      val prevLeaderEpoch = leaderEpoch
       leaderReplicaIdOpt = Option(partitionRegistration.leader)
       leaderEpoch = partitionRegistration.leaderEpoch
       leaderEpochStartOffsetOpt = None
@@ -877,7 +879,7 @@ class Partition(val topicPartition: TopicPartition,
         stateChangeLogger.info(s"Follower $topicPartition starts at leader epoch ${partitionRegistration.leaderEpoch} from " +
           s"offset $leaderEpochEndOffset with partition epoch ${partitionRegistration.partitionEpoch} and " +
           s"high watermark ${followerLog.highWatermark}. Current leader is ${partitionRegistration.leader}. " +
-          s"Previous leader $leaderReplicaIdOpt and previous leader epoch was $leaderEpoch.")
+          s"Previous leader $prevLeaderReplicaIdOpt and previous leader epoch was $prevLeaderEpoch.")
       } else {
         stateChangeLogger.info(s"Skipped the become-follower state change for $topicPartition with topic id $topicId, " +
           s"partition registration $partitionRegistration and isNew=$isNew since it is already a follower with leader epoch $leaderEpoch.")


### PR DESCRIPTION
Stores the existing values for both the fields in a local variable for
logging.

Reviewers: Omnia Ibrahim <o.g.h.ibrahim@gmail.com>
