### PR TITLE
KAFKA-19836: Decouple consumerConfig and shareConsumerConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CommonConsumerConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CommonConsumerConfigs.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.config.SecurityConfig;
+
+import java.util.Locale;
+
+public class CommonConsumerConfigs {
+    /*
+     * NOTE: DO NOT CHANGE EITHER CONFIG STRINGS OR THEIR JAVA VARIABLE NAMES AS
+     * THESE ARE PART OF THE PUBLIC API AND CHANGE WILL BREAK USER CODE.
+     */
+
+    /**
+     * <code>group.id</code>
+     */
+    public static final String GROUP_ID_CONFIG = CommonClientConfigs.GROUP_ID_CONFIG;
+    public static final String GROUP_ID_DOC = CommonClientConfigs.GROUP_ID_DOC;
+
+    /**
+     * <code>group.instance.id</code>
+     */
+    public static final String GROUP_INSTANCE_ID_CONFIG = CommonClientConfigs.GROUP_INSTANCE_ID_CONFIG;
+    public static final String GROUP_INSTANCE_ID_DOC = CommonClientConfigs.GROUP_INSTANCE_ID_DOC;
+
+    /** <code>max.poll.records</code> */
+    public static final String MAX_POLL_RECORDS_CONFIG = "max.poll.records";
+    public static final String MAX_POLL_RECORDS_DOC = "The maximum number of records returned in a single call to poll()."
+            + " Note, that <code>" + MAX_POLL_RECORDS_CONFIG + "</code> does not impact the underlying fetching behavior."
+            + " The consumer will cache the records from each fetch request and returns them incrementally from each poll.";
+    public static final int DEFAULT_MAX_POLL_RECORDS = 500;
+
+    /** <code>max.poll.interval.ms</code> */
+    public static final String MAX_POLL_INTERVAL_MS_CONFIG = CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG;
+    public static final String MAX_POLL_INTERVAL_MS_DOC = CommonClientConfigs.MAX_POLL_INTERVAL_MS_DOC;
+    /**
+     * <code>session.timeout.ms</code>
+     */
+    public static final String SESSION_TIMEOUT_MS_CONFIG = CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG;
+    public static final String SESSION_TIMEOUT_MS_DOC = CommonClientConfigs.SESSION_TIMEOUT_MS_DOC;
+
+    /**
+     * <code>heartbeat.interval.ms</code>
+     */
+    public static final String HEARTBEAT_INTERVAL_MS_CONFIG = CommonClientConfigs.HEARTBEAT_INTERVAL_MS_CONFIG;
+    public static final String HEARTBEAT_INTERVAL_MS_DOC = CommonClientConfigs.HEARTBEAT_INTERVAL_MS_DOC;
+
+    /**
+     * <code>group.protocol</code>
+     */
+    public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
+    public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.CLASSIC.name().toLowerCase(Locale.ROOT);
+    public static final String GROUP_PROTOCOL_DOC = "The group protocol consumer should use. We currently " +
+            "support \"classic\" or \"consumer\". If \"consumer\" is specified, then the consumer group protocol will be " +
+            "used. Otherwise, the classic group protocol will be used.";
+
+    /**
+     * <code>group.remote.assignor</code>
+     */
+    public static final String GROUP_REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
+    public static final String DEFAULT_GROUP_REMOTE_ASSIGNOR = null;
+    public static final String GROUP_REMOTE_ASSIGNOR_DOC = "The name of the server-side assignor to use. " +
+            "If not specified, the group coordinator will pick the first assignor defined in the broker config group.consumer.assignors." +
+            "This configuration is applied only if <code>group.protocol</code> is set to \"consumer\".";
+
+    /**
+     * <code>bootstrap.servers</code>
+     */
+    public static final String BOOTSTRAP_SERVERS_CONFIG = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+    /** <code>client.dns.lookup</code> */
+    public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG;
+
+    /**
+     * <code>enable.auto.commit</code>
+     */
+    public static final String ENABLE_AUTO_COMMIT_CONFIG = "enable.auto.commit";
+    public static final String ENABLE_AUTO_COMMIT_DOC = "If true the consumer's offset will be periodically committed in the background.";
+
+    /**
+     * <code>auto.commit.interval.ms</code>
+     */
+    public static final String AUTO_COMMIT_INTERVAL_MS_CONFIG = "auto.commit.interval.ms";
+    public static final String AUTO_COMMIT_INTERVAL_MS_DOC = "The frequency in milliseconds that the consumer offsets are auto-committed to Kafka if <code>enable.auto.commit</code> is set to <code>true</code>.";
+
+    /**
+     * <code>partition.assignment.strategy</code>
+     */
+    public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = "partition.assignment.strategy";
+    public static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "A list of class names or class types, " +
+            "ordered by preference, of supported partition assignment strategies that the client will use to distribute " +
+            "partition ownership amongst consumer instances when group management is used. Available options are:" +
+            "<ul>" +
+            "<li><code>org.apache.kafka.clients.consumer.RangeAssignor</code>: Assigns partitions on a per-topic basis.</li>" +
+            "<li><code>org.apache.kafka.clients.consumer.RoundRobinAssignor</code>: Assigns partitions to consumers in a round-robin fashion.</li>" +
+            "<li><code>org.apache.kafka.clients.consumer.StickyAssignor</code>: Guarantees an assignment that is " +
+            "maximally balanced while preserving as many existing partition assignments as possible.</li>" +
+            "<li><code>org.apache.kafka.clients.consumer.CooperativeStickyAssignor</code>: Follows the same StickyAssignor " +
+            "logic, but allows for cooperative rebalancing.</li>" +
+            "</ul>" +
+            "<p>The default assignor is [RangeAssignor, CooperativeStickyAssignor], which will use the RangeAssignor by default, " +
+            "but allows upgrading to the CooperativeStickyAssignor with just a single rolling bounce that removes the RangeAssignor from the list.</p>" +
+            "<p>Implementing the <code>org.apache.kafka.clients.consumer.ConsumerPartitionAssignor</code> " +
+            "interface allows you to plug in a custom assignment strategy.</p>";
+
+    /**
+     * <code>auto.offset.reset</code>
+     */
+    public static final String AUTO_OFFSET_RESET_CONFIG = "auto.offset.reset";
+    public static final String AUTO_OFFSET_RESET_DOC = "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server " +
+            "(e.g. because that data has been deleted): " +
+            "<ul><li>earliest: automatically reset the offset to the earliest offset</li>" +
+            "<li>latest: automatically reset the offset to the latest offset</li>" +
+            "<li>by_duration:&lt;duration&gt;: automatically reset the offset to a configured &lt;duration&gt; from the current timestamp. &lt;duration&gt; must be specified in ISO8601 format (PnDTnHnMn.nS). " +
+            "Negative duration is not allowed.</li>" +
+            "<li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li>" +
+            "<li>anything else: throw exception to the consumer.</li></ul>" +
+            "<p>Note that altering partition numbers while setting this config to latest may cause message delivery loss since " +
+            "producers could start to send messages to newly added partitions (i.e. no initial offsets exist yet) before consumers reset their offsets.";
+
+    /**
+     * <code>fetch.min.bytes</code>
+     */
+    public static final String FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
+    public static final int DEFAULT_FETCH_MIN_BYTES = 1;
+    public static final String FETCH_MIN_BYTES_DOC = "The minimum amount of data the server should return for a fetch request. If insufficient data is available the request will wait for that much data to accumulate before answering the request. The default setting of " + DEFAULT_FETCH_MIN_BYTES + " byte means that fetch requests are answered as soon as that many byte(s) of data is available or the fetch request times out waiting for data to arrive. Setting this to a larger value will cause the server to wait for larger amounts of data to accumulate which can improve server throughput a bit at the cost of some additional latency. Even if the total data available in the broker exceeds fetch.min.bytes, the actual returned size may still be less than this value due to per-partition limits max.partition.fetch.bytes and max returned limits fetch.max.bytes.";
+
+    /**
+     * <code>fetch.max.bytes</code>
+     */
+    public static final String FETCH_MAX_BYTES_CONFIG = "fetch.max.bytes";
+    public static final String FETCH_MAX_BYTES_DOC = "The maximum amount of data the server should return for a fetch request. " +
+            "Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than " +
+            "this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. " +
+            "The maximum record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
+            "<code>max.message.bytes</code> (topic config). A fetch request consists of many partitions, and there is another setting that controls how much " +
+            "data is returned for each partition in a fetch request - see <code>max.partition.fetch.bytes</code>. Note that the consumer performs multiple fetches in parallel.";
+    public static final int DEFAULT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
+
+    /**
+     * <code>fetch.max.wait.ms</code>
+     */
+    public static final String FETCH_MAX_WAIT_MS_CONFIG = "fetch.max.wait.ms";
+    public static final String FETCH_MAX_WAIT_MS_DOC = "The maximum amount of time the server will block before " +
+            "answering the fetch request there isn't sufficient data to immediately satisfy the requirement given by " +
+            "fetch.min.bytes. This config is used only for local log fetch. To tune the remote fetch maximum wait " +
+            "time, please refer to 'remote.fetch.max.wait.ms' broker config";
+    public static final int DEFAULT_FETCH_MAX_WAIT_MS = 500;
+
+    /** <code>metadata.max.age.ms</code> */
+    public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
+
+    /**
+     * <code>max.partition.fetch.bytes</code>
+     */
+    public static final String MAX_PARTITION_FETCH_BYTES_CONFIG = "max.partition.fetch.bytes";
+    public static final String MAX_PARTITION_FETCH_BYTES_DOC = "The maximum amount of data per-partition the server " +
+            "will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty " +
+            "partition of the fetch is larger than this limit, the " +
+            "batch will still be returned to ensure that the consumer can make progress. The maximum record batch size " +
+            "accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
+            "<code>max.message.bytes</code> (topic config). See " + FETCH_MAX_BYTES_CONFIG + " for limiting the consumer request size.";
+    public static final int DEFAULT_MAX_PARTITION_FETCH_BYTES = 1 * 1024 * 1024;
+
+    /** <code>send.buffer.bytes</code> */
+    public static final String SEND_BUFFER_CONFIG = CommonClientConfigs.SEND_BUFFER_CONFIG;
+
+    /** <code>receive.buffer.bytes</code> */
+    public static final String RECEIVE_BUFFER_CONFIG = CommonClientConfigs.RECEIVE_BUFFER_CONFIG;
+
+    /**
+     * <code>client.id</code>
+     */
+    public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
+
+    /**
+     * <code>client.rack</code>
+     */
+    public static final String CLIENT_RACK_CONFIG = CommonClientConfigs.CLIENT_RACK_CONFIG;
+    public static final String DEFAULT_CLIENT_RACK = CommonClientConfigs.DEFAULT_CLIENT_RACK;
+
+    /**
+     * <code>reconnect.backoff.ms</code>
+     */
+    public static final String RECONNECT_BACKOFF_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG;
+
+    /**
+     * <code>reconnect.backoff.max.ms</code>
+     */
+    public static final String RECONNECT_BACKOFF_MAX_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG;
+
+    /**
+     * <code>retry.backoff.ms</code>
+     */
+    public static final String RETRY_BACKOFF_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;
+
+    /**
+     * <code>enable.metrics.push</code>
+     */
+    public static final String ENABLE_METRICS_PUSH_CONFIG = CommonClientConfigs.ENABLE_METRICS_PUSH_CONFIG;
+    public static final String ENABLE_METRICS_PUSH_DOC = CommonClientConfigs.ENABLE_METRICS_PUSH_DOC;
+
+    /**
+     * <code>retry.backoff.max.ms</code>
+     */
+    public static final String RETRY_BACKOFF_MAX_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MAX_MS_CONFIG;
+
+    /**
+     * <code>metrics.sample.window.ms</code>
+     */
+    public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
+
+    /**
+     * <code>metrics.num.samples</code>
+     */
+    public static final String METRICS_NUM_SAMPLES_CONFIG = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
+
+    /**
+     * <code>metrics.log.level</code>
+     */
+    public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
+
+    /**
+     * <code>metric.reporters</code>
+     */
+    public static final String METRIC_REPORTER_CLASSES_CONFIG = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG;
+
+    /**
+     * <code>check.crcs</code>
+     */
+    public static final String CHECK_CRCS_CONFIG = "check.crcs";
+    public static final String CHECK_CRCS_DOC = "Automatically check the CRC32 of the records consumed. This ensures no on-the-wire or on-disk corruption to the messages occurred. This check adds some overhead, so it may be disabled in cases seeking extreme performance.";
+
+    /** <code>key.deserializer</code> */
+    public static final String KEY_DESERIALIZER_CLASS_CONFIG = "key.deserializer";
+    public static final String KEY_DESERIALIZER_CLASS_DOC = "Deserializer class for key that implements the <code>org.apache.kafka.common.serialization.Deserializer</code> interface.";
+
+    /** <code>value.deserializer</code> */
+    public static final String VALUE_DESERIALIZER_CLASS_CONFIG = "value.deserializer";
+    public static final String VALUE_DESERIALIZER_CLASS_DOC = "Deserializer class for value that implements the <code>org.apache.kafka.common.serialization.Deserializer</code> interface.";
+
+    /** <code>socket.connection.setup.timeout.ms</code> */
+    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
+
+    /** <code>socket.connection.setup.timeout.max.ms</code> */
+    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
+
+    /** <code>connections.max.idle.ms</code> */
+    public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
+
+    /** <code>request.timeout.ms</code> */
+    public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
+    public static final String REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
+
+    /** <code>default.api.timeout.ms</code> */
+    public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG;
+
+    /** <code>interceptor.classes</code> */
+    public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
+    public static final String INTERCEPTOR_CLASSES_DOC = "A list of classes to use as interceptors. "
+            + "Implementing the <code>org.apache.kafka.clients.consumer.ConsumerInterceptor</code> interface allows you to intercept (and possibly mutate) records "
+            + "received by the consumer. By default, there are no interceptors.";
+
+
+    /** <code>exclude.internal.topics</code> */
+    public static final String EXCLUDE_INTERNAL_TOPICS_CONFIG = "exclude.internal.topics";
+    public static final String EXCLUDE_INTERNAL_TOPICS_DOC = "Whether internal topics matching a subscribed pattern should " +
+            "be excluded from the subscription. It is always possible to explicitly subscribe to an internal topic.";
+    public static final boolean DEFAULT_EXCLUDE_INTERNAL_TOPICS = true;
+
+    /**
+     * <code>internal.throw.on.fetch.stable.offset.unsupported</code>
+     * Whether or not the consumer should throw when the new stable offset feature is supported.
+     * If set to <code>true</code> then the client shall crash upon hitting it.
+     * The purpose of this flag is to prevent unexpected broker downgrade which makes
+     * the offset fetch protection against pending commit invalid. The safest approach
+     * is to fail fast to avoid introducing correctness issue.
+     *
+     * <p>
+     * Note: this is an internal configuration and could be changed in the future in a backward incompatible way
+     *
+     */
+    static final String THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED = "internal.throw.on.fetch.stable.offset.unsupported";
+
+    /** <code>isolation.level</code> */
+    public static final String ISOLATION_LEVEL_CONFIG = "isolation.level";
+    public static final String ISOLATION_LEVEL_DOC = "Controls how to read messages written transactionally. If set to <code>read_committed</code>, consumer.poll() will only return" +
+            " transactional messages which have been committed. If set to <code>read_uncommitted</code> (the default), consumer.poll() will return all messages, even transactional messages" +
+            " which have been aborted. Non-transactional messages will be returned unconditionally in either mode. <p>Messages will always be returned in offset order. Hence, in " +
+            " <code>read_committed</code> mode, consumer.poll() will only return messages up to the last stable offset (LSO), which is the one less than the offset of the first open transaction." +
+            " In particular any messages appearing after messages belonging to ongoing transactions will be withheld until the relevant transaction has been completed. As a result, <code>read_committed</code>" +
+            " consumers will not be able to read up to the high watermark when there are in flight transactions.</p><p> Further, when in <code>read_committed</code> the seekToEnd method will" +
+            " return the LSO</p>";
+
+    public static final String DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_UNCOMMITTED.toString();
+
+    /** <code>allow.auto.create.topics</code> */
+    public static final String ALLOW_AUTO_CREATE_TOPICS_CONFIG = "allow.auto.create.topics";
+    public static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "Allow automatic topic creation on the broker when" +
+            " subscribing to or assigning a topic. A topic being subscribed to will be automatically created only if the" +
+            " broker allows for it using <code>auto.create.topics.enable</code> broker configuration.";
+    public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = true;
+
+    /**
+     * <code>security.providers</code>
+     */
+    public static final String SECURITY_PROVIDERS_CONFIG = SecurityConfig.SECURITY_PROVIDERS_CONFIG;
+    public static final String SECURITY_PROVIDERS_DOC = SecurityConfig.SECURITY_PROVIDERS_DOC;
+
+    /**
+     * <code>share.acknowledgement.mode</code>
+     */
+    public static final String SHARE_ACKNOWLEDGEMENT_MODE_CONFIG = "share.acknowledgement.mode";
+    public static final String SHARE_ACKNOWLEDGEMENT_MODE_DOC = "Controls the acknowledgement mode for a share consumer." +
+            " If set to <code>implicit</code>, the acknowledgement mode of the consumer is implicit and it must not" +
+            " use <code>org.apache.kafka.clients.consumer.ShareConsumer.acknowledge()</code> to acknowledge delivery of records. Instead," +
+            " delivery is acknowledged implicitly on the next call to poll or commit." +
+            " If set to <code>explicit</code>, the acknowledgement mode of the consumer is explicit and it must use" +
+            " <code>org.apache.kafka.clients.consumer.ShareConsumer.acknowledge()</code> to acknowledge delivery of records.";
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CommonConsumerConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CommonConsumerConfigs.java
@@ -335,4 +335,12 @@ public class CommonConsumerConfigs {
             " If set to <code>explicit</code>, the acknowledgement mode of the consumer is explicit and it must use" +
             " <code>org.apache.kafka.clients.consumer.ShareConsumer.acknowledge()</code> to acknowledge delivery of records.";
 
+    // initialize use static due to METADATA_RECOVERY_STRATEGY_DOC is too long.
+    public static final String METADATA_RECOVERY_STRATEGY_CONFIG;
+    public static final String METADATA_RECOVERY_STRATEGY_DOC;
+
+    static {
+        METADATA_RECOVERY_STRATEGY_CONFIG = CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG;
+        METADATA_RECOVERY_STRATEGY_DOC = CommonClientConfigs.METADATA_RECOVERY_STRATEGY_DOC;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -664,13 +664,13 @@ public class ConsumerConfig extends AbstractConfig {
                                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport()
-                                .define(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG,
+                                .define(CommonConsumerConfigs.METADATA_RECOVERY_STRATEGY_CONFIG,
                                         Type.STRING,
                                         CommonClientConfigs.DEFAULT_METADATA_RECOVERY_STRATEGY,
                                         ConfigDef.CaseInsensitiveValidString
                                                 .in(Utils.enumOptions(MetadataRecoveryStrategy.class)),
                                         Importance.LOW,
-                                        CommonClientConfigs.METADATA_RECOVERY_STRATEGY_DOC)
+                                        CommonConsumerConfigs.METADATA_RECOVERY_STRATEGY_DOC)
                                 .define(CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_CONFIG,
                                         Type.LONG,
                                         CommonClientConfigs.DEFAULT_METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -86,10 +86,8 @@ public class ConsumerConfig extends AbstractConfig {
     private static final String GROUP_INSTANCE_ID_DOC = CommonConsumerConfigs.GROUP_INSTANCE_ID_DOC;
 
     /** <code>max.poll.records</code> */
-    public static final String MAX_POLL_RECORDS_CONFIG = "max.poll.records";
-    private static final String MAX_POLL_RECORDS_DOC = "The maximum number of records returned in a single call to poll()."
-        + " Note, that <code>" + MAX_POLL_RECORDS_CONFIG + "</code> does not impact the underlying fetching behavior."
-        + " The consumer will cache the records from each fetch request and returns them incrementally from each poll.";
+    public static final String MAX_POLL_RECORDS_CONFIG = CommonConsumerConfigs.MAX_POLL_RECORDS_CONFIG;
+    private static final String MAX_POLL_RECORDS_DOC = CommonConsumerConfigs.MAX_POLL_RECORDS_DOC;
     public static final int DEFAULT_MAX_POLL_RECORDS = 500;
 
     /** <code>max.poll.interval.ms</code> */
@@ -110,20 +108,16 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>group.protocol</code>
      */
-    public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
+    public static final String GROUP_PROTOCOL_CONFIG = CommonConsumerConfigs.GROUP_PROTOCOL_CONFIG;
     public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.CLASSIC.name().toLowerCase(Locale.ROOT);
-    public static final String GROUP_PROTOCOL_DOC = "The group protocol consumer should use. We currently " +
-        "support \"classic\" or \"consumer\". If \"consumer\" is specified, then the consumer group protocol will be " +
-        "used. Otherwise, the classic group protocol will be used.";
+    public static final String GROUP_PROTOCOL_DOC = CommonConsumerConfigs.GROUP_PROTOCOL_DOC;
 
     /**
     * <code>group.remote.assignor</code>
     */
-    public static final String GROUP_REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
+    public static final String GROUP_REMOTE_ASSIGNOR_CONFIG = CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_CONFIG;
     public static final String DEFAULT_GROUP_REMOTE_ASSIGNOR = null;
-    public static final String GROUP_REMOTE_ASSIGNOR_DOC = "The name of the server-side assignor to use. " +
-        "If not specified, the group coordinator will pick the first assignor defined in the broker config group.consumer.assignors." +
-        "This configuration is applied only if <code>group.protocol</code> is set to \"consumer\".";
+    public static final String GROUP_REMOTE_ASSIGNOR_DOC = CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_DOC;
 
     /**
      * <code>bootstrap.servers</code>
@@ -136,77 +130,45 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>enable.auto.commit</code>
      */
-    public static final String ENABLE_AUTO_COMMIT_CONFIG = "enable.auto.commit";
-    private static final String ENABLE_AUTO_COMMIT_DOC = "If true the consumer's offset will be periodically committed in the background.";
+    public static final String ENABLE_AUTO_COMMIT_CONFIG = CommonConsumerConfigs.ENABLE_AUTO_COMMIT_CONFIG;
+    private static final String ENABLE_AUTO_COMMIT_DOC = CommonConsumerConfigs.ENABLE_AUTO_COMMIT_DOC;
 
     /**
      * <code>auto.commit.interval.ms</code>
      */
-    public static final String AUTO_COMMIT_INTERVAL_MS_CONFIG = "auto.commit.interval.ms";
-    private static final String AUTO_COMMIT_INTERVAL_MS_DOC = "The frequency in milliseconds that the consumer offsets are auto-committed to Kafka if <code>enable.auto.commit</code> is set to <code>true</code>.";
+    public static final String AUTO_COMMIT_INTERVAL_MS_CONFIG = CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_CONFIG;
+    private static final String AUTO_COMMIT_INTERVAL_MS_DOC = CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_DOC;
 
     /**
      * <code>partition.assignment.strategy</code>
      */
-    public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = "partition.assignment.strategy";
-    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = "A list of class names or class types, " +
-        "ordered by preference, of supported partition assignment strategies that the client will use to distribute " +
-        "partition ownership amongst consumer instances when group management is used. Available options are:" +
-        "<ul>" +
-        "<li><code>org.apache.kafka.clients.consumer.RangeAssignor</code>: Assigns partitions on a per-topic basis.</li>" +
-        "<li><code>org.apache.kafka.clients.consumer.RoundRobinAssignor</code>: Assigns partitions to consumers in a round-robin fashion.</li>" +
-        "<li><code>org.apache.kafka.clients.consumer.StickyAssignor</code>: Guarantees an assignment that is " +
-        "maximally balanced while preserving as many existing partition assignments as possible.</li>" +
-        "<li><code>org.apache.kafka.clients.consumer.CooperativeStickyAssignor</code>: Follows the same StickyAssignor " +
-        "logic, but allows for cooperative rebalancing.</li>" +
-        "</ul>" +
-        "<p>The default assignor is [RangeAssignor, CooperativeStickyAssignor], which will use the RangeAssignor by default, " +
-        "but allows upgrading to the CooperativeStickyAssignor with just a single rolling bounce that removes the RangeAssignor from the list.</p>" +
-        "<p>Implementing the <code>org.apache.kafka.clients.consumer.ConsumerPartitionAssignor</code> " +
-        "interface allows you to plug in a custom assignment strategy.</p>";
-
+    public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_CONFIG;
+    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_DOC;
     /**
      * <code>auto.offset.reset</code>
      */
-    public static final String AUTO_OFFSET_RESET_CONFIG = "auto.offset.reset";
-    public static final String AUTO_OFFSET_RESET_DOC = "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server " +
-            "(e.g. because that data has been deleted): " +
-            "<ul><li>earliest: automatically reset the offset to the earliest offset</li>" +
-            "<li>latest: automatically reset the offset to the latest offset</li>" +
-            "<li>by_duration:&lt;duration&gt;: automatically reset the offset to a configured &lt;duration&gt; from the current timestamp. &lt;duration&gt; must be specified in ISO8601 format (PnDTnHnMn.nS). " +
-            "Negative duration is not allowed.</li>" +
-            "<li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li>" +
-            "<li>anything else: throw exception to the consumer.</li></ul>" +
-            "<p>Note that altering partition numbers while setting this config to latest may cause message delivery loss since " +
-            "producers could start to send messages to newly added partitions (i.e. no initial offsets exist yet) before consumers reset their offsets.";
+    public static final String AUTO_OFFSET_RESET_CONFIG = CommonConsumerConfigs.AUTO_OFFSET_RESET_CONFIG;
+    public static final String AUTO_OFFSET_RESET_DOC = CommonConsumerConfigs.AUTO_OFFSET_RESET_DOC;
 
     /**
      * <code>fetch.min.bytes</code>
      */
-    public static final String FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
+    public static final String FETCH_MIN_BYTES_CONFIG = CommonConsumerConfigs.FETCH_MIN_BYTES_CONFIG;
     public static final int DEFAULT_FETCH_MIN_BYTES = 1;
-    private static final String FETCH_MIN_BYTES_DOC = "The minimum amount of data the server should return for a fetch request. If insufficient data is available the request will wait for that much data to accumulate before answering the request. The default setting of " + DEFAULT_FETCH_MIN_BYTES + " byte means that fetch requests are answered as soon as that many byte(s) of data is available or the fetch request times out waiting for data to arrive. Setting this to a larger value will cause the server to wait for larger amounts of data to accumulate which can improve server throughput a bit at the cost of some additional latency. Even if the total data available in the broker exceeds fetch.min.bytes, the actual returned size may still be less than this value due to per-partition limits max.partition.fetch.bytes and max returned limits fetch.max.bytes.";
+    private static final String FETCH_MIN_BYTES_DOC = CommonConsumerConfigs.FETCH_MIN_BYTES_DOC;
 
     /**
      * <code>fetch.max.bytes</code>
      */
-    public static final String FETCH_MAX_BYTES_CONFIG = "fetch.max.bytes";
-    private static final String FETCH_MAX_BYTES_DOC = "The maximum amount of data the server should return for a fetch request. " +
-            "Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than " +
-            "this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. " +
-            "The maximum record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
-            "<code>max.message.bytes</code> (topic config). A fetch request consists of many partitions, and there is another setting that controls how much " +
-            "data is returned for each partition in a fetch request - see <code>max.partition.fetch.bytes</code>. Note that the consumer performs multiple fetches in parallel.";
+    public static final String FETCH_MAX_BYTES_CONFIG = CommonConsumerConfigs.FETCH_MAX_BYTES_CONFIG;
+    private static final String FETCH_MAX_BYTES_DOC = CommonConsumerConfigs.FETCH_MAX_BYTES_DOC;
     public static final int DEFAULT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
 
     /**
      * <code>fetch.max.wait.ms</code>
      */
-    public static final String FETCH_MAX_WAIT_MS_CONFIG = "fetch.max.wait.ms";
-    private static final String FETCH_MAX_WAIT_MS_DOC = "The maximum amount of time the server will block before " +
-            "answering the fetch request there isn't sufficient data to immediately satisfy the requirement given by " +
-            "fetch.min.bytes. This config is used only for local log fetch. To tune the remote fetch maximum wait " +
-            "time, please refer to 'remote.fetch.max.wait.ms' broker config";
+    public static final String FETCH_MAX_WAIT_MS_CONFIG = CommonConsumerConfigs.FETCH_MAX_WAIT_MS_CONFIG;
+    private static final String FETCH_MAX_WAIT_MS_DOC = CommonConsumerConfigs.FETCH_MAX_WAIT_MS_DOC;
     public static final int DEFAULT_FETCH_MAX_WAIT_MS = 500;
 
     /** <code>metadata.max.age.ms</code> */
@@ -215,13 +177,8 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>max.partition.fetch.bytes</code>
      */
-    public static final String MAX_PARTITION_FETCH_BYTES_CONFIG = "max.partition.fetch.bytes";
-    private static final String MAX_PARTITION_FETCH_BYTES_DOC = "The maximum amount of data per-partition the server " +
-            "will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty " +
-            "partition of the fetch is larger than this limit, the " +
-            "batch will still be returned to ensure that the consumer can make progress. The maximum record batch size " +
-            "accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
-            "<code>max.message.bytes</code> (topic config). See " + FETCH_MAX_BYTES_CONFIG + " for limiting the consumer request size.";
+    public static final String MAX_PARTITION_FETCH_BYTES_CONFIG = CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_CONFIG;
+    private static final String MAX_PARTITION_FETCH_BYTES_DOC = CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_DOC;
     public static final int DEFAULT_MAX_PARTITION_FETCH_BYTES = 1 * 1024 * 1024;
 
     /** <code>send.buffer.bytes</code> */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -290,16 +290,16 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>check.crcs</code>
      */
-    public static final String CHECK_CRCS_CONFIG = "check.crcs";
-    private static final String CHECK_CRCS_DOC = "Automatically check the CRC32 of the records consumed. This ensures no on-the-wire or on-disk corruption to the messages occurred. This check adds some overhead, so it may be disabled in cases seeking extreme performance.";
+    public static final String CHECK_CRCS_CONFIG = CommonConsumerConfigs.CHECK_CRCS_CONFIG;
+    private static final String CHECK_CRCS_DOC = CommonConsumerConfigs.CHECK_CRCS_DOC;
 
     /** <code>key.deserializer</code> */
-    public static final String KEY_DESERIALIZER_CLASS_CONFIG = "key.deserializer";
-    public static final String KEY_DESERIALIZER_CLASS_DOC = "Deserializer class for key that implements the <code>org.apache.kafka.common.serialization.Deserializer</code> interface.";
+    public static final String KEY_DESERIALIZER_CLASS_CONFIG = CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG;
+    public static final String KEY_DESERIALIZER_CLASS_DOC = CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_DOC;
 
     /** <code>value.deserializer</code> */
-    public static final String VALUE_DESERIALIZER_CLASS_CONFIG = "value.deserializer";
-    public static final String VALUE_DESERIALIZER_CLASS_DOC = "Deserializer class for value that implements the <code>org.apache.kafka.common.serialization.Deserializer</code> interface.";
+    public static final String VALUE_DESERIALIZER_CLASS_CONFIG = CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG;
+    public static final String VALUE_DESERIALIZER_CLASS_DOC = CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_DOC;
 
     /** <code>socket.connection.setup.timeout.ms</code> */
     public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
@@ -318,16 +318,13 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG;
 
     /** <code>interceptor.classes</code> */
-    public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
-    public static final String INTERCEPTOR_CLASSES_DOC = "A list of classes to use as interceptors. "
-                                                        + "Implementing the <code>org.apache.kafka.clients.consumer.ConsumerInterceptor</code> interface allows you to intercept (and possibly mutate) records "
-                                                        + "received by the consumer. By default, there are no interceptors.";
+    public static final String INTERCEPTOR_CLASSES_CONFIG = CommonConsumerConfigs.INTERCEPTOR_CLASSES_CONFIG;
+    public static final String INTERCEPTOR_CLASSES_DOC = CommonConsumerConfigs.INTERCEPTOR_CLASSES_DOC;
 
 
     /** <code>exclude.internal.topics</code> */
-    public static final String EXCLUDE_INTERNAL_TOPICS_CONFIG = "exclude.internal.topics";
-    private static final String EXCLUDE_INTERNAL_TOPICS_DOC = "Whether internal topics matching a subscribed pattern should " +
-            "be excluded from the subscription. It is always possible to explicitly subscribe to an internal topic.";
+    public static final String EXCLUDE_INTERNAL_TOPICS_CONFIG = CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_CONFIG;
+    private static final String EXCLUDE_INTERNAL_TOPICS_DOC = CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_DOC;
     public static final boolean DEFAULT_EXCLUDE_INTERNAL_TOPICS = true;
 
     /**
@@ -342,25 +339,17 @@ public class ConsumerConfig extends AbstractConfig {
      * Note: this is an internal configuration and could be changed in the future in a backward incompatible way
      *
      */
-    static final String THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED = "internal.throw.on.fetch.stable.offset.unsupported";
+    static final String THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED = CommonConsumerConfigs.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED;
 
     /** <code>isolation.level</code> */
-    public static final String ISOLATION_LEVEL_CONFIG = "isolation.level";
-    public static final String ISOLATION_LEVEL_DOC = "Controls how to read messages written transactionally. If set to <code>read_committed</code>, consumer.poll() will only return" +
-            " transactional messages which have been committed. If set to <code>read_uncommitted</code> (the default), consumer.poll() will return all messages, even transactional messages" +
-            " which have been aborted. Non-transactional messages will be returned unconditionally in either mode. <p>Messages will always be returned in offset order. Hence, in " +
-            " <code>read_committed</code> mode, consumer.poll() will only return messages up to the last stable offset (LSO), which is the one less than the offset of the first open transaction." +
-            " In particular any messages appearing after messages belonging to ongoing transactions will be withheld until the relevant transaction has been completed. As a result, <code>read_committed</code>" +
-            " consumers will not be able to read up to the high watermark when there are in flight transactions.</p><p> Further, when in <code>read_committed</code> the seekToEnd method will" +
-            " return the LSO</p>";
+    public static final String ISOLATION_LEVEL_CONFIG = CommonConsumerConfigs.ISOLATION_LEVEL_CONFIG;
+    public static final String ISOLATION_LEVEL_DOC = CommonConsumerConfigs.ISOLATION_LEVEL_DOC;
 
     public static final String DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_UNCOMMITTED.toString();
 
     /** <code>allow.auto.create.topics</code> */
-    public static final String ALLOW_AUTO_CREATE_TOPICS_CONFIG = "allow.auto.create.topics";
-    private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "Allow automatic topic creation on the broker when" +
-            " subscribing to or assigning a topic. A topic being subscribed to will be automatically created only if the" +
-            " broker allows for it using <code>auto.create.topics.enable</code> broker configuration.";
+    public static final String ALLOW_AUTO_CREATE_TOPICS_CONFIG = CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_CONFIG;
+    private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_DOC;
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = true;
 
     /**
@@ -372,13 +361,8 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>share.acknowledgement.mode</code>
      */
-    public static final String SHARE_ACKNOWLEDGEMENT_MODE_CONFIG = "share.acknowledgement.mode";
-    private static final String SHARE_ACKNOWLEDGEMENT_MODE_DOC = "Controls the acknowledgement mode for a share consumer." +
-            " If set to <code>implicit</code>, the acknowledgement mode of the consumer is implicit and it must not" +
-            " use <code>org.apache.kafka.clients.consumer.ShareConsumer.acknowledge()</code> to acknowledge delivery of records. Instead," +
-            " delivery is acknowledged implicitly on the next call to poll or commit." +
-            " If set to <code>explicit</code>, the acknowledgement mode of the consumer is explicit and it must use" +
-            " <code>org.apache.kafka.clients.consumer.ShareConsumer.acknowledge()</code> to acknowledge delivery of records.";
+    public static final String SHARE_ACKNOWLEDGEMENT_MODE_CONFIG = CommonConsumerConfigs.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG;
+    private static final String SHARE_ACKNOWLEDGEMENT_MODE_DOC = CommonConsumerConfigs.SHARE_ACKNOWLEDGEMENT_MODE_DOC;
 
     private static final AtomicInteger CONSUMER_CLIENT_ID_SEQUENCE = new AtomicInteger(1);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -76,14 +76,14 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>group.id</code>
      */
-    public static final String GROUP_ID_CONFIG = CommonClientConfigs.GROUP_ID_CONFIG;
-    private static final String GROUP_ID_DOC = CommonClientConfigs.GROUP_ID_DOC;
+    public static final String GROUP_ID_CONFIG = CommonConsumerConfigs.GROUP_ID_CONFIG;
+    private static final String GROUP_ID_DOC = CommonConsumerConfigs.GROUP_ID_DOC;
 
     /**
      * <code>group.instance.id</code>
      */
-    public static final String GROUP_INSTANCE_ID_CONFIG = CommonClientConfigs.GROUP_INSTANCE_ID_CONFIG;
-    private static final String GROUP_INSTANCE_ID_DOC = CommonClientConfigs.GROUP_INSTANCE_ID_DOC;
+    public static final String GROUP_INSTANCE_ID_CONFIG = CommonConsumerConfigs.GROUP_INSTANCE_ID_CONFIG;
+    private static final String GROUP_INSTANCE_ID_DOC = CommonConsumerConfigs.GROUP_INSTANCE_ID_DOC;
 
     /** <code>max.poll.records</code> */
     public static final String MAX_POLL_RECORDS_CONFIG = "max.poll.records";
@@ -93,19 +93,19 @@ public class ConsumerConfig extends AbstractConfig {
     public static final int DEFAULT_MAX_POLL_RECORDS = 500;
 
     /** <code>max.poll.interval.ms</code> */
-    public static final String MAX_POLL_INTERVAL_MS_CONFIG = CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG;
-    private static final String MAX_POLL_INTERVAL_MS_DOC = CommonClientConfigs.MAX_POLL_INTERVAL_MS_DOC;
+    public static final String MAX_POLL_INTERVAL_MS_CONFIG = CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_CONFIG;
+    private static final String MAX_POLL_INTERVAL_MS_DOC = CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_DOC;
     /**
      * <code>session.timeout.ms</code>
      */
-    public static final String SESSION_TIMEOUT_MS_CONFIG = CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG;
-    private static final String SESSION_TIMEOUT_MS_DOC = CommonClientConfigs.SESSION_TIMEOUT_MS_DOC;
+    public static final String SESSION_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.SESSION_TIMEOUT_MS_CONFIG;
+    private static final String SESSION_TIMEOUT_MS_DOC = CommonConsumerConfigs.SESSION_TIMEOUT_MS_DOC;
 
     /**
      * <code>heartbeat.interval.ms</code>
      */
-    public static final String HEARTBEAT_INTERVAL_MS_CONFIG = CommonClientConfigs.HEARTBEAT_INTERVAL_MS_CONFIG;
-    private static final String HEARTBEAT_INTERVAL_MS_DOC = CommonClientConfigs.HEARTBEAT_INTERVAL_MS_DOC;
+    public static final String HEARTBEAT_INTERVAL_MS_CONFIG = CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_CONFIG;
+    private static final String HEARTBEAT_INTERVAL_MS_DOC = CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_DOC;
 
     /**
      * <code>group.protocol</code>
@@ -128,10 +128,10 @@ public class ConsumerConfig extends AbstractConfig {
     /**
      * <code>bootstrap.servers</code>
      */
-    public static final String BOOTSTRAP_SERVERS_CONFIG = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+    public static final String BOOTSTRAP_SERVERS_CONFIG = CommonConsumerConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
     /** <code>client.dns.lookup</code> */
-    public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG;
+    public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonConsumerConfigs.CLIENT_DNS_LOOKUP_CONFIG;
 
     /**
      * <code>enable.auto.commit</code>
@@ -210,7 +210,7 @@ public class ConsumerConfig extends AbstractConfig {
     public static final int DEFAULT_FETCH_MAX_WAIT_MS = 500;
 
     /** <code>metadata.max.age.ms</code> */
-    public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
+    public static final String METADATA_MAX_AGE_CONFIG = CommonConsumerConfigs.METADATA_MAX_AGE_CONFIG;
 
     /**
      * <code>max.partition.fetch.bytes</code>
@@ -225,67 +225,67 @@ public class ConsumerConfig extends AbstractConfig {
     public static final int DEFAULT_MAX_PARTITION_FETCH_BYTES = 1 * 1024 * 1024;
 
     /** <code>send.buffer.bytes</code> */
-    public static final String SEND_BUFFER_CONFIG = CommonClientConfigs.SEND_BUFFER_CONFIG;
+    public static final String SEND_BUFFER_CONFIG = CommonConsumerConfigs.SEND_BUFFER_CONFIG;
 
     /** <code>receive.buffer.bytes</code> */
-    public static final String RECEIVE_BUFFER_CONFIG = CommonClientConfigs.RECEIVE_BUFFER_CONFIG;
+    public static final String RECEIVE_BUFFER_CONFIG = CommonConsumerConfigs.RECEIVE_BUFFER_CONFIG;
 
     /**
      * <code>client.id</code>
      */
-    public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
+    public static final String CLIENT_ID_CONFIG = CommonConsumerConfigs.CLIENT_ID_CONFIG;
 
     /**
      * <code>client.rack</code>
      */
-    public static final String CLIENT_RACK_CONFIG = CommonClientConfigs.CLIENT_RACK_CONFIG;
-    public static final String DEFAULT_CLIENT_RACK = CommonClientConfigs.DEFAULT_CLIENT_RACK;
+    public static final String CLIENT_RACK_CONFIG = CommonConsumerConfigs.CLIENT_RACK_CONFIG;
+    public static final String DEFAULT_CLIENT_RACK = CommonConsumerConfigs.DEFAULT_CLIENT_RACK;
 
     /**
      * <code>reconnect.backoff.ms</code>
      */
-    public static final String RECONNECT_BACKOFF_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG;
+    public static final String RECONNECT_BACKOFF_MS_CONFIG = CommonConsumerConfigs.RECONNECT_BACKOFF_MS_CONFIG;
 
     /**
      * <code>reconnect.backoff.max.ms</code>
      */
-    public static final String RECONNECT_BACKOFF_MAX_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG;
+    public static final String RECONNECT_BACKOFF_MAX_MS_CONFIG = CommonConsumerConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG;
 
     /**
      * <code>retry.backoff.ms</code>
      */
-    public static final String RETRY_BACKOFF_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;
+    public static final String RETRY_BACKOFF_MS_CONFIG = CommonConsumerConfigs.RETRY_BACKOFF_MS_CONFIG;
 
     /**
      * <code>enable.metrics.push</code>
      */
-    public static final String ENABLE_METRICS_PUSH_CONFIG = CommonClientConfigs.ENABLE_METRICS_PUSH_CONFIG;
-    public static final String ENABLE_METRICS_PUSH_DOC = CommonClientConfigs.ENABLE_METRICS_PUSH_DOC;
+    public static final String ENABLE_METRICS_PUSH_CONFIG = CommonConsumerConfigs.ENABLE_METRICS_PUSH_CONFIG;
+    public static final String ENABLE_METRICS_PUSH_DOC = CommonConsumerConfigs.ENABLE_METRICS_PUSH_DOC;
 
     /**
      * <code>retry.backoff.max.ms</code>
      */
-    public static final String RETRY_BACKOFF_MAX_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MAX_MS_CONFIG;
+    public static final String RETRY_BACKOFF_MAX_MS_CONFIG = CommonConsumerConfigs.RETRY_BACKOFF_MAX_MS_CONFIG;
 
     /**
      * <code>metrics.sample.window.ms</code>
      */
-    public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
+    public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonConsumerConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
 
     /**
      * <code>metrics.num.samples</code>
      */
-    public static final String METRICS_NUM_SAMPLES_CONFIG = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
+    public static final String METRICS_NUM_SAMPLES_CONFIG = CommonConsumerConfigs.METRICS_NUM_SAMPLES_CONFIG;
 
     /**
      * <code>metrics.log.level</code>
      */
-    public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
+    public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonConsumerConfigs.METRICS_RECORDING_LEVEL_CONFIG;
 
     /**
      * <code>metric.reporters</code>
      */
-    public static final String METRIC_REPORTER_CLASSES_CONFIG = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG;
+    public static final String METRIC_REPORTER_CLASSES_CONFIG = CommonConsumerConfigs.METRIC_REPORTER_CLASSES_CONFIG;
 
     /**
      * <code>check.crcs</code>
@@ -302,20 +302,20 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String VALUE_DESERIALIZER_CLASS_DOC = "Deserializer class for value that implements the <code>org.apache.kafka.common.serialization.Deserializer</code> interface.";
 
     /** <code>socket.connection.setup.timeout.ms</code> */
-    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
+    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
 
     /** <code>socket.connection.setup.timeout.max.ms</code> */
-    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
+    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG = CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
 
     /** <code>connections.max.idle.ms</code> */
-    public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
+    public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonConsumerConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
 
     /** <code>request.timeout.ms</code> */
-    public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
-    private static final String REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
+    public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.REQUEST_TIMEOUT_MS_CONFIG;
+    private static final String REQUEST_TIMEOUT_MS_DOC = CommonConsumerConfigs.REQUEST_TIMEOUT_MS_DOC;
 
     /** <code>default.api.timeout.ms</code> */
-    public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG;
+    public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG;
 
     /** <code>interceptor.classes</code> */
     public static final String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
@@ -733,7 +733,7 @@ public class ConsumerConfig extends AbstractConfig {
     }
 
     private void maybeOverrideEnableAutoCommit(Map<String, Object> configs) {
-        Optional<String> groupId = Optional.ofNullable(getString(CommonClientConfigs.GROUP_ID_CONFIG));
+        Optional<String> groupId = Optional.ofNullable(getString(CommonConsumerConfigs.GROUP_ID_CONFIG));
         Map<String, Object> originals = originals();
         boolean enableAutoCommit = originals.containsKey(ENABLE_AUTO_COMMIT_CONFIG) ? getBoolean(ENABLE_AUTO_COMMIT_CONFIG) : false;
         if (groupId.isEmpty()) { // overwrite in case of default group id where the config is not explicitly provided
@@ -745,7 +745,7 @@ public class ConsumerConfig extends AbstractConfig {
         }
     }
 
-    protected void checkUnsupportedConfigsPostProcess() {
+    private void checkUnsupportedConfigsPostProcess() {
         String groupProtocol = getString(GROUP_PROTOCOL_CONFIG);
         if (GroupProtocol.CLASSIC.name().equalsIgnoreCase(groupProtocol)) {
             checkUnsupportedConfigsPostProcess(GroupProtocol.CLASSIC, CLASSIC_PROTOCOL_UNSUPPORTED_CONFIGS);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
@@ -16,17 +16,37 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.clients.ClientDnsLookup;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.MetadataRecoveryStrategy;
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.ShareAcknowledgementMode;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.Utils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
+
 /**
  * The consumer configuration behavior specific to share groups.
  */
-class ShareConsumerConfig extends ConsumerConfig {
+public class ShareConsumerConfig extends AbstractConfig {
+
+    private static final ConfigDef CONFIG;
+
     /**
      * A list of configuration keys not supported for SHARE consumer.
      */
@@ -43,16 +63,324 @@ class ShareConsumerConfig extends ConsumerConfig {
             ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG
     );
 
-    ShareConsumerConfig(Properties props) {
-        super(props);
+    static {
+        CONFIG = new ConfigDef().define(CommonConsumerConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        ConfigDef.NO_DEFAULT_VALUE,
+                        ConfigDef.ValidList.anyNonDuplicateValues(false, false),
+                        ConfigDef.Importance.HIGH,
+                        CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
+                .define(CommonConsumerConfigs.CLIENT_DNS_LOOKUP_CONFIG,
+                        ConfigDef.Type.STRING,
+                        ClientDnsLookup.USE_ALL_DNS_IPS.toString(),
+                        in(ClientDnsLookup.USE_ALL_DNS_IPS.toString(),
+                                ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY.toString()),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.CLIENT_DNS_LOOKUP_DOC)
+                .define(CommonConsumerConfigs.GROUP_ID_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CommonConsumerConfigs.GROUP_ID_DOC)
+                .define(CommonConsumerConfigs.GROUP_INSTANCE_ID_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        new ConfigDef.NonEmptyString(),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.GROUP_INSTANCE_ID_DOC)
+                .define(CommonConsumerConfigs.SESSION_TIMEOUT_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        45000,
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.SESSION_TIMEOUT_MS_DOC)
+                .define(CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        3000,
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_DOC)
+                .define(CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+                        ConfigDef.Type.LIST,
+                        List.of(RangeAssignor.class, CooperativeStickyAssignor.class),
+                        ConfigDef.ValidList.anyNonDuplicateValues(true, false),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_DOC)
+                .define(CommonConsumerConfigs.METADATA_MAX_AGE_CONFIG,
+                        ConfigDef.Type.LONG,
+                        5 * 60 * 1000,
+                        atLeast(0),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METADATA_MAX_AGE_DOC)
+                .define(CommonConsumerConfigs.ENABLE_AUTO_COMMIT_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        true,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.ENABLE_AUTO_COMMIT_DOC)
+                .define(CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        5000,
+                        atLeast(0),
+                        ConfigDef.Importance.LOW,
+                        CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_DOC)
+                .define(CommonConsumerConfigs.CLIENT_ID_CONFIG,
+                        ConfigDef.Type.STRING,
+                        "",
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.CLIENT_ID_DOC)
+                .define(CommonConsumerConfigs.CLIENT_RACK_CONFIG,
+                        ConfigDef.Type.STRING,
+                        CommonConsumerConfigs.DEFAULT_CLIENT_RACK,
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.CLIENT_RACK_DOC)
+                .define(CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_CONFIG,
+                        ConfigDef.Type.INT,
+                        CommonConsumerConfigs.DEFAULT_MAX_PARTITION_FETCH_BYTES,
+                        atLeast(0),
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_DOC)
+                .define(CommonConsumerConfigs.SEND_BUFFER_CONFIG,
+                        ConfigDef.Type.INT,
+                        128 * 1024,
+                        atLeast(CommonClientConfigs.SEND_BUFFER_LOWER_BOUND),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.SEND_BUFFER_DOC)
+                .define(CommonConsumerConfigs.RECEIVE_BUFFER_CONFIG,
+                        ConfigDef.Type.INT,
+                        64 * 1024,
+                        atLeast(CommonClientConfigs.RECEIVE_BUFFER_LOWER_BOUND),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.RECEIVE_BUFFER_DOC)
+                .define(CommonConsumerConfigs.FETCH_MIN_BYTES_CONFIG,
+                        ConfigDef.Type.INT,
+                        CommonConsumerConfigs.DEFAULT_FETCH_MIN_BYTES,
+                        atLeast(0),
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.FETCH_MIN_BYTES_DOC)
+                .define(CommonConsumerConfigs.FETCH_MAX_BYTES_CONFIG,
+                        ConfigDef.Type.INT,
+                        CommonConsumerConfigs.DEFAULT_FETCH_MAX_BYTES,
+                        atLeast(0),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.FETCH_MAX_BYTES_DOC)
+                .define(CommonConsumerConfigs.FETCH_MAX_WAIT_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        CommonConsumerConfigs.DEFAULT_FETCH_MAX_WAIT_MS,
+                        atLeast(0),
+                        ConfigDef.Importance.LOW,
+                        CommonConsumerConfigs.FETCH_MAX_WAIT_MS_DOC)
+                .define(CommonConsumerConfigs.RECONNECT_BACKOFF_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        50L,
+                        atLeast(0L),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.RECONNECT_BACKOFF_MS_DOC)
+                .define(CommonConsumerConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        1000L,
+                        atLeast(0L),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_DOC)
+                .define(CommonConsumerConfigs.RETRY_BACKOFF_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MS,
+                        atLeast(0L),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.RETRY_BACKOFF_MS_DOC)
+                .define(CommonConsumerConfigs.RETRY_BACKOFF_MAX_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MAX_MS,
+                        atLeast(0L),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.RETRY_BACKOFF_MAX_MS_DOC)
+                .define(CommonConsumerConfigs.ENABLE_METRICS_PUSH_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        true,
+                        ConfigDef.Importance.LOW,
+                        CommonConsumerConfigs.ENABLE_METRICS_PUSH_DOC)
+                .define(CommonConsumerConfigs.AUTO_OFFSET_RESET_CONFIG,
+                        ConfigDef.Type.STRING,
+                        AutoOffsetResetStrategy.LATEST.name(),
+                        new AutoOffsetResetStrategy.Validator(),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.AUTO_OFFSET_RESET_DOC)
+                .define(CommonConsumerConfigs.CHECK_CRCS_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        true,
+                        ConfigDef.Importance.LOW,
+                        CommonConsumerConfigs.CHECK_CRCS_DOC)
+                .define(CommonConsumerConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        30000,
+                        atLeast(0),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_DOC)
+                .define(CommonConsumerConfigs.METRICS_NUM_SAMPLES_CONFIG,
+                        ConfigDef.Type.INT,
+                        2,
+                        atLeast(1),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC)
+                .define(CommonConsumerConfigs.METRICS_RECORDING_LEVEL_CONFIG,
+                        ConfigDef.Type.STRING,
+                        Sensor.RecordingLevel.INFO.toString(),
+                        in(Sensor.RecordingLevel.INFO.toString(), Sensor.RecordingLevel.DEBUG.toString(), Sensor.RecordingLevel.TRACE.toString()),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC)
+                .define(CommonConsumerConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+                        ConfigDef.Type.LIST,
+                        JmxReporter.class.getName(),
+                        ConfigDef.ValidList.anyNonDuplicateValues(true, false),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC)
+                .define(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG,
+                        ConfigDef.Type.CLASS,
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_DOC)
+                .define(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG,
+                        ConfigDef.Type.CLASS,
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_DOC)
+                .define(CommonConsumerConfigs.REQUEST_TIMEOUT_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        30000,
+                        atLeast(0),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.REQUEST_TIMEOUT_MS_DOC)
+                .define(CommonConsumerConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        60 * 1000,
+                        atLeast(0),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_DOC)
+                .define(CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC)
+                .define(CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC)
+                /* default is set to be a bit lower than the server default (10 min), to avoid both client and server closing connection at same time */
+                .define(CommonConsumerConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        9 * 60 * 1000,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_DOC)
+                .define(CommonConsumerConfigs.INTERCEPTOR_CLASSES_CONFIG,
+                        ConfigDef.Type.LIST,
+                        List.of(),
+                        ConfigDef.ValidList.anyNonDuplicateValues(true, false),
+                        ConfigDef.Importance.LOW,
+                        CommonConsumerConfigs.INTERCEPTOR_CLASSES_DOC)
+                .define(CommonConsumerConfigs.MAX_POLL_RECORDS_CONFIG,
+                        ConfigDef.Type.INT,
+                        CommonConsumerConfigs.DEFAULT_MAX_POLL_RECORDS,
+                        atLeast(1),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.MAX_POLL_RECORDS_DOC)
+                .define(CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_CONFIG,
+                        ConfigDef.Type.INT,
+                        300000,
+                        atLeast(1),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_DOC)
+                .define(CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        CommonConsumerConfigs.DEFAULT_EXCLUDE_INTERNAL_TOPICS,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_DOC)
+                .defineInternal(CommonConsumerConfigs.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED,
+                        ConfigDef.Type.BOOLEAN,
+                        false,
+                        ConfigDef.Importance.LOW)
+                .define(CommonConsumerConfigs.ISOLATION_LEVEL_CONFIG,
+                        ConfigDef.Type.STRING,
+                        CommonConsumerConfigs.DEFAULT_ISOLATION_LEVEL,
+                        in(IsolationLevel.READ_COMMITTED.toString(), IsolationLevel.READ_UNCOMMITTED.toString()),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.ISOLATION_LEVEL_DOC)
+                .define(CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        CommonConsumerConfigs.DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_DOC)
+                .define(CommonConsumerConfigs.GROUP_PROTOCOL_CONFIG,
+                        ConfigDef.Type.STRING,
+                        CommonConsumerConfigs.DEFAULT_GROUP_PROTOCOL,
+                        ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
+                        ConfigDef.Importance.HIGH,
+                        CommonConsumerConfigs.GROUP_PROTOCOL_DOC)
+                .define(CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_CONFIG,
+                        ConfigDef.Type.STRING,
+                        CommonConsumerConfigs.DEFAULT_GROUP_REMOTE_ASSIGNOR,
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_DOC)
+                // security support
+                .define(CommonConsumerConfigs.SECURITY_PROVIDERS_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.LOW,
+                        CommonConsumerConfigs.SECURITY_PROVIDERS_DOC)
+                .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+                        ConfigDef.Type.STRING,
+                        CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
+                        ConfigDef.CaseInsensitiveValidString
+                                .in(Utils.enumOptions(SecurityProtocol.class)),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonClientConfigs.SECURITY_PROTOCOL_DOC)
+                .withClientSslSupport()
+                .withClientSaslSupport()
+                .define(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG,
+                        ConfigDef.Type.STRING,
+                        CommonClientConfigs.DEFAULT_METADATA_RECOVERY_STRATEGY,
+                        ConfigDef.CaseInsensitiveValidString
+                                .in(Utils.enumOptions(MetadataRecoveryStrategy.class)),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METADATA_RECOVERY_STRATEGY_DOC)
+                .define(CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        CommonClientConfigs.DEFAULT_METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS,
+                        atLeast(0),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_DOC)
+                .define(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        ShareAcknowledgementMode.IMPLICIT.name(),
+                        new ShareAcknowledgementMode.Validator(),
+                        ConfigDef.Importance.MEDIUM,
+                        CommonConsumerConfigs.SHARE_ACKNOWLEDGEMENT_MODE_DOC)
+                .define(CONFIG_PROVIDERS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        List.of(),
+                        ConfigDef.ValidList.anyNonDuplicateValues(true, false),
+                        ConfigDef.Importance.LOW,
+                        CONFIG_PROVIDERS_DOC);
+    }
+
+    public static Map<String, Object> appendDeserializerToConfig(Map<String, Object> configs,
+                                                                 Deserializer<?> keyDeserializer,
+                                                                 Deserializer<?> valueDeserializer) {
+        // validate deserializer configuration, if the passed deserializer instance is null, the user must explicitly set a valid deserializer configuration value
+        Map<String, Object> newConfigs = new HashMap<>(configs);
+        if (keyDeserializer != null)
+            newConfigs.put(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
+        else if (newConfigs.get(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG) == null)
+            throw new ConfigException(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
+        if (valueDeserializer != null)
+            newConfigs.put(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
+        else if (newConfigs.get(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG) == null)
+            throw new ConfigException(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
+        return newConfigs;
+    }
+
+
+    public ShareConsumerConfig(Properties props) {
+        super(CONFIG, props);
     }
 
     ShareConsumerConfig(Map<String, Object> props) {
-        super(props);
+        super(CONFIG, props);
     }
 
     protected ShareConsumerConfig(Map<?, ?> props, boolean doLog) {
-        super(props, doLog);
+        super(CONFIG, props, doLog);
     }
 
     @Override
@@ -72,9 +400,5 @@ class ShareConsumerConfig extends ConsumerConfig {
             throw new ConfigException(String.join(", ", invalidConfigs) +
                     " cannot be set when using a share group.");
         }
-    }
-
-    @Override
-    protected void checkUnsupportedConfigsPostProcess() {
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
@@ -54,7 +54,6 @@ public class ShareConsumerConfig extends AbstractConfig {
     private static final List<String> SHARE_GROUP_UNSUPPORTED_CONFIGS = List.of(
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
-            ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG,
             ConsumerConfig.GROUP_INSTANCE_ID_CONFIG,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG,
             ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SecurityConfig;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -34,8 +35,10 @@ import org.apache.kafka.common.utils.Utils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
@@ -63,261 +66,517 @@ public class ShareConsumerConfig extends AbstractConfig {
             ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG
     );
 
+    /*
+     * NOTE: DO NOT CHANGE EITHER CONFIG STRINGS OR THEIR JAVA VARIABLE NAMES AS
+     * THESE ARE PART OF THE PUBLIC API AND CHANGE WILL BREAK USER CODE.
+     */
+
+    /**
+     * <code>group.id</code>
+     */
+    public static final String GROUP_ID_CONFIG = CommonConsumerConfigs.GROUP_ID_CONFIG;
+    private static final String GROUP_ID_DOC = CommonConsumerConfigs.GROUP_ID_DOC;
+
+    /**
+     * <code>group.instance.id</code>
+     */
+    public static final String GROUP_INSTANCE_ID_CONFIG = CommonConsumerConfigs.GROUP_INSTANCE_ID_CONFIG;
+    private static final String GROUP_INSTANCE_ID_DOC = CommonConsumerConfigs.GROUP_INSTANCE_ID_DOC;
+
+    /** <code>max.poll.records</code> */
+    public static final String MAX_POLL_RECORDS_CONFIG = CommonConsumerConfigs.MAX_POLL_RECORDS_CONFIG;
+    private static final String MAX_POLL_RECORDS_DOC = CommonConsumerConfigs.MAX_POLL_RECORDS_DOC;
+    public static final int DEFAULT_MAX_POLL_RECORDS = 500;
+
+    /** <code>max.poll.interval.ms</code> */
+    public static final String MAX_POLL_INTERVAL_MS_CONFIG = CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_CONFIG;
+    private static final String MAX_POLL_INTERVAL_MS_DOC = CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_DOC;
+    /**
+     * <code>session.timeout.ms</code>
+     */
+    public static final String SESSION_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.SESSION_TIMEOUT_MS_CONFIG;
+    private static final String SESSION_TIMEOUT_MS_DOC = CommonConsumerConfigs.SESSION_TIMEOUT_MS_DOC;
+
+    /**
+     * <code>heartbeat.interval.ms</code>
+     */
+    public static final String HEARTBEAT_INTERVAL_MS_CONFIG = CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_CONFIG;
+    private static final String HEARTBEAT_INTERVAL_MS_DOC = CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_DOC;
+
+    /**
+     * <code>group.protocol</code>
+     */
+    public static final String GROUP_PROTOCOL_CONFIG = CommonConsumerConfigs.GROUP_PROTOCOL_CONFIG;
+    public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.CLASSIC.name().toLowerCase(Locale.ROOT);
+    public static final String GROUP_PROTOCOL_DOC = CommonConsumerConfigs.GROUP_PROTOCOL_DOC;
+
+    /**
+     * <code>group.remote.assignor</code>
+     */
+    public static final String GROUP_REMOTE_ASSIGNOR_CONFIG = CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_CONFIG;
+    public static final String DEFAULT_GROUP_REMOTE_ASSIGNOR = null;
+    public static final String GROUP_REMOTE_ASSIGNOR_DOC = CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_DOC;
+
+    /**
+     * <code>bootstrap.servers</code>
+     */
+    public static final String BOOTSTRAP_SERVERS_CONFIG = CommonConsumerConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+    /** <code>client.dns.lookup</code> */
+    public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonConsumerConfigs.CLIENT_DNS_LOOKUP_CONFIG;
+
+    /**
+     * <code>enable.auto.commit</code>
+     */
+    public static final String ENABLE_AUTO_COMMIT_CONFIG = CommonConsumerConfigs.ENABLE_AUTO_COMMIT_CONFIG;
+    private static final String ENABLE_AUTO_COMMIT_DOC = CommonConsumerConfigs.ENABLE_AUTO_COMMIT_DOC;
+
+    /**
+     * <code>auto.commit.interval.ms</code>
+     */
+    public static final String AUTO_COMMIT_INTERVAL_MS_CONFIG = CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_CONFIG;
+    private static final String AUTO_COMMIT_INTERVAL_MS_DOC = CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_DOC;
+
+    /**
+     * <code>partition.assignment.strategy</code>
+     */
+    public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_CONFIG;
+    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_DOC;
+    /**
+     * <code>auto.offset.reset</code>
+     */
+    public static final String AUTO_OFFSET_RESET_CONFIG = CommonConsumerConfigs.AUTO_OFFSET_RESET_CONFIG;
+    public static final String AUTO_OFFSET_RESET_DOC = CommonConsumerConfigs.AUTO_OFFSET_RESET_DOC;
+
+    /**
+     * <code>fetch.min.bytes</code>
+     */
+    public static final String FETCH_MIN_BYTES_CONFIG = CommonConsumerConfigs.FETCH_MIN_BYTES_CONFIG;
+    public static final int DEFAULT_FETCH_MIN_BYTES = 1;
+    private static final String FETCH_MIN_BYTES_DOC = CommonConsumerConfigs.FETCH_MIN_BYTES_DOC;
+
+    /**
+     * <code>fetch.max.bytes</code>
+     */
+    public static final String FETCH_MAX_BYTES_CONFIG = CommonConsumerConfigs.FETCH_MAX_BYTES_CONFIG;
+    private static final String FETCH_MAX_BYTES_DOC = CommonConsumerConfigs.FETCH_MAX_BYTES_DOC;
+    public static final int DEFAULT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
+
+    /**
+     * <code>fetch.max.wait.ms</code>
+     */
+    public static final String FETCH_MAX_WAIT_MS_CONFIG = CommonConsumerConfigs.FETCH_MAX_WAIT_MS_CONFIG;
+    private static final String FETCH_MAX_WAIT_MS_DOC = CommonConsumerConfigs.FETCH_MAX_WAIT_MS_DOC;
+    public static final int DEFAULT_FETCH_MAX_WAIT_MS = 500;
+
+    /** <code>metadata.max.age.ms</code> */
+    public static final String METADATA_MAX_AGE_CONFIG = CommonConsumerConfigs.METADATA_MAX_AGE_CONFIG;
+
+    /**
+     * <code>max.partition.fetch.bytes</code>
+     */
+    public static final String MAX_PARTITION_FETCH_BYTES_CONFIG = CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_CONFIG;
+    private static final String MAX_PARTITION_FETCH_BYTES_DOC = CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_DOC;
+    public static final int DEFAULT_MAX_PARTITION_FETCH_BYTES = 1 * 1024 * 1024;
+
+    /** <code>send.buffer.bytes</code> */
+    public static final String SEND_BUFFER_CONFIG = CommonConsumerConfigs.SEND_BUFFER_CONFIG;
+
+    /** <code>receive.buffer.bytes</code> */
+    public static final String RECEIVE_BUFFER_CONFIG = CommonConsumerConfigs.RECEIVE_BUFFER_CONFIG;
+
+    /**
+     * <code>client.id</code>
+     */
+    public static final String CLIENT_ID_CONFIG = CommonConsumerConfigs.CLIENT_ID_CONFIG;
+
+    /**
+     * <code>client.rack</code>
+     */
+    public static final String CLIENT_RACK_CONFIG = CommonConsumerConfigs.CLIENT_RACK_CONFIG;
+    public static final String DEFAULT_CLIENT_RACK = CommonConsumerConfigs.DEFAULT_CLIENT_RACK;
+
+    /**
+     * <code>reconnect.backoff.ms</code>
+     */
+    public static final String RECONNECT_BACKOFF_MS_CONFIG = CommonConsumerConfigs.RECONNECT_BACKOFF_MS_CONFIG;
+
+    /**
+     * <code>reconnect.backoff.max.ms</code>
+     */
+    public static final String RECONNECT_BACKOFF_MAX_MS_CONFIG = CommonConsumerConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG;
+
+    /**
+     * <code>retry.backoff.ms</code>
+     */
+    public static final String RETRY_BACKOFF_MS_CONFIG = CommonConsumerConfigs.RETRY_BACKOFF_MS_CONFIG;
+
+    /**
+     * <code>enable.metrics.push</code>
+     */
+    public static final String ENABLE_METRICS_PUSH_CONFIG = CommonConsumerConfigs.ENABLE_METRICS_PUSH_CONFIG;
+    public static final String ENABLE_METRICS_PUSH_DOC = CommonConsumerConfigs.ENABLE_METRICS_PUSH_DOC;
+
+    /**
+     * <code>retry.backoff.max.ms</code>
+     */
+    public static final String RETRY_BACKOFF_MAX_MS_CONFIG = CommonConsumerConfigs.RETRY_BACKOFF_MAX_MS_CONFIG;
+
+    /**
+     * <code>metrics.sample.window.ms</code>
+     */
+    public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonConsumerConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
+
+    /**
+     * <code>metrics.num.samples</code>
+     */
+    public static final String METRICS_NUM_SAMPLES_CONFIG = CommonConsumerConfigs.METRICS_NUM_SAMPLES_CONFIG;
+
+    /**
+     * <code>metrics.log.level</code>
+     */
+    public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonConsumerConfigs.METRICS_RECORDING_LEVEL_CONFIG;
+
+    /**
+     * <code>metric.reporters</code>
+     */
+    public static final String METRIC_REPORTER_CLASSES_CONFIG = CommonConsumerConfigs.METRIC_REPORTER_CLASSES_CONFIG;
+
+    /**
+     * <code>check.crcs</code>
+     */
+    public static final String CHECK_CRCS_CONFIG = CommonConsumerConfigs.CHECK_CRCS_CONFIG;
+    private static final String CHECK_CRCS_DOC = CommonConsumerConfigs.CHECK_CRCS_DOC;
+
+    /** <code>key.deserializer</code> */
+    public static final String KEY_DESERIALIZER_CLASS_CONFIG = CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG;
+    public static final String KEY_DESERIALIZER_CLASS_DOC = CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_DOC;
+
+    /** <code>value.deserializer</code> */
+    public static final String VALUE_DESERIALIZER_CLASS_CONFIG = CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG;
+    public static final String VALUE_DESERIALIZER_CLASS_DOC = CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_DOC;
+
+    /** <code>socket.connection.setup.timeout.ms</code> */
+    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
+
+    /** <code>socket.connection.setup.timeout.max.ms</code> */
+    public static final String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG = CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
+
+    /** <code>connections.max.idle.ms</code> */
+    public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonConsumerConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
+
+    /** <code>request.timeout.ms</code> */
+    public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.REQUEST_TIMEOUT_MS_CONFIG;
+    private static final String REQUEST_TIMEOUT_MS_DOC = CommonConsumerConfigs.REQUEST_TIMEOUT_MS_DOC;
+
+    /** <code>default.api.timeout.ms</code> */
+    public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG;
+
+    /** <code>interceptor.classes</code> */
+    public static final String INTERCEPTOR_CLASSES_CONFIG = CommonConsumerConfigs.INTERCEPTOR_CLASSES_CONFIG;
+    public static final String INTERCEPTOR_CLASSES_DOC = CommonConsumerConfigs.INTERCEPTOR_CLASSES_DOC;
+
+
+    /** <code>exclude.internal.topics</code> */
+    public static final String EXCLUDE_INTERNAL_TOPICS_CONFIG = CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_CONFIG;
+    private static final String EXCLUDE_INTERNAL_TOPICS_DOC = CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_DOC;
+    public static final boolean DEFAULT_EXCLUDE_INTERNAL_TOPICS = true;
+
+    /**
+     * <code>internal.throw.on.fetch.stable.offset.unsupported</code>
+     * Whether or not the consumer should throw when the new stable offset feature is supported.
+     * If set to <code>true</code> then the client shall crash upon hitting it.
+     * The purpose of this flag is to prevent unexpected broker downgrade which makes
+     * the offset fetch protection against pending commit invalid. The safest approach
+     * is to fail fast to avoid introducing correctness issue.
+     *
+     * <p>
+     * Note: this is an internal configuration and could be changed in the future in a backward incompatible way
+     *
+     */
+    static final String THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED = CommonConsumerConfigs.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED;
+
+    /** <code>isolation.level</code> */
+    public static final String ISOLATION_LEVEL_CONFIG = CommonConsumerConfigs.ISOLATION_LEVEL_CONFIG;
+    public static final String ISOLATION_LEVEL_DOC = CommonConsumerConfigs.ISOLATION_LEVEL_DOC;
+
+    public static final String DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_UNCOMMITTED.toString();
+
+    /** <code>allow.auto.create.topics</code> */
+    public static final String ALLOW_AUTO_CREATE_TOPICS_CONFIG = CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_CONFIG;
+    private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_DOC;
+    public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = true;
+
+    /**
+     * <code>security.providers</code>
+     */
+    public static final String SECURITY_PROVIDERS_CONFIG = SecurityConfig.SECURITY_PROVIDERS_CONFIG;
+    private static final String SECURITY_PROVIDERS_DOC = SecurityConfig.SECURITY_PROVIDERS_DOC;
+
+    /**
+     * <code>share.acknowledgement.mode</code>
+     */
+    public static final String SHARE_ACKNOWLEDGEMENT_MODE_CONFIG = CommonConsumerConfigs.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG;
+    private static final String SHARE_ACKNOWLEDGEMENT_MODE_DOC = CommonConsumerConfigs.SHARE_ACKNOWLEDGEMENT_MODE_DOC;
+
+    private static final AtomicInteger CONSUMER_CLIENT_ID_SEQUENCE = new AtomicInteger(1);
+
+
     static {
-        CONFIG = new ConfigDef().define(CommonConsumerConfigs.BOOTSTRAP_SERVERS_CONFIG,
+        CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                         ConfigDef.Type.LIST,
                         ConfigDef.NO_DEFAULT_VALUE,
                         ConfigDef.ValidList.anyNonDuplicateValues(false, false),
                         ConfigDef.Importance.HIGH,
                         CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
-                .define(CommonConsumerConfigs.CLIENT_DNS_LOOKUP_CONFIG,
+                .define(CLIENT_DNS_LOOKUP_CONFIG,
                         ConfigDef.Type.STRING,
                         ClientDnsLookup.USE_ALL_DNS_IPS.toString(),
                         in(ClientDnsLookup.USE_ALL_DNS_IPS.toString(),
                                 ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY.toString()),
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.CLIENT_DNS_LOOKUP_DOC)
-                .define(CommonConsumerConfigs.GROUP_ID_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CommonConsumerConfigs.GROUP_ID_DOC)
-                .define(CommonConsumerConfigs.GROUP_INSTANCE_ID_CONFIG,
+                .define(GROUP_ID_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CommonConsumerConfigs.GROUP_ID_DOC)
+                .define(GROUP_INSTANCE_ID_CONFIG,
                         ConfigDef.Type.STRING,
                         null,
                         new ConfigDef.NonEmptyString(),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.GROUP_INSTANCE_ID_DOC)
-                .define(CommonConsumerConfigs.SESSION_TIMEOUT_MS_CONFIG,
+                        GROUP_INSTANCE_ID_DOC)
+                .define(SESSION_TIMEOUT_MS_CONFIG,
                         ConfigDef.Type.INT,
                         45000,
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.SESSION_TIMEOUT_MS_DOC)
-                .define(CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_CONFIG,
+                        SESSION_TIMEOUT_MS_DOC)
+                .define(HEARTBEAT_INTERVAL_MS_CONFIG,
                         ConfigDef.Type.INT,
                         3000,
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_DOC)
-                .define(CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+                        HEARTBEAT_INTERVAL_MS_DOC)
+                .define(PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
                         ConfigDef.Type.LIST,
                         List.of(RangeAssignor.class, CooperativeStickyAssignor.class),
                         ConfigDef.ValidList.anyNonDuplicateValues(true, false),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_DOC)
-                .define(CommonConsumerConfigs.METADATA_MAX_AGE_CONFIG,
+                        PARTITION_ASSIGNMENT_STRATEGY_DOC)
+                .define(METADATA_MAX_AGE_CONFIG,
                         ConfigDef.Type.LONG,
                         5 * 60 * 1000,
                         atLeast(0),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METADATA_MAX_AGE_DOC)
-                .define(CommonConsumerConfigs.ENABLE_AUTO_COMMIT_CONFIG,
+                .define(ENABLE_AUTO_COMMIT_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         true,
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.ENABLE_AUTO_COMMIT_DOC)
-                .define(CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_CONFIG,
+                        ENABLE_AUTO_COMMIT_DOC)
+                .define(AUTO_COMMIT_INTERVAL_MS_CONFIG,
                         ConfigDef.Type.INT,
                         5000,
                         atLeast(0),
                         ConfigDef.Importance.LOW,
-                        CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_DOC)
-                .define(CommonConsumerConfigs.CLIENT_ID_CONFIG,
+                        AUTO_COMMIT_INTERVAL_MS_DOC)
+                .define(CLIENT_ID_CONFIG,
                         ConfigDef.Type.STRING,
                         "",
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.CLIENT_ID_DOC)
-                .define(CommonConsumerConfigs.CLIENT_RACK_CONFIG,
+                .define(CLIENT_RACK_CONFIG,
                         ConfigDef.Type.STRING,
-                        CommonConsumerConfigs.DEFAULT_CLIENT_RACK,
+                        DEFAULT_CLIENT_RACK,
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.CLIENT_RACK_DOC)
-                .define(CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_CONFIG,
+                .define(MAX_PARTITION_FETCH_BYTES_CONFIG,
                         ConfigDef.Type.INT,
-                        CommonConsumerConfigs.DEFAULT_MAX_PARTITION_FETCH_BYTES,
+                        DEFAULT_MAX_PARTITION_FETCH_BYTES,
                         atLeast(0),
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.MAX_PARTITION_FETCH_BYTES_DOC)
-                .define(CommonConsumerConfigs.SEND_BUFFER_CONFIG,
+                        MAX_PARTITION_FETCH_BYTES_DOC)
+                .define(SEND_BUFFER_CONFIG,
                         ConfigDef.Type.INT,
                         128 * 1024,
                         atLeast(CommonClientConfigs.SEND_BUFFER_LOWER_BOUND),
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.SEND_BUFFER_DOC)
-                .define(CommonConsumerConfigs.RECEIVE_BUFFER_CONFIG,
+                .define(RECEIVE_BUFFER_CONFIG,
                         ConfigDef.Type.INT,
                         64 * 1024,
                         atLeast(CommonClientConfigs.RECEIVE_BUFFER_LOWER_BOUND),
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.RECEIVE_BUFFER_DOC)
-                .define(CommonConsumerConfigs.FETCH_MIN_BYTES_CONFIG,
+                .define(FETCH_MIN_BYTES_CONFIG,
                         ConfigDef.Type.INT,
-                        CommonConsumerConfigs.DEFAULT_FETCH_MIN_BYTES,
+                        DEFAULT_FETCH_MIN_BYTES,
                         atLeast(0),
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.FETCH_MIN_BYTES_DOC)
-                .define(CommonConsumerConfigs.FETCH_MAX_BYTES_CONFIG,
+                        FETCH_MIN_BYTES_DOC)
+                .define(FETCH_MAX_BYTES_CONFIG,
                         ConfigDef.Type.INT,
-                        CommonConsumerConfigs.DEFAULT_FETCH_MAX_BYTES,
+                        DEFAULT_FETCH_MAX_BYTES,
                         atLeast(0),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.FETCH_MAX_BYTES_DOC)
-                .define(CommonConsumerConfigs.FETCH_MAX_WAIT_MS_CONFIG,
+                        FETCH_MAX_BYTES_DOC)
+                .define(FETCH_MAX_WAIT_MS_CONFIG,
                         ConfigDef.Type.INT,
-                        CommonConsumerConfigs.DEFAULT_FETCH_MAX_WAIT_MS,
+                        DEFAULT_FETCH_MAX_WAIT_MS,
                         atLeast(0),
                         ConfigDef.Importance.LOW,
-                        CommonConsumerConfigs.FETCH_MAX_WAIT_MS_DOC)
-                .define(CommonConsumerConfigs.RECONNECT_BACKOFF_MS_CONFIG,
+                        FETCH_MAX_WAIT_MS_DOC)
+                .define(RECONNECT_BACKOFF_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         50L,
                         atLeast(0L),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.RECONNECT_BACKOFF_MS_DOC)
-                .define(CommonConsumerConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG,
+                .define(RECONNECT_BACKOFF_MAX_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         1000L,
                         atLeast(0L),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_DOC)
-                .define(CommonConsumerConfigs.RETRY_BACKOFF_MS_CONFIG,
+                .define(RETRY_BACKOFF_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MS,
                         atLeast(0L),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.RETRY_BACKOFF_MS_DOC)
-                .define(CommonConsumerConfigs.RETRY_BACKOFF_MAX_MS_CONFIG,
+                .define(RETRY_BACKOFF_MAX_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MAX_MS,
                         atLeast(0L),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.RETRY_BACKOFF_MAX_MS_DOC)
-                .define(CommonConsumerConfigs.ENABLE_METRICS_PUSH_CONFIG,
+                .define(ENABLE_METRICS_PUSH_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         true,
                         ConfigDef.Importance.LOW,
-                        CommonConsumerConfigs.ENABLE_METRICS_PUSH_DOC)
-                .define(CommonConsumerConfigs.AUTO_OFFSET_RESET_CONFIG,
+                        ENABLE_METRICS_PUSH_DOC)
+                .define(AUTO_OFFSET_RESET_CONFIG,
                         ConfigDef.Type.STRING,
                         AutoOffsetResetStrategy.LATEST.name(),
                         new AutoOffsetResetStrategy.Validator(),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.AUTO_OFFSET_RESET_DOC)
-                .define(CommonConsumerConfigs.CHECK_CRCS_CONFIG,
+                        AUTO_OFFSET_RESET_DOC)
+                .define(CHECK_CRCS_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         true,
                         ConfigDef.Importance.LOW,
-                        CommonConsumerConfigs.CHECK_CRCS_DOC)
-                .define(CommonConsumerConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG,
+                        CHECK_CRCS_DOC)
+                .define(METRICS_SAMPLE_WINDOW_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         30000,
                         atLeast(0),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_DOC)
-                .define(CommonConsumerConfigs.METRICS_NUM_SAMPLES_CONFIG,
+                .define(METRICS_NUM_SAMPLES_CONFIG,
                         ConfigDef.Type.INT,
                         2,
                         atLeast(1),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METRICS_NUM_SAMPLES_DOC)
-                .define(CommonConsumerConfigs.METRICS_RECORDING_LEVEL_CONFIG,
+                .define(METRICS_RECORDING_LEVEL_CONFIG,
                         ConfigDef.Type.STRING,
                         Sensor.RecordingLevel.INFO.toString(),
                         in(Sensor.RecordingLevel.INFO.toString(), Sensor.RecordingLevel.DEBUG.toString(), Sensor.RecordingLevel.TRACE.toString()),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC)
-                .define(CommonConsumerConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+                .define(METRIC_REPORTER_CLASSES_CONFIG,
                         ConfigDef.Type.LIST,
                         JmxReporter.class.getName(),
                         ConfigDef.ValidList.anyNonDuplicateValues(true, false),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC)
-                .define(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG,
+                .define(KEY_DESERIALIZER_CLASS_CONFIG,
                         ConfigDef.Type.CLASS,
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_DOC)
-                .define(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG,
+                        KEY_DESERIALIZER_CLASS_DOC)
+                .define(VALUE_DESERIALIZER_CLASS_CONFIG,
                         ConfigDef.Type.CLASS,
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_DOC)
-                .define(CommonConsumerConfigs.REQUEST_TIMEOUT_MS_CONFIG,
+                        VALUE_DESERIALIZER_CLASS_DOC)
+                .define(REQUEST_TIMEOUT_MS_CONFIG,
                         ConfigDef.Type.INT,
                         30000,
                         atLeast(0),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.REQUEST_TIMEOUT_MS_DOC)
-                .define(CommonConsumerConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG,
+                        REQUEST_TIMEOUT_MS_DOC)
+                .define(DEFAULT_API_TIMEOUT_MS_CONFIG,
                         ConfigDef.Type.INT,
                         60 * 1000,
                         atLeast(0),
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_DOC)
-                .define(CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG,
+                .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS,
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC)
-                .define(CommonConsumerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG,
+                .define(SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS,
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC)
                 /* default is set to be a bit lower than the server default (10 min), to avoid both client and server closing connection at same time */
-                .define(CommonConsumerConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG,
+                .define(CONNECTIONS_MAX_IDLE_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         9 * 60 * 1000,
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_DOC)
-                .define(CommonConsumerConfigs.INTERCEPTOR_CLASSES_CONFIG,
+                .define(INTERCEPTOR_CLASSES_CONFIG,
                         ConfigDef.Type.LIST,
                         List.of(),
                         ConfigDef.ValidList.anyNonDuplicateValues(true, false),
                         ConfigDef.Importance.LOW,
-                        CommonConsumerConfigs.INTERCEPTOR_CLASSES_DOC)
-                .define(CommonConsumerConfigs.MAX_POLL_RECORDS_CONFIG,
+                        INTERCEPTOR_CLASSES_DOC)
+                .define(MAX_POLL_RECORDS_CONFIG,
                         ConfigDef.Type.INT,
-                        CommonConsumerConfigs.DEFAULT_MAX_POLL_RECORDS,
+                        DEFAULT_MAX_POLL_RECORDS,
                         atLeast(1),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.MAX_POLL_RECORDS_DOC)
-                .define(CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_CONFIG,
+                        MAX_POLL_RECORDS_DOC)
+                .define(MAX_POLL_INTERVAL_MS_CONFIG,
                         ConfigDef.Type.INT,
                         300000,
                         atLeast(1),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_DOC)
-                .define(CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_CONFIG,
+                        MAX_POLL_INTERVAL_MS_DOC)
+                .define(EXCLUDE_INTERNAL_TOPICS_CONFIG,
                         ConfigDef.Type.BOOLEAN,
-                        CommonConsumerConfigs.DEFAULT_EXCLUDE_INTERNAL_TOPICS,
+                        DEFAULT_EXCLUDE_INTERNAL_TOPICS,
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_DOC)
-                .defineInternal(CommonConsumerConfigs.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED,
+                        EXCLUDE_INTERNAL_TOPICS_DOC)
+                .defineInternal(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED,
                         ConfigDef.Type.BOOLEAN,
                         false,
                         ConfigDef.Importance.LOW)
-                .define(CommonConsumerConfigs.ISOLATION_LEVEL_CONFIG,
+                .define(ISOLATION_LEVEL_CONFIG,
                         ConfigDef.Type.STRING,
-                        CommonConsumerConfigs.DEFAULT_ISOLATION_LEVEL,
+                        DEFAULT_ISOLATION_LEVEL,
                         in(IsolationLevel.READ_COMMITTED.toString(), IsolationLevel.READ_UNCOMMITTED.toString()),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.ISOLATION_LEVEL_DOC)
-                .define(CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_CONFIG,
+                        ISOLATION_LEVEL_DOC)
+                .define(ALLOW_AUTO_CREATE_TOPICS_CONFIG,
                         ConfigDef.Type.BOOLEAN,
-                        CommonConsumerConfigs.DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
+                        DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.ALLOW_AUTO_CREATE_TOPICS_DOC)
-                .define(CommonConsumerConfigs.GROUP_PROTOCOL_CONFIG,
+                        ALLOW_AUTO_CREATE_TOPICS_DOC)
+                .define(GROUP_PROTOCOL_CONFIG,
                         ConfigDef.Type.STRING,
-                        CommonConsumerConfigs.DEFAULT_GROUP_PROTOCOL,
+                        DEFAULT_GROUP_PROTOCOL,
                         ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
                         ConfigDef.Importance.HIGH,
-                        CommonConsumerConfigs.GROUP_PROTOCOL_DOC)
-                .define(CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_CONFIG,
+                        GROUP_PROTOCOL_DOC)
+                .define(GROUP_REMOTE_ASSIGNOR_CONFIG,
                         ConfigDef.Type.STRING,
-                        CommonConsumerConfigs.DEFAULT_GROUP_REMOTE_ASSIGNOR,
+                        DEFAULT_GROUP_REMOTE_ASSIGNOR,
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_DOC)
+                        GROUP_REMOTE_ASSIGNOR_DOC)
                 // security support
-                .define(CommonConsumerConfigs.SECURITY_PROVIDERS_CONFIG,
+                .define(SECURITY_PROVIDERS_CONFIG,
                         ConfigDef.Type.STRING,
                         null,
                         ConfigDef.Importance.LOW,
-                        CommonConsumerConfigs.SECURITY_PROVIDERS_DOC)
+                        SECURITY_PROVIDERS_DOC)
                 .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
                         ConfigDef.Type.STRING,
                         CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
@@ -345,7 +604,7 @@ public class ShareConsumerConfig extends AbstractConfig {
                         ShareAcknowledgementMode.IMPLICIT.name(),
                         new ShareAcknowledgementMode.Validator(),
                         ConfigDef.Importance.MEDIUM,
-                        CommonConsumerConfigs.SHARE_ACKNOWLEDGEMENT_MODE_DOC)
+                        SHARE_ACKNOWLEDGEMENT_MODE_DOC)
                 .define(CONFIG_PROVIDERS_CONFIG,
                         ConfigDef.Type.LIST,
                         List.of(),
@@ -360,13 +619,13 @@ public class ShareConsumerConfig extends AbstractConfig {
         // validate deserializer configuration, if the passed deserializer instance is null, the user must explicitly set a valid deserializer configuration value
         Map<String, Object> newConfigs = new HashMap<>(configs);
         if (keyDeserializer != null)
-            newConfigs.put(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
-        else if (newConfigs.get(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG) == null)
-            throw new ConfigException(CommonConsumerConfigs.KEY_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
+            newConfigs.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
+        else if (newConfigs.get(KEY_DESERIALIZER_CLASS_CONFIG) == null)
+            throw new ConfigException(KEY_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
         if (valueDeserializer != null)
-            newConfigs.put(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
-        else if (newConfigs.get(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG) == null)
-            throw new ConfigException(CommonConsumerConfigs.VALUE_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
+            newConfigs.put(VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
+        else if (newConfigs.get(VALUE_DESERIALIZER_CLASS_CONFIG) == null)
+            throw new ConfigException(VALUE_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
         return newConfigs;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
@@ -327,13 +327,13 @@ public class ShareConsumerConfig extends AbstractConfig {
                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
                 .withClientSslSupport()
                 .withClientSaslSupport()
-                .define(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG,
+                .define(CommonConsumerConfigs.METADATA_RECOVERY_STRATEGY_CONFIG,
                         ConfigDef.Type.STRING,
                         CommonClientConfigs.DEFAULT_METADATA_RECOVERY_STRATEGY,
                         ConfigDef.CaseInsensitiveValidString
                                 .in(Utils.enumOptions(MetadataRecoveryStrategy.class)),
                         ConfigDef.Importance.LOW,
-                        CommonClientConfigs.METADATA_RECOVERY_STRATEGY_DOC)
+                        CommonConsumerConfigs.METADATA_RECOVERY_STRATEGY_DOC)
                 .define(CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         CommonClientConfigs.DEFAULT_METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ShareConsumerConfig.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.MetadataRecoveryStrategy;
-import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.ShareAcknowledgementMode;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -35,7 +34,6 @@ import org.apache.kafka.common.utils.Utils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,6 +54,7 @@ public class ShareConsumerConfig extends AbstractConfig {
     private static final List<String> SHARE_GROUP_UNSUPPORTED_CONFIGS = List.of(
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+            ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG,
             ConsumerConfig.GROUP_INSTANCE_ID_CONFIG,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG,
             ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
@@ -77,11 +76,6 @@ public class ShareConsumerConfig extends AbstractConfig {
     public static final String GROUP_ID_CONFIG = CommonConsumerConfigs.GROUP_ID_CONFIG;
     private static final String GROUP_ID_DOC = CommonConsumerConfigs.GROUP_ID_DOC;
 
-    /**
-     * <code>group.instance.id</code>
-     */
-    public static final String GROUP_INSTANCE_ID_CONFIG = CommonConsumerConfigs.GROUP_INSTANCE_ID_CONFIG;
-    private static final String GROUP_INSTANCE_ID_DOC = CommonConsumerConfigs.GROUP_INSTANCE_ID_DOC;
 
     /** <code>max.poll.records</code> */
     public static final String MAX_POLL_RECORDS_CONFIG = CommonConsumerConfigs.MAX_POLL_RECORDS_CONFIG;
@@ -91,31 +85,6 @@ public class ShareConsumerConfig extends AbstractConfig {
     /** <code>max.poll.interval.ms</code> */
     public static final String MAX_POLL_INTERVAL_MS_CONFIG = CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_CONFIG;
     private static final String MAX_POLL_INTERVAL_MS_DOC = CommonConsumerConfigs.MAX_POLL_INTERVAL_MS_DOC;
-    /**
-     * <code>session.timeout.ms</code>
-     */
-    public static final String SESSION_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.SESSION_TIMEOUT_MS_CONFIG;
-    private static final String SESSION_TIMEOUT_MS_DOC = CommonConsumerConfigs.SESSION_TIMEOUT_MS_DOC;
-
-    /**
-     * <code>heartbeat.interval.ms</code>
-     */
-    public static final String HEARTBEAT_INTERVAL_MS_CONFIG = CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_CONFIG;
-    private static final String HEARTBEAT_INTERVAL_MS_DOC = CommonConsumerConfigs.HEARTBEAT_INTERVAL_MS_DOC;
-
-    /**
-     * <code>group.protocol</code>
-     */
-    public static final String GROUP_PROTOCOL_CONFIG = CommonConsumerConfigs.GROUP_PROTOCOL_CONFIG;
-    public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.CLASSIC.name().toLowerCase(Locale.ROOT);
-    public static final String GROUP_PROTOCOL_DOC = CommonConsumerConfigs.GROUP_PROTOCOL_DOC;
-
-    /**
-     * <code>group.remote.assignor</code>
-     */
-    public static final String GROUP_REMOTE_ASSIGNOR_CONFIG = CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_CONFIG;
-    public static final String DEFAULT_GROUP_REMOTE_ASSIGNOR = null;
-    public static final String GROUP_REMOTE_ASSIGNOR_DOC = CommonConsumerConfigs.GROUP_REMOTE_ASSIGNOR_DOC;
 
     /**
      * <code>bootstrap.servers</code>
@@ -124,29 +93,6 @@ public class ShareConsumerConfig extends AbstractConfig {
 
     /** <code>client.dns.lookup</code> */
     public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonConsumerConfigs.CLIENT_DNS_LOOKUP_CONFIG;
-
-    /**
-     * <code>enable.auto.commit</code>
-     */
-    public static final String ENABLE_AUTO_COMMIT_CONFIG = CommonConsumerConfigs.ENABLE_AUTO_COMMIT_CONFIG;
-    private static final String ENABLE_AUTO_COMMIT_DOC = CommonConsumerConfigs.ENABLE_AUTO_COMMIT_DOC;
-
-    /**
-     * <code>auto.commit.interval.ms</code>
-     */
-    public static final String AUTO_COMMIT_INTERVAL_MS_CONFIG = CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_CONFIG;
-    private static final String AUTO_COMMIT_INTERVAL_MS_DOC = CommonConsumerConfigs.AUTO_COMMIT_INTERVAL_MS_DOC;
-
-    /**
-     * <code>partition.assignment.strategy</code>
-     */
-    public static final String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_CONFIG;
-    private static final String PARTITION_ASSIGNMENT_STRATEGY_DOC = CommonConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_DOC;
-    /**
-     * <code>auto.offset.reset</code>
-     */
-    public static final String AUTO_OFFSET_RESET_CONFIG = CommonConsumerConfigs.AUTO_OFFSET_RESET_CONFIG;
-    public static final String AUTO_OFFSET_RESET_DOC = CommonConsumerConfigs.AUTO_OFFSET_RESET_DOC;
 
     /**
      * <code>fetch.min.bytes</code>
@@ -272,11 +218,6 @@ public class ShareConsumerConfig extends AbstractConfig {
     /** <code>default.api.timeout.ms</code> */
     public static final String DEFAULT_API_TIMEOUT_MS_CONFIG = CommonConsumerConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG;
 
-    /** <code>interceptor.classes</code> */
-    public static final String INTERCEPTOR_CLASSES_CONFIG = CommonConsumerConfigs.INTERCEPTOR_CLASSES_CONFIG;
-    public static final String INTERCEPTOR_CLASSES_DOC = CommonConsumerConfigs.INTERCEPTOR_CLASSES_DOC;
-
-
     /** <code>exclude.internal.topics</code> */
     public static final String EXCLUDE_INTERNAL_TOPICS_CONFIG = CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_CONFIG;
     private static final String EXCLUDE_INTERNAL_TOPICS_DOC = CommonConsumerConfigs.EXCLUDE_INTERNAL_TOPICS_DOC;
@@ -295,10 +236,6 @@ public class ShareConsumerConfig extends AbstractConfig {
      *
      */
     static final String THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED = CommonConsumerConfigs.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED;
-
-    /** <code>isolation.level</code> */
-    public static final String ISOLATION_LEVEL_CONFIG = CommonConsumerConfigs.ISOLATION_LEVEL_CONFIG;
-    public static final String ISOLATION_LEVEL_DOC = CommonConsumerConfigs.ISOLATION_LEVEL_DOC;
 
     public static final String DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_UNCOMMITTED.toString();
 
@@ -336,46 +273,17 @@ public class ShareConsumerConfig extends AbstractConfig {
                                 ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY.toString()),
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.CLIENT_DNS_LOOKUP_DOC)
-                .define(GROUP_ID_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CommonConsumerConfigs.GROUP_ID_DOC)
-                .define(GROUP_INSTANCE_ID_CONFIG,
+                .define(GROUP_ID_CONFIG,
                         ConfigDef.Type.STRING,
                         null,
-                        new ConfigDef.NonEmptyString(),
-                        ConfigDef.Importance.MEDIUM,
-                        GROUP_INSTANCE_ID_DOC)
-                .define(SESSION_TIMEOUT_MS_CONFIG,
-                        ConfigDef.Type.INT,
-                        45000,
                         ConfigDef.Importance.HIGH,
-                        SESSION_TIMEOUT_MS_DOC)
-                .define(HEARTBEAT_INTERVAL_MS_CONFIG,
-                        ConfigDef.Type.INT,
-                        3000,
-                        ConfigDef.Importance.HIGH,
-                        HEARTBEAT_INTERVAL_MS_DOC)
-                .define(PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
-                        ConfigDef.Type.LIST,
-                        List.of(RangeAssignor.class, CooperativeStickyAssignor.class),
-                        ConfigDef.ValidList.anyNonDuplicateValues(true, false),
-                        ConfigDef.Importance.MEDIUM,
-                        PARTITION_ASSIGNMENT_STRATEGY_DOC)
+                        CommonConsumerConfigs.GROUP_ID_DOC)
                 .define(METADATA_MAX_AGE_CONFIG,
                         ConfigDef.Type.LONG,
                         5 * 60 * 1000,
                         atLeast(0),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METADATA_MAX_AGE_DOC)
-                .define(ENABLE_AUTO_COMMIT_CONFIG,
-                        ConfigDef.Type.BOOLEAN,
-                        true,
-                        ConfigDef.Importance.MEDIUM,
-                        ENABLE_AUTO_COMMIT_DOC)
-                .define(AUTO_COMMIT_INTERVAL_MS_CONFIG,
-                        ConfigDef.Type.INT,
-                        5000,
-                        atLeast(0),
-                        ConfigDef.Importance.LOW,
-                        AUTO_COMMIT_INTERVAL_MS_DOC)
                 .define(CLIENT_ID_CONFIG,
                         ConfigDef.Type.STRING,
                         "",
@@ -451,12 +359,6 @@ public class ShareConsumerConfig extends AbstractConfig {
                         true,
                         ConfigDef.Importance.LOW,
                         ENABLE_METRICS_PUSH_DOC)
-                .define(AUTO_OFFSET_RESET_CONFIG,
-                        ConfigDef.Type.STRING,
-                        AutoOffsetResetStrategy.LATEST.name(),
-                        new AutoOffsetResetStrategy.Validator(),
-                        ConfigDef.Importance.MEDIUM,
-                        AUTO_OFFSET_RESET_DOC)
                 .define(CHECK_CRCS_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         true,
@@ -522,12 +424,6 @@ public class ShareConsumerConfig extends AbstractConfig {
                         9 * 60 * 1000,
                         ConfigDef.Importance.MEDIUM,
                         CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_DOC)
-                .define(INTERCEPTOR_CLASSES_CONFIG,
-                        ConfigDef.Type.LIST,
-                        List.of(),
-                        ConfigDef.ValidList.anyNonDuplicateValues(true, false),
-                        ConfigDef.Importance.LOW,
-                        INTERCEPTOR_CLASSES_DOC)
                 .define(MAX_POLL_RECORDS_CONFIG,
                         ConfigDef.Type.INT,
                         DEFAULT_MAX_POLL_RECORDS,
@@ -549,28 +445,11 @@ public class ShareConsumerConfig extends AbstractConfig {
                         ConfigDef.Type.BOOLEAN,
                         false,
                         ConfigDef.Importance.LOW)
-                .define(ISOLATION_LEVEL_CONFIG,
-                        ConfigDef.Type.STRING,
-                        DEFAULT_ISOLATION_LEVEL,
-                        in(IsolationLevel.READ_COMMITTED.toString(), IsolationLevel.READ_UNCOMMITTED.toString()),
-                        ConfigDef.Importance.MEDIUM,
-                        ISOLATION_LEVEL_DOC)
                 .define(ALLOW_AUTO_CREATE_TOPICS_CONFIG,
                         ConfigDef.Type.BOOLEAN,
                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                         ConfigDef.Importance.MEDIUM,
                         ALLOW_AUTO_CREATE_TOPICS_DOC)
-                .define(GROUP_PROTOCOL_CONFIG,
-                        ConfigDef.Type.STRING,
-                        DEFAULT_GROUP_PROTOCOL,
-                        ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
-                        ConfigDef.Importance.HIGH,
-                        GROUP_PROTOCOL_DOC)
-                .define(GROUP_REMOTE_ASSIGNOR_CONFIG,
-                        ConfigDef.Type.STRING,
-                        DEFAULT_GROUP_REMOTE_ASSIGNOR,
-                        ConfigDef.Importance.MEDIUM,
-                        GROUP_REMOTE_ASSIGNOR_DOC)
                 // security support
                 .define(SECURITY_PROVIDERS_CONFIG,
                         ConfigDef.Type.STRING,
@@ -599,7 +478,7 @@ public class ShareConsumerConfig extends AbstractConfig {
                         atLeast(0),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_DOC)
-                .define(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG,
+                .define(SHARE_ACKNOWLEDGEMENT_MODE_CONFIG,
                         ConfigDef.Type.STRING,
                         ShareAcknowledgementMode.IMPLICIT.name(),
                         new ShareAcknowledgementMode.Validator(),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -18,12 +18,12 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.metrics.HeartbeatMetricsManager;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.protocol.Errors;
@@ -103,26 +103,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
     AbstractHeartbeatRequestManager(
             final LogContext logContext,
             final Time time,
-            final ConsumerConfig config,
-            final CoordinatorRequestManager coordinatorRequestManager,
-            final BackgroundEventHandler backgroundEventHandler,
-            final HeartbeatMetricsManager metricsManager) {
-        this.coordinatorRequestManager = coordinatorRequestManager;
-        this.logger = logContext.logger(getClass());
-        this.backgroundEventHandler = backgroundEventHandler;
-        this.maxPollIntervalMs = config.getInt(CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG);
-        long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-        long retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
-        this.heartbeatRequestState = new HeartbeatRequestState(logContext, time, 0, retryBackoffMs,
-                retryBackoffMaxMs, maxPollIntervalMs);
-        this.pollTimer = time.timer(maxPollIntervalMs);
-        this.metricsManager = metricsManager;
-    }
-
-    AbstractHeartbeatRequestManager(
-            final LogContext logContext,
-            final Time time,
-            final ShareConsumerConfig config,
+            final AbstractConfig config,
             final CoordinatorRequestManager coordinatorRequestManager,
             final BackgroundEventHandler backgroundEventHandler,
             final HeartbeatMetricsManager metricsManager) {
@@ -141,7 +122,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
     AbstractHeartbeatRequestManager(
             final LogContext logContext,
             final Timer timer,
-            final ConsumerConfig config,
+            final AbstractConfig config,
             final CoordinatorRequestManager coordinatorRequestManager,
             final HeartbeatRequestState heartbeatRequestState,
             final BackgroundEventHandler backgroundEventHandler,
@@ -154,24 +135,6 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         this.pollTimer = timer;
         this.metricsManager = metricsManager;
     }
-
-    AbstractHeartbeatRequestManager(
-            final LogContext logContext,
-            final Timer timer,
-            final ShareConsumerConfig config,
-            final CoordinatorRequestManager coordinatorRequestManager,
-            final HeartbeatRequestState heartbeatRequestState,
-            final BackgroundEventHandler backgroundEventHandler,
-            final HeartbeatMetricsManager metricsManager) {
-        this.logger = logContext.logger(this.getClass());
-        this.maxPollIntervalMs = config.getInt(CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG);
-        this.coordinatorRequestManager = coordinatorRequestManager;
-        this.heartbeatRequestState = heartbeatRequestState;
-        this.backgroundEventHandler = backgroundEventHandler;
-        this.pollTimer = timer;
-        this.metricsManager = metricsManager;
-    }
-
 
     /**
      * This will build a heartbeat request if one must be sent, determined based on the member

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
@@ -120,6 +121,25 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
 
     AbstractHeartbeatRequestManager(
             final LogContext logContext,
+            final Time time,
+            final ShareConsumerConfig config,
+            final CoordinatorRequestManager coordinatorRequestManager,
+            final BackgroundEventHandler backgroundEventHandler,
+            final HeartbeatMetricsManager metricsManager) {
+        this.coordinatorRequestManager = coordinatorRequestManager;
+        this.logger = logContext.logger(getClass());
+        this.backgroundEventHandler = backgroundEventHandler;
+        this.maxPollIntervalMs = config.getInt(CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG);
+        long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        long retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
+        this.heartbeatRequestState = new HeartbeatRequestState(logContext, time, 0, retryBackoffMs,
+                retryBackoffMaxMs, maxPollIntervalMs);
+        this.pollTimer = time.timer(maxPollIntervalMs);
+        this.metricsManager = metricsManager;
+    }
+
+    AbstractHeartbeatRequestManager(
+            final LogContext logContext,
             final Timer timer,
             final ConsumerConfig config,
             final CoordinatorRequestManager coordinatorRequestManager,
@@ -134,6 +154,24 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         this.pollTimer = timer;
         this.metricsManager = metricsManager;
     }
+
+    AbstractHeartbeatRequestManager(
+            final LogContext logContext,
+            final Timer timer,
+            final ShareConsumerConfig config,
+            final CoordinatorRequestManager coordinatorRequestManager,
+            final HeartbeatRequestState heartbeatRequestState,
+            final BackgroundEventHandler backgroundEventHandler,
+            final HeartbeatMetricsManager metricsManager) {
+        this.logger = logContext.logger(this.getClass());
+        this.maxPollIntervalMs = config.getInt(CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG);
+        this.coordinatorRequestManager = coordinatorRequestManager;
+        this.heartbeatRequestState = heartbeatRequestState;
+        this.backgroundEventHandler = backgroundEventHandler;
+        this.pollTimer = timer;
+        this.metricsManager = metricsManager;
+    }
+
 
     /**
      * This will build a heartbeat request if one must be sent, determined based on the member

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -25,10 +25,10 @@ import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -126,23 +126,12 @@ public final class ConsumerUtils {
         }
     }
 
-    public static IsolationLevel configuredIsolationLevel(ConsumerConfig config) {
+    public static IsolationLevel configuredIsolationLevel(AbstractConfig config) {
         String s = config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT);
         return IsolationLevel.valueOf(s);
     }
 
-    public static IsolationLevel configuredIsolationLevel(ShareConsumerConfig config) {
-        String s = config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT);
-        return IsolationLevel.valueOf(s);
-    }
-
-    public static SubscriptionState createSubscriptionState(ConsumerConfig config, LogContext logContext) {
-        String s = config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
-        AutoOffsetResetStrategy strategy = AutoOffsetResetStrategy.fromString(s);
-        return new SubscriptionState(logContext, strategy);
-    }
-
-    public static SubscriptionState createSubscriptionState(ShareConsumerConfig config, LogContext logContext) {
+    public static SubscriptionState createSubscriptionState(AbstractConfig config, LogContext logContext) {
         String s = config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
         AutoOffsetResetStrategy strategy = AutoOffsetResetStrategy.fromString(s);
         return new SubscriptionState(logContext, strategy);
@@ -153,20 +142,7 @@ public final class ConsumerUtils {
                 config.getString(ConsumerConfig.CLIENT_ID_CONFIG), config));
     }
 
-    public static Metrics createMetrics(ConsumerConfig config, Time time, List<MetricsReporter> reporters) {
-        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
-        Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
-        MetricConfig metricConfig = new MetricConfig()
-                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
-                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
-                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
-                .tags(metricsTags);
-        MetricsContext metricsContext = new KafkaMetricsContext(CONSUMER_JMX_PREFIX,
-                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
-        return new Metrics(metricConfig, reporters, time, metricsContext);
-    }
-
-    public static Metrics createMetrics(ShareConsumerConfig config, Time time, List<MetricsReporter> reporters) {
+    public static Metrics createMetrics(AbstractConfig config, Time time, List<MetricsReporter> reporters) {
         String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
         Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
         MetricConfig metricConfig = new MetricConfig()

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -130,7 +131,18 @@ public final class ConsumerUtils {
         return IsolationLevel.valueOf(s);
     }
 
+    public static IsolationLevel configuredIsolationLevel(ShareConsumerConfig config) {
+        String s = config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT);
+        return IsolationLevel.valueOf(s);
+    }
+
     public static SubscriptionState createSubscriptionState(ConsumerConfig config, LogContext logContext) {
+        String s = config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+        AutoOffsetResetStrategy strategy = AutoOffsetResetStrategy.fromString(s);
+        return new SubscriptionState(logContext, strategy);
+    }
+
+    public static SubscriptionState createSubscriptionState(ShareConsumerConfig config, LogContext logContext) {
         String s = config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
         AutoOffsetResetStrategy strategy = AutoOffsetResetStrategy.fromString(s);
         return new SubscriptionState(logContext, strategy);
@@ -142,6 +154,19 @@ public final class ConsumerUtils {
     }
 
     public static Metrics createMetrics(ConsumerConfig config, Time time, List<MetricsReporter> reporters) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+        Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
+        MetricConfig metricConfig = new MetricConfig()
+                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
+                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
+                .tags(metricsTags);
+        MetricsContext metricsContext = new KafkaMetricsContext(CONSUMER_JMX_PREFIX,
+                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+        return new Metrics(metricConfig, reporters, time, metricsContext);
+    }
+
+    public static Metrics createMetrics(ShareConsumerConfig config, Time time, List<MetricsReporter> reporters) {
         String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
         Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
         MetricConfig metricConfig = new MetricConfig()

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.internals.Plugin;
@@ -46,6 +47,27 @@ public class Deserializers<K, V> implements AutoCloseable {
 
     @SuppressWarnings("unchecked")
     public Deserializers(ConsumerConfig config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer, Metrics metrics) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+
+        if (keyDeserializer == null) {
+            keyDeserializer = config.getConfiguredInstance(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+            keyDeserializer.configure(config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId)), true);
+        } else {
+            config.ignore(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+        }
+        this.keyDeserializerPlugin = Plugin.wrapInstance(keyDeserializer, metrics, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+
+        if (valueDeserializer == null) {
+            valueDeserializer = config.getConfiguredInstance(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+            valueDeserializer.configure(config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId)), false);
+        } else {
+            config.ignore(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+        }
+        this.valueDeserializerPlugin = Plugin.wrapInstance(valueDeserializer, metrics, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Deserializers(ShareConsumerConfig config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer, Metrics metrics) {
         String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
 
         if (keyDeserializer == null) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
@@ -18,8 +18,8 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
 
@@ -79,18 +79,7 @@ public class FetchConfig {
      *
      * @param config Consumer configuration
      */
-    public FetchConfig(ConsumerConfig config) {
-        this.minBytes = config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG);
-        this.maxBytes = config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG);
-        this.maxWaitMs = config.getInt(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG);
-        this.fetchSize = config.getInt(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG);
-        this.maxPollRecords = config.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
-        this.checkCrcs = config.getBoolean(ConsumerConfig.CHECK_CRCS_CONFIG);
-        this.clientRackId = config.getString(ConsumerConfig.CLIENT_RACK_CONFIG);
-        this.isolationLevel = configuredIsolationLevel(config);
-    }
-
-    public FetchConfig(ShareConsumerConfig config) {
+    public FetchConfig(AbstractConfig config) {
         this.minBytes = config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG);
         this.maxBytes = config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG);
         this.maxWaitMs = config.getInt(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
@@ -79,6 +80,17 @@ public class FetchConfig {
      * @param config Consumer configuration
      */
     public FetchConfig(ConsumerConfig config) {
+        this.minBytes = config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG);
+        this.maxBytes = config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG);
+        this.maxWaitMs = config.getInt(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG);
+        this.fetchSize = config.getInt(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG);
+        this.maxPollRecords = config.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
+        this.checkCrcs = config.getBoolean(ConsumerConfig.CHECK_CRCS_CONFIG);
+        this.clientRackId = config.getString(ConsumerConfig.CLIENT_RACK_CONFIG);
+        this.isolationLevel = configuredIsolationLevel(config);
+    }
+
+    public FetchConfig(ShareConsumerConfig config) {
         this.minBytes = config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG);
         this.maxBytes = config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG);
         this.maxWaitMs = config.getInt(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -25,11 +25,11 @@ import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.metrics.AsyncConsumerMetrics;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -77,29 +77,7 @@ public class NetworkClientDelegate implements AutoCloseable {
 
     public NetworkClientDelegate(
             final Time time,
-            final ConsumerConfig config,
-            final LogContext logContext,
-            final KafkaClient client,
-            final Metadata metadata,
-            final BackgroundEventHandler backgroundEventHandler,
-            final boolean notifyMetadataErrorsViaErrorQueue,
-            final AsyncConsumerMetrics asyncConsumerMetrics) {
-        this.time = time;
-        this.client = client;
-        this.metadata = metadata;
-        this.backgroundEventHandler = backgroundEventHandler;
-        this.log = logContext.logger(getClass());
-        this.unsentRequests = new ArrayDeque<>();
-        this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-        this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-        this.metadataError = Optional.empty();
-        this.notifyMetadataErrorsViaErrorQueue = notifyMetadataErrorsViaErrorQueue;
-        this.asyncConsumerMetrics = asyncConsumerMetrics;
-    }
-
-    public NetworkClientDelegate(
-            final Time time,
-            final ShareConsumerConfig config,
+            final AbstractConfig config,
             final LogContext logContext,
             final KafkaClient client,
             final Metadata metadata,
@@ -469,36 +447,7 @@ public class NetworkClientDelegate implements AutoCloseable {
     public static Supplier<NetworkClientDelegate> supplier(final Time time,
                                                            final LogContext logContext,
                                                            final Metadata metadata,
-                                                           final ConsumerConfig config,
-                                                           final ApiVersions apiVersions,
-                                                           final Metrics metrics,
-                                                           final Sensor throttleTimeSensor,
-                                                           final ClientTelemetrySender clientTelemetrySender,
-                                                           final BackgroundEventHandler backgroundEventHandler,
-                                                           final boolean notifyMetadataErrorsViaErrorQueue,
-                                                           final AsyncConsumerMetrics asyncConsumerMetrics) {
-        return new CachedSupplier<>() {
-            @Override
-            protected NetworkClientDelegate create() {
-                KafkaClient client = ClientUtils.createNetworkClient(config,
-                        metrics,
-                        CONSUMER_METRIC_GROUP_PREFIX,
-                        logContext,
-                        apiVersions,
-                        time,
-                        CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
-                        metadata,
-                        throttleTimeSensor,
-                        clientTelemetrySender);
-                return new NetworkClientDelegate(time, config, logContext, client, metadata, backgroundEventHandler, notifyMetadataErrorsViaErrorQueue, asyncConsumerMetrics);
-            }
-        };
-    }
-
-    public static Supplier<NetworkClientDelegate> supplier(final Time time,
-                                                           final LogContext logContext,
-                                                           final Metadata metadata,
-                                                           final ShareConsumerConfig config,
+                                                           final AbstractConfig config,
                                                            final ApiVersions apiVersions,
                                                            final Metrics metrics,
                                                            final Sensor throttleTimeSensor,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.metrics.AsyncConsumerMetrics;
@@ -77,6 +78,28 @@ public class NetworkClientDelegate implements AutoCloseable {
     public NetworkClientDelegate(
             final Time time,
             final ConsumerConfig config,
+            final LogContext logContext,
+            final KafkaClient client,
+            final Metadata metadata,
+            final BackgroundEventHandler backgroundEventHandler,
+            final boolean notifyMetadataErrorsViaErrorQueue,
+            final AsyncConsumerMetrics asyncConsumerMetrics) {
+        this.time = time;
+        this.client = client;
+        this.metadata = metadata;
+        this.backgroundEventHandler = backgroundEventHandler;
+        this.log = logContext.logger(getClass());
+        this.unsentRequests = new ArrayDeque<>();
+        this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+        this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        this.metadataError = Optional.empty();
+        this.notifyMetadataErrorsViaErrorQueue = notifyMetadataErrorsViaErrorQueue;
+        this.asyncConsumerMetrics = asyncConsumerMetrics;
+    }
+
+    public NetworkClientDelegate(
+            final Time time,
+            final ShareConsumerConfig config,
             final LogContext logContext,
             final KafkaClient client,
             final Metadata metadata,
@@ -447,6 +470,35 @@ public class NetworkClientDelegate implements AutoCloseable {
                                                            final LogContext logContext,
                                                            final Metadata metadata,
                                                            final ConsumerConfig config,
+                                                           final ApiVersions apiVersions,
+                                                           final Metrics metrics,
+                                                           final Sensor throttleTimeSensor,
+                                                           final ClientTelemetrySender clientTelemetrySender,
+                                                           final BackgroundEventHandler backgroundEventHandler,
+                                                           final boolean notifyMetadataErrorsViaErrorQueue,
+                                                           final AsyncConsumerMetrics asyncConsumerMetrics) {
+        return new CachedSupplier<>() {
+            @Override
+            protected NetworkClientDelegate create() {
+                KafkaClient client = ClientUtils.createNetworkClient(config,
+                        metrics,
+                        CONSUMER_METRIC_GROUP_PREFIX,
+                        logContext,
+                        apiVersions,
+                        time,
+                        CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                        metadata,
+                        throttleTimeSensor,
+                        clientTelemetrySender);
+                return new NetworkClientDelegate(time, config, logContext, client, metadata, backgroundEventHandler, notifyMetadataErrorsViaErrorQueue, asyncConsumerMetrics);
+            }
+        };
+    }
+
+    public static Supplier<NetworkClientDelegate> supplier(final Time time,
+                                                           final LogContext logContext,
+                                                           final Metadata metadata,
+                                                           final ShareConsumerConfig config,
                                                            final ApiVersions apiVersions,
                                                            final Metrics metrics,
                                                            final Sensor throttleTimeSensor,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -315,6 +315,7 @@ public class RequestManagers implements Closeable {
      * Creates a {@link Supplier} for deferred creation during invocation by
      * {@link ShareConsumerImpl}.
      */
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
     public static Supplier<RequestManagers> supplier(final Time time,
                                                      final LogContext logContext,
                                                      final BackgroundEventHandler backgroundEventHandler,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.metrics.Metrics;
@@ -314,14 +315,13 @@ public class RequestManagers implements Closeable {
      * Creates a {@link Supplier} for deferred creation during invocation by
      * {@link ShareConsumerImpl}.
      */
-    @SuppressWarnings({"checkstyle:ParameterNumber"})
     public static Supplier<RequestManagers> supplier(final Time time,
                                                      final LogContext logContext,
                                                      final BackgroundEventHandler backgroundEventHandler,
                                                      final ShareConsumerMetadata metadata,
                                                      final SubscriptionState subscriptions,
                                                      final ShareFetchBuffer fetchBuffer,
-                                                     final ConsumerConfig config,
+                                                     final ShareConsumerConfig config,
                                                      final GroupRebalanceConfig groupRebalanceConfig,
                                                      final ShareFetchMetricsManager shareFetchMetricsManager,
                                                      final Optional<ClientTelemetryReporter> clientTelemetryReporter,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegateCreator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegateCreator.java
@@ -17,9 +17,9 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaShareConsumer;
 import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.LogContext;
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
  * the {@link ShareConsumer} API contract that should serve as the caller's interface.
  */
 public class ShareConsumerDelegateCreator {
-    public <K, V> ShareConsumerDelegate<K, V> create(final ConsumerConfig config,
+    public <K, V> ShareConsumerDelegate<K, V> create(final ShareConsumerConfig config,
                                                      final Deserializer<K> keyDeserializer,
                                                      final Deserializer<V> valueDeserializer) {
         try {
@@ -57,7 +57,7 @@ public class ShareConsumerDelegateCreator {
     public <K, V> ShareConsumerDelegate<K, V> create(final LogContext logContext,
                                                      final String clientId,
                                                      final String groupId,
-                                                     final ConsumerConfig config,
+                                                     final ShareConsumerConfig config,
                                                      final Deserializer<K> keyDeserializer,
                                                      final Deserializer<V> valueDeserializer,
                                                      final Time time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
@@ -204,7 +205,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     private final AtomicLong currentThread = new AtomicLong(NO_CURRENT_THREAD);
     private final AtomicInteger refCount = new AtomicInteger(0);
 
-    ShareConsumerImpl(final ConsumerConfig config,
+    ShareConsumerImpl(final ShareConsumerConfig config,
                       final Deserializer<K> keyDeserializer,
                       final Deserializer<V> valueDeserializer) {
         this(
@@ -220,7 +221,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     }
 
     // Visible for testing
-    ShareConsumerImpl(final ConsumerConfig config,
+    ShareConsumerImpl(final ShareConsumerConfig config,
                       final Deserializer<K> keyDeserializer,
                       final Deserializer<V> valueDeserializer,
                       final Time time,
@@ -344,7 +345,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     ShareConsumerImpl(final LogContext logContext,
                       final String clientId,
                       final String groupId,
-                      final ConsumerConfig config,
+                      final ShareConsumerConfig config,
                       final Deserializer<K> keyDeserializer,
                       final Deserializer<V> valueDeserializer,
                       final Time time,
@@ -1093,7 +1094,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     /**
      * Initializes the acknowledgement mode based on the configuration.
      */
-    private static ShareAcknowledgementMode initializeAcknowledgementMode(ConsumerConfig config, Logger log) {
+    private static ShareAcknowledgementMode initializeAcknowledgementMode(ShareConsumerConfig config, Logger log) {
         String s = config.getString(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG);
         return ShareAcknowledgementMode.fromString(s);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -1095,7 +1095,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      * Initializes the acknowledgement mode based on the configuration.
      */
     private static ShareAcknowledgementMode initializeAcknowledgementMode(ShareConsumerConfig config, Logger log) {
-        String s = config.getString(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG);
+        String s = config.getString(ShareConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG);
         return ShareAcknowledgementMode.fromString(s);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerMetadata.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.utils.LogContext;
@@ -41,7 +42,7 @@ public class ShareConsumerMetadata extends Metadata {
         this.subscription = subscription;
     }
 
-    public ShareConsumerMetadata(ConsumerConfig config,
+    public ShareConsumerMetadata(ShareConsumerConfig config,
                                  SubscriptionState subscriptions,
                                  LogContext logContext,
                                  ClusterResourceListeners clusterResourceListeners) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManager.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.metrics.HeartbeatMetricsManager;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
@@ -60,7 +60,7 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
     public ShareHeartbeatRequestManager(
             final LogContext logContext,
             final Time time,
-            final ConsumerConfig config,
+            final ShareConsumerConfig config,
             final CoordinatorRequestManager coordinatorRequestManager,
             final SubscriptionState subscriptions,
             final ShareMembershipManager membershipManager,
@@ -76,7 +76,7 @@ public class ShareHeartbeatRequestManager extends AbstractHeartbeatRequestManage
     ShareHeartbeatRequestManager(
             final LogContext logContext,
             final Timer timer,
-            final ConsumerConfig config,
+            final ShareConsumerConfig config,
             final CoordinatorRequestManager coordinatorRequestManager,
             final ShareMembershipManager membershipManager,
             final HeartbeatState heartbeatState,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerConfigTest.java
@@ -30,7 +30,6 @@ public class ShareConsumerConfigTest {
 
     @Test
     public void testUnsupportedShareConsumerConfigs() {
-
         verifyUnsupportedShareConsumerConfig(Map.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
         verifyUnsupportedShareConsumerConfig(Map.of(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
         verifyUnsupportedShareConsumerConfig(Map.of(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "1"));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerConfigTest.java
@@ -30,6 +30,7 @@ public class ShareConsumerConfigTest {
 
     @Test
     public void testUnsupportedShareConsumerConfigs() {
+
         verifyUnsupportedShareConsumerConfig(Map.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
         verifyUnsupportedShareConsumerConfig(Map.of(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
         verifyUnsupportedShareConsumerConfig(Map.of(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "1"));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CompletableEventReaper;
@@ -131,11 +132,11 @@ public class ShareConsumerImplTest {
     }
 
     private ShareConsumerImpl<String, String> newConsumer(Properties props) {
-        final ConsumerConfig config = new ConsumerConfig(props);
+        final ShareConsumerConfig config = new ShareConsumerConfig(props);
         return newConsumer(config);
     }
 
-    private ShareConsumerImpl<String, String> newConsumer(ConsumerConfig config) {
+    private ShareConsumerImpl<String, String> newConsumer(ShareConsumerConfig config) {
         return new ShareConsumerImpl<>(
                 config,
                 new StringDeserializer(),
@@ -211,7 +212,7 @@ public class ShareConsumerImplTest {
         final Properties props = requiredConsumerProperties();
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "group-id");
         props.put(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, "an.invalid.class");
-        final ConsumerConfig config = new ConsumerConfig(props);
+        final ShareConsumerConfig config = new ShareConsumerConfig(props);
 
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister()) {
             KafkaException ce = assertThrows(
@@ -594,7 +595,7 @@ public class ShareConsumerImplTest {
     @Test
     public void testBackgroundError() {
         final String groupId = "shareGroupA";
-        final ConsumerConfig config = new ConsumerConfig(requiredConsumerPropertiesAndGroupId(groupId));
+        final ShareConsumerConfig config = new ShareConsumerConfig(requiredConsumerPropertiesAndGroupId(groupId));
         consumer = newConsumer(config);
 
         final KafkaException expectedException = new KafkaException("Nobody expects the Spanish Inquisition");
@@ -609,7 +610,7 @@ public class ShareConsumerImplTest {
     @Test
     public void testMultipleBackgroundErrors() {
         final String groupId = "shareGroupA";
-        final ConsumerConfig config = new ConsumerConfig(requiredConsumerPropertiesAndGroupId(groupId));
+        final ShareConsumerConfig config = new ShareConsumerConfig(requiredConsumerPropertiesAndGroupId(groupId));
         consumer = newConsumer(config);
 
         final KafkaException expectedException1 = new KafkaException("Nobody expects the Spanish Inquisition");
@@ -628,7 +629,7 @@ public class ShareConsumerImplTest {
     @Test
     public void testGroupIdNull() {
         final Properties props = requiredConsumerProperties();
-        final ConsumerConfig config = new ConsumerConfig(props);
+        final ShareConsumerConfig config = new ShareConsumerConfig(props);
 
         final Exception exception = assertThrows(
                 KafkaException.class,
@@ -650,7 +651,7 @@ public class ShareConsumerImplTest {
 
     private void testInvalidGroupId(final String groupId) {
         final Properties props = requiredConsumerPropertiesAndGroupId(groupId);
-        final ConsumerConfig config = new ConsumerConfig(props);
+        final ShareConsumerConfig config = new ShareConsumerConfig(props);
 
         final Exception exception = assertThrows(
                 KafkaException.class,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.common.KafkaException;
@@ -113,7 +114,7 @@ public class ShareHeartbeatRequestManagerTest {
         metadata = mock(ConsumerMetadata.class);
         metrics = new Metrics(time);
         logContext = new LogContext();
-        ConsumerConfig config = mock(ConsumerConfig.class);
+        ShareConsumerConfig config = mock(ShareConsumerConfig.class);
 
         heartbeatRequestState = spy(new HeartbeatRequestState(
                 logContext,
@@ -711,7 +712,7 @@ public class ShareHeartbeatRequestManagerTest {
                 response);
     }
 
-    private ConsumerConfig config() {
+    private ShareConsumerConfig ShareConsumerConfig() {
         Properties prop = new Properties();
         prop.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         prop.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -720,7 +721,7 @@ public class ShareHeartbeatRequestManagerTest {
         prop.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(DEFAULT_MAX_POLL_INTERVAL_MS));
         prop.setProperty(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, String.valueOf(DEFAULT_RETRY_BACKOFF_MS));
         prop.setProperty(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG, String.valueOf(DEFAULT_RETRY_BACKOFF_MAX_MS));
-        return new ConsumerConfig(prop);
+        return new ShareConsumerConfig(prop);
     }
 
     private KafkaMetric getMetric(final String name) {
@@ -738,7 +739,7 @@ public class ShareHeartbeatRequestManagerTest {
         return new ShareHeartbeatRequestManager(
                 logContext,
                 pollTimer,
-                config(),
+                ShareConsumerConfig(),
                 coordinatorRequestManager,
                 membershipManager,
                 heartbeatState,


### PR DESCRIPTION
ShareConsumerConfig and ConsumerConfig are inherent at the moment.  The
drawback is the config logic is mixed, for example:
ShareAcknowledgementMode.  We can decouple to prevent the logic is
complicated in the future.
