### PR TITLE
[WIP] KAFKA-19768: Update ci-complete to support branch 4.0 buildscan upload

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -38,7 +38,10 @@ run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 jobs:
   upload-build-scan:
     # Skip this workflow if the CI run was skipped or cancelled
-    if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    if: >
+      (github.event.workflow_run.head_branch != '4.0') &&
+      (github.event.workflow_run.conclusion == 'success' || 
+       github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -89,7 +92,7 @@ jobs:
           url: '${{ github.event.workflow_run.html_url }}'
           description: 'Could not find build scan'
           context: Gradle Build Scan / ${{ env.status-context }}
-          state: 'success' # Always mark as successful as a temporary fix; non-trunk branches will miss build scan. Real fix in KAFKA-19768
+          state: 'error'
       - name: Publish Scan
         id: publish-build-scan
         if: ${{ steps.download-build-scan.outcome == 'success' }}
@@ -128,4 +131,93 @@ jobs:
           url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
           description: 'The build scan was successfully published'
           context: Gradle Build Scan / ${{ env.status-context }}
+          state: 'success'
+
+  # All branches use the ci-complete workflow in the trunk branch,
+  # so the 4.0-specific logic must be maintained here in trunk.
+  upload-build-scan-4_0:
+    # Run for all branches except 4.0, and only if CI finished successfully or failed
+    if: >
+      (github.event.workflow_run.head_branch == '4.0') &&
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 23, 17 ]
+        artifact-prefix: [ "build-scan-test-", "build-scan-quarantined-test-"]
+    steps:
+      - name: Env
+        run: printenv
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials:
+            false
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: ${{ matrix.java }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: Download build scan archive
+        id: download-build-scan
+        uses: actions/download-artifact@v4
+        continue-on-error: true  # Don't want this step to fail the overall workflow
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: ${{ matrix.artifact-prefix }}${{ matrix.java }}
+          path: ~/.gradle/build-scan-data  # This is where Gradle buffers unpublished build scan data when --no-scan is given
+      - name: Handle missing scan
+        if: ${{ steps.download-build-scan.outcome == 'failure' }}
+        uses: ./.github/actions/gh-api-update-status
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          url: '${{ github.event.workflow_run.html_url }}'
+          description: 'Could not find build scan'
+          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          state: 'error'
+      - name: Publish Scan
+        id: publish-build-scan
+        if: ${{ steps.download-build-scan.outcome == 'success' }}
+        run: |
+          set +e
+          ./gradlew --info buildScanPublishPrevious > gradle.out
+          exitcode="$?"
+          if [ $exitcode -ne 0 ]; then
+            cat gradle.out
+            echo "Failed to publish build scan" >> $GITHUB_STEP_SUMMARY
+            exit $exitcode
+          else
+            SCAN_URL=$(grep '^https://.*$' gradle.out)
+            cat gradle.out
+            echo "Published build scan to $SCAN_URL" >> $GITHUB_STEP_SUMMARY
+            echo "build-scan-url=$SCAN_URL" >> $GITHUB_OUTPUT
+          fi
+      - name: Handle failed publish
+        if: ${{ failure() && steps.publish-build-scan.outcome == 'failure' }}
+        uses: ./.github/actions/gh-api-update-status
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
+          description: 'The build scan failed to be published'
+          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
+          state: 'error'
+      - name: Update Status Check
+        if: ${{ steps.publish-build-scan.outcome == 'success' }}
+        uses: ./.github/actions/gh-api-update-status
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          url: ${{ steps.publish-build-scan.outputs.build-scan-url }}
+          description: 'The build scan was successfully published'
+          context: 'Gradle Build Scan / Java ${{ matrix.java }}'
           state: 'success'


### PR DESCRIPTION
**This is not working since we cannot get base branch from github env if
`event` is `pull_request`**

---
Currently, if we merge to the 4.0 branch, the 4.0 `CI` workflow will be
triggered. After the 4.0 `CI` completes, it triggeres the
`ci-complete.yml` workflow in the "`trunk`" branch. However, the JDK
versions and the names of the build scan files differ
([KAFKA-18748](https://issues.apache.org/jira/browse/KAFKA-18748)), so
the `trunk` `ci-complete.yml` cannot find the correct build scan files
generated by 4.0 `CI` workflow to upload to Develocity.

To address this, I copied the relevant code from `ci-complete.yml` in
4.0 into the trunk workflow, allowing it to correctly find and upload
the appropriate build scan archives.

There is a potential issue with using Gradle 9 to upload Gradle 8
buildscan archives to Develocity, I am not sure if it will work because
I don't have access to a Develocity server. I could only find the
compatibility table for Develocity plugin and Gradle tools.
https://docs.gradle.com/develocity/compatibility/#build_scans
