### PR TITLE
KAFKA-19821: Duplicated batches should be logged

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1364,6 +1364,7 @@ public class UnifiedLog implements AutoCloseable {
 
                     Optional<BatchMetadata> duplicateBatch = maybeLastEntry.flatMap(e -> e.findDuplicateBatch(batch));
                     if (duplicateBatch.isPresent()) {
+                        logger.info("Found duplicate batch from client, duplicateBatchMetadata={}", duplicateBatch.get());
                         return new AnalyzeAndValidateProducerStateResult(updatedProducers, completedTxns, duplicateBatch);
                     }
                 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1214,6 +1214,8 @@ public class UnifiedLog implements AutoCloseable {
                                 appendInfo.setLastOffset(duplicate.lastOffset());
                                 appendInfo.setLogAppendTime(duplicate.timestamp());
                                 appendInfo.setLogStartOffset(logStartOffset);
+                                logger.info("Duplicate batch detected, returning AppendInfo from duplicate batch with last offset: {}, first offset: {}, next offset: {}, skipped messages: {}",
+                                        appendInfo.lastOffset(), appendInfo.firstOffset(), localLog.logEndOffset(), validRecords);
                             } else {
                                 // Append the records, and increment the local log end offset immediately after the append because a
                                 // write to the transaction index below may fail, and we want to ensure that the offsets
@@ -1364,7 +1366,6 @@ public class UnifiedLog implements AutoCloseable {
 
                     Optional<BatchMetadata> duplicateBatch = maybeLastEntry.flatMap(e -> e.findDuplicateBatch(batch));
                     if (duplicateBatch.isPresent()) {
-                        logger.info("Found duplicate batch from client, duplicateBatchMetadata={}", duplicateBatch.get());
                         return new AnalyzeAndValidateProducerStateResult(updatedProducers, completedTxns, duplicateBatch);
                     }
                 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1214,7 +1214,7 @@ public class UnifiedLog implements AutoCloseable {
                                 appendInfo.setLastOffset(duplicate.lastOffset());
                                 appendInfo.setLogAppendTime(duplicate.timestamp());
                                 appendInfo.setLogStartOffset(logStartOffset);
-                                logger.info("Duplicate batch detected, returning AppendInfo from duplicate batch with last offset: {}, first offset: {}, next offset: {}, skipped messages: {}",
+                                logger.trace("Duplicate batch detected, returning AppendInfo from duplicate batch with last offset: {}, first offset: {}, next offset: {}, skipped messages: {}",
                                         appendInfo.lastOffset(), appendInfo.firstOffset(), localLog.logEndOffset(), validRecords);
                             } else {
                                 // Append the records, and increment the local log end offset immediately after the append because a


### PR DESCRIPTION
When a duplicate batch is detected, the entire MemoryRecords instance is
skipped to prevent appending duplicate data to the log. This operation
is silent, adding a log.info message here to provide better
observability.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
