### PR TITLE
KAFKA-19725: Replace --property with --reader-property in ConsoleProducer (KIP-1147)

### DIFF
--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -60,7 +60,7 @@ class DockerSanityTest(unittest.TestCase):
         return False
         
     def produce_message(self, topic, producer_config, key, value):
-        command = ["echo", f'"{key}:{value}"', "|", f"{self.FIXTURES_DIR}/{constants.KAFKA_CONSOLE_PRODUCER}", "--topic", topic, "--property", "'parse.key=true'", "--property", "'key.separator=:'", "--timeout", f"{constants.CLIENT_TIMEOUT}"]
+        command = ["echo", f'"{key}:{value}"', "|", f"{self.FIXTURES_DIR}/{constants.KAFKA_CONSOLE_PRODUCER}", "--topic", topic, "--reader-property", "'parse.key=true'", "--reader-property", "'key.separator=:'", "--timeout", f"{constants.CLIENT_TIMEOUT}"]
         command.extend(producer_config)
         subprocess.run(["bash", "-c", " ".join(command)])
     

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -61,6 +61,10 @@
                 which is used to specify the properties for the formatter is deprecated in favor of <code>--formatter-property</code>.
             </li>
             <li>
+                In <code>kafka-console-producer.sh</code>, the option <code>--property</code> which is used to specify properties
+                in the form key=value to the message reader is deprecated in favor of <code>--reader-property</code>.
+            </li>
+            <li>
                 In <code>kafka-consumer-perf-test.sh</code> and <code>kafka-share-consumer-perf-test.sh</code>, the option <code>--messages</code>
                 is deprecated in favor of <code>--num-records</code> to bring all performance testing tools in line.
             </li>

--- a/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
@@ -249,7 +249,7 @@ public class ConsoleProducer {
                                     "\n  \"key\\tvalue\"" +
                                     "\n parse.headers=true:" +
                                     "\n  \"h1:v1,h2:v2...\\tvalue\"" +
-                                    "This option will be removed in a future version. Use --reader-property instead.")
+                                    "\n This option will be removed in a future version. Use --reader-property instead.")
                     .withRequiredArg()
                     .describedAs("prop")
                     .ofType(String.class);

--- a/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsoleProducer.java
@@ -129,7 +129,9 @@ public class ConsoleProducer {
         private final OptionSpec<Integer> maxPartitionMemoryBytesOpt;
         private final OptionSpec<String> messageReaderOpt;
         private final OptionSpec<Integer> socketBufferSizeOpt;
+        @Deprecated(since = "4.2", forRemoval = true)
         private final OptionSpec<String> propertyOpt;
+        private OptionSpec<String> readerPropertyOpt;
         private final OptionSpec<String> readerConfigOpt;
         @Deprecated(since = "4.2", forRemoval = true)
         private final OptionSpec<String> producerPropertyOpt;
@@ -230,6 +232,28 @@ public class ConsoleProducer {
                     .ofType(Integer.class)
                     .defaultsTo(1024 * 100);
             propertyOpt = parser.accepts("property",
+                            "(DEPRECATED) A mechanism to pass user-defined properties in the form key=value to the message reader. This allows custom configuration for a user-defined message reader." +
+                                    "\nDefault properties include:" +
+                                    "\n parse.key=false" +
+                                    "\n parse.headers=false" +
+                                    "\n ignore.error=false" +
+                                    "\n key.separator=\\t" +
+                                    "\n headers.delimiter=\\t" +
+                                    "\n headers.separator=," +
+                                    "\n headers.key.separator=:" +
+                                    "\n null.marker=   When set, any fields (key, value and headers) equal to this will be replaced by null" +
+                                    "\nDefault parsing pattern when:" +
+                                    "\n parse.headers=true and parse.key=true:" +
+                                    "\n  \"h1:v1,h2:v2...\\tkey\\tvalue\"" +
+                                    "\n parse.key=true:" +
+                                    "\n  \"key\\tvalue\"" +
+                                    "\n parse.headers=true:" +
+                                    "\n  \"h1:v1,h2:v2...\\tvalue\"" +
+                                    "This option will be removed in a future version. Use --reader-property instead.")
+                    .withRequiredArg()
+                    .describedAs("prop")
+                    .ofType(String.class);
+            readerPropertyOpt = parser.accepts("reader-property",
                             "A mechanism to pass user-defined properties in the form key=value to the message reader. This allows custom configuration for a user-defined message reader." +
                                     "\nDefault properties include:" +
                                     "\n parse.key=false" +
@@ -250,7 +274,7 @@ public class ConsoleProducer {
                     .withRequiredArg()
                     .describedAs("prop")
                     .ofType(String.class);
-            readerConfigOpt = parser.accepts("reader-config", "Config properties file for the message reader. Note that " + propertyOpt + " takes precedence over this config.")
+            readerConfigOpt = parser.accepts("reader-config", "Config properties file for the message reader. Note that " + readerPropertyOpt + " takes precedence over this config.")
                     .withRequiredArg()
                     .describedAs("config file")
                     .ofType(String.class);
@@ -292,6 +316,9 @@ public class ConsoleProducer {
             if (options.has(commandPropertyOpt) && options.has(producerPropertyOpt)) {
                 CommandLineUtils.printUsageAndExit(parser, "Options --command-property and --producer-property cannot be specified together.");
             }
+            if (options.has(readerPropertyOpt) && options.has(propertyOpt)) {
+                CommandLineUtils.printUsageAndExit(parser, "Options --reader-property and --property cannot be specified together.");
+            }
 
             if (options.has(producerPropertyOpt)) {
                 System.out.println("Warning: --producer-property is deprecated and will be removed in a future version. Use --command-property instead.");
@@ -301,6 +328,11 @@ public class ConsoleProducer {
             if (options.has(producerConfigOpt)) {
                 System.out.println("Warning: --producer.config is deprecated and will be removed in a future version. Use --command-config instead.");
                 commandConfigOpt = producerConfigOpt;
+            }
+
+            if (options.has(propertyOpt)) {
+                System.out.println("Warning: --property is deprecated and will be removed in a future version. Use --reader-property instead.");
+                readerPropertyOpt = propertyOpt;
             }
 
             try {
@@ -336,7 +368,7 @@ public class ConsoleProducer {
             }
 
             properties.put("topic", options.valueOf(topicOpt));
-            properties.putAll(propsToStringMap(parseKeyValueArgs(options.valuesOf(propertyOpt))));
+            properties.putAll(propsToStringMap(parseKeyValueArgs(options.valuesOf(readerPropertyOpt))));
 
             return properties;
         }

--- a/tools/src/test/java/org/apache/kafka/tools/ConsoleProducerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConsoleProducerTest.java
@@ -44,11 +44,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsoleProducerTest {
-    private static final String[] BOOTSTRAP_SERVER_VALID_ARGS = new String[]{
+    private static final String[] BOOTSTRAP_SERVER_VALID_ARGS_DEPRECATED = new String[]{
         "--bootstrap-server", "localhost:1003,localhost:1004",
         "--topic", "t3",
         "--property", "parse.key=true",
         "--property", "key.separator=#"
+    };
+    private static final String[] BOOTSTRAP_SERVER_VALID_ARGS = new String[]{
+            "--bootstrap-server", "localhost:1003,localhost:1004",
+            "--topic", "t3",
+            "--reader-property", "parse.key=true",
+            "--reader-property", "key.separator=#"
     };
     private static final String[] INVALID_ARGS = new String[]{
         "--t", // not a valid argument
@@ -115,8 +121,8 @@ public class ConsoleProducerTest {
     }
 
     @Test
-    public void testParseKeyProp() throws ReflectiveOperationException, IOException {
-        ConsoleProducerOptions opts = new ConsoleProducerOptions(BOOTSTRAP_SERVER_VALID_ARGS);
+    public void testParseKeyPropDeprecated() throws ReflectiveOperationException, IOException {
+        ConsoleProducerOptions opts = new ConsoleProducerOptions(BOOTSTRAP_SERVER_VALID_ARGS_DEPRECATED);
         LineMessageReader reader = (LineMessageReader) Class.forName(opts.readerClass()).getDeclaredConstructor().newInstance();
         reader.configure(opts.readerProps());
 
@@ -125,7 +131,7 @@ public class ConsoleProducerTest {
     }
 
     @Test
-    public void testParseReaderConfigFile() throws Exception {
+    public void testParseReaderConfigFileDeprecated() throws Exception {
         File propsFile = TestUtils.tempFile();
         OutputStream propsStream = Files.newOutputStream(propsFile.toPath());
         propsStream.write("parse.key=true\n".getBytes());
@@ -170,6 +176,40 @@ public class ConsoleProducerTest {
         ProducerConfig producerConfig = new ProducerConfig(opts.producerProps());
 
         assertEquals("console-producer", producerConfig.getString(ProducerConfig.CLIENT_ID_CONFIG));
+    }
+
+    @Test
+    public void testParseKeyProp() throws ReflectiveOperationException, IOException {
+        ConsoleProducerOptions opts = new ConsoleProducerOptions(BOOTSTRAP_SERVER_VALID_ARGS);
+        LineMessageReader reader = (LineMessageReader) Class.forName(opts.readerClass()).getDeclaredConstructor().newInstance();
+        reader.configure(opts.readerProps());
+
+        assertEquals("#", reader.keySeparator());
+        assertTrue(reader.parseKey());
+    }
+
+    @Test
+    public void testParseReaderConfigFile() throws Exception {
+        File propsFile = TestUtils.tempFile();
+        OutputStream propsStream = Files.newOutputStream(propsFile.toPath());
+        propsStream.write("parse.key=true\n".getBytes());
+        propsStream.write("key.separator=|".getBytes());
+        propsStream.close();
+
+        String[] args = new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--reader-property", "key.separator=;",
+            "--reader-property", "parse.headers=true",
+            "--reader-config", propsFile.getAbsolutePath()
+        };
+        ConsoleProducerOptions opts = new ConsoleProducerOptions(args);
+        LineMessageReader reader = (LineMessageReader) Class.forName(opts.readerClass()).getDeclaredConstructor().newInstance();
+        reader.configure(opts.readerProps());
+
+        assertEquals(";", reader.keySeparator());
+        assertTrue(reader.parseKey());
+        assertTrue(reader.parseHeaders());
     }
 
     @Test
@@ -267,6 +307,26 @@ public class ConsoleProducerTest {
             "--topic", "test",
             "--producer.config", propsFile.getAbsolutePath(),
             "--command-config", propsFile2.getAbsolutePath()
+        };
+
+        try {
+            assertThrows(IllegalArgumentException.class, () -> new ConsoleProducerOptions(args));
+        } finally {
+            Exit.resetExitProcedure();
+        }
+    }
+
+    @Test
+    public void shouldExitOnBothPropertyAndReaderProperty() {
+        Exit.setExitProcedure((code, message) -> {
+            throw new IllegalArgumentException(message);
+        });
+
+        String[] args = new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--property", "parse.key=true",
+            "--reader-property", "parse.headers=true"
         };
 
         try {

--- a/tools/src/test/java/org/apache/kafka/tools/ConsoleProducerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConsoleProducerTest.java
@@ -51,10 +51,10 @@ public class ConsoleProducerTest {
         "--property", "key.separator=#"
     };
     private static final String[] BOOTSTRAP_SERVER_VALID_ARGS = new String[]{
-            "--bootstrap-server", "localhost:1003,localhost:1004",
-            "--topic", "t3",
-            "--reader-property", "parse.key=true",
-            "--reader-property", "key.separator=#"
+        "--bootstrap-server", "localhost:1003,localhost:1004",
+        "--topic", "t3",
+        "--reader-property", "parse.key=true",
+        "--reader-property", "key.separator=#"
     };
     private static final String[] INVALID_ARGS = new String[]{
         "--t", // not a valid argument


### PR DESCRIPTION
*What*
https://issues.apache.org/jira/browse/KAFKA-19725

- Implement KIP-1147 for ConsoleProducer where we replace --property
with --reader-property.
- Currently the previous names for the options are still usable but
there will be warning message stating those are deprecated and will be
removed in a future version.
- I have added unit tests and also manually verified using the console
tools that things are working as expected.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Jhen-Yung Hsu
 <jhenyunghsu@gmail.com>
