### PR TITLE
MINOR: Add toString() to TaskAssignor implementations for better logging

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignor.java
@@ -37,6 +37,11 @@ public class MockAssignor implements TaskAssignor {
     }
 
     @Override
+    public String toString() {
+        return name();
+    }
+
+    @Override
     public GroupAssignment assign(
         final GroupSpec groupSpec,
         final TopologyDescriber topologyDescriber

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -45,6 +45,11 @@ public class StickyTaskAssignor implements TaskAssignor {
     }
 
     @Override
+    public String toString() {
+        return name();
+    }
+
+    @Override
     public GroupAssignment assign(final GroupSpec groupSpec, final TopologyDescriber topologyDescriber) throws TaskAssignorException {
         initialize(groupSpec, topologyDescriber);
         final GroupAssignment assignments =  doAssign(groupSpec, topologyDescriber);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/MockTaskAssignor.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/MockTaskAssignor.java
@@ -63,6 +63,11 @@ public class MockTaskAssignor implements TaskAssignor {
     }
 
     @Override
+    public String toString() {
+        return name();
+    }
+
+    @Override
     public GroupAssignment assign(final GroupSpec groupSpec, final TopologyDescriber topologyDescriber)
         throws TaskAssignorException {
         assignmentConfigs = groupSpec.assignmentConfigs();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/MockAssignorTest.java
@@ -38,6 +38,12 @@ public class MockAssignorTest {
     private final MockAssignor assignor = new MockAssignor();
 
     @Test
+    public void testToStringReturnsName() {
+        assertEquals("mock", assignor.name());
+        assertEquals(assignor.name(), assignor.toString());
+    }
+
+    @Test
     public void testZeroMembers() {
 
         TaskAssignorException ex = assertThrows(TaskAssignorException.class, () -> assignor.assign(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -46,6 +46,12 @@ public class StickyTaskAssignorTest {
     private final StickyTaskAssignor assignor = new StickyTaskAssignor();
 
     @Test
+    public void testToStringReturnsName() {
+        assertEquals("sticky", assignor.name());
+        assertEquals(assignor.name(), assignor.toString());
+    }
+
+    @Test
     public void shouldAssignOneActiveTaskToEachProcessWhenTaskCountSameAsProcessCount() {
         final AssignmentMemberSpec memberSpec1 = createAssignmentMemberSpec("process1");
         final AssignmentMemberSpec memberSpec2 = createAssignmentMemberSpec("process2");


### PR DESCRIPTION
When TaskAssignor instances are logged in GroupMetadataManager and
TargetAssignmentBuilder, they currently display the default Java object
representation (e.g., "StickyTaskAssignor@1a2b3c4d"). This change adds
toString() implementations to all TaskAssignor classes that return the
assignor's name, providing more meaningful log output.

Note: We implement toString() in each concrete class rather than as a
default method in the TaskAssignor interface because Java does not allow
default methods in interfaces to override methods from java.lang.Object.

Reviewers: Bill Bejeck<bbejeck@apache.org>
