### PR TITLE
KAFKA-19803: Implemented support for allow.os.group.write.access config.

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -261,10 +261,15 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           </tr>
           </thead>
           <tbody valign="top">
-          <tr class="row-even"><td>acceptable.recovery.lag</td>
+          <tr class="row-odd"><td>acceptable.recovery.lag</td>
             <td>Medium</td>
             <td colspan="2">The maximum acceptable lag (number of offsets to catch up) for an instance to be considered caught-up and ready for the active task.</td>
             <td><code class="docutils literal"><span class="pre">10000</span></code></td>
+          </tr>
+          <tr class="even"><td>allow.os.group.write.access</td>
+              <td>Medium</td>
+              <td colspan="2">Allows state store directories created by Kafka Streams to have write access for the OS group.</td>
+              <td><code class="docutils literal"><span class="pre">false</span></code></td>
           </tr>
           <tr class="row-odd"><td>application.server</td>
             <td>Low</td>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -267,7 +267,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td><code class="docutils literal"><span class="pre">10000</span></code></td>
           </tr>
           <tr class="row-even"><td>allow.os.group.write.access</td>
-              <td>Medium</td>
+              <td>Low</td>
               <td colspan="2">Allows state store directories created by Kafka Streams to have write access for the OS group.</td>
               <td><code class="docutils literal"><span class="pre">false</span></code></td>
           </tr>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -266,7 +266,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td colspan="2">The maximum acceptable lag (number of offsets to catch up) for an instance to be considered caught-up and ready for the active task.</td>
             <td><code class="docutils literal"><span class="pre">10000</span></code></td>
           </tr>
-          <tr class="even"><td>allow.os.group.write.access</td>
+          <tr class="row-even"><td>allow.os.group.write.access</td>
               <td>Medium</td>
               <td colspan="2">Allows state store directories created by Kafka Streams to have write access for the OS group.</td>
               <td><code class="docutils literal"><span class="pre">false</span></code></td>

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -420,6 +420,11 @@ public class StreamsConfig extends AbstractConfig {
                                                                   " before processing. To avoid a pause in processing during rebalances, this config" +
                                                                   " should correspond to a recovery time of well under a minute for a given workload. Must be at least 0.";
 
+    /** {@code allow.os.group.write.access} */
+    @SuppressWarnings("WeakerAccess")
+    public static final String ALLOW_OS_GROUP_WRITE_ACCESS_CONFIG = "allow.os.group.write.access";
+    private static final String ALLOW_OS_GROUP_WRITE_ACCESS_DOC = "Allows state store directories created by Kafka Streams to have write access for the OS group. Default is false";
+
     /** {@code application.id} */
     @SuppressWarnings("WeakerAccess")
     public static final String APPLICATION_ID_CONFIG = "application.id";
@@ -1015,6 +1020,11 @@ public class StreamsConfig extends AbstractConfig {
 
             // LOW
 
+            .define(ALLOW_OS_GROUP_WRITE_ACCESS_CONFIG,
+                    Type.BOOLEAN,
+                    false,
+                    Importance.LOW,
+                    ALLOW_OS_GROUP_WRITE_ACCESS_DOC)
             .define(APPLICATION_SERVER_CONFIG,
                     Type.STRING,
                     "",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -46,11 +46,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -165,7 +165,16 @@ public class StateDirectory implements AutoCloseable {
     private void configurePermissions(final File file) {
         final Path path = file.toPath();
         if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-            final Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-x---");
+            final Set<PosixFilePermission> perms = EnumSet.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                    PosixFilePermission.GROUP_READ,
+                    PosixFilePermission.GROUP_EXECUTE
+            );
+            if (config.getBoolean(StreamsConfig.ALLOW_OS_GROUP_WRITE_ACCESS_CONFIG)) {
+                perms.add(PosixFilePermission.GROUP_WRITE);
+            }
             try {
                 Files.setPosixFilePermissions(path, perms);
             } catch (final IOException e) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -101,17 +102,21 @@ public class StateDirectoryTest {
     private File appDir;
 
     private void initializeStateDirectory(final boolean createStateDirectory, final boolean hasNamedTopology) throws IOException {
+        initializeStateDirectory(createStateDirectory, hasNamedTopology, false);
+    }
+
+    private void initializeStateDirectory(final boolean createStateDirectory, final boolean hasNamedTopology,
+            final boolean allowOsGroupWriteAccess) throws IOException {
         stateDir = new File(TestUtils.IO_TMP_DIR, "kafka-" + TestUtils.randomString(5));
         if (!createStateDirectory) {
             cleanup();
         }
-        config = new StreamsConfig(new Properties() {
-            {
-                put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
-                put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-                put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
-            }
-        });
+        config = new StreamsConfig(Map.of(
+                StreamsConfig.APPLICATION_ID_CONFIG, applicationId,
+                StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234",
+                StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath(),
+                StreamsConfig.ALLOW_OS_GROUP_WRITE_ACCESS_CONFIG, allowOsGroupWriteAccess
+        ));
         directory = new StateDirectory(config, time, createStateDirectory, hasNamedTopology);
         appDir = new File(stateDir, applicationId);
     }
@@ -140,7 +145,18 @@ public class StateDirectoryTest {
         assertPermissions(appDir);
     }
 
+    @Test
+    public void shouldHaveSecurePermissionsIfGroupWriteAccessAllowed() throws IOException {
+        initializeStateDirectory(true, false, true);
+        assertPermissions(stateDir, true);
+        assertPermissions(appDir, true);
+    }
+
     private void assertPermissions(final File file) {
+        assertPermissions(file, false);
+    }
+
+    private void assertPermissions(final File file, final boolean allowOsGroupWriteAccess) {
         final Path path = file.toPath();
         if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
             final Set<PosixFilePermission> expectedPermissions = EnumSet.of(
@@ -149,9 +165,12 @@ public class StateDirectoryTest {
                     PosixFilePermission.OWNER_WRITE,
                     PosixFilePermission.GROUP_EXECUTE,
                     PosixFilePermission.OWNER_READ);
+            if (allowOsGroupWriteAccess) {
+                expectedPermissions.add(PosixFilePermission.GROUP_WRITE);
+            }
             try {
                 final Set<PosixFilePermission> filePermissions = Files.getPosixFilePermissions(path);
-                assertThat(expectedPermissions, equalTo(filePermissions));
+                assertThat(filePermissions, equalTo(expectedPermissions));
             } catch (final IOException e) {
                 fail("Should create correct files and set correct permissions");
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -105,8 +105,11 @@ public class StateDirectoryTest {
         initializeStateDirectory(createStateDirectory, hasNamedTopology, false);
     }
 
-    private void initializeStateDirectory(final boolean createStateDirectory, final boolean hasNamedTopology,
-            final boolean allowOsGroupWriteAccess) throws IOException {
+    private void initializeStateDirectory(
+            final boolean createStateDirectory,
+            final boolean hasNamedTopology,
+            final boolean allowOsGroupWriteAccess
+    ) throws IOException {
         stateDir = new File(TestUtils.IO_TMP_DIR, "kafka-" + TestUtils.randomString(5));
         if (!createStateDirectory) {
             cleanup();
@@ -141,19 +144,30 @@ public class StateDirectoryTest {
 
     @Test
     public void shouldHaveSecurePermissions() {
-        assertPermissions(stateDir);
-        assertPermissions(appDir);
+        assertPermissions(stateDir, false);
+        assertPermissions(appDir, false);
     }
 
     @Test
     public void shouldHaveSecurePermissionsIfGroupWriteAccessAllowed() throws IOException {
+        cleanup();
         initializeStateDirectory(true, false, true);
         assertPermissions(stateDir, true);
         assertPermissions(appDir, true);
     }
 
-    private void assertPermissions(final File file) {
-        assertPermissions(file, false);
+    @Test
+    public void shouldUpdateSecurePermissions() throws IOException {
+        assertPermissions(stateDir, false);
+        assertPermissions(appDir, false);
+
+        initializeStateDirectory(true, false, true);
+        assertPermissions(stateDir, true);
+        assertPermissions(appDir, true);
+
+        initializeStateDirectory(true, false, false);
+        assertPermissions(stateDir, false);
+        assertPermissions(appDir, false);
     }
 
     private void assertPermissions(final File file, final boolean allowOsGroupWriteAccess) {


### PR DESCRIPTION
Implements KIP-1230.

Reviewers: Matthias J. Sax <matthias@confluent.io>
