### PR TITLE
MINOR: Document null parameter behavior in ListShareGroupOffsetsSpec#topicPartitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsSpec.java
@@ -37,7 +37,7 @@ public class ListShareGroupOffsetsSpec {
     /**
      * Set the topic partitions whose offsets are to be listed for a share group.
      *
-     * @param topicPartitions List of topic partitions to include
+     * @param topicPartitions List of topic partitions to include, or {@code null} to include all topic partitions.
      */
     public ListShareGroupOffsetsSpec topicPartitions(Collection<TopicPartition> topicPartitions) {
         this.topicPartitions = topicPartitions;


### PR DESCRIPTION
Document that passing null includes all topic partitions in
ListShareGroupOffsetsSpec#topicPartitions.

Reviewers: Ken Huang <s7133700@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
