### PR TITLE
MINOR: Remove out-of-date comments from GC record schemas

### DIFF
--- a/group-coordinator/src/main/resources/common/message/ShareGroupCurrentMemberAssignmentKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupCurrentMemberAssignmentKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 14,
   "type": "coordinator-key",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupCurrentMemberAssignmentValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 14,
   "type": "coordinator-value",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 10,
   "type": "coordinator-key",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupMemberMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 10,
   "type": "coordinator-value",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 11,
   "type": "coordinator-key",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 11,
   "type": "coordinator-value",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupStatePartitionMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupStatePartitionMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 15,
   "type": "coordinator-key",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupStatePartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupStatePartitionMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 15,
   "type": "coordinator-value",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMemberKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMemberKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 13,
   "type": "coordinator-key",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMemberValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMemberValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 13,
   "type": "coordinator-value",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMetadataKey.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMetadataKey.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 12,
   "type": "coordinator-key",

--- a/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ShareGroupTargetAssignmentMetadataValue.json
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// KIP-932 is in development. This schema is subject to non-backwards-compatible changes.
 {
   "apiKey": 12,
   "type": "coordinator-value",


### PR DESCRIPTION
Remove comments from group coordinator record schemas for KIP-932 which
are now out of date.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
