### PR TITLE
KAFKA-19815: Implement acquisitionLockTimeoutMs

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -260,8 +260,10 @@ public class ShareConsumerTest {
             producer.send(record);
             producer.flush();
             shareConsumer.subscribe(Set.of(tp.topic()));
+            assertEquals(Optional.empty(), shareConsumer.acquisitionLockTimeoutMs());
             ConsumerRecords<byte[], byte[]> records = waitedPoll(shareConsumer, 2500L, 1);
             assertEquals(1, records.count());
+            assertEquals(Optional.of(15000), shareConsumer.acquisitionLockTimeoutMs());
             verifyShareGroupStateTopicRecordsProduced();
         }
     }
@@ -276,8 +278,10 @@ public class ShareConsumerTest {
             producer.send(record);
             producer.flush();
             shareConsumer.subscribe(Set.of(tp.topic()));
+            assertEquals(Optional.empty(), shareConsumer.acquisitionLockTimeoutMs());
             ConsumerRecords<byte[], byte[]> records = waitedPoll(shareConsumer, 2500L, 1);
             assertEquals(1, records.count());
+            assertEquals(Optional.of(15000), shareConsumer.acquisitionLockTimeoutMs());
             producer.send(record);
             records = shareConsumer.poll(Duration.ofMillis(5000));
             assertEquals(1, records.count());
@@ -323,11 +327,14 @@ public class ShareConsumerTest {
             shareConsumer.setAcknowledgementCommitCallback(new TestableAcknowledgementCommitCallback(partitionOffsetsMap, partitionExceptionMap));
 
             shareConsumer.subscribe(Set.of(tp.topic()));
+            assertEquals(Optional.empty(), shareConsumer.acquisitionLockTimeoutMs());
 
             TestUtils.waitForCondition(() -> shareConsumer.poll(Duration.ofMillis(2000)).count() == 1,
                 DEFAULT_MAX_WAIT_MS, 100L, () -> "Failed to consume records for share consumer");
 
+            assertEquals(Optional.of(15000), shareConsumer.acquisitionLockTimeoutMs());
             shareConsumer.subscribe(Set.of(tp2.topic()));
+            assertEquals(Optional.of(15000), shareConsumer.acquisitionLockTimeoutMs());
 
             // Waiting for heartbeat to propagate the subscription change.
             TestUtils.waitForCondition(() -> {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -821,6 +821,8 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
                         fetchTarget.id(),
                         tip,
                         partitionData,
+                        response.data().acquisitionLockTimeoutMs() > 0
+                            ? Optional.of(response.data().acquisitionLockTimeoutMs()) : Optional.empty(),
                         shareFetchMetricsAggregator,
                         requestVersion)
                 );

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -892,7 +892,12 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      */
     @Override
     public Optional<Integer> acquisitionLockTimeoutMs() {
-        return currentFetch.acquisitionLockTimeoutMs();
+        acquireAndEnsureOpen();
+        try {
+            return currentFetch.acquisitionLockTimeoutMs();
+        } finally {
+            release();
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -892,8 +892,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      */
     @Override
     public Optional<Integer> acquisitionLockTimeoutMs() {
-        // To be implemented
-        return Optional.empty();
+        return currentFetch.acquisitionLockTimeoutMs();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -36,16 +37,18 @@ public class ShareInFlightBatch<K, V> {
     private Map<Long, ConsumerRecord<K, V>> renewedRecords;
     private final Set<Long> acknowledgedRecords;
     private Acknowledgements acknowledgements;
+    private final Optional<Integer> acquisitionLockTimeoutMs;
     private ShareInFlightBatchException exception;
     private boolean hasCachedException = false;
     private boolean checkForRenewAcknowledgements = false;
 
-    public ShareInFlightBatch(int nodeId, TopicIdPartition partition) {
+    public ShareInFlightBatch(int nodeId, TopicIdPartition partition, Optional<Integer> acquisitionLockTimeoutMs) {
         this.nodeId = nodeId;
         this.partition = partition;
         this.inFlightRecords = new TreeMap<>();
         this.acknowledgedRecords = new TreeSet<>();
         this.acknowledgements = Acknowledgements.empty();
+        this.acquisitionLockTimeoutMs = acquisitionLockTimeoutMs;
     }
 
     public void addAcknowledgement(long offset, AcknowledgeType type) {
@@ -180,6 +183,10 @@ public class ShareInFlightBatch<K, V> {
 
     Acknowledgements getAcknowledgements() {
         return acknowledgements;
+    }
+
+    Optional<Integer> getAcquisitionLockTimeoutMs() {
+        return acquisitionLockTimeoutMs;
     }
 
     public boolean isEmpty() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
@@ -65,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ShareCompletedFetchTest {
     private static final String TOPIC_NAME = "test";
     private static final TopicIdPartition TIP = new TopicIdPartition(Uuid.randomUuid(), 0, TOPIC_NAME);
+    private static final Optional<Integer> DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS = Optional.of(30000);
     private static final long PRODUCER_ID = 1000L;
     private static final short PRODUCER_EPOCH = 0;
 
@@ -428,6 +429,7 @@ public class ShareCompletedFetchTest {
             0,
             TIP,
             partitionData,
+            DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS,
             shareFetchMetricsAggregator,
             ApiKeys.SHARE_FETCH.latestVersion());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareCompletedFetchTest.java
@@ -90,6 +90,7 @@ public class ShareCompletedFetchTest {
         assertEquals(Optional.of((short) 1), record.deliveryCount());
         Acknowledgements acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
 
         batch = completedFetch.fetchRecords(deserializers, 10, true);
         records = batch.getInFlightRecords();
@@ -99,12 +100,14 @@ public class ShareCompletedFetchTest {
         assertEquals(Optional.of((short) 1), record.deliveryCount());
         acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
 
         batch = completedFetch.fetchRecords(deserializers, 10, true);
         records = batch.getInFlightRecords();
         assertEquals(0, records.size());
         acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
     }
 
     @Test
@@ -127,12 +130,14 @@ public class ShareCompletedFetchTest {
         assertEquals(Optional.of((short) 1), record.deliveryCount());
         Acknowledgements acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
 
         batch = completedFetch.fetchRecords(deserializers, 10, true);
         records = batch.getInFlightRecords();
         assertEquals(0, records.size());
         acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
     }
 
     @Test
@@ -155,12 +160,14 @@ public class ShareCompletedFetchTest {
         assertEquals(Optional.of((short) 1), record.deliveryCount());
         Acknowledgements acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
 
         batch = completedFetch.fetchRecords(deserializers, 10, true);
         records = batch.getInFlightRecords();
         assertEquals(0, records.size());
         acknowledgements = batch.getAcknowledgements();
         assertEquals(0, acknowledgements.size());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
     }
 
     @Test
@@ -178,6 +185,7 @@ public class ShareCompletedFetchTest {
             assertEquals(10, records.size());
             Acknowledgements acknowledgements = batch.getAcknowledgements();
             assertEquals(0, acknowledgements.size());
+            assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
         }
     }
 
@@ -196,6 +204,7 @@ public class ShareCompletedFetchTest {
             assertEquals(0, records.size());
             Acknowledgements acknowledgements = batch.getAcknowledgements();
             assertEquals(0, acknowledgements.size());
+            assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
         }
     }
 
@@ -211,6 +220,7 @@ public class ShareCompletedFetchTest {
             assertEquals(0, records.size());
             Acknowledgements acknowledgements = batch.getAcknowledgements();
             assertEquals(0, acknowledgements.size());
+            assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
         }
     }
 
@@ -264,6 +274,7 @@ public class ShareCompletedFetchTest {
                 acknowledgements = batch.getAcknowledgements();
                 assertEquals(1, acknowledgements.size());
                 assertEquals(AcknowledgeType.RELEASE, acknowledgements.get(1L));
+                assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
 
                 // Record 2 then results in an empty batch, because record 1 has now been skipped
                 batch = completedFetch.fetchRecords(deserializers, 10, false);
@@ -281,6 +292,7 @@ public class ShareCompletedFetchTest {
                 acknowledgements = batch.getAcknowledgements();
                 assertEquals(1, acknowledgements.size());
                 assertEquals(AcknowledgeType.RELEASE, acknowledgements.get(2L));
+                assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
 
                 // Record 3 is returned in the next batch, because record 2 has now been skipped
                 batch = completedFetch.fetchRecords(deserializers, 10, false);
@@ -290,6 +302,7 @@ public class ShareCompletedFetchTest {
                 assertEquals(3L, fetchedRecords.get(0).offset());
                 acknowledgements = batch.getAcknowledgements();
                 assertEquals(0, acknowledgements.size());
+                assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, batch.getAcquisitionLockTimeoutMs());
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -347,6 +347,8 @@ public class ShareConsumerImplTest {
         consumer.close();
         final IllegalStateException res = assertThrows(IllegalStateException.class, consumer::subscription);
         assertEquals("This consumer has already been closed.", res.getMessage());
+        final IllegalStateException res2 = assertThrows(IllegalStateException.class, consumer::acquisitionLockTimeoutMs);
+        assertEquals("This consumer has already been closed.", res2.getMessage());
     }
 
     @Test
@@ -427,10 +429,12 @@ public class ShareConsumerImplTest {
         List<String> topics = Collections.singletonList(topic);
         completeShareSubscriptionChangeApplicationEventSuccessfully(subscriptions, topics);
         consumer.subscribe(topics);
+        assertEquals(Optional.empty(), consumer.acquisitionLockTimeoutMs());
 
         // First poll should succeed and return records
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
         assertEquals(2, records.count(), "Should have received 2 records");
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, consumer.acquisitionLockTimeoutMs());
 
         // Second poll should fail because records weren't acknowledged
         IllegalStateException exception = assertThrows(
@@ -441,6 +445,7 @@ public class ShareConsumerImplTest {
             exception.getMessage().contains("All records must be acknowledged in explicit acknowledgement mode."),
             "Unexpected error message: " + exception.getMessage()
         );
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, consumer.acquisitionLockTimeoutMs());
 
         // Verify that acknowledging one record but not all still throws exception
         Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
@@ -508,6 +513,7 @@ public class ShareConsumerImplTest {
         // First poll should succeed and return records
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
         assertEquals(2, records.count(), "Should have received 2 records");
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, consumer.acquisitionLockTimeoutMs());
 
         // Renew the first record and accept the second
         Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
@@ -518,6 +524,7 @@ public class ShareConsumerImplTest {
         records = consumer.poll(Duration.ofMillis(100));
         assertEquals(0, records.count(), "Should have received 1 record");
         assertTrue(firstFetch.hasRenewals());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, consumer.acquisitionLockTimeoutMs());
 
         Acknowledgements acks = Acknowledgements.empty();
         acks.add(0, AcknowledgeType.RENEW);
@@ -532,6 +539,7 @@ public class ShareConsumerImplTest {
         ConsumerRecord<String, String> renewedRecord = iterator.next();
         assertEquals(0, renewedRecord.offset());
         consumer.acknowledge(renewedRecord);
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, consumer.acquisitionLockTimeoutMs());
 
         // Set up next fetch to return no records
         doReturn(ShareFetch.empty())
@@ -557,6 +565,7 @@ public class ShareConsumerImplTest {
         // Verify that poll succeeds and returns new records
         ConsumerRecords<String, String> newRecords = consumer.poll(Duration.ofMillis(100));
         assertEquals(2, newRecords.count(), "Should have received 2 new records");
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, consumer.acquisitionLockTimeoutMs());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImplTest.java
@@ -69,6 +69,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -101,6 +102,7 @@ import static org.mockito.Mockito.verify;
 @SuppressWarnings("unchecked")
 public class ShareConsumerImplTest {
 
+    private static final Optional<Integer> DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS = Optional.of(30000);
     private ShareConsumerImpl<String, String> consumer = null;
 
     private final Time time = new MockTime(1);
@@ -257,7 +259,7 @@ public class ShareConsumerImplTest {
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(subscriptions);
 
-        // Setup subscription
+        // Set up subscription
         final String topicName = "foo";
         final List<String> subscriptionTopic = Collections.singletonList(topicName);
         completeShareSubscriptionChangeApplicationEventSuccessfully(subscriptions, subscriptionTopic);
@@ -265,7 +267,7 @@ public class ShareConsumerImplTest {
 
         // Create a fetch with only GAP (no records)
         final TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), 0, topicName);
-        final ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip);
+        final ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         // Add GAP without adding any records
         batch.addGap(1);
         
@@ -275,7 +277,7 @@ public class ShareConsumerImplTest {
 
         consumer.poll(Duration.ZERO);
 
-        // Verify that a ShareAcknowledeAsyncEvent was sent with the acknowledgement GAP for offset 1
+        // Verify that a ShareAcknowledgeAsyncEvent was sent with the acknowledgement GAP for offset 1
         verify(applicationEventHandler).add(argThat(event -> {
             if (!(event instanceof ShareAcknowledgeAsyncEvent)) {
                 return false;
@@ -316,7 +318,7 @@ public class ShareConsumerImplTest {
         final String topicName = "foo";
         final int partition = 3;
         final TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), partition, topicName);
-        final ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip);
+        final ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         batch.addRecord(new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"));
         doAnswer(invocation -> {
             consumer.wakeup();
@@ -352,9 +354,9 @@ public class ShareConsumerImplTest {
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(subscriptions);
 
-        // Setup test data
+        // Set up test data
         String topic = "test-topic";
-        // Setup an empty fetch.
+        // Set up an empty fetch.
         ShareFetch<String, String> firstFetch = ShareFetch.empty();
 
         doReturn(firstFetch)
@@ -362,7 +364,7 @@ public class ShareConsumerImplTest {
                 .when(fetchCollector)
                 .collect(any(ShareFetchBuffer.class));
 
-        // Setup subscription
+        // Set up subscription
         List<String> topics = Collections.singletonList(topic);
         completeShareSubscriptionChangeApplicationEventSuccessfully(subscriptions, topics);
         consumer.subscribe(topics);
@@ -396,7 +398,7 @@ public class ShareConsumerImplTest {
 
     @Test
     public void testExplicitModeUnacknowledgedRecords() {
-        // Setup consumer with explicit acknowledgement mode
+        // Set up consumer with explicit acknowledgement mode
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(
                 mock(ShareFetchBuffer.class),
@@ -405,15 +407,15 @@ public class ShareConsumerImplTest {
                 "client-id",
                 "explicit");
 
-        // Setup test data
+        // Set up test data
         String topic = "test-topic";
         int partition = 0;
         TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), partition, topic);
-        ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip);
+        ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         batch.addRecord(new ConsumerRecord<>(topic, partition, 0, "key1", "value1"));
         batch.addRecord(new ConsumerRecord<>(topic, partition, 1, "key2", "value2"));
 
-        // Setup first fetch to return records
+        // Set up first fetch to return records
         ShareFetch<String, String> firstFetch = ShareFetch.empty();
         firstFetch.add(tip, batch);
         doReturn(firstFetch)
@@ -421,7 +423,7 @@ public class ShareConsumerImplTest {
             .when(fetchCollector)
             .collect(any(ShareFetchBuffer.class));
 
-        // Setup subscription
+        // Set up subscription
         List<String> topics = Collections.singletonList(topic);
         completeShareSubscriptionChangeApplicationEventSuccessfully(subscriptions, topics);
         consumer.subscribe(topics);
@@ -455,9 +457,9 @@ public class ShareConsumerImplTest {
         // Verify that after acknowledging all records, poll succeeds
         consumer.acknowledge(iterator.next());
         
-        // Setup second fetch to return new records
+        // Set up second fetch to return new records
         ShareFetch<String, String> secondFetch = ShareFetch.empty();
-        ShareInFlightBatch<String, String> newBatch = new ShareInFlightBatch<>(2, tip);
+        ShareInFlightBatch<String, String> newBatch = new ShareInFlightBatch<>(2, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         newBatch.addRecord(new ConsumerRecord<>(topic, partition, 2, "key3", "value3"));
         newBatch.addRecord(new ConsumerRecord<>(topic, partition, 3, "key4", "value4"));
         secondFetch.add(tip, newBatch);
@@ -474,7 +476,7 @@ public class ShareConsumerImplTest {
 
     @Test
     public void testExplicitModeRenewAndAcknowledgeOnPoll() {
-        // Setup consumer with explicit acknowledgement mode
+        // Set up consumer with explicit acknowledgement mode
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(
             mock(ShareFetchBuffer.class),
@@ -483,22 +485,22 @@ public class ShareConsumerImplTest {
             "client-id",
             "explicit");
 
-        // Setup test data
+        // Set up test data
         String topic = "test-topic";
         int partition = 0;
         TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), partition, topic);
-        ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip);
+        ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         batch.addRecord(new ConsumerRecord<>(topic, partition, 0, "key1", "value1"));
         batch.addRecord(new ConsumerRecord<>(topic, partition, 1, "key2", "value2"));
 
-        // Setup first fetch to return records
+        // Set up first fetch to return records
         ShareFetch<String, String> firstFetch = ShareFetch.empty();
         firstFetch.add(tip, batch);
         doReturn(firstFetch)
             .when(fetchCollector)
             .collect(any(ShareFetchBuffer.class));
 
-        // Setup subscription
+        // Set up subscription
         List<String> topics = Collections.singletonList(topic);
         completeShareSubscriptionChangeApplicationEventSuccessfully(subscriptions, topics);
         consumer.subscribe(topics);
@@ -531,7 +533,7 @@ public class ShareConsumerImplTest {
         assertEquals(0, renewedRecord.offset());
         consumer.acknowledge(renewedRecord);
 
-        // Setup next fetch to return no records
+        // Set up next fetch to return no records
         doReturn(ShareFetch.empty())
             .when(fetchCollector)
             .collect(any(ShareFetchBuffer.class));
@@ -540,9 +542,9 @@ public class ShareConsumerImplTest {
         records = consumer.poll(Duration.ofMillis(100));
         assertTrue(records.isEmpty());
 
-        // Setup next fetch to return new records
+        // Set up next fetch to return new records
         ShareFetch<String, String> thirdFetch = ShareFetch.empty();
-        ShareInFlightBatch<String, String> newBatch = new ShareInFlightBatch<>(2, tip);
+        ShareInFlightBatch<String, String> newBatch = new ShareInFlightBatch<>(2, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         newBatch.addRecord(new ConsumerRecord<>(topic, partition, 2, "key3", "value3"));
         newBatch.addRecord(new ConsumerRecord<>(topic, partition, 3, "key4", "value4"));
         thirdFetch.add(tip, newBatch);
@@ -571,7 +573,7 @@ public class ShareConsumerImplTest {
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(subscriptions);
 
-        // Setup the expected successful completion of close events
+        // Set up the expected successful completion of close events
         completeShareAcknowledgeOnCloseApplicationEventSuccessfully();
         completeShareUnsubscribeApplicationEventSuccessfully(subscriptions);
 
@@ -779,7 +781,7 @@ public class ShareConsumerImplTest {
 
         final TopicPartition tp = new TopicPartition("topic", 0);
         final TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), tp);
-        final ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip);
+        final ShareInFlightBatch<String, String> batch = new ShareInFlightBatch<>(0, tip, DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS);
         batch.addRecord(new ConsumerRecord<>("topic", 0, 2, "key1", "value1"));
         final ShareFetch<String, String> fetch = ShareFetch.empty();
         fetch.add(tip, batch);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchBufferTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ShareFetchBufferTest {
 
+    private static final Optional<Integer> DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS = Optional.of(30000);
     private final Time time = new MockTime(0, 0, 0);
     private final TopicIdPartition topicAPartition0 = new TopicIdPartition(Uuid.randomUuid(), 0, "topic-a");
     private final TopicIdPartition topicAPartition1 = new TopicIdPartition(Uuid.randomUuid(), 1, "topic-a");
@@ -170,6 +172,7 @@ public class ShareFetchBufferTest {
                 0,
                 tp,
                 partitionData,
+                DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS,
                 shareFetchMetricsAggregator,
                 ApiKeys.SHARE_FETCH.latestVersion());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
@@ -74,6 +74,7 @@ public class ShareFetchCollectorTest {
 
     private static final int DEFAULT_RECORD_COUNT = 10;
     private static final int DEFAULT_MAX_POLL_RECORDS = ConsumerConfig.DEFAULT_MAX_POLL_RECORDS;
+    private static final Optional<Integer> DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS = Optional.of(30000);
     private final TopicIdPartition topicAPartition0 = new TopicIdPartition(Uuid.randomUuid(), 0, "topic-a");
     private LogContext logContext;
 
@@ -417,6 +418,7 @@ public class ShareFetchCollectorTest {
                     0,
                     topicAPartition0,
                     partitionData,
+                    DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS,
                     shareFetchMetricsAggregator,
                     ApiKeys.SHARE_FETCH.latestVersion());
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareFetchCollectorTest.java
@@ -156,6 +156,7 @@ public class ShareFetchCollectorTest {
         ShareFetch<String, String> fetch = fetchCollector.collect(fetchBuffer);
         assertFalse(fetch.isEmpty());
         assertEquals(recordCount, fetch.numRecords());
+        assertEquals(DEFAULT_ACQUISITION_LOCK_TIMEOUT_MS, fetch.acquisitionLockTimeoutMs());
 
         // When we collected the data from the buffer, this will cause the completed fetch to get initialized.
         assertTrue(completedFetch.isInitialized());


### PR DESCRIPTION
Implement KafkaShareConsumer.acquisitionLockTimeoutMs as part of
KIP-1222.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
