### PR TITLE
MINOR: Migrate `verificationAllTransactionComplete` from EOS system test to smoke test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -375,97 +375,116 @@ public class SmokeTestDriver extends SmokeTestUtil {
         }
     }
 
-    public static VerificationResult verify(final String kafka,
-                                            final Map<String, Set<Integer>> inputs,
-                                            final int maxRecordsPerKey,
-                                            final boolean eosEnabled) {
-        final Properties props = new Properties();
-        props.put(ConsumerConfig.CLIENT_ID_CONFIG, "verifier");
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NumberDeserializer.class);
-        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+    private static class PollResult {
+        final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events;
+        final int recordsProcessed;
+        final VerificationResult verificationResult;
 
-        // Verify all transactions are finished before proceeding with data verification
-        if (eosEnabled) {
-            final VerificationResult txnResult;
-            txnResult = verifyAllTransactionFinished(kafka);
-
-            if (!txnResult.passed()) {
-                System.err.println("Transaction verification failed: " + txnResult.result());
-                System.out.println("FAILED");
-                return txnResult;
-            }
+        PollResult(final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events,
+                   final int recordsProcessed,
+                   final VerificationResult verificationResult) {
+            this.events = events;
+            this.recordsProcessed = recordsProcessed;
+            this.verificationResult = verificationResult;
         }
+    }
+
+    private static VerificationResult preVerifyTransactions(final String kafka, final boolean eosEnabled) {
+        if (!eosEnabled) {
+            return null;
+        }
+
+        final VerificationResult txnResult = verifyAllTransactionFinished(kafka);
+        if (!txnResult.passed()) {
+            System.err.println("Transaction verification failed: " + txnResult.result());
+            System.out.println("FAILED");
+            return txnResult;
+        }
+        return null;
+    }
+
+    private static PollResult pollAndCollect(
+            final KafkaConsumer<String, Number> consumer,
+            final Map<String, Set<Integer>> inputs,
+            final int maxRecordsPerKey,
+            final boolean eosEnabled) {
         final int recordsGenerated = inputs.size() * maxRecordsPerKey;
         final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events = new HashMap<>();
         VerificationResult verificationResult = new VerificationResult(false, "no results yet");
         final long start = System.currentTimeMillis();
         int recordsProcessed = 0;
 
-        try (final KafkaConsumer<String, Number> consumer = new KafkaConsumer<>(props)) {
-            final List<TopicPartition> partitions = getAllPartitions(consumer, NUMERIC_VALUE_TOPICS);
-            consumer.assign(partitions);
-            consumer.seekToBeginning(partitions);
-            final Map<String, AtomicInteger> processed =
-                Stream.of(NUMERIC_VALUE_TOPICS)
-                      .collect(Collectors.toMap(t -> t, t -> new AtomicInteger(0)));
+        final List<TopicPartition> partitions = getAllPartitions(consumer, NUMERIC_VALUE_TOPICS);
+        consumer.assign(partitions);
+        consumer.seekToBeginning(partitions);
+        final Map<String, AtomicInteger> processed =
+            Stream.of(NUMERIC_VALUE_TOPICS)
+                  .collect(Collectors.toMap(t -> t, t -> new AtomicInteger(0)));
 
-            int retry = 0;
-            while (System.currentTimeMillis() - start < TimeUnit.MINUTES.toMillis(6)) {
-                final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(5));
-                if (records.isEmpty() && recordsProcessed >= recordsGenerated) {
-                    verificationResult = verifyAll(inputs, events, false, eosEnabled);
-                    if (verificationResult.passed()) {
-                        break;
-                    } else if (retry++ > MAX_RECORD_EMPTY_RETRIES) {
-                        System.out.println(Instant.now() + " Didn't get any more results, verification hasn't passed, and out of retries.");
-                        break;
-                    } else {
-                        System.out.println(Instant.now() + " Didn't get any more results, but verification hasn't passed (yet). Retrying..." + retry);
-                    }
+        int retry = 0;
+        while (System.currentTimeMillis() - start < TimeUnit.MINUTES.toMillis(6)) {
+            final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(5));
+            if (records.isEmpty() && recordsProcessed >= recordsGenerated) {
+                verificationResult = verifyAll(inputs, events, false, eosEnabled);
+                if (verificationResult.passed()) {
+                    break;
+                } else if (retry++ > MAX_RECORD_EMPTY_RETRIES) {
+                    System.out.println(Instant.now() + " Didn't get any more results, verification hasn't passed, and out of retries.");
+                    break;
                 } else {
-                    System.out.println(Instant.now() + " Get some more results from " + records.partitions() + ", resetting retry.");
+                    System.out.println(Instant.now() + " Didn't get any more results, but verification hasn't passed (yet). Retrying..." + retry);
+                }
+            } else {
+                System.out.println(Instant.now() + " Get some more results from " + records.partitions() + ", resetting retry.");
 
-                    retry = 0;
-                    for (final ConsumerRecord<String, Number> record : records) {
-                        final String key = record.key();
+                retry = 0;
+                for (final ConsumerRecord<String, Number> record : records) {
+                    final String key = record.key();
 
-                        final String topic = record.topic();
-                        processed.get(topic).incrementAndGet();
+                    final String topic = record.topic();
+                    processed.get(topic).incrementAndGet();
 
-                        if (topic.equals("echo")) {
-                            recordsProcessed++;
-                            if (recordsProcessed % 100 == 0) {
-                                System.out.println("Echo records processed = " + recordsProcessed);
-                            }
+                    if (topic.equals("echo")) {
+                        recordsProcessed++;
+                        if (recordsProcessed % 100 == 0) {
+                            System.out.println("Echo records processed = " + recordsProcessed);
                         }
-
-                        events.computeIfAbsent(topic, t -> new HashMap<>())
-                              .computeIfAbsent(key, k -> new LinkedList<>())
-                              .add(record);
                     }
 
-                    System.out.println(processed);
+                    events.computeIfAbsent(topic, t -> new HashMap<>())
+                          .computeIfAbsent(key, k -> new LinkedList<>())
+                          .add(record);
                 }
+
+                System.out.println(processed);
             }
         }
 
-        final long finished = System.currentTimeMillis() - start;
+        return new PollResult(events, recordsProcessed, verificationResult);
+    }
+
+    private static VerificationResult reportAndFinalize(
+            final Map<String, Set<Integer>> inputs,
+            final int maxRecordsPerKey,
+            final long startTime,
+            final boolean eosEnabled,
+            final PollResult pollResult) {
+        final int recordsGenerated = inputs.size() * maxRecordsPerKey;
+        final long finished = System.currentTimeMillis() - startTime;
         System.out.println("Verification time=" + finished);
         System.out.println("-------------------");
         System.out.println("Result Verification");
         System.out.println("-------------------");
         System.out.println("recordGenerated=" + recordsGenerated);
-        System.out.println("recordProcessed=" + recordsProcessed);
+        System.out.println("recordProcessed=" + pollResult.recordsProcessed);
 
-        if (recordsProcessed > recordsGenerated) {
+        if (pollResult.recordsProcessed > recordsGenerated) {
             System.out.println("PROCESSED-MORE-THAN-GENERATED");
-        } else if (recordsProcessed < recordsGenerated) {
+        } else if (pollResult.recordsProcessed < recordsGenerated) {
             System.out.println("PROCESSED-LESS-THAN-GENERATED");
         }
 
-        final Map<String, Set<Number>> received = parseRecordsForEchoTopic(events);
+        final Map<String, Set<Number>> received = parseRecordsForEchoTopic(pollResult.events);
 
         boolean success = inputs.equals(received);
 
@@ -479,9 +498,10 @@ public class SmokeTestDriver extends SmokeTestUtil {
             System.out.println("missedRecords=" + missedCount);
         }
 
+        VerificationResult verificationResult = pollResult.verificationResult;
         // give it one more try if it's not already passing.
         if (!verificationResult.passed()) {
-            verificationResult = verifyAll(inputs, events, true, eosEnabled);
+            verificationResult = verifyAll(inputs, pollResult.events, true, eosEnabled);
         }
         success &= verificationResult.passed();
 
@@ -489,6 +509,29 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
         System.out.println(success ? "SUCCESS" : "FAILURE");
         return verificationResult;
+    }
+
+    public static VerificationResult verify(final String kafka,
+                                            final Map<String, Set<Integer>> inputs,
+                                            final int maxRecordsPerKey,
+                                            final boolean eosEnabled) {
+        final VerificationResult txnResult = preVerifyTransactions(kafka, eosEnabled);
+        if (txnResult != null) {
+            return txnResult;
+        }
+
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.CLIENT_ID_CONFIG, "verifier");
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NumberDeserializer.class);
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+
+        final long start = System.currentTimeMillis();
+        try (final KafkaConsumer<String, Number> consumer = new KafkaConsumer<>(props)) {
+            final PollResult pollResult = pollAndCollect(consumer, inputs, maxRecordsPerKey, eosEnabled);
+            return reportAndFinalize(inputs, maxRecordsPerKey, start, eosEnabled, pollResult);
+        }
     }
 
     private static Map<String, Set<Number>> parseRecordsForEchoTopic(

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -391,16 +391,15 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
     private static VerificationResult preVerifyTransactions(final String kafka, final boolean eosEnabled) {
         if (!eosEnabled) {
-            return null;
+            return new VerificationResult(true, "EOS is disabled; skipping transaction verification");
         }
 
         final VerificationResult txnResult = verifyAllTransactionFinished(kafka);
         if (!txnResult.passed()) {
             System.err.println("Transaction verification failed: " + txnResult.result());
             System.out.println("FAILED");
-            return txnResult;
         }
-        return null;
+        return txnResult;
     }
 
     private static PollResult pollAndCollect(
@@ -516,7 +515,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
                                             final int maxRecordsPerKey,
                                             final boolean eosEnabled) {
         final VerificationResult txnResult = preVerifyTransactions(kafka, eosEnabled);
-        if (txnResult != null) {
+        if (!txnResult.passed()) {
             return txnResult;
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -407,60 +407,60 @@ public class SmokeTestDriver extends SmokeTestUtil {
             }
         }
 
-        final KafkaConsumer<String, Number> consumer = new KafkaConsumer<>(props);
-        final List<TopicPartition> partitions = getAllPartitions(consumer, NUMERIC_VALUE_TOPICS);
-        consumer.assign(partitions);
-        consumer.seekToBeginning(partitions);
+        try (final KafkaConsumer<String, Number> consumer = new KafkaConsumer<>(props)) {
+            final List<TopicPartition> partitions = getAllPartitions(consumer, NUMERIC_VALUE_TOPICS);
+            consumer.assign(partitions);
+            consumer.seekToBeginning(partitions);
 
-        final int recordsGenerated = inputs.size() * maxRecordsPerKey;
-        int recordsProcessed = 0;
-        final Map<String, AtomicInteger> processed =
-            Stream.of(NUMERIC_VALUE_TOPICS)
-                  .collect(Collectors.toMap(t -> t, t -> new AtomicInteger(0)));
+            final int recordsGenerated = inputs.size() * maxRecordsPerKey;
+            int recordsProcessed = 0;
+            final Map<String, AtomicInteger> processed =
+                Stream.of(NUMERIC_VALUE_TOPICS)
+                      .collect(Collectors.toMap(t -> t, t -> new AtomicInteger(0)));
 
-        final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events = new HashMap<>();
+            final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events = new HashMap<>();
 
-        VerificationResult verificationResult = new VerificationResult(false, "no results yet");
-        int retry = 0;
-        final long start = System.currentTimeMillis();
-        while (System.currentTimeMillis() - start < TimeUnit.MINUTES.toMillis(6)) {
-            final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(5));
-            if (records.isEmpty() && recordsProcessed >= recordsGenerated) {
-                verificationResult = verifyAll(inputs, events, false, eosEnabled);
-                if (verificationResult.passed()) {
-                    break;
-                } else if (retry++ > MAX_RECORD_EMPTY_RETRIES) {
-                    System.out.println(Instant.now() + " Didn't get any more results, verification hasn't passed, and out of retries.");
-                    break;
+            VerificationResult verificationResult = new VerificationResult(false, "no results yet");
+            int retry = 0;
+            final long start = System.currentTimeMillis();
+            while (System.currentTimeMillis() - start < TimeUnit.MINUTES.toMillis(6)) {
+                final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(5));
+                if (records.isEmpty() && recordsProcessed >= recordsGenerated) {
+                    verificationResult = verifyAll(inputs, events, false, eosEnabled);
+                    if (verificationResult.passed()) {
+                        break;
+                    } else if (retry++ > MAX_RECORD_EMPTY_RETRIES) {
+                        System.out.println(Instant.now() + " Didn't get any more results, verification hasn't passed, and out of retries.");
+                        break;
+                    } else {
+                        System.out.println(Instant.now() + " Didn't get any more results, but verification hasn't passed (yet). Retrying..." + retry);
+                    }
                 } else {
-                    System.out.println(Instant.now() + " Didn't get any more results, but verification hasn't passed (yet). Retrying..." + retry);
-                }
-            } else {
-                System.out.println(Instant.now() + " Get some more results from " + records.partitions() + ", resetting retry.");
+                    System.out.println(Instant.now() + " Get some more results from " + records.partitions() + ", resetting retry.");
 
-                retry = 0;
-                for (final ConsumerRecord<String, Number> record : records) {
-                    final String key = record.key();
+                    retry = 0;
+                    for (final ConsumerRecord<String, Number> record : records) {
+                        final String key = record.key();
 
-                    final String topic = record.topic();
-                    processed.get(topic).incrementAndGet();
+                        final String topic = record.topic();
+                        processed.get(topic).incrementAndGet();
 
-                    if (topic.equals("echo")) {
-                        recordsProcessed++;
-                        if (recordsProcessed % 100 == 0) {
-                            System.out.println("Echo records processed = " + recordsProcessed);
+                        if (topic.equals("echo")) {
+                            recordsProcessed++;
+                            if (recordsProcessed % 100 == 0) {
+                                System.out.println("Echo records processed = " + recordsProcessed);
+                            }
                         }
+
+                        events.computeIfAbsent(topic, t -> new HashMap<>())
+                              .computeIfAbsent(key, k -> new LinkedList<>())
+                              .add(record);
                     }
 
-                    events.computeIfAbsent(topic, t -> new HashMap<>())
-                          .computeIfAbsent(key, k -> new LinkedList<>())
-                          .add(record);
+                    System.out.println(processed);
                 }
-
-                System.out.println(processed);
             }
         }
-        consumer.close();
 
         final long finished = System.currentTimeMillis() - start;
         System.out.println("Verification time=" + finished);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -406,23 +406,21 @@ public class SmokeTestDriver extends SmokeTestUtil {
                 return txnResult;
             }
         }
+        final int recordsGenerated = inputs.size() * maxRecordsPerKey;
+        final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events = new HashMap<>();
+        VerificationResult verificationResult = new VerificationResult(false, "no results yet");
+        final long start = System.currentTimeMillis();
+        int recordsProcessed = 0;
 
         try (final KafkaConsumer<String, Number> consumer = new KafkaConsumer<>(props)) {
             final List<TopicPartition> partitions = getAllPartitions(consumer, NUMERIC_VALUE_TOPICS);
             consumer.assign(partitions);
             consumer.seekToBeginning(partitions);
-
-            final int recordsGenerated = inputs.size() * maxRecordsPerKey;
-            int recordsProcessed = 0;
             final Map<String, AtomicInteger> processed =
                 Stream.of(NUMERIC_VALUE_TOPICS)
                       .collect(Collectors.toMap(t -> t, t -> new AtomicInteger(0)));
 
-            final Map<String, Map<String, LinkedList<ConsumerRecord<String, Number>>>> events = new HashMap<>();
-
-            VerificationResult verificationResult = new VerificationResult(false, "no results yet");
             int retry = 0;
-            final long start = System.currentTimeMillis();
             while (System.currentTimeMillis() - start < TimeUnit.MINUTES.toMillis(6)) {
                 final ConsumerRecords<String, Number> records = consumer.poll(Duration.ofSeconds(5));
                 if (records.isEmpty() && recordsProcessed >= recordsGenerated) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -388,17 +388,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
 
         // Verify all transactions are finished before proceeding with data verification
         if (eosEnabled) {
-            final Properties txnProps = new Properties();
-            txnProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "verifier");
-            txnProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
-            txnProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-            txnProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-            txnProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString());
-
             final VerificationResult txnResult;
-            try (final KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(txnProps)) {
-                txnResult = verifyAllTransactionFinished(consumer, kafka);
-            }
+            txnResult = verifyAllTransactionFinished(kafka);
 
             if (!txnResult.passed()) {
                 System.err.println("Transaction verification failed: " + txnResult.result());
@@ -736,54 +727,65 @@ public class SmokeTestDriver extends SmokeTestUtil {
         return partitions;
     }
 
-    private static VerificationResult verifyAllTransactionFinished(final KafkaConsumer<byte[], byte[]> consumer,
-                                                                   final String kafka) {
-        // Get all output topics except "data" (which is the input topic)
-        final String[] outputTopics = Arrays.stream(NUMERIC_VALUE_TOPICS)
-                .filter(topic -> !topic.equals("data"))
-                .toArray(String[]::new);
+    private static Properties createConsumerPropsWithByteDeserializer(final String kafka, final String clientId) {
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        return props;
+    }
 
-        final List<TopicPartition> partitions = getAllPartitions(consumer, outputTopics);
-        consumer.assign(partitions);
-        consumer.seekToEnd(partitions);
-        for (final TopicPartition tp : partitions) {
-            System.out.println(tp + " at position " + consumer.position(tp));
-        }
+    private static VerificationResult verifyAllTransactionFinished(final String kafka) {
+        final Properties txnProps = createConsumerPropsWithByteDeserializer(kafka, "verifier");
+        txnProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString());
+        try (final KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(txnProps)) {
+            // Get all output topics except "data" (which is the input topic)
+            final String[] outputTopics = Arrays.stream(NUMERIC_VALUE_TOPICS)
+                    .filter(topic -> !topic.equals("data"))
+                    .toArray(String[]::new);
 
-        final Properties consumerProps = new Properties();
-        consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "consumer-uncommitted");
-        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
-        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-
-        final long maxWaitTime = System.currentTimeMillis() + MAX_IDLE_TIME_MS;
-        try (final KafkaConsumer<byte[], byte[]> consumerUncommitted = new KafkaConsumer<>(consumerProps)) {
-            while (!partitions.isEmpty() && System.currentTimeMillis() < maxWaitTime) {
-                consumer.seekToEnd(partitions);
-                final Map<TopicPartition, Long> topicEndOffsets = consumerUncommitted.endOffsets(partitions);
-
-                final java.util.Iterator<TopicPartition> iterator = partitions.iterator();
-                while (iterator.hasNext()) {
-                    final TopicPartition topicPartition = iterator.next();
-                    final long position = consumer.position(topicPartition);
-
-                    if (position == topicEndOffsets.get(topicPartition)) {
-                        iterator.remove();
-                        System.out.println("Removing " + topicPartition + " at position " + position);
-                    } else if (consumer.position(topicPartition) > topicEndOffsets.get(topicPartition)) {
-                        return new VerificationResult(false, "Offset for partition " + topicPartition + " is larger than topic endOffset: " + position + " > " + topicEndOffsets.get(topicPartition));
-                    } else {
-                        System.out.println("Retry " + topicPartition + " at position " + position);
-                    }
-                }
-                sleep(1000L);
+            final List<TopicPartition> partitions = getAllPartitions(consumer, outputTopics);
+            consumer.assign(partitions);
+            consumer.seekToEnd(partitions);
+            for (final TopicPartition tp : partitions) {
+                System.out.println(tp + " at position " + consumer.position(tp));
             }
-        }
+            final Properties consumerProps = createConsumerPropsWithByteDeserializer(kafka, "consumer-uncommitted");
 
-        if (!partitions.isEmpty()) {
-            return new VerificationResult(false, "Could not read all verification records. Did not receive any new record within the last " + (MAX_IDLE_TIME_MS / 1000L) + " sec.");
+            final long maxWaitTime = System.currentTimeMillis() + MAX_IDLE_TIME_MS;
+            try (final KafkaConsumer<byte[], byte[]> consumerUncommitted = new KafkaConsumer<>(consumerProps)) {
+                while (!partitions.isEmpty() && System.currentTimeMillis() < maxWaitTime) {
+                    consumer.seekToEnd(partitions);
+                    final Map<TopicPartition, Long> topicEndOffsets = consumerUncommitted.endOffsets(partitions);
+
+                    final java.util.Iterator<TopicPartition> iterator = partitions.iterator();
+                    while (iterator.hasNext()) {
+                        final TopicPartition topicPartition = iterator.next();
+                        final long position = consumer.position(topicPartition);
+
+                        if (position == topicEndOffsets.get(topicPartition)) {
+                            iterator.remove();
+                            System.out.println("Removing " + topicPartition + " at position " + position);
+                        } else if (position > topicEndOffsets.get(topicPartition)) {
+                            return new VerificationResult(false, "Offset for partition " + topicPartition + " is larger than topic endOffset: " + position + " > " + topicEndOffsets.get(topicPartition));
+                        } else {
+                            System.out.println("Retry " + topicPartition + " at position " + position);
+                        }
+                    }
+                    sleep(1000L);
+                }
+            }
+
+            if (!partitions.isEmpty()) {
+                return new VerificationResult(false, "Could not read all verification records. Did not receive any new record within the last " + (MAX_IDLE_TIME_MS / 1000L) + " sec.");
+            }
+            return new VerificationResult(true, "All transactions finished successfully");
+        } catch (final Exception e) {
+            e.printStackTrace(System.err);
+            System.out.println("FAILED");
+            return new VerificationResult(false, "Transaction verification failed: " + e.getMessage());
         }
-        return new VerificationResult(true, "All transactions finished successfully");
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -395,12 +395,15 @@ public class SmokeTestDriver extends SmokeTestUtil {
             txnProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
             txnProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString());
 
+            final VerificationResult txnResult;
             try (final KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(txnProps)) {
-                verifyAllTransactionFinished(consumer, kafka);
-            } catch (final Exception e) {
-                e.printStackTrace(System.err);
+                txnResult = verifyAllTransactionFinished(consumer, kafka);
+            }
+
+            if (!txnResult.passed()) {
+                System.err.println("Transaction verification failed: " + txnResult.result());
                 System.out.println("FAILED");
-                return new VerificationResult(false, "Transaction verification failed: " + e.getMessage());
+                return txnResult;
             }
         }
 
@@ -510,24 +513,6 @@ public class SmokeTestDriver extends SmokeTestUtil {
                     entry.getValue().stream().map(ConsumerRecord::value).collect(Collectors.toSet()))
                 )
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)) : Collections.emptyMap();
-    }
-
-    public static class VerificationResult {
-        private final boolean passed;
-        private final String result;
-
-        VerificationResult(final boolean passed, final String result) {
-            this.passed = passed;
-            this.result = result;
-        }
-
-        public boolean passed() {
-            return passed;
-        }
-
-        public String result() {
-            return result;
-        }
     }
 
     private static VerificationResult verifyAll(final Map<String, Set<Integer>> inputs,
@@ -753,8 +738,8 @@ public class SmokeTestDriver extends SmokeTestUtil {
         return partitions;
     }
 
-    private static void verifyAllTransactionFinished(final KafkaConsumer<byte[], byte[]> consumer,
-                                                     final String kafka) {
+    private static VerificationResult verifyAllTransactionFinished(final KafkaConsumer<byte[], byte[]> consumer,
+                                                                   final String kafka) {
         // Get all output topics except "data" (which is the input topic)
         final String[] outputTopics = Arrays.stream(NUMERIC_VALUE_TOPICS)
                 .filter(topic -> !topic.equals("data"))
@@ -788,7 +773,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
                         iterator.remove();
                         System.out.println("Removing " + topicPartition + " at position " + position);
                     } else if (consumer.position(topicPartition) > topicEndOffsets.get(topicPartition)) {
-                        throw new IllegalStateException("Offset for partition " + topicPartition + " is larger than topic endOffset: " + position + " > " + topicEndOffsets.get(topicPartition));
+                        return new VerificationResult(false, "Offset for partition " + topicPartition + " is larger than topic endOffset: " + position + " > " + topicEndOffsets.get(topicPartition));
                     } else {
                         System.out.println("Retry " + topicPartition + " at position " + position);
                     }
@@ -798,8 +783,9 @@ public class SmokeTestDriver extends SmokeTestUtil {
         }
 
         if (!partitions.isEmpty()) {
-            throw new RuntimeException("Could not read all verification records. Did not receive any new record within the last " + (MAX_IDLE_TIME_MS / 1000L) + " sec.");
+            return new VerificationResult(false, "Could not read all verification records. Did not receive any new record within the last " + (MAX_IDLE_TIME_MS / 1000L) + " sec.");
         }
+        return new VerificationResult(true, "All transactions finished successfully");
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -25,9 +25,11 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -92,6 +94,7 @@ public class SmokeTestDriver extends SmokeTestUtil {
     }
 
     private static final int MAX_RECORD_EMPTY_RETRIES = 30;
+    private static final long MAX_IDLE_TIME_MS = 600000L;
 
     private static class ValueList {
         public final String key;
@@ -382,6 +385,24 @@ public class SmokeTestDriver extends SmokeTestUtil {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NumberDeserializer.class);
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+
+        // Verify all transactions are finished before proceeding with data verification
+        if (eosEnabled) {
+            final Properties txnProps = new Properties();
+            txnProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "verifier");
+            txnProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
+            txnProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+            txnProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+            txnProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString());
+
+            try (final KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(txnProps)) {
+                verifyAllTransactionFinished(consumer, kafka);
+            } catch (final Exception e) {
+                e.printStackTrace(System.err);
+                System.out.println("FAILED");
+                return new VerificationResult(false, "Transaction verification failed: " + e.getMessage());
+            }
+        }
 
         final KafkaConsumer<String, Number> consumer = new KafkaConsumer<>(props);
         final List<TopicPartition> partitions = getAllPartitions(consumer, NUMERIC_VALUE_TOPICS);
@@ -730,6 +751,55 @@ public class SmokeTestDriver extends SmokeTestUtil {
             }
         }
         return partitions;
+    }
+
+    private static void verifyAllTransactionFinished(final KafkaConsumer<byte[], byte[]> consumer,
+                                                     final String kafka) {
+        // Get all output topics except "data" (which is the input topic)
+        final String[] outputTopics = Arrays.stream(NUMERIC_VALUE_TOPICS)
+                .filter(topic -> !topic.equals("data"))
+                .toArray(String[]::new);
+
+        final List<TopicPartition> partitions = getAllPartitions(consumer, outputTopics);
+        consumer.assign(partitions);
+        consumer.seekToEnd(partitions);
+        for (final TopicPartition tp : partitions) {
+            System.out.println(tp + " at position " + consumer.position(tp));
+        }
+
+        final Properties consumerProps = new Properties();
+        consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "consumer-uncommitted");
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+
+        final long maxWaitTime = System.currentTimeMillis() + MAX_IDLE_TIME_MS;
+        try (final KafkaConsumer<byte[], byte[]> consumerUncommitted = new KafkaConsumer<>(consumerProps)) {
+            while (!partitions.isEmpty() && System.currentTimeMillis() < maxWaitTime) {
+                consumer.seekToEnd(partitions);
+                final Map<TopicPartition, Long> topicEndOffsets = consumerUncommitted.endOffsets(partitions);
+
+                final java.util.Iterator<TopicPartition> iterator = partitions.iterator();
+                while (iterator.hasNext()) {
+                    final TopicPartition topicPartition = iterator.next();
+                    final long position = consumer.position(topicPartition);
+
+                    if (position == topicEndOffsets.get(topicPartition)) {
+                        iterator.remove();
+                        System.out.println("Removing " + topicPartition + " at position " + position);
+                    } else if (consumer.position(topicPartition) > topicEndOffsets.get(topicPartition)) {
+                        throw new IllegalStateException("Offset for partition " + topicPartition + " is larger than topic endOffset: " + position + " > " + topicEndOffsets.get(topicPartition));
+                    } else {
+                        System.out.println("Retry " + topicPartition + " at position " + position);
+                    }
+                }
+                sleep(1000L);
+            }
+        }
+
+        if (!partitions.isEmpty()) {
+            throw new RuntimeException("Could not read all verification records. Did not receive any new record within the last " + (MAX_IDLE_TIME_MS / 1000L) + " sec.");
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestUtil.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestUtil.java
@@ -128,4 +128,22 @@ public class SmokeTestUtil {
         } catch (final Exception ignore) { }
     }
 
+    public static class VerificationResult {
+        private final boolean passed;
+        private final String result;
+
+        public VerificationResult(final boolean passed, final String result) {
+            this.passed = passed;
+            this.result = result;
+        }
+
+        public boolean passed() {
+            return passed;
+        }
+
+        public String result() {
+            return result;
+        }
+    }
+
 }


### PR DESCRIPTION
Migrate `verificationAllTransactionComplete` and add
`VerificationResult` to smoke test utils and make
`verificationAllTransactionComplete` return `VerificationResult` to
avoid extra exception handling

Refactor the verify() method since it has complexity problem:
- **Extracted `preVerifyTransactions`**: Encapsulates the logic for
verifying EOS transactions before processing records.
- **Extracted `pollAndCollect`**: Isolates the consumer polling loop,
partition assignment, and event collection logic.
- **Extracted `reportAndFinalize`**: Handles the calculation of results,
console reporting, and final verification assertions.
- **Introduced `PollResult`**: A private static helper class used to
pass state (events, processed counts, results) between the polling and
reporting phases.

Reviewers: Matthias J. Sax <matthias@confluent.io>
