### PR TITLE
MINOR: Disable RemoteLogManagerTest.testCopyQuota for green builds.

### DIFF
--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -73,6 +73,7 @@ import com.yammer.metrics.core.MetricName;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -3401,9 +3402,9 @@ public class RemoteLogManagerTest {
     }
 
 
+    @Disabled("KAFKA-19578")
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    @Flaky("KAFKA-19578")
     public void testCopyQuota(boolean quotaExceeded) throws Exception {
         RemoteLogManager.RLMCopyTask task = setupRLMTask(quotaExceeded);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.record.RemoteLogInputStream;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.OffsetAndEpoch;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.record.RemoteLogInputStream;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.OffsetAndEpoch;
@@ -3402,6 +3403,7 @@ public class RemoteLogManagerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @Flaky("KAFKA-19578")
     public void testCopyQuota(boolean quotaExceeded) throws Exception {
         RemoteLogManager.RLMCopyTask task = setupRLMTask(quotaExceeded);
 


### PR DESCRIPTION
Issue already exists - https://issues.apache.org/jira/browse/KAFKA-19578

Reviewers: Andrew Schofield <aschofield@confluent.io>
