### PR TITLE
KAFKA-19783 Custom Gradle tasks (`unitTest` and `integrationTest`) are not executing tests in Gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -602,7 +602,12 @@ subprojects {
     finalizedBy("copyTestXml")
   }
 
-  task integrationTest(type: Test, dependsOn: compileJava) {
+  tasks.register('integrationTest', Test) {
+    dependsOn(tasks.compileJava)
+
+    testClassesDirs = testing.suites.test.sources.output.classesDirs
+    classpath = testing.suites.test.sources.runtimeClasspath
+
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
 
@@ -634,7 +639,12 @@ subprojects {
     }
   }
 
-  task unitTest(type: Test, dependsOn: compileJava) {
+  tasks.register('unitTest', Test)  {
+    dependsOn(tasks.compileJava)
+
+    testClassesDirs = testing.suites.test.sources.output.classesDirs
+    classpath = testing.suites.test.sources.runtimeClasspath
+
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
 

--- a/build.gradle
+++ b/build.gradle
@@ -605,9 +605,6 @@ subprojects {
   tasks.register('integrationTest', Test) {
     dependsOn(tasks.compileJava)
 
-    testClassesDirs = testing.suites.test.sources.output.classesDirs
-    classpath = testing.suites.test.sources.runtimeClasspath
-
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
 
@@ -642,9 +639,6 @@ subprojects {
   tasks.register('unitTest', Test)  {
     dependsOn(tasks.compileJava)
 
-    testClassesDirs = testing.suites.test.sources.output.classesDirs
-    classpath = testing.suites.test.sources.runtimeClasspath
-
     maxParallelForks = maxTestForks
     ignoreFailures = userIgnoreFailures
 
@@ -671,6 +665,17 @@ subprojects {
         maxRetries = userMaxTestRetries
         maxFailures = userMaxTestRetryFailures
       }
+    }
+  }
+
+  testing {
+    suites {
+        test {
+            targets {
+                integrationTest
+                unitTest
+            }
+        }
     }
   }
 


### PR DESCRIPTION
Solves regression in Gradle 9 build  reported by @omkreddy: https://github.com/apache/kafka/pull/19513#issuecomment-3388441851

FYI @chia7712 and @yeikel 