### PR TITLE
MINOR: Fix removal warning in connect:runtime:test

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/connector/policy/PrincipalConnectorClientConfigOverridePolicyTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/connector/policy/PrincipalConnectorClientConfigOverridePolicyTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 public class PrincipalConnectorClientConfigOverridePolicyTest extends BaseConnectorClientConfigOverridePolicyTest {
 
+    @SuppressWarnings("removal")
     ConnectorClientConfigOverridePolicy principalConnectorClientConfigOverridePolicy = new PrincipalConnectorClientConfigOverridePolicy();
 
     @Test


### PR DESCRIPTION
Fix removal warning in PrincipalConnectorClientConfigOverridePolicyTest

Reviewers: PoAn Yang <payang@apache.org>, Chris Egerton
 <fearthecellos@gmail.com>, Ming-Yen Chung <mingyen066@gmail.com>, Ken
 Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
