### PR TITLE
KAFKA-19795: Mark the minOneMessage as false when delayedRemoteFetch is present in the first partition.

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -3657,8 +3657,8 @@ class ReplicaManagerTest {
       val capturedFetchInfos = remoteStorageFetchInfoArg.getAllValues.asScala
       assertEquals(2, capturedFetchInfos.size, "Should have 2 remote storage fetch info calls")
 
-      val capturedTopicPartitions = capturedFetchInfos.map(_.topicIdPartition.topicPartition).toSet
-      assertTrue(capturedTopicPartitions.contains(tp0), "Should contain " + tp0)
+      val capturedTopicPartitions = capturedFetchInfos.map(_.topicIdPartition.topicPartition)
+      assertEquals(tp0, capturedTopicPartitions.head, "Should contain " + tp0 + " as first item")
       assertTrue(capturedTopicPartitions.contains(tp1), "Should contain " + tp1)
 
       // Verify the fetch info details are correct for both partitions
@@ -3671,6 +3671,7 @@ class ReplicaManagerTest {
           assertTrue(fetchInfo.minOneMessage())
         } else {
           assertEquals(fetchOffsetTp1, fetchInfo.fetchInfo.fetchOffset)
+          assertFalse(fetchInfo.minOneMessage())
         }
       }
 
@@ -3764,8 +3765,8 @@ class ReplicaManagerTest {
       val capturedFetchInfos = remoteStorageFetchInfoArg.getAllValues.asScala
       assertEquals(2, capturedFetchInfos.size, "Should have 2 remote storage fetch info calls")
 
-      val capturedTopicPartitions = capturedFetchInfos.map(_.topicIdPartition.topicPartition).toSet
-      assertTrue(capturedTopicPartitions.contains(tp0), "Should contain " + tp0)
+      val capturedTopicPartitions = capturedFetchInfos.map(_.topicIdPartition.topicPartition)
+      assertEquals(tp0, capturedTopicPartitions.head, "Should contain " + tp0 + " as first item")
       assertTrue(capturedTopicPartitions.contains(tp1), "Should contain " + tp1)
 
       // Verify the fetch info details are correct for both partitions
@@ -3778,6 +3779,7 @@ class ReplicaManagerTest {
           assertTrue(fetchInfo.minOneMessage())
         } else {
           assertEquals(fetchOffsetTp1, fetchInfo.fetchInfo.fetchOffset)
+          assertFalse(fetchInfo.minOneMessage())
         }
       }
 


### PR DESCRIPTION
When the FETCH request read from remote log for multiple partitions,
then all the partitions are marked with minOneMessage as true. This is
not the expected behavior:

Assume that the FETCH request is configured with fetchMaxBytes as 50 MB
and max.partition.fetch.bytes as 1 MB. And, the broker is hosting 5
partitions as leader for the topic. The FETCH request might try to read
the data from remote for all the 5 partitions. If the size of the
message in the topic is 30 MB, then we might be returning back 150 MB of
response instead of 30 MB due to minOneMessage set to true for all the
remote-read requests.

Mark the minOneMessage as false when delayedRemoteFetch is present in
the first partition.

Discussion thread:
https://github.com/apache/kafka/pull/20088#discussion_r2412551590

Reviewers: Luke Chen <showuon@gmail.com>, Satish Duggana
 <satishd@apache.org>
