### PR TITLE
[Draft] KAFKA-19393: Consolidate consumer assignment state views.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -117,18 +117,6 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
     protected final Logger log;
 
     /**
-     * Local cache of assigned topic IDs and names. Topics are added here when received in a
-     * target assignment, as we discover their names in the Metadata cache, and removed when the
-     * topic is not in the subscription anymore. The purpose of this cache is to avoid metadata
-     * requests in cases where a currently assigned topic is in the target assignment (new
-     * partition assigned, or revoked), but it is not present the Metadata cache at that moment.
-     * The cache is cleared when the subscription changes ({@link #transitionToJoining()}, the
-     * member fails ({@link #transitionToFatal()} or leaves the group
-     * ({@link #leaveGroup()}/{@link #leaveGroupOnClose(CloseOptions.GroupMembershipOperation)}).
-     */
-    private final Map<Uuid, String> assignedTopicNamesCache;
-
-    /**
      * Topic IDs and partitions received in the last target assignment, together with its local epoch.
      *
      * This member variable is reassigned every time a new assignment is received.
@@ -214,7 +202,6 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
         this.state = MemberState.UNSUBSCRIBED;
         this.subscriptions = subscriptions;
         this.metadata = metadata;
-        this.assignedTopicNamesCache = new HashMap<>();
         this.currentTargetAssignment = LocalAssignment.NONE;
         this.currentAssignment = LocalAssignment.NONE;
         this.log = log;
@@ -1104,14 +1091,15 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
         if (nameFromMetadataCache != null) {
             // Add topic name to local cache, so it can be reused if included in a next target
             // assignment if metadata cache not available.
-            assignedTopicNamesCache.put(topicId, nameFromMetadataCache);
+            subscriptions.putAssignedTopicNames(topicId, nameFromMetadataCache);
             return Optional.of(nameFromMetadataCache);
         } else {
             // Topic ID was not found in metadata. Check if the topic name is in the local
             // cache of topics currently assigned. This will avoid a metadata request in the
             // case where the metadata cache may have been flushed right before the
             // revocation of a previously assigned topic.
-            String nameFromSubscriptionCache = assignedTopicNamesCache.getOrDefault(topicId, null);
+
+            String nameFromSubscriptionCache = subscriptions.getAssignTopicNamesFromCacheOrDefault(topicId, null);
             return Optional.ofNullable(nameFromSubscriptionCache);
         }
     }
@@ -1222,7 +1210,7 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
 
         // Clear topic names cache, removing topics that are not assigned to the member anymore.
         Set<String> assignedTopics = assignedPartitions.topicNames();
-        assignedTopicNamesCache.values().retainAll(assignedTopics);
+        subscriptions.removeNotAssignedTopicsFromCache(assignedTopics);
 
         return result;
     }
@@ -1276,7 +1264,7 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
      */
     private void clearPendingAssignmentsAndLocalNamesCache() {
         currentTargetAssignment = LocalAssignment.NONE;
-        assignedTopicNamesCache.clear();
+        subscriptions.clearAssignedTopicNamesCache();
     }
 
     protected void resetEpoch() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.SubscriptionPattern;
@@ -92,20 +93,10 @@ public class SubscriptionState {
     /* the list of topics the user has requested */
     private Set<String> subscription;
 
-    /**
-     * Topic IDs received in an assignment from the coordinator when using the Consumer rebalance protocol.
-     * This will be used to include assigned topic IDs in metadata requests when the consumer
-     * does not know the topic names (ex. when the user subscribes to a RE2J regex computed on the broker)
-     */
-    private Set<Uuid> assignedTopicIds;
-
     /* The list of topics the group has subscribed to. This may include some topics which are not part
      * of `subscription` for the leader of a group since it is responsible for detecting metadata changes
      * which require a group rebalance. */
     private Set<String> groupSubscription;
-
-    /* the partitions that are currently assigned, note that the order of partition matters (see FetchBuilder for more details) */
-    private final PartitionStates<TopicPartitionState> assignment;
 
     /* Default offset reset strategy */
     private final AutoOffsetResetStrategy defaultResetStrategy;
@@ -113,7 +104,7 @@ public class SubscriptionState {
     /* User-provided listener to be invoked when assignment changes */
     private Optional<ConsumerRebalanceListener> rebalanceListener = Optional.empty();
 
-    private int assignmentId = 0;
+    private final AssignState assignState;
 
     @Override
     public synchronized String toString() {
@@ -123,7 +114,7 @@ public class SubscriptionState {
             ", subscription=" + String.join(",", subscription) +
             ", groupSubscription=" + String.join(",", groupSubscription) +
             ", defaultResetStrategy=" + defaultResetStrategy +
-            ", assignment=" + assignment.partitionStateValues() + " (id=" + assignmentId + ")}";
+            ", assignment=" + assignState.partitionStateValues() + " (id=" + assignState.getAssignmentId() + ")}";
     }
 
     private Object subscribedPatternInUse() {
@@ -145,7 +136,7 @@ public class SubscriptionState {
             case AUTO_PATTERN_RE2J:
                 return "Subscribe(" + subscribedRe2JPattern + ")";
             case USER_ASSIGNED:
-                return "Assign(" + assignedPartitions() + " , id=" + assignmentId + ")";
+                return "Assign(" + assignedPartitions() + " , id=" + assignState.getAssignmentId() + ")";
             case AUTO_TOPICS_SHARE:
                 return "Subscribe to Share Group(" + String.join(",", subscription) + ")";
             default:
@@ -157,12 +148,11 @@ public class SubscriptionState {
         this.log = logContext.logger(this.getClass());
         this.defaultResetStrategy = defaultResetStrategy;
         this.subscription = new TreeSet<>(); // use a sorted set for better logging
-        this.assignedTopicIds = new TreeSet<>();
-        this.assignment = new PartitionStates<>();
         this.groupSubscription = new HashSet<>();
         this.subscribedPattern = null;
         this.subscribedRe2JPattern = null;
         this.subscriptionType = SubscriptionType.NONE;
+        this.assignState = new AssignState();
     }
 
     /**
@@ -172,7 +162,7 @@ public class SubscriptionState {
      * @return The current assignment Id
      */
     synchronized int assignmentId() {
-        return assignmentId;
+        return assignState.getAssignmentId();
     }
 
     /**
@@ -257,16 +247,16 @@ public class SubscriptionState {
     public synchronized boolean assignFromUser(Set<TopicPartition> partitions) {
         setSubscriptionType(SubscriptionType.USER_ASSIGNED);
 
-        if (this.assignment.partitionSet().equals(partitions))
+        if (this.assignState.topicPartitionSet().equals(partitions))
             return false;
 
-        assignmentId++;
+        this.assignState.increaseAssignmentId();
 
         // update the subscribed topics
         Set<String> manualSubscribedTopics = new HashSet<>();
         Map<TopicPartition, TopicPartitionState> partitionToState = new HashMap<>();
         for (TopicPartition partition : partitions) {
-            TopicPartitionState state = assignment.stateValue(partition);
+            TopicPartitionState state = this.assignState.stateValue(partition);
             if (state == null)
                 state = new TopicPartitionState();
             partitionToState.put(partition, state);
@@ -274,7 +264,7 @@ public class SubscriptionState {
             manualSubscribedTopics.add(partition.topic());
         }
 
-        this.assignment.set(partitionToState);
+        this.assignState.setPartitionToState(partitionToState);
         return changeSubscription(manualSubscribedTopics);
     }
 
@@ -317,14 +307,14 @@ public class SubscriptionState {
 
         Map<TopicPartition, TopicPartitionState> assignedPartitionStates = new HashMap<>(assignments.size());
         for (TopicPartition tp : assignments) {
-            TopicPartitionState state = this.assignment.stateValue(tp);
+            TopicPartitionState state = this.assignState.stateValue(tp);
             if (state == null)
                 state = new TopicPartitionState();
             assignedPartitionStates.put(tp, state);
         }
 
-        assignmentId++;
-        this.assignment.set(assignedPartitionStates);
+        this.assignState.increaseAssignmentId();
+        this.assignState.setPartitionToState(assignedPartitionStates);
     }
 
     private void registerRebalanceListener(Optional<ConsumerRebalanceListener> listener) {
@@ -346,11 +336,9 @@ public class SubscriptionState {
     public synchronized void unsubscribe() {
         this.subscription = Collections.emptySet();
         this.groupSubscription = Collections.emptySet();
-        this.assignment.clear();
-        this.assignedTopicIds = Collections.emptySet();
         this.subscribedPattern = null;
         this.subscriptionType = SubscriptionType.NONE;
-        this.assignmentId++;
+        this.assignState.unsubscribe();
     }
 
     /**
@@ -423,14 +411,14 @@ public class SubscriptionState {
     }
 
     private TopicPartitionState assignedState(TopicPartition tp) {
-        TopicPartitionState state = this.assignment.stateValue(tp);
+        TopicPartitionState state = this.assignState.stateValue(tp);
         if (state == null)
             throw new IllegalStateException("No current assignment for partition " + tp);
         return state;
     }
 
     private TopicPartitionState assignedStateOrNull(TopicPartition tp) {
-        return this.assignment.stateValue(tp);
+        return this.assignState.stateValue(tp);
     }
 
     public synchronized void seekValidated(TopicPartition tp, FetchPosition position) {
@@ -463,14 +451,14 @@ public class SubscriptionState {
      * @return a modifiable copy of the currently assigned partitions
      */
     public synchronized Set<TopicPartition> assignedPartitions() {
-        return new HashSet<>(this.assignment.partitionSet());
+        return assignState.assignedPartitions();
     }
 
     /**
      * @return a modifiable copy of the currently assigned partitions as a list
      */
     public synchronized List<TopicPartition> assignedPartitionsList() {
-        return new ArrayList<>(this.assignment.partitionSet());
+        return this.assignState.assignedPartitionsList();
     }
 
     /**
@@ -478,14 +466,14 @@ public class SubscriptionState {
      * @return the number of assigned partitions.
      */
     public synchronized int numAssignedPartitions() {
-        return this.assignment.size();
+        return this.assignState.numAssignedPartitions();
     }
 
     // Visible for testing
     public synchronized List<TopicPartition> fetchablePartitions(Predicate<TopicPartition> isAvailable) {
         // Since this is in the hot-path for fetching, we do this instead of using java.util.stream API
         List<TopicPartition> result = new ArrayList<>();
-        assignment.forEach((topicPartition, topicPartitionState) -> {
+        this.assignState.getAssignment().forEach((topicPartition, topicPartitionState) -> {
             // Cheap check is first to avoid evaluating the predicate if possible
             if ((subscriptionType.equals(SubscriptionType.AUTO_TOPICS_SHARE) || isFetchableAndSubscribed(topicPartition, topicPartitionState))
                     && isAvailable.test(topicPartition)) {
@@ -522,7 +510,7 @@ public class SubscriptionState {
             return false;
         }
 
-        return this.assignedTopicIds.contains(topicId);
+        return this.assignState.isAssignedFromRe2j(topicId);
     }
 
     public synchronized void position(TopicPartition tp, FetchPosition position) {
@@ -772,13 +760,7 @@ public class SubscriptionState {
     }
 
     public synchronized Map<TopicPartition, OffsetAndMetadata> allConsumed() {
-        Map<TopicPartition, OffsetAndMetadata> allConsumed = new HashMap<>();
-        assignment.forEach((topicPartition, partitionState) -> {
-            if (partitionState.hasValidPosition())
-                allConsumed.put(topicPartition, new OffsetAndMetadata(partitionState.position.offset,
-                        partitionState.position.offsetEpoch, ""));
-        });
-        return allConsumed;
+        return this.assignState.allConsumed();
     }
 
     public synchronized void requestOffsetReset(TopicPartition partition, AutoOffsetResetStrategy offsetResetStrategy) {
@@ -824,7 +806,7 @@ public class SubscriptionState {
 
     public synchronized boolean hasAllFetchPositions() {
         // Since this is in the hot-path for fetching, we do this instead of using java.util.stream API
-        Iterator<TopicPartitionState> it = assignment.stateIterator();
+        Iterator<TopicPartitionState> it = assignState.assignmentIterator();
         while (it.hasNext()) {
             if (!it.next().hasValidPosition()) {
                 return false;
@@ -838,13 +820,7 @@ public class SubscriptionState {
     }
 
     private Set<TopicPartition> collectPartitions(Predicate<TopicPartitionState> filter) {
-        Set<TopicPartition> result = new HashSet<>();
-        assignment.forEach((topicPartition, topicPartitionState) -> {
-            if (filter.test(topicPartitionState)) {
-                result.add(topicPartition);
-            }
-        });
-        return result;
+        return this.assignState.collectPartitions(filter);
     }
 
     /**
@@ -857,7 +833,7 @@ public class SubscriptionState {
      */
     public synchronized void resetInitializingPositions(Predicate<TopicPartition> initPartitionsToInclude) {
         final Set<TopicPartition> partitionsWithNoOffsets = new HashSet<>();
-        assignment.forEach((tp, partitionState) -> {
+        this.assignState.getAssignment().forEach((tp, partitionState) -> {
             if (partitionState.shouldInitialize() && initPartitionsToInclude.test(tp)) {
                 if (defaultResetStrategy == AutoOffsetResetStrategy.NONE)
                     partitionsWithNoOffsets.add(tp);
@@ -883,7 +859,7 @@ public class SubscriptionState {
     }
 
     public synchronized boolean isAssigned(TopicPartition tp) {
-        return assignment.contains(tp);
+        return assignState.isAssigned(tp);
     }
 
     public synchronized boolean isPaused(TopicPartition tp) {
@@ -936,15 +912,19 @@ public class SubscriptionState {
      * @return Topic IDs received in an assignment that have not been reconciled yet, so we need metadata for them.
      */
     public synchronized Set<Uuid> assignedTopicIds() {
-        return assignedTopicIds;
+        return this.assignState.assignedTopicIds();
     }
 
     /**
      * Set the set of topic IDs that have been assigned to the consumer by the coordinator.
      * This is used for topic IDs received in an assignment when using the new consumer rebalance protocol (KIP-848).
      */
-    public synchronized  void setAssignedTopicIds(Set<Uuid> assignedTopicIds) {
-        this.assignedTopicIds = assignedTopicIds;
+    public synchronized void setAssignedTopicIds(Set<Uuid> assignedTopicIds) {
+        this.assignState.setAssignedTopicIds(assignedTopicIds);
+    }
+
+    public synchronized void putAssignedTopicNames(Uuid topicId, String nameFromMetadataCache) {
+        this.assignState.putAssignedTopicNames(topicId, nameFromMetadataCache);
     }
 
     /**
@@ -971,13 +951,26 @@ public class SubscriptionState {
     }
 
     synchronized void movePartitionToEnd(TopicPartition tp) {
-        assignment.moveToEnd(tp);
+        assignState.movePartitionToEnd(tp);
     }
 
     public synchronized Optional<ConsumerRebalanceListener> rebalanceListener() {
         return rebalanceListener;
     }
 
+    public synchronized String getAssignTopicNamesFromCacheOrDefault(Uuid topicId, String defaultValue) {
+        return assignState.getAssignedTopicNamesFromCacheOrDefault(topicId, defaultValue);
+    }
+
+    public synchronized void clearAssignedTopicNamesCache() {
+        assignState.clearAssignedTopicNamesCache();
+    }
+
+    public synchronized void removeNotAssignedTopicsFromCache(Set<String> assignedTopics) {
+        assignState.removeNotAssignedTopicsFromCache(assignedTopics);
+    }
+    
+    
     private static class TopicPartitionState {
 
         private FetchState fetchState;
@@ -1421,4 +1414,145 @@ public class SubscriptionState {
 
         }
     }
+
+    static class AssignState {
+
+        /**
+         * Topic IDs received in an assignment from the coordinator when using the Consumer rebalance protocol.
+         * This will be used to include assigned topic IDs in metadata requests when the consumer
+         * does not know the topic names (ex. when the user subscribes to a RE2J regex computed on the broker)
+         */
+        private Set<Uuid> assignedTopicIds;
+
+        /* the partitions that are currently assigned, note that the order of partition matters (see FetchBuilder for more details) */
+        private final PartitionStates<TopicPartitionState> assignment;
+
+        private int assignmentId = 0;
+
+        /**
+         * Local cache of assigned topic IDs and names. Topics are added here when received in a
+         * target assignment, as we discover their names in the Metadata cache, and removed when the
+         * topic is not in the subscription anymore. The purpose of this cache is to avoid metadata
+         * requests in cases where a currently assigned topic is in the target assignment (new
+         * partition assigned, or revoked), but it is not present the Metadata cache at that moment.
+         * The cache is cleared when the subscription changes ({@link AbstractMembershipManager#transitionToJoining()}, the
+         * member fails ({@link AbstractMembershipManager#transitionToFatal()} or leaves the group
+         * ({@link AbstractMembershipManager#leaveGroup()}/{@link AbstractMembershipManager#leaveGroupOnClose(CloseOptions.GroupMembershipOperation)}).
+         */
+        private final Map<Uuid, String> assignedTopicNamesCache;
+        
+
+        public AssignState() {
+            this.assignedTopicIds = new TreeSet<>();
+            this.assignment = new PartitionStates<>();
+            this.assignedTopicNamesCache = new HashMap<>(); 
+        }
+
+        public void unsubscribe() {
+            this.assignedTopicIds = Collections.emptySet();
+            this.assignment.clear();
+            increaseAssignmentId();
+        }
+
+        public boolean isAssignedFromRe2j(Uuid topicId) {
+            return this.assignedTopicIds.contains(topicId);
+        }
+
+        public Set<Uuid> assignedTopicIds() {
+            return assignedTopicIds;
+        }
+
+        public void setAssignedTopicIds(Set<Uuid> assignedTopicIds) {
+            this.assignedTopicIds = assignedTopicIds;
+        }
+
+        public int getAssignmentId() {
+            return assignmentId;
+        }
+
+        public void increaseAssignmentId() {
+            assignmentId++;
+        }
+
+        PartitionStates<TopicPartitionState> getAssignment() {
+            return assignment;
+        }
+
+        public Set<TopicPartition> topicPartitionSet() {
+            return this.assignment.partitionSet();
+        }
+
+        public Set<TopicPartition> assignedPartitions() {
+            return new HashSet<>(this.assignment.partitionSet());
+        }
+
+        public List<TopicPartition> assignedPartitionsList() {
+            return new ArrayList<>(this.assignment.partitionSet());
+        }
+
+        TopicPartitionState stateValue(TopicPartition topicPartition) {
+            return this.assignment.stateValue(topicPartition);
+        }
+
+        void setPartitionToState(Map<TopicPartition, TopicPartitionState> partitionToState) {
+            this.assignment.set(partitionToState);
+        }
+
+        public void movePartitionToEnd(TopicPartition tp) {
+            assignment.moveToEnd(tp);
+        }
+
+        Iterator<TopicPartitionState> assignmentIterator() {
+            return this.assignment.stateIterator();
+        }
+
+        public boolean isAssigned(TopicPartition tp) {
+            return assignment.contains(tp);
+        }
+
+        public int numAssignedPartitions() {
+            return this.assignment.size();
+        }
+
+        List<TopicPartitionState> partitionStateValues() {
+            return this.assignment.partitionStateValues();
+        }
+
+        public Map<TopicPartition, OffsetAndMetadata> allConsumed() {
+            Map<TopicPartition, OffsetAndMetadata> allConsumed = new HashMap<>();
+            this.assignment.forEach((topicPartition, partitionState) -> {
+                if (partitionState.hasValidPosition())
+                    allConsumed.put(topicPartition, new OffsetAndMetadata(partitionState.position.offset,
+                            partitionState.position.offsetEpoch, ""));
+            });
+            return allConsumed;
+        }
+
+        Set<TopicPartition> collectPartitions(Predicate<TopicPartitionState> filter) {
+            Set<TopicPartition> result = new HashSet<>();
+            this.assignment.forEach((topicPartition, topicPartitionState) -> {
+                if (filter.test(topicPartitionState)) {
+                    result.add(topicPartition);
+                }
+            });
+            return result;
+        }
+
+        public void putAssignedTopicNames(Uuid topicId, String nameFromMetadataCache) {
+            this.assignedTopicNamesCache.put(topicId, nameFromMetadataCache);
+        }
+        
+        public String getAssignedTopicNamesFromCacheOrDefault(Uuid topicId, String defaultValue) {
+            return this.assignedTopicNamesCache.getOrDefault(topicId, defaultValue);
+        }
+
+        public void clearAssignedTopicNamesCache() {
+            this.assignedTopicNamesCache.clear();
+        }
+
+        public void removeNotAssignedTopicsFromCache(Set<String> assignedTopics) {
+            assignedTopicNamesCache.values().retainAll(assignedTopics);
+        }
+    }
+    
 }


### PR DESCRIPTION
### Description
- Related Issue - https://issues.apache.org/jira/browse/KAFKA-19393
Currently, Both `SubscriptionState` and `AbstractMembershipManager` have states related with Assignment as their member fields.
So, it can be confusing point because which one is source of truth. 
Therefore, It would be better to consolidate consumer assignment state views.

### Discussion Points.
In this PR, `AbstractMembershipManager` has still `currentAssignments` and `currentTargetAssignments`. 
The `LocalAssignment` includes information of assignment and information of protocol between consumer - broker. 
So, I'm not sure that `AssignState` or `SubscriptionState` knows information of protocol between consumer - broker. 

So, apart from that, I’ve extracted all the remaining assignment-related data into `AssignState`.
In addition to, IMHO, Also, since `AssignState` is a subdomain of `Subscription` in terms of meaning, it has been extracted as an internal state within `Subscription`.

I made a commit based on my thoughts! 
It would like to hear feedback from others.

Please take a look, @lianetm  and other reviewer 🙇‍♂️ 
