### PR TITLE
MINOR: Correct ShareGroupAssignmentBuilder#filterAssignedPartitions to use method parameter

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupAssignmentBuilder.java
@@ -145,7 +145,7 @@ public class ShareGroupAssignmentBuilder {
         Map<Uuid, Set<Integer>> partitions,
         Set<String> subscribedTopicNames
     ) {
-        TopicIds subscribedTopicIds = new TopicIds(member.subscribedTopicNames(), metadataImage);
+        TopicIds subscribedTopicIds = new TopicIds(subscribedTopicNames, metadataImage);
 
         // Reuse the original map if no topics need to be removed.
         Map<Uuid, Set<Integer>> filteredPartitions = partitions;


### PR DESCRIPTION
Fix the usage of the `subscribedTopicNames` parameter in the
`filterAssignedPartitions` method to ensure correct partition filtering
based on the provided method argument.

Reviewers: Ken Huang <s7133700@gmail.com>, Kuan-Po Tseng
 <brandboat@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
