### PR TITLE
MINOR: Remove "share" from the valid values of `group.coordinator.rebalance.protocols` in doc

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerRackAwareTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerRackAwareTest.java
@@ -49,7 +49,7 @@ public class ShareConsumerRackAwareTest {
             @ClusterConfigProperty(id = 0, key = "broker.rack", value = "rack0"),
             @ClusterConfigProperty(id = 1, key = "broker.rack", value = "rack1"),
             @ClusterConfigProperty(id = 2, key = "broker.rack", value = "rack2"),
-            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic, share"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic"),
             @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNORS_CONFIG, value = "org.apache.kafka.clients.consumer.RackAwareAssignor")
         }
     )

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1802,11 +1802,6 @@ class KafkaConfigTest {
     props.put(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,streams")
     val config2 = KafkaConfig.fromProps(props)
     assertEquals(Set(GroupType.CLASSIC, GroupType.STREAMS), config2.groupCoordinatorRebalanceProtocols)
-
-    // Including "share" is also OK
-    props.put(GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, "classic,consumer,share")
-    val config3 = KafkaConfig.fromProps(props)
-    assertEquals(Set(GroupType.CLASSIC, GroupType.CONSUMER, GroupType.SHARE), config3.groupCoordinatorRebalanceProtocols)
   }
 
   @Test

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -71,7 +71,8 @@ public interface Group {
         
         static String[] documentValidValues() {
             return Arrays.stream(GroupType.values())
-                .filter(type -> type != UNKNOWN)
+                // This config no longer controls share group enablement
+                .filter(type -> type != UNKNOWN && type != SHARE) //
                 .map(GroupType::toString)
                 .toArray(String[]::new);
         }


### PR DESCRIPTION
I think "share" should be completely removed from
`group.coordinator.rebalance.protocols` because the KIP-932 doesn't
mention enabling it via this configuration at all, and the 4.1
documentation doesn't mention it either. Users looking at the 4.1 and
4.2 documentation would only see "share" listed in the valid values, and
according to the configuration description, protocols not specified
should be disabled. However, share groups work even when "share" is not
included in the configuration, which is inconsistent.
