### PR TITLE
MINOR: Improve error message for unsupported metadata version downgrades

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -402,13 +402,13 @@ public class FeatureControlManager {
             if (!metadataChanged) {
                 log.warn("Downgrading metadata.version from {} to {}.", currentVersion, newVersion);
             } else if (allowUnsafeDowngrade) {
-                return invalidMetadataVersion(newVersionLevel, "Unsafe metadata downgrade is not supported " +
-                        "in this version.");
+                return unsupportedMetadataDowngrade(currentVersion, newVersion, 
+                        "Unsafe metadata downgrade is not supported in this version.");
             } else {
                 // The phrase "Retry using UNSAFE_DOWNGRADE if you want to force the downgrade to proceed." has been removed
                 // because unsafe metadata downgrades are not yet supported. We can add it back when implemented (KAFKA-13896).
-                return invalidMetadataVersion(newVersionLevel, "Refusing to perform the requested " +
-                        "downgrade because it might delete metadata information.");
+                return unsupportedMetadataDowngrade(currentVersion, newVersion,
+                        "Refusing to perform the requested downgrade because it might delete metadata information.");
             }
         } else {
             log.warn("Upgrading metadata.version from {} to {}.", currentVersion, newVersion);
@@ -424,6 +424,13 @@ public class FeatureControlManager {
 
     private ApiError invalidMetadataVersion(short version, String message) {
         String errorMessage = String.format("Invalid metadata.version %d. %s", version, message);
+        log.warn(errorMessage);
+        return new ApiError(Errors.INVALID_UPDATE_VERSION, errorMessage);
+    }
+
+    private ApiError unsupportedMetadataDowngrade(MetadataVersion currentVersion, MetadataVersion targetVersion, String message) {
+        String errorMessage = String.format("Unsupported metadata.version downgrade from %s to %s. %s", 
+                currentVersion.featureLevel(), targetVersion.featureLevel(), message);
         log.warn(errorMessage);
         return new ApiError(Errors.INVALID_UPDATE_VERSION, errorMessage);
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -339,7 +339,7 @@ public class FeatureControlManagerTest {
     public void testCannotUseSafeDowngradeIfMetadataChanged() {
         FeatureControlManager manager = createTestManager();
         assertEquals(ControllerResult.of(List.of(), new ApiError(Errors.INVALID_UPDATE_VERSION,
-            "Invalid metadata.version 7. Refusing to perform the requested downgrade because " +
+            "Unsupported metadata.version downgrade from 8 to 7. Refusing to perform the requested downgrade because " +
             "it might delete metadata information.")),
             manager.updateFeatures(
                 Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_3_3_IV3.featureLevel()),
@@ -352,7 +352,7 @@ public class FeatureControlManagerTest {
     public void testUnsafeDowngradeIsTemporarilyDisabled() {
         FeatureControlManager manager = createTestManager();
         assertEquals(ControllerResult.of(List.of(), new ApiError(Errors.INVALID_UPDATE_VERSION,
-            "Invalid metadata.version 7. Unsafe metadata downgrade is not supported in this version.")),
+            "Unsupported metadata.version downgrade from 8 to 7. Unsafe metadata downgrade is not supported in this version.")),
                 manager.updateFeatures(
                     Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_3_3_IV3.featureLevel()),
                     Map.of(MetadataVersion.FEATURE_NAME, FeatureUpdate.UpgradeType.UNSAFE_DOWNGRADE),

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -134,7 +134,7 @@ public class FeatureCommandTest {
 
         );
         assertEquals(format("`metadata` flag is deprecated and may be removed in a future release.%nCould not downgrade metadata.version to 7." +
-                " The update failed for all features since the following feature had an error: Invalid metadata.version 7." +
+                " The update failed for all features since the following feature had an error: Unsupported metadata.version downgrade from 8 to 7." +
                 " Refusing to perform the requested downgrade because it might delete metadata information."), commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
@@ -143,7 +143,7 @@ public class FeatureCommandTest {
 
         );
         assertEquals(format("`metadata` flag is deprecated and may be removed in a future release.%nCould not downgrade metadata.version to 7." +
-                " The update failed for all features since the following feature had an error: Invalid metadata.version 7." +
+                " The update failed for all features since the following feature had an error: Unsupported metadata.version downgrade from 8 to 7." +
                 " Unsafe metadata downgrade is not supported in this version."), commandOutput);
     }
 


### PR DESCRIPTION
Use dedicated error method for metadata downgrade failures instead of
invalidMetadataVersion(), which incorrectly suggested the metadata
version number  was invalid. The new error message clearly shows the
version transition,  e.g., "Unsupported metadata.version downgrade from
8 to 7"  instead of  "Invalid metadata.version 7".

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
