### PR TITLE
MINOR: A few more annotations for removal deprecation in tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -58,6 +58,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         return null;
     }
 
+    @SuppressWarnings("removal")
     @Override
     public Subscription buildSubscriptionV1(List<String> topics, List<TopicPartition> partitions, int generationId, int consumerIndex) {
         assignor.onAssignment(new ConsumerPartitionAssignor.Assignment(partitions), new ConsumerGroupMetadata(groupId, generationId, consumer1, Optional.empty()));
@@ -69,12 +70,14 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         return new Subscription(topics, assignor.subscriptionUserData(new HashSet<>(topics)), partitions, generationId, consumerRackId(consumerIndex));
     }
 
+    @SuppressWarnings("removal")
     @Override
     public ByteBuffer generateUserData(List<String> topics, List<TopicPartition> partitions, int generation) {
         assignor.onAssignment(new ConsumerPartitionAssignor.Assignment(partitions), new ConsumerGroupMetadata(groupId, generationId, consumer1, Optional.empty()));
         return assignor.subscriptionUserData(new HashSet<>(topics));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testEncodeAndDecodeGeneration() {
         Subscription subscription = new Subscription(topics(topic), assignor.subscriptionUserData(new HashSet<>(topics(topic))));
@@ -141,6 +144,7 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testMemberDataWithInconsistentData() {
         List<TopicPartition> ownedPartitionsInUserdata = partitions(tp1);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -313,6 +313,7 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
         assertTrue(isFullyBalanced(assignment));
     }
 
+    @SuppressWarnings("removal")
     @ParameterizedTest(name = TEST_NAME_WITH_RACK_CONFIG)
     @EnumSource(RackConfig.class)
     public void testMemberDataWithInconsistentData(RackConfig rackConfig) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -1364,6 +1364,7 @@ public class AsyncKafkaConsumerTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testGroupMetadataIsResetAfterUnsubscribe() {
         final String groupId = "consumerGroupA";

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1970,6 +1970,7 @@ public class KafkaProducerTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSendTxnOffsetsWithGroupId() {
         Map<String, Object> configs = new HashMap<>();
@@ -2187,6 +2188,7 @@ public class KafkaProducerTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSendTxnOffsetsWithGroupMetadata() {
         final short maxVersion = (short) 3;
@@ -2241,6 +2243,7 @@ public class KafkaProducerTest {
         verifyInvalidGroupMetadata(null);
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testInvalidGenerationIdAndMemberIdCombinedInSendOffsets() {
         verifyInvalidGroupMetadata(new ConsumerGroupMetadata("group", 2, JoinGroupRequest.UNKNOWN_MEMBER_ID, Optional.empty()));


### PR DESCRIPTION
A few more compiler warnings from
https://github.com/apache/kafka/pull/18977 in tests.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
