### PR TITLE
MINOR: Correct missing space in RecordState exception message

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
@@ -49,7 +49,7 @@ public enum RecordState {
     public RecordState validateTransition(RecordState newState) throws IllegalStateException {
         Objects.requireNonNull(newState, "newState cannot be null");
         if (this == newState) {
-            throw new IllegalStateException("The state transition is invalid as the new state is"
+            throw new IllegalStateException("The state transition is invalid as the new state is "
                 + "the same as the current state");
         }
 


### PR DESCRIPTION
Correct a missing space in `RecordState#validateTransition` exception
message to improve log readability.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Ken Huang
 <s7133700@gmail.com>
