### PR TITLE
KAFKA-19792: Gradle build fails after Swagger patch version update

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -253,7 +253,7 @@ License Version 2.0:
 - scala-reflect-2.13.17
 - snappy-java-1.1.10.7
 - snakeyaml-2.4
-- swagger-annotations-2.2.25
+- swagger-annotations-2.2.39
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/build.gradle
+++ b/build.gradle
@@ -3726,8 +3726,12 @@ project(':connect:runtime') {
     buildClasspath = classpath + configurations.swagger
     outputFileName = 'connect_rest'
     outputFormat = 'YAML'
-    prettyPrint = 'TRUE'
-    sortOutput = 'TRUE'
+    prettyPrint = true
+    sortOutput = true
+    encoding = 'UTF-8'
+    alwaysResolveAppPath = false
+    skipResolveAppPath = false
+    readAllResources = true
     openApiFile = file("${layout.buildDirectory.get().asFile.path}/resources/docs/openapi.yaml")
     resourcePackages = ['org.apache.kafka.connect.runtime.rest.resources']
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ group=org.apache.kafka
 version=4.2.0-SNAPSHOT
 scalaVersion=2.13.17
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
-swaggerVersion=2.2.25
+swaggerVersion=2.2.39
 task=build
 org.gradle.jvmargs=-Xmx4g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true


### PR DESCRIPTION
Since version **2.2.27**, the Swagger Gradle Plugin introduced lazy
configuration using Gradle's `Property<T>` API (see
https://github.com/swagger-api/swagger-core/commit/583c21b11a9628aa87f030fb2b5b722d6bfedbb8)

With lazy configuration, properties are not evaluated until task
execution. However, access a property must have a value set. Attempting
to query a property without a value throws:
```
Cannot query the value of property 'xyz' because it has no value
available
```

And in `genConnectOpenAPIDocs`, we manually create a `ResolveTask`
instance which is responsible for setting default values for these
properties.

This patch explicitly sets these required properties to match their
default values from the Swagger Gradle Plugin conventions defined in
[SwaggerPlugin.java](https://github.com/swagger-api/swagger-core/blob/v2.2.39/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/SwaggerPlugin.java#L25-L38)
- set alwaysResolveAppPath to false: default is false
- set skipResolveAppPath to false: default is false
- set readAllResources to true: default is true
- set encoding to UTF-8: default is UTF-8

This ensures the manually created `ResolveTask` has all required
property values, preventing the "Cannot query the value of property"
error.

Reviewers: Dejan Stojadinović <dejan2609@users.noreply.github.com>,
 Chia-Ping Tsai <chia7712@gmail.com>
