### PR TITLE
MINOR: Fix typo in KafkaApisTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -7492,7 +7492,7 @@ class KafkaApisTest extends Logging {
           ).iterator))
       ).iterator))
 
-    val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
+    val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val topicNames = util.Map.of(topicId1, "foo1", topicId2, "foo2")
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 
@@ -7554,7 +7554,7 @@ class KafkaApisTest extends Logging {
           ).iterator))
       ).iterator))
 
-    val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
+    val shareAcknowledgeRequest = new ShareAcknowledgeRequest.Builder(shareAcknowledgeRequestData).build(ApiKeys.SHARE_ACKNOWLEDGE.latestVersion)
     val topicIdNames = util.Map.of(topicId1, "foo1") // topicId2 not present in topicIdNames
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
 


### PR DESCRIPTION
While bumping the API version for `ShareFetchRequest`, two failed tests
occurred: <img width="585" height="77" alt="image"
src="https://github.com/user-attachments/assets/b9908884-73fc-483d-952e-846e5de231e4"
/>

This pull request corrects the usage of the API key version when
building a `ShareAcknowledgeRequest` in the Kafka API tests. The change
ensures that the request uses the appropriate API key for share
acknowledgement instead of share fetch.

Reviewers: Andrew Schofield <aschofield@confluent.io>
