### PR TITLE
KAFKA-19889  max.connections.per.ip.overrides does not apply overrides to all IPs for multi-IP hostnames

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1285,7 +1285,10 @@ private[kafka] class Processor(
 class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extends Logging with AutoCloseable {
 
   @volatile private var defaultMaxConnectionsPerIp: Int = config.maxConnectionsPerIp
-  @volatile private var maxConnectionsPerIpOverrides = config.maxConnectionsPerIpOverrides.map { case (host, count) => (InetAddress.getByName(host), count) }
+  @volatile private var maxConnectionsPerIpOverrides =
+    config.maxConnectionsPerIpOverrides.flatMap { case (host, count) =>
+      InetAddress.getAllByName(host).toSeq.map(addr => addr -> count)
+    }
   @volatile private var brokerMaxConnections = config.maxConnections
   private val interBrokerListenerName = config.interBrokerListenerName
   private val counts = mutable.Map[InetAddress, Int]()

--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -751,6 +751,47 @@ class ConnectionQuotasTest {
       s"Number of connections on EXTERNAL listener:")
   }
 
+  @Test
+  def testMaxConnectionsPerIpOverrideAppliedToAllResolvedAddresses(): Unit = {
+
+    val overrideLimit = 5
+    val props = brokerPropsWithDefaultConnectionLimits
+    props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_CONFIG, 1)
+    props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$overrideLimit")
+    val config = KafkaConfig.fromProps(props)
+    connectionQuotas = new ConnectionQuotas(config, time, metrics)
+
+    addListenersAndVerify(config, connectionQuotas)
+
+    val listener = listeners("EXTERNAL")
+    // resolve "localhost" to all its addresses (e.g. IPv4 and IPv6)
+    val resolvedAddrs = InetAddress.getAllByName("localhost").toSeq
+
+    // For each resolved address, ensure override applies independently
+    resolvedAddrs.foreach { addr =>
+      // start from a clean slate for this address
+      assertEquals(0, connectionQuotas.get(addr), s"Expected 0 connections for $addr before test")
+
+      // increment up to the override limit
+      for (_ <- 0 until overrideLimit) {
+        connectionQuotas.inc(listener.listenerName, addr, blockedPercentMeters("EXTERNAL"))
+      }
+      assertEquals(overrideLimit, connectionQuotas.get(addr), s"Expected $overrideLimit connections for $addr after increments")
+
+      // next increment should be rejected (but inc() still increments the counter)
+      assertThrows(classOf[TooManyConnectionsException], () =>
+        connectionQuotas.inc(listener.listenerName, addr, blockedPercentMeters("EXTERNAL"))
+      )
+
+      // remove the rejected connection increment before normal cleanup
+      connectionQuotas.dec(listener.listenerName, addr)
+
+      // cleanup: remove the added connections
+      for (_ <- 0 until overrideLimit) connectionQuotas.dec(listener.listenerName, addr)
+      assertEquals(0, connectionQuotas.get(addr), s"Expected 0 connections for $addr after cleanup")
+    }
+  }
+
   private def addListenersAndVerify(config: KafkaConfig, connectionQuotas: ConnectionQuotas) : Unit = {
     addListenersAndVerify(config, util.Map.of, connectionQuotas)
   }


### PR DESCRIPTION
This fix addresses a bug where `max.connections.per.ip.overrides` does not correctly apply the override value to all IP addresses resolved from a multi-IP hostname.

### Background

`max.connections.per.ip` can be overridden per host using the `max.connections.per.ip.overrides` configuration.
The override can be specified using either an IP address or a hostname.

When a hostname resolves to multiple IP addresses (e.g., when pointing to a load balancer or an auto-scaling group), the broker currently applies the override only to the first resolved IP address.
This occurs because the existing implementation relies on InetAddress.getByName(host), which internally returns only the first value from InetAddress.getAllByName(host).

As a result, additional backend IPs continue to use the default max.connections.per.ip value, leading to inconsistent connection limits for the same logical host.