### PR TITLE
KAFKA-18836: KIP-1136 annotate constructors in ConsumerGroupMetadata @Deprecated

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -31,6 +31,10 @@ public class ConsumerGroupMetadata {
     private final String memberId;
     private final Optional<String> groupInstanceId;
 
+    /**
+     * @deprecated Since 4.2, please use {@link KafkaConsumer#groupMetadata()} instead. This class will be an interface in Kafka 5.0.
+     */
+    @Deprecated
     public ConsumerGroupMetadata(String groupId,
                                  int generationId,
                                  String memberId,
@@ -41,6 +45,10 @@ public class ConsumerGroupMetadata {
         this.groupInstanceId = Objects.requireNonNull(groupInstanceId, "group.instance.id can't be null");
     }
 
+    /**
+     * @deprecated Since 4.2, please use {@link KafkaConsumer#groupMetadata()} instead. This class will be an interface in Kafka 5.0.
+     */
+    @Deprecated
     public ConsumerGroupMetadata(String groupId) {
         this(groupId,
             JoinGroupRequest.UNKNOWN_GENERATION_ID,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadata.java
@@ -34,7 +34,7 @@ public class ConsumerGroupMetadata {
     /**
      * @deprecated Since 4.2, please use {@link KafkaConsumer#groupMetadata()} instead. This class will be an interface in Kafka 5.0.
      */
-    @Deprecated
+    @Deprecated(since = "4.2", forRemoval = true)
     public ConsumerGroupMetadata(String groupId,
                                  int generationId,
                                  String memberId,
@@ -48,7 +48,7 @@ public class ConsumerGroupMetadata {
     /**
      * @deprecated Since 4.2, please use {@link KafkaConsumer#groupMetadata()} instead. This class will be an interface in Kafka 5.0.
      */
-    @Deprecated
+    @Deprecated(since = "4.2", forRemoval = true)
     public ConsumerGroupMetadata(String groupId) {
         this(groupId,
             JoinGroupRequest.UNKNOWN_GENERATION_ID,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -687,6 +687,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override
     public ConsumerGroupMetadata groupMetadata() {
         return new ConsumerGroupMetadata("dummy.group.id", 1, "1", Optional.empty());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -747,6 +747,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         return Optional.empty();
     }
 
+    @SuppressWarnings("removal")
     private ConsumerGroupMetadata initializeConsumerGroupMetadata(final String groupId,
                                                                   final Optional<String> groupInstanceId) {
         return new ConsumerGroupMetadata(
@@ -757,6 +758,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         );
     }
 
+    @SuppressWarnings("removal")
     private void updateGroupMetadata(final Optional<Integer> memberEpoch, final String memberId) {
         memberEpoch.ifPresent(epoch -> groupMetadata.updateAndGet(
                 oldGroupMetadataOptional -> oldGroupMetadataOptional.map(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -199,6 +199,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     /**
      * Initialize the coordination manager.
      */
+    @SuppressWarnings("removal")
     public ConsumerCoordinator(GroupRebalanceConfig rebalanceConfig,
                                LogContext logContext,
                                ConsumerNetworkClient client,
@@ -371,6 +372,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         return null;
     }
 
+    @SuppressWarnings("removal")
     @Override
     protected void onJoinComplete(int generation,
                                   String memberId,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("removal")
 public class ConsumerGroupMetadataTest {
 
     private final String groupId = "group";

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1520,6 +1520,7 @@ public class KafkaProducerTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSendOffsetsNotAllowedInPreparedTransactionState() throws Exception {
         StringSerializer serializer = new StringSerializer();
@@ -2006,6 +2007,7 @@ public class KafkaProducerTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSendTxnOffsetsWithGroupIdTransactionV2() {
         Properties properties = new Properties();
@@ -2132,6 +2134,7 @@ public class KafkaProducerTest {
         return value;
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testMeasureTransactionDurations() {
         Map<String, Object> configs = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("removal")
 public class MockProducerTest {
 
     private final String topic = "topic";

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -121,6 +121,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("removal")
 public class TransactionManagerTest {
     private static final int MAX_REQUEST_SIZE = 1024 * 1024;
     private static final short ACKS_ALL = -1;

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -408,6 +408,7 @@ class TransactionsTest extends IntegrationTestHarness {
     }
   }
 
+  @SuppressWarnings(Array("removal"))
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testFencingOnSendOffsets(groupProtocol: String): Unit = {
@@ -440,6 +441,7 @@ class TransactionsTest extends IntegrationTestHarness {
     }
   }
 
+  @SuppressWarnings(Array("removal"))
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testOffsetMetadataInSendOffsetsToTransaction(groupProtocol: String): Unit = {
@@ -472,6 +474,7 @@ class TransactionsTest extends IntegrationTestHarness {
     testTimeout(needInitAndSendMsg = false, producer => producer.initTransactions())
   }
 
+  @SuppressWarnings(Array("removal"))
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testSendOffsetsToTransactionTimeout(groupProtocol: String): Unit = {

--- a/examples/src/main/java/kafka/examples/TransactionalClientDemo.java
+++ b/examples/src/main/java/kafka/examples/TransactionalClientDemo.java
@@ -16,7 +16,6 @@
  */
 package kafka.examples;
 
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -65,7 +64,7 @@ public class TransactionalClientDemo {
     private static final String CONSUMER_GROUP_ID = "my-group-id";
     private static final String OUTPUT_TOPIC = "output";
     private static final String INPUT_TOPIC = "input";
-    private static final ConsumerGroupMetadata GROUP_METADATA = new ConsumerGroupMetadata(CONSUMER_GROUP_ID);
+
     private static KafkaConsumer<String, String> consumer;
     private static KafkaProducer<String, String> producer;
     private static volatile boolean isRunning = true;
@@ -113,7 +112,7 @@ public class TransactionalClientDemo {
                         offsetsToCommit.put(partition, new OffsetAndMetadata(offset + 1));
                     }
 
-                    producer.sendOffsetsToTransaction(offsetsToCommit, GROUP_METADATA);
+                    producer.sendOffsetsToTransaction(offsetsToCommit, consumer.groupMetadata());
                     Utils.printOut("Sent offsets to transaction for commit");
 
                     producer.commitTransaction();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -342,6 +342,7 @@ public class StreamsProducerTest {
         assertThat(thrown.getMessage(), is("KABOOM!"));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldFailOnCommitIfEosDisabled() {
         final IllegalStateException thrown = assertThrows(
@@ -395,6 +396,7 @@ public class StreamsProducerTest {
         assertThat(eosMockProducer.uncommittedRecords().get(0), is(record));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldBeginTxOnEosCommit() {
         eosStreamsProducerWithMock.initTransaction();
@@ -406,12 +408,14 @@ public class StreamsProducerTest {
         verify(mockedProducer).commitTransaction();
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldSendOffsetToTxOnEosCommit() {
         eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
         assertThat(eosMockProducer.sentOffsets(), is(true));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldCommitTxOnEosCommit() {
         eosStreamsProducer.send(record, null);
@@ -428,6 +432,7 @@ public class StreamsProducerTest {
         assertThat(eosMockProducer.consumerGroupOffsetsHistory().get(0).get("appId"), is(offsetsAndMetadata));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldCommitTxWithConsumerGroupMetadataOnEosCommit() {
         when(mockedProducer.send(record, null)).thenReturn(null);
@@ -449,6 +454,7 @@ public class StreamsProducerTest {
         verify(mockedProducer).commitTransaction();
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldAbortTxOnEosAbort() {
         // call `send()` to start a transaction
@@ -670,6 +676,7 @@ public class StreamsProducerTest {
         testThrowTaskMigrateExceptionOnEosSendOffset(new InvalidProducerEpochException("KABOOM!"));
     }
 
+    @SuppressWarnings("removal")
     private void testThrowTaskMigrateExceptionOnEosSendOffset(final RuntimeException exception) {
         // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
         eosMockProducer.sendOffsetsToTransactionException = exception;
@@ -689,6 +696,7 @@ public class StreamsProducerTest {
         );
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldThrowStreamsExceptionOnEosSendOffsetError() {
         eosMockProducer.sendOffsetsToTransactionException = new KafkaException("KABOOM!");
@@ -707,6 +715,7 @@ public class StreamsProducerTest {
         );
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldFailOnEosSendOffsetFatal() {
         eosMockProducer.sendOffsetsToTransactionException = new RuntimeException("KABOOM!");
@@ -736,6 +745,7 @@ public class StreamsProducerTest {
         testThrowTaskMigratedExceptionOnEos(new InvalidProducerEpochException("KABOOM!"));
     }
 
+    @SuppressWarnings("removal")
     private void testThrowTaskMigratedExceptionOnEos(final RuntimeException exception) {
         // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
         eosMockProducer.commitTransactionException = exception;
@@ -754,6 +764,7 @@ public class StreamsProducerTest {
         );
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldThrowStreamsExceptionOnEosCommitTxError() {
         eosMockProducer.commitTransactionException = new KafkaException("KABOOM!");
@@ -771,6 +782,7 @@ public class StreamsProducerTest {
         );
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldFailOnEosCommitTxFatal() {
         eosMockProducer.commitTransactionException = new RuntimeException("KABOOM!");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2464,6 +2464,7 @@ public class TaskManagerTest {
         verify(stateManager).markChangelogAsCorrupted(taskId00Partitions);
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldCloseAndReviveUncorruptedTasksWhenTimeoutExceptionThrownFromCommitDuringHandleCorruptedWithEOS() {
         final TaskManager taskManager = setUpTaskManagerWithoutStateUpdater(ProcessingMode.EXACTLY_ONCE_V2, null, false);
@@ -2596,6 +2597,7 @@ public class TaskManagerTest {
         assertThat(unrevokedActiveTaskWithoutCommitNeeded.state(), is(State.RUNNING));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldCloseAndReviveUncorruptedTasksWhenTimeoutExceptionThrownFromCommitDuringRevocationWithEOS() {
         final TaskManager taskManager = setUpTaskManagerWithoutStateUpdater(ProcessingMode.EXACTLY_ONCE_V2, null, false);
@@ -2837,6 +2839,7 @@ public class TaskManagerTest {
         assertThat(task00.state(), is(Task.State.SUSPENDED));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldCommitAllActiveTasksThatNeedCommittingOnHandleRevocationWithEosV2() {
         final StreamsProducer producer = mock(StreamsProducer.class);
@@ -3766,6 +3769,7 @@ public class TaskManagerTest {
         verify(consumer).commitSync(offsets);
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void shouldCommitViaProducerIfEosV2Enabled() {
         final StreamsProducer producer = mock(StreamsProducer.class);

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -605,6 +605,7 @@ public class TopologyTestDriver implements Closeable {
         }
     }
 
+    @SuppressWarnings("removal")
     private void commit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
         if (processingMode == EXACTLY_ONCE_V2) {
             testDriverProducer.commitTransaction(offsets, new ConsumerGroupMetadata("dummy-app-id"));

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -301,6 +301,7 @@ public class TransactionalMessageCopier {
         }
     }
 
+    @SuppressWarnings("removal")
     public static void runEventLoop(Namespace parsedArgs) {
         final String transactionalId = parsedArgs.getString("transactionalId");
         final String outputTopic = parsedArgs.getString("outputTopic");


### PR DESCRIPTION
[KIP-1136](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1136%3A+Make+ConsumerGroupMetadata+an+interface)
Marking ConsumerGroupMetadata class constructors deprecated. since 4.2.0

Reviewers: Andrew Schofield <aschofield@confluent.io>
