### PR TITLE
MINOR: Improve error handling for StorageTool

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -212,7 +212,14 @@ object StorageTool extends Logging {
 
     // Iterate over each feature specified with --feature
     for (featureArg <- featureArgs) {
-      val Array(featureName, versionStr) = featureArg.split("=")
+      // Improved error handling for feature argument format
+      val parts = featureArg.split("=", 2)
+      if (parts.length != 2) {
+        throw new TerseFailure(s"Invalid feature format: $featureArg. Expected format: 'feature=version' (e.g. 'group.version=1')")
+      }
+
+      val featureName = parts(0).trim
+      val versionStr = parts(1).trim
 
       val featureLevel = try {
         versionStr.toShort

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -838,6 +838,16 @@ Found problem:
   }
 
   @Test
+  def testHandleFeatureDependenciesForInvalidFormat(): Unit = {
+    val stream = new ByteArrayOutputStream()
+
+    val exception = assertThrows(classOf[TerseFailure], () => {
+      runFeatureDependenciesCommand(stream, Seq("metadata.version"))
+    })
+    assertEquals("Invalid feature format: metadata.version. Expected format: 'feature=version' (e.g. 'group.version=1')", exception.getMessage)
+  }
+
+  @Test
   def testBootstrapScramRecords(): Unit = {
     val availableDirs = Seq(TestUtils.tempDir())
     val properties = new Properties()


### PR DESCRIPTION
This PR improves error handling for feature argument parsing in the
`StorageTool`. The main change is stricter validation of the expected
format for feature arguments, ensuring users provide them in the correct
`feature=version` format.

**Before:**
* If user using argument like: `./bin/kafka-storage.sh
feature-dependencies --feature group.version`, the following error will
occur, which is a bit confusing:
<img width="970" height="162" alt="image"
src="https://github.com/user-attachments/assets/aa4341f9-6eb8-488e-b88e-f5244560184b"
/>

**After:**
<img width="812" height="55" alt="image"
src="https://github.com/user-attachments/assets/9aedecdb-e657-4bd3-8b9b-22d6282a1dc1"
/>

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
