### PR TITLE
MINOR: Fix warnings in build

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/QuorumControllerMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/QuorumControllerMetricsTest.java
@@ -190,6 +190,7 @@ public class QuorumControllerMetricsTest {
         }
     }
 
+    @SuppressWarnings("unchecked") // do not warn about Gauge typecast.
     @Test
     public void testAvgIdleRatio() {
         final double delta = 0.001;

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -250,7 +250,7 @@ public class AssignmentsManagerTest {
             return queuedReplicaToDirAssignments.value();
         }
 
-        @SuppressWarnings("unchecked") // do not warn about Gauge typecast.
+        @SuppressWarnings({"unchecked", "deprecation"}) // do not warn about Gauge typecast or the deprecation.
         int deprecatedQueuedReplicaToDirAssignments() {
             Gauge<Integer> queuedReplicaToDirAssignments =
                     (Gauge<Integer>) findMetric(AssignmentsManager.DEPRECATED_QUEUED_REPLICA_TO_DIR_ASSIGNMENTS_METRIC);


### PR DESCRIPTION
Currently on running `./gradlew clean jar` on trunk, the following two
warnings pop up:

```
> Task :metadata:compileTestJava
Note:
~/kafka/metadata/src/test/java/org/apache/kafka/controller/metrics/QuorumControllerMetricsTest.java
uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :server:compileTestJava
Note:
~/kafka/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

The PR attempts to fix the same

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
