### PR TITLE
MINOR: Fix --fetch-size description in ConsumerPerformance

### DIFF
--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -32,7 +32,7 @@ class ConsumerPerformanceService(PerformanceService):
 
         "group", "The group id to consume on."
 
-        "fetch-size", "The amount of data to fetch in a single request."
+        "fetch-size", "The maximum amount of data to fetch from a single partition per request."
 
         "from-latest", "If the consumer does not already have an establishedoffset to consume from,
                         start with the latest message present in the log rather than the earliest message."

--- a/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
@@ -301,7 +301,7 @@ public class ConsumerPerformance {
                 .describedAs("gid")
                 .defaultsTo("perf-consumer-" + RND.nextInt(100_000))
                 .ofType(String.class);
-            fetchSizeOpt = parser.accepts("fetch-size", "The amount of data to fetch in a single request.")
+            fetchSizeOpt = parser.accepts("fetch-size", "The maximum amount of data to fetch from a single partition per request.")
                 .withRequiredArg()
                 .describedAs("size")
                 .ofType(Integer.class)


### PR DESCRIPTION
As
[discussed](https://github.com/apache/kafka/pull/18415/files#r2495342682),
the `--fetch-size` parameter description in `ConsumerPerformance` is
misleading. It actually sets `max.partition.fetch.bytes` (per-partition
limit), not the total fetch size per request.

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Yung <yungyung7654321@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
