### PR TITLE
MINOR: Fix typos in RPC files

### DIFF
--- a/clients/src/main/resources/common/message/AllocateProducerIdsRequest.json
+++ b/clients/src/main/resources/common/message/AllocateProducerIdsRequest.json
@@ -9,7 +9,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implie
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 

--- a/clients/src/main/resources/common/message/AlterPartitionRequest.json
+++ b/clients/src/main/resources/common/message/AlterPartitionRequest.json
@@ -9,7 +9,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implie
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 

--- a/clients/src/main/resources/common/message/AlterShareGroupOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/AlterShareGroupOffsetsResponse.json
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 {
   "apiKey": 91,

--- a/clients/src/main/resources/common/message/DescribeQuorumResponse.json
+++ b/clients/src/main/resources/common/message/DescribeQuorumResponse.json
@@ -18,7 +18,7 @@
   "type": "response",
   "name": "DescribeQuorumResponse",
   // Version 1 adds LastFetchTimeStamp and LastCaughtUpTimestamp in ReplicaState (KIP-836).
-  // Version 2 adds ErrorMessage, Nodes, ErrorMessage in ParitionData, ReplicaDirectoryId in ReplicaState (KIP-853).
+  // Version 2 adds ErrorMessage, Nodes, ErrorMessage in PartitionData, ReplicaDirectoryId in ReplicaState (KIP-853).
   "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/main/resources/common/message/InitProducerIdRequest.json
+++ b/clients/src/main/resources/common/message/InitProducerIdRequest.json
@@ -26,7 +26,7 @@
   //
   // Version 4 adds the support for new error code PRODUCER_FENCED.
   //
-  // Verison 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
+  // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   //
   // Version 6 adds support for 2PC (KIP-939).
   "latestVersionUnstable": true,

--- a/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
+++ b/clients/src/main/resources/common/message/ShareAcknowledgeRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "ShareAcknowledgeRequest",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   //

--- a/clients/src/main/resources/common/message/ShareAcknowledgeResponse.json
+++ b/clients/src/main/resources/common/message/ShareAcknowledgeResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 79,
   "type": "response",
   "name": "ShareAcknowledgeResponse",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   //

--- a/clients/src/main/resources/common/message/ShareFetchRequest.json
+++ b/clients/src/main/resources/common/message/ShareFetchRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "ShareFetchRequest",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   //

--- a/clients/src/main/resources/common/message/ShareFetchResponse.json
+++ b/clients/src/main/resources/common/message/ShareFetchResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 78,
   "type": "response",
   "name": "ShareFetchResponse",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   //

--- a/clients/src/main/resources/common/message/ShareGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ShareGroupDescribeRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "ShareGroupDescribeRequest",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   "validVersions": "1",

--- a/clients/src/main/resources/common/message/ShareGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ShareGroupDescribeResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 77,
   "type": "response",
   "name": "ShareGroupDescribeResponse",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   "validVersions": "1",

--- a/clients/src/main/resources/common/message/ShareGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/ShareGroupHeartbeatRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "ShareGroupHeartbeatRequest",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   "validVersions": "1",

--- a/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 76,
   "type": "response",
   "name": "ShareGroupHeartbeatResponse",
-  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apacke Kafka 4.1.
+  // Version 0 was used for early access of KIP-932 in Apache Kafka 4.0 but removed in Apache Kafka 4.1.
   //
   // Version 1 is the initial stable version (KIP-932).
   "validVersions": "1",


### PR DESCRIPTION
There are some minor typos in our RPC jsons. The PR fixes the same for
consistency.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
