### PR TITLE
KAFKA-12999: Make RecordHeader reads thread-safe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -40,8 +40,14 @@ import java.util.Optional;
  * </ul>
  *
  * <p>
- * However, the {@link #headers()} collection and individual header instances are
- * <b>read thread-safe</b>, allowing concurrent access for reading without additional synchronization.
+ * In particular, the {@link #headers()} method returns a mutable collection of headers. If multiple
+ * threads access or modify these headers concurrently, it may lead to race conditions or inconsistent
+ * states. It is the responsibility of the user to ensure that multi-threaded access is properly synchronized.
+ *
+ * <p>
+ * However, each individual {@link org.apache.kafka.common.header.Header} instance
+ * is <b>read thread-safe</b>; that is, it is safe for multiple threads to read the same header's key or value concurrently
+ * as long as no thread modifies it.
  *
  * <p>
  * Refer to the {@link KafkaConsumer} documentation for more details on multi-threaded consumption and processing strategies.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -40,9 +40,8 @@ import java.util.Optional;
  * </ul>
  *
  * <p>
- * In particular, the {@link #headers()} method returns a mutable collection of headers. If multiple
- * threads access or modify these headers concurrently, it may lead to race conditions or inconsistent
- * states. It is the responsibility of the user to ensure that multi-threaded access is properly synchronized.
+ * However, the {@link #headers()} collection and individual header instances are
+ * <b>read thread-safe</b>, allowing concurrent access for reading without additional synchronization.
  *
  * <p>
  * Refer to the {@link KafkaConsumer} documentation for more details on multi-threaded consumption and processing strategies.

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -273,18 +273,12 @@ public class RecordHeadersTest {
         assertArrayEquals(value.getBytes(), actual.value());
     }
 
-    @RepeatedTest(100)
-    public void testRecordHeaderIsReadThreadSafe() throws Exception {
-        int threads = 32;
-        RecordHeader header = new RecordHeader(
-            ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
-            ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8))
-        );
-
+    private void assertRecordHeaderReadThreadSafe(RecordHeader header) throws Exception {
+        int threadCount = 32;
         CountDownLatch startLatch = new CountDownLatch(1);
         AtomicBoolean raceDetected = new AtomicBoolean(false);
 
-        var fs = IntStream.range(0, threads)
+        var futures = IntStream.range(0, threadCount)
             .mapToObj(i -> CompletableFuture.runAsync(() -> {
                 try {
                     startLatch.await();
@@ -299,39 +293,26 @@ public class RecordHeadersTest {
             })).collect(Collectors.toUnmodifiableList());
 
         startLatch.countDown();
-        fs.forEach(CompletableFuture::join);
+        futures.forEach(CompletableFuture::join);
 
-        assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
+        assertFalse(raceDetected.get());
+    }
+
+    @RepeatedTest(100)
+    public void testRecordHeaderIsReadThreadSafe() throws Exception {
+        RecordHeader header = new RecordHeader(
+            ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
+            ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8))
+        );
+        assertRecordHeaderReadThreadSafe(header);
     }
 
     @RepeatedTest(100)
     public void testRecordHeaderWithNullValueIsReadThreadSafe() throws Exception {
-        int threadCount = 32;
         RecordHeader header = new RecordHeader(
             ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
             null
         );
-
-        CountDownLatch startLatch = new CountDownLatch(1);
-        AtomicBoolean raceDetected = new AtomicBoolean(false);
-
-        var fs = IntStream.range(0, threadCount)
-            .mapToObj(i -> CompletableFuture.runAsync(() -> {
-                try {
-                    startLatch.await();
-                    header.key();
-                    header.value(); // may be null, should not throw
-                } catch (NullPointerException e) {
-                    raceDetected.set(true);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
-            })).collect(Collectors.toUnmodifiableList());
-
-        startLatch.countDown();
-        fs.forEach(CompletableFuture::join);
-
-        assertFalse(raceDetected.get(), "Read race condition detected when value is null in RecordHeader!");
+        assertRecordHeaderReadThreadSafe(header);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -22,7 +22,14 @@ import org.apache.kafka.common.header.Headers;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -265,4 +272,40 @@ public class RecordHeadersTest {
         assertArrayEquals(value.getBytes(), actual.value());
     }
 
+    @Test
+    public void testRecordHeaderIsReadThreadSafe() throws Exception {
+        int repeats = 5000;
+        int threads = 8;
+
+        for (int test = 0; test < repeats; test++) {
+            RecordHeader header = new RecordHeader(
+                ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
+                ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8))
+            );
+
+            ExecutorService pool = Executors.newFixedThreadPool(threads);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            AtomicBoolean raceDetected = new AtomicBoolean(false);
+
+            Runnable task = () -> {
+                try {
+                    startLatch.await();
+                    header.key();
+                    header.value();
+                } catch (NullPointerException e) {
+                    raceDetected.set(true);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            for (int i = 0; i < threads; i++) pool.submit(task);
+
+            startLatch.countDown();
+            pool.shutdown();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+
+            assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
+        }
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -275,18 +275,17 @@ public class RecordHeadersTest {
 
     @RepeatedTest(100)
     public void testRecordHeaderIsReadThreadSafe() throws Exception {
-        int threads = 8;
+        int threads = 32;
         RecordHeader header = new RecordHeader(
             ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
             ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8))
         );
 
-        ExecutorService pool = Executors.newFixedThreadPool(threads);
         CountDownLatch startLatch = new CountDownLatch(1);
         AtomicBoolean raceDetected = new AtomicBoolean(false);
 
-        try {
-            Runnable task = () -> {
+        var fs = IntStream.range(0, threads)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
                 try {
                     startLatch.await();
                     header.key();
@@ -297,20 +296,42 @@ public class RecordHeadersTest {
                     Thread.currentThread().interrupt();
                     throw new RuntimeException(e);
                 }
-            };
+            })).collect(Collectors.toUnmodifiableList());
 
-            for (int i = 0; i < threads; i++) pool.submit(task);
+        startLatch.countDown();
+        fs.forEach(CompletableFuture::join);
 
-            startLatch.countDown();
+        assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
+    }
 
-            pool.shutdown();
-            pool.awaitTermination(5, TimeUnit.SECONDS);
+    @RepeatedTest(100)
+    public void testRecordHeaderWithNullValueIsReadThreadSafe() throws Exception {
+        int threadCount = 32;
+        RecordHeader header = new RecordHeader(
+            ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
+            null
+        );
 
-            assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
-        } finally {
-            if (!pool.isTerminated()) {
-                pool.shutdownNow();
-            }
-        }
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean raceDetected = new AtomicBoolean(false);
+
+        var fs = IntStream.range(0, threadCount)
+            .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                try {
+                    startLatch.await();
+                    header.key();
+                    header.value(); // may be null, should not throw
+                } catch (NullPointerException e) {
+                    raceDetected.set(true);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            })).collect(Collectors.toUnmodifiableList());
+
+        startLatch.countDown();
+        fs.forEach(CompletableFuture::join);
+
+        assertFalse(raceDetected.get(), "Read race condition detected when value is null in RecordHeader!");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -273,10 +273,9 @@ public class RecordHeadersTest {
         assertArrayEquals(value.getBytes(), actual.value());
     }
 
-    private void assertRecordHeaderReadThreadSafe(RecordHeader header) throws Exception {
-        int threadCount = 32;
+    private void assertRecordHeaderReadThreadSafe(RecordHeader header) {
+        int threadCount = 16;
         CountDownLatch startLatch = new CountDownLatch(1);
-        AtomicBoolean raceDetected = new AtomicBoolean(false);
 
         var futures = IntStream.range(0, threadCount)
             .mapToObj(i -> CompletableFuture.runAsync(() -> {
@@ -284,8 +283,6 @@ public class RecordHeadersTest {
                     startLatch.await();
                     header.key();
                     header.value();
-                } catch (NullPointerException e) {
-                    raceDetected.set(true);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new RuntimeException(e);
@@ -294,8 +291,6 @@ public class RecordHeadersTest {
 
         startLatch.countDown();
         futures.forEach(CompletableFuture::join);
-
-        assertFalse(raceDetected.get());
     }
 
     @RepeatedTest(100)

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -285,24 +285,32 @@ public class RecordHeadersTest {
         CountDownLatch startLatch = new CountDownLatch(1);
         AtomicBoolean raceDetected = new AtomicBoolean(false);
 
-        Runnable task = () -> {
-            try {
-                startLatch.await();
-                header.key();
-                header.value();
-            } catch (NullPointerException e) {
-                raceDetected.set(true);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+        try {
+            Runnable task = () -> {
+                try {
+                    startLatch.await();
+                    header.key();
+                    header.value();
+                } catch (NullPointerException e) {
+                    raceDetected.set(true);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            };
+
+            for (int i = 0; i < threads; i++) pool.submit(task);
+
+            startLatch.countDown();
+
+            pool.shutdown();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+
+            assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
+        } finally {
+            if (!pool.isTerminated()) {
+                pool.shutdownNow();
             }
-        };
-
-        for (int i = 0; i < threads; i++) pool.submit(task);
-
-        startLatch.countDown();
-        pool.shutdown();
-        pool.awaitTermination(5, TimeUnit.SECONDS);
-
-        assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.header.internals;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -272,40 +273,36 @@ public class RecordHeadersTest {
         assertArrayEquals(value.getBytes(), actual.value());
     }
 
-    @Test
+    @RepeatedTest(100)
     public void testRecordHeaderIsReadThreadSafe() throws Exception {
-        int repeats = 5000;
         int threads = 8;
+        RecordHeader header = new RecordHeader(
+            ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
+            ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8))
+        );
 
-        for (int test = 0; test < repeats; test++) {
-            RecordHeader header = new RecordHeader(
-                ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)),
-                ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8))
-            );
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicBoolean raceDetected = new AtomicBoolean(false);
 
-            ExecutorService pool = Executors.newFixedThreadPool(threads);
-            CountDownLatch startLatch = new CountDownLatch(1);
-            AtomicBoolean raceDetected = new AtomicBoolean(false);
+        Runnable task = () -> {
+            try {
+                startLatch.await();
+                header.key();
+                header.value();
+            } catch (NullPointerException e) {
+                raceDetected.set(true);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
 
-            Runnable task = () -> {
-                try {
-                    startLatch.await();
-                    header.key();
-                    header.value();
-                } catch (NullPointerException e) {
-                    raceDetected.set(true);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            };
+        for (int i = 0; i < threads; i++) pool.submit(task);
 
-            for (int i = 0; i < threads; i++) pool.submit(task);
+        startLatch.countDown();
+        pool.shutdown();
+        pool.awaitTermination(5, TimeUnit.SECONDS);
 
-            startLatch.countDown();
-            pool.shutdown();
-            pool.awaitTermination(5, TimeUnit.SECONDS);
-
-            assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
-        }
+        assertFalse(raceDetected.get(), "Read race condition detected in RecordHeader!");
     }
 }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -27,7 +27,7 @@
 <ul>
     <li>
         The <code>org.apache.kafka.common.header.internals.RecordHeader</code> class has been updated to be read thread-safe. See <a href="https://cwiki.apache.org/confluence/x/nYmhFg">KIP-1205</a> for details.
-        In other words, <code>ConsumerRecord</code> headers can now be safely read from multiple threads concurrently.
+        In other words, each individual <code>Header</code> object within a <code>ConsumerRecord</code>'s <code>headers</code> can now be safely read from multiple threads concurrently.
     </li>
     <li>
         The <code>org.apache.kafka.disallowed.login.modules</code> config was deprecated. Please use the <code>org.apache.kafka.allowed.login.modules</code>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -27,6 +27,7 @@
 <ul>
     <li>
         The <code>org.apache.kafka.common.header.internals.RecordHeader</code> class has been updated to be read thread-safe. See <a href="https://cwiki.apache.org/confluence/x/nYmhFg">KIP-1205</a> for details.
+        In other words, <code>ConsumerRecord</code> headers can now be safely read from multiple threads concurrently.
     </li>
     <li>
         The <code>org.apache.kafka.disallowed.login.modules</code> config was deprecated. Please use the <code>org.apache.kafka.allowed.login.modules</code>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -26,6 +26,9 @@
 <h5><a id="upgrade_420_notable" href="#upgrade_420_notable">Notable changes in 4.2.0</a></h5>
 <ul>
     <li>
+        The <code>org.apache.kafka.common.header.internals.RecordHeader</code> class has been updated to be read thread-safe. See <a href="https://cwiki.apache.org/confluence/x/nYmhFg">KIP-1205</a> for details.
+    </li>
+    <li>
         The <code>org.apache.kafka.disallowed.login.modules</code> config was deprecated. Please use the <code>org.apache.kafka.allowed.login.modules</code>
         instead.
     </li>


### PR DESCRIPTION
This patch implements
[KIP-1205](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1205%3A+Improve+RecordHeader+to+be+Thread-Safe)
to address concurrency issues (NPE) related to the lazy initialization
of `RecordHeader` fields.

The added test verified that concurrent access to `RecordHeader.key()`
and `RecordHeader.value()` no longer throws `NullPointerException`

Reviewers: TaiJuWu <tjwu1217@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
