### PR TITLE
KAFKA-19578: Fix flaky test for RemoteLogManagerTest.testCopyQuota

### DIFF
--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -72,7 +72,6 @@ import com.yammer.metrics.core.MetricName;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -3400,8 +3399,6 @@ public class RemoteLogManagerTest {
         assertEquals(expectedEpoch + " " + expectedStartOffset, bufferedReader.readLine());
     }
 
-
-    @Disabled("KAFKA-19578")
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testCopyQuota(boolean quotaExceeded) throws Exception {

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -3424,7 +3424,7 @@ public class RemoteLogManagerTest {
             assertEquals(-1L, capture.getValue());
         } else {
             // Verify the copy operation completes within the timeout, since it does not need to wait for quota availability
-            assertTimeoutPreemptively(Duration.ofMillis(100), () -> task.copyLogSegmentsToRemote(mockLog));
+            assertTimeoutPreemptively(Duration.ofMillis(1000), () -> task.copyLogSegmentsToRemote(mockLog));
 
             // Verify quota check was performed
             verify(rlmCopyQuotaManager, times(1)).getThrottleTimeMs();


### PR DESCRIPTION
Found the flaky test on
https://github.com/apache/kafka/actions/runs/19152512773/job/54746814581?pr=20842

Core Issue: Class loading time is unpredictable, total 100ms timeout for
whole process is too short

The Error:
```
Gradle Test Run :storage:test > Gradle Test Executor 121 >
RemoteLogManagerTest > testCopyQuota(boolean) >
"testCopyQuota(boolean).quotaExceeded=false" STARTED
org.apache.kafka.server.log.remote.storage.RemoteLogManagerTest.testCopyQuota(boolean)[1]
failed, log available in
/home/runner/work/kafka/kafka/storage/build/reports/testOutput/org.apache.kafka.server.log.remote.storage.RemoteLogManagerTest.testCopyQuota(boolean)[1].test.stdout

Gradle Test Run :storage:test > Gradle Test Executor 121 >
RemoteLogManagerTest > testCopyQuota(boolean) >
"testCopyQuota(boolean).quotaExceeded=false" FAILED
org.opentest4j.AssertionFailedError: execution timed out after 100 ms at
app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
at
app//org.junit.jupiter.api.AssertTimeoutPreemptively.createAssertionFailure(AssertTimeoutPreemptively.java:132)
at
app//org.junit.jupiter.api.AssertTimeoutPreemptively.resolveFutureAndHandleException(AssertTimeoutPreemptively.java:116)
at
app//org.junit.jupiter.api.AssertTimeoutPreemptively.assertTimeoutPreemptively(AssertTimeoutPreemptively.java:82)
at
app//org.junit.jupiter.api.AssertTimeoutPreemptively.assertTimeoutPreemptively(AssertTimeoutPreemptively.java:65)
at
app//org.junit.jupiter.api.AssertTimeoutPreemptively.assertTimeoutPreemptively(AssertTimeoutPreemptively.java:47)
at
app//org.junit.jupiter.api.AssertTimeoutPreemptively.assertTimeoutPreemptively(AssertTimeoutPreemptively.java:43)
at
app//org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Assertions.java:3459)
at
app//org.apache.kafka.server.log.remote.storage.RemoteLogManagerTest.testCopyQuota(RemoteLogManagerTest.java:3425)

        Caused by:
org.junit.jupiter.api.AssertTimeoutPreemptively$ExecutionTimeoutException:
Execution timed out in thread junit-timeout-thread-1
            at
java.base@25.0.1/sun.net.www.protocol.file.Handler.parseURL(Handler.java:56)
            at java.base@25.0.1/java.net.URL.<init>(URL.java:764)
            at java.base@25.0.1/java.net.URL.<init>(URL.java:630)
            at
java.base@25.0.1/jdk.internal.loader.URLClassPath$FileLoader.getResource(URLClassPath.java:935)
            at
java.base@25.0.1/jdk.internal.loader.URLClassPath.getResource(URLClassPath.java:332)
            at
java.base@25.0.1/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:688)
```

Reviewers: Uladzislau Blok <blokv75@gmail.com>, Chang-Yu Huang
 <changyuh1919@vt.edu>, Chia-Ping Tsai <chia7712@gmail.com>
