### PR TITLE
MINOR: fix some tasks in build.gradle after Gradle version upgrade 8 -->> 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew srcJar
 
 ### Build aggregated javadoc ###
-    ./gradlew aggregatedJavadoc
+    ./gradlew aggregatedJavadoc --no-parallel
 
 ### Build javadoc and scaladoc ###
     ./gradlew javadoc

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew srcJar
 
 ### Build aggregated javadoc ###
-    ./gradlew aggregatedJavadoc --no-parallel
+    ./gradlew aggregatedJavadoc
 
 ### Build javadoc and scaladoc ###
     ./gradlew javadoc

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ ext {
   userKeepAliveModeString = project.hasProperty("keepAliveMode") ? keepAliveMode : "daemon"
   userKeepAliveMode = KeepAliveMode.values().find(m -> m.name().toLowerCase().equals(userKeepAliveModeString))
   if (userKeepAliveMode == null) {
-    def keepAliveValues = KeepAliveMode.values().collect(m -> m.name.toLowerCase())
+    def keepAliveValues = KeepAliveMode.values().collect(m -> m.name().toLowerCase())
     throw new GradleException("Unexpected value for keepAliveMode property. Expected one of $keepAliveValues, but received: $userKeepAliveModeString")
   }
 
@@ -603,6 +603,9 @@ subprojects {
   }
 
   task integrationTest(type: Test, dependsOn: compileJava) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
 
@@ -635,6 +638,9 @@ subprojects {
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
 


### PR DESCRIPTION
from: https://github.com/apache/kafka/pull/19513#issuecomment-3390113268
1. Fix the task `unitTest` and `integrationTest`;
2. Change the `name` to a method call `name()` for `KeepAliveMode`.

Reviewers: Ken Huang <s7133700@gmail.com>, dejan2609
 <dejan2609@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
