### PR TITLE
MINOR: README.md manual is changed: `aggregatedJavadoc` task is extended with a `--no-parallel` switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew srcJar
 
 ### Build aggregated javadoc ###
-    ./gradlew aggregatedJavadoc
+    ./gradlew aggregatedJavadoc --no-parallel
 
 ### Build javadoc and scaladoc ###
     ./gradlew javadoc


### PR DESCRIPTION
Prologue:
https://github.com/apache/kafka/pull/19513#issuecomment-3390249764

Also related to: #20652

@chia7712 I double-checked custom gradle commands in `README.md` and
AFAIK we should be fine now.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
