### PR TITLE
MINOR: Prevent joint compilation error in core under session keepAliveMode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,12 @@ ext {
       options.compilerArgs << "-Xlint:-serial"
       options.compilerArgs << "-Xlint:-try"
       options.compilerArgs << "-Werror"
+      if (userKeepAliveMode == KeepAliveMode.SESSION){
+        // Suppress warning triggered under keepAliveMode=SESSION during joint compilation
+        //   Unexpected javac output: warning: [path] bad path element ".../core/build/classes/java/main": no such file or directory
+        // This becomes an error under -Werror
+        options.compilerArgs << "-Xlint:-path"
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -138,8 +138,7 @@ ext {
       options.compilerArgs << "-Werror"
       if (userKeepAliveMode == KeepAliveMode.SESSION){
         // Suppress warning triggered under keepAliveMode=SESSION during joint compilation
-        //   Unexpected javac output: warning: [path] bad path element ".../core/build/classes/java/main": no such file or directory
-        // This becomes an error under -Werror
+        // Unexpected javac output: warning: [path] bad path element ".../core/build/classes/java/main": no such file or directory
         options.compilerArgs << "-Xlint:-path"
       }
     }


### PR DESCRIPTION
In Scala/Java joint compilation, builds that run with
`keepAliveMode=SESSION` can fail in the `:core:compileScala` task. This
happens when `javac` is given a non-existent Java output directory on
its classpath.

```
Unexpected javac output: warning: [path] bad path element
".../core/build/classes/java/main": no such file or directory
error: warnings found and -Werror specified
```

This issue occurs after a clean build because
`core/build/classes/java/main` does not exist, as Java classes are
written to `classes/scala/main` during joint compilation. With `-Werror`
enabled, the resulting `[path]` warning is treated as an error and stops
the build.

This PR adds a workaround scoped to **SESSION** builds, while continuing
to investigate the underlying classpath assembly logic during joint
compilation.

Related discussion:
https://github.com/apache/kafka/pull/20684#issuecomment-3394713911
Tracked by:
[KAFKA-19786](https://issues.apache.org/jira/browse/KAFKA-19786)

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
