### PR TITLE
MINOR: Suppress warning logs for UnsupportedVersionException in ClientTelemetryReporter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -636,12 +636,6 @@ public class ClientTelemetryReporter implements MetricsReporter {
                 (maybeFatalException.getCause() != null && maybeFatalException.getCause() instanceof RetriableException);
         }
 
-        private boolean shouldLog(final KafkaException maybeFatalException) {
-            return maybeFatalException == null ||
-                !(maybeFatalException instanceof UnsupportedVersionException ||
-                    maybeFatalException.getCause() instanceof UnsupportedVersionException);
-        }
-
         private Optional<Builder<?>> createSubscriptionRequest(ClientTelemetrySubscription localSubscription) {
             /*
              If we've previously retrieved a subscription, it will contain the client instance ID
@@ -875,12 +869,10 @@ public class ClientTelemetryReporter implements MetricsReporter {
                  again. We may disconnect from the broker and connect to a broker that supports client
                  telemetry.
                 */
-                boolean shouldWait = isRetryable(maybeFatalException);
-                if (shouldWait) {
+                if (isRetryable(maybeFatalException)) {
                     updateErrorResult(DEFAULT_PUSH_INTERVAL_MS, nowMs);
                 } else {
-                    boolean shouldLog = shouldLog(maybeFatalException);
-                    if (shouldLog) {
+                    if (!(maybeFatalException instanceof UnsupportedVersionException)) {
                         log.warn("Received unrecoverable error from broker, disabling telemetry");
                     }
                     updateErrorResult(Integer.MAX_VALUE, nowMs);

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsRequestData;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsResponseData;
 import org.apache.kafka.common.message.PushTelemetryRequestData;
@@ -529,13 +530,13 @@ public class ClientTelemetryReporter implements MetricsReporter {
         @Override
         public void handleFailedGetTelemetrySubscriptionsRequest(KafkaException maybeFatalException) {
             log.debug("The broker generated an error for the get telemetry network API request", maybeFatalException);
-            handleFailedRequest(isRetryable(maybeFatalException));
+            handleFailedRequest(maybeFatalException);
         }
 
         @Override
         public void handleFailedPushTelemetryRequest(KafkaException maybeFatalException) {
             log.debug("The broker generated an error for the push telemetry network API request", maybeFatalException);
-            handleFailedRequest(isRetryable(maybeFatalException));
+            handleFailedRequest(maybeFatalException);
         }
 
         @Override
@@ -633,6 +634,12 @@ public class ClientTelemetryReporter implements MetricsReporter {
             return maybeFatalException == null ||
                 (maybeFatalException instanceof RetriableException) ||
                 (maybeFatalException.getCause() != null && maybeFatalException.getCause() instanceof RetriableException);
+        }
+
+        private boolean shouldLog(final KafkaException maybeFatalException) {
+            return maybeFatalException == null ||
+                !(maybeFatalException instanceof UnsupportedVersionException ||
+                    maybeFatalException.getCause() instanceof UnsupportedVersionException);
         }
 
         private Optional<Builder<?>> createSubscriptionRequest(ClientTelemetrySubscription localSubscription) {
@@ -850,7 +857,7 @@ public class ClientTelemetryReporter implements MetricsReporter {
             }
         }
 
-        private void handleFailedRequest(boolean shouldWait) {
+        private void handleFailedRequest(KafkaException maybeFatalException) {
             final long nowMs = time.milliseconds();
             lock.writeLock().lock();
             try {
@@ -868,10 +875,14 @@ public class ClientTelemetryReporter implements MetricsReporter {
                  again. We may disconnect from the broker and connect to a broker that supports client
                  telemetry.
                 */
+                boolean shouldWait = isRetryable(maybeFatalException);
                 if (shouldWait) {
                     updateErrorResult(DEFAULT_PUSH_INTERVAL_MS, nowMs);
                 } else {
-                    log.warn("Received unrecoverable error from broker, disabling telemetry");
+                    boolean shouldLog = shouldLog(maybeFatalException);
+                    if (shouldLog) {
+                        log.warn("Received unrecoverable error from broker, disabling telemetry");
+                    }
                     updateErrorResult(Integer.MAX_VALUE, nowMs);
                 }
 


### PR DESCRIPTION
see https://github.com/apache/kafka/pull/20661/files#r2433576874
Suppress warning logs for `UnsupportedVersionException` in
`ClientTelemetryReporter`.

Reviewers: Andrew Schofield <aschofield@confluent.io>
