### PR TITLE
KAFKA-19767: Add partitions to share fetch buffer together

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -87,8 +88,7 @@ public class ShareFetchBufferTest {
         try (ShareFetchBuffer fetchBuffer = new ShareFetchBuffer(logContext)) {
             ShareCompletedFetch completedFetch = completedFetch(topicAPartition0);
             assertTrue(fetchBuffer.isEmpty());
-            fetchBuffer.add(completedFetch);
-            assertTrue(fetchBuffer.hasCompletedFetches(p -> true));
+            fetchBuffer.add(List.of(completedFetch));
             assertFalse(fetchBuffer.isEmpty());
             assertNotNull(fetchBuffer.peek());
             assertSame(completedFetch, fetchBuffer.peek());
@@ -111,7 +111,7 @@ public class ShareFetchBufferTest {
             assertNull(fetchBuffer.nextInLineFetch());
             assertTrue(fetchBuffer.isEmpty());
 
-            fetchBuffer.add(completedFetch(topicAPartition0));
+            fetchBuffer.add(List.of(completedFetch(topicAPartition0)));
             assertFalse(fetchBuffer.isEmpty());
 
             fetchBuffer.setNextInLineFetch(completedFetch(topicAPartition0));
@@ -132,8 +132,7 @@ public class ShareFetchBufferTest {
     public void testBufferedPartitions() {
         try (ShareFetchBuffer fetchBuffer = new ShareFetchBuffer(logContext)) {
             fetchBuffer.setNextInLineFetch(completedFetch(topicAPartition0));
-            fetchBuffer.add(completedFetch(topicAPartition1));
-            fetchBuffer.add(completedFetch(topicAPartition2));
+            fetchBuffer.add(List.of(completedFetch(topicAPartition1), completedFetch(topicAPartition2)));
             assertEquals(allPartitions, fetchBuffer.bufferedPartitions());
 
             fetchBuffer.setNextInLineFetch(null);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
@@ -95,7 +95,7 @@ public class ShareFetchCollectorTest {
 
         // Validate that the buffer is empty until after we add the fetch data.
         assertTrue(fetchBuffer.isEmpty());
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
         assertFalse(fetchBuffer.isEmpty());
 
         // Validate that the completed fetch isn't initialized just because we add it to the buffer.
@@ -153,7 +153,7 @@ public class ShareFetchCollectorTest {
         ShareCompletedFetch completedFetch = completedFetchBuilder
                 .recordCount(10)
                 .build();
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
 
         // At first, the queue is populated
         assertFalse(fetchBuffer.isEmpty());
@@ -170,7 +170,7 @@ public class ShareFetchCollectorTest {
         ShareCompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.TOPIC_AUTHORIZATION_FAILED)
                 .build();
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
         assertThrows(TopicAuthorizationException.class, () -> fetchCollector.collect(fetchBuffer));
     }
 
@@ -182,7 +182,7 @@ public class ShareFetchCollectorTest {
         ShareCompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.UNKNOWN_LEADER_EPOCH)
                 .build();
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
         ShareFetch<String, String> fetch = fetchCollector.collect(fetchBuffer);
         assertTrue(fetch.isEmpty());
     }
@@ -195,7 +195,7 @@ public class ShareFetchCollectorTest {
         ShareCompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.UNKNOWN_SERVER_ERROR)
                 .build();
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
         ShareFetch<String, String> fetch = fetchCollector.collect(fetchBuffer);
         assertTrue(fetch.isEmpty());
     }
@@ -208,7 +208,7 @@ public class ShareFetchCollectorTest {
         ShareCompletedFetch completedFetch = completedFetchBuilder
                 .error(Errors.CORRUPT_MESSAGE)
                 .build();
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
         assertThrows(KafkaException.class, () -> fetchCollector.collect(fetchBuffer));
     }
 
@@ -221,7 +221,7 @@ public class ShareFetchCollectorTest {
         ShareCompletedFetch completedFetch = completedFetchBuilder
                 .error(error)
                 .build();
-        fetchBuffer.add(completedFetch);
+        fetchBuffer.add(List.of(completedFetch));
         assertThrows(IllegalStateException.class, () -> fetchCollector.collect(fetchBuffer));
     }
 


### PR DESCRIPTION
For a ShareFetchResponse containing data from multiple partitions, the
code used to add the records for each partition separately to the share
fetch buffer, signalling completion for each. This small change adds
them all in the same operation.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
