### PR TITLE
MINOR: Fix KafkaApisTest sharePartitionManager and ShareSessionContext parameters

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4593,8 +4593,8 @@ class KafkaApisTest extends Logging {
       ))
     )
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(new ShareRequestMetadata(memberId, shareSessionEpoch), util.List.of(
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(shareSessionEpoch, util.List.of(
         new TopicIdPartition(topicId, partitionIndex, topicName)))
     )
 


### PR DESCRIPTION
## What
Follow up on
https://github.com/apache/kafka/commit/cc62985c2a1cc9fa0b330b0d6f08b6be5b5c8fc1,
the input for `sharePartitionManager.newContext()` and
`ShareSessionContext()` seems to be broken.

Reviewers: @apoorvmittal10 @TaiJuWu
