### PR TITLE
KAFKA-19761 Gradle Shadow plugin version upgrade: 8.3.9 -->> 9.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ plugins {
 
   id "com.github.spotbugs" version '6.4.4' apply false
   id 'org.scoverage' version '8.1' apply false
-  id 'com.gradleup.shadow' version '8.3.9' apply false
+  id 'com.gradleup.shadow' version '9.3.1' apply false
   id 'com.diffplug.spotless' version "8.0.0"
 }
 


### PR DESCRIPTION
**Prologue:**
https://github.com/apache/kafka/pull/19513#discussion_r2365708218

:bulb: **Rationale:**   Gradle 10 will be released in Q4 2026 or Q1 2027
and we can't expect that Shadow plugin version 8 will be compatible:

<img width="780" height="215" alt="image"
src="https://github.com/user-attachments/assets/f9db215c-f6c8-4a6f-ad9d-f5fbb2871482"
/>

**Release notes for Shadow plugin:**
- https://gradleup.com/shadow/changes/#931-2026-01-06
___
I did some testing, and results look just fine :white_check_mark::
- gradle builds `./gradlew :jmh-benchmarks:shadowJar` and `./gradlew
releaseTarGz` are successful
- generated distributions (`kafka_2.13-4.3.0-SNAPSHOT-site-docs.tgz and`
and  `kafka_2.13-4.3.0-SNAPSHOT.tgz`) have identical file numbers (for
trunk and this branch)
- Kafka cluster starts and messages can be produced and consumed:
https://kafka.apache.org/quickstart
___
:warning: **~disclaimer notes:~**
- ~solution is generated via Gemini CLI~
- ~Gemini prompt is based on~ Jira ticket (previously created by me):
KAFKA-19761

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
