### PR TITLE
MINOR: Checkstyle ImportControl cleanup

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -52,7 +52,6 @@
     <module name="UpperEll"/>
     <module name="LeftCurly"/>
     <module name="RightCurly"/>
-    <module name="EmptyStatement"/>
     <module name="ConstantName">
       <property name="format" value="(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)"/>
     </module>

--- a/checkstyle/import-control-clients-integration-tests.xml
+++ b/checkstyle/import-control-clients-integration-tests.xml
@@ -24,7 +24,6 @@
 
     <!-- These are tests, allow whatever -->
     <allow pkg="org.apache.kafka"/>
-    <allow pkg="org.junit"/>
     <allow pkg="kafka"/>
     <allow pkg="org.slf4j"/>
 

--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -48,10 +48,7 @@
   <allow pkg="com.yammer.metrics"/>
 
   <subpackage name="tools">
-    <allow pkg="org.apache.kafka.clients.admin" />
     <allow pkg="kafka.admin" />
-    <allow pkg="org.apache.kafka.clients.consumer" />
-    <allow pkg="org.apache.kafka.server.util" />
     <allow pkg="joptsimple" />
   </subpackage>
 
@@ -79,13 +76,9 @@
     <allow pkg="kafka.security.authorizer"/>
     <allow pkg="kafka.server"/>
     <allow pkg="kafka.zk"/>
-    <allow pkg="org.apache.kafka.clients"/>
-    <allow pkg="org.apache.kafka.clients.admin"/>
     <allow pkg="org.apache.kafka.coordinator.group"/>
     <allow pkg="org.apache.kafka.metadata"/>
-    <allow pkg="org.apache.kafka.metadata.authorizer"/>
     <allow pkg="org.apache.kafka.security"/>
-    <allow pkg="org.apache.kafka.server"/>
     <allow pkg="org.apache.kafka.storage.internals.checkpoint"/>
     <allow pkg="org.apache.kafka.storage.internals.log"/>
     <allow pkg="org.apache.kafka.test"/>
@@ -98,8 +91,6 @@
     <allow pkg="org.apache.commons" />
     <allow pkg="org.apache.directory" />
     <allow pkg="org.apache.mina.core.service" />
-    <allow pkg="org.apache.kafka.clients" />
-    <allow pkg="org.apache.kafka.clients.admin" />
     <allow pkg="org.apache.kafka.test" />
   </subpackage>
 

--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -35,12 +35,13 @@
   <allow pkg="kafka.common" />
   <allow pkg="kafka.utils" />
   <allow pkg="kafka.serializer" />
-  <allow pkg="org.apache.kafka.clients" class="CommonClientConfigs"/>
-  <allow pkg="org.apache.kafka.common" />
+  <allow pkg="org.apache.kafka.clients"/>
+  <allow pkg="org.apache.kafka.common" exact-match="true" />
+  <allow pkg="org.apache.kafka.common.utils" />
   <allow pkg="org.apache.kafka.common.test.api" />
-  <allow pkg="org.mockito" class="AssignmentsManagerTest"/>
   <allow pkg="org.apache.kafka.server"/>
-  <allow pkg="org.opentest4j" class="RemoteLogManagerTest"/>
+  <allow pkg="org.mockito"/>
+  <allow pkg="org.opentest4j"/>
   <!-- see KIP-544 for why KafkaYammerMetrics should be used instead of the global default yammer metrics registry
        https://cwiki.apache.org/confluence/display/KAFKA/KIP-544%3A+Make+metrics+exposed+via+JMX+configurable -->
   <disallow class="com.yammer.metrics.Metrics" />
@@ -71,37 +72,6 @@
     <allow pkg="org.apache.kafka" />
   </subpackage>
 
-  <subpackage name="test">
-    <allow pkg="org.apache.kafka.controller"/>
-    <allow pkg="org.apache.kafka.metadata"/>
-    <allow pkg="org.apache.kafka.server.authorizer"/>
-    <allow pkg="org.apache.kafka.server.common" />
-    <allow pkg="org.apache.kafka.test" />
-    <allow pkg="org.apache.kafka.common.test"/>
-    <allow pkg="org.apache.kafka.common.test.api"/>
-    <allow pkg="org.apache.kafka.common.test.api"/>
-    <allow pkg="kafka.network"/>
-    <allow pkg="kafka.api"/>
-    <allow pkg="kafka.server"/>
-    <allow pkg="kafka.zk" />
-    <allow pkg="org.apache.kafka.clients.admin"/>
-    <allow pkg="org.apache.kafka.clients.consumer"/>
-    <allow pkg="org.apache.kafka.clients.producer"/>
-    <allow pkg="org.apache.kafka.coordinator.group"/>
-    <allow pkg="org.apache.kafka.coordinator.transaction"/>
-    <subpackage name="annotation">
-      <allow pkg="kafka.test"/>
-    </subpackage>
-    <subpackage name="junit">
-      <allow pkg="kafka.test"/>
-      <allow pkg="org.apache.kafka.clients"/>
-      <allow pkg="org.apache.kafka.metadata" />
-    </subpackage>
-    <subpackage name="server">
-      <allow pkg="kafka.test" />
-    </subpackage>
-  </subpackage>
-
   <subpackage name="admin">
     <allow pkg="kafka.admin"/>
     <allow pkg="kafka.cluster"/>
@@ -121,8 +91,6 @@
     <allow pkg="org.apache.kafka.test"/>
     <allow pkg="org.apache.logging.log4j"/>
     <allow pkg="org.apache.kafka.common.test"/>
-    <allow pkg="org.apache.kafka.common.test.api"/>
-    <allow pkg="org.apache.kafka.common.test.api"/>
     <allow pkg="org.apache.kafka.admin"/>
   </subpackage>
 
@@ -142,7 +110,4 @@
     </file>
   </subpackage>
 
-  <subpackage name="clients">
-    <allow pkg="org.apache.kafka.clients" />
-  </subpackage>
 </import-control>

--- a/checkstyle/import-control-examples.xml
+++ b/checkstyle/import-control-examples.xml
@@ -34,7 +34,7 @@
   <allow pkg="org.apache.kafka.clients.consumer" />
   <allow pkg="org.apache.kafka.clients.producer" />
   <allow pkg="org.apache.kafka.clients.admin" />
-  <allow pkg="org.apache.kafka.common" />
+  <allow pkg="org.apache.kafka.common" exact-match="true" />
   <allow pkg="org.apache.kafka.common.errors" />
   <allow pkg="org.apache.kafka.common.serialization" />
   

--- a/checkstyle/import-control-group-coordinator.xml
+++ b/checkstyle/import-control-group-coordinator.xml
@@ -75,7 +75,6 @@
             <allow pkg="org.apache.kafka.test" />
             <allow pkg="org.apache.kafka.timeline" />
             <allow pkg="org.apache.kafka.coordinator.common" />
-            <allow pkg="org.apache.kafka.coordinator.common.runtime" />
             <allow pkg="com.google.re2j" />
             <allow pkg="com.dynatrace.hash4j.hashing" />
             <allow pkg="org.apache.kafka.metadata" />

--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -42,8 +42,6 @@
     <allow pkg="kafka.network"/>
     <allow pkg="kafka.utils"/>
     <allow pkg="kafka.zk"/>
-    <allow class="kafka.utils.KafkaScheduler"/>
-    <allow class="org.apache.kafka.clients.FetchSessionHandler"/>
     <allow pkg="kafka.common"/>
     <allow pkg="kafka.message"/>
     <allow pkg="org.mockito"/>

--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -32,7 +32,6 @@
     <allow pkg="com.yammer.metrics.core"/>
     <allow pkg="org.apache.kafka.common"/>
     <allow pkg="org.apache.commons"/>
-    <allow pkg="org.apache.kafka.clients.producer"/>
     <allow pkg="kafka.cluster"/>
     <allow pkg="kafka.log"/>
     <allow pkg="kafka.server"/>
@@ -61,6 +60,4 @@
     <allow class="org.apache.kafka.raft.QuorumConfig"/>
     <allow pkg="joptsimple"/>
 
-    <subpackage name="cache">
-    </subpackage>
 </import-control>

--- a/checkstyle/import-control-metadata.xml
+++ b/checkstyle/import-control-metadata.xml
@@ -82,7 +82,6 @@
         <allow pkg="org.apache.kafka.image.writer" />
         <allow pkg="org.apache.kafka.metadata" />
         <allow pkg="org.apache.kafka.metadata.authorizer" />
-        <allow pkg="org.apache.kafka.metadata.migration" />
         <allow pkg="org.apache.kafka.deferred" />
         <allow pkg="org.apache.kafka.queue" />
         <allow pkg="org.apache.kafka.raft" />
@@ -182,12 +181,6 @@
         </subpackage>
         <subpackage name="bootstrap">
             <allow pkg="org.apache.kafka.snapshot" />
-        </subpackage>
-        <subpackage name="fault">
-            <allow pkg="org.apache.kafka.server.fault" />
-        </subpackage>
-        <subpackage name="migration">
-            <allow pkg="org.apache.kafka.controller" />
         </subpackage>
         <subpackage name="storage">
             <allow pkg="org.apache.kafka.common.internals" />

--- a/checkstyle/import-control-metadata.xml
+++ b/checkstyle/import-control-metadata.xml
@@ -53,7 +53,6 @@
         <subpackage name="metadata">
             <allow pkg="com.fasterxml.jackson" />
             <allow pkg="org.apache.kafka.common.protocol" />
-            <allow pkg="org.apache.kafka.common.protocol.types" />
             <allow pkg="org.apache.kafka.common.message" />
             <allow pkg="org.apache.kafka.common.metadata" />
         </subpackage>
@@ -64,7 +63,6 @@
 
     <subpackage name="controller">
         <allow pkg="org.apache.kafka.clients" />
-        <allow pkg="org.apache.kafka.clients.admin" />
         <allow pkg="org.apache.kafka.common.acl" />
         <allow pkg="org.apache.kafka.common.annotation" />
         <allow pkg="org.apache.kafka.common.config" />
@@ -79,9 +77,7 @@
         <allow pkg="org.apache.kafka.common.resource" />
         <allow pkg="org.apache.kafka.controller" />
         <allow pkg="org.apache.kafka.image" />
-        <allow pkg="org.apache.kafka.image.writer" />
         <allow pkg="org.apache.kafka.metadata" />
-        <allow pkg="org.apache.kafka.metadata.authorizer" />
         <allow pkg="org.apache.kafka.deferred" />
         <allow pkg="org.apache.kafka.queue" />
         <allow pkg="org.apache.kafka.raft" />
@@ -113,7 +109,6 @@
         <allow pkg="org.apache.kafka.common.requests" />
         <allow pkg="org.apache.kafka.common.resource" />
         <allow pkg="org.apache.kafka.image" />
-        <allow pkg="org.apache.kafka.image.writer" />
         <allow pkg="org.apache.kafka.metadata" />
         <allow pkg="org.apache.kafka.queue" />
         <allow pkg="org.apache.kafka.clients.admin" />
@@ -169,12 +164,7 @@
         <allow pkg="org.apache.kafka.server.util"/>
         <allow pkg="org.apache.kafka.test" />
         <subpackage name="authorizer">
-            <allow pkg="org.apache.kafka.common.acl" />
-            <allow pkg="org.apache.kafka.common.requests" />
-            <allow pkg="org.apache.kafka.common.resource" />
             <allow pkg="org.apache.kafka.controller" />
-            <allow pkg="org.apache.kafka.metadata" />
-            <allow pkg="org.apache.kafka.common.internals" />
             <allow pkg="org.apache.kafka.common.metrics" />
             <allow pkg="org.apache.kafka.common.metrics.internals" />
             <allow pkg="org.apache.kafka.common.metrics.stats" />
@@ -183,7 +173,6 @@
             <allow pkg="org.apache.kafka.snapshot" />
         </subpackage>
         <subpackage name="storage">
-            <allow pkg="org.apache.kafka.common.internals" />
             <allow pkg="org.apache.kafka.snapshot" />
         </subpackage>
         <subpackage name="util">

--- a/checkstyle/import-control-server-common.xml
+++ b/checkstyle/import-control-server-common.xml
@@ -39,7 +39,7 @@
     <disallow pkg="kafka" />
 
     <!-- anyone can use public classes -->
-    <allow pkg="org.apache.kafka.common" />
+    <allow pkg="org.apache.kafka.common" exact-match="true" />
     <allow pkg="org.apache.kafka.common.security" />
     <allow pkg="org.apache.kafka.common.serialization" />
     <allow pkg="org.apache.kafka.common.utils" />
@@ -68,8 +68,6 @@
         <allow pkg="org.apache.kafka.common.config" />
         <allow pkg="org.apache.kafka.common.config.types" />
         <allow pkg="org.apache.kafka.server.util" />
-        <allow pkg="javax.crypto" />
-        <allow pkg="javax.crypto.spec" />
     </subpackage>
 
     <subpackage name="server">
@@ -141,6 +139,10 @@
 
     <subpackage name="admin">
         <allow pkg="org.apache.kafka.server.common" />
+    </subpackage>
+
+    <subpackage name="config">
+        <allow class="org.apache.kafka.common.config.AbstractConfig" />
     </subpackage>
 
 </import-control>

--- a/checkstyle/import-control-server.xml
+++ b/checkstyle/import-control-server.xml
@@ -84,22 +84,14 @@
     <allow pkg="javax.crypto" />
     <allow pkg="org.apache.kafka.server" />
     <allow pkg="org.apache.kafka.image" />
-    <allow pkg="org.apache.kafka.network.metrics" />
     <allow pkg="org.apache.kafka.network" />
     <allow pkg="org.apache.kafka.storage.internals.log" />
     <allow pkg="org.apache.kafka.storage.internals.checkpoint" />
     <allow pkg="org.apache.logging.log4j" />
-    <allow pkg="org.apache.logging.log4j.core" />
-    <allow pkg="org.apache.logging.log4j.core.config" />
     <subpackage name="metrics">
       <allow class="org.apache.kafka.server.authorizer.AuthorizableRequestContext" />
       <allow class="org.apache.kafka.controller.QuorumFeatures" />
       <allow pkg="org.apache.kafka.server.telemetry" />
-    </subpackage>
-    <subpackage name="config">
-      <allow pkg="org.apache.kafka.server" />
-      <allow pkg="org.apache.kafka.network" />
-      <allow pkg="org.apache.kafka.storage.internals.log" />
     </subpackage>
     <subpackage name="share">
       <allow pkg="org.apache.kafka.storage.log.metrics" />

--- a/checkstyle/import-control-server.xml
+++ b/checkstyle/import-control-server.xml
@@ -63,7 +63,6 @@
   <allow pkg="org.apache.kafka.queue" />
   <allow pkg="org.apache.kafka.security" />
   <allow pkg="org.apache.kafka.server.common" />
-  <allow pkg="org.apache.kafka.server.metrics" />
   <allow pkg="org.apache.kafka.server.util" />
   <allow pkg="com.yammer.metrics" />
 

--- a/checkstyle/import-control-share-coordinator.xml
+++ b/checkstyle/import-control-share-coordinator.xml
@@ -61,9 +61,7 @@
             <allow pkg="org.apache.kafka.server.share" />
             <allow pkg="org.apache.kafka.server.record" />
             <allow pkg="org.apache.kafka.server.util" />
-            <allow pkg="org.apache.kafka.server.util.timer" />
             <allow pkg="org.apache.kafka.timeline" />
-            <allow pkg="org.junit.jupiter.api" />
             <allow pkg="org.junit.jupiter.params" />
             <allow pkg="org.mockito" />
             <allow pkg="org.slf4j" />

--- a/checkstyle/import-control-share-coordinator.xml
+++ b/checkstyle/import-control-share-coordinator.xml
@@ -65,7 +65,6 @@
             <allow pkg="org.apache.kafka.timeline" />
             <allow pkg="org.junit.jupiter.api" />
             <allow pkg="org.junit.jupiter.params" />
-            <allow pkg="org.junit.jupiter.provider" />
             <allow pkg="org.mockito" />
             <allow pkg="org.slf4j" />
             <subpackage name="generated">
@@ -73,7 +72,6 @@
             </subpackage>
             <subpackage name="metrics">
                 <allow pkg="com.yammer.metrics.core" />
-                <allow pkg="org.apache.kafka.timeline" />
             </subpackage>
         </subpackage>
     </subpackage>

--- a/checkstyle/import-control-storage.xml
+++ b/checkstyle/import-control-storage.xml
@@ -60,7 +60,6 @@
             <allow pkg="com.fasterxml.jackson" />
             <allow pkg="kafka.api" />
             <allow pkg="kafka.utils" />
-            <allow pkg="org.apache.kafka.common.test" />
             <allow pkg="org.apache.kafka.clients" />
             <allow pkg="org.apache.kafka.server.common" />
             <allow pkg="org.apache.kafka.server.config" />
@@ -75,7 +74,6 @@
                 </subpackage>
                 <subpackage name="storage">
                     <allow pkg="com.yammer.metrics.core" />
-                    <allow pkg="org.apache.kafka.common.test" />
                     <allow pkg="org.apache.kafka.server.metrics" />
                     <allow pkg="org.apache.kafka.server.purgatory" />
                     <allow pkg="org.apache.kafka.server.quota" />
@@ -160,14 +158,14 @@
         <subpackage name="integration">
         </subpackage>
     </subpackage>
-    <!-- END OF TIERED STORAGE INTEGRATION TEST IMPORT DEPENDENCIES -->
 
     <subpackage name="admin">
-        <allow pkg="org.apache.kafka.clients.admin" class="Admin" />
+        <allow pkg="org.apache.kafka.clients.admin" />
         <allow pkg="org.apache.kafka.common.config" />
         <allow pkg="org.apache.kafka.server.log.remote.storage" />
         <allow pkg="scala.jdk.javaapi" />
         <allow pkg="org.apache.kafka.test" />
     </subpackage>
+    <!-- END OF TIERED STORAGE INTEGRATION TEST IMPORT DEPENDENCIES -->
     
 </import-control>

--- a/checkstyle/import-control-storage.xml
+++ b/checkstyle/import-control-storage.xml
@@ -73,8 +73,6 @@
                     <allow pkg="org.apache.kafka.server.quota" />
                 </subpackage>
                 <subpackage name="storage">
-                    <allow pkg="com.yammer.metrics.core" />
-                    <allow pkg="org.apache.kafka.server.metrics" />
                     <allow pkg="org.apache.kafka.server.purgatory" />
                     <allow pkg="org.apache.kafka.server.quota" />
                     <allow pkg="org.apache.kafka.server.storage.log" />
@@ -116,9 +114,6 @@
         <allow pkg="scala" />
 
         <allow pkg="org.apache.kafka.tiered.storage" />
-        <allow pkg="org.apache.kafka.tiered.storage.actions" />
-        <allow pkg="org.apache.kafka.tiered.storage.specs" />
-        <allow pkg="org.apache.kafka.tiered.storage.utils" />
 
         <allow pkg="kafka.api" />
         <allow pkg="kafka.log" />
@@ -132,31 +127,14 @@
         <allow pkg="org.apache.kafka.common.network" />
 
         <allow pkg="org.apache.kafka.clients" />
-        <allow pkg="org.apache.kafka.clients.admin" />
-        <allow pkg="org.apache.kafka.clients.consumer" />
-        <allow pkg="org.apache.kafka.clients.producer" />
 
         <allow pkg="org.apache.kafka.metadata" />
         <allow pkg="org.apache.kafka.storage"/>
-        <allow pkg="org.apache.kafka.storage.internals.log" />
 
         <allow pkg="org.apache.kafka.server.log" />
-        <allow pkg="org.apache.kafka.server.log.remote" />
-        <allow pkg="org.apache.kafka.server.log.remote.storage" />
         <allow pkg="org.apache.kafka.server.config" />
 
         <allow pkg="org.apache.kafka.test" />
-        <subpackage name="actions">
-        </subpackage>
-
-        <subpackage name="specs">
-        </subpackage>
-
-        <subpackage name="utils">
-        </subpackage>
-
-        <subpackage name="integration">
-        </subpackage>
     </subpackage>
 
     <subpackage name="admin">

--- a/checkstyle/import-control-transaction-coordinator.xml
+++ b/checkstyle/import-control-transaction-coordinator.xml
@@ -37,15 +37,10 @@
             <allow pkg="org.apache.kafka.coordinator.common.runtime" />
             <allow pkg="org.apache.kafka.coordinator.transaction" />
             <allow pkg="org.apache.kafka.common" />
-            <allow pkg="org.apache.kafka.common.test.api" />
             <allow pkg="org.apache.kafka.test" />
             <allow pkg="org.slf4j" />
             <allow pkg="kafka.coordinator.transaction" />
             <subpackage name="generated">
-                <allow pkg="org.apache.kafka.common.protocol" />
-                <allow pkg="org.apache.kafka.common.errors" />
-                <allow pkg="org.apache.kafka.coordinator.transaction.generated" />
-                <allow pkg="org.apache.kafka.common.utils" />
                 <allow pkg="com.fasterxml.jackson" />
             </subpackage>
         </subpackage>

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -61,7 +61,6 @@
     <allow pkg="org.apache.kafka.test" />
 
     <subpackage name="acl">
-      <allow pkg="org.apache.kafka.common.annotation" />
       <allow pkg="org.apache.kafka.common.acl" />
       <allow pkg="org.apache.kafka.common.resource" />
     </subpackage>
@@ -108,30 +107,23 @@
     </subpackage>
 
     <subpackage name="network">
-      <allow pkg="org.apache.kafka.common.security.auth" />
       <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.config" />
       <allow pkg="org.apache.kafka.common.metrics" />
-      <allow pkg="org.apache.kafka.common.security" />
       <allow class="org.apache.kafka.common.requests.ApiVersionsResponse" />
     </subpackage>
 
     <subpackage name="resource">
-      <allow pkg="org.apache.kafka.common.annotation" />
       <allow pkg="org.apache.kafka.common.resource" />
     </subpackage>
 
     <subpackage name="security">
-      <allow pkg="org.apache.kafka.common.annotation" />
       <allow pkg="org.apache.kafka.common.network" />
       <allow pkg="org.apache.kafka.common.config" />
       <allow pkg="org.apache.kafka.common.protocol" />
-      <allow pkg="org.apache.kafka.common.errors" />
       <!-- To access DefaultPrincipalData -->
       <allow pkg="org.apache.kafka.common.message" />
       <subpackage name="authenticator">
-        <allow pkg="org.apache.kafka.common.message" />
-        <allow pkg="org.apache.kafka.common.protocol.types" />
         <allow pkg="org.apache.kafka.common.requests" />
         <allow pkg="org.apache.kafka.clients" />
       </subpackage>
@@ -149,7 +141,6 @@
     </subpackage>
 
     <subpackage name="protocol">
-      <allow pkg="org.apache.kafka.common.errors" />
       <allow class="org.apache.kafka.common.compress.Compression" exact-match="true" />
       <allow pkg="org.apache.kafka.common.message" />
       <allow pkg="org.apache.kafka.common.network" />
@@ -170,7 +161,6 @@
       <allow pkg="org.apache.kafka.common.network" />
       <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.protocol.types" />
-      <allow pkg="org.apache.kafka.common.errors" />
     </subpackage>
 
     <subpackage name="header">
@@ -194,7 +184,6 @@
       <!-- for IncrementalAlterConfigsRequest Builder -->
       <allow pkg="org.apache.kafka.clients.admin" />
       <!-- for testing -->
-      <allow pkg="org.apache.kafka.common.errors" />
       <!-- for testing -->
       <allow pkg="io.opentelemetry.proto"/>
       <!-- for testing -->
@@ -205,7 +194,6 @@
 
     <subpackage name="serialization">
       <allow pkg="org.apache.kafka.clients" />
-      <allow class="org.apache.kafka.common.errors.SerializationException" />
       <allow class="org.apache.kafka.common.header.Headers" />
     </subpackage>
 
@@ -312,9 +300,6 @@
     <allow pkg="org.apache.kafka.server.quota" />
     <allow pkg="org.apache.kafka.streams" />
     <allow pkg="org.apache.kafka.clients" />
-    <allow pkg="org.apache.kafka.clients.admin" />
-    <allow pkg="org.apache.kafka.clients.producer" />
-    <allow pkg="org.apache.kafka.clients.consumer" />
     <allow pkg="org.apache.kafka.test" />
     <allow pkg="org.apache.kafka.connect.runtime" />
     <allow pkg="org.apache.kafka.connect.runtime.isolation" />
@@ -323,9 +308,6 @@
     <allow pkg="net.sourceforge.argparse4j" />
     <allow pkg="org.apache.log4j" />
     <allow pkg="org.apache.logging.log4j" />
-    <allow pkg="org.apache.logging.log4j.core.config" />
-    <allow pkg="org.apache.logging.log4j.core.config.properties" />
-    <allow pkg="org.apache.logging.log4j.core.spi" />
     <allow pkg="org.apache.kafka.common.test" />
     <allow pkg="joptsimple" />
     <allow pkg="javax.rmi.ssl"/>
@@ -335,21 +317,15 @@
     <allow pkg="org.apache.kafka.coordinator.transaction" />
     <allow pkg="org.apache.kafka.coordinator.group" />
     <allow pkg="org.apache.kafka.tools" />
-    <allow pkg="org.apache.kafka.tools.api" />
-    <allow pkg="org.apache.kafka.tools.filter" />
     <allow pkg="org.apache.kafka.image" />
     <allow pkg="org.apache.kafka.security" />
 
     <subpackage name="consumer">
-      <allow pkg="org.apache.kafka.tools"/>
       <allow pkg="org.apache.kafka.coordinator.common.runtime" />
       <subpackage name="group">
-        <allow pkg="org.apache.kafka.coordinator.group"/>
         <allow pkg="kafka.api"/>
         <allow pkg="kafka.security"/>
         <allow pkg="kafka.zk" />
-        <allow pkg="org.apache.kafka.tools"/>
-        <allow pkg="org.apache.kafka.server.config" />
         <allow pkg="scala"/>
         <allow pkg="com.google.re2j"/>
         <subpackage name="share">
@@ -361,16 +337,12 @@
 
     <subpackage name="reassign">
       <allow pkg="org.apache.kafka.admin"/>
-      <allow pkg="org.apache.kafka.tools"/>
-      <allow pkg="kafka.admin" />
       <allow pkg="kafka.cluster" />
       <allow pkg="kafka.log" />
-      <allow pkg="kafka.server" />
       <allow pkg="scala" />
     </subpackage>
 
     <subpackage name="other">
-      <allow pkg="org.apache.kafka.tools.reassign"/>
       <allow pkg="kafka.log" />
       <allow pkg="org.jfree"/>
       <allow pkg="javax.imageio" />
@@ -384,9 +356,6 @@
     <allow pkg="jakarta.ws.rs" />
     <allow pkg="net.sourceforge.argparse4j" />
     <allow pkg="org.apache.kafka.clients" />
-    <allow pkg="org.apache.kafka.clients.admin" />
-    <allow pkg="org.apache.kafka.clients.consumer" exact-match="true"/>
-    <allow pkg="org.apache.kafka.clients.producer" exact-match="true"/>
     <allow pkg="org.apache.kafka.common" />
     <allow pkg="org.apache.kafka.test"/>
     <allow pkg="org.apache.kafka.trogdor" />
@@ -407,8 +376,6 @@
     <allow pkg="org.apache.kafka.common"/>
     <allow pkg="org.apache.kafka.test"/>
     <allow pkg="org.apache.kafka.clients"/>
-    <allow pkg="org.apache.kafka.clients.producer" exact-match="true"/>
-    <allow pkg="org.apache.kafka.clients.consumer" exact-match="true"/>
     <allow pkg="org.apache.kafka.server.util"/>
     <allow pkg="org.apache.logging.log4j"/>
 
@@ -624,7 +591,6 @@
 
     <subpackage name="storage">
       <allow pkg="org.apache.kafka.connect" />
-      <allow pkg="org.apache.kafka.common.serialization" />
       <allow pkg="javax.crypto.spec"/>
     </subpackage>
 
@@ -663,8 +629,6 @@
 
     <subpackage name="json">
       <allow pkg="com.fasterxml.jackson" />
-      <allow pkg="org.apache.kafka.common.serialization" />
-      <allow pkg="org.apache.kafka.common.errors" />
       <allow pkg="org.apache.kafka.connect.storage" />
     </subpackage>
 

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -55,7 +55,6 @@
     <allow class="org.apache.kafka.clients.NodeApiVersions" exact-match="true" />
     <allow class="org.apache.kafka.common.message.ApiMessageType" exact-match="true" />
     <disallow pkg="org.apache.kafka.clients" />
-    <allow pkg="org.apache.kafka.common" exact-match="true" />
     <allow pkg="org.apache.kafka.common.annotation" />
     <allow pkg="org.apache.kafka.common.config" exact-match="true" />
     <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
@@ -401,7 +400,6 @@
     <allow pkg="com.fasterxml.jackson.annotation" />
     <allow pkg="net.sourceforge.argparse4j" />
     <allow pkg="org.apache.kafka.message" />
-    <allow pkg="org.apache.message" />
     <allow pkg="org.eclipse.jgit" />
   </subpackage>
 
@@ -423,10 +421,6 @@
 
     <subpackage name="internals">
       <allow pkg="com.fasterxml.jackson" />
-    </subpackage>
-
-    <subpackage name="perf">
-      <allow pkg="com.fasterxml.jackson.databind" />
     </subpackage>
 
     <subpackage name="integration">


### PR DESCRIPTION
This PR cleans up the import control rules in checkstyle, including
removing duplicate rules, cleaning up non-existent packages, and fixing
some incorrect usages.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
