### PR TITLE
KAFKA-19823: PartitionMaxBytesStrategy bug when request bytes is lesser than acquired topic partitions

### DIFF
--- a/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
+++ b/core/src/test/java/kafka/server/share/DelayedShareFetchTest.java
@@ -1027,9 +1027,11 @@ public class DelayedShareFetchTest {
         sharePartitions.put(tp3, sp3);
         sharePartitions.put(tp4, sp4);
 
-        ShareFetch shareFetch = new ShareFetch(FETCH_PARAMS, groupId, Uuid.randomUuid().toString(),
-            new CompletableFuture<>(), List.of(tp0, tp1, tp2, tp3, tp4), BATCH_SIZE, MAX_FETCH_RECORDS,
-            BROKER_TOPIC_STATS);
+        ShareFetch shareFetch = new ShareFetch(new FetchParams(
+            FetchRequest.ORDINARY_CONSUMER_ID, -1, MAX_WAIT_MS, 1, 1024 * 1020,
+            FetchIsolation.HIGH_WATERMARK, Optional.empty(), true), groupId,
+            Uuid.randomUuid().toString(), new CompletableFuture<>(), List.of(tp0, tp1, tp2, tp3, tp4), BATCH_SIZE,
+            MAX_FETCH_RECORDS, BROKER_TOPIC_STATS);
 
         when(sp0.acquire(anyString(), anyInt(), anyInt(), anyLong(), any(FetchPartitionData.class), any())).thenReturn(
             createShareAcquiredRecords(new ShareFetchResponseData.AcquiredRecords().setFirstOffset(0).setLastOffset(3).setDeliveryCount((short) 1)));
@@ -1075,8 +1077,8 @@ public class DelayedShareFetchTest {
         assertTrue(delayedShareFetch.tryComplete());
         assertTrue(delayedShareFetch.isCompleted());
 
-        // Since all partitions are acquirable, maxbytes per partition = requestMaxBytes(i.e. 1024*1024) / acquiredTopicPartitions(i.e. 5)
-        int expectedPartitionMaxBytes = 1024 * 1024 / 5;
+        // Since all partitions are acquirable, maxbytes per partition = requestMaxBytes(i.e. 1024*1020) / acquiredTopicPartitions(i.e. 5)
+        int expectedPartitionMaxBytes = 1024 * 1020 / 5;
         LinkedHashMap<TopicIdPartition, FetchRequest.PartitionData> expectedReadPartitionInfo = new LinkedHashMap<>();
         sharePartitions.keySet().forEach(topicIdPartition -> expectedReadPartitionInfo.put(topicIdPartition,
             new FetchRequest.PartitionData(
@@ -1206,7 +1208,7 @@ public class DelayedShareFetchTest {
 
         ShareFetch shareFetch = new ShareFetch(
             new FetchParams(FetchRequest.ORDINARY_CONSUMER_ID, -1, MAX_WAIT_MS,
-                1, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()), groupId, Uuid.randomUuid().toString(),
+                1, 1024 * 1020, FetchIsolation.HIGH_WATERMARK, Optional.empty()), groupId, Uuid.randomUuid().toString(),
             new CompletableFuture<>(), List.of(tp0, tp1, tp2), BATCH_SIZE, MAX_FETCH_RECORDS,
             BROKER_TOPIC_STATS);
 
@@ -1239,8 +1241,8 @@ public class DelayedShareFetchTest {
         LinkedHashMap<TopicIdPartition, LogReadResult> combinedLogReadResponse = delayedShareFetch.combineLogReadResponse(topicPartitionData, logReadResponse);
 
         assertEquals(topicPartitionData.keySet(), combinedLogReadResponse.keySet());
-        // Since only 2 partitions are fetchable but the third one has already been fetched, maxbytes per partition = requestMaxBytes(i.e. 1024*1024) / acquiredTopicPartitions(i.e. 3)
-        int expectedPartitionMaxBytes = 1024 * 1024 / 3;
+        // Since only 2 partitions are fetchable but the third one has already been fetched, maxbytes per partition = requestMaxBytes(i.e. 1024*1020) / acquiredTopicPartitions(i.e. 3)
+        int expectedPartitionMaxBytes = 1024 * 1020 / 3;
         LinkedHashMap<TopicIdPartition, FetchRequest.PartitionData> expectedReadPartitionInfo = new LinkedHashMap<>();
         fetchableTopicPartitions.forEach(topicIdPartition -> expectedReadPartitionInfo.put(topicIdPartition,
             new FetchRequest.PartitionData(

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
@@ -18,7 +18,11 @@ package org.apache.kafka.server.share.fetch;
 
 import org.apache.kafka.common.TopicIdPartition;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -58,7 +62,27 @@ public interface PartitionMaxBytesStrategy {
     private static LinkedHashMap<TopicIdPartition, Integer> uniformPartitionMaxBytes(int requestMaxBytes, Set<TopicIdPartition> partitions, int acquiredPartitionsSize) {
         checkValidArguments(requestMaxBytes, partitions, acquiredPartitionsSize);
         LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
-        partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / acquiredPartitionsSize));
+        if (requestMaxBytes >= acquiredPartitionsSize) {
+            // Case 1: requestMaxBytes can be evenly distributed within partitions.
+            partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / acquiredPartitionsSize));
+        } else if (requestMaxBytes >= partitions.size()) {
+            // Case 2: we will be distributing requestMaxBytes greedily in this scenario to prevent any starvation.
+            partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / partitions.size()));
+        } else {
+            // Case 3: we will distribute requestMaxBytes to as many partitions possible randomly to avoid starvation.
+            List<TopicIdPartition> partitionsList = new ArrayList<>(partitions);
+            Collections.shuffle(partitionsList);
+            Set<TopicIdPartition> nonEmptyPartitions = new HashSet<>(partitionsList.subList(0, requestMaxBytes));
+            partitions.forEach(
+                partition -> {
+                    if (nonEmptyPartitions.contains(partition)) {
+                        partitionMaxBytes.put(partition, 1);
+                    } else {
+                        partitionMaxBytes.put(partition, 0);
+                    }
+                }
+            );
+        }
         return partitionMaxBytes;
     }
 

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
@@ -19,8 +19,6 @@ package org.apache.kafka.server.share.fetch;
 import org.apache.kafka.common.TopicIdPartition;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -44,8 +42,7 @@ public interface PartitionMaxBytesStrategy {
 
     /**
      * Returns the partition max bytes for a given partition based on the strategy type.
-     * The partitions passed for maxBytes calculation are a subset of total acquired partitions for the share fetch request.
-     * Thus, partitions for which we want to compute the max bytes <= acquired partitions.
+     * The partitions passed for maxBytes calculation can be a subset of total acquired partitions for the share fetch request.
      *
      * @param requestMaxBytes - The total max bytes available for the share fetch request
      * @param partitions - The topic partitions in the order for which we compute the partition max bytes.
@@ -65,46 +62,44 @@ public interface PartitionMaxBytesStrategy {
 
     private static LinkedHashMap<TopicIdPartition, Integer> uniformPartitionMaxBytes(int requestMaxBytes, Set<TopicIdPartition> partitions, int acquiredPartitionsSize) {
         checkValidArguments(requestMaxBytes, partitions, acquiredPartitionsSize);
-        LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
         if (requestMaxBytes >= acquiredPartitionsSize) {
             // Case 1: requestMaxBytes can be evenly distributed within partitions. If there is extra bytes left post
             // dividing it uniformly, assign it randomly to any one of the partitions.
-            partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / acquiredPartitionsSize));
-            if (requestMaxBytes % acquiredPartitionsSize != 0) {
-                TopicIdPartition randomPartition = selectPartitionRandomly(partitionMaxBytes);
-                partitionMaxBytes.put(randomPartition,
-                    (requestMaxBytes / acquiredPartitionsSize) + (requestMaxBytes % acquiredPartitionsSize));
-            }
+            return allotUniformBytesToPartitions(partitions, requestMaxBytes, acquiredPartitionsSize);
         } else if (requestMaxBytes >= partitions.size()) {
-            // Case 2: we will be distributing requestMaxBytes greedily in this scenario to prevent any starvation. If
+            // Case 2: requestMaxBytes can be distributed greedily in this scenario to prevent any starvation. If
             // there is extra bytes left post dividing it uniformly, assign it randomly to any one of the partitions.
-            partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / partitions.size()));
-            if (requestMaxBytes % partitions.size() != 0) {
-                TopicIdPartition randomPartition = selectPartitionRandomly(partitionMaxBytes);
-                partitionMaxBytes.put(randomPartition,
-                    (requestMaxBytes / partitions.size()) + (requestMaxBytes % partitions.size()));
-            }
+            return allotUniformBytesToPartitions(partitions, requestMaxBytes, partitions.size());
         } else {
             // Case 3: we will distribute requestMaxBytes to as many partitions possible randomly to avoid starvation.
+            LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
+            partitions.forEach(partition -> partitionMaxBytes.put(partition, 0));
             List<TopicIdPartition> partitionsList = new ArrayList<>(partitions);
-            Collections.shuffle(partitionsList);
-            Set<TopicIdPartition> nonEmptyPartitions = new HashSet<>(partitionsList.subList(0, requestMaxBytes));
-            partitions.forEach(
-                partition -> {
-                    if (nonEmptyPartitions.contains(partition)) {
-                        partitionMaxBytes.put(partition, 1);
-                    } else {
-                        partitionMaxBytes.put(partition, 0);
-                    }
-                }
-            );
+            int index = RANDOM.nextInt(partitionsList.size());
+            int count = 0;
+            while (count < requestMaxBytes) {
+                partitionMaxBytes.put(partitionsList.get(index), 1);
+                count += 1;
+                index = (index + 1) % partitionsList.size();
+            }
+            return partitionMaxBytes;
         }
-        return partitionMaxBytes;
     }
 
-    private static TopicIdPartition selectPartitionRandomly(LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes) {
-        List<TopicIdPartition> partitionsList = new ArrayList<>(partitionMaxBytes.keySet());
-        return partitionsList.get(RANDOM.nextInt(partitionsList.size()));
+    private static LinkedHashMap<TopicIdPartition, Integer> allotUniformBytesToPartitions(
+        Set<TopicIdPartition> partitions,
+        int requestMaxBytes,
+        int partitionsSize) {
+        LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
+        int uniformPartitionBytes = requestMaxBytes / partitionsSize;
+        int remainingBytes = requestMaxBytes % partitionsSize;
+        partitions.forEach(partition -> partitionMaxBytes.put(partition, uniformPartitionBytes));
+        if (remainingBytes != 0) {
+            List<TopicIdPartition> partitionsList = new ArrayList<>(partitionMaxBytes.keySet());
+            TopicIdPartition randomPartition = partitionsList.get(RANDOM.nextInt(partitionsList.size()));
+            partitionMaxBytes.put(randomPartition, uniformPartitionBytes + remainingBytes);
+        }
+        return partitionMaxBytes;
     }
 
     // Visible for testing.

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
@@ -42,13 +42,13 @@ public interface PartitionMaxBytesStrategy {
 
     /**
      * Returns the partition max bytes for a given partition based on the strategy type.
+     * The partitions passed for maxBytes calculation are a subset of total acquired partitions for the share fetch request.
+     * Thus, partitions for which we want to compute the max bytes <= acquired partitions.
      *
      * @param requestMaxBytes - The total max bytes available for the share fetch request
      * @param partitions - The topic partitions in the order for which we compute the partition max bytes.
      * @param acquiredPartitionsSize - The total partitions that have been acquired.
      * @return the partition max bytes for the topic partitions
-     * The partitions passed for maxBytes calculation are a subset of total acquired partitions for the share fetch request.
-     * Thus, partitions for which we want to compute the max bytes <= acquired partitions.
      */
     LinkedHashMap<TopicIdPartition, Integer> maxBytes(int requestMaxBytes, Set<TopicIdPartition> partitions, int acquiredPartitionsSize);
 

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
@@ -24,12 +24,14 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Random;
 import java.util.Set;
 
 /**
  * This interface helps identify the max bytes for topic partitions in a share fetch request based on different strategy types.
  */
 public interface PartitionMaxBytesStrategy {
+    Random RANDOM = new Random();
 
     enum StrategyType {
         UNIFORM;
@@ -65,11 +67,23 @@ public interface PartitionMaxBytesStrategy {
         checkValidArguments(requestMaxBytes, partitions, acquiredPartitionsSize);
         LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
         if (requestMaxBytes >= acquiredPartitionsSize) {
-            // Case 1: requestMaxBytes can be evenly distributed within partitions.
+            // Case 1: requestMaxBytes can be evenly distributed within partitions. If there is extra bytes left post
+            // dividing it uniformly, assign it randomly to any one of the partitions.
             partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / acquiredPartitionsSize));
+            if (requestMaxBytes % acquiredPartitionsSize != 0) {
+                TopicIdPartition randomPartition = selectPartitionRandomly(partitionMaxBytes);
+                partitionMaxBytes.put(randomPartition,
+                    (requestMaxBytes / acquiredPartitionsSize) + (requestMaxBytes % acquiredPartitionsSize));
+            }
         } else if (requestMaxBytes >= partitions.size()) {
-            // Case 2: we will be distributing requestMaxBytes greedily in this scenario to prevent any starvation.
+            // Case 2: we will be distributing requestMaxBytes greedily in this scenario to prevent any starvation. If
+            // there is extra bytes left post dividing it uniformly, assign it randomly to any one of the partitions.
             partitions.forEach(partition -> partitionMaxBytes.put(partition, requestMaxBytes / partitions.size()));
+            if (requestMaxBytes % partitions.size() != 0) {
+                TopicIdPartition randomPartition = selectPartitionRandomly(partitionMaxBytes);
+                partitionMaxBytes.put(randomPartition,
+                    (requestMaxBytes / partitions.size()) + (requestMaxBytes % partitions.size()));
+            }
         } else {
             // Case 3: we will distribute requestMaxBytes to as many partitions possible randomly to avoid starvation.
             List<TopicIdPartition> partitionsList = new ArrayList<>(partitions);
@@ -86,6 +100,11 @@ public interface PartitionMaxBytesStrategy {
             );
         }
         return partitionMaxBytes;
+    }
+
+    private static TopicIdPartition selectPartitionRandomly(LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes) {
+        List<TopicIdPartition> partitionsList = new ArrayList<>(partitionMaxBytes.keySet());
+        return partitionsList.get(RANDOM.nextInt(partitionsList.size()));
     }
 
     // Visible for testing.

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
@@ -18,9 +18,8 @@ package org.apache.kafka.server.share.fetch;
 
 import org.apache.kafka.common.TopicIdPartition;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
@@ -74,14 +73,15 @@ public interface PartitionMaxBytesStrategy {
             // Case 3: we will distribute requestMaxBytes to as many partitions possible randomly to avoid starvation.
             LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
             partitions.forEach(partition -> partitionMaxBytes.put(partition, 0));
-            List<TopicIdPartition> partitionsList = new ArrayList<>(partitions);
-            int index = RANDOM.nextInt(partitionsList.size());
-            int count = 0;
-            while (count < requestMaxBytes) {
-                partitionMaxBytes.put(partitionsList.get(index), 1);
-                count += 1;
-                index = (index + 1) % partitionsList.size();
+            int randomIndex = RANDOM.nextInt(partitions.size());
+            int nonEmptyPartitionsCount = 0;
+            Set<Integer> nonEmptyPartitionIndexes = new HashSet<>();
+            while (nonEmptyPartitionsCount < requestMaxBytes) {
+                nonEmptyPartitionIndexes.add(randomIndex);
+                nonEmptyPartitionsCount += 1;
+                randomIndex = (randomIndex + 1) % partitions.size();
             }
+            allotBytesByPartitionIndex(1, partitions, partitionMaxBytes, nonEmptyPartitionIndexes);
             return partitionMaxBytes;
         }
     }
@@ -89,17 +89,38 @@ public interface PartitionMaxBytesStrategy {
     private static LinkedHashMap<TopicIdPartition, Integer> allotUniformBytesToPartitions(
         Set<TopicIdPartition> partitions,
         int requestMaxBytes,
-        int partitionsSize) {
+        int partitionsSize
+    ) {
         LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes = new LinkedHashMap<>();
         int uniformPartitionBytes = requestMaxBytes / partitionsSize;
         int remainingBytes = requestMaxBytes % partitionsSize;
         partitions.forEach(partition -> partitionMaxBytes.put(partition, uniformPartitionBytes));
         if (remainingBytes != 0) {
-            List<TopicIdPartition> partitionsList = new ArrayList<>(partitionMaxBytes.keySet());
-            TopicIdPartition randomPartition = partitionsList.get(RANDOM.nextInt(partitionsList.size()));
-            partitionMaxBytes.put(randomPartition, uniformPartitionBytes + remainingBytes);
+            int randomPartitionIndex = RANDOM.nextInt(partitionMaxBytes.keySet().size());
+            allotBytesByPartitionIndex(uniformPartitionBytes + remainingBytes, partitions,
+                partitionMaxBytes, Set.of(randomPartitionIndex));
         }
         return partitionMaxBytes;
+    }
+
+    private static void allotBytesByPartitionIndex(
+        int bytes,
+        Set<TopicIdPartition> partitions,
+        LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes,
+        Set<Integer> partitionIndexesToAllot
+    ) {
+        int index = 0;
+        int count = 0;
+        for (TopicIdPartition partition : partitions) {
+            if (partitionIndexesToAllot.contains(index)) {
+                partitionMaxBytes.put(partition, bytes);
+                count += 1;
+                if (count == partitionIndexesToAllot.size()) {
+                    break;
+                }
+            }
+            index += 1;
+        }
     }
 
     // Visible for testing.

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategy.java
@@ -47,6 +47,8 @@ public interface PartitionMaxBytesStrategy {
      * @param partitions - The topic partitions in the order for which we compute the partition max bytes.
      * @param acquiredPartitionsSize - The total partitions that have been acquired.
      * @return the partition max bytes for the topic partitions
+     * The partitions passed for maxBytes calculation are a subset of total acquired partitions for the share fetch request.
+     * Thus, partitions for which we want to compute the max bytes <= acquired partitions.
      */
     LinkedHashMap<TopicIdPartition, Integer> maxBytes(int requestMaxBytes, Set<TopicIdPartition> partitions, int acquiredPartitionsSize);
 

--- a/server/src/test/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategyTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategyTest.java
@@ -81,7 +81,7 @@ public class PartitionMaxBytesStrategyTest {
         // Case 1: requestMaxBytes is greater than acquiredPartitions, so max bytes is distributed evenly.
         LinkedHashMap<TopicIdPartition, Integer> result = partitionMaxBytesStrategy.maxBytes(
             100, partitions, 3);
-        assertEquals(List.of(33, 33, 33), result.values().stream().toList());
+        assertEquals(List.of(33, 33, 34), result.values().stream().sorted().toList());
 
         result = partitionMaxBytesStrategy.maxBytes(
             100, partitions, 5);
@@ -90,8 +90,12 @@ public class PartitionMaxBytesStrategyTest {
         // Case 2: requestMaxBytes < acquiredPartitions and requestMaxBytes >= partitions for which we want to
         // calculate the max bytes.
         result = partitionMaxBytesStrategy.maxBytes(
-            10, partitions, 12);
+            9, partitions, 12);
         assertEquals(List.of(3, 3, 3), result.values().stream().toList());
+
+        result = partitionMaxBytesStrategy.maxBytes(
+            10, partitions, 12);
+        assertEquals(List.of(3, 3, 4), result.values().stream().sorted().toList());
 
         // Case 3: requestMaxBytes < partitions for which we want to calculate the max bytes.
         result = partitionMaxBytesStrategy.maxBytes(

--- a/server/src/test/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategyTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategyTest.java
@@ -78,6 +78,7 @@ public class PartitionMaxBytesStrategyTest {
         partitions.add(topicIdPartition2);
         partitions.add(topicIdPartition3);
 
+        // Case 1: requestMaxBytes is greater than acquiredPartitions, so max bytes is distributed evenly.
         LinkedHashMap<TopicIdPartition, Integer> result = partitionMaxBytesStrategy.maxBytes(
             100, partitions, 3);
         assertEquals(result.values().stream().toList(), List.of(33, 33, 33));
@@ -85,5 +86,16 @@ public class PartitionMaxBytesStrategyTest {
         result = partitionMaxBytesStrategy.maxBytes(
             100, partitions, 5);
         assertEquals(result.values().stream().toList(), List.of(20, 20, 20));
+
+        // Case 2: requestMaxBytes < acquiredPartitions and requestMaxBytes >= partitions for which we want to
+        // calculate the max bytes.
+        result = partitionMaxBytesStrategy.maxBytes(
+            10, partitions, 12);
+        assertEquals(result.values().stream().toList(), List.of(3, 3, 3));
+
+        // Case 3: requestMaxBytes < partitions for which we want to calculate the max bytes.
+        result = partitionMaxBytesStrategy.maxBytes(
+            2, partitions, 4);
+        assertEquals(result.values().stream().sorted().toList(), List.of(0, 1, 1));
     }
 }

--- a/server/src/test/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategyTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/fetch/PartitionMaxBytesStrategyTest.java
@@ -81,21 +81,21 @@ public class PartitionMaxBytesStrategyTest {
         // Case 1: requestMaxBytes is greater than acquiredPartitions, so max bytes is distributed evenly.
         LinkedHashMap<TopicIdPartition, Integer> result = partitionMaxBytesStrategy.maxBytes(
             100, partitions, 3);
-        assertEquals(result.values().stream().toList(), List.of(33, 33, 33));
+        assertEquals(List.of(33, 33, 33), result.values().stream().toList());
 
         result = partitionMaxBytesStrategy.maxBytes(
             100, partitions, 5);
-        assertEquals(result.values().stream().toList(), List.of(20, 20, 20));
+        assertEquals(List.of(20, 20, 20), result.values().stream().toList());
 
         // Case 2: requestMaxBytes < acquiredPartitions and requestMaxBytes >= partitions for which we want to
         // calculate the max bytes.
         result = partitionMaxBytesStrategy.maxBytes(
             10, partitions, 12);
-        assertEquals(result.values().stream().toList(), List.of(3, 3, 3));
+        assertEquals(List.of(3, 3, 3), result.values().stream().toList());
 
         // Case 3: requestMaxBytes < partitions for which we want to calculate the max bytes.
         result = partitionMaxBytesStrategy.maxBytes(
             2, partitions, 4);
-        assertEquals(result.values().stream().sorted().toList(), List.of(0, 1, 1));
+        assertEquals(List.of(0, 1, 1), result.values().stream().sorted().toList());
     }
 }


### PR DESCRIPTION
### About
There is a bug in the broker logic of splitting bytes in
`PartitionMaxBytesStrategy.java` due to which we are setting
`partitionMaxBytes` as 0 in case `requestMaxBytes` is lesser than
`acquiredPartitionsSize`

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
