### PR TITLE
MINOR: Fix the typo “milli seconds” to “milliseconds”

### DIFF
--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -52,7 +52,7 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
     private final long endOffset;
 
     /**
-     * Maximum timestamp in milli seconds in the segment
+     * Maximum timestamp in milliseconds in the segment
      */
     private final long maxTimestampMs;
 
@@ -90,9 +90,9 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
      * @param remoteLogSegmentId  Universally unique remote log segment id.
      * @param startOffset         Start offset of this segment (inclusive).
      * @param endOffset           End offset of this segment (inclusive).
-     * @param maxTimestampMs      Maximum timestamp in milli seconds in this segment.
+     * @param maxTimestampMs      Maximum timestamp in milliseconds in this segment.
      * @param brokerId            Broker id from which this event is generated.
-     * @param eventTimestampMs    Epoch time in milli seconds at which the remote log segment is copied to the remote tier storage.
+     * @param eventTimestampMs    Epoch time in milliseconds at which the remote log segment is copied to the remote tier storage.
      * @param segmentSizeInBytes  Size of this segment in bytes.
      * @param customMetadata      Custom metadata.
      * @param state               State of the respective segment of remoteLogSegmentId.
@@ -121,9 +121,9 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
      * @param remoteLogSegmentId  Universally unique remote log segment id.
      * @param startOffset         Start offset of this segment (inclusive).
      * @param endOffset           End offset of this segment (inclusive).
-     * @param maxTimestampMs      Maximum timestamp in milli seconds in this segment.
+     * @param maxTimestampMs      Maximum timestamp in milliseconds in this segment.
      * @param brokerId            Broker id from which this event is generated.
-     * @param eventTimestampMs    Epoch time in milli seconds at which the remote log segment is copied to the remote tier storage.
+     * @param eventTimestampMs    Epoch time in milliseconds at which the remote log segment is copied to the remote tier storage.
      * @param segmentSizeInBytes  Size of this segment in bytes.
      * @param customMetadata      Custom metadata.
      * @param state               State of the respective segment of remoteLogSegmentId.
@@ -178,7 +178,7 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
      * @param endOffset           End offset of this segment (inclusive).
      * @param maxTimestampMs      Maximum timestamp in this segment
      * @param brokerId            Broker id from which this event is generated.
-     * @param eventTimestampMs    Epoch time in milli seconds at which the remote log segment is copied to the remote tier storage.
+     * @param eventTimestampMs    Epoch time in milliseconds at which the remote log segment is copied to the remote tier storage.
      * @param segmentSizeInBytes  Size of this segment in bytes.
      * @param segmentLeaderEpochs leader epochs occurred within this segment
      */
@@ -212,7 +212,7 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
      * @param endOffset           End offset of this segment (inclusive).
      * @param maxTimestampMs      Maximum timestamp in this segment
      * @param brokerId            Broker id from which this event is generated.
-     * @param eventTimestampMs    Epoch time in milli seconds at which the remote log segment is copied to the remote tier storage.
+     * @param eventTimestampMs    Epoch time in milliseconds at which the remote log segment is copied to the remote tier storage.
      * @param segmentSizeInBytes  Size of this segment in bytes.
      * @param segmentLeaderEpochs leader epochs occurred within this segment
      * @param txnIdxEmpty         True if the transaction index is empty, false otherwise.
@@ -259,7 +259,7 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
     }
 
     /**
-     * @return Maximum timestamp in milli seconds of a record within this segment.
+     * @return Maximum timestamp in milliseconds of a record within this segment.
      */
     public long maxTimestampMs() {
         return maxTimestampMs;

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadataUpdate.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadataUpdate.java
@@ -46,7 +46,7 @@ public class RemoteLogSegmentMetadataUpdate extends RemoteLogMetadata {
 
     /**
      * @param remoteLogSegmentId Universally unique remote log segment id.
-     * @param eventTimestampMs   Epoch time in milli seconds at which the remote log segment is copied to the remote tier storage.
+     * @param eventTimestampMs   Epoch time in milliseconds at which the remote log segment is copied to the remote tier storage.
      * @param customMetadata     Custom metadata.
      * @param state              State of the remote log segment.
      * @param brokerId           Broker id from which this event is generated.

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemotePartitionDeleteMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemotePartitionDeleteMetadata.java
@@ -34,7 +34,7 @@ public class RemotePartitionDeleteMetadata extends RemoteLogMetadata {
      *
      * @param topicIdPartition topic partition for which this event is meant for.
      * @param state            State of the remote topic partition.
-     * @param eventTimestampMs Epoch time in milli seconds at which this event is occurred.
+     * @param eventTimestampMs Epoch time in milliseconds at which this event is occurred.
      * @param brokerId         Id of the broker in which this event is raised.
      */
     public RemotePartitionDeleteMetadata(TopicIdPartition topicIdPartition,

--- a/storage/src/main/resources/message/RemoteLogSegmentMetadataRecord.json
+++ b/storage/src/main/resources/message/RemoteLogSegmentMetadataRecord.json
@@ -82,13 +82,13 @@
       "name": "MaxTimestampMs",
       "type": "int64",
       "versions": "0+",
-      "about": "Maximum timestamp in milli seconds with in this segment."
+      "about": "Maximum timestamp in milliseconds with in this segment."
     },
     {
       "name": "EventTimestampMs",
       "type": "int64",
       "versions": "0+",
-      "about": "Epoch time in milli seconds at which this event is generated."
+      "about": "Epoch time in milliseconds at which this event is generated."
     },
     {
       "name": "SegmentLeaderEpochs",

--- a/storage/src/main/resources/message/RemoteLogSegmentMetadataUpdateRecord.json
+++ b/storage/src/main/resources/message/RemoteLogSegmentMetadataUpdateRecord.json
@@ -70,7 +70,7 @@
       "name": "EventTimestampMs",
       "type": "int64",
       "versions": "0+",
-      "about": "Epoch time in milli seconds at which this event is generated."
+      "about": "Epoch time in milliseconds at which this event is generated."
     },
     {
       "name": "CustomMetadata",

--- a/storage/src/main/resources/message/RemotePartitionDeleteMetadataRecord.json
+++ b/storage/src/main/resources/message/RemotePartitionDeleteMetadataRecord.json
@@ -56,7 +56,7 @@
       "name": "EventTimestampMs",
       "type": "int64",
       "versions": "0+",
-      "about": "Epoch time in milli seconds at which this event is generated."
+      "about": "Epoch time in milliseconds at which this event is generated."
     },
     {
       "name": "RemotePartitionDeleteState",

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
@@ -414,7 +414,7 @@ public class EmbeddedKafkaCluster {
     }
 
     public void waitForRemainingTopics(final long timeoutMs, final String... topics) throws InterruptedException {
-        TestUtils.waitForCondition(new TopicsRemainingCondition(topics), timeoutMs, "Topics are not expected after " + timeoutMs + " milli seconds.");
+        TestUtils.waitForCondition(new TopicsRemainingCondition(topics), timeoutMs, "Topics are not expected after " + timeoutMs + " milliseconds.");
     }
 
     public Set<String> getAllTopicsInCluster() {


### PR DESCRIPTION
milli seconds → milliseconds

Reviewers: Andrew Schofield <aschofield@confluent.io>
