### PR TITLE
MINOR: update docker_scan.yaml with 4.1.1

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # This is an array of supported tags. Make sure this array only contains the supported tags
-        supported_image_tag: ['latest', '3.9.1', '4.0.0', '4.1.0']
+        supported_image_tag: ['latest', '3.9.1', '4.0.0', '4.1.1']
     steps:
       - name: Run CVE scan
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1

--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # This is an array of supported tags. Make sure this array only contains the supported tags
-        supported_image_tag: ['latest', '3.9.1', '4.0.0', '4.1.1']
+        supported_image_tag: ['latest', '3.9.1', '4.0.1', '4.1.1']
     steps:
       - name: Run CVE scan
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1


### PR DESCRIPTION
Update docker supported tags as part of the 4.1.1 release

Fix for previous 4.0.1 release

Reviewers: Matthias J. Sax <matthias@confluent.io>
