### PR TITLE
KAFKA-19876 Replace the base image since openjdk image is deprecated

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -44,8 +44,9 @@ docker_run_memory_limit="2000m"
 # The default number of cluster nodes to bring up if a number is not specified.
 default_num_nodes=14
 
-# The default OpenJDK base image.
-default_jdk="sapmachine:17-jdk-ubuntu-jammy:
+# The default JDK base image with apt-get support.
+# The openjdk image has been officially deprecated. For more imformation, see: https://hub.docker.com/_/openjdk
+default_jdk="sapmachine:17-jdk-ubuntu-jammy"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -45,9 +45,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-# The base image of openjdk:17 is typically oraclelinux:8-slim, which doesn't include apt-get. 
-# Therefore, use openjdk:17-bullseye instead.
-default_jdk="openjdk:17-bullseye"
+default_jdk="sapmachine:17-jdk-ubuntu-jammy:
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"


### PR DESCRIPTION
The openjdk image has been officially deprecated (ref:
https://hub.docker.com/_/openjdk  ), so we’ll need to switch to another
base image for our E2E test environment.

I tested this on my local machine using the following command:
```
jdk_version="sapmachine:17-jdk-ubuntu-jammy" \
image_name="ducker-ak:$(git rev-parse --short HEAD)" \
TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py" \
/bin/bash tests/docker/run_tests.sh
```
result:
```
[INFO:2025-11-14 14:40:35,072]: RunnerClient:
kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT:
PASS
[WARNING - 2025-11-14 14:40:35,072 - runner_client - log - lineno:459]:
RunnerClient:
kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT:
Test requested 4 nodes, used only 3
[WARNING:2025-11-14 14:40:35,072]: RunnerClient:
kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT:
Test requested 4 nodes, used only 3
[INFO:2025-11-14 14:40:35,073]: RunnerClient:
kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT:
Data: None
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-11-14--004
run time:         13.568 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:
kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   13.460 seconds
--------------------------------------------------------------------------------
```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ming-Yen Chung
 <mingyen066@gmail.com>, PoAn Yang <payang@apache.org>
