### PR TITLE
MINOR: Update OffsetResetStrategy Javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
@@ -19,7 +19,8 @@ package org.apache.kafka.clients.consumer;
 import java.util.Locale;
 
 /**
- * @deprecated Since 4.0. Use {@link org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy} instead.
+ * @deprecated since 4.0; will be removed in a future release.
+ * Not required by Kafka client users; no replacement is provided.
  */
 @Deprecated
 public enum OffsetResetStrategy {


### PR DESCRIPTION
updates the Javadoc for
`org.apache.kafka.clients.consumer.OffsetResetStrategy` to clearly state
that it is deprecated for removal with no replacement.

Related to
https://github.com/apache/kafka/pull/17858#discussion_r1856384709
