### PR TITLE
MINOR: Correct the typo 'paramter' to 'parameter'

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2063,7 +2063,7 @@ public class StreamsPartitionAssignorTest {
 
     private void shouldReturnLowestAssignmentVersionForDifferentSubscriptionVersions(final int smallestVersion,
                                                                                      final int otherVersion,
-                                                                                     final Map<String, Object> paramterizedObject) {
+                                                                                     final Map<String, Object> parameterizedObject) {
         subscriptions.put("consumer1",
                           new Subscription(
                               Collections.singletonList("topic1"),
@@ -2083,7 +2083,7 @@ public class StreamsPartitionAssignorTest {
                           )
         );
 
-        configureDefault(paramterizedObject);
+        configureDefault(parameterizedObject);
 
         final Map<String, Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/README.md
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/README.md
@@ -23,7 +23,7 @@ public class SampleTest {
 }
 ```
 
-The defaults can be modified by setting specific paramters on the annotation. 
+The defaults can be modified by setting specific parameters on the annotation. 
 
 ```java
 public class SampleTest {


### PR DESCRIPTION
Correct the typo 'paramter' to 'parameter'

Reviewers: Andrew Schofield <aschofield@confluent.io>, Liam
 Clarke-Hutchinson <liam@steelsky.co.nz>, Nick Guo
 <lansg0504@gmail.com>, Ken Huang <s7133700@gmail.com>
