### PR TITLE
MINOR: Enhance reportCoverage docs with coverage report output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Generate coverage for a single module, i.e.:
 
     ./gradlew clients:reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false
 
-Reports are placed in the respective module's build directory, using the tool specific to the module's language (JaCoCo for Java, Scoverage for Scala).
+Reports are placed in the respective module's build directory, using the tool specific to the module's language (JaCoCo for all modules except :core, which uses Scoverage as it is a Scala project).
 You can find the HTML reports at the following locations: 
 
     <module>/build/reports/jacoco/test/html/index.html

--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ Generate coverage reports for the whole project:
 Generate coverage for a single module, i.e.: 
 
     ./gradlew clients:reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false
-    
+
+Reports are placed in the respective module's build directory, using the tool specific to the module's language (JaCoCo for Java, Scoverage for Scala).
+You can find the HTML reports at the following locations: 
+
+    <module>/build/reports/jacoco/test/html/index.html
+
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Generate coverage for a single module, i.e.:
 
 Coverage reports are located within the module's build directory, categorized by module type:
 
-Java Modules: `<module>/build/reports/jacoco/test/html/index.html`
+Core Module (:core): `core/build/reports/scoverageTest/index.html`
 
-Scala Module (:core): `core/build/reports/scoverageTest/index.html`
+Other Modules: `<module>/build/reports/jacoco/test/html/index.html`
 
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ Generate coverage for a single module, i.e.:
 
     ./gradlew clients:reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false
 
-Reports are located in the module's build directory. JaCoCo is used for all modules, except for the Scala-based :core which uses Scoverage.
+Coverage reports are located within the module's build directory, categorized by module type:
 
-JaCoCo (Java Modules): `<module>/build/reports/jacoco/test/html/index.html`
+Java Modules: `<module>/build/reports/jacoco/test/html/index.html`
 
-Scoverage (:core): `core/build/reports/scoverageTest/index.html`
+Scala Module (:core): `core/build/reports/scoverageTest/index.html`
 
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ Generate coverage for a single module, i.e.:
 
     ./gradlew clients:reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false
 
-Reports are placed in the respective module's build directory, using the tool specific to the module's language (JaCoCo for all modules except :core, which uses Scoverage as it is a Scala project).
-You can find the HTML reports at the following locations: 
+Reports are located in the module's build directory. JaCoCo is used for all modules, except for the Scala-based :core which uses Scoverage.
 
-    <module>/build/reports/jacoco/test/html/index.html
+JaCoCo (Java Modules): `<module>/build/reports/jacoco/test/html/index.html`
+
+Scoverage (:core): `core/build/reports/scoverageTest/index.html`
 
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz


### PR DESCRIPTION
This PR updates the documentation to clearly specify the HTML report
paths generated by the reportCoverage task.

We use Scoverage for the Scala module (:core) and JaCoCo for all other
modules. This ensures developers can quickly locate all generated
coverage reports.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
