### PR TITLE
KAFKA-19685: Add possibility of passing in revoked partitions in task precommit

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -130,6 +130,7 @@ public abstract class SinkTask implements Task {
      *                       {@link Transformation transformations} have been applied. These can be tracked by the task
      *                       through the {@link SinkRecord#originalTopic()}, {@link SinkRecord#originalKafkaPartition()}
      *                       and {@link SinkRecord#originalKafkaOffset()} methods.
+     *                       During rebalancing, this map may contain revoked partitions.
      *
      * @return an empty map if Connect-managed offset commit is not desired, otherwise a map of offsets by topic-partition that are
      *         safe to commit. Note that the returned topic-partition to offsets map should use the original Kafka


### PR DESCRIPTION
This patch clarifies `SinkTask.precommit`, which may see revoked partitions during rebalancing and stopping.

As pointed out in [KAFKA-19685](https://issues.apache.org/jira/browse/KAFKA-19685), there is a difference in whether `SinkTask.precommit` sees revoked partitions during iteration or stopping.  

This difference appears to be intentional for correctness w.r.t. rebalance
- During [iteration](https://github.com/apache/kafka/blob/2c444485123a5790170856284f613384b4b033c2/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L237), partition ownership may change due to rebalanced, so revoked partitions should be [cleaned up](https://github.com/apache/kafka/blob/2c444485123a5790170856284f613384b4b033c2/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L795) at each poll, to avoid committing offsets for partitions no longer owned
- During [stopping](https://github.com/apache/kafka/blob/2c444485123a5790170856284f613384b4b033c2/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L223), all current offsets are committed regardless of partition ownership to record the final state.  The task is ending its lifecycle and no new records will be processed.
