### PR TITLE
KAFKA-19857: Fix CoordinatorExecutorImpl.cancelAll implementation

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
 import java.time.Duration;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -128,9 +127,6 @@ public class CoordinatorExecutorImpl<S extends CoordinatorShard<U>, U> implement
     }
 
     public void cancelAll() {
-        Iterator<String> iterator = tasks.keySet().iterator();
-        while (iterator.hasNext()) {
-            iterator.remove();
-        }
+        tasks.clear();
     }
 }

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.server.util.FutureUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.util.List;
@@ -167,8 +169,9 @@ public class CoordinatorExecutorImplTest {
         assertTrue(operationCalled.get());
     }
 
-    @Test
-    public void testTaskCancelledBeforeBeingExecuted() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testTaskCancelledBeforeBeingExecuted(boolean useCancelAll) {
         CoordinatorRuntime<CoordinatorShard<String>, String> runtime = mock(CoordinatorRuntime.class);
         ExecutorService executorService = mock(ExecutorService.class);
         CoordinatorExecutorImpl<CoordinatorShard<String>, String> executor = new CoordinatorExecutorImpl<>(
@@ -181,7 +184,11 @@ public class CoordinatorExecutorImplTest {
 
         when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
             // Cancel the task before running it.
-            executor.cancel(TASK_KEY);
+            if (useCancelAll) {
+                executor.cancelAll();
+            } else {
+                executor.cancel(TASK_KEY);
+            }
 
             // Running the task.
             Runnable op = args.getArgument(0);
@@ -211,8 +218,9 @@ public class CoordinatorExecutorImplTest {
         assertFalse(operationCalled.get());
     }
 
-    @Test
-    public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted(boolean useCancelAll) {
         CoordinatorShard<String> coordinatorShard = mock(CoordinatorShard.class);
         CoordinatorRuntime<CoordinatorShard<String>, String> runtime = mock(CoordinatorRuntime.class);
         ExecutorService executorService = mock(ExecutorService.class);
@@ -231,7 +239,11 @@ public class CoordinatorExecutorImplTest {
             any()
         )).thenAnswer(args -> {
             // Cancel the task before running the write operation.
-            executor.cancel(TASK_KEY);
+            if (useCancelAll) {
+                executor.cancelAll();
+            } else {
+                executor.cancel(TASK_KEY);
+            }
 
             CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String> op =
                 args.getArgument(3);

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -21,15 +21,15 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.server.util.FutureUtils;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -169,9 +170,8 @@ public class CoordinatorExecutorImplTest {
         assertTrue(operationCalled.get());
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void testTaskCancelledBeforeBeingExecuted(boolean useCancelAll) {
+    @Test
+    public void testTaskCancelledBeforeBeingExecuted() {
         CoordinatorRuntime<CoordinatorShard<String>, String> runtime = mock(CoordinatorRuntime.class);
         ExecutorService executorService = mock(ExecutorService.class);
         CoordinatorExecutorImpl<CoordinatorShard<String>, String> executor = new CoordinatorExecutorImpl<>(
@@ -184,11 +184,7 @@ public class CoordinatorExecutorImplTest {
 
         when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
             // Cancel the task before running it.
-            if (useCancelAll) {
-                executor.cancelAll();
-            } else {
-                executor.cancel(TASK_KEY);
-            }
+            executor.cancel(TASK_KEY);
 
             // Running the task.
             Runnable op = args.getArgument(0);
@@ -218,9 +214,8 @@ public class CoordinatorExecutorImplTest {
         assertFalse(operationCalled.get());
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted(boolean useCancelAll) {
+    @Test
+    public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted() {
         CoordinatorShard<String> coordinatorShard = mock(CoordinatorShard.class);
         CoordinatorRuntime<CoordinatorShard<String>, String> runtime = mock(CoordinatorRuntime.class);
         ExecutorService executorService = mock(ExecutorService.class);
@@ -239,11 +234,7 @@ public class CoordinatorExecutorImplTest {
             any()
         )).thenAnswer(args -> {
             // Cancel the task before running the write operation.
-            if (useCancelAll) {
-                executor.cancelAll();
-            } else {
-                executor.cancel(TASK_KEY);
-            }
+            executor.cancel(TASK_KEY);
 
             CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String> op =
                 args.getArgument(3);
@@ -325,5 +316,71 @@ public class CoordinatorExecutorImplTest {
         assertTrue(taskCalled.get());
         assertFalse(operationCalled.get());
         assertFalse(executor.isScheduled(TASK_KEY));
+    }
+
+    @Test
+    public void testCancelAllTasks() {
+        CoordinatorShard<String> coordinatorShard = mock(CoordinatorShard.class);
+        CoordinatorRuntime<CoordinatorShard<String>, String> runtime = mock(CoordinatorRuntime.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        CoordinatorExecutorImpl<CoordinatorShard<String>, String> executor = new CoordinatorExecutorImpl<>(
+            LOG_CONTEXT,
+            SHARD_PARTITION,
+            runtime,
+            executorService,
+            WRITE_TIMEOUT
+        );
+
+        List<CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String>> writeOperations = new ArrayList<>();
+        List<CompletableFuture<Void>> writeFutures = new ArrayList<>();
+        when(runtime.scheduleWriteOperation(
+            anyString(),
+            eq(SHARD_PARTITION),
+            eq(WRITE_TIMEOUT),
+            any()
+        )).thenAnswer(args -> {
+            writeOperations.add(args.getArgument(3));
+            CompletableFuture<Void> writeFuture = new CompletableFuture<>();
+            writeFutures.add(writeFuture);
+            return writeFuture;
+        });
+
+        when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
+            Runnable op = args.getArgument(0);
+            op.run();
+            return CompletableFuture.completedFuture(null);
+        });
+
+        AtomicInteger taskCallCount = new AtomicInteger(0);
+        CoordinatorExecutor.TaskRunnable<String> taskRunnable = () -> {
+            taskCallCount.incrementAndGet();
+            return "Hello!";
+        };
+
+        AtomicInteger operationCallCount = new AtomicInteger(0);
+        CoordinatorExecutor.TaskOperation<String, String> taskOperation = (result, exception) -> {
+            operationCallCount.incrementAndGet();
+            return null;
+        };
+
+        for (int i = 0; i < 2; i++) {
+            executor.schedule(
+                TASK_KEY + i,
+                taskRunnable,
+                taskOperation
+            );
+        }
+
+        executor.cancelAll();
+
+        for (int i = 0; i < writeOperations.size(); i++) {
+            CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String> writeOperation = writeOperations.get(i);
+            CompletableFuture<Void> writeFuture = writeFutures.get(i);
+            Throwable ex = assertThrows(RejectedExecutionException.class, () -> writeOperation.generateRecordsAndResult(coordinatorShard));
+            writeFuture.completeExceptionally(ex);
+        }
+
+        assertEquals(2, taskCallCount.get());
+        assertEquals(0, operationCallCount.get());
     }
 }


### PR DESCRIPTION
The previous implementation was buggy and always threw an
IllegalStateException when there were scheduled tasks because it called
Iterator.remove() without a preceding call to Iterator.next().

Reviewers: David Jacot <djacot@confluent.io>
