### PR TITLE
KAFKA-19853: commit open tasks before handling assignment

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1458,7 +1458,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     @Override
     public void onAssignment(final Assignment assignment, final ConsumerGroupMetadata metadata) {
-        Set<Task> tasksWithOpenTransactions = taskManager.allOwnedTasks()
+        final Set<Task> tasksWithOpenTransactions = taskManager.allOwnedTasks()
             .values()
             .stream()
             .filter(t -> t.commitNeeded())

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1458,6 +1458,14 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     @Override
     public void onAssignment(final Assignment assignment, final ConsumerGroupMetadata metadata) {
+        Set<Task> tasksWithOpenTransactions = taskManager.allOwnedTasks()
+            .values()
+            .stream()
+            .filter(t -> t.commitNeeded())
+            .collect(Collectors.toSet());
+        log.info("Committing {} tasks with open transactions before onAssignment()", tasksWithOpenTransactions.size());
+        taskManager.commit(tasksWithOpenTransactions);
+
         final List<TopicPartition> partitions = new ArrayList<>(assignment.partitions());
         partitions.sort(PARTITION_COMPARATOR);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1442,6 +1442,14 @@ public class StreamsPartitionAssignorTest {
         setUp(parameterizedConfig, false);
         taskManager = mock(TaskManager.class);
 
+        final Task notToCommit = mock(Task.class);
+        final Task toCommit = mock(Task.class);
+        final TaskId notToCommitId = new TaskId(0, 0);
+        final TaskId toCommitId = new TaskId(0, 1);
+        when(notToCommit.commitNeeded()).thenReturn(false);
+        when(toCommit.commitNeeded()).thenReturn(true);
+        when(taskManager.allOwnedTasks()).thenReturn(Map.of(notToCommitId, notToCommit, toCommitId, toCommit));
+
         final Map<HostInfo, Set<TopicPartition>> hostState = Collections.singletonMap(
             new HostInfo("localhost", 9090),
             Set.of(t3p0, t3p3));
@@ -1465,6 +1473,7 @@ public class StreamsPartitionAssignorTest {
 
         verify(streamsMetadataState).onChange(eq(hostState), any(), topicPartitionInfoCaptor.capture());
         verify(taskManager).handleAssignment(activeTasks, standbyTasks);
+        verify(taskManager).commit(Set.of(toCommit));
 
         assertTrue(topicPartitionInfoCaptor.getValue().containsKey(t3p0));
         assertTrue(topicPartitionInfoCaptor.getValue().containsKey(t3p3));


### PR DESCRIPTION
Under stress with active restorations going on, the
`StateUpdater#runOnce()` method can block on write stalls. This causes
the `StreamThread` to block on `TaskManager#handleAssignment()` in the
consumer rebalance callback. This is because
`TaskManager#handleAssignment()` waits for a future on the State
Updater. If rocksdb is stalling, which is very common during restoration
or when processing a warmup task, that future can take some time to show
up.

This blocking can cause transaction timeouts in EOS, which is
disruptive. This commit mitigates that issue by committing any open
transactions before blocking on the State Updater.
