### PR TITLE
KAFKA-19890: Fix stop command failure after wmic removal in newer Windows.

### DIFF
--- a/bin/windows/kafka-server-stop.bat
+++ b/bin/windows/kafka-server-stop.bat
@@ -14,5 +14,10 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-wmic process where (commandline like "%%kafka.Kafka%%" and not name="wmic.exe") delete
+where wmic >nul 2>&1
+IF NOT ERRORLEVEL 1 (
+    wmic process where "commandline like '%%kafka.Kafka%%' and not name='wmic.exe'" delete
+) ELSE (
+	powershell -Command "Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'java.exe' -and $_.CommandLine -like '*kafka.Kafka*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }"
+)
 rem ps ax | grep -i 'kafka.Kafka' | grep -v grep | awk '{print $1}' | xargs kill -SIGTERM


### PR DESCRIPTION
Hi Team:

Refer to https://issues.apache.org/jira/browse/KAFKA-19890

In windows 11. It failed to start/stop the kafka due to the WMIC tool is superseded by Windows PowerShell.
WMIC is used only in two places (start + stop)
<img width="1232" height="179" alt="image" src="https://github.com/user-attachments/assets/8de656a1-c717-4524-b957-5f76d1434558" />

More background information: 
https://techcommunity.microsoft.com/blog/windows-itpro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/4039242


Proposing a new PR to fix this issue. Since I found that PR #20257 already covers the startup side, So I removed my startup changes and kept only the stop fix. Thanks.

Attach part of the tests of result (verify the command) for this PR except the basic tests:
<img width="1668" height="313" alt="image" src="https://github.com/user-attachments/assets/ca9af8ad-0fdc-4444-9928-b338ef6dcc15" />

Thanks a lot!