### PR TITLE
KAFKA-19771 Update SpotBugs version and enable Spotbugs Gradle tasks on Java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: 17
+          java-version: 25
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
-  id "com.github.spotbugs" version '6.2.5' apply false
+  id "com.github.spotbugs" version '6.4.4' apply false
   id 'org.scoverage' version '8.1' apply false
   id 'com.gradleup.shadow' version '8.3.9' apply false
   id 'com.diffplug.spotless' version "8.0.0"
@@ -70,13 +70,6 @@ ext {
       "--add-opens=java.base/java.time=ALL-UNNAMED",
       "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
     )
-
-  if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
-    // Spotbugs is not compatible with Java 25+ so Gradle related tasks are disabled
-    // until version can be upgraded: https://github.com/spotbugs/spotbugs/issues/3564
-    project.gradle.startParameter.excludedTaskNames.add("spotbugsMain")
-    project.gradle.startParameter.excludedTaskNames.add("spotbugsTest")
-  }    
 
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
   maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -123,7 +123,7 @@ versions += [
   scoverage: "2.3.0",
   slf4j: "1.7.36",
   snappy: "1.1.10.7",
-  spotbugs: "4.9.4",
+  spotbugs: "4.9.8",
   mockOAuth2Server: "2.2.1",
   zinc: "1.11.0",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json


### PR DESCRIPTION
Prologue:
- https://github.com/apache/kafka/pull/20561#issuecomment-3380364683
___

Related JIRA ticket: KAFKA-19771

details:

- spotbugs: 4.9.4 -->> 4.9.8
- spotbugs gradle plugin: 6.2.5 -->> 6.4.4
- spotbugs tasks are enabled for Java 25

related links:
-
https://github.com/spotbugs/spotbugs/blob/4.9.8/CHANGELOG.md#498---2025-10-18
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.4.4

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
