### PR TITLE
KAFKA-18973  gracefully stopping test execution if .git does not exist

### DIFF
--- a/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
@@ -31,14 +31,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MetadataSchemaCheckerToolTest {
     @Test
     public void testVerifyEvolutionGit() throws Exception {
-        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            Path rootKafkaDirectory = Paths.get("").toAbsolutePath();
-            while (!Files.exists(rootKafkaDirectory.resolve(".git"))) {
-                rootKafkaDirectory = rootKafkaDirectory.getParent();
-                if (rootKafkaDirectory == null) {
-                    throw new RuntimeException("Invalid directory, need to be within a Git repository");
-                }
+        // Try to find the Git root directory
+        Path rootKafkaDirectory = Paths.get("").toAbsolutePath();
+        boolean gitFound = false;
+        
+        while (rootKafkaDirectory != null) {
+            if (Files.exists(rootKafkaDirectory.resolve(".git"))) {
+                gitFound = true;
+                break;
             }
+            rootKafkaDirectory = rootKafkaDirectory.getParent();
+        }
+        
+        if (!gitFound) {
+            System.out.println("Skipping testVerifyEvolutionGit - not in a Git repository");
+            return; // Skip test when running from source release without Git
+        }
+        
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             Path schemaPath = rootKafkaDirectory.resolve("metadata/src/main/resources/common/metadata/AbortTransactionRecord.json");
             MetadataSchemaCheckerTool.run(
                 // In the CI environment because the CI fetch command only creates HEAD and refs/remotes/pull/... references.

--- a/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 
 import static org.apache.kafka.message.checker.CheckerTestUtils.messageSpecStringToTempFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class MetadataSchemaCheckerToolTest {
     @Test
@@ -43,10 +44,7 @@ public class MetadataSchemaCheckerToolTest {
             rootKafkaDirectory = rootKafkaDirectory.getParent();
         }
         
-        if (!gitFound) {
-            System.out.println("Skipping testVerifyEvolutionGit - not in a Git repository");
-            return; // Skip test when running from source release without Git
-        }
+        assumeTrue(gitFound, "Skipping test - not in a Git repository");
         
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             Path schemaPath = rootKafkaDirectory.resolve("metadata/src/main/resources/common/metadata/AbortTransactionRecord.json");


### PR DESCRIPTION
The test logic covers three main scenarios:

1. Running from the Kafka Root Directory

    Action: The test immediately finds the .git directory.

    Result: It uses this location to correctly find the schema file and
runs the test successfully.

2. Running from a Subdirectory

    Action: The test searches up the directory tree (e.g., from
generator/ or generator/src/test/java/).

    Result: It finds the .git directory at the Kafka root, uses that
root to build the correct path to the schema file, and runs the test
successfully.

3. Running from a Source Release (No Git)

    Action: The test searches all the way up the entire directory tree
to the filesystem root.

    Result: It never finds the .git directory, and the test skips
gracefully with a message.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
