### PR TITLE
KAFKA-19874: Fix resource leak in TopicBasedRemoteLogMetadataManager.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -345,19 +345,27 @@ public class TopicBasedRemoteLogMetadataManager implements BrokerReadyCallback, 
                     continue;
                 }
                 // Create producer and consumer managers.
+                ProducerManager tempProducerManager = null;
+                ConsumerManager tempConsumerManager = null;
                 lock.writeLock().lock();
                 try {
-                    producerManager = new ProducerManager(rlmmConfig, partitioner);
-                    consumerManager = new ConsumerManager(rlmmConfig, remotePartitionMetadataStore, partitioner, time);
-                    consumerManager.startConsumerThread();
+                    tempProducerManager = new ProducerManager(rlmmConfig, partitioner);
+                    tempConsumerManager = new ConsumerManager(rlmmConfig, remotePartitionMetadataStore, partitioner, time);
+                    tempConsumerManager.startConsumerThread();
                     if (!pendingAssignPartitions.isEmpty()) {
                         assignPartitions(pendingAssignPartitions);
                         pendingAssignPartitions.clear();
                     }
+                    // Only assign to instance variables after successful initialization
+                    producerManager = tempProducerManager;
+                    consumerManager = tempConsumerManager;
                     initialized.set(true);
                     log.info("Initialized topic-based RLMM resources successfully");
                 } catch (Exception e) {
                     log.error("Encountered error while initializing producer/consumer", e);
+                    // Clean up resources if initialization fails
+                    Utils.closeQuietly(tempConsumerManager, "ConsumerManager");
+                    Utils.closeQuietly(tempProducerManager, "ProducerManager");
                     initializationFailed = true;
                 } finally {
                     lock.writeLock().unlock();


### PR DESCRIPTION
## Problem
There is a resource leak in the TopicBasedRemoteLogMetadataManager initialization 
process. If ProducerManager is created successfully but ConsumerManager creation 
fails, the ProducerManager instance is not properly closed, leading to resource 
leaks (e.g., unclosed Kafka producer, threads, network connections).

## Current Code (Problematic)
lock.writeLock().lock();
try {
    producerManager = new ProducerManager(rlmmConfig, partitioner);
    consumerManager = new ConsumerManager(rlmmConfig, remotePartitionMetadataStore, partitioner, time);
    consumerManager.startConsumerThread();
    // If exception occurs here, producerManager is not closed
} catch (Exception e) {
    log.error("Encountered error while initializing producer/consumer", e);
    initializationFailed = true;
} finally {
    lock.writeLock().unlock();
}## Solution
Use temporary variables to hold manager instances and only assign to instance 
variables after successful initialization. Clean up temporary resources in the 
catch block if any exception occurs.

## Impact
- Prevents resource leaks during initialization failures
- Ensures proper cleanup of Kafka clients
- Improves system stability and resource management