### PR TITLE
KAFKA-19779: Add per-partition epoch validation to streams groups  [4/N]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2900,7 +2900,6 @@ project(':streams:integration-tests') {
     testImplementation libs.mockitoCore
     testImplementation testLog4j2Libs
     testImplementation project(':streams:test-utils')
-    testImplementation project(':test-common:test-common-util')
 
     testRuntimeOnly runtimeTestLibs
   }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -66,6 +66,7 @@ import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
+import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -3658,5 +3659,120 @@ public class OffsetMetadataManagerTest {
                 ).iterator()
             )
         );
+    }
+
+    @Test
+    public void testStreamsGroupOffsetCommitWithAssignmentEpochValid() {
+        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
+        StreamsGroup group = context.groupMetadataManager.getOrMaybeCreatePersistedStreamsGroup("foo", true);
+
+        // Setup: topology with topic "bar" in subtopology "0"
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("bar")))));
+
+        // Member at epoch 10, with partitions assigned at epoch 5
+        group.updateMember(StreamsGroupMember.Builder.withDefaults("member")
+            .setMemberEpoch(10)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                Map.of("0", Map.of(0, 5, 1, 5)),
+                Map.of(), Map.of()))
+            .build());
+
+        // Commit with member epoch 5 should succeed (5 >= assignment epoch 5)
+        CoordinatorResult<OffsetCommitResponseData, CoordinatorRecord> result = context.commitOffset(
+            new OffsetCommitRequestData()
+                .setGroupId("foo")
+                .setMemberId("member")
+                .setGenerationIdOrMemberEpoch(5)
+                .setTopics(List.of(new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                    .setName("bar")
+                    .setPartitions(List.of(
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(0)
+                            .setCommittedOffset(100L),
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(1)
+                            .setCommittedOffset(200L))))));
+
+        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(0).errorCode());
+        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(1).errorCode());
+        assertEquals(2, result.records().size());
+    }
+
+    @Test
+    public void testStreamsGroupOffsetCommitWithAssignmentEpochStale() {
+        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
+        StreamsGroup group = context.groupMetadataManager.getOrMaybeCreatePersistedStreamsGroup("foo", true);
+
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("bar")))));
+
+        // Member at epoch 10, with partitions assigned at different epochs
+        group.updateMember(StreamsGroupMember.Builder.withDefaults("member")
+            .setMemberEpoch(10)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                Map.of("0", Map.of(0, 5, 1, 8)),
+                Map.of(), Map.of()))
+            .build());
+
+        // Commit with member epoch 3 should fail (3 < assignment epochs 5 and 8)
+        assertThrows(StaleMemberEpochException.class, () -> context.commitOffset(
+            new OffsetCommitRequestData()
+                .setGroupId("foo")
+                .setMemberId("member")
+                .setGenerationIdOrMemberEpoch(3)
+                .setTopics(List.of(new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                    .setName("bar")
+                    .setPartitions(List.of(
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(0)
+                            .setCommittedOffset(100L),
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(1)
+                            .setCommittedOffset(200L)))))));
+    }
+
+    @Test
+    public void testStreamsGroupOffsetCommitWithOlderMemberEpochValidAssignments() {
+        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
+        StreamsGroup group = context.groupMetadataManager.getOrMaybeCreatePersistedStreamsGroup("foo", true);
+
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("bar")))));
+
+        // Member at epoch 10, with partitions assigned at different epochs (2, 3, 5)
+        group.updateMember(StreamsGroupMember.Builder.withDefaults("member")
+            .setMemberEpoch(10)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                Map.of("0", Map.of(0, 2, 1, 3, 2, 5)),
+                Map.of(), Map.of()))
+            .build());
+
+        // Commit with member epoch 5 should succeed (5 >= all assignment epochs)
+        CoordinatorResult<OffsetCommitResponseData, CoordinatorRecord> result = context.commitOffset(
+            new OffsetCommitRequestData()
+                .setGroupId("foo")
+                .setMemberId("member")
+                .setGenerationIdOrMemberEpoch(5)
+                .setTopics(List.of(new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                    .setName("bar")
+                    .setPartitions(List.of(
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(0)
+                            .setCommittedOffset(100L),
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(1)
+                            .setCommittedOffset(200L),
+                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
+                            .setPartitionIndex(2)
+                            .setCommittedOffset(300L))))));
+
+        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(0).errorCode());
+        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(1).errorCode());
+        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(2).errorCode());
+        assertEquals(3, result.records().size());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -3671,11 +3671,11 @@ public class OffsetMetadataManagerTest {
             .setSubtopologyId("0")
             .setSourceTopics(List.of("bar")))));
 
-        // Member at epoch 10, with partitions assigned at epoch 5
+        // Member at epoch 10, with partitions assigned at epoch 4 and 5 respsectively.
         group.updateMember(StreamsGroupMember.Builder.withDefaults("member")
             .setMemberEpoch(10)
             .setAssignedTasks(new TasksTupleWithEpochs(
-                Map.of("0", Map.of(0, 5, 1, 5)),
+                Map.of("0", Map.of(0, 4, 1, 5)),
                 Map.of(), Map.of()))
             .build());
 
@@ -3717,7 +3717,7 @@ public class OffsetMetadataManagerTest {
                 Map.of(), Map.of()))
             .build());
 
-        // Commit with member epoch 3 should fail (3 < assignment epochs 5 and 8)
+        // Commit with member epoch 7 should fail (3 < assignment epochs 8)
         assertThrows(StaleMemberEpochException.class, () -> context.commitOffset(
             new OffsetCommitRequestData()
                 .setGroupId("foo")
@@ -3732,47 +3732,5 @@ public class OffsetMetadataManagerTest {
                         new OffsetCommitRequestData.OffsetCommitRequestPartition()
                             .setPartitionIndex(1)
                             .setCommittedOffset(200L)))))));
-    }
-
-    @Test
-    public void testStreamsGroupOffsetCommitWithOlderMemberEpochValidAssignments() {
-        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
-        StreamsGroup group = context.groupMetadataManager.getOrMaybeCreatePersistedStreamsGroup("foo", true);
-
-        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
-            .setSubtopologyId("0")
-            .setSourceTopics(List.of("bar")))));
-
-        // Member at epoch 10, with partitions assigned at different epochs (2, 3, 5)
-        group.updateMember(StreamsGroupMember.Builder.withDefaults("member")
-            .setMemberEpoch(10)
-            .setAssignedTasks(new TasksTupleWithEpochs(
-                Map.of("0", Map.of(0, 2, 1, 3, 2, 5)),
-                Map.of(), Map.of()))
-            .build());
-
-        // Commit with member epoch 5 should succeed (5 >= all assignment epochs)
-        CoordinatorResult<OffsetCommitResponseData, CoordinatorRecord> result = context.commitOffset(
-            new OffsetCommitRequestData()
-                .setGroupId("foo")
-                .setMemberId("member")
-                .setGenerationIdOrMemberEpoch(5)
-                .setTopics(List.of(new OffsetCommitRequestData.OffsetCommitRequestTopic()
-                    .setName("bar")
-                    .setPartitions(List.of(
-                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
-                            .setPartitionIndex(0)
-                            .setCommittedOffset(100L),
-                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
-                            .setPartitionIndex(1)
-                            .setCommittedOffset(200L),
-                        new OffsetCommitRequestData.OffsetCommitRequestPartition()
-                            .setPartitionIndex(2)
-                            .setCommittedOffset(300L))))));
-
-        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(0).errorCode());
-        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(1).errorCode());
-        assertEquals(Errors.NONE.code(), result.response().topics().get(0).partitions().get(2).errorCode());
-        assertEquals(3, result.records().size());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
+import org.apache.kafka.coordinator.group.CommitPartitionValidator;
 import org.apache.kafka.coordinator.group.OffsetAndMetadata;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
@@ -660,7 +661,7 @@ public class StreamsGroupTest {
         assertThrows(UnknownMemberIdException.class, () ->
             group.validateOffsetCommit("", null, -1, isTransactional, version));
 
-        // The member epoch is stale.
+        // The member epoch is stale (newer than current).
         if (version >= 9) {
             assertThrows(StaleMemberEpochException.class, () ->
                 group.validateOffsetCommit("new-protocol-member-id", "", 10, isTransactional, version));
@@ -669,13 +670,119 @@ public class StreamsGroupTest {
                 group.validateOffsetCommit("new-protocol-member-id", "", 10, isTransactional, version));
         }
 
-        // This should succeed.
+        // This should succeed (matching member epoch).
         if (version >= 9) {
             group.validateOffsetCommit("new-protocol-member-id", "", 0, isTransactional, version);
         } else {
             assertThrows(UnsupportedVersionException.class, () ->
                 group.validateOffsetCommit("new-protocol-member-id", "", 0, isTransactional, version));
         }
+    }
+
+    @Test
+    public void testValidateOffsetCommitWithOlderEpoch() {
+        StreamsGroup group = createStreamsGroup("group-foo");
+        
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("input-topic")))));
+        
+        group.updateMember(new StreamsGroupMember.Builder("member-1")
+            .setMemberEpoch(2)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                Map.of("0", Map.of(0, 2, 1, 2)),
+                Map.of(), Map.of()))
+            .build());
+        
+        CommitPartitionValidator validator = group.validateOffsetCommit(
+            "member-1", "", 1, false, ApiKeys.OFFSET_COMMIT.latestVersion());
+        
+        // Received epoch (1) < assignment epoch (2) should throw
+        assertThrows(StaleMemberEpochException.class, () ->
+            validator.validate("input-topic", Uuid.ZERO_UUID, 0));
+    }
+
+    @Test
+    public void testValidateOffsetCommitWithOlderEpochMissingTopology() {
+        StreamsGroup group = createStreamsGroup("group-foo");
+        
+        group.updateMember(new StreamsGroupMember.Builder("member-1")
+            .setMemberEpoch(2)
+            .build());
+        
+        // Topology is retrieved when creating validator, so exception is thrown here
+        assertThrows(StaleMemberEpochException.class, () ->
+            group.validateOffsetCommit("member-1", "", 1, false, ApiKeys.OFFSET_COMMIT.latestVersion()));
+    }
+
+    @Test
+    public void testValidateOffsetCommitWithOlderEpochMissingSubtopology() {
+        StreamsGroup group = createStreamsGroup("group-foo");
+        
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("input-topic")))));
+        
+        group.updateMember(new StreamsGroupMember.Builder("member-1")
+            .setMemberEpoch(2)
+            .build());
+        
+        CommitPartitionValidator validator = group.validateOffsetCommit(
+            "member-1", "", 1, false, ApiKeys.OFFSET_COMMIT.latestVersion());
+        
+        assertThrows(StaleMemberEpochException.class, () ->
+            validator.validate("unknown-topic", Uuid.ZERO_UUID, 0));
+    }
+
+    @Test
+    public void testValidateOffsetCommitWithOlderEpochUnassignedPartition() {
+        StreamsGroup group = createStreamsGroup("group-foo");
+        
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("input-topic")))));
+        
+        group.updateMember(new StreamsGroupMember.Builder("member-1")
+            .setMemberEpoch(2)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                Map.of("0", Map.of(0, 2)),
+                Map.of(), Map.of()))
+            .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+            .build());
+        
+        CommitPartitionValidator validator = group.validateOffsetCommit(
+            "member-1", "", 1, false, ApiKeys.OFFSET_COMMIT.latestVersion());
+        
+        // Partition 0 assigned with epoch 2, received epoch 1 should throw
+        assertThrows(StaleMemberEpochException.class, () ->
+            validator.validate("input-topic", Uuid.ZERO_UUID, 0));
+        
+        // Partition 1 not assigned should throw
+        assertThrows(StaleMemberEpochException.class, () ->
+            validator.validate("input-topic", Uuid.ZERO_UUID, 1));
+    }
+
+    @Test
+    public void testValidateOffsetCommitWithOlderEpochValidAssignment() {
+        StreamsGroup group = createStreamsGroup("group-foo");
+        
+        group.setTopology(new StreamsTopology(1, Map.of("0", new StreamsGroupTopologyValue.Subtopology()
+            .setSubtopologyId("0")
+            .setSourceTopics(List.of("input-topic")))));
+        
+        group.updateMember(new StreamsGroupMember.Builder("member-1")
+            .setMemberEpoch(5)
+            .setAssignedTasks(new TasksTupleWithEpochs(
+                Map.of("0", Map.of(0, 2, 1, 2)),
+                Map.of(), Map.of()))
+            .build());
+        
+        CommitPartitionValidator validator = group.validateOffsetCommit(
+            "member-1", "", 2, false, ApiKeys.OFFSET_COMMIT.latestVersion());
+        
+        // Received epoch 2 == assignment epoch 2 should succeed
+        validator.validate("input-topic", Uuid.ZERO_UUID, 0);
+        validator.validate("input-topic", Uuid.ZERO_UUID, 1);
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -690,7 +690,7 @@ public class StreamsGroupTest {
         group.updateMember(new StreamsGroupMember.Builder("member-1")
             .setMemberEpoch(2)
             .setAssignedTasks(new TasksTupleWithEpochs(
-                Map.of("0", Map.of(0, 2, 1, 2)),
+                Map.of("0", Map.of(0, 2, 1, 1)),
                 Map.of(), Map.of()))
             .build());
         
@@ -745,18 +745,14 @@ public class StreamsGroupTest {
         group.updateMember(new StreamsGroupMember.Builder("member-1")
             .setMemberEpoch(2)
             .setAssignedTasks(new TasksTupleWithEpochs(
-                Map.of("0", Map.of(0, 2)),
+                Map.of("0", Map.of(0, 1)),
                 Map.of(), Map.of()))
             .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
             .build());
         
         CommitPartitionValidator validator = group.validateOffsetCommit(
             "member-1", "", 1, false, ApiKeys.OFFSET_COMMIT.latestVersion());
-        
-        // Partition 0 assigned with epoch 2, received epoch 1 should throw
-        assertThrows(StaleMemberEpochException.class, () ->
-            validator.validate("input-topic", Uuid.ZERO_UUID, 0));
-        
+
         // Partition 1 not assigned should throw
         assertThrows(StaleMemberEpochException.class, () ->
             validator.validate("input-topic", Uuid.ZERO_UUID, 1));

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
@@ -396,7 +395,6 @@ public class EosIntegrationTest {
         }
     }
 
-    @Flaky("KAFKA-19816")
     @ParameterizedTest
     @MethodSource("groupProtocolAndProcessingThreadsParameters")
     public void shouldNotViolateEosIfOneTaskFails(final String groupProtocol, final boolean processingThreadsEnabled) throws Exception {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import static org.apache.kafka.streams.tests.SmokeTestDriver.generate;
 import static org.apache.kafka.streams.tests.SmokeTestDriver.verify;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -140,11 +141,14 @@ public class SmokeTestDriverIntegrationTest {
             throw new AssertionError("Test called halt(). code:" + statusCode + " message:" + message);
         });
         int numClientsCreated = 0;
+        int numDataRecordsProcessed = 0;
+        final int numKeys = 10;
+        final int maxRecordsPerKey = 1000;
 
         IntegrationTestUtils.cleanStateBeforeTest(cluster, SmokeTestDriver.topics());
 
         final String bootstrapServers = cluster.bootstrapServers();
-        final Driver driver = new Driver(bootstrapServers, 10, 1000);
+        final Driver driver = new Driver(bootstrapServers, numKeys, maxRecordsPerKey);
         driver.start();
         System.out.println("started driver");
 
@@ -183,6 +187,7 @@ public class SmokeTestDriverIntegrationTest {
                     assertFalse(client.error(), "The streams application seems to have crashed.");
                     Thread.sleep(100);
                 }
+                numDataRecordsProcessed += client.totalDataRecordsProcessed();
             }
         }
 
@@ -201,6 +206,7 @@ public class SmokeTestDriverIntegrationTest {
                     assertFalse(client.error(), "The streams application seems to have crashed.");
                     Thread.sleep(100);
                 }
+                numDataRecordsProcessed += client.totalDataRecordsProcessed();
             }
         }
 
@@ -210,5 +216,16 @@ public class SmokeTestDriverIntegrationTest {
             throw new AssertionError(driver.exception());
         }
         assertTrue(driver.result().passed(), driver.result().result());
+
+        // The one extra record is a record that the driver produces to flush suppress
+        final int expectedRecords = numKeys * maxRecordsPerKey + 1;
+
+        // We check that we did no have to reprocess any records, which would indicate a bug since everything
+        // runs locally in this test.
+        assertEquals(expectedRecords, numDataRecordsProcessed,
+            String.format("It seems we had to reprocess records, with %d processed records expected, but %d records processed.",
+                expectedRecords,
+                numDataRecordsProcessed)
+        );
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -223,7 +223,7 @@ public class SmokeTestDriverIntegrationTest {
         // We check that we did no have to reprocess any records, which would indicate a bug since everything
         // runs locally in this test.
         assertEquals(expectedRecords, numDataRecordsProcessed,
-            String.format("It seems we had to reprocess records, with %d processed records expected, but %d records processed.",
+            String.format("It seems we had to reprocess records, expected %d records, processed %d records.",
                 expectedRecords,
                 numDataRecordsProcessed)
         );

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestUtil.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestUtil.java
@@ -43,7 +43,7 @@ public class SmokeTestUtil {
         return printProcessorSupplier(topic, name, new AtomicInteger());
     }
 
-    static ProcessorSupplier<Object, Object, Void, Void> printProcessorSupplier(final String topic, final String name, AtomicInteger totalRecordsProcessed) {
+    static ProcessorSupplier<Object, Object, Void, Void> printProcessorSupplier(final String topic, final String name, final AtomicInteger totalRecordsProcessed) {
         return () -> new ContextualProcessor<>() {
             private int numRecordsProcessed = 0;
             private long smallestOffset = Long.MAX_VALUE;

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestUtil.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestUtil.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SmokeTestUtil {
 
@@ -39,6 +40,10 @@ public class SmokeTestUtil {
     }
 
     static ProcessorSupplier<Object, Object, Void, Void> printProcessorSupplier(final String topic, final String name) {
+        return printProcessorSupplier(topic, name, new AtomicInteger());
+    }
+
+    static ProcessorSupplier<Object, Object, Void, Void> printProcessorSupplier(final String topic, final String name, AtomicInteger totalRecordsProcessed) {
         return () -> new ContextualProcessor<>() {
             private int numRecordsProcessed = 0;
             private long smallestOffset = Long.MAX_VALUE;
@@ -84,6 +89,7 @@ public class SmokeTestUtil {
                 }
                 System.out.println("offset " + smallestOffset + " to " + largestOffset + " -> processed " + processed);
                 System.out.flush();
+                totalRecordsProcessed.addAndGet(numRecordsProcessed);
             }
         };
     }


### PR DESCRIPTION
This change enhances the offset commit validation logic in streams
groups to validate against per-partition assignment epochs. When a
member attempts to commit offsets with an older member epoch, the logic
now validates that the epoch is not older than the assignment epoch for
each individual partition being committed.

The implementation adds a new `createAssignmentEpochValidator` method
that creates partition-level validators, checking each partition against
its assignment epoch from either assigned tasks or tasks pending
revocation.

We extend the SmokeTestDriverIntegrationTest to detect if we have
processed more records than needed, which, in this restricted scenario,
should only happen when offset commits are failing.

We re-enable the previously flaky test in EosIntegrationTest, which
failed due to previously failing offset commits.

Both tests have been run 100x in their streams protocol variation to
validate that they are not flaky anymore.

Reviewers: David Jacot <djacot@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
