### PR TITLE
MINOR: scala coverage plugin upgrade: 2.3.0 -->> 2.4.0 (version tested against Scala 2.13.17)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1122,7 +1122,7 @@ project(':core') {
   if (userEnableTestCoverage) {
     scoverage {
       scoverageVersion = versions.scoverage
-      scoverageScalaVersion = '2.13.16' // `org.scoverage:scalac-scoverage-plugin_2.13.16:2.3.0` is the latest as of now
+      scoverageScalaVersion = versions.scala
       reportDir = file("${layout.buildDirectory.get().asFile.path}/scoverage")
       highlighting = false
       minimumRate = 0.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -120,7 +120,7 @@ versions += [
   // has the version field as mandatory in its configuration, see
   // https://github.com/scalameta/scalafmt/releases/tag/v3.1.0.
   scalafmt: "3.10.0",
-  scoverage: "2.3.0",
+  scoverage: "2.4.0",
   slf4j: "1.7.36",
   snappy: "1.1.10.7",
   spotbugs: "4.9.8",


### PR DESCRIPTION
Release notes:
https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v2.4.0

In more detail:   `org.scoverage:scalac-scoverage-plugin_2.13.16:2.3.0`
will be upgraded to
`org.scoverage:scalac-scoverage-plugin_2.13.17:2.4.0`

:information_source:   Note: this PR is marked as `MINOR`, but in
essence it's a trivial one-liner that could wait for a while to be
completed via some other version update PR.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
