### PR TITLE
KAFKA-19772: enhance the documentation for `Node#isFanced`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Node.java
+++ b/clients/src/main/java/org/apache/kafka/common/Node.java
@@ -114,7 +114,10 @@ public class Node {
     }
 
     /**
-     * Whether if this node is fenced
+     * Returns whether this node is fenced.
+     * <p>
+     * This applies to broker nodes only. For controller quorum nodes, this field
+     * is not relevant and is defined to be {@code false}.
      */
     public boolean isFenced() {
         return isFenced;


### PR DESCRIPTION
Clarify the Javadoc for `Node#isFenced` to align with KIP-1073, which
introduced the “fenced” field in `DescribeCluster` for brokers. The
“fenced” flag applies only to broker nodes returned by
`DescribeCluster`. For controller quorum nodes, it doesn’t apply and is
always `false`. This clarifies that not every node has a meaningful
fenced state.

Reviewers: TaiJuWu <tjwu1217@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
