### PR TITLE
KAFKA-19757: [1/N] Mark KIP-932 as generally available

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaShareConsumer.java
@@ -50,8 +50,6 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
 
 /**
  * A client that consumes records from a Kafka cluster using a share group.
- * <p>
- *     <em>This is a preview feature introduced by KIP-932. It is not yet recommended for production use.</em>
  *
  * <h3>Cross-Version Compatibility</h3>
  * This client can communicate with brokers that are a version that supports share groups. You will receive an

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegateCreator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerDelegateCreator.java
@@ -25,8 +25,6 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
-import org.slf4j.Logger;
-
 /**
  * {@code ShareConsumerDelegateCreator} implements a quasi-factory pattern to allow the caller to remain unaware of the
  * underlying {@link ShareConsumer} implementation that is created. This provides the means by which
@@ -43,9 +41,6 @@ public class ShareConsumerDelegateCreator {
                                                      final Deserializer<K> keyDeserializer,
                                                      final Deserializer<V> valueDeserializer) {
         try {
-            LogContext logContext = new LogContext();
-            Logger log = logContext.logger(getClass());
-            log.warn("Share groups and KafkaShareConsumer are part of a preview feature introduced by KIP-932, and are not recommended for use in production.");
             return new ShareConsumerImpl<>(config, keyDeserializer, valueDeserializer);
         } catch (KafkaException e) {
             throw e;
@@ -65,8 +60,6 @@ public class ShareConsumerDelegateCreator {
                                                      final SubscriptionState subscriptions,
                                                      final ShareConsumerMetadata metadata) {
         try {
-            Logger log = logContext.logger(getClass());
-            log.warn("Share groups and KafkaShareConsumer are part of a preview feature introduced by KIP-932, and are not recommended for use in production.");
             return new ShareConsumerImpl<>(
                     logContext,
                     clientId,

--- a/docs/api.html
+++ b/docs/api.html
@@ -55,9 +55,9 @@
 	&lt;version&gt;{{fullDotVersion}}&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
 
-	<h3 class="anchor-heading"><a id="shareconsumerapi" class="anchor-link"></a><a href="#shareconsumerapi">2.3 Share Consumer API (Preview)</a></h3>
+	<h3 class="anchor-heading"><a id="shareconsumerapi" class="anchor-link"></a><a href="#shareconsumerapi">2.3 Share Consumer API</a></h3>
 
-	The Share Consumer API (Preview) enables applications within a share group to cooperatively consume and process data from Kafka topics.
+	The Share Consumer API enables applications within a share group to cooperatively consume and process data from Kafka topics.
 	<p>
 	Examples of using the share consumer are shown in the
 	<a href="/{{version}}/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaShareConsumer.html" title="Kafka {{dotVersion}} Javadoc">javadocs</a>.

--- a/docs/design.html
+++ b/docs/design.html
@@ -358,8 +358,6 @@
 
     <h3 class="anchor-heading"><a id="sharegroups" class="anchor-link"></a><a href="#sharegroups">4.8 Share groups</a></h3>
     <p>
-    Share groups are available as a preview in Apache Kafka 4.1.
-    <p>
     Share groups are a new type of group, existing alongside traditional consumer groups. Share groups enable Kafka consumers to cooperatively consume and process records from topics.
     They offer an alternative to traditional consumer groups, particularly when applications require finer-grained sharing of partitions and records.
     <p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -230,10 +230,6 @@ topic1                         0          0</code></pre>
 
   <h4 class="anchor-heading"><a id="basic_ops_share_group" class="anchor-link"></a><a href="#basic_ops_share_group">Managing share groups</a></h4>
 
-  NOTE: Apache Kafka 4.1 ships with a preview of share groups which is not enabled by default. To enable share groups, use the <code>kafka-features.sh</code> tool to upgrade to <code>share.version=1</code>.
-  For more information, please read the <a href="https://cwiki.apache.org/confluence/x/CIq3FQ"> release notes</a>.
-
-  <p>
   Use the ShareGroupCommand tool to list, describe, or delete the share groups. Only share groups without any active members can be deleted.
 
   For example, to list all share groups in a cluster:

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -36,7 +36,7 @@
             <ul>
                 <li><a href="#producerapi">2.1 Producer API</a>
                 <li><a href="#consumerapi">2.2 Consumer API</a>
-                <li><a href="#shareconsumerapi">2.3 Share Consumer API (Preview)</a>
+                <li><a href="#shareconsumerapi">2.3 Share Consumer API</a>
                 <li><a href="#streamsapi">2.4 Streams API</a>
                 <li><a href="#connectapi">2.5 Connect API</a>
                 <li><a href="#adminapi">2.6 Admin API</a>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -26,6 +26,12 @@
 <h5><a id="upgrade_420_notable" href="#upgrade_420_notable">Notable changes in 4.2.0</a></h5>
 <ul>
     <li>
+        Queues for Kafka (<a href="https://cwiki.apache.org/confluence/x/4hA0Dw">KIP-932</a>) is production-ready in Apache Kafka 4.2. This feature introduces a new kind of group called
+        share groups, as an alternative to consumer groups. Consumers in a share group cooperatively consume records from topics, without assigning each partition to just one consumer.
+        Share groups also introduce per-record acknowledgement and counting of delivery attempts. Use share groups in cases where records are processed one at a time, rather than as part
+        of an ordered stream.
+    </li>
+    <li>
         The <code>org.apache.kafka.common.header.internals.RecordHeader</code> class has been updated to be read thread-safe. See <a href="https://cwiki.apache.org/confluence/x/nYmhFg">KIP-1205</a> for details.
         In other words, each individual <code>Header</code> object within a <code>ConsumerRecord</code>'s <code>headers</code> can now be safely read from multiple threads concurrently.
     </li>


### PR DESCRIPTION
This is the first PR to mark KIP-932 as generally available. It removes
warning messages, updates the javadoc and removes "Preview" from the
docs.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
