### PR TITLE
MINOR: Remove early access warning for streams rebalance protocol

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -63,8 +63,7 @@ public class GroupCoordinatorConfig {
     /// Group coordinator configs
     ///
     public static final String GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG = "group.coordinator.rebalance.protocols";
-    public static final String GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DOC = "The list of enabled rebalance protocols." +
-            "The " + Group.GroupType.STREAMS + " rebalance protocol is in early access and therefore must not be used in production.";
+    public static final String GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DOC = "The list of enabled rebalance protocols.";
     public static final List<String> GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DEFAULT = List.of(
         Group.GroupType.CLASSIC.toString(),
         Group.GroupType.CONSUMER.toString(),


### PR DESCRIPTION
The streams rebalance protocol will go GA in AK 4.2 according to
StreamsVersion
https://github.com/apache/kafka/blob/b0a26bc2f485fa7ec05ba1b5f9e9120fd43abbf4/server-common/src/main/java/org/apache/kafka/server/common/StreamsVersion.java#L29

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
