### PR TITLE
MINOR: improve error message on TLS certificate validation failure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -42,6 +42,7 @@ import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.UnresolvedAddressException;
+import java.security.cert.CertPathValidatorException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -619,6 +620,10 @@ public class Selector implements Selectable, AutoCloseable {
                     String exceptionMessage = e.getMessage();
                     if (e instanceof DelayedResponseAuthenticationException)
                         exceptionMessage = e.getCause().getMessage();
+                    CertPathValidatorException certPathValidatorException = maybeGetCertPathValidatorException(e);
+                    if (certPathValidatorException != null) {
+                        exceptionMessage += "; certificate validation failed with reason " + certPathValidatorException.getReason();
+                    }
                     log.info("Failed {}authentication with {} ({})", isReauthentication ? "re-" : "",
                         desc, exceptionMessage);
                 } else {
@@ -633,6 +638,14 @@ public class Selector implements Selectable, AutoCloseable {
                 maybeRecordTimePerConnection(channel, channelStartTimeNanos);
             }
         }
+    }
+
+    private CertPathValidatorException maybeGetCertPathValidatorException(Throwable throwable)  {
+        Throwable current = throwable;
+        while (current != null && !(current instanceof CertPathValidatorException)) {
+            current = current.getCause();
+        }
+        return (CertPathValidatorException) current;
     }
 
     private void attemptWrite(SelectionKey key, KafkaChannel channel, long nowNanos) throws IOException {


### PR DESCRIPTION
A TLS handshake failure results in an `INFO` log with a generic message of `SSL handshake failed`. The absence of a stacktrace, which I believe is to avoid polluting the logs in case of a misbehaving client, makes it hard to diagnose the underlying cause of the handshake failure.

This change modifies the message to include the certificate failure reason which can provide a valuable hint to users regarding the underlying issue during an incident.