### PR TITLE
KAFKA-19827: Call ack commit callback at end of waiting calls

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -609,6 +609,15 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             throw e.cause();
         } finally {
             kafkaShareConsumerMetrics.recordPollEnd(timer.currentTimeMs());
+
+            // Handle any acknowledgements which completed while we were waiting, but do not throw
+            // the exception because the fetched records would then not be returned to the caller
+            try {
+                handleCompletedAcknowledgements(false);
+            } catch (Throwable t) {
+                log.warn("Failed invoking acknowledgement commit callback", t);
+            }
+
             release();
         }
     }
@@ -752,8 +761,11 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                             result.put(tip, Optional.of(exception));
                         }
                     });
-                    return result;
 
+                    // Handle any acknowledgements which completed while we were waiting
+                    handleCompletedAcknowledgements(false);
+
+                    return result;
                 } finally {
                     wakeupTrigger.clearTask();
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -615,7 +615,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
             try {
                 handleCompletedAcknowledgements(false);
             } catch (Throwable t) {
-                log.warn("Failed invoking acknowledgement commit callback", t);
+                log.warn("Exception thrown in acknowledgement commit callback", t);
             }
 
             release();


### PR DESCRIPTION
The acknowledgement commit callback in the share consumer gets called on
the application thread at the start of the poll, commitSync and
commitAsync methods. Specifically in the peculiar case of using the
callback together with commitSync, the acknowledgement callback for the
committed records is called at the start of the next eligible call, even
though the information is already known at the end of the commitSync's
execution. The results are correct already, but the timing could be
improved in some situations.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Shivsundar R
 <shr@confluent.io>
