### PR TITLE
MINOR: Fix topic option description in kafka-topics.sh

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -751,7 +751,7 @@ public abstract class TopicCommand {
                     KAFKA_CONFIGS_CLI_SUPPORTS_ALTERING_TOPIC_CONFIGS);
             describeOpt = parser.accepts("describe", "List details for the given topics.");
             topicOpt = parser.accepts("topic", "The topic to create, alter, describe or delete. It also accepts a regular " +
-                            "expression, except for --create option. Put topic name in double quotes; e.g. \"test.*\".")
+                            "expression, except for --create option.")
                 .withRequiredArg()
                 .describedAs("topic")
                 .ofType(String.class);

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -751,8 +751,7 @@ public abstract class TopicCommand {
                     KAFKA_CONFIGS_CLI_SUPPORTS_ALTERING_TOPIC_CONFIGS);
             describeOpt = parser.accepts("describe", "List details for the given topics.");
             topicOpt = parser.accepts("topic", "The topic to create, alter, describe or delete. It also accepts a regular " +
-                            "expression, except for --create option. Put topic name in double quotes and use the '\\' prefix " +
-                            "to escape regular expression symbols; e.g. \"test\\.topic\".")
+                            "expression, except for --create option. Put topic name in double quotes; e.g. \"test.*\".")
                 .withRequiredArg()
                 .describedAs("topic")
                 .ofType(String.class);


### PR DESCRIPTION
Update the --topic option description to clarify that regex symbols
don't   require backslash escaping. Using wildcards directly in double
quotes (e.g. "test.*")   works correctly.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
