### PR TITLE
MINOR: Tidy up comments in MetadataVersion

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -108,8 +108,6 @@ public enum MetadataVersion {
     IBP_4_0_IV3(25, "4.0", "IV3", false),
 
     // Enables ELR by default for new clusters (KIP-966).
-    // Share groups are preview in 4.1 (KIP-932).
-    // Streams groups are early access in 4.1 (KIP-1071).
     IBP_4_1_IV0(26, "4.1", "IV0", false),
 
     // Send FETCH version 18 in the replica fetcher (KIP-1166)
@@ -121,24 +119,10 @@ public enum MetadataVersion {
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 
-    // Insert any additional IBP_4_1_IVx versions above this comment, and bump the feature level of
-    // IBP_4_2_IVx accordingly. When 4.2 development begins, IBP_4_2_IV0 will cease to be
-    // a placeholder.
-
     // Enables share groups by default for new clusters (KIP-932).
-    //
-    // *** THIS IS A PLACEHOLDER UNSTABLE VERSION WHICH IS USED TO DEFINE THE POINT AT WHICH   ***
-    // *** SHARE GROUPS BECOME PRODUCTION-READY IN THE FUTURE. ITS DEFINITION ALLOWS A SHARE   ***
-    // *** GROUPS FEATURE TO BE DEFINED IN 4.1 BUT TURNED OFF BY DEFAULT, ABLE TO BE TURNED ON ***
-    // *** DYNAMICALLY TO TRY OUT THE PREVIEW CAPABILITY.                                      ***
     IBP_4_2_IV0(28, "4.2", "IV0", false),
 
     // Enables "streams" groups by default for new clusters (KIP-1071).
-    //
-    // *** THIS IS A PLACEHOLDER UNSTABLE VERSION WHICH IS USED TO DEFINE THE POINT AT WHICH     ***
-    // *** STREAMS GROUPS BECOME PRODUCTION-READY IN THE FUTURE. ITS DEFINITION ALLOWS A STREAMS ***
-    // *** GROUPS FEATURE TO BE DEFINED IN 4.1 BUT TURNED OFF BY DEFAULT, ABLE TO BE TURNED ON   ***
-    // *** DYNAMICALLY TO TRY OUT THE EARLY ACCESS CAPABILITY.                                   ***
     IBP_4_2_IV1(29, "4.2", "IV1", false);
 
     // NOTES when adding a new version:

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -96,7 +96,8 @@ public enum MetadataVersion {
     // Bootstrap metadata version for version 1 of the GroupVersion feature (KIP-848).
     IBP_4_0_IV0(22, "4.0", "IV0", false),
 
-    // Add ELR related metadata records (KIP-966). Note, ELR is for preview only in 4.0.
+    // Add ELR related metadata records (KIP-966).
+    // Note, ELR was for preview only in 4.0 which required enabling explicitly.
     // PartitionRecord and PartitionChangeRecord are updated.
     // ClearElrRecord is added.
     IBP_4_0_IV1(23, "4.0", "IV1", true),
@@ -115,7 +116,8 @@ public enum MetadataVersion {
 
     //
     // NOTE: MetadataVersions after this point are unstable and may be changed.
-    // If users attempt to use an unstable MetadataVersion, they will get an error.
+    // If users attempt to use an unstable MetadataVersion, they will get an error unless
+    // they have set the configuration unstable.feature.versions.enable=true.
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 

--- a/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
@@ -24,7 +24,7 @@ public enum ShareVersion implements FeatureVersion {
     SV_0(0, MetadataVersion.MINIMUM_VERSION, Map.of()),
 
     // Version 1 enables share groups (KIP-932).
-    // This is a preview in 4.1, and expected to be production-ready in 4.2.
+    // This was a preview in 4.1 which required enabling explicitly.
     SV_1(1, MetadataVersion.IBP_4_2_IV0, Map.of());
 
     public static final String FEATURE_NAME = "share.version";


### PR DESCRIPTION
The PR just tidies up the comments in the MetadataVersion class to do
with using placeholder metadata versions for a future release as a way
to use features to enable share groups and streams groups as previews in
AK 4.1. The metadata versions are simply unstable 4.2 MVs now, which is
entirely usual at this stage of the release.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
