### PR TITLE
Add `error-prone.picnic.tech` featuring `RedundantStringConversion`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ plugins {
   id 'org.scoverage' version '8.0.3' apply false
   id 'com.gradleup.shadow' version '8.3.9' apply false
   id 'com.diffplug.spotless' version "7.2.1"
+  id 'net.ltgt.errorprone' version '4.3.0' apply false
 }
 
 ext {
@@ -76,7 +77,7 @@ ext {
     // until version can be upgraded: https://github.com/spotbugs/spotbugs/issues/3564
     project.gradle.startParameter.excludedTaskNames.add("spotbugsMain")
     project.gradle.startParameter.excludedTaskNames.add("spotbugsTest")
-  }    
+  }
 
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
   maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :
@@ -228,6 +229,8 @@ allprojects {
     delete "${projectDir}/src/generated"
     delete "${projectDir}/src/generated-test"
   }
+
+  apply from: rootProject.file('gradle/error-prone.gradle')
 }
 
 def determineCommitId() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -387,7 +387,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                 if (hasCycles(topicMovementPairs)) {
                     log.error("Stickiness is violated for topic {}"
                         + "\nPartition movements for this topic occurred among the following consumer pairs:"
-                        + "\n{}", topicMovements.getKey(), topicMovements.getValue().toString());
+                        + "\n{}", topicMovements.getKey(), topicMovements.getValue());
                     return false;
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
@@ -119,6 +119,6 @@ public final class RecordMetadata {
 
     @Override
     public String toString() {
-        return topicPartition.toString() + "@" + offset;
+        return topicPartition + "@" + offset;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -661,7 +661,7 @@ public final class Metrics implements Closeable {
         
         if (!runtimeTagKeys.equals(templateTagKeys)) {
             throw new IllegalArgumentException("For '" + template.name() + "', runtime-defined metric tags do not match the tags in the template. "
-                    + "Runtime = " + runtimeTagKeys + " Template = " + templateTagKeys.toString());
+                    + "Runtime = " + runtimeTagKeys + " Template = " + templateTagKeys);
         }
                 
         return this.metricName(template.name(), template.group(), template.description(), tags);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/internals/IntGaugeSuite.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/internals/IntGaugeSuite.java
@@ -167,7 +167,7 @@ public final class IntGaugeSuite<K> implements AutoCloseable {
         synchronized (this) {
             if (closed) {
                 log.warn("{}: Attempted to increment {}, but the GaugeSuite was closed.",
-                    suiteName, key.toString());
+                    suiteName, key);
                 return;
             }
             StoredIntGauge gauge = gauges.get(key);
@@ -181,7 +181,7 @@ public final class IntGaugeSuite<K> implements AutoCloseable {
             if (gauges.size() == maxEntries) {
                 if (removable.isEmpty()) {
                     log.debug("{}: Attempted to increment {}, but there are already {} entries.",
-                        suiteName, key.toString(), maxEntries);
+                        suiteName, key, maxEntries);
                     return;
                 }
                 Iterator<K> iter = removable.iterator();
@@ -191,13 +191,13 @@ public final class IntGaugeSuite<K> implements AutoCloseable {
                 gauges.remove(keyToRemove);
                 pending.push(new PendingMetricsChange(metricNameToRemove, null));
                 log.trace("{}: Removing the metric {}, which has a value of 0.",
-                    suiteName, keyToRemove.toString());
+                    suiteName, keyToRemove);
             }
             MetricName metricNameToAdd = metricNameCalculator.apply(key);
             gauge = new StoredIntGauge(metricNameToAdd);
             gauges.put(key, gauge);
             pending.push(new PendingMetricsChange(metricNameToAdd, gauge));
-            log.trace("{}: Adding a new metric {}.", suiteName, key.toString());
+            log.trace("{}: Adding a new metric {}.", suiteName, key);
         }
         // Drop the object monitor and perform any pending metrics additions or removals.
         performPendingMetricsOperations();
@@ -236,17 +236,17 @@ public final class IntGaugeSuite<K> implements AutoCloseable {
     public synchronized void decrement(K key) {
         if (closed) {
             log.warn("{}: Attempted to decrement {}, but the gauge suite was closed.",
-                suiteName, key.toString());
+                suiteName, key);
             return;
         }
         StoredIntGauge gauge = gauges.get(key);
         if (gauge == null) {
             log.debug("{}: Attempted to decrement {}, but no such metric was registered.",
-                suiteName, key.toString());
+                suiteName, key);
         } else {
             int cur = gauge.decrement();
             log.trace("{}: Removed a reference to {}.  {} reference(s) remaining.",
-                suiteName, key.toString(), cur);
+                suiteName, key, cur);
             if (cur <= 0) {
                 removable.add(key);
             }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -57,7 +57,7 @@ public final class MessageUtil {
         while (iter.hasNext()) {
             Object object = iter.next();
             bld.append(prefix);
-            bld.append(object.toString());
+            bld.append(object);
             prefix = ", ";
         }
         bld.append("]");

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -181,7 +181,7 @@ public final class Schema extends Type {
         StringBuilder b = new StringBuilder();
         b.append('{');
         for (int i = 0; i < this.fields.length; i++) {
-            b.append(this.fields[i].toString());
+            b.append(this.fields[i]);
             if (i < this.fields.length - 1)
                 b.append(',');
         }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -138,7 +138,7 @@ public class TaggedFields extends DocumentedType {
         for (Map.Entry<Integer, Field> field : fields.entrySet()) {
             bld.append(prefix);
             prefix = ", ";
-            bld.append(field.getKey()).append(" -> ").append(field.getValue().toString());
+            bld.append(field.getKey()).append(" -> ").append(field.getValue());
         }
         bld.append(")");
         return bld.toString();

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -892,7 +892,7 @@ public class SelectorTest {
                 entry.getKey().name().equals(name) && entry.getKey().tags().equals(tags))
             .findFirst();
         if (metric.isEmpty())
-            throw new Exception(String.format("Could not find metric called %s with tags %s", name, tags.toString()));
+            throw new Exception(String.format("Could not find metric called %s with tags %s", name, tags));
 
         return metric.get().getValue();
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -226,12 +226,12 @@ public class MirrorMaker {
 
     private void checkHerder(SourceAndTarget sourceAndTarget) {
         if (!herders.containsKey(sourceAndTarget)) {
-            throw new IllegalArgumentException("No herder for " + sourceAndTarget.toString());
+            throw new IllegalArgumentException("No herder for " + sourceAndTarget);
         }
     }
 
     private void addHerder(SourceAndTarget sourceAndTarget) {
-        log.info("creating herder for {}", sourceAndTarget.toString());
+        log.info("creating herder for {}", sourceAndTarget);
         Map<String, String> workerProps = config.workerConfig(sourceAndTarget);
         DistributedConfig distributedConfig = new DistributedConfig(workerProps);
         String encodedSource = encodePath(sourceAndTarget.source());
@@ -289,13 +289,13 @@ public class MirrorMaker {
 
     private String generateWorkerId(SourceAndTarget sourceAndTarget) {
         if (config.enableInternalRest()) {
-            return advertisedUrl.getHost() + ":" + advertisedUrl.getPort() + "/" + sourceAndTarget.toString();
+            return advertisedUrl.getHost() + ":" + advertisedUrl.getPort() + "/" + sourceAndTarget;
         }
         try {
             //UUID to make sure it is unique even if multiple workers running on the same host
-            return InetAddress.getLocalHost().getCanonicalHostName() + "/" + sourceAndTarget.toString() + "/" + UUID.randomUUID();
+            return InetAddress.getLocalHost().getCanonicalHostName() + "/" + sourceAndTarget + "/" + UUID.randomUUID();
         } catch (UnknownHostException e) {
-            return sourceAndTarget.toString() + "/" + UUID.randomUUID();
+            return sourceAndTarget + "/" + UUID.randomUUID();
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/converters/BooleanConverter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/converters/BooleanConverter.java
@@ -71,7 +71,7 @@ public class BooleanConverter implements Converter, HeaderConverter, Versioned {
     @Override
     public byte[] fromConnectData(String topic, Schema schema, Object value) {
         if (schema != null && schema.type() != Type.BOOLEAN)
-            throw new DataException("Invalid schema type for BooleanConverter: " + schema.type().toString());
+            throw new DataException("Invalid schema type for BooleanConverter: " + schema.type());
 
         try {
             return serializer.serialize(topic, (Boolean) value);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/converters/ByteArrayConverter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/converters/ByteArrayConverter.java
@@ -58,7 +58,7 @@ public class ByteArrayConverter implements Converter, HeaderConverter, Versioned
     @Override
     public byte[] fromConnectData(String topic, Schema schema, Object value) {
         if (schema != null && schema.type() != Schema.Type.BYTES)
-            throw new DataException("Invalid schema type for ByteArrayConverter: " + schema.type().toString());
+            throw new DataException("Invalid schema type for ByteArrayConverter: " + schema.type());
 
         if (value != null && !(value instanceof byte[]) && !(value instanceof ByteBuffer))
             throw new DataException("ByteArrayConverter is not compatible with objects of type " + value.getClass());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/LoggingContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/LoggingContext.java
@@ -185,7 +185,7 @@ public final class LoggingContext implements AutoCloseable {
         // Append non-task scopes (e.g., worker and offset)
         if (scope != Scope.TASK) {
             sb.append("|");
-            sb.append(scope.toString());
+            sb.append(scope);
         }
         sb.append("] ");
         return sb.toString();

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -283,7 +283,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
                 default -> throw new DataException(targetType + " is not supported in the Cast transformation.");
             };
         } catch (NumberFormatException e) {
-            throw new DataException("Value (" + value.toString() + ") was out of range for requested data type", e);
+            throw new DataException("Value (" + value + ") was out of range for requested data type", e);
         }
     }
 

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -379,7 +379,7 @@ public interface FieldType {
 
         @Override
         public String toString() {
-            return "[]" + elementType.toString();
+            return "[]" + elementType;
         }
     }
 

--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -262,7 +262,7 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
         } else if (target.field().type().isStruct()) {
             buffer.printf("%s;%n", target.assignmentStatement(
                 String.format("%s%s.read(%s, _version)",
-                target.field().type().toString(), SUFFIX, target.sourceVariable())));
+                target.field().type(), SUFFIX, target.sourceVariable())));
         } else {
             throw new RuntimeException("Unexpected type " + target.field().type());
         }
@@ -439,7 +439,7 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
         } else if (target.field().type().isStruct()) {
             buffer.printf("%s;%n", target.assignmentStatement(
                 String.format("%sJsonConverter.write(%s, _version, _serializeRecords)",
-                    target.field().type().toString(), target.sourceVariable())));
+                    target.field().type(), target.sourceVariable())));
         } else {
             throw new RuntimeException("unknown type " + target.field().type());
         }

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -250,7 +250,7 @@ public final class MessageGenerator {
                     numProcessed++;
                     typeClassGenerators.forEach(generator -> generator.registerMessageType(spec));
                 } catch (Exception e) {
-                    throw new RuntimeException("Exception while processing " + inputPath.toString(), e);
+                    throw new RuntimeException("Exception while processing " + inputPath, e);
                 }
             }
         }

--- a/gradle/error-prone.gradle
+++ b/gradle/error-prone.gradle
@@ -1,0 +1,37 @@
+import static java.lang.System.getenv
+
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+apply plugin: 'net.ltgt.errorprone'
+
+dependencies {
+    errorprone('com.google.errorprone:error_prone_core:2.42.0')
+    errorprone('tech.picnic.error-prone-support:error-prone-contrib:0.25.0')
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true // consider removal to avoid error prone error´s, following convention over configuration.
+        error('RedundantStringConversion')
+        errorproneArgs.add('-XepExcludedPaths:.*/build/generated/.*')
+        if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
+            errorproneArgs.addAll(
+                    '-XepPatchLocation:IN_PLACE',
+                    '-XepPatchChecks:RedundantStringConversion'
+            )
+        }
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3699,8 +3699,8 @@ public class GroupMetadataManager {
             log.info("[GroupId {}][MemberId {}] Member's new assignment state: epoch={}, previousEpoch={}, state={}, "
                     + "assignedTasks={} and tasksPendingRevocation={}.",
                 groupId, updatedMember.memberId(), updatedMember.memberEpoch(), updatedMember.previousMemberEpoch(), updatedMember.state(),
-                updatedMember.assignedTasks().toString(),
-                updatedMember.tasksPendingRevocation().toString());
+                updatedMember.assignedTasks(),
+                updatedMember.tasksPendingRevocation());
 
             // Schedule/cancel the rebalance timeout.
             if (updatedMember.state() == org.apache.kafka.coordinator.group.streams.MemberState.UNREVOKED_TASKS) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -659,10 +659,10 @@ public class ClusterControlManager {
         BrokerRegistration curRegistration = brokerRegistrations.get(brokerId);
         if (curRegistration == null) {
             throw new RuntimeException(String.format("Unable to replay %s: no broker " +
-                "registration found for that id", record.toString()));
+                "registration found for that id", record));
         } else if (curRegistration.epoch() != brokerEpoch) {
             throw new RuntimeException(String.format("Unable to replay %s: no broker " +
-                "registration with that epoch found", record.toString()));
+                "registration with that epoch found", record));
         } else {
             BrokerRegistration nextRegistration = curRegistration.cloneWith(
                 fencingChange,

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -331,7 +331,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         this.image = image;
 
         if (stillNeedToCatchUp(
-            "maybePublishMetadata(" + manifest.type().toString() + ")",
+            "maybePublishMetadata(" + manifest.type() + ")",
             manifest.provenance().lastContainedOffset())
         ) {
             return;

--- a/metadata/src/main/java/org/apache/kafka/metadata/VersionRange.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/VersionRange.java
@@ -72,9 +72,9 @@ public class VersionRange {
         if (min == max) {
             return String.valueOf(min);
         } else if (max == Short.MAX_VALUE) {
-            return String.valueOf(min) + "+";
+            return min + "+";
         } else {
-            return String.valueOf(min) + "-" + String.valueOf(max);
+            return min + "-" + max;
         }
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/MockRaftClientListener.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockRaftClientListener.java
@@ -54,7 +54,7 @@ public class MockRaftClientListener implements RaftClient.Listener<ApiMessageAnd
 
                 for (ApiMessageAndVersion messageAndVersion : batch.records()) {
                     ApiMessage message = messageAndVersion.message();
-                    serializedEvents.add(COMMIT + " " + message.toString());
+                    serializedEvents.add(COMMIT + " " + message);
                 }
                 serializedEvents.add(LAST_COMMITTED_OFFSET + " " + lastCommittedOffset);
             }
@@ -72,7 +72,7 @@ public class MockRaftClientListener implements RaftClient.Listener<ApiMessageAnd
 
                 for (ApiMessageAndVersion messageAndVersion : batch.records()) {
                     ApiMessage message = messageAndVersion.message();
-                    serializedEvents.add(SNAPSHOT + " " + message.toString());
+                    serializedEvents.add(SNAPSHOT + " " + message);
                 }
                 serializedEvents.add(LAST_COMMITTED_OFFSET + " " + lastCommittedOffset);
             }

--- a/raft/src/main/java/org/apache/kafka/raft/DynamicVoters.java
+++ b/raft/src/main/java/org/apache/kafka/raft/DynamicVoters.java
@@ -109,7 +109,7 @@ public final class DynamicVoters {
         for (DynamicVoter voter : voters.values()) {
             builder.append(prefix);
             prefix = ",";
-            builder.append(voter.toString());
+            builder.append(voter);
         }
         return builder.toString();
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientPreVoteTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientPreVoteTest.java
@@ -478,7 +478,7 @@ public class KafkaRaftClientPreVoteTest {
         // invalid voter id is rejected
         context.deliverRequest(
             context.voteRequest(
-                context.clusterId.toString(),
+                context.clusterId,
                 epoch,
                 otherNodeKey,
                 ReplicaKey.of(10, Uuid.randomUuid()),
@@ -493,7 +493,7 @@ public class KafkaRaftClientPreVoteTest {
         // invalid voter directory id is rejected
         context.deliverRequest(
             context.voteRequest(
-                context.clusterId.toString(),
+                context.clusterId,
                 epoch,
                 otherNodeKey,
                 ReplicaKey.of(0, Uuid.randomUuid()),

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -838,7 +838,7 @@ public final class KafkaRaftClientSnapshotTest {
         int epoch = context.currentEpoch();
 
         FetchSnapshotRequestData voter1FetchSnapshotRequest = fetchSnapshotRequest(
-                context.clusterId.toString(),
+                context.clusterId,
                 voter1,
                 context.metadataPartition,
                 epoch,
@@ -848,7 +848,7 @@ public final class KafkaRaftClientSnapshotTest {
         );
 
         FetchSnapshotRequestData voter2FetchSnapshotRequest = fetchSnapshotRequest(
-                context.clusterId.toString(),
+                context.clusterId,
                 voter2,
                 context.metadataPartition,
                 epoch,
@@ -858,7 +858,7 @@ public final class KafkaRaftClientSnapshotTest {
         );
 
         FetchSnapshotRequestData observerFetchSnapshotRequest = fetchSnapshotRequest(
-                context.clusterId.toString(),
+                context.clusterId,
                 observer3,
                 context.metadataPartition,
                 epoch,
@@ -1867,7 +1867,7 @@ public final class KafkaRaftClientSnapshotTest {
         // valid cluster id is accepted
         context.deliverRequest(
             fetchSnapshotRequest(
-                context.clusterId.toString(),
+                context.clusterId,
                 otherNode,
                 context.metadataPartition,
                 epoch,

--- a/server/src/main/java/org/apache/kafka/server/purgatory/DeleteRecordsPartitionStatus.java
+++ b/server/src/main/java/org/apache/kafka/server/purgatory/DeleteRecordsPartitionStatus.java
@@ -50,7 +50,7 @@ public class DeleteRecordsPartitionStatus {
     @Override
     public String toString() {
         return String.format("[acksPending: %b, error: %s, lowWatermark: %d, requiredOffset: %d]",
-                acksPending, Errors.forCode(responseStatus.errorCode()).toString(), responseStatus.lowWatermark(),
+                acksPending, Errors.forCode(responseStatus.errorCode()), responseStatus.lowWatermark(),
                 requiredOffset);
     }
 

--- a/server/src/main/java/org/apache/kafka/server/quota/ClientQuotaManager.java
+++ b/server/src/main/java/org/apache/kafka/server/quota/ClientQuotaManager.java
@@ -482,11 +482,11 @@ public class ClientQuotaManager {
     }
 
     private String getThrottleTimeSensorName(Map<String, String> metricTags) {
-        return quotaType.toString() + "ThrottleTime-" + metricTagsToSensorSuffix(metricTags);
+        return quotaType + "ThrottleTime-" + metricTagsToSensorSuffix(metricTags);
     }
 
     private String getQuotaSensorName(Map<String, String> metricTags) {
-        return quotaType.toString() + "-" + metricTagsToSensorSuffix(metricTags);
+        return quotaType + "-" + metricTagsToSensorSuffix(metricTags);
     }
 
     protected MetricConfig getQuotaMetricConfig(Map<String, String> metricTags) {

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/InFlightState.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/InFlightState.java
@@ -273,7 +273,7 @@ public class InFlightState {
     @Override
     public String toString() {
         return "InFlightState(" +
-            "state=" + state.toString() +
+            "state=" + state +
             ", deliveryCount=" + deliveryCount +
             ", memberId=" + memberId +
             ")";

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogMetadataSerde.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogMetadataSerde.java
@@ -114,7 +114,7 @@ public class RemoteLogMetadataSerde {
             output.printf("partition: %d, offset: %d, value: %s%n",
                     consumerRecord.partition(),
                     consumerRecord.offset(),
-                    remoteLogMetadataSerde.deserialize(consumerRecord.value()).toString());
+                    remoteLogMetadataSerde.deserialize(consumerRecord.value()));
         }
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandler.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/CleanShutdownFileHandler.java
@@ -109,6 +109,6 @@ public class CleanShutdownFileHandler {
 
     @Override
     public String toString() {
-        return "CleanShutdownFile=(" + "file=" + cleanShutdownFile.toString() + ')';
+        return "CleanShutdownFile=(" + "file=" + cleanShutdownFile + ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -670,7 +670,7 @@ public class RemoteIndexCache implements Closeable {
         long startOffset = remoteLogSegmentMetadata.startOffset();
         Uuid segmentId = remoteLogSegmentMetadata.remoteLogSegmentId().id();
         // uuid.toString uses URL encoding which is safe for filenames and URLs.
-        return startOffset + "_" + segmentId.toString();
+        return startOffset + "_" + segmentId;
     }
 
     static File remoteOffsetIndexFile(File dir, RemoteLogSegmentMetadata remoteLogSegmentMetadata) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/StrictBufferConfigImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/StrictBufferConfigImpl.java
@@ -119,7 +119,7 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
         return "StrictBufferConfigImpl{maxKeys=" + maxRecords +
             ", maxBytes=" + maxBytes +
             ", bufferFullStrategy=" + bufferFullStrategy +
-            ", logConfig=" + logConfig().toString() +
+            ", logConfig=" + logConfig() +
              '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -161,11 +161,11 @@ public class ClientUtils {
                 result.put(partition, future.get());
             } catch (final ExecutionException e) {
                 final Throwable cause = e.getCause();
-                final String msg = String.format("Error while attempting to read end offsets for partition '%s'", partition.toString());
+                final String msg = String.format("Error while attempting to read end offsets for partition '%s'", partition);
                 throw new StreamsException(msg, cause);
             } catch (final InterruptedException e) {
                 Thread.interrupted();
-                final String msg = String.format("Interrupted while attempting to read end offsets for partition '%s'", partition.toString());
+                final String msg = String.format("Interrupted while attempting to read end offsets for partition '%s'", partition);
                 throw new StreamsException(msg, e);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1347,7 +1347,7 @@ public class InternalTopologyBuilder {
             latestResetPatterns.stream().anyMatch(p -> p.matcher(topic).matches())) {
             return AutoOffsetResetStrategy.LATEST;
         } else if (maybeDecorateInternalSourceTopics(durationResetTopics.keySet()).contains(topic)) {
-            return AutoOffsetResetStrategy.fromString("by_duration:" + durationResetTopics.get(topic).toString());
+            return AutoOffsetResetStrategy.fromString("by_duration:" + durationResetTopics.get(topic));
         } else if ((resetDuration = findDuration(topic)).isPresent()) {
             return AutoOffsetResetStrategy.fromString("by_duration:" + resetDuration.get());
         } else if (containsTopic(topic)) {
@@ -1719,8 +1719,8 @@ public class InternalTopologyBuilder {
         @Override
         public String toString() {
             return "Sub-topology: " + id + " for global store (will not generate tasks)\n"
-                    + "    " + source.toString() + "\n"
-                    + "    " + processor.toString() + "\n";
+                    + "    " + source + "\n"
+                    + "    " + processor + "\n";
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/QuickUnion.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/QuickUnion.java
@@ -39,7 +39,7 @@ public class QuickUnion<T> {
         T parent = ids.get(current);
 
         if (parent == null) {
-            throw new NoSuchElementException("id: " + id.toString());
+            throw new NoSuchElementException("id: " + id);
         }
 
         while (!parent.equals(current)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -465,7 +465,7 @@ public class RecordCollectorImpl implements RecordCollector {
                                  final ProducerRecord<byte[], byte[]> serializedRecord,
                                  final InternalProcessorContext<?, ?> context,
                                  final String processorNodeId) {
-        String errorMessage = String.format(SEND_EXCEPTION_MESSAGE, topic, taskId, productionException.toString());
+        String errorMessage = String.format(SEND_EXCEPTION_MESSAGE, topic, taskId, productionException);
 
         if (isFatalException(productionException)) {
             errorMessage += "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.";

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
@@ -79,7 +79,7 @@ public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
     @Override
     public String toString() {
-        return value.toString() + ", timestamp = " + timestamp;
+        return value + ", timestamp = " + timestamp;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1045,7 +1045,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             log.warn(
                 "Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop." +
                     "\nConsider overwriting consumer config {} to a larger value to avoid timeout errors",
-                timeoutException.toString(),
+                timeoutException,
                 ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
 
             // re-throw to trigger `task.timeout.ms`

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -490,7 +490,7 @@ public class TopologyMetadata {
         }
         final StringBuilder sb = new StringBuilder();
 
-        applyToEachBuilder(b -> sb.append(b.describe().toString()));
+        applyToEachBuilder(b -> sb.append(b.describe()));
 
         return sb.toString();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -216,13 +216,13 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
         if (baseKeySchema instanceof PrefixedWindowKeySchemas.TimeFirstWindowKeySchema) {
             if (timestampFromRawKey < observedStreamTime - retentionPeriod) {
                 LOG.debug("Record with key {} is expired as timestamp from key ({}) < actual stream time ({})",
-                        rawKey.toString(), timestampFromRawKey, observedStreamTime - retentionPeriod);
+                        rawKey, timestampFromRawKey, observedStreamTime - retentionPeriod);
                 return null;
             }
         } else {
             if (timestampFromRawKey < observedStreamTime - retentionPeriod + 1) {
                 LOG.debug("Record with key {} is expired as timestamp from key ({}) < actual stream time ({})",
-                        rawKey.toString(), timestampFromRawKey, observedStreamTime - retentionPeriod + 1);
+                        rawKey, timestampFromRawKey, observedStreamTime - retentionPeriod + 1);
                 return null;
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -95,7 +95,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         final long actualFrom = getActualFrom(from);
 
         if (keySchema instanceof WindowKeySchema && to < actualFrom) {
-            LOG.debug("Returning no records for key {} as to ({}) < actualFrom ({}) ", key.toString(), to, actualFrom);
+            LOG.debug("Returning no records for key {} as to ({}) < actualFrom ({}) ", key, to, actualFrom);
             return KeyValueIterators.emptyIterator();
         }
 
@@ -275,7 +275,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         // check if timestamp is expired
         if (timestampFromKey < observedStreamTime - retentionPeriod + 1) {
             LOG.debug("Record with key {} is expired as timestamp from key ({}) < actual stream time ({})",
-                    key.toString(), timestampFromKey, observedStreamTime - retentionPeriod + 1);
+                    key, timestampFromKey, observedStreamTime - retentionPeriod + 1);
             return null;
         }
         final S segment = segments.segmentForTimestamp(timestampFromKey);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -313,7 +313,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             return mergeColumnFamilyHandleLists(existingColumnFamilies, createdColumnFamilies, allDescriptors);
 
         } catch (final RocksDBException e) {
-            throw new ProcessorStateException("Error opening store " + name + " at location " + dbDir.toString(), e);
+            throw new ProcessorStateException("Error opening store " + name + " at location " + dbDir, e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTrigger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecordingTrigger.java
@@ -34,7 +34,7 @@ public class RocksDBMetricsRecordingTrigger implements Runnable {
         final String metricsRecorderName = metricsRecorderName(metricsRecorder);
         if (metricsRecordersToTrigger.containsKey(metricsRecorderName)) {
             throw new IllegalStateException("RocksDB metrics recorder for store \"" + metricsRecorder.storeName() +
-                "\" of task " + metricsRecorder.taskId().toString() + " has already been added. "
+                "\" of task " + metricsRecorder.taskId() + " has already been added. "
                 + "This is a bug in Kafka Streams.");
         }
         metricsRecordersToTrigger.put(metricsRecorderName, metricsRecorder);
@@ -51,7 +51,7 @@ public class RocksDBMetricsRecordingTrigger implements Runnable {
     }
 
     private String metricsRecorderName(final RocksDBMetricsRecorder metricsRecorder) {
-        return metricsRecorder.taskId().toString() + "-" + metricsRecorder.storeName();
+        return metricsRecorder.taskId() + "-" + metricsRecorder.storeName();
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -246,7 +246,7 @@ public class GetOffsetShell {
                     partitionInfo = listOffsetsResult.partitionResult(partition).get();
                 } catch (ExecutionException e) {
                     if (e.getCause() instanceof KafkaException) {
-                        System.err.println("Skip getting offsets for topic-partition " + partition.toString() + " due to error: " + e.getMessage());
+                        System.err.println("Skip getting offsets for topic-partition " + partition + " due to error: " + e.getMessage());
                     } else {
                         throw e;
                     }

--- a/tools/src/main/java/org/apache/kafka/tools/JmxTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/JmxTool.java
@@ -251,11 +251,11 @@ public class JmxTool {
             for (Attribute attribute : attributes.asList()) {
                 if (attributesInclude.isPresent()) {
                     if (List.of(attributesInclude.get()).contains(attribute.getName())) {
-                        result.put(String.format("%s:%s", objectName.toString(), attribute.getName()),
+                        result.put(String.format("%s:%s", objectName, attribute.getName()),
                                 attribute.getValue());
                     }
                 } else {
-                    result.put(String.format("%s:%s", objectName.toString(), attribute.getName()),
+                    result.put(String.format("%s:%s", objectName, attribute.getName()),
                             attribute.getValue());
                 }
             }

--- a/tools/src/main/java/org/apache/kafka/tools/LogCompactionTester.java
+++ b/tools/src/main/java/org/apache/kafka/tools/LogCompactionTester.java
@@ -370,7 +370,7 @@ public class LogCompactionTester {
 
         ProcessBuilder builder = new ProcessBuilder(
                 "sort", "--key=1,2", "--stable", "--buffer-size=20%",
-                "--temporary-directory=" + tempDir.toString(), file.getAbsolutePath());
+                "--temporary-directory=" + tempDir, file.getAbsolutePath());
         builder.redirectError(ProcessBuilder.Redirect.INHERIT);
         
         Process process;

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -323,7 +323,7 @@ public class MetadataQuorumCommand {
                 sb.append(", \"endpoints\": [");
                 for (RaftVoterEndpoint endpoint : endpoints) {
                     sb.append("\"");
-                    sb.append(endpoint.toString()).append("\", ");
+                    sb.append(endpoint).append("\", ");
                 }
                 sb.setLength(sb.length() - 2);  // remove the last comma and space
                 sb.append("]");

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -648,7 +648,7 @@ public class ProducerPerformance {
                 Optional<String> txIdInProps =
                         Optional.ofNullable(producerProps.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG))
                                 .map(Object::toString);
-                String transactionId = Optional.ofNullable(transactionIdArg).orElse(txIdInProps.orElse(DEFAULT_TRANSACTION_ID_PREFIX + Uuid.randomUuid().toString()));
+                String transactionId = Optional.ofNullable(transactionIdArg).orElse(txIdInProps.orElse(DEFAULT_TRANSACTION_ID_PREFIX + Uuid.randomUuid()));
                 producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionId);
 
                 if (transactionDurationMsArg == null) {

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommand.java
@@ -567,12 +567,12 @@ public class ShareGroupCommand {
                 if (verbose) {
                     String fmt = "\n%" + -groupLen + "s %" + -coordinatorLen + "s %-15s %-12s %-17s %s";
                     System.out.printf(fmt, "GROUP", "COORDINATOR (ID)", "STATE", "GROUP-EPOCH", "ASSIGNMENT-EPOCH", "#MEMBERS");
-                    System.out.printf(fmt, groupId, coordinator, description.groupState().toString(),
+                    System.out.printf(fmt, groupId, coordinator, description.groupState(),
                         description.groupEpoch(), description.targetAssignmentEpoch(), description.members().size());
                 } else {
                     String fmt = "\n%" + -groupLen + "s %" + -coordinatorLen + "s %-15s %s";
                     System.out.printf(fmt, "GROUP", "COORDINATOR (ID)", "STATE", "#MEMBERS");
-                    System.out.printf(fmt, groupId, coordinator, description.groupState().toString(), description.members().size());
+                    System.out.printf(fmt, groupId, coordinator, description.groupState(), description.members().size());
                 }
                 System.out.println();
             });

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -361,12 +361,12 @@ public class StreamsGroupCommand {
             if (!verbose) {
                 String fmt = "%" + -groupLen + "s %" + -coordinatorLen + "s %" + -stateLen + "s %s\n";
                 System.out.printf(fmt, "GROUP", "COORDINATOR (ID)", "STATE", "#MEMBERS");
-                System.out.printf(fmt, description.groupId(), coordinator, description.groupState().toString(), description.members().size());
+                System.out.printf(fmt, description.groupId(), coordinator, description.groupState(), description.members().size());
             } else {
                 final int groupEpochLen = 15, targetAssignmentEpochLen = 25;
                 String fmt = "%" + -groupLen + "s %" + -coordinatorLen + "s %" + -stateLen + "s %" + -groupEpochLen + "s %" + -targetAssignmentEpochLen + "s %s\n";
                 System.out.printf(fmt, "GROUP", "COORDINATOR (ID)", "STATE", "GROUP-EPOCH", "TARGET-ASSIGNMENT-EPOCH", "#MEMBERS");
-                System.out.printf(fmt, description.groupId(), coordinator, description.groupState().toString(), description.groupEpoch(), description.targetAssignmentEpoch(), description.members().size());
+                System.out.printf(fmt, description.groupId(), coordinator, description.groupState(), description.groupEpoch(), description.targetAssignmentEpoch(), description.members().size());
             }
         }
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ExternalCommandWorker.java
@@ -208,7 +208,7 @@ public class ExternalCommandWorker implements TaskWorker {
                     log.trace("{}: read line from stdin: {}", id, line);
                     JsonNode resp = readObject(line);
                     if (resp.has("status")) {
-                        log.info("{}: New status: {}", id, resp.get("status").toString());
+                        log.info("{}: New status: {}", id, resp.get("status"));
                         status.update(resp.get("status"));
                     }
                     if (resp.has("log")) {


### PR DESCRIPTION
Hello friends,

I'm reaching out to propose we enhance our static code analysis implementation by leveraging Spotless to automate Checkstyle formatting. This approach is gaining industry traction, with Keycloak currently evaluating a similar integration as referenced below.

- https://github.com/keycloak/keycloak/issues/43232

By adopting this proven methodology, we can significantly improve code quality and developer experience. The benefits include:

- **Standardized Code Formatting**: Automated, consistent code style across the codebase
- **Reduced Review Overhead**: Less time spent on stylistic debates in PR reviews
- **Faster Development**: Streamlined workflow with automated formatting checks
- **Lower Contribution Barrier**: Clear, enforced standards for new contributors

Having successfully implemented this pattern across multiple projects, I'd be happy to contribute to this initiative for Kafka. We can assess various implementation strategies to find the optimal approach for our specific needs.

For reference, here are several successful implementations demonstrating the tangible benefits:

- https://github.com/diffplug/spotless/pull/2636
- https://github.com/diffplug/spotless/pull/2641
- https://github.com/junit-team/junit-framework/pull/5006
- https://github.com/checkstyle/checkstyle/pull/17892
- https://github.com/checkstyle/checkstyle/pull/17806
- https://github.com/apache/kafka/pull/20219

I'm available to discuss this further and help drive this quality improvement forward.

Best regard
Vincent