### PR TITLE
KAFKA-19779: Track assignment epochs in streams groups [3/N]

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2194,7 +2194,7 @@ public class GroupMetadataManager {
         }
     }
 
-    private List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIds(final Map<String, Set<Integer>> taskIds) {
+    private static List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIds(final Map<String, Set<Integer>> taskIds) {
         return taskIds.entrySet().stream()
             .map(entry -> new StreamsGroupHeartbeatResponseData.TaskIds()
                 .setSubtopologyId(entry.getKey())
@@ -2202,7 +2202,7 @@ public class GroupMetadataManager {
             .collect(Collectors.toList());
     }
 
-    private List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(
+    private static List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(
         final Map<String, Map<Integer, Integer>> taskIdsWithEpochs
     ) {
         return taskIdsWithEpochs.entrySet().stream()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -155,6 +155,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
+import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
@@ -1473,6 +1474,30 @@ public class GroupMetadataManager {
     }
 
     /**
+     * Checks whether all the tasks contained in the list are included in the provided assignment with epochs.
+     *
+     * @param ownedTasks              The tasks provided by the streams group member in the request.
+     * @param assignedTasksWithEpochs The tasks that the member should have (with epochs).
+     * @return A boolean indicating whether the owned partitions are a subset or not.
+     */
+    private static boolean areOwnedTasksContainedInAssignedTasksWithEpochs(
+        List<StreamsGroupHeartbeatRequestData.TaskIds> ownedTasks,
+        Map<String, Map<Integer, Integer>> assignedTasksWithEpochs
+    ) {
+        if (ownedTasks == null) return false;
+
+        for (StreamsGroupHeartbeatRequestData.TaskIds ownedTasksOfSubtopology : ownedTasks) {
+            Map<Integer, Integer> partitionsWithEpochs = assignedTasksWithEpochs.get(ownedTasksOfSubtopology.subtopologyId());
+            if (partitionsWithEpochs == null) return false;
+            for (Integer partitionId : ownedTasksOfSubtopology.partitions()) {
+                if (!partitionsWithEpochs.containsKey(partitionId)) return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Checks whether the consumer group can accept a new member or not based on the
      * max group size defined.
      *
@@ -1686,7 +1711,7 @@ public class GroupMetadataManager {
             // If the member comes with the previous epoch and has a subset of the current assignment partitions,
             // we accept it because the response with the bumped epoch may have been lost.
             if (receivedMemberEpoch != member.previousMemberEpoch()
-                || !areOwnedTasksContainedInAssignedTasks(ownedActiveTasks, member.assignedTasks().activeTasks())
+                || !areOwnedTasksContainedInAssignedTasksWithEpochs(ownedActiveTasks, member.assignedTasks().activeTasksWithEpochs())
                 || !areOwnedTasksContainedInAssignedTasks(ownedStandbyTasks, member.assignedTasks().standbyTasks())
                 || !areOwnedTasksContainedInAssignedTasks(ownedWarmupTasks, member.assignedTasks().warmupTasks())) {
                 throw new FencedMemberEpochException("The streams group member has a smaller member "
@@ -2060,7 +2085,7 @@ public class GroupMetadataManager {
         // 1. The member is joining.
         // 2. The member's assignment has been updated.
         if (memberEpoch == 0 || hasAssignedTasksChanged(member, updatedMember)) {
-            response.setActiveTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().activeTasks()));
+            response.setActiveTasks(createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(updatedMember.assignedTasks().activeTasksWithEpochs()));
             response.setStandbyTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().standbyTasks()));
             response.setWarmupTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().warmupTasks()));
             if (memberEpoch != 0 || !updatedMember.assignedTasks().isEmpty()) {
@@ -2170,6 +2195,16 @@ public class GroupMetadataManager {
             .map(entry -> new StreamsGroupHeartbeatResponseData.TaskIds()
                 .setSubtopologyId(entry.getKey())
                 .setPartitions(entry.getValue().stream().sorted().toList()))
+            .collect(Collectors.toList());
+    }
+
+    private List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(
+        final Map<String, Map<Integer, Integer>> taskIdsWithEpochs
+    ) {
+        return taskIdsWithEpochs.entrySet().stream()
+            .map(entry -> new StreamsGroupHeartbeatResponseData.TaskIds()
+                .setSubtopologyId(entry.getKey())
+                .setPartitions(entry.getValue().keySet().stream().sorted().toList()))
             .collect(Collectors.toList());
     }
 
@@ -5726,8 +5761,8 @@ public class GroupMetadataManager {
             StreamsGroupMember newMember = new StreamsGroupMember.Builder(oldMember)
                 .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH)
                 .setPreviousMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH)
-                .setAssignedTasks(TasksTuple.EMPTY)
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
             streamsGroup.updateMember(newMember);
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1452,6 +1452,8 @@ public class GroupMetadataManager {
      * it owns any other tasks.
      *
      * @param ownedTasks    The tasks provided by the streams group member in the request.
+     *                      If this is null, it indicates that we do not know which
+     *                      tasks are owned by the member, so we return false.
      * @param assignedTasks The tasks that the member should have.
      *
      * @return A boolean indicating whether the owned partitions are a subset or not.
@@ -1477,6 +1479,8 @@ public class GroupMetadataManager {
      * Checks whether all the tasks contained in the list are included in the provided assignment with epochs.
      *
      * @param ownedTasks              The tasks provided by the streams group member in the request.
+     *                                If this is null, it indicates that we do not know which
+     *                                tasks are owned by the member, so we return false.
      * @param assignedTasksWithEpochs The tasks that the member should have (with epochs).
      * @return A boolean indicating whether the owned partitions are a subset or not.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
@@ -165,8 +165,7 @@ public class CurrentAssignmentBuilder {
                 if (member.memberEpoch() != targetAssignmentEpoch) {
                     return computeNextAssignment(
                         member.memberEpoch(),
-                        member.assignedTasks(),
-                        member.tasksPendingRevocation()
+                        member.assignedTasks()
                     );
                 } else {
                     return member;
@@ -193,8 +192,7 @@ public class CurrentAssignmentBuilder {
                 // its state towards the latest target assignment.
                 return computeNextAssignment(
                     member.memberEpoch() + 1,
-                    member.assignedTasks(),
-                    member.tasksPendingRevocation()
+                    member.assignedTasks()
                 );
 
             case UNRELEASED_TASKS:
@@ -203,8 +201,7 @@ public class CurrentAssignmentBuilder {
                 // of the unreleased tasks when they become available.
                 return computeNextAssignment(
                     member.memberEpoch(),
-                    member.assignedTasks(),
-                    member.tasksPendingRevocation()
+                    member.assignedTasks()
                 );
 
             case UNKNOWN:
@@ -220,8 +217,7 @@ public class CurrentAssignmentBuilder {
 
                 return computeNextAssignment(
                     targetAssignmentEpoch,
-                    member.assignedTasks(),
-                    member.tasksPendingRevocation()
+                    member.assignedTasks()
                 );
         }
 
@@ -321,16 +317,12 @@ public class CurrentAssignmentBuilder {
      * another member, as defined by the `isUnreleasedTask` predicate).
      *
      * Epoch Handling:
-     * - For tasks in resultAssignedTasks, the epoch from currentAssignment is preserved.
-     * - For tasks in resultTasksPendingAssignment, the epoch is determined as follows:
-     *   - If the task is present in memberTasksPendingRevocation, its epoch from that map is used
-     *     (to preserve the revocation epoch for tasks being revoked and re-assigned).
-     *   - Otherwise, the targetAssignmentEpoch is used.
+     * - For tasks in resultAssignedTasks and resultTasksPendingRevocation, the epoch from currentAssignment is preserved.
+     * - For tasks in resultTasksPendingAssignment, the targetAssignmentEpoch is used.
      */
     private boolean computeAssignmentDifferenceWithEpoch(Map<String, Map<Integer, Integer>> currentAssignment,
                                                          Map<String, Set<Integer>> targetAssignment,
                                                          int targetAssignmentEpoch,
-                                                         Map<String, Map<Integer, Integer>> memberTasksPendingRevocation,
                                                          Map<String, Map<Integer, Integer>> resultAssignedTasks,
                                                          Map<String, Map<Integer, Integer>> resultTasksPendingRevocation,
                                                          Map<String, Map<Integer, Integer>> resultTasksPendingAssignment,
@@ -346,7 +338,6 @@ public class CurrentAssignmentBuilder {
                 currentAssignment.getOrDefault(subtopologyId, Map.of()),
                 targetAssignment.getOrDefault(subtopologyId, Set.of()),
                 targetAssignmentEpoch,
-                memberTasksPendingRevocation.getOrDefault(subtopologyId, Map.of()),
                 resultAssignedTasks,
                 resultTasksPendingRevocation,
                 resultTasksPendingAssignment,
@@ -360,7 +351,6 @@ public class CurrentAssignmentBuilder {
                                                                                  final Map<Integer, Integer> currentTasksForThisSubtopology,
                                                                                  final Set<Integer> targetTasksForThisSubtopology,
                                                                                  final int targetAssignmentEpoch,
-                                                                                 final Map<Integer, Integer> currentTasksPendingRevocationForThisSubtopology,
                                                                                  final Map<String, Map<Integer, Integer>> resultAssignedTasks,
                                                                                  final Map<String, Map<Integer, Integer>> resultTasksPendingRevocation,
                                                                                  final Map<String, Map<Integer, Integer>> resultTasksPendingAssignment,
@@ -387,9 +377,7 @@ public class CurrentAssignmentBuilder {
         Map<Integer, Integer> resultTasksPendingAssignmentForThisSubtopology = new HashMap<>();
         for (Integer taskId : targetTasksForThisSubtopology) {
             if (!resultAssignedTasksForThisSubtopology.containsKey(taskId)) {
-                // Use the epoch from pending revocation if the task is there, otherwise use targetAssignmentEpoch
-                Integer epoch = currentTasksPendingRevocationForThisSubtopology.getOrDefault(taskId, targetAssignmentEpoch);
-                resultTasksPendingAssignmentForThisSubtopology.put(taskId, epoch);
+                resultTasksPendingAssignmentForThisSubtopology.put(taskId, targetAssignmentEpoch);
             }
         }
         boolean hasUnreleasedTasks = resultTasksPendingAssignmentForThisSubtopology.keySet().removeIf(taskId ->
@@ -414,15 +402,13 @@ public class CurrentAssignmentBuilder {
     /**
      * Computes the next assignment.
      *
-     * @param memberEpoch                  The epoch of the member to use. This may be different from
-     *                                     the epoch in {@link CurrentAssignmentBuilder#member}.
-     * @param memberAssignedTasks          The assigned tasks of the member to use.
-     * @param memberTasksPendingRevocation The tasks pending revocation of the member.
+     * @param memberEpoch         The epoch of the member to use. This may be different from
+     *                            the epoch in {@link CurrentAssignmentBuilder#member}.
+     * @param memberAssignedTasks The assigned tasks of the member to use.
      * @return A new StreamsGroupMember.
      */
     private StreamsGroupMember computeNextAssignment(int memberEpoch,
-                                                     TasksTupleWithEpochs memberAssignedTasks,
-                                                     TasksTupleWithEpochs memberTasksPendingRevocation) {
+                                                     TasksTupleWithEpochs memberAssignedTasks) {
         Map<String, Map<Integer, Integer>> newActiveAssignedTasks = new HashMap<>();
         Map<String, Map<Integer, Integer>> newActiveTasksPendingRevocation = new HashMap<>();
         Map<String, Map<Integer, Integer>> newActiveTasksPendingAssignment = new HashMap<>();
@@ -437,7 +423,6 @@ public class CurrentAssignmentBuilder {
             memberAssignedTasks.activeTasksWithEpochs(),
             targetAssignment.activeTasks(),
             targetAssignmentEpoch,
-            memberTasksPendingRevocation.activeTasksWithEpochs(),
             newActiveAssignedTasks,
             newActiveTasksPendingRevocation,
             newActiveTasksPendingAssignment,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
@@ -309,6 +309,109 @@ public class CurrentAssignmentBuilder {
     }
 
     /**
+     * Takes the current currentAssignment and the targetAssignment, and generates three
+     * collections:
+     *
+     * - the resultAssignedTasks: the tasks that are assigned in both the current and target
+     * assignments.
+     * - the resultTasksPendingRevocation: the tasks that are assigned in the current
+     * assignment but not in the target assignment.
+     * - the resultTasksPendingAssignment: the tasks that are assigned in the target assignment but
+     * not in the current assignment, and can be assigned currently (i.e., they are not owned by
+     * another member, as defined by the `isUnreleasedTask` predicate).
+     *
+     * Epoch Handling:
+     * - For tasks in resultAssignedTasks, the epoch from currentAssignment is preserved.
+     * - For tasks in resultTasksPendingAssignment, the epoch is determined as follows:
+     *   - If the task is present in memberTasksPendingRevocation, its epoch from that map is used
+     *     (to preserve the revocation epoch for tasks being revoked and re-assigned).
+     *   - Otherwise, the targetAssignmentEpoch is used.
+     */
+    private boolean computeAssignmentDifferenceWithEpoch(Map<String, Map<Integer, Integer>> currentAssignment,
+                                                         Map<String, Set<Integer>> targetAssignment,
+                                                         int targetAssignmentEpoch,
+                                                         Map<String, Map<Integer, Integer>> memberTasksPendingRevocation,
+                                                         Map<String, Map<Integer, Integer>> resultAssignedTasks,
+                                                         Map<String, Map<Integer, Integer>> resultTasksPendingRevocation,
+                                                         Map<String, Map<Integer, Integer>> resultTasksPendingAssignment,
+                                                         BiPredicate<String, Integer> isUnreleasedTask) {
+        boolean hasUnreleasedTasks = false;
+
+        Set<String> allSubtopologyIds = new HashSet<>(targetAssignment.keySet());
+        allSubtopologyIds.addAll(currentAssignment.keySet());
+
+        for (String subtopologyId : allSubtopologyIds) {
+            hasUnreleasedTasks |= computeAssignmentDifferenceForOneSubtopologyWithEpoch(
+                subtopologyId,
+                currentAssignment.getOrDefault(subtopologyId, Map.of()),
+                targetAssignment.getOrDefault(subtopologyId, Set.of()),
+                targetAssignmentEpoch,
+                memberTasksPendingRevocation.getOrDefault(subtopologyId, Map.of()),
+                resultAssignedTasks,
+                resultTasksPendingRevocation,
+                resultTasksPendingAssignment,
+                isUnreleasedTask
+            );
+        }
+        return hasUnreleasedTasks;
+    }
+
+    private static boolean computeAssignmentDifferenceForOneSubtopologyWithEpoch(final String subtopologyId,
+                                                                                 final Map<Integer, Integer> currentTasksForThisSubtopology,
+                                                                                 final Set<Integer> targetTasksForThisSubtopology,
+                                                                                 final int targetAssignmentEpoch,
+                                                                                 final Map<Integer, Integer> currentTasksPendingRevocationForThisSubtopology,
+                                                                                 final Map<String, Map<Integer, Integer>> resultAssignedTasks,
+                                                                                 final Map<String, Map<Integer, Integer>> resultTasksPendingRevocation,
+                                                                                 final Map<String, Map<Integer, Integer>> resultTasksPendingAssignment,
+                                                                                 final BiPredicate<String, Integer> isUnreleasedTask) {
+        // Result Assigned Tasks = Current Tasks ∩ Target Tasks
+        // i.e. we remove all tasks from the current assignment that are not in the target
+        //         assignment
+        Map<Integer, Integer> resultAssignedTasksForThisSubtopology = new HashMap<>();
+        for (Map.Entry<Integer, Integer> entry : currentTasksForThisSubtopology.entrySet()) {
+            if (targetTasksForThisSubtopology.contains(entry.getKey())) {
+                resultAssignedTasksForThisSubtopology.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // Result Tasks Pending Revocation = Current Tasks - Result Assigned Tasks
+        // i.e. we will ask the member to revoke all tasks in its current assignment that
+        //      are not in the target assignment
+        Map<Integer, Integer> resultTasksPendingRevocationForThisSubtopology = new HashMap<>(currentTasksForThisSubtopology);
+        resultTasksPendingRevocationForThisSubtopology.keySet().removeAll(resultAssignedTasksForThisSubtopology.keySet());
+
+        // Result Tasks Pending Assignment = Target Tasks - Result Assigned Tasks - Unreleased Tasks
+        // i.e. we will ask the member to assign all tasks in its target assignment,
+        //      except those that are already assigned, and those that are unreleased
+        Map<Integer, Integer> resultTasksPendingAssignmentForThisSubtopology = new HashMap<>();
+        for (Integer taskId : targetTasksForThisSubtopology) {
+            if (!resultAssignedTasksForThisSubtopology.containsKey(taskId)) {
+                // Use the epoch from pending revocation if the task is there, otherwise use targetAssignmentEpoch
+                Integer epoch = currentTasksPendingRevocationForThisSubtopology.getOrDefault(taskId, targetAssignmentEpoch);
+                resultTasksPendingAssignmentForThisSubtopology.put(taskId, epoch);
+            }
+        }
+        boolean hasUnreleasedTasks = resultTasksPendingAssignmentForThisSubtopology.keySet().removeIf(taskId ->
+            isUnreleasedTask.test(subtopologyId, taskId)
+        );
+
+        if (!resultAssignedTasksForThisSubtopology.isEmpty()) {
+            resultAssignedTasks.put(subtopologyId, resultAssignedTasksForThisSubtopology);
+        }
+
+        if (!resultTasksPendingRevocationForThisSubtopology.isEmpty()) {
+            resultTasksPendingRevocation.put(subtopologyId, resultTasksPendingRevocationForThisSubtopology);
+        }
+
+        if (!resultTasksPendingAssignmentForThisSubtopology.isEmpty()) {
+            resultTasksPendingAssignment.put(subtopologyId, resultTasksPendingAssignmentForThisSubtopology);
+        }
+
+        return hasUnreleasedTasks;
+    }
+
+    /**
      * Computes the next assignment.
      *
      * @param memberEpoch                  The epoch of the member to use. This may be different from
@@ -320,9 +423,9 @@ public class CurrentAssignmentBuilder {
     private StreamsGroupMember computeNextAssignment(int memberEpoch,
                                                      TasksTupleWithEpochs memberAssignedTasks,
                                                      TasksTupleWithEpochs memberTasksPendingRevocation) {
-        Map<String, Set<Integer>> newActiveAssignedTasks = new HashMap<>();
-        Map<String, Set<Integer>> newActiveTasksPendingRevocation = new HashMap<>();
-        Map<String, Set<Integer>> newActiveTasksPendingAssignment = new HashMap<>();
+        Map<String, Map<Integer, Integer>> newActiveAssignedTasks = new HashMap<>();
+        Map<String, Map<Integer, Integer>> newActiveTasksPendingRevocation = new HashMap<>();
+        Map<String, Map<Integer, Integer>> newActiveTasksPendingAssignment = new HashMap<>();
         Map<String, Set<Integer>> newStandbyAssignedTasks = new HashMap<>();
         Map<String, Set<Integer>> newStandbyTasksPendingRevocation = new HashMap<>();
         Map<String, Set<Integer>> newStandbyTasksPendingAssignment = new HashMap<>();
@@ -330,9 +433,11 @@ public class CurrentAssignmentBuilder {
         Map<String, Set<Integer>> newWarmupTasksPendingRevocation = new HashMap<>();
         Map<String, Set<Integer>> newWarmupTasksPendingAssignment = new HashMap<>();
 
-        boolean hasUnreleasedActiveTasks = computeAssignmentDifference(
-            memberAssignedTasks.activeTasks(),
+        boolean hasUnreleasedActiveTasks = computeAssignmentDifferenceWithEpoch(
+            memberAssignedTasks.activeTasksWithEpochs(),
             targetAssignment.activeTasks(),
+            targetAssignmentEpoch,
+            memberTasksPendingRevocation.activeTasksWithEpochs(),
             newActiveAssignedTasks,
             newActiveTasksPendingRevocation,
             newActiveTasksPendingAssignment,
@@ -374,97 +479,25 @@ public class CurrentAssignmentBuilder {
                         .contains(member.processId())
         );
 
-        // Add epochs to the computed task tuples
-        // Preserve previous epochs for tasks that were already assigned or pending revocation,
-        // and use the target assignment epoch for newly assigned tasks.
-        TasksTupleWithEpochs newTasksPendingRevocationWithEpochs = new TasksTupleWithEpochs(
-            addEpochsToTasks(
-                newActiveTasksPendingRevocation,
-                memberAssignedTasks,
-                memberTasksPendingRevocation,
-                targetAssignmentEpoch
-            ),
-            newStandbyTasksPendingRevocation,
-            newWarmupTasksPendingRevocation
-        );
-        TasksTupleWithEpochs newAssignedTasksWithEpochs = new TasksTupleWithEpochs(
-            addEpochsToTasks(
-                newActiveAssignedTasks,
-                memberAssignedTasks,
-                memberTasksPendingRevocation,
-                targetAssignmentEpoch
-            ),
-            newStandbyAssignedTasks,
-            newWarmupAssignedTasks
-        );
-        TasksTupleWithEpochs newTasksPendingAssignmentWithEpochs = new TasksTupleWithEpochs(
-            addEpochsToTasks(
-                newActiveTasksPendingAssignment,
-                memberAssignedTasks,
-                memberTasksPendingRevocation,
-                targetAssignmentEpoch
-            ),
-            newStandbyTasksPendingAssignment,
-            newWarmupTasksPendingAssignment
-        );
-
         return buildNewMember(
             memberEpoch,
-            newTasksPendingRevocationWithEpochs,
-            newAssignedTasksWithEpochs,
-            newTasksPendingAssignmentWithEpochs,
+            new TasksTupleWithEpochs(
+                newActiveTasksPendingRevocation,
+                newStandbyTasksPendingRevocation,
+                newWarmupTasksPendingRevocation
+            ),
+            new TasksTupleWithEpochs(
+                newActiveAssignedTasks,
+                newStandbyAssignedTasks,
+                newWarmupAssignedTasks
+            ),
+            new TasksTupleWithEpochs(
+                newActiveTasksPendingAssignment,
+                newStandbyTasksPendingAssignment,
+                newWarmupTasksPendingAssignment
+            ),
             hasUnreleasedActiveTasks || hasUnreleasedStandbyTasks || hasUnreleasedWarmupTasks
         );
-    }
-
-    /**
-     * Helper method to add epochs to active tasks. This method looks up epochs from existing assignments
-     * (memberAssignedTasks or memberTasksPendingRevocation) or uses the provided default epoch
-     * for newly assigned tasks.
-     *
-     * @param activeTasks                  The active tasks without epochs.
-     * @param memberAssignedTasks          The member's currently assigned tasks with epochs.
-     * @param memberTasksPendingRevocation The member's tasks pending revocation with epochs.
-     * @param defaultEpoch                 The default epoch to use for tasks not found in existing assignments.
-     * @return Active tasks with epochs attached.
-     */
-    private Map<String, Map<Integer, Integer>> addEpochsToTasks(
-        Map<String, Set<Integer>> activeTasks,
-        TasksTupleWithEpochs memberAssignedTasks,
-        TasksTupleWithEpochs memberTasksPendingRevocation,
-        int defaultEpoch
-    ) {
-        Map<String, Map<Integer, Integer>> activeTasksWithEpochs = new HashMap<>();
-
-        // For each active task, try to find its epoch from existing assignments
-        activeTasks.forEach((subtopologyId, partitions) -> {
-            Map<Integer, Integer> partitionsWithEpochs = new HashMap<>();
-            for (Integer partition : partitions) {
-                // First check in assigned tasks
-                Integer epoch = memberAssignedTasks.activeTasksWithEpochs()
-                    .getOrDefault(subtopologyId, Map.of())
-                    .get(partition);
-
-                // If not found, check in tasks pending revocation
-                if (epoch == null) {
-                    epoch = memberTasksPendingRevocation.activeTasksWithEpochs()
-                        .getOrDefault(subtopologyId, Map.of())
-                        .get(partition);
-                }
-
-                // If still not found, use the default epoch
-                if (epoch == null) {
-                    epoch = defaultEpoch;
-                }
-
-                partitionsWithEpochs.put(partition, epoch);
-            }
-            if (!partitionsWithEpochs.isEmpty()) {
-                activeTasksWithEpochs.put(subtopologyId, partitionsWithEpochs);
-            }
-        });
-
-        return activeTasksWithEpochs;
     }
 
     private StreamsGroupMember buildNewMember(final int memberEpoch,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilder.java
@@ -165,7 +165,8 @@ public class CurrentAssignmentBuilder {
                 if (member.memberEpoch() != targetAssignmentEpoch) {
                     return computeNextAssignment(
                         member.memberEpoch(),
-                        member.assignedTasks()
+                        member.assignedTasks(),
+                        member.tasksPendingRevocation()
                     );
                 } else {
                     return member;
@@ -192,7 +193,8 @@ public class CurrentAssignmentBuilder {
                 // its state towards the latest target assignment.
                 return computeNextAssignment(
                     member.memberEpoch() + 1,
-                    member.assignedTasks()
+                    member.assignedTasks(),
+                    member.tasksPendingRevocation()
                 );
 
             case UNRELEASED_TASKS:
@@ -201,7 +203,8 @@ public class CurrentAssignmentBuilder {
                 // of the unreleased tasks when they become available.
                 return computeNextAssignment(
                     member.memberEpoch(),
-                    member.assignedTasks()
+                    member.assignedTasks(),
+                    member.tasksPendingRevocation()
                 );
 
             case UNKNOWN:
@@ -217,7 +220,8 @@ public class CurrentAssignmentBuilder {
 
                 return computeNextAssignment(
                     targetAssignmentEpoch,
-                    member.assignedTasks()
+                    member.assignedTasks(),
+                    member.tasksPendingRevocation()
                 );
         }
 
@@ -307,13 +311,15 @@ public class CurrentAssignmentBuilder {
     /**
      * Computes the next assignment.
      *
-     * @param memberEpoch         The epoch of the member to use. This may be different from
-     *                            the epoch in {@link CurrentAssignmentBuilder#member}.
-     * @param memberAssignedTasks The assigned tasks of the member to use.
+     * @param memberEpoch                  The epoch of the member to use. This may be different from
+     *                                     the epoch in {@link CurrentAssignmentBuilder#member}.
+     * @param memberAssignedTasks          The assigned tasks of the member to use.
+     * @param memberTasksPendingRevocation The tasks pending revocation of the member.
      * @return A new StreamsGroupMember.
      */
     private StreamsGroupMember computeNextAssignment(int memberEpoch,
-                                                     TasksTuple memberAssignedTasks) {
+                                                     TasksTupleWithEpochs memberAssignedTasks,
+                                                     TasksTupleWithEpochs memberTasksPendingRevocation) {
         Map<String, Set<Integer>> newActiveAssignedTasks = new HashMap<>();
         Map<String, Set<Integer>> newActiveTasksPendingRevocation = new HashMap<>();
         Map<String, Set<Integer>> newActiveTasksPendingAssignment = new HashMap<>();
@@ -368,31 +374,103 @@ public class CurrentAssignmentBuilder {
                         .contains(member.processId())
         );
 
+        // Add epochs to the computed task tuples
+        // Preserve previous epochs for tasks that were already assigned or pending revocation,
+        // and use the target assignment epoch for newly assigned tasks.
+        TasksTupleWithEpochs newTasksPendingRevocationWithEpochs = new TasksTupleWithEpochs(
+            addEpochsToTasks(
+                newActiveTasksPendingRevocation,
+                memberAssignedTasks,
+                memberTasksPendingRevocation,
+                targetAssignmentEpoch
+            ),
+            newStandbyTasksPendingRevocation,
+            newWarmupTasksPendingRevocation
+        );
+        TasksTupleWithEpochs newAssignedTasksWithEpochs = new TasksTupleWithEpochs(
+            addEpochsToTasks(
+                newActiveAssignedTasks,
+                memberAssignedTasks,
+                memberTasksPendingRevocation,
+                targetAssignmentEpoch
+            ),
+            newStandbyAssignedTasks,
+            newWarmupAssignedTasks
+        );
+        TasksTupleWithEpochs newTasksPendingAssignmentWithEpochs = new TasksTupleWithEpochs(
+            addEpochsToTasks(
+                newActiveTasksPendingAssignment,
+                memberAssignedTasks,
+                memberTasksPendingRevocation,
+                targetAssignmentEpoch
+            ),
+            newStandbyTasksPendingAssignment,
+            newWarmupTasksPendingAssignment
+        );
+
         return buildNewMember(
             memberEpoch,
-            new TasksTuple(
-                newActiveTasksPendingRevocation,
-                newStandbyTasksPendingRevocation,
-                newWarmupTasksPendingRevocation
-            ),
-            new TasksTuple(
-                newActiveAssignedTasks,
-                newStandbyAssignedTasks,
-                newWarmupAssignedTasks
-            ),
-            new TasksTuple(
-                newActiveTasksPendingAssignment,
-                newStandbyTasksPendingAssignment,
-                newWarmupTasksPendingAssignment
-            ),
+            newTasksPendingRevocationWithEpochs,
+            newAssignedTasksWithEpochs,
+            newTasksPendingAssignmentWithEpochs,
             hasUnreleasedActiveTasks || hasUnreleasedStandbyTasks || hasUnreleasedWarmupTasks
         );
     }
 
+    /**
+     * Helper method to add epochs to active tasks. This method looks up epochs from existing assignments
+     * (memberAssignedTasks or memberTasksPendingRevocation) or uses the provided default epoch
+     * for newly assigned tasks.
+     *
+     * @param activeTasks                  The active tasks without epochs.
+     * @param memberAssignedTasks          The member's currently assigned tasks with epochs.
+     * @param memberTasksPendingRevocation The member's tasks pending revocation with epochs.
+     * @param defaultEpoch                 The default epoch to use for tasks not found in existing assignments.
+     * @return Active tasks with epochs attached.
+     */
+    private Map<String, Map<Integer, Integer>> addEpochsToTasks(
+        Map<String, Set<Integer>> activeTasks,
+        TasksTupleWithEpochs memberAssignedTasks,
+        TasksTupleWithEpochs memberTasksPendingRevocation,
+        int defaultEpoch
+    ) {
+        Map<String, Map<Integer, Integer>> activeTasksWithEpochs = new HashMap<>();
+
+        // For each active task, try to find its epoch from existing assignments
+        activeTasks.forEach((subtopologyId, partitions) -> {
+            Map<Integer, Integer> partitionsWithEpochs = new HashMap<>();
+            for (Integer partition : partitions) {
+                // First check in assigned tasks
+                Integer epoch = memberAssignedTasks.activeTasksWithEpochs()
+                    .getOrDefault(subtopologyId, Map.of())
+                    .get(partition);
+
+                // If not found, check in tasks pending revocation
+                if (epoch == null) {
+                    epoch = memberTasksPendingRevocation.activeTasksWithEpochs()
+                        .getOrDefault(subtopologyId, Map.of())
+                        .get(partition);
+                }
+
+                // If still not found, use the default epoch
+                if (epoch == null) {
+                    epoch = defaultEpoch;
+                }
+
+                partitionsWithEpochs.put(partition, epoch);
+            }
+            if (!partitionsWithEpochs.isEmpty()) {
+                activeTasksWithEpochs.put(subtopologyId, partitionsWithEpochs);
+            }
+        });
+
+        return activeTasksWithEpochs;
+    }
+
     private StreamsGroupMember buildNewMember(final int memberEpoch,
-                                              final TasksTuple newTasksPendingRevocation,
-                                              final TasksTuple newAssignedTasks,
-                                              final TasksTuple newTasksPendingAssignment,
+                                              final TasksTupleWithEpochs newTasksPendingRevocation,
+                                              final TasksTupleWithEpochs newAssignedTasks,
+                                              final TasksTupleWithEpochs newTasksPendingAssignment,
                                               final boolean hasUnreleasedTasks) {
 
         final boolean hasTasksToBeRevoked =
@@ -424,7 +502,7 @@ public class CurrentAssignmentBuilder {
                 .setState(newState)
                 .updateMemberEpoch(targetAssignmentEpoch)
                 .setAssignedTasks(newAssignedTasks.merge(newTasksPendingAssignment))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
         } else if (hasUnreleasedTasks) {
             // If there are no tasks to be revoked nor to be assigned but some
@@ -434,7 +512,7 @@ public class CurrentAssignmentBuilder {
                 .setState(MemberState.UNRELEASED_TASKS)
                 .updateMemberEpoch(targetAssignmentEpoch)
                 .setAssignedTasks(newAssignedTasks)
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
         } else {
             // Otherwise, the member transitions to the target epoch and to the
@@ -443,7 +521,7 @@ public class CurrentAssignmentBuilder {
                 .setState(MemberState.STABLE)
                 .updateMemberEpoch(targetAssignmentEpoch)
                 .setAssignedTasks(newAssignedTasks)
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -49,8 +49,8 @@ import java.util.stream.Collectors;
  * @param userEndpoint                  The user endpoint exposed for Interactive Queries by the Streams client that
  *                                      contains the member.
  * @param clientTags                    Tags of the client of the member used for rack-aware assignment.
- * @param assignedTasks                 Tasks assigned to the member.
- * @param tasksPendingRevocation        Tasks owned by the member pending revocation.
+ * @param assignedTasks                 Tasks assigned to the member, including assignment epochs for active tasks.
+ * @param tasksPendingRevocation        Tasks owned by the member pending revocation, including assignment epochs for active tasks.
  */
 @SuppressWarnings("checkstyle:JavaNCSS")
 public record StreamsGroupMember(String memberId,
@@ -66,8 +66,8 @@ public record StreamsGroupMember(String memberId,
                                  String processId,
                                  Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint,
                                  Map<String, String> clientTags,
-                                 TasksTuple assignedTasks,
-                                 TasksTuple tasksPendingRevocation) {
+                                 TasksTupleWithEpochs assignedTasks,
+                                 TasksTupleWithEpochs tasksPendingRevocation) {
 
     public StreamsGroupMember {
         Objects.requireNonNull(memberId, "memberId cannot be null");
@@ -94,8 +94,8 @@ public record StreamsGroupMember(String memberId,
         private String processId = null;
         private Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint = null;
         private Map<String, String> clientTags = null;
-        private TasksTuple assignedTasks = null;
-        private TasksTuple tasksPendingRevocation = null;
+        private TasksTupleWithEpochs assignedTasks = null;
+        private TasksTupleWithEpochs tasksPendingRevocation = null;
 
         public Builder(String memberId) {
             this.memberId = Objects.requireNonNull(memberId, "memberId cannot be null");
@@ -223,12 +223,12 @@ public record StreamsGroupMember(String memberId,
             return this;
         }
 
-        public Builder setAssignedTasks(TasksTuple assignedTasks) {
+        public Builder setAssignedTasks(TasksTupleWithEpochs assignedTasks) {
             this.assignedTasks = assignedTasks;
             return this;
         }
 
-        public Builder setTasksPendingRevocation(TasksTuple tasksPendingRevocation) {
+        public Builder setTasksPendingRevocation(TasksTupleWithEpochs tasksPendingRevocation) {
             this.tasksPendingRevocation = tasksPendingRevocation;
             return this;
         }
@@ -254,28 +254,22 @@ public record StreamsGroupMember(String memberId,
             setPreviousMemberEpoch(record.previousMemberEpoch());
             setState(MemberState.fromValue(record.state()));
             setAssignedTasks(
-                new TasksTuple(
-                    assignmentFromTaskIds(record.activeTasks()),
-                    assignmentFromTaskIds(record.standbyTasks()),
-                    assignmentFromTaskIds(record.warmupTasks())
+                TasksTupleWithEpochs.fromCurrentAssignmentRecord(
+                    record.activeTasks(),
+                    record.standbyTasks(),
+                    record.warmupTasks(),
+                    record.memberEpoch()
                 )
             );
             setTasksPendingRevocation(
-                new TasksTuple(
-                    assignmentFromTaskIds(record.activeTasksPendingRevocation()),
-                    assignmentFromTaskIds(record.standbyTasksPendingRevocation()),
-                    assignmentFromTaskIds(record.warmupTasksPendingRevocation())
+                TasksTupleWithEpochs.fromCurrentAssignmentRecord(
+                    record.activeTasksPendingRevocation(),
+                    record.standbyTasksPendingRevocation(),
+                    record.warmupTasksPendingRevocation(),
+                    record.memberEpoch()
                 )
             );
             return this;
-        }
-
-        private static Map<String, Set<Integer>> assignmentFromTaskIds(
-            List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> topicPartitionsList
-        ) {
-            return topicPartitionsList.stream().collect(Collectors.toMap(
-                StreamsGroupCurrentMemberAssignmentValue.TaskIds::subtopologyId,
-                taskIds -> Set.copyOf(taskIds.partitions())));
         }
 
         public static Builder withDefaults(String memberId) {
@@ -284,12 +278,14 @@ public record StreamsGroupMember(String memberId,
                 .setTopologyEpoch(-1)
                 .setInstanceId(null)
                 .setRackId(null)
+                .setClientId("")
+                .setClientHost("")
                 .setProcessId("")
                 .setClientTags(Collections.emptyMap())
                 .setState(MemberState.STABLE)
                 .setMemberEpoch(0)
-                .setAssignedTasks(TasksTuple.EMPTY)
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .setUserEndpoint(null);
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -340,7 +340,7 @@ public record StreamsGroupMember(String memberId,
             .setMemberId(memberId)
             .setAssignment(
                 new StreamsGroupDescribeResponseData.Assignment()
-                    .setActiveTasks(taskIdsFromMap(assignedTasks.activeTasks()))
+                    .setActiveTasks(taskIdsFromMapWithEpochs(assignedTasks.activeTasksWithEpochs()))
                     .setStandbyTasks(taskIdsFromMap(assignedTasks.standbyTasks()))
                     .setWarmupTasks(taskIdsFromMap(assignedTasks.warmupTasks())))
             .setTargetAssignment(describedTargetAssignment)
@@ -370,6 +370,16 @@ public record StreamsGroupMember(String memberId,
             taskIds.add(new StreamsGroupDescribeResponseData.TaskIds()
                 .setSubtopologyId(subtopologyId)
                 .setPartitions(tasks.get(subtopologyId).stream().sorted().toList()));
+        });
+        return taskIds;
+    }
+
+    private static List<StreamsGroupDescribeResponseData.TaskIds> taskIdsFromMapWithEpochs(Map<String, Map<Integer, Integer>> tasksWithEpochs) {
+        List<StreamsGroupDescribeResponseData.TaskIds> taskIds = new ArrayList<>();
+        tasksWithEpochs.keySet().stream().sorted().forEach(subtopologyId -> {
+            taskIds.add(new StreamsGroupDescribeResponseData.TaskIds()
+                .setSubtopologyId(subtopologyId)
+                .setPartitions(tasksWithEpochs.get(subtopologyId).keySet().stream().sorted().toList()));
         });
         return taskIds;
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTuple.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTuple.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -67,41 +66,18 @@ public record TasksTuple(Map<String, Set<Integer>> activeTasks,
     }
 
     /**
-     * Merges this task tuple with another task tuple.
+     * Checks if this task tuple contains any of the tasks in another task tuple with epochs.
      *
-     * @param other The other task tuple.
-     * @return A new task tuple, containing all active tasks, standby tasks and warm-up tasks from both tuples.
-     */
-    public TasksTuple merge(TasksTuple other) {
-        Map<String, Set<Integer>> mergedActiveTasks = merge(activeTasks, other.activeTasks);
-        Map<String, Set<Integer>> mergedStandbyTasks = merge(standbyTasks, other.standbyTasks);
-        Map<String, Set<Integer>> mergedWarmupTasks = merge(warmupTasks, other.warmupTasks);
-        return new TasksTuple(mergedActiveTasks, mergedStandbyTasks, mergedWarmupTasks);
-    }
-
-    private static Map<String, Set<Integer>> merge(final Map<String, Set<Integer>> tasks1, final Map<String, Set<Integer>> tasks2) {
-        HashMap<String, Set<Integer>> result = new HashMap<>();
-        tasks1.forEach((subtopologyId, tasks) ->
-            result.put(subtopologyId, new HashSet<>(tasks)));
-        tasks2.forEach((subtopologyId, tasks) -> result
-            .computeIfAbsent(subtopologyId, __ -> new HashSet<>())
-            .addAll(tasks));
-        return result;
-    }
-
-    /**
-     * Checks if this task tuple contains any of the tasks in another task tuple.
-     *
-     * @param other Another task tuple.
+     * @param other Another task tuple with epochs.
      * @return true if there is at least one active, standby or warm-up task that is present in both tuples.
      */
-    public boolean containsAny(TasksTuple other) {
+    public boolean containsAny(TasksTupleWithEpochs other) {
         return activeTasks.entrySet().stream().anyMatch(
-            entry -> other.activeTasks.containsKey(entry.getKey()) && !Collections.disjoint(entry.getValue(), other.activeTasks.get(entry.getKey()))
+            entry -> other.activeTasksWithEpochs().containsKey(entry.getKey()) && !Collections.disjoint(entry.getValue(), other.activeTasksWithEpochs().get(entry.getKey()).keySet())
         ) || standbyTasks.entrySet().stream().anyMatch(
-            entry -> other.standbyTasks.containsKey(entry.getKey()) && !Collections.disjoint(entry.getValue(), other.standbyTasks.get(entry.getKey()))
+            entry -> other.standbyTasks().containsKey(entry.getKey()) && !Collections.disjoint(entry.getValue(), other.standbyTasks().get(entry.getKey()))
         ) || warmupTasks.entrySet().stream().anyMatch(
-            entry -> other.warmupTasks.containsKey(entry.getKey()) && !Collections.disjoint(entry.getValue(), other.warmupTasks.get(entry.getKey()))
+            entry -> other.warmupTasks().containsKey(entry.getKey()) && !Collections.disjoint(entry.getValue(), other.warmupTasks().get(entry.getKey()))
         );
     }
 
@@ -172,8 +148,10 @@ public record TasksTuple(Map<String, Set<Integer>> activeTasks,
      *
      * Example:
      * [subtopologyID1-0, subtopologyID1-1, subtopologyID2-0, subtopologyID2-1]
+     * 
+     * Package-private to allow TasksTupleWithEpochs to use it.
      */
-    private static String taskAssignmentToString(
+    static String taskAssignmentToString(
         Map<String, Set<Integer>> assignment
     ) {
         StringBuilder builder = new StringBuilder("[");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTuple.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTuple.java
@@ -21,10 +21,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -155,17 +153,27 @@ public record TasksTuple(Map<String, Set<Integer>> activeTasks,
         Map<String, Set<Integer>> assignment
     ) {
         StringBuilder builder = new StringBuilder("[");
-        Iterator<Entry<String, Set<Integer>>> subtopologyIterator = assignment.entrySet().iterator();
-        while (subtopologyIterator.hasNext()) {
-            Map.Entry<String, Set<Integer>> entry = subtopologyIterator.next();
-            Iterator<Integer> partitionsIterator = entry.getValue().iterator();
-            while (partitionsIterator.hasNext()) {
-                builder.append(entry.getKey());
-                builder.append("-");
-                builder.append(partitionsIterator.next());
-                if (partitionsIterator.hasNext() || subtopologyIterator.hasNext()) {
+        
+        // Sort subtopology IDs for deterministic output
+        String[] subtopologyIds = assignment.keySet().toArray(new String[0]);
+        java.util.Arrays.sort(subtopologyIds);
+        
+        boolean first = true;
+        for (String subtopologyId : subtopologyIds) {
+            Set<Integer> partitions = assignment.get(subtopologyId);
+            
+            // Sort partition IDs for deterministic output
+            Integer[] partitionIds = partitions.toArray(new Integer[0]);
+            java.util.Arrays.sort(partitionIds);
+            
+            for (Integer partitionId : partitionIds) {
+                if (!first) {
                     builder.append(", ");
                 }
+                builder.append(subtopologyId);
+                builder.append("-");
+                builder.append(partitionId);
+                first = false;
             }
         }
         builder.append("]");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An immutable tuple containing active, standby and warm-up tasks with assignment epochs.
+ * <p>
+ * Active tasks include epoch information to support fencing of zombie commits.
+ * Standby and warmup tasks do not have epochs as they don't commit offsets.
+ *
+ * @param activeTasksWithEpochs Active tasks with their assignment epochs.
+ *                              The outer map key is the subtopology ID, the inner map key is the partition ID,
+ *                              and the inner map value is the assignment epoch.
+ * @param standbyTasks          Standby tasks.
+ *                              The key of the map is the subtopology ID, and the value is the set of partition IDs.
+ * @param warmupTasks           Warm-up tasks.
+ *                              The key of the map is the subtopology ID, and the value is the set of partition IDs.
+ */
+public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTasksWithEpochs,
+                                   Map<String, Set<Integer>> standbyTasks,
+                                   Map<String, Set<Integer>> warmupTasks) {
+
+    public TasksTupleWithEpochs {
+        activeTasksWithEpochs = Collections.unmodifiableMap(Objects.requireNonNull(activeTasksWithEpochs));
+        standbyTasks = Collections.unmodifiableMap(Objects.requireNonNull(standbyTasks));
+        warmupTasks = Collections.unmodifiableMap(Objects.requireNonNull(warmupTasks));
+    }
+
+    /**
+     * An empty task tuple.
+     */
+    public static final TasksTupleWithEpochs EMPTY = new TasksTupleWithEpochs(
+        Map.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    /**
+     * Returns a map of active tasks (subtopology ID to partition IDs) by extracting just the keys
+     * from the activeTasksWithEpochs map, discarding epoch information.
+     * <p>
+     * This method creates a new map on each call. Consider using {@link #activeTasksWithEpochs()}
+     * directly when possible to avoid the conversion.
+     *
+     * @return A map of active task partition IDs keyed by subtopology ID.
+     */
+    public Map<String, Set<Integer>> activeTasks() {
+        return activeTasksWithEpochs.entrySet().stream()
+            .collect(Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().keySet()
+            ));
+    }
+
+    /**
+     * @return true if all collections in the tuple are empty.
+     */
+    public boolean isEmpty() {
+        return activeTasksWithEpochs.isEmpty() && standbyTasks.isEmpty() && warmupTasks.isEmpty();
+    }
+
+    /**
+     * Merges this task tuple with another task tuple.
+     * For overlapping active tasks, epochs from the other tuple take precedence.
+     *
+     * @param other The other task tuple.
+     * @return A new task tuple, containing all active tasks, standby tasks and warm-up tasks from both tuples.
+     */
+    public TasksTupleWithEpochs merge(TasksTupleWithEpochs other) {
+        Map<String, Map<Integer, Integer>> mergedActive = new HashMap<>();
+
+        // Add all tasks from this tuple
+        this.activeTasksWithEpochs.forEach((subtopologyId, partitionsWithEpochs) -> {
+            mergedActive.put(subtopologyId, new HashMap<>(partitionsWithEpochs));
+        });
+
+        // Add tasks from other tuple, overwriting epochs for overlapping partitions
+        other.activeTasksWithEpochs.forEach((subtopologyId, partitionsWithEpochs) -> {
+            mergedActive.computeIfAbsent(subtopologyId, k -> new HashMap<>())
+                .putAll(partitionsWithEpochs);
+        });
+
+        Map<String, Set<Integer>> mergedStandby = mergeTasks(this.standbyTasks, other.standbyTasks);
+        Map<String, Set<Integer>> mergedWarmup = mergeTasks(this.warmupTasks, other.warmupTasks);
+        return new TasksTupleWithEpochs(mergedActive, mergedStandby, mergedWarmup);
+    }
+
+    /**
+     * Creates a TasksTupleWithEpochs from a current assignment record.
+     *
+     * @param activeTasks                    The active tasks from the record.
+     * @param standbyTasks                   The standby tasks from the record.
+     * @param warmupTasks                    The warmup tasks from the record.
+     * @param memberEpoch                    The member epoch to use as default for tasks without explicit epochs.
+     * @return The TasksTupleWithEpochs
+     */
+    public static TasksTupleWithEpochs fromCurrentAssignmentRecord(
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> activeTasks,
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> standbyTasks,
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> warmupTasks,
+        int memberEpoch
+    ) {
+        return new TasksTupleWithEpochs(
+            parseActiveTasksWithEpochs(activeTasks, memberEpoch),
+            parseSimpleTasks(standbyTasks),
+            parseSimpleTasks(warmupTasks)
+        );
+    }
+
+    private static Map<String, Set<Integer>> mergeTasks(final Map<String, Set<Integer>> tasks1, final Map<String, Set<Integer>> tasks2) {
+        HashMap<String, Set<Integer>> result = new HashMap<>();
+        tasks1.forEach((subtopologyId, tasks) ->
+            result.put(subtopologyId, new HashSet<>(tasks)));
+        tasks2.forEach((subtopologyId, tasks) -> result
+            .computeIfAbsent(subtopologyId, __ -> new HashSet<>())
+            .addAll(tasks));
+        return result;
+    }
+
+    private static Map<String, Map<Integer, Integer>> parseActiveTasksWithEpochs(
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> taskIdsList,
+        int defaultEpoch
+    ) {
+        Map<String, Map<Integer, Integer>> result = new HashMap<>();
+
+        for (StreamsGroupCurrentMemberAssignmentValue.TaskIds taskIds : taskIdsList) {
+            String subtopologyId = taskIds.subtopologyId();
+            List<Integer> partitions = taskIds.partitions();
+            List<Integer> epochs = taskIds.assignmentEpochs();
+
+            Map<Integer, Integer> partitionsWithEpochs = new HashMap<>();
+
+            if (epochs != null && !epochs.isEmpty()) {
+                if (epochs.size() != partitions.size()) {
+                    throw new IllegalStateException(
+                        "Assignment epochs must be provided for all partitions. " +
+                        "Subtopology " + subtopologyId + " has " + partitions.size() +
+                        " partitions but " + epochs.size() + " epochs"
+                    );
+                }
+
+                for (int i = 0; i < partitions.size(); i++) {
+                    partitionsWithEpochs.put(partitions.get(i), epochs.get(i));
+                }
+            } else {
+                // Legacy record without epochs: use member epoch as default
+                for (Integer partition : partitions) {
+                    partitionsWithEpochs.put(partition, defaultEpoch);
+                }
+            }
+
+            result.put(subtopologyId, partitionsWithEpochs);
+        }
+
+        return result;
+    }
+
+    private static Map<String, Set<Integer>> parseSimpleTasks(
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> taskIdsList
+    ) {
+        Map<String, Set<Integer>> result = new HashMap<>();
+
+        for (StreamsGroupCurrentMemberAssignmentValue.TaskIds taskIds : taskIdsList) {
+            result.put(taskIds.subtopologyId(), new HashSet<>(taskIds.partitions()));
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "(active=" + taskAssignmentToString(activeTasksWithEpochs) +
+            ", standby=" + TasksTuple.taskAssignmentToString(standbyTasks) +
+            ", warmup=" + TasksTuple.taskAssignmentToString(warmupTasks) +
+            ')';
+    }
+
+    private static String taskAssignmentToString(Map<String, Map<Integer, Integer>> assignment) {
+        StringBuilder builder = new StringBuilder("[");
+        
+        // Sort subtopology IDs
+        String[] subtopologyIds = assignment.keySet().toArray(new String[0]);
+        java.util.Arrays.sort(subtopologyIds);
+        
+        boolean first = true;
+        for (String subtopologyId : subtopologyIds) {
+            Map<Integer, Integer> partitions = assignment.get(subtopologyId);
+            
+            // Sort partition IDs
+            Integer[] partitionIds = partitions.keySet().toArray(new Integer[0]);
+            java.util.Arrays.sort(partitionIds);
+            
+            for (Integer partitionId : partitionIds) {
+                if (!first) {
+                    builder.append(", ");
+                }
+                builder.append(subtopologyId);
+                builder.append("-");
+                builder.append(partitionId);
+                builder.append("@");
+                builder.append(partitions.get(partitionId));
+                first = false;
+            }
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -126,7 +126,7 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
 
     private static Map<String, Map<Integer, Integer>> parseActiveTasksWithEpochs(
         List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> taskIdsList,
-        int defaultEpoch
+        int memberEpoch
     ) {
         Map<String, Map<Integer, Integer>> result = new HashMap<>();
 
@@ -152,7 +152,7 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
             } else {
                 // Legacy record without epochs: use member epoch as default
                 for (Integer partition : partitions) {
-                    partitionsWithEpochs.put(partition, defaultEpoch);
+                    partitionsWithEpochs.put(partition, memberEpoch);
                 }
             }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * An immutable tuple containing active, standby and warm-up tasks with assignment epochs.
@@ -59,23 +58,6 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
         Map.of(),
         Map.of()
     );
-
-    /**
-     * Returns a map of active tasks (subtopology ID to partition IDs) by extracting just the keys
-     * from the activeTasksWithEpochs map, discarding epoch information.
-     * <p>
-     * This method creates a new map on each call. Consider using {@link #activeTasksWithEpochs()}
-     * directly when possible to avoid the conversion.
-     *
-     * @return A map of active task partition IDs keyed by subtopology ID.
-     */
-    public Map<String, Set<Integer>> activeTasks() {
-        return activeTasksWithEpochs.entrySet().stream()
-            .collect(Collectors.toUnmodifiableMap(
-                Map.Entry::getKey,
-                entry -> entry.getValue().keySet()
-            ));
-    }
 
     /**
      * @return true if all collections in the tuple are empty.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManager.java
@@ -40,7 +40,11 @@ public class EndpointToPartitionsManager {
                                                                                               final StreamsGroup streamsGroup,
                                                                                               final CoordinatorMetadataImage metadataImage) {
         StreamsGroupHeartbeatResponseData.EndpointToPartitions endpointToPartitions = new StreamsGroupHeartbeatResponseData.EndpointToPartitions();
-        Map<String, Set<Integer>> activeTasks = streamsGroupMember.assignedTasks().activeTasks();
+        Map<String, Set<Integer>> activeTasks = streamsGroupMember.assignedTasks().activeTasksWithEpochs().entrySet().stream()
+            .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().keySet()
+            ));
         Map<String, Set<Integer>> standbyTasks = streamsGroupMember.assignedTasks().standbyTasks();
         endpointToPartitions.setUserEndpoint(responseEndpoint);
         Map<String, ConfiguredSubtopology> configuredSubtopologies = streamsGroup.configuredTopology().flatMap(ConfiguredTopology::subtopologies).get();

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -45,7 +45,9 @@
       { "name": "SubtopologyId", "type": "string", "versions": "0+",
         "about": "The subtopology ID." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partitions of the input topics processed by this member." }
+        "about": "The partitions of the input topics processed by this member." },
+      { "name": "AssignmentEpochs", "versions": "0+", "nullableVersions": "0+", "taggedVersions": "0+", "tag": 0, "type": "[]int32", "default": null,
+        "about": "The epoch at which the partition was assigned to the member. Used to fence zombie commits requests. Of the same length as Partitions. Only defined for active tasks." }
     ]}
   ]
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -139,6 +139,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
+import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
 import org.apache.kafka.image.MetadataDelta;
@@ -219,6 +220,9 @@ import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.STABL
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CONSUMER_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.SHARE_GROUP_REBALANCES_SENSOR_NAME;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithEpochs;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksWithEpochs;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -4267,15 +4271,13 @@ public class GroupMetadataManagerTest {
                     .setInstanceId(null)
                     .setRebalanceTimeoutMs(100)
                     .setClientTags(new HashMap<>())
-                    .setAssignedTasks(TasksTuple.EMPTY)
-                    .setTasksPendingRevocation(TasksTuple.EMPTY)
                     .setTopologyEpoch(1)
                     .setUserEndpoint(new Endpoint().setHost("localhost").setPort(1500))
                     .setClientId(DEFAULT_CLIENT_ID)
                     .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 9,
                         TaskAssignmentTestUtil.mkTasks(fooTopicName, 0, 1, 2)))
-                    .setTasksPendingRevocation(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 9,
                         TaskAssignmentTestUtil.mkTasks(fooTopicName, 3, 4, 5)))
                     .build())
                 .withMember(new StreamsGroupMember.Builder("foo-2")
@@ -4285,8 +4287,8 @@ public class GroupMetadataManagerTest {
                     .setProcessId("process-id")
                     .setRackId(null)
                     .setInstanceId(null)
-                    .setAssignedTasks(TasksTuple.EMPTY)
-                    .setTasksPendingRevocation(TasksTuple.EMPTY)
+                    .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+                    .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                     .setRebalanceTimeoutMs(100)
                     .setClientTags(new HashMap<>())
                     .setTopologyEpoch(1)
@@ -4491,8 +4493,8 @@ public class GroupMetadataManagerTest {
             .setRackId(null)
             .setInstanceId(null)
             .setRebalanceTimeoutMs(1500)
-            .setAssignedTasks(TasksTuple.EMPTY)
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .setTopologyEpoch(0)
             .setClientTags(Map.of())
             .setClientId(DEFAULT_CLIENT_ID)
@@ -16035,7 +16037,7 @@ public class GroupMetadataManagerTest {
         StreamsGroupMember member = streamsGroupMemberBuilderWithDefaults(memberId)
             .setMemberEpoch(100)
             .setPreviousMemberEpoch(99)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 1, 2, 3)))
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 100, TaskAssignmentTestUtil.mkTasks(subtopology1, 1, 2, 3)))
             .build();
 
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, member));
@@ -16125,7 +16127,7 @@ public class GroupMetadataManagerTest {
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)))
                     .build())
                 .withTopology(StreamsTopology.fromHeartbeatRequest(topology))
@@ -16280,9 +16282,10 @@ public class GroupMetadataManagerTest {
             .setClientId(DEFAULT_CLIENT_ID)
             .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(1500)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 1,
                 TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5),
                 TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1, 2)))
+            
             .build();
 
         List<CoordinatorRecord> expectedRecords = List.of(
@@ -16363,7 +16366,7 @@ public class GroupMetadataManagerTest {
             .setClientId(DEFAULT_CLIENT_ID)
             .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRebalanceTimeoutMs(1500)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 1,
                 TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5)))
             .build();
 
@@ -16765,14 +16768,14 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)))
                     .build())
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId2)
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5)))
                     .build())
                 .withTargetAssignment(memberId1, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
@@ -16961,7 +16964,7 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5)))
                     .build())
                 .withTargetAssignment(memberId, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
@@ -17009,9 +17012,22 @@ public class GroupMetadataManagerTest {
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-                TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5),
-                TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1, 2)))
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(subtopology1,
+                    Map.of(
+                        0, 10,
+                        1, 10,
+                        2, 10,
+                        3, 10,
+                        4, 10,
+                        5, 10
+                    )),
+                mkTasksWithEpochs(subtopology2,
+                    Map.of(
+                        0, 11,
+                        1, 11,
+                        2, 11
+                    ))))
             .setProcessId("process-id2")
             .build();
 
@@ -17069,7 +17085,7 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5)))
                     .build())
                 .withTargetAssignment(memberId, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
@@ -17116,9 +17132,22 @@ public class GroupMetadataManagerTest {
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-                TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5),
-                TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1, 2)))
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(subtopology1,
+                    Map.of(
+                        0, 10,
+                        1, 10,
+                        2, 10,
+                        3, 10,
+                        4, 10,
+                        5, 10
+                    )),
+                mkTasksWithEpochs(subtopology2,
+                    Map.of(
+                        0, 11,
+                        1, 11,
+                        2, 11
+                    ))))
             .setProcessId("process-id2")
             .build();
 
@@ -17173,14 +17202,14 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1)))
                     .build())
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId2)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
                     .build())
@@ -17265,14 +17294,14 @@ public class GroupMetadataManagerTest {
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1)))
                     .build())
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId2)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
                     .build())
@@ -17415,14 +17444,14 @@ public class GroupMetadataManagerTest {
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0, 1)))
                     .build())
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId2)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 3, 4, 5),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
                     .build())
@@ -17536,10 +17565,10 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.UNREVOKED_TASKS)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0)))
-                    .setTasksPendingRevocation(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 2),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 1)))
                     .build())),
@@ -17582,10 +17611,10 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.UNREVOKED_TASKS)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 3),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
-                    .setTasksPendingRevocation(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 4, 5)))
                     .build())),
             result.records()
@@ -17655,7 +17684,8 @@ public class GroupMetadataManagerTest {
                 StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberId1)
                     .setMemberEpoch(11)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    // Assignment epoch not bumped
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1),
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 0)))
                     .build())),
@@ -17712,7 +17742,7 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.UNRELEASED_TASKS)
                     .setMemberEpoch(11)
                     .setPreviousMemberEpoch(11)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 11,
                         TaskAssignmentTestUtil.mkTasks(subtopology2, 1)))
                     .build())),
             result.records()
@@ -17785,9 +17815,11 @@ public class GroupMetadataManagerTest {
                 StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberId2)
                     .setMemberEpoch(11)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-                        TaskAssignmentTestUtil.mkTasks(subtopology1, 2, 3),
-                        TaskAssignmentTestUtil.mkTasks(subtopology2, 2)))
+                    // Assignment epoch of previous tasks is preserved, new tasks gets new assignment epoch
+                    .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                        mkTasksWithEpochs(subtopology1, Map.of(2, 11, 3, 10)),
+                        mkTasksWithEpochs(subtopology2, Map.of(2, 10))
+                    ))
                     .build())),
             result.records()
         );
@@ -17830,9 +17862,10 @@ public class GroupMetadataManagerTest {
                 StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberId3)
                     .setMemberEpoch(11)
                     .setPreviousMemberEpoch(11)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-                        TaskAssignmentTestUtil.mkTasks(subtopology1, 4, 5),
-                        TaskAssignmentTestUtil.mkTasks(subtopology2, 1)))
+                    // All tasks were assigned in epoch 11
+                    .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                        mkTasksWithEpochs(subtopology1, Map.of(4, 11, 5, 11)),
+                        mkTasksWithEpochs(subtopology2, Map.of(1, 11))))
                     .build())),
             result.records()
         );
@@ -17900,7 +17933,8 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(10)
                 .setAssignedTasks(
-                    TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 1, 2, 3)))
+                    mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 11,
+                        TaskAssignmentTestUtil.mkTasks(subtopology1, 1, 2, 3)))
                 .build()));
 
         assertEquals(StreamsGroup.StreamsGroupState.RECONCILING, context.streamsGroupState(groupId));
@@ -17910,7 +17944,8 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(10)
                 .setAssignedTasks(
-                    TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 1, 2, 3)))
+                    mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 11,
+                        TaskAssignmentTestUtil.mkTasks(subtopology1, 1, 2, 3)))
                 .build()));
 
         assertEquals(StreamsGroup.StreamsGroupState.STABLE, context.streamsGroupState(groupId));
@@ -17981,7 +18016,7 @@ public class GroupMetadataManagerTest {
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)))
                     .build())
                 .withTopology(StreamsTopology.fromHeartbeatRequest(topology))
@@ -18035,8 +18070,17 @@ public class GroupMetadataManagerTest {
         StreamsGroupMember expectedMember = streamsGroupMemberBuilderWithDefaults(memberId)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-                TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5)))
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(subtopology1,
+                    Map.of(
+                        0, 10, // 0, 1, 2 were already assigned in epoch 10
+                        1, 10,
+                        2, 10,
+                        3, 11, // 3, 4, 5 were added in epoch 11
+                        4, 11,
+                        5, 11
+                    ))
+            ))
             .build();
 
         List<CoordinatorRecord> expectedRecords = List.of(
@@ -18082,7 +18126,7 @@ public class GroupMetadataManagerTest {
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 11,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)))
                     .build())
                 .withTopology(StreamsTopology.fromHeartbeatRequest(topology))
@@ -18156,9 +18200,9 @@ public class GroupMetadataManagerTest {
         StreamsGroupMember expectedMember = streamsGroupMemberBuilderWithDefaults(memberId)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 11,
                 TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         List<CoordinatorRecord> expectedRecords = List.of(
@@ -18845,7 +18889,7 @@ public class GroupMetadataManagerTest {
                     .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
-                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                    .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
                         TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2, 3, 4, 5)))
                     .build())
                 .withTargetAssignment(memberId, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
@@ -18996,8 +19040,8 @@ public class GroupMetadataManagerTest {
             .setRebalanceTimeoutMs(5000)
             .setClientId(DEFAULT_CLIENT_ID)
             .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
-            .setAssignedTasks(TasksTuple.EMPTY)
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .setRebalanceTimeoutMs(12000)
             .setTopologyEpoch(0)
             .build();
@@ -19820,12 +19864,14 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.UNRELEASED_TASKS)
-            .setAssignedTasks(new TasksTuple(
-                TaskAssignmentTestUtil.mkTasksPerSubtopology(TaskAssignmentTestUtil.mkTasks("subtopology-1", 0, 1, 2)),
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                TaskAssignmentTestUtil.mkTasksPerSubtopologyWithCommonEpoch(10,
+                    TaskAssignmentTestUtil.mkTasks("subtopology-1", 0, 1, 2)
+                ),
                 TaskAssignmentTestUtil.mkTasksPerSubtopology(TaskAssignmentTestUtil.mkTasks("subtopology-1", 3, 4, 5)),
                 TaskAssignmentTestUtil.mkTasksPerSubtopology(TaskAssignmentTestUtil.mkTasks("subtopology-1", 6, 7, 8))
             ))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         // The group and the member are created if they do not exist.
@@ -19852,9 +19898,9 @@ public class GroupMetadataManagerTest {
 
     @Test
     public void testReplayStreamsGroupCurrentMemberAssignmentTombstoneExisting() {
-        final TasksTuple tasks =
-            new TasksTuple(
-                TaskAssignmentTestUtil.mkTasksPerSubtopology(
+        final TasksTupleWithEpochs tasks =
+            new TasksTupleWithEpochs(
+                TaskAssignmentTestUtil.mkTasksPerSubtopologyWithCommonEpoch(1,
                     TaskAssignmentTestUtil.mkTasks("subtopology-1", 0, 1, 2)),
                 TaskAssignmentTestUtil.mkTasksPerSubtopology(
                     TaskAssignmentTestUtil.mkTasks("subtopology-1", 3, 4, 5)),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -113,7 +113,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupBuilder;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
-import org.apache.kafka.coordinator.group.streams.TasksTuple;
+import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
 import org.apache.kafka.server.authorizer.Authorizer;
@@ -1790,8 +1790,8 @@ public class GroupMetadataManagerTestContext {
     public static StreamsGroupMember.Builder streamsGroupMemberBuilderWithDefaults(String memberId) {
         return new StreamsGroupMember.Builder(memberId)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
-            .setAssignedTasks(TasksTuple.EMPTY)
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .setClientId(DEFAULT_CLIENT_ID)
             .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
             .setRackId(null)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
@@ -24,10 +24,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithEpochs;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksWithEpochs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -50,11 +54,12 @@ public class CurrentAssignmentBuilderTest {
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
                 .setAssignedTasks(
-                    mkTasksTuple(
+                    mkTasksTupleWithCommonEpoch(
                         taskRole,
+                        memberEpoch,
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -73,11 +78,12 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(
                     taskRole,
+                    memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -95,11 +101,12 @@ public class CurrentAssignmentBuilderTest {
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
                 .setAssignedTasks(
-                    mkTasksTuple(
+                    mkTasksTupleWithCommonEpoch(
                         taskRole,
+                        memberEpoch,
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -118,11 +125,12 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(
                     taskRole,
+                    memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -138,10 +146,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
-                mkTasks(SUBTOPOLOGY_ID1, 1, 2),
-                mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setAssignedTasks(mkTasksTupleWithEpochs(taskRole,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 9, 2, 8)),
+                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 9, 4, 8))))
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -160,10 +168,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
-                    mkTasks(SUBTOPOLOGY_ID1, 1, 2, 4),
-                    mkTasks(SUBTOPOLOGY_ID2, 3, 4, 7)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setAssignedTasks(mkTasksTupleWithEpochs(taskRole,
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID1,  Map.of(1, 9, 2, 8, 4, memberEpoch + 1)),
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 9, 4, 8, 7, memberEpoch + 1))))
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -179,10 +187,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -201,10 +209,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 4)))
-                .setTasksPendingRevocation(mkTasksTuple(taskRole,
+                .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 1),
                     mkTasks(SUBTOPOLOGY_ID2, 3)))
                 .build(),
@@ -224,11 +232,12 @@ public class CurrentAssignmentBuilderTest {
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
                 .setAssignedTasks(
-                    mkTasksTuple(
+                    mkTasksTupleWithCommonEpoch(
                         taskRole,
+                        memberEpoch,
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -245,10 +254,11 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(TasksTuple.EMPTY)
+                .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
                 .setTasksPendingRevocation(
-                    mkTasksTuple(
+                    mkTasksTupleWithCommonEpoch(
                         taskRole,
+                        memberEpoch,
                         mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                         mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .build(),
@@ -266,10 +276,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -288,10 +298,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -307,10 +317,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -332,10 +342,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -351,10 +361,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(mkTasksTuple(taskRole,
+            .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
             .build();
@@ -378,10 +388,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -397,10 +407,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(mkTasksTuple(taskRole,
+            .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
             .build();
@@ -452,10 +462,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(mkTasksTuple(taskRole,
+            .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
             .build();
@@ -476,10 +486,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 6)))
-                .setTasksPendingRevocation(mkTasksTuple(taskRole,
+                .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 5)))
                 .build(),
@@ -497,10 +507,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch - 1)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(mkTasksTuple(taskRole,
+            .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 1),
                 mkTasks(SUBTOPOLOGY_ID2, 4)))
             .build();
@@ -525,10 +535,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -544,10 +554,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId("process1")
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -567,10 +577,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId("process1")
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -586,10 +596,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId("process1")
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -608,10 +618,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId("process1")
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2, 3, 4),
                     mkTasks(SUBTOPOLOGY_ID2, 5, 6, 7)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );
@@ -627,10 +637,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -658,10 +668,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -692,9 +702,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(TaskRole.ACTIVE,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember expectedMember = new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -702,10 +713,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId(PROCESS_ID)
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(TaskRole.ACTIVE,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6, 7)))
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
@@ -734,10 +745,10 @@ public class CurrentAssignmentBuilderTest {
             .setProcessId("process1")
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 5, 6)))
-            .setTasksPendingRevocation(mkTasksTuple(TaskRole.ACTIVE,
+            .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 4),
                 mkTasks(SUBTOPOLOGY_ID2, 7)))
             .build();
@@ -758,10 +769,10 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId("process1")
                 .setMemberEpoch(memberEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 6)))
-                .setTasksPendingRevocation(mkTasksTuple(taskRole,
+                .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 5)))
                 .build(),
@@ -779,10 +790,10 @@ public class CurrentAssignmentBuilderTest {
             .setMemberEpoch(memberEpoch)
             .setPreviousMemberEpoch(memberEpoch)
             .setProcessId(PROCESS_ID)
-            .setAssignedTasks(mkTasksTuple(taskRole,
+            .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 3),
                 mkTasks(SUBTOPOLOGY_ID2, 6)))
-            .setTasksPendingRevocation(mkTasksTuple(taskRole,
+            .setTasksPendingRevocation(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                 mkTasks(SUBTOPOLOGY_ID1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 5)))
             .build();
@@ -814,10 +825,265 @@ public class CurrentAssignmentBuilderTest {
                 .setProcessId(PROCESS_ID)
                 .setMemberEpoch(memberEpoch + 1)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTuple(taskRole,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(taskRole, memberEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 3),
                     mkTasks(SUBTOPOLOGY_ID2, 6)))
-                .setTasksPendingRevocation(TasksTuple.EMPTY)
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+                .build(),
+            updatedMember
+        );
+    }
+
+    /**
+     * Tests epoch assignment from assigned tasks.
+     * This tests the first lookup path in addEpochsToTasks where epochs are found in assigned tasks.
+     */
+    @Test
+    public void testEpochLookupFromAssignedTasks() {
+        final int memberEpoch = 10;
+
+        // Create a member with tasks that have specific epochs in assigned tasks
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
+            .setState(MemberState.STABLE)
+            .setProcessId(PROCESS_ID)
+            .setMemberEpoch(memberEpoch)
+            .setPreviousMemberEpoch(memberEpoch)
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6)),
+                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8))))
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+            .build();
+
+        // Same tasks in target assignment should retain their epochs from assigned tasks
+        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1, 2),
+                mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
+            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> PROCESS_ID)
+            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .build();
+
+        // Verify that epochs are preserved from assigned tasks
+        assertEquals(
+            new StreamsGroupMember.Builder(MEMBER_NAME)
+                .setState(MemberState.STABLE)
+                .setProcessId(PROCESS_ID)
+                .setMemberEpoch(memberEpoch + 1)
+                .setPreviousMemberEpoch(memberEpoch)
+                .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6)),
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8))))
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+                .build(),
+            updatedMember
+        );
+    }
+
+    /**
+     * Tests epoch assignment from tasks pending revocation.
+     * This tests the second lookup path in addEpochsToTasks where epochs are found in pending revocation.
+     * When tasks pending revocation are brought back into the target assignment after the member revokes them,
+     * the epochs should be preserved from the pending revocation.
+     */
+    @Test
+    public void testEpochLookupFromPendingRevocation() {
+        final int memberEpoch = 10;
+
+        // Create a member in UNREVOKED_TASKS state with:
+        // - Some tasks assigned (5, 6) with epochs (9, 10)
+        // - Some tasks pending revocation (1, 2, 3, 4) with specific epochs (5, 6, 7, 8)
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
+            .setState(MemberState.UNREVOKED_TASKS)
+            .setProcessId(PROCESS_ID)
+            .setMemberEpoch(memberEpoch)
+            .setPreviousMemberEpoch(memberEpoch)
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(5, 9)),
+                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(6, 10))))
+            .setTasksPendingRevocation(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6)),
+                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8))))
+            .build();
+
+        // Target assignment brings back the pending tasks (1, 2, 3, 4) along with current assigned (5, 6)
+        // The member has revoked the pending tasks (they're not in owned assignment)
+        // So it should transition to next epoch and assign the tasks
+        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1, 2, 5),
+                mkTasks(SUBTOPOLOGY_ID2, 3, 4, 6)))
+            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> null)
+            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withOwnedAssignment(mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 5),  // Only owns the assigned tasks, not the pending revocation
+                mkTasks(SUBTOPOLOGY_ID2, 6)))
+            .build();
+
+        // Verify that:
+        // - Tasks from pending revocation (1@5, 2@6, 3@7, 4@8) retain their epochs when re-assigned
+        // - Tasks from assigned (5@9, 6@10) retain their epochs
+        assertEquals(
+            new StreamsGroupMember.Builder(MEMBER_NAME)
+                .setState(MemberState.STABLE)
+                .setProcessId(PROCESS_ID)
+                .setMemberEpoch(memberEpoch + 1)
+                .setPreviousMemberEpoch(memberEpoch)
+                .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6, 5, 9)),
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8, 6, 10))))
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+                .build(),
+            updatedMember
+        );
+    }
+
+    /**
+     * Tests fallback to default epoch.
+     * This tests the third path in addEpochsToTasks where epochs are not found in assigned or pending,
+     * so the default epoch (target assignment epoch) is used.
+     */
+    @Test
+    public void testEpochFallbackToDefault() {
+        final int memberEpoch = 10;
+
+        // Create a member with empty assignments
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
+            .setState(MemberState.STABLE)
+            .setProcessId(PROCESS_ID)
+            .setMemberEpoch(memberEpoch)
+            .setPreviousMemberEpoch(memberEpoch)
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+            .build();
+
+        // New tasks are assigned
+        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1, 2),
+                mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
+            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> null)
+            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .build();
+
+        // Verify that all tasks use the default epoch (memberEpoch + 1)
+        assertEquals(
+            new StreamsGroupMember.Builder(MEMBER_NAME)
+                .setState(MemberState.STABLE)
+                .setProcessId(PROCESS_ID)
+                .setMemberEpoch(memberEpoch + 1)
+                .setPreviousMemberEpoch(memberEpoch)
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, memberEpoch + 1,
+                    mkTasks(SUBTOPOLOGY_ID1, 1, 2),
+                    mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+                .build(),
+            updatedMember
+        );
+    }
+
+    /**
+     * Tests mixed epoch assignment scenarios.
+     * This tests all three paths in addEpochsToTasks:
+     * - Some epochs from assigned tasks
+     * - Some epochs from pending revocation
+     * - Some epochs fallback to default
+     */
+    @Test
+    public void testMixedEpochLookup() {
+        final int memberEpoch = 10;
+
+        // Create a member with:
+        // - Tasks 1, 2 in assigned with epochs 5, 6
+        // - Tasks 3, 4 in pending revocation with epochs 7, 8
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
+            .setState(MemberState.UNREVOKED_TASKS)
+            .setProcessId(PROCESS_ID)
+            .setMemberEpoch(memberEpoch)
+            .setPreviousMemberEpoch(memberEpoch)
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6))))
+            .setTasksPendingRevocation(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8))))
+            .build();
+
+        // Target assignment includes:
+        // - Task 1 from assigned (should use epoch 5)
+        // - Task 3 from pending revocation (should use epoch 7)
+        // - Task 5 (new task, should use default epoch memberEpoch + 1 = 11)
+        // The member revokes tasks 2, 3, 4 (not in owned), transitions to next epoch
+        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1),
+                mkTasks(SUBTOPOLOGY_ID2, 3, 5)))
+            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> null)
+            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withOwnedAssignment(mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1)))  // Only owns task 1 (task 2 is being revoked, tasks 3,4 already revoked)
+            .build();
+
+        // Verify mixed epoch assignment:
+        // - Task 1 from SUBTOPOLOGY_ID1 should have epoch 5 (from assigned)
+        // - Task 3 from SUBTOPOLOGY_ID2 should have epoch 7 (from pending revocation)
+        // - Task 5 from SUBTOPOLOGY_ID2 should have epoch 11 (default)
+        assertEquals(
+            new StreamsGroupMember.Builder(MEMBER_NAME)
+                .setState(MemberState.STABLE)
+                .setProcessId(PROCESS_ID)
+                .setMemberEpoch(memberEpoch + 1)
+                .setPreviousMemberEpoch(memberEpoch)
+                .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5)),
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 5, memberEpoch + 1))))
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+                .build(),
+            updatedMember
+        );
+    }
+
+    /**
+     * Tests that assigned tasks take precedence over pending revocation.
+     * If a task exists in both assigned and pending revocation, the epoch from assigned should be used.
+     */
+    @Test
+    public void testAssignedTasksHavePrecedenceOverPendingRevocation() {
+        final int memberEpoch = 10;
+
+        // Create a member with task 1 in both assigned (epoch 5) and pending revocation (epoch 7)
+        // This shouldn't normally happen, but tests the precedence logic
+        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
+            .setState(MemberState.STABLE)
+            .setProcessId(PROCESS_ID)
+            .setMemberEpoch(memberEpoch)
+            .setPreviousMemberEpoch(memberEpoch)
+            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6))))
+            .setTasksPendingRevocation(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 7))))
+            .build();
+
+        // Target assignment includes task 1
+        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
+            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1, 2)))
+            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> PROCESS_ID)
+            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
+            .build();
+
+        // Verify that task 1 uses epoch 5 from assigned, not epoch 7 from pending revocation
+        assertEquals(
+            new StreamsGroupMember.Builder(MEMBER_NAME)
+                .setState(MemberState.STABLE)
+                .setProcessId(PROCESS_ID)
+                .setMemberEpoch(memberEpoch + 1)
+                .setPreviousMemberEpoch(memberEpoch)
+                .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6))))
+                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
@@ -834,12 +834,8 @@ public class CurrentAssignmentBuilderTest {
         );
     }
 
-    /**
-     * Tests epoch assignment from assigned tasks.
-     * This tests the first lookup path in addEpochsToTasks where epochs are found in assigned tasks.
-     */
     @Test
-    public void testEpochLookupFromAssignedTasks() {
+    public void testAssignmentEpochsShouldBePreservedFromPreviousAssignment() {
         final int memberEpoch = 10;
 
         // Create a member with tasks that have specific epochs in assigned tasks
@@ -880,73 +876,10 @@ public class CurrentAssignmentBuilderTest {
         );
     }
 
-    /**
-     * Tests epoch assignment from tasks pending revocation.
-     * This tests the second lookup path in addEpochsToTasks where epochs are found in pending revocation.
-     * When tasks pending revocation are brought back into the target assignment after the member revokes them,
-     * the epochs should be preserved from the pending revocation.
-     */
     @Test
-    public void testEpochLookupFromPendingRevocation() {
+    public void testNewlyAssignedTasksGetTargetAssignmentEpoch() {
         final int memberEpoch = 10;
-
-        // Create a member in UNREVOKED_TASKS state with:
-        // - Some tasks assigned (5, 6) with epochs (9, 10)
-        // - Some tasks pending revocation (1, 2, 3, 4) with specific epochs (5, 6, 7, 8)
-        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
-            .setState(MemberState.UNREVOKED_TASKS)
-            .setProcessId(PROCESS_ID)
-            .setMemberEpoch(memberEpoch)
-            .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(5, 9)),
-                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(6, 10))))
-            .setTasksPendingRevocation(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6)),
-                mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8))))
-            .build();
-
-        // Target assignment brings back the pending tasks (1, 2, 3, 4) along with current assigned (5, 6)
-        // The member has revoked the pending tasks (they're not in owned assignment)
-        // So it should transition to next epoch and assign the tasks
-        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
-            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
-                mkTasks(SUBTOPOLOGY_ID1, 1, 2, 5),
-                mkTasks(SUBTOPOLOGY_ID2, 3, 4, 6)))
-            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> null)
-            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
-            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
-            .withOwnedAssignment(mkTasksTuple(TaskRole.ACTIVE,
-                mkTasks(SUBTOPOLOGY_ID1, 5),  // Only owns the assigned tasks, not the pending revocation
-                mkTasks(SUBTOPOLOGY_ID2, 6)))
-            .build();
-
-        // Verify that:
-        // - Tasks from pending revocation (1@5, 2@6, 3@7, 4@8) retain their epochs when re-assigned
-        // - Tasks from assigned (5@9, 6@10) retain their epochs
-        assertEquals(
-            new StreamsGroupMember.Builder(MEMBER_NAME)
-                .setState(MemberState.STABLE)
-                .setProcessId(PROCESS_ID)
-                .setMemberEpoch(memberEpoch + 1)
-                .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6, 5, 9)),
-                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8, 6, 10))))
-                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
-                .build(),
-            updatedMember
-        );
-    }
-
-    /**
-     * Tests fallback to default epoch.
-     * This tests the third path in addEpochsToTasks where epochs are not found in assigned or pending,
-     * so the default epoch (target assignment epoch) is used.
-     */
-    @Test
-    public void testEpochFallbackToDefault() {
-        final int memberEpoch = 10;
+        final int targetAssignmentEpoch = 11;
 
         // Create a member with empty assignments
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
@@ -960,7 +893,7 @@ public class CurrentAssignmentBuilderTest {
 
         // New tasks are assigned
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
-            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
+            .withTargetAssignment(targetAssignmentEpoch, mkTasksTuple(TaskRole.ACTIVE,
                 mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
             .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> null)
@@ -968,14 +901,14 @@ public class CurrentAssignmentBuilderTest {
             .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
             .build();
 
-        // Verify that all tasks use the default epoch (memberEpoch + 1)
+        // Verify that all tasks use the target assignment epoch
         assertEquals(
             new StreamsGroupMember.Builder(MEMBER_NAME)
                 .setState(MemberState.STABLE)
                 .setProcessId(PROCESS_ID)
-                .setMemberEpoch(memberEpoch + 1)
+                .setMemberEpoch(targetAssignmentEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, memberEpoch + 1,
+                .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, targetAssignmentEpoch,
                     mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                     mkTasks(SUBTOPOLOGY_ID2, 3, 4)))
                 .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
@@ -986,14 +919,16 @@ public class CurrentAssignmentBuilderTest {
 
     /**
      * Tests mixed epoch assignment scenarios.
-     * This tests all three paths in addEpochsToTasks:
-     * - Some epochs from assigned tasks
-     * - Some epochs from pending revocation
-     * - Some epochs fallback to default
+     * - Some epochs from previously assigned tasks (Tasks 1, 2).
+     *   This happens regardless of whether the assigned task is reconciled (owned) by the client (Task 1) or not (Task 2)
+     * - Some newly assigned task (Task 5) which should get the target assignment epoch.
+     * - Some tasks are revoked by the member (Task 3, 4). One is immediately reassigned, which also gets
+     *   the target assignment epoch (Task 3).
      */
     @Test
-    public void testMixedEpochLookup() {
+    public void testMixedPreservedAndNewAssignmentEpochs() {
         final int memberEpoch = 10;
+        final int targetAssignmentEpoch = 11;
 
         // Create a member with:
         // - Tasks 1, 2 in assigned with epochs 5, 6
@@ -1009,80 +944,31 @@ public class CurrentAssignmentBuilderTest {
                 mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 4, 8))))
             .build();
 
-        // Target assignment includes:
-        // - Task 1 from assigned (should use epoch 5)
-        // - Task 3 from pending revocation (should use epoch 7)
-        // - Task 5 (new task, should use default epoch memberEpoch + 1 = 11)
-        // The member revokes tasks 2, 3, 4 (not in owned), transitions to next epoch
+        // The member revokes tasks 3, 4 (not in owned), transitions to next epoch
         StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
-            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
-                mkTasks(SUBTOPOLOGY_ID1, 1),
+            .withTargetAssignment(targetAssignmentEpoch, mkTasksTuple(TaskRole.ACTIVE,
+                mkTasks(SUBTOPOLOGY_ID1, 1, 2),
                 mkTasks(SUBTOPOLOGY_ID2, 3, 5)))
             .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> null)
             .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
             .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
             .withOwnedAssignment(mkTasksTuple(TaskRole.ACTIVE,
-                mkTasks(SUBTOPOLOGY_ID1, 1)))  // Only owns task 1 (task 2 is being revoked, tasks 3,4 already revoked)
+                mkTasks(SUBTOPOLOGY_ID1, 1)))  // Only owns task 1 (task 2 is not yet reconciled, tasks 3,4 already revoked)
             .build();
 
         // Verify mixed epoch assignment:
-        // - Task 1 from SUBTOPOLOGY_ID1 should have epoch 5 (from assigned)
-        // - Task 3 from SUBTOPOLOGY_ID2 should have epoch 7 (from pending revocation)
-        // - Task 5 from SUBTOPOLOGY_ID2 should have epoch 11 (default)
+        // - Task 1 from SUBTOPOLOGY_ID1 should have epoch 5 (previous assignment epoch)
+        // - Task 3 from SUBTOPOLOGY_ID2 should have epoch 11 (target assignment epoch)
+        // - Task 5 from SUBTOPOLOGY_ID2 should have epoch 11 (target assignment epoch)
         assertEquals(
             new StreamsGroupMember.Builder(MEMBER_NAME)
                 .setState(MemberState.STABLE)
                 .setProcessId(PROCESS_ID)
-                .setMemberEpoch(memberEpoch + 1)
+                .setMemberEpoch(targetAssignmentEpoch)
                 .setPreviousMemberEpoch(memberEpoch)
                 .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5)),
-                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, 7, 5, memberEpoch + 1))))
-                .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
-                .build(),
-            updatedMember
-        );
-    }
-
-    /**
-     * Tests that assigned tasks take precedence over pending revocation.
-     * If a task exists in both assigned and pending revocation, the epoch from assigned should be used.
-     */
-    @Test
-    public void testAssignedTasksHavePrecedenceOverPendingRevocation() {
-        final int memberEpoch = 10;
-
-        // Create a member with task 1 in both assigned (epoch 5) and pending revocation (epoch 7)
-        // This shouldn't normally happen, but tests the precedence logic
-        StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_NAME)
-            .setState(MemberState.STABLE)
-            .setProcessId(PROCESS_ID)
-            .setMemberEpoch(memberEpoch)
-            .setPreviousMemberEpoch(memberEpoch)
-            .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6))))
-            .setTasksPendingRevocation(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 7))))
-            .build();
-
-        // Target assignment includes task 1
-        StreamsGroupMember updatedMember = new CurrentAssignmentBuilder(member)
-            .withTargetAssignment(memberEpoch + 1, mkTasksTuple(TaskRole.ACTIVE,
-                mkTasks(SUBTOPOLOGY_ID1, 1, 2)))
-            .withCurrentActiveTaskProcessId((subtopologyId, partitionId) -> PROCESS_ID)
-            .withCurrentStandbyTaskProcessIds((subtopologyId, partitionId) -> Set.of())
-            .withCurrentWarmupTaskProcessIds((subtopologyId, partitionId) -> Set.of())
-            .build();
-
-        // Verify that task 1 uses epoch 5 from assigned, not epoch 7 from pending revocation
-        assertEquals(
-            new StreamsGroupMember.Builder(MEMBER_NAME)
-                .setState(MemberState.STABLE)
-                .setProcessId(PROCESS_ID)
-                .setMemberEpoch(memberEpoch + 1)
-                .setPreviousMemberEpoch(memberEpoch)
-                .setAssignedTasks(mkTasksTupleWithEpochs(TaskRole.ACTIVE,
-                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6))))
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID1, Map.of(1, 5, 2, 6)),
+                    mkTasksWithEpochs(SUBTOPOLOGY_ID2, Map.of(3, targetAssignmentEpoch, 5, targetAssignmentEpoch))))
                 .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
                 .build(),
             updatedMember

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
@@ -44,7 +44,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksWithEpochs;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksWithEpochsPerSubtopology;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -411,27 +414,19 @@ class StreamsCoordinatorRecordHelpersTest {
             .setProcessId(PROCESS_ID)
             .setUserEndpoint(new Endpoint().setHost(USER_ENDPOINT).setPort(USER_ENDPOINT_PORT))
             .setClientTags(Map.of(TAG_1, VALUE_1, TAG_2, VALUE_2))
-            .setAssignedTasks(new TasksTuple(
-                Map.of(
-                    SUBTOPOLOGY_1, Set.of(1, 2, 3)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                mkTasksWithEpochsPerSubtopology(
+                    mkTasksWithEpochs(SUBTOPOLOGY_1, Map.of(1, 10, 2, 11, 3, 12))
                 ),
-                Map.of(
-                    SUBTOPOLOGY_2, Set.of(4, 5, 6)
-                ),
-                Map.of(
-                    SUBTOPOLOGY_3, Set.of(7, 8, 9)
-                )
+                mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY_2, 4, 5, 6)),
+                mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY_3, 7, 8, 9))
             ))
-            .setTasksPendingRevocation(new TasksTuple(
-                Map.of(
-                    SUBTOPOLOGY_1, Set.of(1, 2, 3)
+            .setTasksPendingRevocation(new TasksTupleWithEpochs(
+                mkTasksWithEpochsPerSubtopology(
+                    mkTasksWithEpochs(SUBTOPOLOGY_1, Map.of(1, 5, 2, 6, 3, 7))
                 ),
-                Map.of(
-                    SUBTOPOLOGY_2, Set.of(4, 5, 6)
-                ),
-                Map.of(
-                    SUBTOPOLOGY_3, Set.of(7, 8, 9)
-                )
+                mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY_2, 4, 5, 6)),
+                mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY_3, 7, 8, 9))
             ))
             .build();
 
@@ -448,6 +443,7 @@ class StreamsCoordinatorRecordHelpersTest {
                         new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
                             .setSubtopologyId(SUBTOPOLOGY_1)
                             .setPartitions(List.of(1, 2, 3))
+                            .setAssignmentEpochs(List.of(10, 11, 12))
                     ))
                     .setStandbyTasks(List.of(
                         new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
@@ -463,6 +459,7 @@ class StreamsCoordinatorRecordHelpersTest {
                         new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
                             .setSubtopologyId(SUBTOPOLOGY_1)
                             .setPartitions(List.of(1, 2, 3))
+                            .setAssignmentEpochs(List.of(5, 6, 7))
                     ))
                     .setStandbyTasksPendingRevocation(List.of(
                         new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
@@ -496,8 +493,8 @@ class StreamsCoordinatorRecordHelpersTest {
             .setProcessId(PROCESS_ID)
             .setUserEndpoint(new Endpoint().setHost(USER_ENDPOINT).setPort(USER_ENDPOINT_PORT))
             .setClientTags(Map.of(TAG_1, VALUE_1, TAG_2, VALUE_2))
-            .setAssignedTasks(new TasksTuple(Map.of(), Map.of(), Map.of()))
-            .setTasksPendingRevocation(new TasksTuple(Map.of(), Map.of(), Map.of()))
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         CoordinatorRecord expectedRecord = CoordinatorRecord.record(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -37,6 +37,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopologyWithCommonEpoch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -70,15 +71,17 @@ public class StreamsGroupMemberTest {
     private static final List<Integer> TASKS4 = List.of(3, 2, 1);
     private static final List<Integer> TASKS5 = List.of(6, 5, 4);
     private static final List<Integer> TASKS6 = List.of(9, 7);
-    private static final TasksTuple ASSIGNED_TASKS =
-        new TasksTuple(
-            mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS1.toArray(Integer[]::new))),
+    // Assignment epochs for active tasks: task 1 -> epoch 5, task 2 -> epoch 6, task 3 -> epoch 7
+    private static final TasksTupleWithEpochs ASSIGNED_TASKS =
+        new TasksTupleWithEpochs(
+            mkMap(mkEntry(SUBTOPOLOGY1, mkMap(mkEntry(1, 5), mkEntry(2, 6), mkEntry(3, 7)))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS2.toArray(Integer[]::new))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS3.toArray(Integer[]::new)))
         );
-    private static final TasksTuple TASKS_PENDING_REVOCATION =
-        new TasksTuple(
-            mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS4.toArray(Integer[]::new))),
+    // Assignment epochs for active tasks pending revocation: task 3 -> epoch 4, task 2 -> epoch 3, task 1 -> epoch 2
+    private static final TasksTupleWithEpochs TASKS_PENDING_REVOCATION =
+        new TasksTupleWithEpochs(
+            mkMap(mkEntry(SUBTOPOLOGY2, mkMap(mkEntry(3, 4), mkEntry(2, 3), mkEntry(1, 2)))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS5.toArray(Integer[]::new))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS6.toArray(Integer[]::new)))
         );
@@ -102,7 +105,7 @@ public class StreamsGroupMemberTest {
     }
 
     @Test
-    public void testBuilderWithDefaults() {
+    public void testBuilderWithoutDefaults() {
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID).build();
 
         assertEquals(MEMBER_ID, member.memberId());
@@ -120,6 +123,27 @@ public class StreamsGroupMemberTest {
         assertNull(member.clientTags());
         assertNull(member.assignedTasks());
         assertNull(member.tasksPendingRevocation());
+    }
+
+    @Test
+    public void testBuilderWithDefaults() {
+        StreamsGroupMember member = StreamsGroupMember.Builder.withDefaults(MEMBER_ID)
+            .build();
+
+        assertEquals(MEMBER_ID, member.memberId());
+        assertEquals(0, member.memberEpoch());
+        assertEquals(MemberState.STABLE, member.state());
+        assertEquals(Optional.empty(), member.instanceId());
+        assertEquals(Optional.empty(), member.rackId());
+        assertEquals("", member.clientId());
+        assertEquals("", member.clientHost());
+        assertEquals(-1, member.rebalanceTimeoutMs());
+        assertEquals(-1, member.topologyEpoch());
+        assertEquals("", member.processId());
+        assertEquals(Optional.empty(), member.userEndpoint());
+        assertEquals(Map.of(), member.clientTags());
+        assertEquals(TasksTupleWithEpochs.EMPTY, member.assignedTasks());
+        assertEquals(TasksTupleWithEpochs.EMPTY, member.tasksPendingRevocation());
     }
 
     @Test
@@ -183,14 +207,23 @@ public class StreamsGroupMemberTest {
 
     @Test
     public void testBuilderUpdateWithConsumerGroupCurrentMemberAssignmentValue() {
+        List<Integer> assignmentEpochsForTasks1 = List.of(5, 6, 7);
+        List<Integer> assignmentEpochsForTasks4 = List.of(4, 3, 2);
+        
         StreamsGroupCurrentMemberAssignmentValue record = new StreamsGroupCurrentMemberAssignmentValue()
             .setMemberEpoch(MEMBER_EPOCH)
             .setPreviousMemberEpoch(PREVIOUS_MEMBER_EPOCH)
             .setState(STATE.value())
-            .setActiveTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS1)))
+            .setActiveTasks(List.of(new TaskIds()
+                .setSubtopologyId(SUBTOPOLOGY1)
+                .setPartitions(TASKS1)
+                .setAssignmentEpochs(assignmentEpochsForTasks1)))
             .setStandbyTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS2)))
             .setWarmupTasks(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS3)))
-            .setActiveTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS4)))
+            .setActiveTasksPendingRevocation(List.of(new TaskIds()
+                .setSubtopologyId(SUBTOPOLOGY2)
+                .setPartitions(TASKS4)
+                .setAssignmentEpochs(assignmentEpochsForTasks4)))
             .setStandbyTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY1).setPartitions(TASKS5)))
             .setWarmupTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS6)));
 
@@ -262,6 +295,7 @@ public class StreamsGroupMemberTest {
         assertEquals(member.memberId(), updatedMember.memberId());
         assertEquals(member.memberEpoch(), updatedMember.memberEpoch());
         assertEquals(member.previousMemberEpoch(), updatedMember.previousMemberEpoch());
+        assertEquals(member.assignedTasks(), updatedMember.assignedTasks());
         assertEquals(member.state(), updatedMember.state());
         assertEquals(member.clientId(), updatedMember.clientId());
         assertEquals(member.clientHost(), updatedMember.clientHost());
@@ -280,8 +314,8 @@ public class StreamsGroupMemberTest {
 
         assertEquals(member.memberId(), updatedMember.memberId());
         assertEquals(newMemberEpoch, updatedMember.memberEpoch());
-        // The previous member epoch becomes the old current member epoch.
         assertEquals(member.memberEpoch(), updatedMember.previousMemberEpoch());
+        assertEquals(member.assignedTasks(), updatedMember.assignedTasks());
         assertEquals(member.state(), updatedMember.state());
         assertEquals(member.instanceId(), updatedMember.instanceId());
         assertEquals(member.rackId(), updatedMember.rackId());
@@ -375,38 +409,46 @@ public class StreamsGroupMemberTest {
 
     @Test
     public void testHasAssignedTasksChanged() {
+        TasksTupleWithEpochs assignedTasks1 = new TasksTupleWithEpochs(
+            mkTasksPerSubtopologyWithCommonEpoch(MEMBER_EPOCH, mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS1))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS2))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS3)))
+        );
         StreamsGroupMember member1 = new StreamsGroupMember.Builder(MEMBER_ID)
-            .setAssignedTasks(new TasksTuple(
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS1))),
-                mkMap(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS2))),
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS3)))
-            ))
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setAssignedTasks(assignedTasks1)
             .build();
 
+        TasksTupleWithEpochs assignedTasks2 = new TasksTupleWithEpochs(
+            mkTasksPerSubtopologyWithCommonEpoch(MEMBER_EPOCH, mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS4))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS5))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS6)))
+        );
         StreamsGroupMember member2 = new StreamsGroupMember.Builder(MEMBER_ID)
-            .setAssignedTasks(new TasksTuple(
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS4))),
-                mkMap(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS5))),
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS6)))
-            ))
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setAssignedTasks(assignedTasks2)
             .build();
 
         assertTrue(StreamsGroupMember.hasAssignedTasksChanged(member1, member2));
 
+        TasksTupleWithEpochs assignedTasks3 = new TasksTupleWithEpochs(
+            mkTasksPerSubtopologyWithCommonEpoch(MEMBER_EPOCH, mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS1))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS2))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS3)))
+        );
         StreamsGroupMember member3 = new StreamsGroupMember.Builder(MEMBER_ID)
-            .setAssignedTasks(new TasksTuple(
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS1))),
-                mkMap(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS2))),
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS3)))
-            ))
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setAssignedTasks(assignedTasks3)
             .build();
 
+        TasksTupleWithEpochs assignedTasks4 = new TasksTupleWithEpochs(
+            mkTasksPerSubtopologyWithCommonEpoch(MEMBER_EPOCH, mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS1))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS2))),
+            mkTasksPerSubtopology(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS3)))
+        );
         StreamsGroupMember member4 = new StreamsGroupMember.Builder(MEMBER_ID)
-            .setAssignedTasks(new TasksTuple(
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS1))),
-                mkMap(mkEntry(SUBTOPOLOGY2, new HashSet<>(TASKS2))),
-                mkMap(mkEntry(SUBTOPOLOGY1, new HashSet<>(TASKS3)))
-            ))
+            .setMemberEpoch(MEMBER_EPOCH)
+            .setAssignedTasks(assignedTasks4)
             .build();
 
         assertFalse(StreamsGroupMember.hasAssignedTasksChanged(member3, member4));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -71,14 +71,12 @@ public class StreamsGroupMemberTest {
     private static final List<Integer> TASKS4 = List.of(3, 2, 1);
     private static final List<Integer> TASKS5 = List.of(6, 5, 4);
     private static final List<Integer> TASKS6 = List.of(9, 7);
-    // Assignment epochs for active tasks: task 1 -> epoch 5, task 2 -> epoch 6, task 3 -> epoch 7
     private static final TasksTupleWithEpochs ASSIGNED_TASKS =
         new TasksTupleWithEpochs(
             mkMap(mkEntry(SUBTOPOLOGY1, mkMap(mkEntry(1, 5), mkEntry(2, 6), mkEntry(3, 7)))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS2.toArray(Integer[]::new))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS3.toArray(Integer[]::new)))
         );
-    // Assignment epochs for active tasks pending revocation: task 3 -> epoch 4, task 2 -> epoch 3, task 1 -> epoch 2
     private static final TasksTupleWithEpochs TASKS_PENDING_REVOCATION =
         new TasksTupleWithEpochs(
             mkMap(mkEntry(SUBTOPOLOGY2, mkMap(mkEntry(3, 4), mkEntry(2, 3), mkEntry(1, 2)))),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
-import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopologyWithCommonEpoch;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -223,15 +223,15 @@ public class StreamsGroupTest {
         member = new StreamsGroupMember.Builder("member")
             .setProcessId("process")
             .setAssignedTasks(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopology, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopology, 1)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopology, 2)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopology, 3))
                 )
             )
             .setTasksPendingRevocation(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(barSubtopology, 4)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(barSubtopology, 4)),
                     mkTasksPerSubtopology(mkTasks(barSubtopology, 5)),
                     mkTasksPerSubtopology(mkTasks(barSubtopology, 6))
                 )
@@ -259,15 +259,15 @@ public class StreamsGroupTest {
         member = new StreamsGroupMember.Builder(member)
             .setProcessId("process1")
             .setAssignedTasks(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopology, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopology, 1)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopology, 2)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopology, 3))
                 )
             )
             .setTasksPendingRevocation(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(barSubtopology, 4)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(barSubtopology, 4)),
                     mkTasksPerSubtopology(mkTasks(barSubtopology, 5)),
                     mkTasksPerSubtopology(mkTasks(barSubtopology, 6))
                 )
@@ -302,16 +302,10 @@ public class StreamsGroupTest {
 
         member = new StreamsGroupMember.Builder("member")
             .setProcessId("process")
-            .setAssignedTasks(
-                new TasksTuple(
-                    Map.of(),
-                    Map.of(),
-                    Map.of()
-                )
-            )
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
             .setTasksPendingRevocation(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 2)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 3))
                 )
@@ -325,13 +319,13 @@ public class StreamsGroupTest {
         member = new StreamsGroupMember.Builder(member)
             .setProcessId("process1")
             .setAssignedTasks(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 2)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 3))
                 )
             )
-            .setTasksPendingRevocation(TasksTuple.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build();
 
         streamsGroup.updateMember(member);
@@ -347,8 +341,8 @@ public class StreamsGroupTest {
         StreamsGroupMember m1 = new StreamsGroupMember.Builder("m1")
             .setProcessId("process")
             .setAssignedTasks(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                     Map.of(),
                     Map.of()
                 )
@@ -360,8 +354,8 @@ public class StreamsGroupTest {
         StreamsGroupMember m2 = new StreamsGroupMember.Builder("m2")
             .setProcessId("process")
             .setAssignedTasks(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                     Map.of(),
                     Map.of()
                 )
@@ -382,20 +376,20 @@ public class StreamsGroupTest {
 
         // Removing should fail because there is no epoch set.
         assertThrows(IllegalStateException.class, () -> streamsGroup.removeTaskProcessIds(
-            mkTasksTuple(taskRole, mkTasks(fooSubtopologyId, 1)),
+            TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
             "process"
         ));
 
         StreamsGroupMember m1 = new StreamsGroupMember.Builder("m1")
             .setProcessId("process")
-            .setAssignedTasks(mkTasksTuple(taskRole, mkTasks(fooSubtopologyId, 1)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)))
             .build();
 
         streamsGroup.updateMember(m1);
 
         // Removing should fail because the expected epoch is incorrect.
         assertThrows(IllegalStateException.class, () -> streamsGroup.removeTaskProcessIds(
-            mkTasksTuple(taskRole, mkTasks(fooSubtopologyId, 1)),
+            TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
             "process1"
         ));
     }
@@ -406,8 +400,8 @@ public class StreamsGroupTest {
         StreamsGroup streamsGroup = createStreamsGroup("foo");
 
         streamsGroup.addTaskProcessId(
-            new TasksTuple(
-                mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 1)),
+            new TasksTupleWithEpochs(
+                mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 2)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 3))
             ),
@@ -417,8 +411,8 @@ public class StreamsGroupTest {
         // Changing the epoch should fail because the owner of the partition
         // should remove it first.
         assertThrows(IllegalStateException.class, () -> streamsGroup.addTaskProcessId(
-            new TasksTuple(
-                mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 1)),
+            new TasksTupleWithEpochs(
+                mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 2)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 3))
             ),
@@ -438,15 +432,15 @@ public class StreamsGroupTest {
         member = new StreamsGroupMember.Builder("member")
             .setProcessId("process")
             .setAssignedTasks(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(fooSubtopology, 1)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopology, 1)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopology, 2)),
                     mkTasksPerSubtopology(mkTasks(fooSubtopology, 3))
                 )
             )
             .setTasksPendingRevocation(
-                new TasksTuple(
-                    mkTasksPerSubtopology(mkTasks(barSubtopology, 4)),
+                new TasksTupleWithEpochs(
+                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(barSubtopology, 4)),
                     mkTasksPerSubtopology(mkTasks(barSubtopology, 5)),
                     mkTasksPerSubtopology(mkTasks(barSubtopology, 6))
                 )
@@ -822,8 +816,8 @@ public class StreamsGroupTest {
             .setProcessId("process1")
             .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host1").setPort(9092))
             .setClientTags(Map.of("tag1", "value1"))
-            .setAssignedTasks(new TasksTuple(Map.of(), Map.of(), Map.of()))
-            .setTasksPendingRevocation(new TasksTuple(Map.of(), Map.of(), Map.of()))
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build());
         group.updateMember(new StreamsGroupMember.Builder("member2")
             .setMemberEpoch(1)
@@ -838,8 +832,8 @@ public class StreamsGroupTest {
             .setProcessId("process2")
             .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host2").setPort(9092))
             .setClientTags(Map.of("tag2", "value2"))
-            .setAssignedTasks(new TasksTuple(Map.of(), Map.of(), Map.of()))
-            .setTasksPendingRevocation(new TasksTuple(Map.of(), Map.of(), Map.of()))
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build());
         snapshotRegistry.idempotentCreateSnapshot(1);
 
@@ -1047,8 +1041,8 @@ public class StreamsGroupTest {
             .setProcessId("process1")
             .setUserEndpoint(new StreamsGroupMemberMetadataValue.Endpoint().setHost("host1").setPort(9092))
             .setClientTags(Map.of("tag1", "value1"))
-            .setAssignedTasks(new TasksTuple(Map.of(), Map.of(), Map.of()))
-            .setTasksPendingRevocation(new TasksTuple(Map.of(), Map.of(), Map.of()))
+            .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build());
         snapshotRegistry.idempotentCreateSnapshot(1);
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
@@ -40,6 +40,24 @@ public class TaskAssignmentTestUtil {
         };
     }
 
+    @SafeVarargs
+    public static TasksTupleWithEpochs mkTasksTupleWithCommonEpoch(TaskRole taskRole, int defaultAssignmentEpoch, Map.Entry<String, Set<Integer>>... entries) {
+        return switch (taskRole) {
+            case ACTIVE -> new TasksTupleWithEpochs(mkTasksPerSubtopologyWithCommonEpoch(defaultAssignmentEpoch, entries), new HashMap<>(), new HashMap<>());
+            case STANDBY -> new TasksTupleWithEpochs(new HashMap<>(), mkTasksPerSubtopology(entries), new HashMap<>());
+            case WARMUP -> new TasksTupleWithEpochs(new HashMap<>(), new HashMap<>(), mkTasksPerSubtopology(entries));
+        };
+    }
+
+    @SafeVarargs
+    public static TasksTupleWithEpochs mkTasksTupleWithEpochs(TaskRole taskRole, Map.Entry<String, Map<Integer, Integer>>... entries) {
+        return switch (taskRole) {
+            case ACTIVE -> new TasksTupleWithEpochs(mkTasksWithEpochsPerSubtopology(entries), new HashMap<>(), new HashMap<>());
+            case STANDBY -> new TasksTupleWithEpochs(new HashMap<>(), mkTasksPerSubtopologyStripEpoch(entries), new HashMap<>());
+            case WARMUP -> new TasksTupleWithEpochs(new HashMap<>(), new HashMap<>(), mkTasksPerSubtopologyStripEpoch(entries));
+        };
+    }
+
     public static Map.Entry<String, Set<Integer>> mkTasks(String subtopologyId,
                                                           Integer... tasks) {
         return new AbstractMap.SimpleEntry<>(
@@ -48,10 +66,49 @@ public class TaskAssignmentTestUtil {
         );
     }
 
+    public static Map.Entry<String, Map<Integer, Integer>> mkTasksWithEpochs(String subtopologyId,
+                                                                             Map<Integer, Integer> tasks) {
+        return new AbstractMap.SimpleEntry<>(
+            subtopologyId,
+            tasks
+        );
+    }
+
     @SafeVarargs
     public static Map<String, Set<Integer>> mkTasksPerSubtopology(Map.Entry<String, Set<Integer>>... entries) {
         Map<String, Set<Integer>> assignment = new HashMap<>();
         for (Map.Entry<String, Set<Integer>> entry : entries) {
+            assignment.put(entry.getKey(), entry.getValue());
+        }
+        return assignment;
+    }
+
+    @SafeVarargs
+    public static Map<String, Set<Integer>> mkTasksPerSubtopologyStripEpoch(Map.Entry<String, Map<Integer, Integer>>... entries) {
+        Map<String, Set<Integer>> assignment = new HashMap<>();
+        for (Map.Entry<String, Map<Integer, Integer>> entry : entries) {
+            assignment.put(entry.getKey(), entry.getValue().keySet());
+        }
+        return assignment;
+    }
+
+    @SafeVarargs
+    public static Map<String, Map<Integer, Integer>> mkTasksPerSubtopologyWithCommonEpoch(int defaultAssignmentEpoch, Map.Entry<String, Set<Integer>>... entries) {
+        Map<String, Map<Integer, Integer>> assignment = new HashMap<>();
+        for (Map.Entry<String, Set<Integer>> entry : entries) {
+            Map<Integer, Integer> partitionEpochMap = new HashMap<>();
+            for (Integer partition : entry.getValue()) {
+                partitionEpochMap.put(partition, defaultAssignmentEpoch);
+            }
+            assignment.put(entry.getKey(), partitionEpochMap);
+        }
+        return assignment;
+    }
+
+    @SafeVarargs
+    public static Map<String, Map<Integer, Integer>> mkTasksWithEpochsPerSubtopology(Map.Entry<String, Map<Integer, Integer>>... entries) {
+        Map<String, Map<Integer, Integer>> assignment = new HashMap<>();
+        for (Map.Entry<String, Map<Integer, Integer>> entry : entries) {
             assignment.put(entry.getKey(), entry.getValue());
         }
         return assignment;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleTest.java
@@ -122,27 +122,6 @@ public class TasksTupleTest {
     }
 
     @Test
-    public void testMerge() {
-        TasksTuple tuple1 = new TasksTuple(
-            Map.of(SUBTOPOLOGY_1, Set.of(1, 2, 3)),
-            Map.of(SUBTOPOLOGY_2, Set.of(4, 5, 6)),
-            Map.of(SUBTOPOLOGY_3, Set.of(7, 8, 9))
-        );
-
-        TasksTuple tuple2 = new TasksTuple(
-            Map.of(SUBTOPOLOGY_1, Set.of(10, 11)),
-            Map.of(SUBTOPOLOGY_2, Set.of(12, 13)),
-            Map.of(SUBTOPOLOGY_3, Set.of(14, 15))
-        );
-
-        TasksTuple mergedTuple = tuple1.merge(tuple2);
-
-        assertEquals(Map.of(SUBTOPOLOGY_1, Set.of(1, 2, 3, 10, 11)), mergedTuple.activeTasks());
-        assertEquals(Map.of(SUBTOPOLOGY_2, Set.of(4, 5, 6, 12, 13)), mergedTuple.standbyTasks());
-        assertEquals(Map.of(SUBTOPOLOGY_3, Set.of(7, 8, 9, 14, 15)), mergedTuple.warmupTasks());
-    }
-
-    @Test
     public void testContainsAny() {
         TasksTuple tuple1 = new TasksTuple(
             Map.of(SUBTOPOLOGY_1, Set.of(1, 2, 3)),
@@ -150,21 +129,41 @@ public class TasksTupleTest {
             Map.of(SUBTOPOLOGY_3, Set.of(7, 8, 9))
         );
 
-        TasksTuple tuple2 = new TasksTuple(
-            Map.of(SUBTOPOLOGY_1, Set.of(3, 10, 11)),
+        // Test with overlapping active tasks
+        TasksTupleWithEpochs tuple2 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(3, 5, 10, 5, 11, 5)),
             Map.of(SUBTOPOLOGY_2, Set.of(12, 13)),
             Map.of(SUBTOPOLOGY_3, Set.of(14, 15))
         );
 
         assertTrue(tuple1.containsAny(tuple2));
 
-        TasksTuple tuple3 = new TasksTuple(
-            Map.of(SUBTOPOLOGY_1, Set.of(10, 11)),
+        // Test with no overlapping tasks
+        TasksTupleWithEpochs tuple3 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(10, 5, 11, 5)),
             Map.of(SUBTOPOLOGY_2, Set.of(12, 13)),
             Map.of(SUBTOPOLOGY_3, Set.of(14, 15))
         );
 
         assertFalse(tuple1.containsAny(tuple3));
+
+        // Test with overlapping standby tasks
+        TasksTupleWithEpochs tuple4 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(10, 5, 11, 5)),
+            Map.of(SUBTOPOLOGY_2, Set.of(4, 12, 13)),
+            Map.of(SUBTOPOLOGY_3, Set.of(14, 15))
+        );
+
+        assertTrue(tuple1.containsAny(tuple4));
+
+        // Test with overlapping warmup tasks
+        TasksTupleWithEpochs tuple5 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(10, 5, 11, 5)),
+            Map.of(SUBTOPOLOGY_2, Set.of(12, 13)),
+            Map.of(SUBTOPOLOGY_3, Set.of(7, 14, 15))
+        );
+
+        assertTrue(tuple1.containsAny(tuple5));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TasksTupleWithEpochsTest {
+
+    private static final String SUBTOPOLOGY_1 = "1";
+    private static final String SUBTOPOLOGY_2 = "2";
+    private static final String SUBTOPOLOGY_3 = "3";
+
+    @Test
+    public void testTasksCannotBeNull() {
+        assertThrows(NullPointerException.class, () -> new TasksTupleWithEpochs(null, Map.of(), Map.of()));
+        assertThrows(NullPointerException.class, () -> new TasksTupleWithEpochs(Map.of(), null, Map.of()));
+        assertThrows(NullPointerException.class, () -> new TasksTupleWithEpochs(Map.of(), Map.of(), null));
+    }
+
+    @Test
+    public void testReturnUnmodifiableTaskAssignments() {
+        Map<String, Map<Integer, Integer>> activeTasks = Map.of(
+            SUBTOPOLOGY_1, Map.of(1, 10, 2, 11, 3, 12)
+        );
+        Map<String, Set<Integer>> standbyTasks = mkTasksPerSubtopology(
+            mkTasks(SUBTOPOLOGY_2, 9, 8, 7)
+        );
+        Map<String, Set<Integer>> warmupTasks = mkTasksPerSubtopology(
+            mkTasks(SUBTOPOLOGY_3, 4, 5, 6)
+        );
+        TasksTupleWithEpochs tuple = new TasksTupleWithEpochs(activeTasks, standbyTasks, warmupTasks);
+
+        assertEquals(activeTasks, tuple.activeTasksWithEpochs());
+        assertThrows(UnsupportedOperationException.class, () -> tuple.activeTasksWithEpochs().put("not allowed", Map.of()));
+        assertEquals(standbyTasks, tuple.standbyTasks());
+        assertThrows(UnsupportedOperationException.class, () -> tuple.standbyTasks().put("not allowed", Set.of()));
+        assertEquals(warmupTasks, tuple.warmupTasks());
+        assertThrows(UnsupportedOperationException.class, () -> tuple.warmupTasks().put("not allowed", Set.of()));
+    }
+
+    @Test
+    public void testActiveTasksMethod() {
+        Map<String, Map<Integer, Integer>> activeTasks = Map.of(
+            SUBTOPOLOGY_1, Map.of(1, 10, 2, 11, 3, 12),
+            SUBTOPOLOGY_2, Map.of(4, 20, 5, 21)
+        );
+        TasksTupleWithEpochs tuple = new TasksTupleWithEpochs(activeTasks, Map.of(), Map.of());
+
+        Map<String, Set<Integer>> expectedActiveTasks = mkTasksPerSubtopology(
+            mkTasks(SUBTOPOLOGY_1, 1, 2, 3),
+            mkTasks(SUBTOPOLOGY_2, 4, 5)
+        );
+
+        assertEquals(expectedActiveTasks, tuple.activeTasks());
+    }
+
+    @Test
+    public void testFromCurrentAssignmentRecord() {
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> activeTasks = new ArrayList<>();
+        activeTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(1, 2, 3))
+            .setAssignmentEpochs(Arrays.asList(10, 11, 12)));
+        activeTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setPartitions(Arrays.asList(4, 5, 6))
+            .setAssignmentEpochs(Arrays.asList(20, 21, 22)));
+
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> standbyTasks = new ArrayList<>();
+        standbyTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(7, 8, 9)));
+        standbyTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setPartitions(Arrays.asList(1, 2, 3)));
+
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> warmupTasks = new ArrayList<>();
+        warmupTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(4, 5, 6)));
+        warmupTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_2)
+            .setPartitions(Arrays.asList(7, 8, 9)));
+
+        TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(
+            activeTasks, standbyTasks, warmupTasks, 100
+        );
+
+        assertEquals(
+            Map.of(
+                SUBTOPOLOGY_1, Map.of(1, 10, 2, 11, 3, 12),
+                SUBTOPOLOGY_2, Map.of(4, 20, 5, 21, 6, 22)
+            ),
+            tuple.activeTasksWithEpochs()
+        );
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_1, 7, 8, 9),
+                mkTasks(SUBTOPOLOGY_2, 1, 2, 3)
+            ),
+            tuple.standbyTasks()
+        );
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_1, 4, 5, 6),
+                mkTasks(SUBTOPOLOGY_2, 7, 8, 9)
+            ),
+            tuple.warmupTasks()
+        );
+    }
+
+    @Test
+    public void testFromCurrentAssignmentRecordWithoutEpochs() {
+        // Test legacy format where epochs are not present
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> activeTasks = new ArrayList<>();
+        activeTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(1, 2, 3)));
+
+        int memberEpoch = 100;
+        TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(
+            activeTasks, List.of(), List.of(), memberEpoch
+        );
+
+        // Should use member epoch as default
+        assertEquals(
+            Map.of(SUBTOPOLOGY_1, Map.of(1, memberEpoch, 2, memberEpoch, 3, memberEpoch)),
+            tuple.activeTasksWithEpochs()
+        );
+    }
+
+    @Test
+    public void testFromCurrentAssignmentRecordWithMismatchedEpochs() {
+        // Test error case where number of epochs doesn't match number of partitions
+        List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> activeTasks = new ArrayList<>();
+        activeTasks.add(new StreamsGroupCurrentMemberAssignmentValue.TaskIds()
+            .setSubtopologyId(SUBTOPOLOGY_1)
+            .setPartitions(Arrays.asList(1, 2, 3))
+            .setAssignmentEpochs(Arrays.asList(10, 11))); // Only 2 epochs for 3 partitions
+
+        assertThrows(IllegalStateException.class, () ->
+            TasksTupleWithEpochs.fromCurrentAssignmentRecord(activeTasks, List.of(), List.of(), 100)
+        );
+    }
+
+    @Test
+    public void testIsEmpty() {
+        TasksTupleWithEpochs emptyTuple = new TasksTupleWithEpochs(Map.of(), Map.of(), Map.of());
+        assertTrue(emptyTuple.isEmpty());
+        assertEquals(TasksTupleWithEpochs.EMPTY, emptyTuple);
+
+        TasksTupleWithEpochs nonEmptyTuple = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(1, 10)),
+            Map.of(),
+            Map.of()
+        );
+        assertFalse(nonEmptyTuple.isEmpty());
+    }
+
+    @Test
+    public void testMerge() {
+        TasksTupleWithEpochs tuple1 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(1, 10, 2, 11)),
+            Map.of(SUBTOPOLOGY_2, Set.of(4, 5)),
+            Map.of(SUBTOPOLOGY_3, Set.of(7, 8))
+        );
+
+        TasksTupleWithEpochs tuple2 = new TasksTupleWithEpochs(
+            Map.of(
+                SUBTOPOLOGY_1, Map.of(3, 13), // Different partition in same subtopology
+                SUBTOPOLOGY_2, Map.of(6, 26)  // Different subtopology
+            ),
+            Map.of(SUBTOPOLOGY_2, Set.of(9, 10)),
+            Map.of(SUBTOPOLOGY_3, Set.of(11, 12))
+        );
+
+        TasksTupleWithEpochs merged = tuple1.merge(tuple2);
+
+        assertEquals(
+            Map.of(
+                SUBTOPOLOGY_1, Map.of(1, 10, 2, 11, 3, 13),
+                SUBTOPOLOGY_2, Map.of(6, 26)
+            ),
+            merged.activeTasksWithEpochs()
+        );
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_2, 4, 5, 9, 10)
+            ),
+            merged.standbyTasks()
+        );
+        assertEquals(
+            mkTasksPerSubtopology(
+                mkTasks(SUBTOPOLOGY_3, 7, 8, 11, 12)
+            ),
+            merged.warmupTasks()
+        );
+    }
+
+    @Test
+    public void testMergeWithOverlappingActiveTasks() {
+        // When merging overlapping active tasks, epochs from the second tuple take precedence
+        TasksTupleWithEpochs tuple1 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(1, 10, 2, 11)),
+            Map.of(),
+            Map.of()
+        );
+
+        TasksTupleWithEpochs tuple2 = new TasksTupleWithEpochs(
+            Map.of(SUBTOPOLOGY_1, Map.of(1, 99, 3, 13)), // partition 1 overlaps with different epoch
+            Map.of(),
+            Map.of()
+        );
+
+        TasksTupleWithEpochs merged = tuple1.merge(tuple2);
+
+        // Epoch for partition 1 should be from tuple2 (99, not 10) since the second tuple takes precedence
+        assertEquals(99, merged.activeTasksWithEpochs().get(SUBTOPOLOGY_1).get(1));
+        assertEquals(11, merged.activeTasksWithEpochs().get(SUBTOPOLOGY_1).get(2));
+        assertEquals(13, merged.activeTasksWithEpochs().get(SUBTOPOLOGY_1).get(3));
+    }
+
+    @Test
+    public void testToString() {
+        TasksTupleWithEpochs tuple = new TasksTupleWithEpochs(
+            Map.of(
+                SUBTOPOLOGY_1, Map.of(1, 10, 2, 11),
+                SUBTOPOLOGY_2, Map.of(3, 20)
+            ),
+            Map.of(SUBTOPOLOGY_2, Set.of(4, 5)),
+            Map.of(SUBTOPOLOGY_3, Set.of(6))
+        );
+
+        String result = tuple.toString();
+        
+        // Verify the exact toString format
+        assertEquals(
+            "(active=[1-1@10, 1-2@11, 2-3@20], " +
+            "standby=[2-4, 2-5], " +
+            "warmup=[3-6])",
+            result
+        );
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
@@ -67,21 +67,6 @@ public class TasksTupleWithEpochsTest {
         assertThrows(UnsupportedOperationException.class, () -> tuple.warmupTasks().put("not allowed", Set.of()));
     }
 
-    @Test
-    public void testActiveTasksMethod() {
-        Map<String, Map<Integer, Integer>> activeTasks = Map.of(
-            SUBTOPOLOGY_1, Map.of(1, 10, 2, 11, 3, 12),
-            SUBTOPOLOGY_2, Map.of(4, 20, 5, 21)
-        );
-        TasksTupleWithEpochs tuple = new TasksTupleWithEpochs(activeTasks, Map.of(), Map.of());
-
-        Map<String, Set<Integer>> expectedActiveTasks = mkTasksPerSubtopology(
-            mkTasks(SUBTOPOLOGY_1, 1, 2, 3),
-            mkTasks(SUBTOPOLOGY_2, 4, 5)
-        );
-
-        assertEquals(expectedActiveTasks, tuple.activeTasks());
-    }
 
     @Test
     public void testFromCurrentAssignmentRecord() {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/topics/EndpointToPartitionsManagerTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
-import org.apache.kafka.coordinator.group.streams.TasksTuple;
+import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.image.MetadataImage;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +44,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopology;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksPerSubtopologyWithCommonEpoch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
@@ -56,9 +59,6 @@ class EndpointToPartitionsManagerTest {
     private ConfiguredTopology configuredTopology;
     private ConfiguredSubtopology configuredSubtopologyOne;
     private ConfiguredSubtopology configuredSubtopologyTwo;
-    private final Map<String, Set<Integer>> activeTasks = new HashMap<>();
-    private final Map<String, Set<Integer>> standbyTasks = new HashMap<>();
-    private TasksTuple tasksTuple;
     private final StreamsGroupHeartbeatResponseData.Endpoint responseEndpoint = new StreamsGroupHeartbeatResponseData.Endpoint();
 
     @BeforeEach
@@ -86,11 +86,13 @@ class EndpointToPartitionsManagerTest {
             .addTopic(Uuid.randomUuid(), "Topic-B", 3)
             .build();
 
-        activeTasks.put("0", Set.of(0, 1, 2));
-        standbyTasks.put("1", Set.of(0, 1, 2));
-        tasksTuple = new TasksTuple(activeTasks, standbyTasks, Collections.emptyMap());
-        when(streamsGroupMember.assignedTasks()).thenReturn(tasksTuple);
-        //when(streamsGroupMember.assignedTasks().standbyTasks()).thenReturn(tasksTuple.standbyTasks());
+        when(streamsGroupMember.assignedTasks()).thenReturn(
+            new TasksTupleWithEpochs(
+                mkTasksPerSubtopologyWithCommonEpoch(0, mkEntry("0", Set.of(0, 1, 2))),
+                mkTasksPerSubtopology(mkEntry("1", Set.of(0, 1, 2))),
+                Map.of()
+            )
+        );
         when(streamsGroup.configuredTopology()).thenReturn(Optional.of(configuredTopology));
         SortedMap<String, ConfiguredSubtopology> configuredSubtopologyMap = new TreeMap<>();
         configuredSubtopologyMap.put("0", configuredSubtopologyOne);
@@ -131,8 +133,13 @@ class EndpointToPartitionsManagerTest {
             .build();
         configuredSubtopologyOne = new ConfiguredSubtopology(Math.max(topicAPartitions, topicBPartitions), Set.of("Topic-A", "Topic-B"), new HashMap<>(), new HashSet<>(), new HashMap<>());
 
-        activeTasks.put("0", Set.of(0, 1, 2, 3, 4));
-        when(streamsGroupMember.assignedTasks()).thenReturn(new TasksTuple(activeTasks, Collections.emptyMap(), Collections.emptyMap()));
+        when(streamsGroupMember.assignedTasks()).thenReturn(
+            new TasksTupleWithEpochs(
+                mkTasksPerSubtopologyWithCommonEpoch(0, mkEntry("0", Set.of(0, 1, 2, 3, 4))),
+                Map.of(),
+                Map.of()
+            )
+        );
         when(streamsGroup.configuredTopology()).thenReturn(Optional.of(configuredTopology));
         SortedMap<String, ConfiguredSubtopology> configuredSubtopologyOneMap = new TreeMap<>();
         configuredSubtopologyOneMap.put("0", configuredSubtopologyOne);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsAssignorBenchmarkUtils.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsAssignorBenchmarkUtils.java
@@ -56,9 +56,9 @@ public class StreamsAssignorBenchmarkUtils {
             memberSpecs.put(memberId, new AssignmentMemberSpec(
                 member.instanceId(),
                 member.rackId(),
-                member.assignedTasks().activeTasks(),
-                member.assignedTasks().standbyTasks(),
-                member.assignedTasks().warmupTasks(),
+                Map.of(),
+                Map.of(),
+                Map.of(),
                 member.processId(),
                 member.clientTags(),
                 Map.of(),


### PR DESCRIPTION
This PR implements assignment epoch tracking for streams groups.

Fundamentally, this replaces the representation of current assignments
and pending revocations from Map<String, Set<Integer>> to Map<String,
Map<Integer, Integer>> where the  value of the inner map is the
assignment epoch. Target assignments, and the tasks reported  as
currently owned, still use the former representation, since they do not
include assignment epochs. This change only applies to active tasks.
From `TasksTuple`, we create `TasksTupleWithEpochs`, which carries the
assignment epochs.

The core of the change is in `CurrentAssignmentBuilder`, which takes the
previous assignment epochs from `assignedTasks` and
`tasksPendingRevocation` and applies them to all tasks in the new
assignment. If a task in the new assignment was not previously assigned,
it gets the targetAssignmentEpoch, that the member transitions to.

There are a lot of mechanic follow-up changes to use
`TasksTupleWithEpochs` in-place of `TasksTuple`. In general, I tried to
follow the following strategy when adapting existing tests:   - When
assignment epochs do no play a role in a test, we instantiate all tasks
with the same assignments epoch using TestAssignmentUtils.   - The main
tests for correctly updating the assignment epoch are in
`CurrentAssignmentBuilderTest`.

Reviewers: David Jacot <djacot@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
