### PR TITLE
KAFKA-19756: Add documentation for Gradle version upgrade process

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,43 @@ only safe if the Scala library version is the same at compile time and runtime. 
 may depend on the kafka jar for integration tests where they may include a scala library with a different version), we don't enable it by
 default. See https://www.lightbend.com/blog/scala-inliner-optimizer for more details.
 
+### Upgrading Gradle version ###
+
+When upgrading the Gradle version used by the Kafka project, update the following files in order:
+
+1. **Update Gradle version** in `gradle/dependencies.gradle`:
+   ```groovy
+   gradle: "9.2.0"
+   ```
+
+2. **Update distribution checksums** in `gradle/wrapper/gradle-wrapper.properties`:
+   - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
+   - Update `distributionSha256Sum` with the Binary-only (-bin) ZIP Checksum
+   - Update `distributionUrl` to point to the new version:
+     ```properties
+     distributionSha256Sum=<sha256-checksum-from-release-page>
+     distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+     ```
+   - Verify the distribution URL is accessible
+
+3. **Update wrapper JAR checksum** in `wrapper.gradle`:
+   - Find the Wrapper JAR Checksum at https://gradle.org/release-checksums/
+   - Update the `wrapperChecksum` variable (line 42):
+     ```groovy
+     String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
+     ```
+   - Verify the wrapper JAR URL is accessible at:
+     `https://raw.githubusercontent.com/gradle/gradle/v<VERSION>/gradle/wrapper/gradle-wrapper.jar`
+
+4. **Regenerate the wrapper script**:
+   ```
+   ./gradlew wrapper
+   ```
+
+After upgrading, verify the Gradle version:
+
+    ./gradlew --version
+
 ### Running system tests ###
 
 See [tests/README.md](tests/README.md).

--- a/README.md
+++ b/README.md
@@ -267,40 +267,7 @@ default. See https://www.lightbend.com/blog/scala-inliner-optimizer for more det
 
 ### Upgrading Gradle version ###
 
-When upgrading the Gradle version used by the Kafka project, update the following files in order:
-
-1. **Update Gradle version** in `gradle/dependencies.gradle`:
-   ```groovy
-   gradle: "9.2.0"
-   ```
-
-2. **Update distribution checksums** in `gradle/wrapper/gradle-wrapper.properties`:
-   - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
-   - Update `distributionSha256Sum` with the Binary-only (-bin) ZIP Checksum
-   - Update `distributionUrl` to point to the new version:
-     ```properties
-     distributionSha256Sum=<sha256-checksum-from-release-page>
-     distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
-     ```
-   - Verify the distribution URL is accessible
-
-3. **Update wrapper JAR checksum** in `wrapper.gradle`:
-   - Find the Wrapper JAR Checksum at https://gradle.org/release-checksums/
-   - Update the `wrapperChecksum` variable (line 42):
-     ```groovy
-     String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
-     ```
-   - Verify the wrapper JAR URL is accessible at:
-     `https://raw.githubusercontent.com/gradle/gradle/v<VERSION>/gradle/wrapper/gradle-wrapper.jar`
-
-4. **Regenerate the wrapper script**:
-   ```
-   ./gradlew wrapper
-   ```
-
-After upgrading, verify the Gradle version:
-
-    ./gradlew --version
+See [gradle/wrapper/README.md](gradle/wrapper/README.md) for instructions on upgrading the Gradle version.
 
 ### Running system tests ###
 

--- a/gradle/wrapper/README.md
+++ b/gradle/wrapper/README.md
@@ -12,7 +12,7 @@ When upgrading the Gradle version used by the Kafka project, update the followin
    ```
 
 2. **Update wrapper JAR checksum** in `wrapper.gradle`:
-   - Find the Wrapper JAR Checksum at https://gradle.org/release-checksums/
+   - Find the ***Wrapper JAR Checksum*** at https://gradle.org/release-checksums/
    - Update the `wrapperChecksum` variable:
    ```groovy
    task bootstrapWrapper() {
@@ -29,7 +29,7 @@ When upgrading the Gradle version used by the Kafka project, update the followin
 
 
 3. **Regenerate the `gradle/wrapper/gradle-wrapper.properties` and the wrapper script**:
-   - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
+   - Find the ***Binary-only (-bin) ZIP Checksum*** for the binary distribution at https://gradle.org/release-checksums/
 
       ```shell
       ./gradlew wrapper --gradle-version <gradle-version> \

--- a/gradle/wrapper/README.md
+++ b/gradle/wrapper/README.md
@@ -1,0 +1,40 @@
+# Gradle Wrapper
+
+This directory contains the Gradle wrapper files for the Apache Kafka project.
+
+## Upgrading Gradle version
+
+When upgrading the Gradle version used by the Kafka project, update the following files in order:
+
+1. **Update Gradle version** in `gradle/dependencies.gradle`:
+   ```groovy
+   gradle: "9.2.0"
+   ```
+
+2. **Update distribution checksums** in `gradle/wrapper/gradle-wrapper.properties`:
+   - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
+   - Update `distributionSha256Sum` with the Binary-only (-bin) ZIP Checksum
+   - Update `distributionUrl` to point to the new version:
+     ```properties
+     distributionSha256Sum=<sha256-checksum-from-release-page>
+     distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+     ```
+   - Verify the distribution URL is accessible
+
+3. **Update wrapper JAR checksum** in `wrapper.gradle`:
+   - Find the Wrapper JAR Checksum at https://gradle.org/release-checksums/
+   - Update the `wrapperChecksum` variable (line 42):
+     ```groovy
+     String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
+     ```
+   - Verify the wrapper JAR URL is accessible at:
+     `https://raw.githubusercontent.com/gradle/gradle/v<VERSION>/gradle/wrapper/gradle-wrapper.jar`
+
+4. **Regenerate the wrapper script**:
+   ```
+   ./gradlew wrapper
+   ```
+
+After upgrading, verify the Gradle version:
+
+    ./gradlew --version

--- a/gradle/wrapper/README.md
+++ b/gradle/wrapper/README.md
@@ -11,33 +11,31 @@ When upgrading the Gradle version used by the Kafka project, update the followin
    gradle: "9.2.0"
    ```
 
-2. **Update distribution checksums** in `gradle/wrapper/gradle-wrapper.properties`:
-   - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
-   - Update `distributionSha256Sum` with the Binary-only (-bin) ZIP Checksum
-   - Update `distributionUrl` to use the latest version from `https://services.gradle.org/distributions/`:
-     ```properties
-     distributionSha256Sum=<sha256-checksum-from-release-page>
-     distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
-     ```
-   - Verify the distribution URL is accessible
-
-3. **Update wrapper JAR checksum** in `wrapper.gradle`:
+2. **Update wrapper JAR checksum** in `wrapper.gradle`:
    - Find the Wrapper JAR Checksum at https://gradle.org/release-checksums/
    - Update the `wrapperChecksum` variable:
    ```groovy
    task bootstrapWrapper() {
-    ...
-    doLast {
-        ...
-        String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
-     ```
+       // ... (other code)
+       doLast {
+           // ... (other code)
+           String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
+           // ...
+       }
+   }
+   ```
    - Verify the wrapper JAR URL is accessible at:
-     `https://raw.githubusercontent.com/gradle/gradle/v<VERSION>/gradle/wrapper/gradle-wrapper.jar`
+     `https://raw.githubusercontent.com/gradle/gradle/v<gradle-version>/gradle/wrapper/gradle-wrapper.jar`
 
-4. **Regenerate the wrapper script**:
-   ```
-   ./gradlew wrapper
-   ```
+
+3. **Regenerate the `gradle/wrapper/gradle-wrapper.properties` and the wrapper script**:
+   - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
+
+      ```shell
+      ./gradlew wrapper --gradle-version <gradle-version> \
+      --distribution-type bin \
+      --gradle-distribution-sha256-sum <binary-distribution-checksum>
+      ```
 
 After upgrading, verify the Gradle version:
 

--- a/gradle/wrapper/README.md
+++ b/gradle/wrapper/README.md
@@ -30,8 +30,6 @@ When upgrading the Gradle version used by the Kafka project, update the followin
     doLast {
         ...
         String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
-     ```groovy
-     String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
      ```
    - Verify the wrapper JAR URL is accessible at:
      `https://raw.githubusercontent.com/gradle/gradle/v<VERSION>/gradle/wrapper/gradle-wrapper.jar`

--- a/gradle/wrapper/README.md
+++ b/gradle/wrapper/README.md
@@ -14,7 +14,7 @@ When upgrading the Gradle version used by the Kafka project, update the followin
 2. **Update distribution checksums** in `gradle/wrapper/gradle-wrapper.properties`:
    - Find the SHA256 checksum for the binary distribution at https://gradle.org/release-checksums/
    - Update `distributionSha256Sum` with the Binary-only (-bin) ZIP Checksum
-   - Update `distributionUrl` to point to the new version:
+   - Update `distributionUrl` to use the latest version from `https://services.gradle.org/distributions/`:
      ```properties
      distributionSha256Sum=<sha256-checksum-from-release-page>
      distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
@@ -23,7 +23,13 @@ When upgrading the Gradle version used by the Kafka project, update the followin
 
 3. **Update wrapper JAR checksum** in `wrapper.gradle`:
    - Find the Wrapper JAR Checksum at https://gradle.org/release-checksums/
-   - Update the `wrapperChecksum` variable (line 42):
+   - Update the `wrapperChecksum` variable:
+   ```groovy
+   task bootstrapWrapper() {
+    ...
+    doLast {
+        ...
+        String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
      ```groovy
      String wrapperChecksum = "<wrapper-jar-sha256-checksum>"
      ```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,3 @@
-# Gradle Wrapper Configuration
-# For instructions on upgrading Gradle version, see README.md in this directory
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,5 @@
+# Gradle Wrapper Configuration
+# For instructions on upgrading Gradle version, see README.md in this directory
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806


### PR DESCRIPTION
Currently, there is no documentation describing how to upgrade Gradle in
the Kafka project. The upgrade process involves   updating three
separate configuration files with specific checksums and URLs, which can
be error-prone without clear guidance.

- Added a new "Upgrading Gradle version" section to README.md
- Documents the 3-step process for upgrading Gradle:
  - Update Gradle version in gradle/dependencies.gradle
  - Update wrapper JAR checksum in wrapper.gradle
  - Regenerate the `gradle-wrapper.properties` and  the wrapper script

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Ming-Yen Chung <mingyen066@gmail.com>, Chia-Ping
 Tsai <chia7712@gmail.com>
