### PR TITLE
MINOR: Remove outdated license header comment in wrapper.gradle

### DIFF
--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -28,7 +28,6 @@ wrapper {
 
 // Custom task to inject support for downloading the gradle wrapper jar if it doesn't exist.
 // This allows us to avoid checking in the jar to our repository.
-// Additionally adds a license header to the wrapper while editing the file contents.
 task bootstrapWrapper() {
     // In the doLast block so this runs when the task is called and not during project configuration.
     doLast {


### PR DESCRIPTION
The comment stating "Additionally adds a license header to the wrapper
while editing the file contents" is no longer accurate. This
functionality was removed in PR #7742 (commit 45842a3962) since Gradle
5.6+ automatically handles license headers in wrapper files.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
