### PR TITLE
MINOR: Add client response auth and version exp handling.

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2600,7 +2600,7 @@ public class SharePartition {
             case FENCED_LEADER_EPOCH, FENCED_STATE_EPOCH ->
                 new NotLeaderOrFollowerException(errorMessage);
             case SASL_AUTHENTICATION_FAILED, UNSUPPORTED_VERSION ->
-                new UnknownServerException("Unable to complete operation due to internal error.");
+                new UnknownServerException("Unable to complete operation due to server error.");
             default ->
                 new UnknownServerException(errorMessage);
         };

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -2599,6 +2599,8 @@ public class SharePartition {
                 new UnknownTopicOrPartitionException(errorMessage);
             case FENCED_LEADER_EPOCH, FENCED_STATE_EPOCH ->
                 new NotLeaderOrFollowerException(errorMessage);
+            case SASL_AUTHENTICATION_FAILED, UNSUPPORTED_VERSION ->
+                new UnknownServerException("Unable to complete operation due to internal error.");
             default ->
                 new UnknownServerException(errorMessage);
         };


### PR DESCRIPTION
* UnsupportedVersion and AuthenticationException were not explicitly
handled in `PersisterStateManger`.
* The issue to addressed in the PR.
* Comprehensive unit tests have been added.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Apoorv Mittal
 <apoorvmittal10@gmail.com>
