### PR TITLE
KAFKA-19779: Relax offset commit validation for streams groups [1/N]

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3696,9 +3696,10 @@ public class GroupMetadataManager {
         if (!updatedMember.equals(member)) {
             records.add(newStreamsGroupCurrentAssignmentRecord(groupId, updatedMember));
 
-            log.info("[GroupId {}][MemberId {}] Member's new assignment state: epoch={}, previousEpoch={}, state={}, "
+            log.info("[GroupId {}][MemberId {}] Member's new assignment state: epoch={}, previousEpoch={}, revocationEpoch={}, state={}, "
                     + "assignedTasks={} and tasksPendingRevocation={}.",
-                groupId, updatedMember.memberId(), updatedMember.memberEpoch(), updatedMember.previousMemberEpoch(), updatedMember.state(),
+                groupId, updatedMember.memberId(), updatedMember.memberEpoch(), updatedMember.previousMemberEpoch(),
+                updatedMember.revocationEpoch(), updatedMember.state(),
                 updatedMember.assignedTasks().toString(),
                 updatedMember.tasksPendingRevocation().toString());
 
@@ -5679,6 +5680,7 @@ public class GroupMetadataManager {
             StreamsGroupMember newMember = new StreamsGroupMember.Builder(oldMember)
                 .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH)
                 .setPreviousMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH)
+                .setRevocationEpoch(LEAVE_GROUP_MEMBER_EPOCH)
                 .setAssignedTasks(TasksTuple.EMPTY)
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
                 .build();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
@@ -165,7 +165,8 @@ public class CurrentAssignmentBuilder {
                 if (member.memberEpoch() != targetAssignmentEpoch) {
                     return computeNextAssignment(
                         member.memberEpoch(),
-                        member.assignedTasks()
+                        member.assignedTasks(),
+                        member.revocationEpoch()
                     );
                 } else {
                     return member;
@@ -190,9 +191,12 @@ public class CurrentAssignmentBuilder {
                 // When the member has revoked all the pending tasks, it can
                 // transition to the next epoch (current + 1) and we can reconcile
                 // its state towards the latest target assignment.
+                // Since we finished revocation of all tasks, we bump the revocation
+                // epoch to the old member epoch.
                 return computeNextAssignment(
                     member.memberEpoch() + 1,
-                    member.assignedTasks()
+                    member.assignedTasks(),
+                    member.memberEpoch()
                 );
 
             case UNRELEASED_TASKS:
@@ -201,7 +205,8 @@ public class CurrentAssignmentBuilder {
                 // of the unreleased tasks when they become available.
                 return computeNextAssignment(
                     member.memberEpoch(),
-                    member.assignedTasks()
+                    member.assignedTasks(),
+                    member.revocationEpoch()
                 );
 
             case UNKNOWN:
@@ -217,7 +222,8 @@ public class CurrentAssignmentBuilder {
 
                 return computeNextAssignment(
                     targetAssignmentEpoch,
-                    member.assignedTasks()
+                    member.assignedTasks(),
+                    member.revocationEpoch()
                 );
         }
 
@@ -313,7 +319,8 @@ public class CurrentAssignmentBuilder {
      * @return A new StreamsGroupMember.
      */
     private StreamsGroupMember computeNextAssignment(int memberEpoch,
-                                                     TasksTuple memberAssignedTasks) {
+                                                     TasksTuple memberAssignedTasks,
+                                                     int newRevocationEpoch) {
         Map<String, Set<Integer>> newActiveAssignedTasks = new HashMap<>();
         Map<String, Set<Integer>> newActiveTasksPendingRevocation = new HashMap<>();
         Map<String, Set<Integer>> newActiveTasksPendingAssignment = new HashMap<>();
@@ -385,7 +392,8 @@ public class CurrentAssignmentBuilder {
                 newStandbyTasksPendingAssignment,
                 newWarmupTasksPendingAssignment
             ),
-            hasUnreleasedActiveTasks || hasUnreleasedStandbyTasks || hasUnreleasedWarmupTasks
+            hasUnreleasedActiveTasks || hasUnreleasedStandbyTasks || hasUnreleasedWarmupTasks,
+            newRevocationEpoch
         );
     }
 
@@ -393,7 +401,8 @@ public class CurrentAssignmentBuilder {
                                               final TasksTuple newTasksPendingRevocation,
                                               final TasksTuple newAssignedTasks,
                                               final TasksTuple newTasksPendingAssignment,
-                                              final boolean hasUnreleasedTasks) {
+                                              final boolean hasUnreleasedTasks,
+                                              final int newRevocationEpoch) {
 
         final boolean hasTasksToBeRevoked =
             (!newTasksPendingRevocation.isEmpty())
@@ -409,6 +418,7 @@ public class CurrentAssignmentBuilder {
                 .updateMemberEpoch(memberEpoch)
                 .setAssignedTasks(newAssignedTasks)
                 .setTasksPendingRevocation(newTasksPendingRevocation)
+                .setRevocationEpoch(newRevocationEpoch)
                 .build();
         } else if (!newTasksPendingAssignment.isEmpty()) {
             // If there are tasks to be assigned, the member transitions to the
@@ -425,6 +435,7 @@ public class CurrentAssignmentBuilder {
                 .updateMemberEpoch(targetAssignmentEpoch)
                 .setAssignedTasks(newAssignedTasks.merge(newTasksPendingAssignment))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(newRevocationEpoch)
                 .build();
         } else if (hasUnreleasedTasks) {
             // If there are no tasks to be revoked nor to be assigned but some
@@ -435,6 +446,7 @@ public class CurrentAssignmentBuilder {
                 .updateMemberEpoch(targetAssignmentEpoch)
                 .setAssignedTasks(newAssignedTasks)
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(newRevocationEpoch)
                 .build();
         } else {
             // Otherwise, the member transitions to the target epoch and to the
@@ -444,6 +456,7 @@ public class CurrentAssignmentBuilder {
                 .updateMemberEpoch(targetAssignmentEpoch)
                 .setAssignedTasks(newAssignedTasks)
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(newRevocationEpoch)
                 .build();
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
@@ -260,7 +260,8 @@ public class StreamsCoordinatorRecordHelpers {
                     .setWarmupTasks(toTaskIds(member.assignedTasks().warmupTasks()))
                     .setActiveTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().activeTasks()))
                     .setStandbyTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().standbyTasks()))
-                    .setWarmupTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().warmupTasks())),
+                    .setWarmupTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().warmupTasks()))
+                    .setRevocationEpoch(member.revocationEpoch()),
                 (short) 0
             )
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -703,7 +703,13 @@ public class StreamsGroup implements Group {
                 "by members using the streams group protocol");
         }
 
-        validateMemberEpoch(memberEpoch, member.memberEpoch());
+        if (member.revocationEpoch() >= 0) {
+            validateMemberEpochWithRevocationEpoch(memberEpoch, member.revocationEpoch(), member.memberEpoch());
+        } else {
+            // If the member was read from a legacy record without a revocation epoch, 
+            // we don't know the revocation epoch, so we fall back to the original behavior.
+            validateMemberEpoch(memberEpoch, member.memberEpoch());
+        }
     }
 
     /**
@@ -824,6 +830,31 @@ public class StreamsGroup implements Group {
         if (receivedMemberEpoch != expectedMemberEpoch) {
             throw new StaleMemberEpochException(String.format("The received member epoch %d does not match "
                 + "the expected member epoch %d.", receivedMemberEpoch, expectedMemberEpoch));
+        }
+    }
+
+
+    /**
+     * Throws a StaleMemberEpochException if the received member epoch does not match the range of allowed member epochs.
+     *
+     * @param receivedMemberEpoch The received member epoch.
+     * @param revocationEpoch The revocation epoch.
+     * @param brokerSideMemberEpoch The broker-side member epoch.
+     * @throws StaleMemberEpochException If the received member epoch does not match the range of allowed member epochs.
+     */
+    private void validateMemberEpochWithRevocationEpoch(
+        int receivedMemberEpoch,
+        int revocationEpoch,
+        int brokerSideMemberEpoch
+    ) throws StaleMemberEpochException {
+        if (receivedMemberEpoch <= revocationEpoch || receivedMemberEpoch > brokerSideMemberEpoch) {
+            throw new StaleMemberEpochException(String.format("The received member epoch %d does not match "
+                + "the range of allowed member epochs from %d to %d.",
+                receivedMemberEpoch, revocationEpoch + 1, brokerSideMemberEpoch));
+        }
+        if (receivedMemberEpoch != brokerSideMemberEpoch) {
+            log.trace("Permitting stale member epoch {} sent by the client (broker-side member epoch is {}), since it's larger than revocation epoch {}", 
+                receivedMemberEpoch, brokerSideMemberEpoch, revocationEpoch);
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -706,7 +706,7 @@ public class StreamsGroup implements Group {
         if (member.revocationEpoch() >= 0) {
             validateMemberEpochWithRevocationEpoch(memberEpoch, member.revocationEpoch(), member.memberEpoch());
         } else {
-            // If the member was read from a legacy record without a revocation epoch, 
+            // If the member was read from a legacy record without a revocation epoch,
             // we don't know the revocation epoch, so we fall back to the original behavior.
             validateMemberEpoch(memberEpoch, member.memberEpoch());
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -854,7 +854,7 @@ public class StreamsGroup implements Group {
         }
         if (receivedMemberEpoch != brokerSideMemberEpoch) {
             log.trace("Permitting stale member epoch {} sent by the client (broker-side member epoch is {}), since it's larger than revocation epoch {}", 
-                receivedMemberEpoch, brokerSideMemberEpoch, revocationEpoch);
+                    receivedMemberEpoch, brokerSideMemberEpoch, revocationEpoch);
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -51,6 +51,8 @@ import java.util.stream.Collectors;
  * @param clientTags                    Tags of the client of the member used for rack-aware assignment.
  * @param assignedTasks                 Tasks assigned to the member.
  * @param tasksPendingRevocation        Tasks owned by the member pending revocation.
+ * @param revocationEpoch               The largest epoch at which any task was revoked from the member and which
+ *                                      is not the current member epoch. Used to fence zombie commits requests.
  */
 @SuppressWarnings("checkstyle:JavaNCSS")
 public record StreamsGroupMember(String memberId,
@@ -67,7 +69,8 @@ public record StreamsGroupMember(String memberId,
                                  Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint,
                                  Map<String, String> clientTags,
                                  TasksTuple assignedTasks,
-                                 TasksTuple tasksPendingRevocation) {
+                                 TasksTuple tasksPendingRevocation,
+                                 Integer revocationEpoch) {
 
     public StreamsGroupMember {
         Objects.requireNonNull(memberId, "memberId cannot be null");
@@ -96,6 +99,7 @@ public record StreamsGroupMember(String memberId,
         private Map<String, String> clientTags = null;
         private TasksTuple assignedTasks = null;
         private TasksTuple tasksPendingRevocation = null;
+        private Integer revocationEpoch = null;
 
         public Builder(String memberId) {
             this.memberId = Objects.requireNonNull(memberId, "memberId cannot be null");
@@ -107,6 +111,7 @@ public record StreamsGroupMember(String memberId,
             this.memberId = member.memberId;
             this.memberEpoch = member.memberEpoch;
             this.previousMemberEpoch = member.previousMemberEpoch;
+            this.revocationEpoch = member.revocationEpoch;
             this.instanceId = member.instanceId;
             this.rackId = member.rackId;
             this.rebalanceTimeoutMs = member.rebalanceTimeoutMs;
@@ -135,6 +140,11 @@ public record StreamsGroupMember(String memberId,
 
         public Builder setPreviousMemberEpoch(int previousMemberEpoch) {
             this.previousMemberEpoch = previousMemberEpoch;
+            return this;
+        }
+
+        public Builder setRevocationEpoch(int activeTaskRevocationEpoch) {
+            this.revocationEpoch = activeTaskRevocationEpoch;
             return this;
         }
 
@@ -252,6 +262,7 @@ public record StreamsGroupMember(String memberId,
         public Builder updateWith(StreamsGroupCurrentMemberAssignmentValue record) {
             setMemberEpoch(record.memberEpoch());
             setPreviousMemberEpoch(record.previousMemberEpoch());
+            setRevocationEpoch(record.revocationEpoch());
             setState(MemberState.fromValue(record.state()));
             setAssignedTasks(
                 new TasksTuple(
@@ -284,13 +295,16 @@ public record StreamsGroupMember(String memberId,
                 .setTopologyEpoch(-1)
                 .setInstanceId(null)
                 .setRackId(null)
+                .setClientId("")
+                .setClientHost("")
                 .setProcessId("")
                 .setClientTags(Collections.emptyMap())
                 .setState(MemberState.STABLE)
                 .setMemberEpoch(0)
                 .setAssignedTasks(TasksTuple.EMPTY)
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
-                .setUserEndpoint(null);
+                .setUserEndpoint(null)
+                .setRevocationEpoch(0);
         }
 
         public StreamsGroupMember build() {
@@ -309,7 +323,8 @@ public record StreamsGroupMember(String memberId,
                 userEndpoint,
                 clientTags,
                 assignedTasks,
-                tasksPendingRevocation
+                tasksPendingRevocation,
+                revocationEpoch
             );
         }
     }

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -38,7 +38,9 @@
     { "name": "StandbyTasksPendingRevocation", "versions": "0+", "type": "[]TaskIds",
       "about": "The standby tasks that must be revoked by this member." },
     { "name": "WarmupTasksPendingRevocation", "versions": "0+", "type": "[]TaskIds",
-      "about": "The warmup tasks that must be revoked by this member." }
+      "about": "The warmup tasks that must be revoked by this member." },
+    { "name": "RevocationEpoch", "versions": "0+", "taggedVersions": "0+", "tag": 0, "type": "int32", "default": -1,
+      "about": "The largest epoch at which any task was revoked from the member and which is not the current member epoch. Used to fence zombie commits requests." }
   ],
   "commonStructs": [
     { "name": "TaskIds", "versions": "0+", "fields": [

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -4276,6 +4276,7 @@ public class GroupMetadataManagerTest {
                         TaskAssignmentTestUtil.mkTasks(fooTopicName, 0, 1, 2)))
                     .setTasksPendingRevocation(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(fooTopicName, 3, 4, 5)))
+                    .setRevocationEpoch(7)
                     .build())
                 .withMember(new StreamsGroupMember.Builder("foo-2")
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
@@ -4292,6 +4293,7 @@ public class GroupMetadataManagerTest {
                     .setUserEndpoint(new Endpoint().setHost("localhost").setPort(1500))
                     .setClientId(DEFAULT_CLIENT_ID)
                     .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+                    .setRevocationEpoch(7)
                     .build())
                 .withTargetAssignment("foo-1", TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                     TaskAssignmentTestUtil.mkTasks(fooTopicName, 3, 4, 5)))
@@ -4488,6 +4490,7 @@ public class GroupMetadataManagerTest {
             .setRebalanceTimeoutMs(1500)
             .setAssignedTasks(TasksTuple.EMPTY)
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(0)
             .setTopologyEpoch(0)
             .setClientTags(Map.of())
             .setClientId(DEFAULT_CLIENT_ID)
@@ -17317,6 +17320,7 @@ public class GroupMetadataManagerTest {
                     .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1)))
+                    .setRevocationEpoch(7)
                     .build())
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId2)
                     .setMemberEpoch(10)
@@ -17324,6 +17328,7 @@ public class GroupMetadataManagerTest {
                     .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
+                    .setRevocationEpoch(7)
                     .build())
                 .withTopology(StreamsTopology.fromHeartbeatRequest(topology))
                 .withTargetAssignment(memberId1, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
@@ -17440,6 +17445,7 @@ public class GroupMetadataManagerTest {
                     .setTasksPendingRevocation(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 2),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 1)))
+                    .setRevocationEpoch(7)
                     .build())),
             result.records()
         );
@@ -17485,6 +17491,7 @@ public class GroupMetadataManagerTest {
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
                     .setTasksPendingRevocation(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 4, 5)))
+                    .setRevocationEpoch(7)
                     .build())),
             result.records()
         );
@@ -17556,6 +17563,7 @@ public class GroupMetadataManagerTest {
                     .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0)))
+                    .setRevocationEpoch(10) // Revocation epoch was bumped, since we transitioned to a new epoch after revoking tasks.
                     .build())),
             result.records()
         );
@@ -17686,6 +17694,7 @@ public class GroupMetadataManagerTest {
                     .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 2, 3),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
+                    .setRevocationEpoch(10) // Revocation epoch is preserved
                     .build())),
             result.records()
         );
@@ -17731,6 +17740,7 @@ public class GroupMetadataManagerTest {
                     .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 4, 5),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 1)))
+                    .setRevocationEpoch(0) // Nothing was ever revoked from the member
                     .build())),
             result.records()
         );
@@ -19617,6 +19627,7 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksPerSubtopology(TaskAssignmentTestUtil.mkTasks("subtopology-1", 6, 7, 8))
             ))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(7)
             .build();
 
         // The group and the member are created if they do not exist.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
@@ -42,6 +42,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToStable(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member =
             new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -55,6 +56,7 @@ public class CurrentAssignmentBuilderTest {
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch)
                 .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -78,6 +80,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -87,6 +90,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToStableAtTargetEpoch(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member =
             new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -100,6 +104,7 @@ public class CurrentAssignmentBuilderTest {
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch)
                 .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -123,6 +128,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -132,6 +138,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToStableWithNewTasks(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.STABLE)
@@ -142,6 +149,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -164,6 +172,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2, 4),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4, 7)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -173,6 +182,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToUnrevokedTasks(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.STABLE)
@@ -183,6 +193,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -207,6 +218,7 @@ public class CurrentAssignmentBuilderTest {
                 .setTasksPendingRevocation(mkTasksTuple(taskRole,
                     mkTasks(SUBTOPOLOGY_ID1, 1),
                     mkTasks(SUBTOPOLOGY_ID2, 3)))
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -216,6 +228,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToUnrevokedWithEmptyAssignment(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member =
             new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -229,6 +242,7 @@ public class CurrentAssignmentBuilderTest {
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch)
                 .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -251,6 +265,7 @@ public class CurrentAssignmentBuilderTest {
                         taskRole,
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -260,6 +275,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToUnreleasedTasks(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.STABLE)
@@ -270,6 +286,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -292,6 +309,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -301,6 +319,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testStableToUnreleasedTasksWithOwnedTasksNotHavingRevokedTasks(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.STABLE)
@@ -311,6 +330,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -336,6 +356,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -345,6 +366,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnrevokedTasksToStable(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNREVOKED_TASKS)
@@ -357,6 +379,7 @@ public class CurrentAssignmentBuilderTest {
             .setTasksPendingRevocation(mkTasksTuple(taskRole,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -382,6 +405,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(memberEpoch) // We transitioned out of a revocation epoch, so bump it
                 .build(),
             updatedMember
         );
@@ -391,6 +415,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testRemainsInUnrevokedTasks(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNREVOKED_TASKS)
@@ -403,6 +428,7 @@ public class CurrentAssignmentBuilderTest {
             .setTasksPendingRevocation(mkTasksTuple(taskRole,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         CurrentAssignmentBuilder currentAssignmentBuilder = new CurrentAssignmentBuilder(
@@ -446,6 +472,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnrevokedTasksToUnrevokedTasks(TaskRole taskRole) {
         final int memberEpoch = 10;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNREVOKED_TASKS)
@@ -458,6 +485,7 @@ public class CurrentAssignmentBuilderTest {
             .setTasksPendingRevocation(mkTasksTuple(taskRole,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -482,6 +510,7 @@ public class CurrentAssignmentBuilderTest {
                 .setTasksPendingRevocation(mkTasksTuple(taskRole,
                     mkTasks(SUBTOPOLOGY_ID1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 5)))
+                .setRevocationEpoch(memberEpoch) // We transitioned out of a revocation epoch, so bump it
                 .build(),
             updatedMember
         );
@@ -491,6 +520,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnrevokedTasksToUnreleasedTasks(TaskRole taskRole) {
         final int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNREVOKED_TASKS)
@@ -503,6 +533,7 @@ public class CurrentAssignmentBuilderTest {
             .setTasksPendingRevocation(mkTasksTuple(taskRole,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -529,6 +560,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(memberEpoch) // We transitioned out of a revocation epoch, so bump it
                 .build(),
             updatedMember
         );
@@ -538,6 +570,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnreleasedTasksToStable(TaskRole taskRole) {
         final int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNRELEASED_TASKS)
@@ -548,6 +581,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -571,6 +605,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch)
                 .build(),
             updatedMember
         );
@@ -580,6 +615,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnreleasedTasksToStableWithNewTasks(TaskRole taskRole) {
         int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNRELEASED_TASKS)
@@ -590,6 +626,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -612,6 +649,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3, 4),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6, 7)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch)
                 .build(),
             updatedMember
         );
@@ -621,6 +659,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnreleasedTasksToUnreleasedTasks(TaskRole taskRole) {
         int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNRELEASED_TASKS)
@@ -631,6 +670,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -651,6 +691,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnreleasedTasksToUnreleasedTasksOtherUnreleasedTaskRole(TaskRole taskRole) {
         int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         // The unreleased task is owned by a task of a different role on the same process.
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -662,6 +703,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -683,6 +725,7 @@ public class CurrentAssignmentBuilderTest {
     @Test
     public void testUnreleasedTasksToUnreleasedTasksAnyActiveOwner() {
         int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         // The unreleased task remains unreleased, because it is owned by any other instance in
         // an active role, no matter the process.
@@ -695,6 +738,7 @@ public class CurrentAssignmentBuilderTest {
             .setAssignedTasks(mkTasksTuple(TaskRole.ACTIVE,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember expectedMember = new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -706,6 +750,7 @@ public class CurrentAssignmentBuilderTest {
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6, 7)))
             .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -728,6 +773,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnreleasedTasksToUnrevokedTasks(TaskRole taskRole) {
         int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNRELEASED_TASKS)
@@ -740,6 +786,7 @@ public class CurrentAssignmentBuilderTest {
             .setTasksPendingRevocation(mkTasksTuple(TaskRole.ACTIVE,
                 mkTasks(SUBTOPOLOGY_ID1, 4),
                 mkTasks(SUBTOPOLOGY_ID2, 7)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -764,6 +811,7 @@ public class CurrentAssignmentBuilderTest {
                 .setTasksPendingRevocation(mkTasksTuple(taskRole,
                     mkTasks(SUBTOPOLOGY_ID1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 5)))
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );
@@ -773,6 +821,7 @@ public class CurrentAssignmentBuilderTest {
     @EnumSource(TaskRole.class)
     public void testUnknownState(TaskRole taskRole) {
         int memberEpoch = 11;
+        final int revocationEpoch = 9;
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
             .setState(MemberState.UNKNOWN)
@@ -785,6 +834,7 @@ public class CurrentAssignmentBuilderTest {
             .setTasksPendingRevocation(mkTasksTuple(taskRole,
                 mkTasks(SUBTOPOLOGY_ID1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 5)))
+            .setRevocationEpoch(revocationEpoch)
             .build();
 
         // When the member is in an unknown state, the member is first to force
@@ -818,6 +868,7 @@ public class CurrentAssignmentBuilderTest {
                     mkTasks(SUBTOPOLOGY_ID1, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 6)))
                 .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setRevocationEpoch(revocationEpoch) // Preserve the existing revocation epoch
                 .build(),
             updatedMember
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
@@ -396,6 +396,7 @@ class StreamsCoordinatorRecordHelpersTest {
             .setProcessId(PROCESS_ID)
             .setUserEndpoint(new Endpoint().setHost(USER_ENDPOINT).setPort(USER_ENDPOINT_PORT))
             .setClientTags(Map.of(TAG_1, VALUE_1, TAG_2, VALUE_2))
+            .setRevocationEpoch(0)
             .setAssignedTasks(new TasksTuple(
                 Map.of(
                     SUBTOPOLOGY_1, Set.of(1, 2, 3)
@@ -458,7 +459,8 @@ class StreamsCoordinatorRecordHelpersTest {
                         new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
                             .setSubtopologyId(SUBTOPOLOGY_3)
                             .setPartitions(List.of(7, 8, 9))
-                    )),
+                    ))
+                    .setRevocationEpoch(0),
                 (short) 0
             )
         );
@@ -481,6 +483,7 @@ class StreamsCoordinatorRecordHelpersTest {
             .setProcessId(PROCESS_ID)
             .setUserEndpoint(new Endpoint().setHost(USER_ENDPOINT).setPort(USER_ENDPOINT_PORT))
             .setClientTags(Map.of(TAG_1, VALUE_1, TAG_2, VALUE_2))
+            .setRevocationEpoch(0)
             .setAssignedTasks(new TasksTuple(Map.of(), Map.of(), Map.of()))
             .setTasksPendingRevocation(new TasksTuple(Map.of(), Map.of(), Map.of()))
             .build();
@@ -499,7 +502,8 @@ class StreamsCoordinatorRecordHelpersTest {
                     .setWarmupTasks(List.of())
                     .setActiveTasksPendingRevocation(List.of())
                     .setStandbyTasksPendingRevocation(List.of())
-                    .setWarmupTasksPendingRevocation(List.of()),
+                    .setWarmupTasksPendingRevocation(List.of())
+                    .setRevocationEpoch(0),
                 (short) 0
             )
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -48,6 +48,7 @@ public class StreamsGroupMemberTest {
     private static final String MEMBER_ID = "member-id";
     private static final int MEMBER_EPOCH = 10;
     private static final int PREVIOUS_MEMBER_EPOCH = 9;
+    private static final int REVOCATION_EPOCH = 8;
     private static final MemberState STATE = MemberState.UNRELEASED_TASKS;
     private static final String INSTANCE_ID = "instance-id";
     private static final String RACK_ID = "rack-id";
@@ -102,12 +103,13 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testBuilderWithDefaults() {
+    public void testBuilderWithoutDefaults() {
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID).build();
 
         assertEquals(MEMBER_ID, member.memberId());
         assertNull(member.memberEpoch());
         assertNull(member.previousMemberEpoch());
+        assertNull(member.revocationEpoch());
         assertNull(member.state());
         assertNull(member.instanceId());
         assertNull(member.rackId());
@@ -123,12 +125,35 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
+    public void testBuilderWithDefaults() {
+        StreamsGroupMember member = StreamsGroupMember.Builder.withDefaults(MEMBER_ID)
+            .build();
+
+        assertEquals(MEMBER_ID, member.memberId());
+        assertEquals(0, member.memberEpoch());
+        assertEquals(0, member.revocationEpoch());
+        assertEquals(MemberState.STABLE, member.state());
+        assertEquals(Optional.empty(), member.instanceId());
+        assertEquals(Optional.empty(), member.rackId());
+        assertEquals("", member.clientId());
+        assertEquals("", member.clientHost());
+        assertEquals(-1, member.rebalanceTimeoutMs());
+        assertEquals(-1, member.topologyEpoch());
+        assertEquals("", member.processId());
+        assertEquals(Optional.empty(), member.userEndpoint());
+        assertEquals(Map.of(), member.clientTags());
+        assertEquals(TasksTuple.EMPTY, member.assignedTasks());
+        assertEquals(TasksTuple.EMPTY, member.tasksPendingRevocation());
+    }
+
+    @Test
     public void testBuilderNewMember() {
         StreamsGroupMember member = createStreamsGroupMember();
 
         assertEquals(MEMBER_ID, member.memberId());
         assertEquals(MEMBER_EPOCH, member.memberEpoch());
         assertEquals(PREVIOUS_MEMBER_EPOCH, member.previousMemberEpoch());
+        assertEquals(REVOCATION_EPOCH, member.revocationEpoch());
         assertEquals(STATE, member.state());
         assertEquals(Optional.of(INSTANCE_ID), member.instanceId());
         assertEquals(Optional.of(RACK_ID), member.rackId());
@@ -176,6 +201,7 @@ public class StreamsGroupMemberTest {
         assertEquals(MEMBER_ID, member.memberId());
         assertNull(member.memberEpoch());
         assertNull(member.previousMemberEpoch());
+        assertNull(member.revocationEpoch());
         assertNull(member.state());
         assertNull(member.assignedTasks());
         assertNull(member.tasksPendingRevocation());
@@ -186,6 +212,7 @@ public class StreamsGroupMemberTest {
         StreamsGroupCurrentMemberAssignmentValue record = new StreamsGroupCurrentMemberAssignmentValue()
             .setMemberEpoch(MEMBER_EPOCH)
             .setPreviousMemberEpoch(PREVIOUS_MEMBER_EPOCH)
+            .setRevocationEpoch(REVOCATION_EPOCH)
             .setState(STATE.value())
             .setActiveTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS1)))
             .setStandbyTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS2)))
@@ -201,6 +228,7 @@ public class StreamsGroupMemberTest {
         assertEquals(MEMBER_ID, member.memberId());
         assertEquals(record.memberEpoch(), member.memberEpoch());
         assertEquals(record.previousMemberEpoch(), member.previousMemberEpoch());
+        assertEquals(record.revocationEpoch(), member.revocationEpoch());
         assertEquals(MemberState.fromValue(record.state()), member.state());
         assertEquals(ASSIGNED_TASKS, member.assignedTasks());
         assertEquals(TASKS_PENDING_REVOCATION, member.tasksPendingRevocation());
@@ -213,6 +241,28 @@ public class StreamsGroupMemberTest {
         assertNull(member.processId());
         assertNull(member.userEndpoint());
         assertNull(member.clientTags());
+    }
+
+
+    @Test
+    public void testBuilderSetRevocationEpoch() {
+        int newRevocationEpoch = 15;
+
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID)
+            .setRevocationEpoch(newRevocationEpoch)
+            .build();
+
+        assertEquals(newRevocationEpoch, member.revocationEpoch());
+    }
+
+    @Test
+    public void testBuilderCopiesRevocationEpoch() {
+        StreamsGroupMember originalMember = createStreamsGroupMember();
+
+        StreamsGroupMember copiedMember = new StreamsGroupMember.Builder(originalMember)
+            .build();
+
+        assertEquals(REVOCATION_EPOCH, copiedMember.revocationEpoch());
     }
 
     @Test
@@ -262,6 +312,7 @@ public class StreamsGroupMemberTest {
         assertEquals(member.memberId(), updatedMember.memberId());
         assertEquals(member.memberEpoch(), updatedMember.memberEpoch());
         assertEquals(member.previousMemberEpoch(), updatedMember.previousMemberEpoch());
+        assertEquals(member.revocationEpoch(), updatedMember.revocationEpoch());
         assertEquals(member.state(), updatedMember.state());
         assertEquals(member.clientId(), updatedMember.clientId());
         assertEquals(member.clientHost(), updatedMember.clientHost());
@@ -282,6 +333,7 @@ public class StreamsGroupMemberTest {
         assertEquals(newMemberEpoch, updatedMember.memberEpoch());
         // The previous member epoch becomes the old current member epoch.
         assertEquals(member.memberEpoch(), updatedMember.previousMemberEpoch());
+        assertEquals(member.revocationEpoch(), updatedMember.revocationEpoch());
         assertEquals(member.state(), updatedMember.state());
         assertEquals(member.instanceId(), updatedMember.instanceId());
         assertEquals(member.rackId(), updatedMember.rackId());
@@ -416,6 +468,7 @@ public class StreamsGroupMemberTest {
         return new StreamsGroupMember.Builder(MEMBER_ID)
             .setMemberEpoch(MEMBER_EPOCH)
             .setPreviousMemberEpoch(PREVIOUS_MEMBER_EPOCH)
+            .setRevocationEpoch(REVOCATION_EPOCH)
             .setState(STATE)
             .setInstanceId(INSTANCE_ID)
             .setRackId(RACK_ID)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -654,7 +654,7 @@ public class StreamsGroupTest {
         assertThrows(UnknownMemberIdException.class, () ->
             group.validateOffsetCommit("member-id", null, 0, isTransactional, version));
 
-        // Create a member with revocation epoch.3
+        // Create a member with revocation epoch 3
         group.updateMember(new StreamsGroupMember.Builder("member-id").setMemberEpoch(5).setRevocationEpoch(3).build());
 
         // A call from the admin client should fail as the group is not empty.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -609,7 +609,7 @@ public class StreamsGroupTest {
 
     @ParameterizedTest
     @ApiKeyVersionsSource(apiKey = ApiKeys.TXN_OFFSET_COMMIT)
-    public void testValidateTransactionalOffsetCommit(short version) {
+    public void testValidateTransactionalOffsetCommitWithoutRevocationEpoch(short version) {
         boolean isTransactional = true;
         StreamsGroup group = createStreamsGroup("group-foo");
 
@@ -622,8 +622,8 @@ public class StreamsGroupTest {
         assertThrows(UnknownMemberIdException.class, () ->
             group.validateOffsetCommit("member-id", null, 0, isTransactional, version));
 
-        // Create a member.
-        group.updateMember(new StreamsGroupMember.Builder("member-id").setMemberEpoch(0).build());
+        // Create a member without revocation epoch (read from a legacy record).
+        group.updateMember(new StreamsGroupMember.Builder("member-id").setMemberEpoch(0).setRevocationEpoch(-1).build());
 
         // A call from the admin client should fail as the group is not empty.
         assertThrows(UnknownMemberIdException.class, () ->
@@ -641,8 +641,47 @@ public class StreamsGroupTest {
     }
 
     @ParameterizedTest
+    @ApiKeyVersionsSource(apiKey = ApiKeys.TXN_OFFSET_COMMIT)
+    public void testValidateTransactionalOffsetCommitWithRevocationEpoch(short version) {
+        boolean isTransactional = true;
+        StreamsGroup group = createStreamsGroup("group-foo");
+
+        // Simulate a call from the admin client without member ID and member epoch.
+        // This should pass only if the group is empty.
+        group.validateOffsetCommit("", "", -1, isTransactional, version);
+
+        // The member does not exist.
+        assertThrows(UnknownMemberIdException.class, () ->
+            group.validateOffsetCommit("member-id", null, 0, isTransactional, version));
+
+        // Create a member with revocation epoch.3
+        group.updateMember(new StreamsGroupMember.Builder("member-id").setMemberEpoch(5).setRevocationEpoch(3).build());
+
+        // A call from the admin client should fail as the group is not empty.
+        assertThrows(UnknownMemberIdException.class, () ->
+            group.validateOffsetCommit("", "", -1, isTransactional, version));
+
+        // The member epoch is stale.
+        assertThrows(StaleMemberEpochException.class, () ->
+            group.validateOffsetCommit("member-id", "", 10, isTransactional, version));
+
+        // Allowed range is (revocationEpoch, memberEpoch] i.e. 4..5
+        assertThrows(StaleMemberEpochException.class, () ->
+            group.validateOffsetCommit("member-id", "", 3, true, version));
+        assertThrows(StaleMemberEpochException.class, () ->
+            group.validateOffsetCommit("member-id", "", 6, true, version));
+
+        // This should succeed.
+        group.validateOffsetCommit("member-id", "", 4, true, version);
+        group.validateOffsetCommit("member-id", "", 5, true, version);
+
+        // This should succeed.
+        group.validateOffsetCommit("", null, -1, isTransactional, version);
+    }
+
+    @ParameterizedTest
     @ApiKeyVersionsSource(apiKey = ApiKeys.OFFSET_COMMIT)
-    public void testValidateOffsetCommit(short version) {
+    public void testValidateOffsetCommitWithoutRevocationEpoch(short version) {
         boolean isTransactional = false;
         StreamsGroup group = createStreamsGroup("group-foo");
 
@@ -657,7 +696,7 @@ public class StreamsGroupTest {
         // Create members.
         group.updateMember(
             new StreamsGroupMember
-                .Builder("new-protocol-member-id").setMemberEpoch(0).build()
+                .Builder("new-protocol-member-id").setMemberEpoch(0).setRevocationEpoch(-1).build()
         );
 
         // A call from the admin client should fail as the group is not empty.
@@ -681,6 +720,56 @@ public class StreamsGroupTest {
         } else {
             assertThrows(UnsupportedVersionException.class, () ->
                 group.validateOffsetCommit("new-protocol-member-id", "", 0, isTransactional, version));
+        }
+    }
+
+    @ParameterizedTest
+    @ApiKeyVersionsSource(apiKey = ApiKeys.OFFSET_COMMIT)
+    public void testValidateOffsetCommitWithRevocationEpoch(short version) {
+        boolean isTransactional = false;
+        StreamsGroup group = createStreamsGroup("group-foo");
+
+        // Simulate a call from the admin client without member ID and member epoch.
+        // This should pass only if the group is empty.
+        group.validateOffsetCommit("", "", -1, isTransactional, version);
+
+        // The member does not exist.
+        assertThrows(UnknownMemberIdException.class, () ->
+            group.validateOffsetCommit("member-id", null, 0, isTransactional, version));
+
+        // Create members.
+        group.updateMember(
+            new StreamsGroupMember
+                .Builder("new-protocol-member-id").setMemberEpoch(5).setRevocationEpoch(3).build()
+        );
+
+        // A call from the admin client should fail as the group is not empty.
+        assertThrows(UnknownMemberIdException.class, () ->
+            group.validateOffsetCommit("", "", -1, isTransactional, version));
+        assertThrows(UnknownMemberIdException.class, () ->
+            group.validateOffsetCommit("", null, -1, isTransactional, version));
+
+        // The member epoch is stale.
+        if (version >= 9) {
+            // Allowed range is (revocationEpoch, memberEpoch] i.e. 4..5
+            assertThrows(StaleMemberEpochException.class, () ->
+                group.validateOffsetCommit("new-protocol-member-id", "", 3, isTransactional, version));
+            assertThrows(StaleMemberEpochException.class, () ->
+                group.validateOffsetCommit("new-protocol-member-id", "", 6, isTransactional, version));
+        } else {
+            assertThrows(UnsupportedVersionException.class, () ->
+                group.validateOffsetCommit("new-protocol-member-id", "", 6, isTransactional, version));
+        }
+
+        // This should succeed.
+        if (version >= 9) {
+            // Lower bound just above revocationEpoch should pass
+            group.validateOffsetCommit("new-protocol-member-id", "", 4, isTransactional, version);
+            // Upper bound equal to broker-side memberEpoch should pass
+            group.validateOffsetCommit("new-protocol-member-id", "", 5, isTransactional, version);
+        } else {
+            assertThrows(UnsupportedVersionException.class, () ->
+                group.validateOffsetCommit("new-protocol-member-id", "", 5, isTransactional, version));
         }
     }
 


### PR DESCRIPTION
The changes introduce a revocationEpoch field to track the last epoch at
which tasks were revoked from a member. This allows members to commit
offsets using slightly stale epochs if no tasks were revoked from the
member in the epoch range from the stale epoch to the current member
epoch.

Most of the changes are just adding the new revocation epoch field to
the model of a streams group member, both in the persisted state of the
consumer offset topic, and in the member model.

The revocation is only updated in CurrentAssignmentBuilder: When
transitioning from UNREVOKED_TASKS to a new member epoch, the revocation
is bumped to the old epoch. In all other states, the previous revocation
epoch is preserved.

The revocation epoch defaults to 0 for new members, and -1 for members
whose metdata was restored from the consumer offset topic withou the new
tagged field.

The core logic change is inside `StreamsGroup`. If the revocationEpoch
of the member is -1, we preserve the old commit validation logic. If the
revocation epoch is zero or positive, we allow all offset commits with
member epochs in the range (revocationEpoch, memberEpoch].

Delete this text and replace it with a detailed description of your
change. The   PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload
images, or  include other supplemental information that should not be
part of the eventual  commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy
(including   rationale) for the proposed change. Unit and/or integration
tests are expected  for any behavior change and system tests should be
considered for larger  changes.


