### PR TITLE
KAFKA-19286: Fix flaky testConcurrentRemoveReadForCache1

### DIFF
--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/RemoteIndexCacheTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.storage.internals.log;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
@@ -122,7 +121,7 @@ public class RemoteIndexCacheTest {
         rlsMetadata = new RemoteLogSegmentMetadata(remoteLogSegmentId, baseOffset, lastOffset, time.milliseconds(),
                 brokerId, time.milliseconds(), segmentSize, Collections.singletonMap(0, 0L));
         cache = new RemoteIndexCache(defaultRemoteIndexCacheSizeBytes, rsm, logDir.toString());
-        cache.setFileDeleteDelayMs(0);
+        cache.setFileDeleteDelayMs(20);
         mockRsmFetchIndex(rsm);
     }
 
@@ -773,7 +772,6 @@ public class RemoteIndexCacheTest {
     }
 
     @Test
-    @Flaky("KAFKA-19286")
     public void testConcurrentRemoveReadForCache1() throws IOException, InterruptedException, ExecutionException {
         // Create a spy Cache Entry
         RemoteIndexCache.Entry spyEntry = generateSpyCacheEntry();


### PR DESCRIPTION
## Fix for flaky testConcurrentRemoveReadForCache1

### Short description of root cause:
Before scheduler starts clean up, he's triggering read thread. If it's
happening before RemoteIndexCache#remove does remove entity from cache,
reader thread will successfully read entity, and won't trigger fetching
from remote log

### Full analysis:
https://issues.apache.org/jira/browse/KAFKA-19286

### Evidence:
Run entire test class and annotate testConcurrentRemoveReadForCache1 as
RepeatedTest to run 100_000 times

**Result:**

`./gradlew storage:test --tests
org.apache.kafka.storage.internals.log.RemoteIndexCacheTest`  ...
`BUILD SUCCESSFUL in 48m 11s`
