### PR TITLE
KAFKA-7138: Add DLQ name and replication factor to Connect configuration

### DIFF
--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -71,6 +71,7 @@ status.storage.replication.factor=1
 # to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
 errors.deadletterqueue.topic.name=connect-dlq
 errors.deadletterqueue.topic.replication.factor=1
+errors.deadletterqueue.context.headers.enable=true
 
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -63,6 +63,15 @@ status.storage.topic=connect-status
 status.storage.replication.factor=1
 #status.storage.partitions=5
 
+# Topic to use for storing messages that result in an error when processed by this sink connector, or its transformations or converters.
+# Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+# the topic before starting Kafka Connect if a specific topic configuration is needed.
+# Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+# Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+# to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
+errors.deadletterqueue.topic.name=connect-dlq
+errors.deadletterqueue.topic.replication.factor=1
+
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000
 


### PR DESCRIPTION
This patch address [KAFKA-7138](https://issues.apache.org/jira/browse/KAFKA-7138).  This is an old issue, but the default in local can perhaps still be improved.

This patch changes the default in `connecti-distributed.properties` configuration by conforming to the others, `status` and `storage` topics:
- Enable the dead letter queue of topic name `connect-dlq`
- Set the replication factor to `1`
- Enable context header
- Comment on recommended production environment value