### PR TITLE
KAFKA-19831: removed the futureless remove task as it's no longer used.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskAndAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskAndAction.java
@@ -55,11 +55,6 @@ public class TaskAndAction {
         return new TaskAndAction(null, taskId, Action.REMOVE, future);
     }
 
-    public static TaskAndAction createRemoveTask(final TaskId taskId) {
-        Objects.requireNonNull(taskId, "Task ID of task to remove is null!");
-        return new TaskAndAction(null, taskId, Action.REMOVE, null);
-    }
-
     public Task task() {
         if (action != Action.ADD) {
             throw new IllegalStateException("Action type " + action + " cannot have a task!");


### PR DESCRIPTION
The usage of the futureless remove task was removed in PR #15896  This
PR cleans up the old code that's no longer used.

Reviewers: Matthias J. Sax <matthias@confluent.io>
