### PR TITLE
KAFKA-19825 [2/2]: Add coordinator batch flush rate metric

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorState;
 
 import java.util.Arrays;
@@ -127,9 +128,9 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     private final Sensor lingerTimeSensor;
 
     /**
-     * Sensor to measure the flush time.
+     * Sensor to measure the flush time and rate.
      */
-    private final Sensor flushTimeSensor;
+    private final Sensor flushSensor;
 
     public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup) {
         this.metrics = Objects.requireNonNull(metrics);
@@ -224,8 +225,14 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
                 "The " + suffix + " flush time in milliseconds"
             )
         );
-        this.flushTimeSensor = metrics.sensor(this.metricsGroup + "-FlushTime");
-        this.flushTimeSensor.add(flushTimeHistogram);
+        this.flushSensor = metrics.sensor(this.metricsGroup + "-Flush");
+        this.flushSensor.add(flushTimeHistogram);
+        this.flushSensor.add(
+            metrics.metricName(
+                "batch-flush-rate",
+                this.metricsGroup,
+                "The flushes per second."),
+            new Rate(TimeUnit.SECONDS, new WindowedCount()));
     }
 
     /**
@@ -254,7 +261,7 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
         metrics.removeSensor(eventProcessingTimeSensor.name());
         metrics.removeSensor(eventPurgatoryTimeSensor.name());
         metrics.removeSensor(lingerTimeSensor.name());
-        metrics.removeSensor(flushTimeSensor.name());
+        metrics.removeSensor(flushSensor.name());
     }
 
     /**
@@ -321,7 +328,7 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
 
     @Override
     public void recordFlushTime(long durationMs) {
-        flushTimeSensor.record(durationMs);
+        flushSensor.record(durationMs);
     }
 
     @Override

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1931,6 +1931,11 @@ The following set of metrics are available for monitoring the group coordinator:
       <td>The time that a batch took to be flushed to the local partition</td>
     </tr>
     <tr>
+      <td>Batch Flush Rate</td>
+      <td>kafka.server:type=group-coordinator-metrics,name=batch-flush-rate</td>
+      <td>The number of batches flushed per second</td>
+    </tr>
+    <tr>
       <td>Group Count, per group type</td>
       <td>kafka.server:type=group-coordinator-metrics,name=group-count,protocol={consumer|classic}</td>
       <td>Total number of group per group type: Classic or Consumer</td>


### PR DESCRIPTION
Add a batch flush rate metric for the group coordinator and share
coordinator. Once we allow the batch linger time to be adaptive, the
batch flush rate becomes less predictable.

Reviewers: David Jacot <djacot@confluent.io>
