### PR TITLE
KAFKA-19807: Add RPC-level integration tests for StreamsGroupHeartbeat [1/2]

### DIFF
--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -880,6 +880,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     warmupTasks: List[StreamsGroupHeartbeatRequestData.TaskIds] = null,
     topology: StreamsGroupHeartbeatRequestData.Topology = null,
     expectedError: Errors = Errors.NONE,
+    processId: String = null,
     version: Short = ApiKeys.STREAMS_GROUP_HEARTBEAT.latestVersion(isUnstableApiEnabled)
   ): StreamsGroupHeartbeatResponseData = {
     val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
@@ -892,6 +893,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
         .setStandbyTasks(standbyTasks.asJava)
         .setWarmupTasks(warmupTasks.asJava)
         .setTopology(topology)
+        .setProcessId(processId)
     ).build(version)
 
     // Send the request until receiving a successful response. There is a delay

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -1,5 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.server
-
 
 import kafka.utils.TestUtils
 import org.apache.kafka.common.message.{StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData}

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -298,7 +298,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       }, "Second StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify second member gets assigned
-      assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse2, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId2, streamsGroupHeartbeatResponse2.memberId())
       assertEquals(2, streamsGroupHeartbeatResponse2.memberEpoch())
 

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -19,7 +19,7 @@ package kafka.server
 import kafka.utils.TestUtils
 import org.apache.kafka.common.message.{StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData}
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse}
+import org.apache.kafka.common.requests.StreamsGroupHeartbeatRequest
 import org.apache.kafka.common.test.ClusterInstance
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterFeature, ClusterTest, ClusterTestDefaults, Type}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
@@ -27,7 +27,6 @@ import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.server.common.Feature
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertThrows, assertTrue}
 
-import java.util.Collections
 import scala.jdk.CollectionConverters._
 
 @ClusterTestDefaults(
@@ -68,21 +67,20 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       .setEpoch(1)
       .setSubtopologies(java.util.Collections.emptyList())
     
-    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-      new StreamsGroupHeartbeatRequestData()
-        .setGroupId("test-group")
-        .setMemberId("test-member")
-        .setMemberEpoch(0)
-        .setRebalanceTimeoutMs(1000)
-        .setActiveTasks(java.util.Collections.emptyList())
-        .setStandbyTasks(java.util.Collections.emptyList())
-        .setWarmupTasks(java.util.Collections.emptyList())
-        .setTopology(topology)
-    ).build(0)
+    val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+      groupId = "test-group",
+      memberId = "test-member",
+      memberEpoch = 0,
+      rebalanceTimeoutMs = 1000,
+      activeTasks = List.empty,
+      standbyTasks = List.empty,
+      warmupTasks = List.empty,
+      topology = topology,
+      expectedError = Errors.UNSUPPORTED_VERSION,
+    )
     
-    val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
     val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code())
-    assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+    assertEquals(expectedResponse, streamsGroupHeartbeatResponse)
   }
 
   @ClusterTest(
@@ -95,22 +93,20 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       .setEpoch(1)
       .setSubtopologies(java.util.Collections.emptyList())
     
-    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-      new StreamsGroupHeartbeatRequestData()
-        .setGroupId("test-group")
-        .setMemberId("test-member")
-        .setMemberEpoch(0)
-        .setRebalanceTimeoutMs(1000)
-        .setActiveTasks(java.util.Collections.emptyList())
-        .setStandbyTasks(java.util.Collections.emptyList())
-        .setWarmupTasks(java.util.Collections.emptyList())
-        .setTopology(topology),
-      true  // enableUnstableLastVersion = true
-    ).build(0)
+    val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+      groupId = "test-group",
+      memberId = "test-member",
+      memberEpoch = 0,
+      rebalanceTimeoutMs = 1000,
+      activeTasks = List.empty,
+      standbyTasks = List.empty,
+      warmupTasks = List.empty,
+      topology = topology,
+      expectedError = Errors.UNSUPPORTED_VERSION
+    )
 
-    val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
     val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code())
-    assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+    assertEquals(expectedResponse, streamsGroupHeartbeatResponse)
   }
 
   @ClusterTest(
@@ -123,22 +119,20 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       .setEpoch(1)
       .setSubtopologies(java.util.Collections.emptyList())
     
-    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-      new StreamsGroupHeartbeatRequestData()
-        .setGroupId("test-group")
-        .setMemberId("test-member")
-        .setMemberEpoch(0)
-        .setRebalanceTimeoutMs(1000)
-        .setActiveTasks(java.util.Collections.emptyList())
-        .setStandbyTasks(java.util.Collections.emptyList())
-        .setWarmupTasks(java.util.Collections.emptyList())
-        .setTopology(topology),
-      false  // enableUnstableLastVersion = false
-    ).build(0)
+    val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+      groupId = "test-group",
+      memberId = "test-member",
+      memberEpoch = 0,
+      rebalanceTimeoutMs = 1000,
+      activeTasks = List.empty,
+      standbyTasks = List.empty,
+      warmupTasks = List.empty,
+      topology = topology,
+      expectedError = Errors.NOT_COORDINATOR
+    )
 
-    val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
     val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.NOT_COORDINATOR.code())
-    assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+    assertEquals(expectedResponse, streamsGroupHeartbeatResponse)
   }
 
   @ClusterTest
@@ -159,33 +153,30 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
 
       val topology = createMockTopology(topicName)
 
-      val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-          .setGroupId(groupId)
-          .setMemberId(memberId)
-          .setMemberEpoch(0)
-          .setRebalanceTimeoutMs(1000)
-          .setActiveTasks(java.util.Collections.emptyList())
-          .setStandbyTasks(java.util.Collections.emptyList())
-          .setWarmupTasks(java.util.Collections.emptyList())
-          .setTopology(topology)
-      ).build(0)
-
       // Heartbeat when topic does not exist
-      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponse = null
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponseData = null
       TestUtils.waitUntilTrue(() => {
-        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
-        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+        streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId,
+          memberEpoch = 0,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = List.empty,
+          standbyTasks = List.empty,
+          warmupTasks = List.empty,
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse.errorCode == Errors.NONE.code()
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify the response
       assertNotNull(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals(memberId, streamsGroupHeartbeatResponse.data.memberId())
-      assertEquals(1, streamsGroupHeartbeatResponse.data.memberEpoch())
+      assertEquals(memberId, streamsGroupHeartbeatResponse.memberId())
+      assertEquals(1, streamsGroupHeartbeatResponse.memberEpoch())
       val expectedStatus = new StreamsGroupHeartbeatResponseData.Status()
         .setStatusCode(1)
         .setStatusDetail(s"Source topics $topicName are missing.")
-      assertEquals(expectedStatus, streamsGroupHeartbeatResponse.data.status().get(0))
+      assertEquals(expectedStatus, streamsGroupHeartbeatResponse.status().get(0))
 
       // Create topic
       TestUtils.createTopicWithAdmin(
@@ -202,21 +193,30 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
 
       // Heartbeat after topic is created
       TestUtils.waitUntilTrue(() => {
-        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
-        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+        streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId,
+          memberEpoch = 0,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = List.empty,
+          standbyTasks = List.empty,
+          warmupTasks = List.empty,
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse.errorCode == Errors.NONE.code()
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Active task assignment should be available
       assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals(memberId, streamsGroupHeartbeatResponse.data.memberId())
-      assertEquals(2, streamsGroupHeartbeatResponse.data.memberEpoch())
-      assertEquals(null, streamsGroupHeartbeatResponse.data.status())
+      assertEquals(memberId, streamsGroupHeartbeatResponse.memberId())
+      assertEquals(2, streamsGroupHeartbeatResponse.memberEpoch())
+      assertEquals(null, streamsGroupHeartbeatResponse.status())
       val expectedActiveTasks = List(
         new StreamsGroupHeartbeatResponseData.TaskIds()
           .setSubtopologyId("subtopology-1")
           .setPartitions(List(0, 1, 2).map(_.asInstanceOf[Integer]).asJava)
       ).asJava
-      assertEquals(expectedActiveTasks, streamsGroupHeartbeatResponse.data.activeTasks())
+      assertEquals(expectedActiveTasks, streamsGroupHeartbeatResponse.activeTasks())
     } finally {
       admin.close()
     }
@@ -254,111 +254,101 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       val topology = createMockTopology(topicName)
 
       // First member joins the group
-      var streamsGroupHeartbeatResponse1: StreamsGroupHeartbeatResponse = null
+      var streamsGroupHeartbeatResponse1: StreamsGroupHeartbeatResponseData = null
       TestUtils.waitUntilTrue(() => {
-        val streamsGroupHeartbeatRequest1 = new StreamsGroupHeartbeatRequest.Builder(
-          new StreamsGroupHeartbeatRequestData()
-            .setGroupId(groupId)
-            .setMemberId(memberId1)
-            .setMemberEpoch(0)
-            .setRebalanceTimeoutMs(1000)
-            .setActiveTasks(Option(streamsGroupHeartbeatResponse1)
-              .map(r => convertTaskIds(r.data().activeTasks()))
-              .getOrElse(Collections.emptyList()))
-            .setStandbyTasks(Option(streamsGroupHeartbeatResponse1)
-              .map(r => convertTaskIds(r.data().standbyTasks()))
-              .getOrElse(Collections.emptyList()))
-            .setWarmupTasks(Option(streamsGroupHeartbeatResponse1)
-              .map(r => convertTaskIds(r.data().warmupTasks()))
-              .getOrElse(Collections.emptyList()))
-            .setTopology(topology)
-        ).build(0)
-
-        streamsGroupHeartbeatResponse1 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest1)
-        streamsGroupHeartbeatResponse1.data.errorCode == Errors.NONE.code()
+        streamsGroupHeartbeatResponse1 = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId1,
+          memberEpoch = 0,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = Option(streamsGroupHeartbeatResponse1)
+            .map(r => convertTaskIds(r.activeTasks()))
+            .getOrElse(List.empty),
+          standbyTasks = Option(streamsGroupHeartbeatResponse1)
+            .map(r => convertTaskIds(r.standbyTasks()))
+            .getOrElse(List.empty),
+          warmupTasks = Option(streamsGroupHeartbeatResponse1)
+            .map(r => convertTaskIds(r.warmupTasks()))
+            .getOrElse(List.empty),
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse1.errorCode == Errors.NONE.code()
       }, "First StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify first member gets all tasks initially
       assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals(memberId1, streamsGroupHeartbeatResponse1.data.memberId())
-      assertEquals(1, streamsGroupHeartbeatResponse1.data.memberEpoch())
-      assertEquals(1, streamsGroupHeartbeatResponse1.data.activeTasks().size())
-      assertEquals(3, streamsGroupHeartbeatResponse1.data.activeTasks().get(0).partitions().size())
+      assertEquals(memberId1, streamsGroupHeartbeatResponse1.memberId())
+      assertEquals(1, streamsGroupHeartbeatResponse1.memberEpoch())
+      assertEquals(1, streamsGroupHeartbeatResponse1.activeTasks().size())
+      assertEquals(3, streamsGroupHeartbeatResponse1.activeTasks().get(0).partitions().size())
 
       // Second member joins the group (should trigger a rebalance)
-      var streamsGroupHeartbeatResponse2: StreamsGroupHeartbeatResponse = null
+      var streamsGroupHeartbeatResponse2: StreamsGroupHeartbeatResponseData = null
       TestUtils.waitUntilTrue(() => {
-        val streamsGroupHeartbeatRequest2 = new StreamsGroupHeartbeatRequest.Builder(
-          new StreamsGroupHeartbeatRequestData()
-            .setGroupId(groupId)
-            .setMemberId(memberId2)
-            .setMemberEpoch(0)
-            .setRebalanceTimeoutMs(1000)
-            .setActiveTasks(Option(streamsGroupHeartbeatResponse2)
-              .map(r => convertTaskIds(r.data().activeTasks()))
-              .getOrElse(Collections.emptyList()))
-            .setStandbyTasks(Option(streamsGroupHeartbeatResponse2)
-              .map(r => convertTaskIds(r.data().standbyTasks()))
-              .getOrElse(Collections.emptyList()))
-            .setWarmupTasks(Option(streamsGroupHeartbeatResponse2)
-              .map(r => convertTaskIds(r.data().warmupTasks()))
-              .getOrElse(Collections.emptyList()))
-            .setTopology(topology)
-        ).build(0)
-
-        streamsGroupHeartbeatResponse2 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest2)
-        streamsGroupHeartbeatResponse2.data.errorCode == Errors.NONE.code()
+        streamsGroupHeartbeatResponse2 = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId2,
+          memberEpoch = 0,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = Option(streamsGroupHeartbeatResponse2)
+            .map(r => convertTaskIds(r.activeTasks()))
+            .getOrElse(List.empty),
+          standbyTasks = Option(streamsGroupHeartbeatResponse2)
+            .map(r => convertTaskIds(r.standbyTasks()))
+            .getOrElse(List.empty),
+          warmupTasks = Option(streamsGroupHeartbeatResponse2)
+            .map(r => convertTaskIds(r.warmupTasks()))
+            .getOrElse(List.empty),
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse2.errorCode == Errors.NONE.code()
       }, "Second StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify second member gets assigned
       assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals(memberId2, streamsGroupHeartbeatResponse2.data.memberId())
-      assertEquals(2, streamsGroupHeartbeatResponse2.data.memberEpoch())
+      assertEquals(memberId2, streamsGroupHeartbeatResponse2.memberId())
+      assertEquals(2, streamsGroupHeartbeatResponse2.memberEpoch())
 
-      // Both members continue to send heartbeats with their assigned tasks
+      // Wait for both members to get their task assignments by sending heartbeats
+      // until they both have non-null activeTasks
       TestUtils.waitUntilTrue(() => {
-        val streamsGroupHeartbeatRequest1 = new StreamsGroupHeartbeatRequest.Builder(
-          new StreamsGroupHeartbeatRequestData()
-            .setGroupId(groupId)
-            .setMemberId(memberId1)
-            .setMemberEpoch(streamsGroupHeartbeatResponse1.data.memberEpoch())
-            .setRebalanceTimeoutMs(1000)
-            .setActiveTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.activeTasks()))
-            .setStandbyTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.standbyTasks()))
-            .setWarmupTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.warmupTasks()))
-            .setTopology(topology)
-        ).build(0)
-
-        streamsGroupHeartbeatResponse1 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest1)
-        streamsGroupHeartbeatResponse1.data.errorCode == Errors.NONE.code()
-      }, "First member rebalance heartbeat did not succeed within the timeout period.")
+        streamsGroupHeartbeatResponse1 = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId1,
+          memberEpoch = streamsGroupHeartbeatResponse1.memberEpoch(),
+          rebalanceTimeoutMs = 1000,
+          activeTasks = convertTaskIds(streamsGroupHeartbeatResponse1.activeTasks()),
+          standbyTasks = convertTaskIds(streamsGroupHeartbeatResponse1.standbyTasks()),
+          warmupTasks = convertTaskIds(streamsGroupHeartbeatResponse1.warmupTasks())
+        )
+        streamsGroupHeartbeatResponse1.errorCode == Errors.NONE.code() && 
+        streamsGroupHeartbeatResponse1.activeTasks() != null
+      }, "First member did not get task assignment within the timeout period.")
 
       TestUtils.waitUntilTrue(() => {
-        val streamsGroupHeartbeatRequest2 = new StreamsGroupHeartbeatRequest.Builder(
-          new StreamsGroupHeartbeatRequestData()
-            .setGroupId(groupId)
-            .setMemberId(memberId2)
-            .setMemberEpoch(streamsGroupHeartbeatResponse2.data.memberEpoch())
-            .setRebalanceTimeoutMs(1000)
-            .setActiveTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.activeTasks()))
-            .setStandbyTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.standbyTasks()))
-            .setWarmupTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.warmupTasks()))
-            .setTopology(topology)
-        ).build(0)
+        streamsGroupHeartbeatResponse2 = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId2,
+          memberEpoch = streamsGroupHeartbeatResponse2.memberEpoch(),
+          rebalanceTimeoutMs = 1000,
+          activeTasks = convertTaskIds(streamsGroupHeartbeatResponse2.activeTasks()),
+          standbyTasks = convertTaskIds(streamsGroupHeartbeatResponse2.standbyTasks()),
+          warmupTasks = convertTaskIds(streamsGroupHeartbeatResponse2.warmupTasks())
+        )
+        streamsGroupHeartbeatResponse2.errorCode == Errors.NONE.code() && 
+        streamsGroupHeartbeatResponse2.activeTasks() != null
+      }, "Second member did not get task assignment within the timeout period.")
 
-        streamsGroupHeartbeatResponse2 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest2)
-        streamsGroupHeartbeatResponse2.data.errorCode == Errors.NONE.code()
-      }, "Second member rebalance heartbeat did not succeed within the timeout period.")
 
       // Verify both members should have tasks assigned
       assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals(memberId1, streamsGroupHeartbeatResponse1.data.memberId())
+      assertEquals(memberId1, streamsGroupHeartbeatResponse1.memberId())
       
       assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals(memberId2, streamsGroupHeartbeatResponse2.data.memberId())
+      assertEquals(memberId2, streamsGroupHeartbeatResponse2.memberId())
 
       // At least one member should have active tasks
-      val totalActiveTasks = streamsGroupHeartbeatResponse1.data.activeTasks().size() + streamsGroupHeartbeatResponse2.data.activeTasks().size()
+      val totalActiveTasks = streamsGroupHeartbeatResponse1.activeTasks().size() + streamsGroupHeartbeatResponse2.activeTasks().size()
       assertTrue(totalActiveTasks > 0, "At least one member should have active tasks")
 
     } finally {
@@ -381,23 +371,22 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         .setEpoch(1)
         .setSubtopologies(java.util.Collections.emptyList())
 
-      val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-          .setGroupId("")  // Empty group ID
-          .setMemberId("test-member")
-          .setMemberEpoch(0)
-          .setRebalanceTimeoutMs(1000)
-          .setActiveTasks(java.util.Collections.emptyList())
-          .setStandbyTasks(java.util.Collections.emptyList())
-          .setWarmupTasks(java.util.Collections.emptyList())
-          .setTopology(topology)
-      ).build(0)
-
-      val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+      val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+        groupId = "",  // Empty group ID
+        memberId = "test-member",
+        memberEpoch = 0,
+        rebalanceTimeoutMs = 1000,
+        activeTasks = List.empty,
+        standbyTasks = List.empty,
+        warmupTasks = List.empty,
+        topology = topology,
+        expectedError = Errors.INVALID_REQUEST
+      )
+      
       val expectedResponse = new StreamsGroupHeartbeatResponseData()
         .setErrorCode(Errors.INVALID_REQUEST.code())
         .setErrorMessage("GroupId can't be empty.")
-      assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+      assertEquals(expectedResponse, streamsGroupHeartbeatResponse)
     } finally {
       admin.close()
     }
@@ -430,47 +419,41 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       val topology = createMockTopology(topicName)
 
       // Join group
-      var streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-          .setGroupId("test-group")
-          .setMemberId("test-member")
-          .setMemberEpoch(0)
-          .setRebalanceTimeoutMs(1000)
-          .setActiveTasks(java.util.Collections.emptyList())
-          .setStandbyTasks(java.util.Collections.emptyList())
-          .setWarmupTasks(java.util.Collections.emptyList())
-          .setTopology(topology)
-      ).build(0)
-
-      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponse = null
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponseData = null
       TestUtils.waitUntilTrue(() => {
-        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
-        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+        streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+          groupId = "test-group",
+          memberId = "test-member",
+          memberEpoch = 0,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = List.empty,
+          standbyTasks = List.empty,
+          warmupTasks = List.empty,
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse.errorCode == Errors.NONE.code()
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify the member joined successfully
       assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
-      assertEquals("test-member", streamsGroupHeartbeatResponse.data.memberId())
-      assertEquals(1, streamsGroupHeartbeatResponse.data.memberEpoch())
+      assertEquals("test-member", streamsGroupHeartbeatResponse.memberId())
+      assertEquals(1, streamsGroupHeartbeatResponse.memberEpoch())
 
       // Send a leave request
-      streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-          .setGroupId("test-group")
-          .setMemberId(streamsGroupHeartbeatResponse.data.memberId())
-          .setMemberEpoch(-1)  // LEAVE_GROUP_MEMBER_EPOCH
-          .setRebalanceTimeoutMs(1000)
-          .setActiveTasks(java.util.Collections.emptyList())
-          .setStandbyTasks(java.util.Collections.emptyList())
-          .setWarmupTasks(java.util.Collections.emptyList())
-      ).build(0)
-
-      streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+      streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+        groupId = "test-group",
+        memberId = streamsGroupHeartbeatResponse.memberId(),
+        memberEpoch = -1,  // LEAVE_GROUP_MEMBER_EPOCH
+        rebalanceTimeoutMs = 1000,
+        activeTasks = List.empty,
+        standbyTasks = List.empty,
+        warmupTasks = List.empty
+      )
       
       // Verify the leave request was successful
-      assertEquals(Errors.NONE.code(), streamsGroupHeartbeatResponse.data.errorCode())
-      assertEquals("test-member", streamsGroupHeartbeatResponse.data.memberId())
-      assertEquals(-1, streamsGroupHeartbeatResponse.data.memberEpoch())
+      assertEquals(Errors.NONE.code(), streamsGroupHeartbeatResponse.errorCode())
+      assertEquals("test-member", streamsGroupHeartbeatResponse.memberId())
+      assertEquals(-1, streamsGroupHeartbeatResponse.memberEpoch())
 
     } finally {
       admin.close()
@@ -503,54 +486,51 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
 
       val topology = createMockTopology(topicName)
 
-      var streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-          .setGroupId("test-group")
-          .setMemberId("test-member")
-          .setMemberEpoch(0)
-          .setRebalanceTimeoutMs(1000)
-          .setActiveTasks(java.util.Collections.emptyList())
-          .setStandbyTasks(java.util.Collections.emptyList())
-          .setWarmupTasks(java.util.Collections.emptyList())
-          .setTopology(topology)
-      ).build(0)
-
-      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponse = null
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponseData = null
       TestUtils.waitUntilTrue(() => {
-        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
-        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+        streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+          groupId = "test-group",
+          memberId = "test-member",
+          memberEpoch = 0,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = List.empty,
+          standbyTasks = List.empty,
+          warmupTasks = List.empty,
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse.errorCode == Errors.NONE.code()
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
-      streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-          .setGroupId("test-group")
-          .setMemberId(streamsGroupHeartbeatResponse.data.memberId())
-          .setMemberEpoch(999)  // Too high member epoch
-          .setRebalanceTimeoutMs(1000)
-          .setActiveTasks(java.util.Collections.emptyList())
-          .setStandbyTasks(java.util.Collections.emptyList())
-          .setWarmupTasks(java.util.Collections.emptyList())
-      ).build(0)
-
-      streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+      streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+        groupId = "test-group",
+        memberId = streamsGroupHeartbeatResponse.memberId(),
+        memberEpoch = 999,  // Too high member epoch
+        rebalanceTimeoutMs = 1000,
+        activeTasks = List.empty,
+        standbyTasks = List.empty,
+        warmupTasks = List.empty,
+        topology = null,
+        expectedError = Errors.FENCED_MEMBER_EPOCH
+      )
+      
       val expectedResponse = new StreamsGroupHeartbeatResponseData()
         .setErrorCode(Errors.FENCED_MEMBER_EPOCH.code())
         .setErrorMessage("The streams group member has a greater member epoch (999) than the one known by the group coordinator (1). The member must abandon all its partitions and rejoin.")
-      assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+      assertEquals(expectedResponse, streamsGroupHeartbeatResponse)
     } finally {
       admin.close()
     }
   }
 
-  private def convertTaskIds(responseTasks: java.util.List[StreamsGroupHeartbeatResponseData.TaskIds]): java.util.List[StreamsGroupHeartbeatRequestData.TaskIds] = {
+  private def convertTaskIds(responseTasks: java.util.List[StreamsGroupHeartbeatResponseData.TaskIds]): List[StreamsGroupHeartbeatRequestData.TaskIds] = {
     if (responseTasks == null) {
-      java.util.Collections.emptyList()
+      List.empty
     } else {
       responseTasks.asScala.map { responseTask =>
         new StreamsGroupHeartbeatRequestData.TaskIds()
           .setSubtopologyId(responseTask.subtopologyId)
           .setPartitions(responseTask.partitions)
-      }.asJava
+      }.toList
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -142,6 +142,8 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         controllers = cluster.controllers().values().asScala.toSeq
       )
 
+      val topology = createMockTopology(topicName)
+
       val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
         new StreamsGroupHeartbeatRequestData()
           .setGroupId(groupId)
@@ -151,18 +153,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
           .setActiveTasks(java.util.Collections.emptyList())
           .setStandbyTasks(java.util.Collections.emptyList())
           .setWarmupTasks(java.util.Collections.emptyList())
-          .setTopology(
-            new StreamsGroupHeartbeatRequestData.Topology()
-              .setEpoch(1)
-              .setSubtopologies(List(
-                new StreamsGroupHeartbeatRequestData.Subtopology()
-                  .setSubtopologyId("subtopology-1")
-                  .setSourceTopics(List(topicName).asJava)
-                  .setRepartitionSinkTopics(List.empty.asJava)
-                  .setRepartitionSourceTopics(List.empty.asJava)
-                  .setStateChangelogTopics(List.empty.asJava)
-              ).asJava)
-          )
+          .setTopology(topology)
       ).build(0)
 
       // Heartbeat when topic does not exist
@@ -211,8 +202,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
           .setPartitions(List(0, 1, 2).map(_.asInstanceOf[Integer]).asJava)
       ).asJava
       assertEquals(expectedActiveTasks, streamsGroupHeartbeatResponse.data.activeTasks())
-
-
     } finally {
       admin.close()
     }
@@ -248,6 +237,8 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         admin.listTopics().names().get().contains(topicName)
       }, msg = s"Topic $topicName is not available to the group coordinator")
 
+      val topology = createMockTopology(topicName)
+
       // First member joins the group
       var streamsGroupHeartbeatResponse1: StreamsGroupHeartbeatResponse = null
       TestUtils.waitUntilTrue(() => {
@@ -266,18 +257,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
             .setWarmupTasks(Option(streamsGroupHeartbeatResponse1)
               .map(r => convertTaskIds(r.data().warmupTasks()))
               .getOrElse(Collections.emptyList()))
-            .setTopology(
-              new StreamsGroupHeartbeatRequestData.Topology()
-                .setEpoch(1)
-                .setSubtopologies(List(
-                  new StreamsGroupHeartbeatRequestData.Subtopology()
-                    .setSubtopologyId("subtopology-1")
-                    .setSourceTopics(List(topicName).asJava)
-                    .setRepartitionSinkTopics(List.empty.asJava)
-                    .setRepartitionSourceTopics(List.empty.asJava)
-                    .setStateChangelogTopics(List.empty.asJava)
-                ).asJava)
-            )
+            .setTopology(topology)
         ).build(0)
 
         streamsGroupHeartbeatResponse1 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest1)
@@ -309,18 +289,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
             .setWarmupTasks(Option(streamsGroupHeartbeatResponse2)
               .map(r => convertTaskIds(r.data().warmupTasks()))
               .getOrElse(Collections.emptyList()))
-            .setTopology(
-              new StreamsGroupHeartbeatRequestData.Topology()
-                .setEpoch(1)
-                .setSubtopologies(List(
-                  new StreamsGroupHeartbeatRequestData.Subtopology()
-                    .setSubtopologyId("subtopology-1")
-                    .setSourceTopics(List(topicName).asJava)
-                    .setRepartitionSinkTopics(List.empty.asJava)
-                    .setRepartitionSourceTopics(List.empty.asJava)
-                    .setStateChangelogTopics(List.empty.asJava)
-                ).asJava)
-            )
+            .setTopology(topology)
         ).build(0)
 
         streamsGroupHeartbeatResponse2 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest2)
@@ -344,18 +313,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
             .setActiveTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.activeTasks()))
             .setStandbyTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.standbyTasks()))
             .setWarmupTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.warmupTasks()))
-            .setTopology(
-              new StreamsGroupHeartbeatRequestData.Topology()
-                .setEpoch(1)
-                .setSubtopologies(List(
-                  new StreamsGroupHeartbeatRequestData.Subtopology()
-                    .setSubtopologyId("subtopology-1")
-                    .setSourceTopics(List(topicName).asJava)
-                    .setRepartitionSinkTopics(List.empty.asJava)
-                    .setRepartitionSourceTopics(List.empty.asJava)
-                    .setStateChangelogTopics(List.empty.asJava)
-                ).asJava)
-            )
+            .setTopology(topology)
         ).build(0)
 
 
@@ -374,18 +332,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
             .setActiveTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.activeTasks()))
             .setStandbyTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.standbyTasks()))
             .setWarmupTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.warmupTasks()))
-            .setTopology(
-              new StreamsGroupHeartbeatRequestData.Topology()
-                .setEpoch(1)
-                .setSubtopologies(List(
-                  new StreamsGroupHeartbeatRequestData.Subtopology()
-                    .setSubtopologyId("subtopology-1")
-                    .setSourceTopics(List(topicName).asJava)
-                    .setRepartitionSinkTopics(List.empty.asJava)
-                    .setRepartitionSourceTopics(List.empty.asJava)
-                    .setStateChangelogTopics(List.empty.asJava)
-                ).asJava)
-            )
+            .setTopology(topology)
         ).build(0)
 
         streamsGroupHeartbeatResponse2 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest2)
@@ -408,6 +355,172 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     }
   }
 
+  @ClusterTest
+  def testEmptyStreamsGroupId(): Unit = {
+    val admin = cluster.admin()
+
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    try {
+      TestUtils.createOffsetsTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq
+      )
+
+      val topology = new StreamsGroupHeartbeatRequestData.Topology()
+        .setEpoch(1)
+        .setSubtopologies(java.util.Collections.emptyList())
+
+      val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+          .setGroupId("")  // Empty group ID
+          .setMemberId("test-member")
+          .setMemberEpoch(0)
+          .setRebalanceTimeoutMs(1000)
+          .setActiveTasks(java.util.Collections.emptyList())
+          .setStandbyTasks(java.util.Collections.emptyList())
+          .setWarmupTasks(java.util.Collections.emptyList())
+          .setTopology(topology)
+      ).build(0)
+
+      val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+      val expectedResponse = new StreamsGroupHeartbeatResponseData()
+        .setErrorCode(Errors.INVALID_REQUEST.code())
+        .setErrorMessage("GroupId can't be empty.")
+      assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+    } finally {
+      admin.close()
+    }
+  }
+
+  @ClusterTest
+  def testInvalidTopologyAtSecondHeartbeat(): Unit = {
+    val admin = cluster.admin()
+    val topicName = "test-topic"
+
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    try {
+      TestUtils.createOffsetsTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq
+      )
+
+      val topology = createMockTopology(topicName)
+
+      // First, join the group with a valid request
+      var streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+          .setGroupId("test-group")
+          .setMemberId("test-member")
+          .setMemberEpoch(0)
+          .setRebalanceTimeoutMs(1000)
+          .setActiveTasks(java.util.Collections.emptyList())
+          .setStandbyTasks(java.util.Collections.emptyList())
+          .setWarmupTasks(java.util.Collections.emptyList())
+          .setTopology(topology)
+      ).build(0)
+
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponse = null
+      TestUtils.waitUntilTrue(() => {
+        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+      }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
+
+      // Now send a request with an invalid member epoch (negative epoch)
+      streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+          .setGroupId("test-group")
+          .setMemberId(streamsGroupHeartbeatResponse.data.memberId())
+          .setMemberEpoch(-1)  // Invalid negative epoch
+          .setRebalanceTimeoutMs(1000)
+          .setActiveTasks(java.util.Collections.emptyList())
+          .setStandbyTasks(java.util.Collections.emptyList())
+          .setWarmupTasks(java.util.Collections.emptyList())
+          .setTopology(topology)
+      ).build(0)
+
+      streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+      val expectedResponse = new StreamsGroupHeartbeatResponseData()
+        .setErrorCode(Errors.INVALID_REQUEST.code())
+        .setErrorMessage("Topology can only be provided when (re-)joining.")
+      assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+    } finally {
+      admin.close()
+    }
+  }
+
+  @ClusterTest
+  def testInvalidMemberEpoch(): Unit = {
+    val admin = cluster.admin()
+    val topicName = "test-topic"
+
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    try {
+      TestUtils.createOffsetsTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq
+      )
+
+      // Create topic
+      TestUtils.createTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq,
+        topic = topicName,
+        numPartitions = 3
+      )
+      // Wait for topic to be available
+      TestUtils.waitUntilTrue(() => {
+        admin.listTopics().names().get().contains(topicName)
+      }, msg = s"Topic $topicName is not available to the group coordinator")
+
+      val topology = createMockTopology(topicName)
+
+      // First, join the group with a valid request
+      var streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+          .setGroupId("test-group")
+          .setMemberId("test-member")
+          .setMemberEpoch(0)
+          .setRebalanceTimeoutMs(1000)
+          .setActiveTasks(java.util.Collections.emptyList())
+          .setStandbyTasks(java.util.Collections.emptyList())
+          .setWarmupTasks(java.util.Collections.emptyList())
+          .setTopology(topology)
+      ).build(0)
+
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponse = null
+      TestUtils.waitUntilTrue(() => {
+        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+      }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
+
+      streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+          .setGroupId("test-group")
+          .setMemberId(streamsGroupHeartbeatResponse.data.memberId())
+          .setMemberEpoch(999)  // Too high member epoch
+          .setRebalanceTimeoutMs(1000)
+          .setActiveTasks(java.util.Collections.emptyList())
+          .setStandbyTasks(java.util.Collections.emptyList())
+          .setWarmupTasks(java.util.Collections.emptyList())
+      ).build(0)
+
+      streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+      val expectedResponse = new StreamsGroupHeartbeatResponseData()
+        .setErrorCode(Errors.FENCED_MEMBER_EPOCH.code())
+        .setErrorMessage("The streams group member has a greater member epoch (999) than the one known by the group coordinator (1). The member must abandon all its partitions and rejoin.")
+      assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+    } finally {
+      admin.close()
+    }
+  }
+
   private def convertTaskIds(responseTasks: java.util.List[StreamsGroupHeartbeatResponseData.TaskIds]): java.util.List[StreamsGroupHeartbeatRequestData.TaskIds] = {
     if (responseTasks == null) {
       java.util.Collections.emptyList()
@@ -418,5 +531,18 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
           .setPartitions(responseTask.partitions)
       }.asJava
     }
+  }
+
+  private def createMockTopology(topicName: String): StreamsGroupHeartbeatRequestData.Topology = {
+    new StreamsGroupHeartbeatRequestData.Topology()
+      .setEpoch(1)
+      .setSubtopologies(List(
+        new StreamsGroupHeartbeatRequestData.Subtopology()
+          .setSubtopologyId("subtopology-1")
+          .setSourceTopics(List(topicName).asJava)
+          .setRepartitionSinkTopics(List.empty.asJava)
+          .setRepartitionSourceTopics(List.empty.asJava)
+          .setStateChangelogTopics(List.empty.asJava)
+      ).asJava)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -10,7 +10,7 @@ import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterFeature, 
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.server.common.Feature
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertThrows, assertTrue}
 
 import java.util.Collections
 import scala.jdk.CollectionConverters._
@@ -47,7 +47,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       new ClusterFeature(feature = Feature.STREAMS_VERSION, version = 0)
     )
   )
-  def testStreamsGroupHeartbeatIsInaccessableWhenDisabledByFeatureConfig(): Unit = {
+  def testStreamsGroupHeartbeatIsInaccessibleWhenDisabledByFeatureConfig(): Unit = {
     // Test with streams.version = 0, the API is disabled at server level
     val topology = new StreamsGroupHeartbeatRequestData.Topology()
       .setEpoch(1)
@@ -75,7 +75,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       new ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer"),
     )
   )
-  def testStreamsGroupHeartbeatIsInaccessableWhenDisabledByStaticGroupCoordinatorProtocolConfig(): Unit = {
+  def testStreamsGroupHeartbeatIsInaccessibleWhenDisabledByStaticGroupCoordinatorProtocolConfig(): Unit = {
     val topology = new StreamsGroupHeartbeatRequestData.Topology()
       .setEpoch(1)
       .setSubtopologies(java.util.Collections.emptyList())
@@ -127,7 +127,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   }
 
   @ClusterTest
-  def tesStreamsGroupHeartbeatIsAccessibleWhenNewGroupCoordinatorIsEnabledTopicNotExistFirst(): Unit = {
+  def testStreamsGroupHeartbeatIsAccessibleWhenNewGroupCoordinatorIsEnabledTopicNotExistFirst(): Unit = {
     val admin = cluster.admin()
     val memberId = "test-member"
     val groupId = "test-group"
@@ -164,7 +164,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify the response
-      assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId, streamsGroupHeartbeatResponse.data.memberId())
       assertEquals(1, streamsGroupHeartbeatResponse.data.memberEpoch())
       val expectedStatus = new StreamsGroupHeartbeatResponseData.Status()
@@ -208,7 +208,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   }
 
   @ClusterTest
-  def tesStreamsGroupHeartbeatForMultipleMembers(): Unit = {
+  def testStreamsGroupHeartbeatForMultipleMembers(): Unit = {
     val admin = cluster.admin()
     val memberId1 = "test-member-1"
     val memberId2 = "test-member-2"

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -426,7 +426,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify the member joined successfully
-      assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals("test-member", streamsGroupHeartbeatResponse.memberId())
       assertEquals(1, streamsGroupHeartbeatResponse.memberEpoch())
 

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -270,7 +270,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       }, "First StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify first member gets all tasks initially
-      assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse1, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId1, streamsGroupHeartbeatResponse1.memberId())
       assertEquals(1, streamsGroupHeartbeatResponse1.memberEpoch())
       assertEquals(1, streamsGroupHeartbeatResponse1.activeTasks().size())

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -65,7 +65,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     // Test with streams.version = 0, the API is disabled at server level
     val topology = new StreamsGroupHeartbeatRequestData.Topology()
       .setEpoch(1)
-      .setSubtopologies(java.util.Collections.emptyList())
+      .setSubtopologies(List().asJava)
     
     val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
       groupId = "test-group",
@@ -90,7 +90,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   def testStreamsGroupHeartbeatIsInaccessibleWhenDisabledByStaticGroupCoordinatorProtocolConfig(): Unit = {
     val topology = new StreamsGroupHeartbeatRequestData.Topology()
       .setEpoch(1)
-      .setSubtopologies(java.util.Collections.emptyList())
+      .setSubtopologies(List().asJava)
     
     val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
       groupId = "test-group",
@@ -115,7 +115,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   def testStreamsGroupHeartbeatIsInaccessibleWhenUnstableLatestVersionNotEnabled(): Unit = {
     val topology = new StreamsGroupHeartbeatRequestData.Topology()
       .setEpoch(1)
-      .setSubtopologies(java.util.Collections.emptyList())
+      .setSubtopologies(List().asJava)
     
     val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
       groupId = "test-group",
@@ -362,7 +362,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
 
       val topology = new StreamsGroupHeartbeatRequestData.Topology()
         .setEpoch(1)
-        .setSubtopologies(java.util.Collections.emptyList())
+        .setSubtopologies(List().asJava)
 
       val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
         groupId = "",  // Empty group ID

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -337,7 +337,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       assertNotNull(streamsGroupHeartbeatResponse1, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId1, streamsGroupHeartbeatResponse1.memberId())
       
-      assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse2, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId2, streamsGroupHeartbeatResponse2.memberId())
 
       // At least one member should have active tasks

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -10,9 +10,9 @@ import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterFeature, 
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.server.common.Feature
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
-import java.util.Collections
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 
+import java.util.Collections
 import scala.jdk.CollectionConverters._
 
 @ClusterTestDefaults(
@@ -399,9 +399,9 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId2, streamsGroupHeartbeatResponse2.data.memberId())
 
-      // At least one member should have active tasks (in a real scenario, tasks would be distributed)
+      // At least one member should have active tasks
       val totalActiveTasks = streamsGroupHeartbeatResponse1.data.activeTasks().size() + streamsGroupHeartbeatResponse2.data.activeTasks().size()
-      assert(totalActiveTasks > 0, "At least one member should have active tasks")
+      assertTrue(totalActiveTasks > 0, "At least one member should have active tasks")
 
     } finally {
       admin.close()

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -166,7 +166,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Verify the response
-      assertNotNull(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId, streamsGroupHeartbeatResponse.memberId())
       assertEquals(1, streamsGroupHeartbeatResponse.memberEpoch())
       val expectedStatus = new StreamsGroupHeartbeatResponseData.Status()

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -1,0 +1,422 @@
+package kafka.server
+
+
+import kafka.utils.TestUtils
+import org.apache.kafka.common.message.{StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{StreamsGroupHeartbeatRequest, StreamsGroupHeartbeatResponse}
+import org.apache.kafka.common.test.ClusterInstance
+import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterFeature, ClusterTest, ClusterTestDefaults, Type}
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
+import org.apache.kafka.common.errors.UnsupportedVersionException
+import org.apache.kafka.server.common.Feature
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
+import java.util.Collections
+
+import scala.jdk.CollectionConverters._
+
+@ClusterTestDefaults(
+  types = Array(Type.KRAFT),
+  serverProperties = Array(
+    new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+    new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+    new ClusterConfigProperty(key = "unstable.api.versions.enable", value = "true")
+  )
+)
+class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBaseRequestTest(cluster) {
+
+  @ClusterTest(
+    serverProperties = Array(
+      new ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,streams"),
+    )
+  )
+  def testStreamsGroupHeartbeatWithInvalidAPIVersion(): Unit = {
+    // Test that invalid API version throws UnsupportedVersionException
+    assertThrows(classOf[UnsupportedVersionException], () => {
+      new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+      ).build(-1)
+    })
+  }
+
+  @ClusterTest(
+    serverProperties = Array(
+      new ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,streams"),
+    ),
+    features = Array(
+      new ClusterFeature(feature = Feature.STREAMS_VERSION, version = 0)
+    )
+  )
+  def testStreamsGroupHeartbeatIsInaccessableWhenDisabledByFeatureConfig(): Unit = {
+    // Test with streams.version = 0, the API is disabled at server level
+    val topology = new StreamsGroupHeartbeatRequestData.Topology()
+      .setEpoch(1)
+      .setSubtopologies(java.util.Collections.emptyList())
+    
+    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+      new StreamsGroupHeartbeatRequestData()
+        .setGroupId("test-group")
+        .setMemberId("test-member")
+        .setMemberEpoch(0)
+        .setRebalanceTimeoutMs(1000)
+        .setActiveTasks(java.util.Collections.emptyList())
+        .setStandbyTasks(java.util.Collections.emptyList())
+        .setWarmupTasks(java.util.Collections.emptyList())
+        .setTopology(topology)
+    ).build(0)
+    
+    val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+    val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+    assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+  }
+
+  @ClusterTest(
+    serverProperties = Array(
+      new ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer"),
+    )
+  )
+  def testStreamsGroupHeartbeatIsInaccessableWhenDisabledByStaticGroupCoordinatorProtocolConfig(): Unit = {
+    val topology = new StreamsGroupHeartbeatRequestData.Topology()
+      .setEpoch(1)
+      .setSubtopologies(java.util.Collections.emptyList())
+    
+    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+      new StreamsGroupHeartbeatRequestData()
+        .setGroupId("test-group")
+        .setMemberId("test-member")
+        .setMemberEpoch(0)
+        .setRebalanceTimeoutMs(1000)
+        .setActiveTasks(java.util.Collections.emptyList())
+        .setStandbyTasks(java.util.Collections.emptyList())
+        .setWarmupTasks(java.util.Collections.emptyList())
+        .setTopology(topology),
+      true  // enableUnstableLastVersion = true
+    ).build(0)  // Explicitly use version 0
+
+    val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+    val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code())
+    assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+  }
+
+  @ClusterTest(
+    serverProperties = Array(
+      new ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,streams"),
+    )
+  )
+  def testStreamsGroupHeartbeatIsInaccessibleWhenUnstableLatestVersionNotEnabled(): Unit = {
+    val topology = new StreamsGroupHeartbeatRequestData.Topology()
+      .setEpoch(1)
+      .setSubtopologies(java.util.Collections.emptyList())
+    
+    val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+      new StreamsGroupHeartbeatRequestData()
+        .setGroupId("test-group")
+        .setMemberId("test-member")
+        .setMemberEpoch(0)
+        .setRebalanceTimeoutMs(1000)
+        .setActiveTasks(java.util.Collections.emptyList())
+        .setStandbyTasks(java.util.Collections.emptyList())
+        .setWarmupTasks(java.util.Collections.emptyList())
+        .setTopology(topology),
+      false  // enableUnstableLastVersion = false
+    ).build(0)  // Explicitly use version 0
+
+    val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+    val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.NOT_COORDINATOR.code())
+    assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+  }
+
+  @ClusterTest
+  def tesStreamsGroupHeartbeatIsAccessibleWhenNewGroupCoordinatorIsEnabledTopicNotExistFirst(): Unit = {
+    val admin = cluster.admin()
+    val memberId = "test-member"
+    val groupId = "test-group"
+    val topicName = "test-topic"
+
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    try {
+      TestUtils.createOffsetsTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq
+      )
+
+      val streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
+        new StreamsGroupHeartbeatRequestData()
+          .setGroupId(groupId)
+          .setMemberId(memberId)
+          .setMemberEpoch(0)
+          .setRebalanceTimeoutMs(1000)
+          .setActiveTasks(java.util.Collections.emptyList())
+          .setStandbyTasks(java.util.Collections.emptyList())
+          .setWarmupTasks(java.util.Collections.emptyList())
+          .setTopology(
+            new StreamsGroupHeartbeatRequestData.Topology()
+              .setEpoch(1)
+              .setSubtopologies(List(
+                new StreamsGroupHeartbeatRequestData.Subtopology()
+                  .setSubtopologyId("subtopology-1")
+                  .setSourceTopics(List(topicName).asJava)
+                  .setRepartitionSinkTopics(List.empty.asJava)
+                  .setRepartitionSourceTopics(List.empty.asJava)
+                  .setStateChangelogTopics(List.empty.asJava)
+              ).asJava)
+          )
+      ).build(0)
+
+      // Heartbeat when topic does not exist
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponse = null
+      TestUtils.waitUntilTrue(() => {
+        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+      }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
+
+      // Verify the response
+      assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals(memberId, streamsGroupHeartbeatResponse.data.memberId())
+      assertEquals(1, streamsGroupHeartbeatResponse.data.memberEpoch())
+      val expectedStatus = new StreamsGroupHeartbeatResponseData.Status()
+        .setStatusCode(1)
+        .setStatusDetail(s"Source topics $topicName are missing.")
+      assertEquals(expectedStatus, streamsGroupHeartbeatResponse.data.status().get(0))
+
+      // Create topic
+      TestUtils.createTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq,
+        topic = topicName,
+        numPartitions = 3
+      )
+      // Wait for topic to be available
+      TestUtils.waitUntilTrue(() => {
+        admin.listTopics().names().get().contains(topicName)
+      }, msg = s"Topic $topicName is not available to the group coordinator")
+
+      // Heartbeat after topic is created
+      TestUtils.waitUntilTrue(() => {
+        streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
+        streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
+      }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
+
+      // Active task assignment should be available
+      assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals(memberId, streamsGroupHeartbeatResponse.data.memberId())
+      assertEquals(2, streamsGroupHeartbeatResponse.data.memberEpoch())
+      assertEquals(null, streamsGroupHeartbeatResponse.data.status())
+      val expectedActiveTasks = List(
+        new StreamsGroupHeartbeatResponseData.TaskIds()
+          .setSubtopologyId("subtopology-1")
+          .setPartitions(List(0, 1, 2).map(_.asInstanceOf[Integer]).asJava)
+      ).asJava
+      assertEquals(expectedActiveTasks, streamsGroupHeartbeatResponse.data.activeTasks())
+
+
+    } finally {
+      admin.close()
+    }
+  }
+
+  @ClusterTest
+  def tesStreamsGroupHeartbeatIsAccessibleWhenNewGroupCoordinatorIsEnabledTwoMembers(): Unit = {
+    val admin = cluster.admin()
+    val memberId1 = "test-member-1"
+    val memberId2 = "test-member-2"
+    val groupId = "test-group"
+    val topicName = "test-topic"
+
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    try {
+      TestUtils.createOffsetsTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq
+      )
+
+      // Create topic
+      TestUtils.createTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq,
+        topic = topicName,
+        numPartitions = 3
+      )
+      // Wait for topic to be available
+      TestUtils.waitUntilTrue(() => {
+        admin.listTopics().names().get().contains(topicName)
+      }, msg = s"Topic $topicName is not available to the group coordinator")
+
+      // First member joins the group
+      var streamsGroupHeartbeatResponse1: StreamsGroupHeartbeatResponse = null
+      TestUtils.waitUntilTrue(() => {
+        val streamsGroupHeartbeatRequest1 = new StreamsGroupHeartbeatRequest.Builder(
+          new StreamsGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId1)
+            .setMemberEpoch(0)
+            .setRebalanceTimeoutMs(1000)
+            .setActiveTasks(Option(streamsGroupHeartbeatResponse1)
+              .map(r => convertTaskIds(r.data().activeTasks()))
+              .getOrElse(Collections.emptyList()))
+            .setStandbyTasks(Option(streamsGroupHeartbeatResponse1)
+              .map(r => convertTaskIds(r.data().standbyTasks()))
+              .getOrElse(Collections.emptyList()))
+            .setWarmupTasks(Option(streamsGroupHeartbeatResponse1)
+              .map(r => convertTaskIds(r.data().warmupTasks()))
+              .getOrElse(Collections.emptyList()))
+            .setTopology(
+              new StreamsGroupHeartbeatRequestData.Topology()
+                .setEpoch(1)
+                .setSubtopologies(List(
+                  new StreamsGroupHeartbeatRequestData.Subtopology()
+                    .setSubtopologyId("subtopology-1")
+                    .setSourceTopics(List(topicName).asJava)
+                    .setRepartitionSinkTopics(List.empty.asJava)
+                    .setRepartitionSourceTopics(List.empty.asJava)
+                    .setStateChangelogTopics(List.empty.asJava)
+                ).asJava)
+            )
+        ).build(0)
+
+        streamsGroupHeartbeatResponse1 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest1)
+        streamsGroupHeartbeatResponse1.data.errorCode == Errors.NONE.code()
+      }, "First StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
+
+      // Verify first member gets all tasks initially
+      assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals(memberId1, streamsGroupHeartbeatResponse1.data.memberId())
+      assertEquals(1, streamsGroupHeartbeatResponse1.data.memberEpoch())
+      assertEquals(1, streamsGroupHeartbeatResponse1.data.activeTasks().size())
+      assertEquals(3, streamsGroupHeartbeatResponse1.data.activeTasks().get(0).partitions().size())
+
+      // Second member joins the group (should trigger a rebalance)
+      var streamsGroupHeartbeatResponse2: StreamsGroupHeartbeatResponse = null
+      TestUtils.waitUntilTrue(() => {
+        val streamsGroupHeartbeatRequest2 = new StreamsGroupHeartbeatRequest.Builder(
+          new StreamsGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId2)
+            .setMemberEpoch(0)
+            .setRebalanceTimeoutMs(1000)
+            .setActiveTasks(Option(streamsGroupHeartbeatResponse2)
+              .map(r => convertTaskIds(r.data().activeTasks()))
+              .getOrElse(Collections.emptyList()))
+            .setStandbyTasks(Option(streamsGroupHeartbeatResponse2)
+              .map(r => convertTaskIds(r.data().standbyTasks()))
+              .getOrElse(Collections.emptyList()))
+            .setWarmupTasks(Option(streamsGroupHeartbeatResponse2)
+              .map(r => convertTaskIds(r.data().warmupTasks()))
+              .getOrElse(Collections.emptyList()))
+            .setTopology(
+              new StreamsGroupHeartbeatRequestData.Topology()
+                .setEpoch(1)
+                .setSubtopologies(List(
+                  new StreamsGroupHeartbeatRequestData.Subtopology()
+                    .setSubtopologyId("subtopology-1")
+                    .setSourceTopics(List(topicName).asJava)
+                    .setRepartitionSinkTopics(List.empty.asJava)
+                    .setRepartitionSourceTopics(List.empty.asJava)
+                    .setStateChangelogTopics(List.empty.asJava)
+                ).asJava)
+            )
+        ).build(0)
+
+        streamsGroupHeartbeatResponse2 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest2)
+        streamsGroupHeartbeatResponse2.data.errorCode == Errors.NONE.code()
+      }, "Second StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
+
+      // Verify second member gets assigned
+      assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals(memberId2, streamsGroupHeartbeatResponse2.data.memberId())
+      assertEquals(2, streamsGroupHeartbeatResponse2.data.memberEpoch())
+
+      // Now both members should send heartbeats with their assigned tasks
+      // First member should continue with its tasks
+      TestUtils.waitUntilTrue(() => {
+        val streamsGroupHeartbeatRequest1 = new StreamsGroupHeartbeatRequest.Builder(
+          new StreamsGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId1)
+            .setMemberEpoch(streamsGroupHeartbeatResponse1.data.memberEpoch())
+            .setRebalanceTimeoutMs(1000)
+            .setActiveTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.activeTasks()))
+            .setStandbyTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.standbyTasks()))
+            .setWarmupTasks(convertTaskIds(streamsGroupHeartbeatResponse1.data.warmupTasks()))
+            .setTopology(
+              new StreamsGroupHeartbeatRequestData.Topology()
+                .setEpoch(1)
+                .setSubtopologies(List(
+                  new StreamsGroupHeartbeatRequestData.Subtopology()
+                    .setSubtopologyId("subtopology-1")
+                    .setSourceTopics(List(topicName).asJava)
+                    .setRepartitionSinkTopics(List.empty.asJava)
+                    .setRepartitionSourceTopics(List.empty.asJava)
+                    .setStateChangelogTopics(List.empty.asJava)
+                ).asJava)
+            )
+        ).build(0)
+
+
+        streamsGroupHeartbeatResponse1 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest1)
+        streamsGroupHeartbeatResponse1.data.errorCode == Errors.NONE.code()
+      }, "First member rebalance heartbeat did not succeed within the timeout period.")
+
+      // Second member should also send heartbeat with its assigned tasks
+      TestUtils.waitUntilTrue(() => {
+        val streamsGroupHeartbeatRequest2 = new StreamsGroupHeartbeatRequest.Builder(
+          new StreamsGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId2)
+            .setMemberEpoch(streamsGroupHeartbeatResponse2.data.memberEpoch())
+            .setRebalanceTimeoutMs(1000)
+            .setActiveTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.activeTasks()))
+            .setStandbyTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.standbyTasks()))
+            .setWarmupTasks(convertTaskIds(streamsGroupHeartbeatResponse2.data.warmupTasks()))
+            .setTopology(
+              new StreamsGroupHeartbeatRequestData.Topology()
+                .setEpoch(1)
+                .setSubtopologies(List(
+                  new StreamsGroupHeartbeatRequestData.Subtopology()
+                    .setSubtopologyId("subtopology-1")
+                    .setSourceTopics(List(topicName).asJava)
+                    .setRepartitionSinkTopics(List.empty.asJava)
+                    .setRepartitionSourceTopics(List.empty.asJava)
+                    .setStateChangelogTopics(List.empty.asJava)
+                ).asJava)
+            )
+        ).build(0)
+
+        streamsGroupHeartbeatResponse2 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest2)
+        streamsGroupHeartbeatResponse2.data.errorCode == Errors.NONE.code()
+      }, "Second member rebalance heartbeat did not succeed within the timeout period.")
+
+      // Verify final state - both members should have tasks assigned
+      assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals(memberId1, streamsGroupHeartbeatResponse1.data.memberId())
+      
+      assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals(memberId2, streamsGroupHeartbeatResponse2.data.memberId())
+
+      // At least one member should have active tasks (in a real scenario, tasks would be distributed)
+      val totalActiveTasks = streamsGroupHeartbeatResponse1.data.activeTasks().size() + streamsGroupHeartbeatResponse2.data.activeTasks().size()
+      assert(totalActiveTasks > 0, "At least one member should have active tasks")
+
+    } finally {
+      admin.close()
+    }
+  }
+
+  private def convertTaskIds(responseTasks: java.util.List[StreamsGroupHeartbeatResponseData.TaskIds]): java.util.List[StreamsGroupHeartbeatRequestData.TaskIds] = {
+    if (responseTasks == null) {
+      java.util.Collections.emptyList()
+    } else {
+      responseTasks.asScala.map { responseTask =>
+        new StreamsGroupHeartbeatRequestData.TaskIds()
+          .setSubtopologyId(responseTask.subtopologyId)
+          .setPartitions(responseTask.partitions)
+      }.asJava
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -91,7 +91,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         .setWarmupTasks(java.util.Collections.emptyList())
         .setTopology(topology),
       true  // enableUnstableLastVersion = true
-    ).build(0)  // Explicitly use version 0
+    ).build(0)
 
     val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
     val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code())
@@ -119,7 +119,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         .setWarmupTasks(java.util.Collections.emptyList())
         .setTopology(topology),
       false  // enableUnstableLastVersion = false
-    ).build(0)  // Explicitly use version 0
+    ).build(0)
 
     val streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
     val expectedResponse = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.NOT_COORDINATOR.code())
@@ -208,7 +208,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   }
 
   @ClusterTest
-  def tesStreamsGroupHeartbeatIsAccessibleWhenNewGroupCoordinatorIsEnabledTwoMembers(): Unit = {
+  def tesStreamsGroupHeartbeatForMultipleMembers(): Unit = {
     val admin = cluster.admin()
     val memberId1 = "test-member-1"
     val memberId2 = "test-member-2"
@@ -232,7 +232,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         topic = topicName,
         numPartitions = 3
       )
-      // Wait for topic to be available
       TestUtils.waitUntilTrue(() => {
         admin.listTopics().names().get().contains(topicName)
       }, msg = s"Topic $topicName is not available to the group coordinator")
@@ -301,8 +300,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       assertEquals(memberId2, streamsGroupHeartbeatResponse2.data.memberId())
       assertEquals(2, streamsGroupHeartbeatResponse2.data.memberEpoch())
 
-      // Now both members should send heartbeats with their assigned tasks
-      // First member should continue with its tasks
+      // Both members continue to send heartbeats with their assigned tasks
       TestUtils.waitUntilTrue(() => {
         val streamsGroupHeartbeatRequest1 = new StreamsGroupHeartbeatRequest.Builder(
           new StreamsGroupHeartbeatRequestData()
@@ -316,12 +314,10 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
             .setTopology(topology)
         ).build(0)
 
-
         streamsGroupHeartbeatResponse1 = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest1)
         streamsGroupHeartbeatResponse1.data.errorCode == Errors.NONE.code()
       }, "First member rebalance heartbeat did not succeed within the timeout period.")
 
-      // Second member should also send heartbeat with its assigned tasks
       TestUtils.waitUntilTrue(() => {
         val streamsGroupHeartbeatRequest2 = new StreamsGroupHeartbeatRequest.Builder(
           new StreamsGroupHeartbeatRequestData()
@@ -339,7 +335,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse2.data.errorCode == Errors.NONE.code()
       }, "Second member rebalance heartbeat did not succeed within the timeout period.")
 
-      // Verify final state - both members should have tasks assigned
+      // Verify both members should have tasks assigned
       assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId1, streamsGroupHeartbeatResponse1.data.memberId())
       
@@ -359,8 +355,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   def testEmptyStreamsGroupId(): Unit = {
     val admin = cluster.admin()
 
-    // Creates the __consumer_offsets topics because it won't be created automatically
-    // in this test because it does not use FindCoordinator API.
     try {
       TestUtils.createOffsetsTopicWithAdmin(
         admin = admin,
@@ -395,12 +389,10 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   }
 
   @ClusterTest
-  def testInvalidTopologyAtSecondHeartbeat(): Unit = {
+  def testMemberLeaveHeartbeat(): Unit = {
     val admin = cluster.admin()
     val topicName = "test-topic"
 
-    // Creates the __consumer_offsets topics because it won't be created automatically
-    // in this test because it does not use FindCoordinator API.
     try {
       TestUtils.createOffsetsTopicWithAdmin(
         admin = admin,
@@ -408,9 +400,21 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         controllers = cluster.controllers().values().asScala.toSeq
       )
 
+      // Create topic
+      TestUtils.createTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq,
+        topic = topicName,
+        numPartitions = 3
+      )
+      TestUtils.waitUntilTrue(() => {
+        admin.listTopics().names().get().contains(topicName)
+      }, msg = s"Topic $topicName is not available to the group coordinator")
+
       val topology = createMockTopology(topicName)
 
-      // First, join the group with a valid request
+      // Join group
       var streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
         new StreamsGroupHeartbeatRequestData()
           .setGroupId("test-group")
@@ -429,24 +433,30 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse.data.errorCode == Errors.NONE.code()
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
-      // Now send a request with an invalid member epoch (negative epoch)
+      // Verify the member joined successfully
+      assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertEquals("test-member", streamsGroupHeartbeatResponse.data.memberId())
+      assertEquals(1, streamsGroupHeartbeatResponse.data.memberEpoch())
+
+      // Send a leave request
       streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
         new StreamsGroupHeartbeatRequestData()
           .setGroupId("test-group")
           .setMemberId(streamsGroupHeartbeatResponse.data.memberId())
-          .setMemberEpoch(-1)  // Invalid negative epoch
+          .setMemberEpoch(-1)  // LEAVE_GROUP_MEMBER_EPOCH
           .setRebalanceTimeoutMs(1000)
           .setActiveTasks(java.util.Collections.emptyList())
           .setStandbyTasks(java.util.Collections.emptyList())
           .setWarmupTasks(java.util.Collections.emptyList())
-          .setTopology(topology)
       ).build(0)
 
       streamsGroupHeartbeatResponse = connectAndReceive[StreamsGroupHeartbeatResponse](streamsGroupHeartbeatRequest)
-      val expectedResponse = new StreamsGroupHeartbeatResponseData()
-        .setErrorCode(Errors.INVALID_REQUEST.code())
-        .setErrorMessage("Topology can only be provided when (re-)joining.")
-      assertEquals(expectedResponse, streamsGroupHeartbeatResponse.data)
+      
+      // Verify the leave request was successful
+      assertEquals(Errors.NONE.code(), streamsGroupHeartbeatResponse.data.errorCode())
+      assertEquals("test-member", streamsGroupHeartbeatResponse.data.memberId())
+      assertEquals(-1, streamsGroupHeartbeatResponse.data.memberEpoch())
+
     } finally {
       admin.close()
     }
@@ -457,8 +467,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     val admin = cluster.admin()
     val topicName = "test-topic"
 
-    // Creates the __consumer_offsets topics because it won't be created automatically
-    // in this test because it does not use FindCoordinator API.
     try {
       TestUtils.createOffsetsTopicWithAdmin(
         admin = admin,
@@ -474,14 +482,12 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         topic = topicName,
         numPartitions = 3
       )
-      // Wait for topic to be available
       TestUtils.waitUntilTrue(() => {
         admin.listTopics().names().get().contains(topicName)
       }, msg = s"Topic $topicName is not available to the group coordinator")
 
       val topology = createMockTopology(topicName)
 
-      // First, join the group with a valid request
       var streamsGroupHeartbeatRequest = new StreamsGroupHeartbeatRequest.Builder(
         new StreamsGroupHeartbeatRequestData()
           .setGroupId("test-group")

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -202,7 +202,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       }, "StreamsGroupHeartbeatRequest did not succeed within the timeout period.")
 
       // Active task assignment should be available
-      assert(streamsGroupHeartbeatResponse != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId, streamsGroupHeartbeatResponse.memberId())
       assertEquals(2, streamsGroupHeartbeatResponse.memberEpoch())
       assertEquals(null, streamsGroupHeartbeatResponse.status())

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -334,7 +334,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
 
 
       // Verify both members should have tasks assigned
-      assert(streamsGroupHeartbeatResponse1 != null, "StreamsGroupHeartbeatResponse should not be null")
+      assertNotNull(streamsGroupHeartbeatResponse1, "StreamsGroupHeartbeatResponse should not be null")
       assertEquals(memberId1, streamsGroupHeartbeatResponse1.memberId())
       
       assert(streamsGroupHeartbeatResponse2 != null, "StreamsGroupHeartbeatResponse should not be null")

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -19,7 +19,6 @@ package kafka.server
 import kafka.utils.TestUtils
 import org.apache.kafka.common.message.{StreamsGroupHeartbeatRequestData, StreamsGroupHeartbeatResponseData}
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.StreamsGroupHeartbeatRequest
 import org.apache.kafka.common.test.ClusterInstance
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterFeature, ClusterTest, ClusterTestDefaults, Type}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
@@ -46,11 +45,12 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
   )
   def testStreamsGroupHeartbeatWithInvalidAPIVersion(): Unit = {
     // Test that invalid API version throws UnsupportedVersionException
-    assertThrows(classOf[UnsupportedVersionException], () => {
-      new StreamsGroupHeartbeatRequest.Builder(
-        new StreamsGroupHeartbeatRequestData()
-      ).build(-1)
-    })
+    assertThrows(classOf[UnsupportedVersionException], () =>
+      streamsGroupHeartbeat(
+        groupId = "test-group",
+        expectedError = Errors.UNSUPPORTED_VERSION,
+        version = -1)
+    )
   }
 
   @ClusterTest(
@@ -70,7 +70,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
       groupId = "test-group",
       memberId = "test-member",
-      memberEpoch = 0,
       rebalanceTimeoutMs = 1000,
       activeTasks = List.empty,
       standbyTasks = List.empty,
@@ -96,7 +95,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
       groupId = "test-group",
       memberId = "test-member",
-      memberEpoch = 0,
       rebalanceTimeoutMs = 1000,
       activeTasks = List.empty,
       standbyTasks = List.empty,
@@ -122,7 +120,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
       groupId = "test-group",
       memberId = "test-member",
-      memberEpoch = 0,
       rebalanceTimeoutMs = 1000,
       activeTasks = List.empty,
       standbyTasks = List.empty,
@@ -159,7 +156,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
           groupId = groupId,
           memberId = memberId,
-          memberEpoch = 0,
           rebalanceTimeoutMs = 1000,
           activeTasks = List.empty,
           standbyTasks = List.empty,
@@ -196,7 +192,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
           groupId = groupId,
           memberId = memberId,
-          memberEpoch = 0,
           rebalanceTimeoutMs = 1000,
           activeTasks = List.empty,
           standbyTasks = List.empty,
@@ -259,7 +254,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse1 = streamsGroupHeartbeat(
           groupId = groupId,
           memberId = memberId1,
-          memberEpoch = 0,
           rebalanceTimeoutMs = 1000,
           activeTasks = Option(streamsGroupHeartbeatResponse1)
             .map(r => convertTaskIds(r.activeTasks()))
@@ -288,7 +282,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse2 = streamsGroupHeartbeat(
           groupId = groupId,
           memberId = memberId2,
-          memberEpoch = 0,
           rebalanceTimeoutMs = 1000,
           activeTasks = Option(streamsGroupHeartbeatResponse2)
             .map(r => convertTaskIds(r.activeTasks()))
@@ -374,7 +367,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
       val streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
         groupId = "",  // Empty group ID
         memberId = "test-member",
-        memberEpoch = 0,
         rebalanceTimeoutMs = 1000,
         activeTasks = List.empty,
         standbyTasks = List.empty,
@@ -424,7 +416,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
           groupId = "test-group",
           memberId = "test-member",
-          memberEpoch = 0,
           rebalanceTimeoutMs = 1000,
           activeTasks = List.empty,
           standbyTasks = List.empty,
@@ -491,7 +482,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
           groupId = "test-group",
           memberId = "test-member",
-          memberEpoch = 0,
           rebalanceTimeoutMs = 1000,
           activeTasks = List.empty,
           standbyTasks = List.empty,


### PR DESCRIPTION
## What
Ticket: https://issues.apache.org/jira/browse/KAFKA-19807

Add integration test similar to `ShareGroupHeartbeatRequestTest` and
`ConsumerGroupHeartbeatRequestTest` for `StreamsGroupHeartbeat`

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
