### PR TITLE
MINOR: update collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,16 +29,16 @@ notifications:
 # Read more here: https://github.com/apache/infrastructure-asfyaml
 github:
   collaborators:
+    - brandboat
+    - chirag-wadhwa5
+    - DL1231
     - m1a2st
+    - mingyen066
+    - Rancho-7
+    - sjhajharia
     - smjn
     - TaiJuWu
-    - brandboat
     - Yunyung
-    - xijiu
-    - chirag-wadhwa5
-    - mingyen066
-    - ShivsundarR
-    - Rancho-7
   enabled_merge_buttons:
     squash: true
     squash_commit_message: PR_TITLE_AND_DESC


### PR DESCRIPTION
Update collaborators (as part for the 4.1.1 release)

Update generated using the refresh_collaborators.py script (with the
script fixes from https://github.com/apache/kafka/pull/19459)

Reviewers: Andrew Schofield <aschofield@confluent.io>
