### PR TITLE
KAFKA-19862: Group coordinator loading may fail when there is concurrent compaction

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -815,10 +815,10 @@ public class GroupMetadataManager {
         }
 
         if (group == null) {
-            return new ConsumerGroup(snapshotRegistry, groupId);
+            return new ConsumerGroup(logContext, snapshotRegistry, groupId);
         } else if (createIfNotExists && maybeDeleteEmptyClassicGroup(group, records)) {
             log.info("[GroupId {}] Converted the empty classic group to a consumer group.", groupId);
-            return new ConsumerGroup(snapshotRegistry, groupId);
+            return new ConsumerGroup(logContext, snapshotRegistry, groupId);
         } else {
             if (group.type() == CONSUMER) {
                 return (ConsumerGroup) group;
@@ -982,7 +982,7 @@ public class GroupMetadataManager {
         }
 
         if (group == null) {
-            ConsumerGroup consumerGroup = new ConsumerGroup(snapshotRegistry, groupId);
+            ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId);
             groups.put(groupId, consumerGroup);
             return consumerGroup;
         } else if (group.type() == CONSUMER) {
@@ -992,7 +992,7 @@ public class GroupMetadataManager {
             // offsets if no group existed. Simple classic groups are not backed by any records
             // in the __consumer_offsets topic hence we can safely replace it here. Without this,
             // replaying consumer group records after offset commit records would not work.
-            ConsumerGroup consumerGroup = new ConsumerGroup(snapshotRegistry, groupId);
+            ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId);
             groups.put(groupId, consumerGroup);
             return consumerGroup;
         } else {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1371,6 +1371,7 @@ public class GroupMetadataManager {
         ConsumerGroup consumerGroup;
         try {
             consumerGroup = ConsumerGroup.fromClassicGroup(
+                logContext,
                 snapshotRegistry,
                 classicGroup,
                 topicHashCache,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -28,8 +28,8 @@ import org.apache.kafka.common.message.ConsumerProtocolAssignment;
 import org.apache.kafka.common.message.ConsumerProtocolSubscription;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.SchemaException;
-import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.CommitPartitionValidator;
@@ -49,6 +49,7 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
 import org.apache.kafka.timeline.TimelineObject;
+
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
@@ -1055,7 +1056,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                     assignedPartitions.forEach(partitionId -> {
                         Integer prevValue = partitionsOrNull.get(partitionId);
                         if (prevValue != expectedEpoch) {
-                            log.warn(
+                            log.debug(
                                 String.format("Cannot remove the epoch %d from %s-%s because the partition is " +
                                     "still owned at a different epoch %d", expectedEpoch, topicId, partitionId, prevValue));
                         } else {
@@ -1068,7 +1069,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                         return partitionsOrNull;
                     }
                 } else {
-                    log.warn(
+                    log.debug(
                         String.format("Cannot remove the epoch %d from %s because it does not have any epoch",
                             expectedEpoch, topicId));
                     return partitionsOrNull;
@@ -1096,7 +1097,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                 for (Integer partitionId : assignedPartitions) {
                     Integer prevValue = partitionsOrNull.put(partitionId, epoch);
                     if (prevValue != null) {
-                        log.warn(
+                        log.debug(
                             String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
                                 "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
                     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -174,7 +174,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         SnapshotRegistry snapshotRegistry,
         String groupId
     ) {
-        ConsumerGroup(new LogContext("[Group Coordinator id=" + groupId + "]"), snapshotRegistry, groupId);
+        this(new LogContext("[Group Coordinator id=" + groupId + "]"), snapshotRegistry, groupId);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -107,6 +107,9 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         }
     }
 
+    /**
+     * The logger.
+     */
     private final Logger log;
 
     /**
@@ -1084,6 +1087,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @param assignment    The assignment.
      * @param epoch         The new epoch.
+     * @throws IllegalStateException if updating a partition with a smaller or equal epoch.
      * package-private for testing.
      */
     void addPartitionEpochs(
@@ -1096,12 +1100,16 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                     partitionsOrNull = new TimelineHashMap<>(snapshotRegistry, assignedPartitions.size());
                 }
                 for (Integer partitionId : assignedPartitions) {
-                    Integer prevValue = partitionsOrNull.put(partitionId, epoch);
+                    Integer prevValue = partitionsOrNull.get(partitionId);
                     if (prevValue != null) {
-                        log.debug(
-                            String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
-                                "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
+                        if (prevValue > epoch) {
+                            throw new IllegalStateException(
+                                String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
+                                    "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
+                        }
                     }
+                    // Update if previous epoch does not exist or the new epoch is larger.
+                    partitionsOrNull.put(partitionId, epoch);
                 }
                 return partitionsOrNull;
             });
@@ -1133,7 +1141,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     /**
      * Create a new consumer group according to the given classic group.
      *
-     * @param logContext        The LogContext.
+     * @param logContext        The log context.
      * @param snapshotRegistry  The SnapshotRegistry.
      * @param classicGroup      The converted classic group.
      * @param topicHashCache    The cache for topic hashes.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -106,6 +106,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         }
     }
 
+    private final Logger log;
+
     /**
      * The group state.
      */
@@ -150,16 +152,13 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
 
     private final TimelineObject<Boolean> hasSubscriptionMetadataRecord;
 
-    private final LogContext logContext;
-
-    private final Logger log;
-
     public ConsumerGroup(
         LogContext logContext,
         SnapshotRegistry snapshotRegistry,
         String groupId
     ) {
         super(snapshotRegistry, groupId);
+        this.log = logContext.logger(ConsumerGroup.class);
         this.state = new TimelineObject<>(snapshotRegistry, EMPTY);
         this.staticMembers = new TimelineHashMap<>(snapshotRegistry, 0);
         this.serverAssignors = new TimelineHashMap<>(snapshotRegistry, 0);
@@ -169,26 +168,6 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         this.subscribedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
         this.resolvedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
         this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
-        this.logContext = logContext;
-        this.log = logContext.logger(ConsumerGroup.class);
-    }
-
-    public ConsumerGroup(
-        SnapshotRegistry snapshotRegistry,
-        String groupId
-    ) {
-        super(snapshotRegistry, groupId);
-        this.state = new TimelineObject<>(snapshotRegistry, EMPTY);
-        this.staticMembers = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.serverAssignors = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.numClassicProtocolMembers = new TimelineInteger(snapshotRegistry);
-        this.classicProtocolMembersSupportedProtocols = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.currentPartitionEpoch = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.subscribedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.resolvedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
-        this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
-        this.logContext = new LogContext("[Group Coordinator id=" + groupId + "]");
-        this.log = logContext.logger(ConsumerGroup.class);
     }
 
     /**
@@ -1168,7 +1147,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         CoordinatorMetadataImage metadataImage
     ) {
         String groupId = classicGroup.groupId();
-        ConsumerGroup consumerGroup = new ConsumerGroup(snapshotRegistry, groupId);
+        ConsumerGroup consumerGroup = new ConsumerGroup(new LogContext("[Group Coordinator id=" + groupId + "]"), snapshotRegistry, groupId);
         consumerGroup.setGroupEpoch(classicGroup.generationId());
         consumerGroup.setTargetAssignmentEpoch(classicGroup.generationId());
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -1138,6 +1138,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
     /**
      * Create a new consumer group according to the given classic group.
      *
+     * @param logContext        The LogContext.
      * @param snapshotRegistry  The SnapshotRegistry.
      * @param classicGroup      The converted classic group.
      * @param topicHashCache    The cache for topic hashes.
@@ -1148,13 +1149,14 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      * @throws UnsupportedVersionException if userData from a custom assignor would be lost.
      */
     public static ConsumerGroup fromClassicGroup(
+        LogContext logContext,
         SnapshotRegistry snapshotRegistry,
         ClassicGroup classicGroup,
         Map<String, Long> topicHashCache,
         CoordinatorMetadataImage metadataImage
     ) {
         String groupId = classicGroup.groupId();
-        ConsumerGroup consumerGroup = new ConsumerGroup(new LogContext("[Group Coordinator id=" + groupId + "]"), snapshotRegistry, groupId);
+        ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId);
         consumerGroup.setGroupEpoch(classicGroup.generationId());
         consumerGroup.setTargetAssignmentEpoch(classicGroup.generationId());
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -170,13 +170,6 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
     }
 
-    public ConsumerGroup(
-        SnapshotRegistry snapshotRegistry,
-        String groupId
-    ) {
-        this(new LogContext("[Group Coordinator id=" + groupId + "]"), snapshotRegistry, groupId);
-    }
-
     /**
      * @return The group type (Consumer).
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -48,6 +48,8 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
 import org.apache.kafka.timeline.TimelineObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -77,6 +79,8 @@ import static org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMe
  * records in the __consumer_offsets partitions.
  */
 public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsumerGroup.class);
 
     public enum ConsumerGroupState {
         EMPTY("Empty"),
@@ -1037,7 +1041,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @param assignment    The assignment.
      * @param expectedEpoch The expected epoch.
-     * @throws IllegalStateException if the epoch does not match the expected one.
+     * @throws IllegalStateException if the epoch does not exist.
      * package-private for testing.
      */
     void removePartitionEpochs(
@@ -1050,7 +1054,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                     assignedPartitions.forEach(partitionId -> {
                         Integer prevValue = partitionsOrNull.remove(partitionId);
                         if (prevValue != expectedEpoch) {
-                            throw new IllegalStateException(
+                            log.warn(
                                 String.format("Cannot remove the epoch %d from %s-%s because the partition is " +
                                     "still owned at a different epoch %d", expectedEpoch, topicId, partitionId, prevValue));
                         }
@@ -1074,7 +1078,6 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @param assignment    The assignment.
      * @param epoch         The new epoch.
-     * @throws IllegalStateException if the partition already has an epoch assigned.
      * package-private for testing.
      */
     void addPartitionEpochs(
@@ -1089,7 +1092,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                 for (Integer partitionId : assignedPartitions) {
                     Integer prevValue = partitionsOrNull.put(partitionId, epoch);
                     if (prevValue != null) {
-                        throw new IllegalStateException(
+                        log.warn(
                             String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
                                 "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
                     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -170,6 +170,13 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
     }
 
+    public ConsumerGroup(
+        SnapshotRegistry snapshotRegistry,
+        String groupId
+    ) {
+        ConsumerGroup(new LogContext("[Group Coordinator id=" + groupId + "]"), snapshotRegistry, groupId);
+    }
+
     /**
      * @return The group type (Consumer).
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -1050,7 +1050,6 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @param assignment    The assignment.
      * @param expectedEpoch The expected epoch.
-     * @throws IllegalStateException if the epoch does not exist.
      * package-private for testing.
      */
     void removePartitionEpochs(
@@ -1076,9 +1075,10 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                         return partitionsOrNull;
                     }
                 } else {
-                    throw new IllegalStateException(
+                    log.warn(
                         String.format("Cannot remove the epoch %d from %s because it does not have any epoch",
                             expectedEpoch, topicId));
+                    return partitionsOrNull;
                 }
             });
         });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.message.ConsumerProtocolAssignment;
 import org.apache.kafka.common.message.ConsumerProtocolSubscription;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.SchemaException;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -49,7 +50,6 @@ import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
 import org.apache.kafka.timeline.TimelineObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -79,8 +79,6 @@ import static org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMe
  * records in the __consumer_offsets partitions.
  */
 public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerGroup.class);
 
     public enum ConsumerGroupState {
         EMPTY("Empty"),
@@ -152,6 +150,29 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
 
     private final TimelineObject<Boolean> hasSubscriptionMetadataRecord;
 
+    private final LogContext logContext;
+
+    private final Logger log;
+
+    public ConsumerGroup(
+        LogContext logContext,
+        SnapshotRegistry snapshotRegistry,
+        String groupId
+    ) {
+        super(snapshotRegistry, groupId);
+        this.state = new TimelineObject<>(snapshotRegistry, EMPTY);
+        this.staticMembers = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.serverAssignors = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.numClassicProtocolMembers = new TimelineInteger(snapshotRegistry);
+        this.classicProtocolMembersSupportedProtocols = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.currentPartitionEpoch = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.subscribedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.resolvedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
+        this.logContext = logContext;
+        this.log = logContext.logger(ConsumerGroup.class);
+    }
+
     public ConsumerGroup(
         SnapshotRegistry snapshotRegistry,
         String groupId
@@ -166,6 +187,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         this.subscribedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
         this.resolvedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
         this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
+        this.logContext = new LogContext("[Group Coordinator id=" + groupId + "]");
+        this.log = logContext.logger(ConsumerGroup.class);
     }
 
     /**
@@ -1052,11 +1075,13 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
             currentPartitionEpoch.compute(topicId, (__, partitionsOrNull) -> {
                 if (partitionsOrNull != null) {
                     assignedPartitions.forEach(partitionId -> {
-                        Integer prevValue = partitionsOrNull.remove(partitionId);
+                        Integer prevValue = partitionsOrNull.get(partitionId);
                         if (prevValue != expectedEpoch) {
                             log.warn(
                                 String.format("Cannot remove the epoch %d from %s-%s because the partition is " +
                                     "still owned at a different epoch %d", expectedEpoch, topicId, partitionId, prevValue));
+                        } else {
+                            partitionsOrNull.remove(partitionId);
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -162,8 +162,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         String groupId
     ) {
         super(snapshotRegistry, groupId);
-        // Add the GroupId to the log prefix for context.
-        this.log = new LogContext(String.format("%s [Group %s]: ", logContext.logPrefix(), groupId)).logger(ConsumerGroup.class);
+        this.log = logContext.logger(ConsumerGroup.class);
         this.state = new TimelineObject<>(snapshotRegistry, EMPTY);
         this.staticMembers = new TimelineHashMap<>(snapshotRegistry, 0);
         this.serverAssignors = new TimelineHashMap<>(snapshotRegistry, 0);
@@ -1059,12 +1058,13 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                 if (partitionsOrNull != null) {
                     assignedPartitions.forEach(partitionId -> {
                         Integer prevValue = partitionsOrNull.get(partitionId);
-                        if (prevValue != expectedEpoch) {
-                            log.debug(
-                                String.format("Cannot remove the epoch %d from %s-%s because the partition is " +
-                                    "still owned at a different epoch %d", expectedEpoch, topicId, partitionId, prevValue));
-                        } else {
+                        if (prevValue != null && prevValue == expectedEpoch) {
                             partitionsOrNull.remove(partitionId);
+                        } else {
+                            // GroupId added for context. 
+                            log.debug(
+                                String.format("[Group %s]: Cannot remove the epoch %d from %s-%s because the partition is " +
+                                    "still owned at a different epoch %d", groupId, expectedEpoch, topicId, partitionId, prevValue));
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {
@@ -1074,8 +1074,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                     }
                 } else {
                     log.debug(
-                        String.format("Cannot remove the epoch %d from %s because it does not have any epoch",
-                            expectedEpoch, topicId));
+                        String.format("[Group %s]: Cannot remove the epoch %d from %s because it does not have any epoch",
+                            groupId, expectedEpoch, topicId));
                     return partitionsOrNull;
                 }
             });
@@ -1087,7 +1087,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @param assignment    The assignment.
      * @param epoch         The new epoch.
-     * @throws IllegalStateException if updating a partition with a smaller or equal epoch.
+     * @throws IllegalStateException if updating a partition with a smaller epoch.
      * package-private for testing.
      */
     void addPartitionEpochs(
@@ -1101,15 +1101,13 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                 }
                 for (Integer partitionId : assignedPartitions) {
                     Integer prevValue = partitionsOrNull.get(partitionId);
-                    if (prevValue != null) {
-                        if (prevValue > epoch) {
-                            throw new IllegalStateException(
-                                String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
-                                    "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
-                        }
+                    if (prevValue == null || prevValue <= epoch) {
+                        partitionsOrNull.put(partitionId, epoch);
+                    } else {
+                        throw new IllegalStateException(
+                            String.format("Cannot set the epoch of %s-%s to %d because the partition is " +
+                                "still owned at epoch %d", topicId, partitionId, epoch, prevValue));
                     }
-                    // Update if previous epoch does not exist or the new epoch is larger.
-                    partitionsOrNull.put(partitionId, epoch);
                 }
                 return partitionsOrNull;
             });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -1061,10 +1061,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                         if (prevValue != null && prevValue == expectedEpoch) {
                             partitionsOrNull.remove(partitionId);
                         } else {
-                            // GroupId added for context. 
-                            log.debug(
-                                String.format("[Group %s]: Cannot remove the epoch %d from %s-%s because the partition is " +
-                                    "still owned at a different epoch %d", groupId, expectedEpoch, topicId, partitionId, prevValue));
+                            log.debug("[GroupId {}] Cannot remove the epoch {} from {}-{} because the partition is " +
+                                    "still owned at a different epoch {}", groupId, expectedEpoch, topicId, partitionId, prevValue);
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {
@@ -1073,9 +1071,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                         return partitionsOrNull;
                     }
                 } else {
-                    log.debug(
-                        String.format("[Group %s]: Cannot remove the epoch %d from %s because it does not have any epoch",
-                            groupId, expectedEpoch, topicId));
+                    log.debug("[GroupId {}] Cannot remove the epoch {} from {} because it does not have any epoch",
+                            groupId, expectedEpoch, topicId);
                     return partitionsOrNull;
                 }
             });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -159,7 +159,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         String groupId
     ) {
         super(snapshotRegistry, groupId);
-        this.log = logContext.logger(ConsumerGroup.class);
+        // Add the GroupId to the log prefix for context.
+        this.log = new LogContext(String.format("%s [Group %s]: ", logContext.logPrefix(), groupId)).logger(ConsumerGroup.class);
         this.state = new TimelineObject<>(snapshotRegistry, EMPTY);
         this.staticMembers = new TimelineHashMap<>(snapshotRegistry, 0);
         this.serverAssignors = new TimelineHashMap<>(snapshotRegistry, 0);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -1084,7 +1084,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
      *
      * @param assignment    The assignment.
      * @param epoch         The new epoch.
-     * @throws IllegalStateException if updating a partition with a smaller epoch.
+     * @throws IllegalStateException if updating a partition with a smaller or equal epoch.
      * package-private for testing.
      */
     void addPartitionEpochs(
@@ -1098,7 +1098,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
                 }
                 for (Integer partitionId : assignedPartitions) {
                     Integer prevValue = partitionsOrNull.get(partitionId);
-                    if (prevValue == null || prevValue <= epoch) {
+                    if (prevValue == null || prevValue < epoch) {
                         partitionsOrNull.put(partitionId, epoch);
                     } else {
                         throw new IllegalStateException(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -931,7 +931,7 @@ public class StreamsGroup implements Group {
      *
      * @param assignment    The assignment.
      * @param expectedProcessId The expected process ID.
-     * @throws IllegalStateException if the process ID does not exist. package-private for testing.
+     * package-private for testing.
      */
     private void removeTaskProcessIds(
         Map<String, Map<Integer, Integer>> assignment,
@@ -971,7 +971,7 @@ public class StreamsGroup implements Group {
      *
      * @param assignment    The assignment.
      * @param processIdToRemove The expected process ID.
-     * @throws IllegalStateException if the process ID does not exist. package-private for testing.
+     * package-private for testing.
      */
     private void removeTaskProcessIdsFromSet(
         Map<String, Set<Integer>> assignment,
@@ -994,9 +994,10 @@ public class StreamsGroup implements Group {
                         return partitionsOrNull;
                     }
                 } else {
-                    throw new IllegalStateException(
+                    log.warn(
                         String.format("Cannot remove the process ID %s from %s because it does not have any process ID",
                             processIdToRemove, subtopologyId));
+                    return partitionsOrNull;
                 }
             });
         });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -942,11 +942,13 @@ public class StreamsGroup implements Group {
             currentTasksProcessId.compute(subtopologyId, (__, partitionsOrNull) -> {
                 if (partitionsOrNull != null) {
                     assignedPartitions.keySet().forEach(partitionId -> {
-                        String prevValue = partitionsOrNull.remove(partitionId);
+                        String prevValue = partitionsOrNull.get(partitionId);
                         if (!Objects.equals(prevValue, expectedProcessId)) {
                             log.warn(
                                 String.format("Cannot remove the process ID %s from task %s_%s because the partition is " +
                                     "still owned at a different process ID %s", expectedProcessId, subtopologyId, partitionId, prevValue));
+                        } else {
+                            partitionsOrNull.remove(partitionId);
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -32,7 +32,7 @@ import org.apache.kafka.coordinator.group.Group;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
 import org.apache.kafka.coordinator.group.Utils;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -944,7 +944,7 @@ public class StreamsGroup implements Group {
                     assignedPartitions.keySet().forEach(partitionId -> {
                         String prevValue = partitionsOrNull.get(partitionId);
                         if (!Objects.equals(prevValue, expectedProcessId)) {
-                            log.warn(
+                            log.debug(
                                 String.format("Cannot remove the process ID %s from task %s_%s because the partition is " +
                                     "still owned at a different process ID %s", expectedProcessId, subtopologyId, partitionId, prevValue));
                         } else {
@@ -957,7 +957,7 @@ public class StreamsGroup implements Group {
                         return partitionsOrNull;
                     }
                 } else {
-                    log.warn(
+                    log.debug(
                         String.format("Cannot remove the process ID %s from %s because it does not have any processId",
                             expectedProcessId, subtopologyId));
                     return partitionsOrNull;
@@ -983,7 +983,7 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull != null) {
                     assignedPartitions.forEach(partitionId -> {
                         if (!partitionsOrNull.get(partitionId).remove(processIdToRemove)) {
-                            log.warn(
+                            log.debug(
                                 String.format("Cannot remove the process ID %s from task %s_%s because the task is " +
                                     "not owned by this process ID", processIdToRemove, subtopologyId, partitionId));
                         }
@@ -994,7 +994,7 @@ public class StreamsGroup implements Group {
                         return partitionsOrNull;
                     }
                 } else {
-                    log.warn(
+                    log.debug(
                         String.format("Cannot remove the process ID %s from %s because it does not have any process ID",
                             processIdToRemove, subtopologyId));
                     return partitionsOrNull;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -931,7 +931,7 @@ public class StreamsGroup implements Group {
      *
      * @param assignment    The assignment.
      * @param expectedProcessId The expected process ID.
-     * @throws IllegalStateException if the process ID does not match the expected one. package-private for testing.
+     * @throws IllegalStateException if the process ID does not exist. package-private for testing.
      */
     private void removeTaskProcessIds(
         Map<String, Map<Integer, Integer>> assignment,
@@ -944,7 +944,7 @@ public class StreamsGroup implements Group {
                     assignedPartitions.keySet().forEach(partitionId -> {
                         String prevValue = partitionsOrNull.remove(partitionId);
                         if (!Objects.equals(prevValue, expectedProcessId)) {
-                            throw new IllegalStateException(
+                            log.warn(
                                 String.format("Cannot remove the process ID %s from task %s_%s because the partition is " +
                                     "still owned at a different process ID %s", expectedProcessId, subtopologyId, partitionId, prevValue));
                         }
@@ -968,7 +968,7 @@ public class StreamsGroup implements Group {
      *
      * @param assignment    The assignment.
      * @param processIdToRemove The expected process ID.
-     * @throws IllegalStateException if the process ID does not match the expected one. package-private for testing.
+     * @throws IllegalStateException if the process ID does not exist. package-private for testing.
      */
     private void removeTaskProcessIdsFromSet(
         Map<String, Set<Integer>> assignment,
@@ -980,7 +980,7 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull != null) {
                     assignedPartitions.forEach(partitionId -> {
                         if (!partitionsOrNull.get(partitionId).remove(processIdToRemove)) {
-                            throw new IllegalStateException(
+                            log.warn(
                                 String.format("Cannot remove the process ID %s from task %s_%s because the task is " +
                                     "not owned by this process ID", processIdToRemove, subtopologyId, partitionId));
                         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -32,7 +32,7 @@ import org.apache.kafka.coordinator.group.Group;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
 import org.apache.kafka.coordinator.group.Utils;
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -946,10 +946,8 @@ public class StreamsGroup implements Group {
                         if (Objects.equals(prevValue, expectedProcessId)) {
                             partitionsOrNull.remove(partitionId);
                         } else {
-                            // Include the GroupId in the log message for context.
-                            log.debug(
-                                String.format("[Group %s]: Cannot remove the process ID %s from task %s_%s because the partition is " +
-                                    "still owned at a different process ID %s", groupId, expectedProcessId, subtopologyId, partitionId, prevValue));
+                            log.debug("[GroupId {}] Cannot remove the process ID {} from task {}_{} because the partition is " +
+                                    "still owned at a different process ID {}", groupId, expectedProcessId, subtopologyId, partitionId, prevValue);
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {
@@ -958,9 +956,8 @@ public class StreamsGroup implements Group {
                         return partitionsOrNull;
                     }
                 } else {
-                    log.debug(
-                        String.format("[Group %s]: Cannot remove the process ID %s from %s because it does not have any processId",
-                            groupId, expectedProcessId, subtopologyId));
+                    log.debug("[GroupId {}] Cannot remove the process ID {} from {} because it does not have any processId",
+                            groupId, expectedProcessId, subtopologyId);
                     return partitionsOrNull;
                 }
             });
@@ -984,9 +981,8 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull != null) {
                     assignedPartitions.forEach(partitionId -> {
                         if (!partitionsOrNull.get(partitionId).remove(processIdToRemove)) {
-                            log.debug(
-                                String.format("[Group %s]: Cannot remove the process ID %s from task %s_%s because the task is " +
-                                    "not owned by this process ID", groupId, processIdToRemove, subtopologyId, partitionId));
+                            log.debug("[GroupId {}] Cannot remove the process ID {} from task {}_{} because the task is " +
+                                    "not owned by this process ID", groupId, processIdToRemove, subtopologyId, partitionId);
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {
@@ -995,9 +991,8 @@ public class StreamsGroup implements Group {
                         return partitionsOrNull;
                     }
                 } else {
-                    log.debug(
-                        String.format("[Group %s]: Cannot remove the process ID %s from %s because it does not have any process ID",
-                            groupId, processIdToRemove, subtopologyId));
+                    log.debug("[GroupId {}] Cannot remove the process ID {} from {} because it does not have any process ID",
+                            groupId, processIdToRemove, subtopologyId);
                     return partitionsOrNull;
                 }
             });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -1004,7 +1004,7 @@ public class StreamsGroup implements Group {
      *
      * @param tasks     The assigned tasks.
      * @param processId The process ID.
-     * @throws IllegalStateException if the partition already has an epoch assigned. package-private for testing.
+     * @throws IllegalStateException if the existing partition has larger epoch than the new one. package-private for testing.
      */
     void addTaskProcessId(
         TasksTupleWithEpochs tasks,
@@ -1027,12 +1027,28 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull == null) {
                     partitionsOrNull = new TimelineHashMap<>(snapshotRegistry, assignedTaskPartitionsWithEpochs.size());
                 }
-                for (Integer partitionId : assignedTaskPartitionsWithEpochs.keySet()) {
-                    String prevValue = partitionsOrNull.put(partitionId, processId);
-                    if (prevValue != null) {
-                        throw new IllegalStateException(
-                            String.format("Cannot set the process ID of %s-%s to %s because the partition is " +
-                                "still owned by process ID %s", subtopologyId, partitionId, processId, prevValue));
+                for (Map.Entry<Integer, Integer> partitionEntry : assignedTaskPartitionsWithEpochs.entrySet()) {
+                    Integer partitionId = partitionEntry.getKey();
+                    String prevValue = partitionsOrNull.get(partitionId);
+                    
+                    if (prevValue == null) {
+                        partitionsOrNull.put(partitionId, processId);
+                    } else {
+                        String memberId = null;
+                        for (Map.Entry<String, StreamsGroupMember> memberEntry : members.entrySet()) {
+                            if (memberEntry.getValue().processId().equals(prevValue)) {
+                                memberId = memberEntry.getKey();
+                                break;
+                            }
+                        }
+                        if (memberId != null && 
+                            members.get(memberId).assignedTasks().activeTasksWithEpochs().get(subtopologyId).get(partitionId) <= partitionEntry.getValue()) {
+                            partitionsOrNull.put(partitionId, processId);
+                        } else {
+                            throw new IllegalStateException(
+                                String.format("[GroupId {}] Cannot set the process ID of {}-{} to {} because the partition is " +
+                                "still owned by process ID {}", groupId, subtopologyId, partitionId, processId, prevValue));
+                        }
                     }
                 }
                 return partitionsOrNull;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -943,12 +943,13 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull != null) {
                     assignedPartitions.keySet().forEach(partitionId -> {
                         String prevValue = partitionsOrNull.get(partitionId);
-                        if (!Objects.equals(prevValue, expectedProcessId)) {
-                            log.debug(
-                                String.format("Cannot remove the process ID %s from task %s_%s because the partition is " +
-                                    "still owned at a different process ID %s", expectedProcessId, subtopologyId, partitionId, prevValue));
-                        } else {
+                        if (Objects.equals(prevValue, expectedProcessId)) {
                             partitionsOrNull.remove(partitionId);
+                        } else {
+                            // Include the GroupId in the log message for context.
+                            log.debug(
+                                String.format("[Group %s]: Cannot remove the process ID %s from task %s_%s because the partition is " +
+                                    "still owned at a different process ID %s", groupId, expectedProcessId, subtopologyId, partitionId, prevValue));
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {
@@ -958,8 +959,8 @@ public class StreamsGroup implements Group {
                     }
                 } else {
                     log.debug(
-                        String.format("Cannot remove the process ID %s from %s because it does not have any processId",
-                            expectedProcessId, subtopologyId));
+                        String.format("[Group %s]: Cannot remove the process ID %s from %s because it does not have any processId",
+                            groupId, expectedProcessId, subtopologyId));
                     return partitionsOrNull;
                 }
             });
@@ -984,8 +985,8 @@ public class StreamsGroup implements Group {
                     assignedPartitions.forEach(partitionId -> {
                         if (!partitionsOrNull.get(partitionId).remove(processIdToRemove)) {
                             log.debug(
-                                String.format("Cannot remove the process ID %s from task %s_%s because the task is " +
-                                    "not owned by this process ID", processIdToRemove, subtopologyId, partitionId));
+                                String.format("[Group %s]: Cannot remove the process ID %s from task %s_%s because the task is " +
+                                    "not owned by this process ID", groupId, processIdToRemove, subtopologyId, partitionId));
                         }
                     });
                     if (partitionsOrNull.isEmpty()) {
@@ -995,8 +996,8 @@ public class StreamsGroup implements Group {
                     }
                 } else {
                     log.debug(
-                        String.format("Cannot remove the process ID %s from %s because it does not have any process ID",
-                            processIdToRemove, subtopologyId));
+                        String.format("[Group %s]: Cannot remove the process ID %s from %s because it does not have any process ID",
+                            groupId, processIdToRemove, subtopologyId));
                     return partitionsOrNull;
                 }
             });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -1027,28 +1027,11 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull == null) {
                     partitionsOrNull = new TimelineHashMap<>(snapshotRegistry, assignedTaskPartitionsWithEpochs.size());
                 }
-                for (Map.Entry<Integer, Integer> partitionEntry : assignedTaskPartitionsWithEpochs.entrySet()) {
-                    Integer partitionId = partitionEntry.getKey();
-                    String prevValue = partitionsOrNull.get(partitionId);
-                    
-                    if (prevValue == null) {
-                        partitionsOrNull.put(partitionId, processId);
-                    } else {
-                        String memberId = null;
-                        for (Map.Entry<String, StreamsGroupMember> memberEntry : members.entrySet()) {
-                            if (memberEntry.getValue().processId().equals(prevValue)) {
-                                memberId = memberEntry.getKey();
-                                break;
-                            }
-                        }
-                        if (memberId != null && 
-                            members.get(memberId).assignedTasks().activeTasksWithEpochs().get(subtopologyId).get(partitionId) <= partitionEntry.getValue()) {
-                            partitionsOrNull.put(partitionId, processId);
-                        } else {
-                            throw new IllegalStateException(
-                                String.format("[GroupId {}] Cannot set the process ID of {}-{} to {} because the partition is " +
-                                "still owned by process ID {}", groupId, subtopologyId, partitionId, processId, prevValue));
-                        }
+                for (Integer partitionId: assignedTaskPartitionsWithEpochs.keySet()) {
+                    String prevValue = partitionsOrNull.put(partitionId, processId);
+                    if (prevValue != null) {
+                        log.debug("[GroupId {}] Cannot set the process ID of {}-{} to {} because the partition is " +
+                            "still owned by process ID {}", groupId, subtopologyId, partitionId, processId, prevValue);
                     }
                 }
                 return partitionsOrNull;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -957,9 +957,10 @@ public class StreamsGroup implements Group {
                         return partitionsOrNull;
                     }
                 } else {
-                    throw new IllegalStateException(
+                    log.warn(
                         String.format("Cannot remove the process ID %s from %s because it does not have any processId",
                             expectedProcessId, subtopologyId));
+                    return partitionsOrNull;
                 }
             });
         });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -1004,7 +1004,7 @@ public class StreamsGroup implements Group {
      *
      * @param tasks     The assigned tasks.
      * @param processId The process ID.
-     * @throws IllegalStateException if the existing partition has larger epoch than the new one. package-private for testing.
+     * package-private for testing.
      */
     void addTaskProcessId(
         TasksTupleWithEpochs tasks,
@@ -1027,10 +1027,10 @@ public class StreamsGroup implements Group {
                 if (partitionsOrNull == null) {
                     partitionsOrNull = new TimelineHashMap<>(snapshotRegistry, assignedTaskPartitionsWithEpochs.size());
                 }
-                for (Integer partitionId: assignedTaskPartitionsWithEpochs.keySet()) {
+                for (Integer partitionId : assignedTaskPartitionsWithEpochs.keySet()) {
                     String prevValue = partitionsOrNull.put(partitionId, processId);
                     if (prevValue != null) {
-                        log.debug("[GroupId {}] Cannot set the process ID of {}-{} to {} because the partition is " +
+                        log.debug("[GroupId {}]Setting the process ID of {}-{} to {} even though the partition is " +
                             "still owned by process ID {}", groupId, subtopologyId, partitionId, processId, prevValue);
                     }
                 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -980,7 +980,7 @@ public class StreamsGroup implements Group {
             currentTasksProcessId.compute(subtopologyId, (__, partitionsOrNull) -> {
                 if (partitionsOrNull != null) {
                     assignedPartitions.forEach(partitionId -> {
-                        if (!partitionsOrNull.get(partitionId).remove(processIdToRemove)) {
+                        if (!partitionsOrNull.containsKey(partitionId) || !partitionsOrNull.get(partitionId).remove(processIdToRemove)) {
                             log.debug("[GroupId {}] Cannot remove the process ID {} from task {}_{} because the task is " +
                                     "not owned by this process ID", groupId, processIdToRemove, subtopologyId, partitionId);
                         }
@@ -1030,7 +1030,7 @@ public class StreamsGroup implements Group {
                 for (Integer partitionId : assignedTaskPartitionsWithEpochs.keySet()) {
                     String prevValue = partitionsOrNull.put(partitionId, processId);
                     if (prevValue != null) {
-                        log.debug("[GroupId {}]Setting the process ID of {}-{} to {} even though the partition is " +
+                        log.debug("[GroupId {}] Setting the process ID of {}-{} to {} even though the partition is " +
                             "still owned by process ID {}", groupId, subtopologyId, partitionId, processId, prevValue);
                     }
                 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -1384,8 +1384,8 @@ public class GroupCoordinatorShardTest {
 
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
 
-        ConsumerGroup group1 = new ConsumerGroup(snapshotRegistry, "group-id");
-        ConsumerGroup group2 = new ConsumerGroup(snapshotRegistry, "other-group-id");
+        ConsumerGroup group1 = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id");
+        ConsumerGroup group2 = new ConsumerGroup(new LogContext(), snapshotRegistry, "other-group-id");
 
         when(groupMetadataManager.groupIds()).thenReturn(Set.of("group-id", "other-group-id"));
         when(groupMetadataManager.group("group-id")).thenReturn(group1);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24387,6 +24387,252 @@ public class GroupMetadataManagerTest {
         assertDoesNotThrow(() -> context.replay(record));
     }
 
+    @Test
+    public void testConsumerGroupAssignmentResolvesWithCompaction() {
+        String groupId = "fooup";
+        String memberA = "memberA";
+        String memberB = "memberB";
+
+        Uuid topicId = Uuid.randomUuid();
+        String topicName = "foo";
+
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(topicId, topicName, 2)
+            .addRacks()
+            .buildCoordinatorMetadataImage();
+        long topicHash = computeTopicHash(topicName, metadataImage);
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMetadataHash(topicHash))
+            .build();
+
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+
+        // Assign partition 0 to member A
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
+            .build()));
+
+        // Assign partition 0 to member B. This is allowed even though partition 0 is already owned by member A.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
+            .build()));
+
+        // Now assign partition 1 to member A.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(13)
+            .setPreviousMemberEpoch(12)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 1)))
+            .build()));
+
+        // Verify partition epochs.
+        assertEquals(group.currentPartitionEpoch(topicId, 0), 12);
+        assertEquals(group.currentPartitionEpoch(topicId, 1), 13);
+    }
+
+    @Test
+    public void testConsumerGroupUnassignmentResolvesWithCompaction() {
+        String groupId = "fooup";
+        String memberA = "memberA";
+        String memberB = "memberB";
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(fooTopicId, fooTopicName, 3)
+            .addTopic(barTopicId, barTopicName, 2)
+            .addRacks()
+            .buildCoordinatorMetadataImage();
+        long fooTopicHash = computeTopicHash(fooTopicName, metadataImage);
+        long barTopicHash = computeTopicHash(barTopicName, metadataImage);
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMetadataHash(computeGroupHash(Map.of(fooTopicName, fooTopicHash, barTopicName, barTopicHash))))
+            .build();
+
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+
+        // Assign partition foo-1 to member A
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0, 1)))
+            .build()));
+
+
+        // Unassign partition foo-1 from member A.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
+            .build()));
+
+        // Assign partition foo-1 to member B.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(13)
+            .setPreviousMemberEpoch(12)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2)))
+            .build()));
+
+        // Unassign partition foo-1 to member B.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(14)
+            .setPreviousMemberEpoch(13)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 2)))
+            .build()));
+
+        // Assign partition bar-0 to member A.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(15)
+            .setPreviousMemberEpoch(11)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(barTopicId, 0)))
+            .build()));
+
+        // Verify member A has ownership of partition bar-0. member B has no partitions.
+        assertEquals(group.currentPartitionEpoch(barTopicId, 0), 15);
+    }
+
+    @Test
+    public void testStreamsGroupAssignmentResolvesWithCompaction() {
+        String groupId = "fooup";
+        String memberA = "memberA";
+        String memberB = "memberB";
+
+        String subtopology = "subtopology";
+        String topicName = "foo";
+        Uuid topicId = Uuid.randomUuid();
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10))
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(topicId, topicName, 2)
+                .buildCoordinatorMetadataImage())
+            .build();
+        assignor.prepareGroupAssignment(Map.of(memberA, TasksTuple.EMPTY));
+
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
+
+        // Assign task 0 to member A
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+            .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 0)))
+            .build()));
+
+        // Assign task 0 to member B.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 0)))
+            .build()));
+
+        // Then assign task 1 as well to member A.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+            .setMemberEpoch(13)
+            .setPreviousMemberEpoch(12)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 1)))
+            .build()));
+
+        // Check task 1 is assigned to member A and task 0 to member B.
+        assertEquals(group.members().get(memberA).assignedTasks(), 
+            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 1)));
+        assertEquals(group.members().get(memberB).assignedTasks(), 
+            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 0)));
+    }
+
+    @Test
+    public void testStreamsGroupUnassignmentResolvesWithCompaction() {
+        String groupId = "fooup";
+        String memberA = "memberA";
+        String memberB = "memberB";
+
+        String subtopologyFoo = "subtopologyFoo";
+        String fooTopicName = "foo";
+        Uuid fooTopicId = Uuid.randomUuid();
+        String subtopologyBar = "subtopologyBar";
+        String barTopicName = "bar";
+        Uuid barTopicId = Uuid.randomUuid();
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10))
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 2)
+                .addTopic(barTopicId, barTopicName, 2)
+                .buildCoordinatorMetadataImage())
+            .build();
+        assignor.prepareGroupAssignment(Map.of(memberA, TasksTuple.EMPTY));
+
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
+
+        // Assign task foo-0,1 to member A
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+            .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0, 1)))
+            .build()));
+
+        // Unassign task foo-0 from member A.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+            .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 1)))
+            .build()));
+
+        // Assign task foo-0,2 to member B
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0)))
+            .build()));
+
+        // Unassign task foo-0 from member B.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 2)))
+            .build()));
+
+        // Assign task bar-0 to member A. 
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+            .setMemberEpoch(13)
+            .setPreviousMemberEpoch(12)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyBar, 0)))
+            .build()));
+
+        // Check task bar-0 is assigned to member A and task foo-2 is assigned to member B.
+        assertEquals(group.members().get(memberA).assignedTasks(), 
+            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyBar, 0)));
+        assertEquals(group.members().get(memberB).assignedTasks(), TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 2)));
+    }
+
     private record PendingAssignmentCase(
         String description,
         String groupId,
@@ -24704,158 +24950,5 @@ public class GroupMetadataManagerTest {
     private Map<String, String> getDefaultAssignmentConfigs() {
         // Use the same default value as GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT
         return Map.of("num.standby.replicas", String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT));
-    }
-
-    @Test
-    public void testStreamsGroupResolvesWithConcurrentCompactionAndUnassignment() {
-        String groupId = "fooup";
-        String memberIdA = "memberA";
-        String memberIdB = "memberB";
-
-        String subtopologyFoo = "subtopology";
-        String subtopologyBar = "subtopologyBar";
-        String fooTopicName = "foo";
-        Uuid fooTopicId = Uuid.randomUuid();
-        String barTopicName = "bar";
-        Uuid barTopicId = Uuid.randomUuid();
-        Topology topology = new Topology().setSubtopologies(List.of(
-            new Subtopology().setSubtopologyId(subtopologyFoo).setSourceTopics(List.of(fooTopicName)),
-            new Subtopology().setSubtopologyId(subtopologyBar).setSourceTopics(List.of(barTopicName))
-        ));
-
-        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withStreamsGroupTaskAssignors(List.of(assignor))
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(fooTopicId, fooTopicName, 3)
-                .addTopic(barTopicId, barTopicName, 3)
-                .buildCoordinatorMetadataImage())
-            .build();
-        assignor.prepareGroupAssignment(Map.of(memberIdA, TasksTuple.EMPTY));
-
-        StreamsGroupMember memberA = streamsGroupMemberBuilderWithDefaults(memberIdA)
-            .setMemberEpoch(11)
-            .setPreviousMemberEpoch(10)
-            .build();
-
-        StreamsGroupMember memberB = streamsGroupMemberBuilderWithDefaults(memberIdB)
-            .setMemberEpoch(11)
-            .setPreviousMemberEpoch(10)
-            .build();
-
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, memberA));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, memberB));
-
-        // Assign task foo-0 to member A
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 11, 0, 0));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(groupId, memberIdA,
-            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-            TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0)
-        )));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 12));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, memberA));
-
-        // Unassign task foo-0 from member A.
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 12, 0, 0));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 12));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, new StreamsGroupMember.Builder(memberA)
-            .setMemberEpoch(12)
-            .setPreviousMemberEpoch(11)
-            .setTasksPendingRevocation(
-                TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-                TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0))
-            )
-            .build()));
-
-        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
-            new StreamsGroupHeartbeatRequestData()
-                .setGroupId(groupId)
-                .setMemberId(memberIdA)
-                .setMemberEpoch(12)
-                .setRebalanceTimeoutMs(1500)
-                .setActiveTasks(List.of(new StreamsGroupHeartbeatRequestData.TaskIds()
-                    .setSubtopologyId(subtopologyFoo)
-                    .setPartitions(List.of()),
-                    new StreamsGroupHeartbeatRequestData.TaskIds()
-                    .setSubtopologyId(subtopologyBar)
-                    .setPartitions(List.of())))
-                .setStandbyTasks(List.of())
-                .setWarmupTasks(List.of()));
-        
-        assertResponseEquals(
-            new StreamsGroupHeartbeatResponseData()
-                .setMemberId(memberIdA)
-                .setMemberEpoch(14)
-                .setHeartbeatIntervalMs(5000)
-                .setActiveTasks(List.of(
-                    new StreamsGroupHeartbeatResponseData.TaskIds()
-                        .setSubtopologyId(subtopologyFoo)
-                        .setPartitions(List.of(0, 1))
-                ))
-                .setStandbyTasks(List.of())
-                .setWarmupTasks(List.of()),
-            result.response().data());
-
-        // // Assign task foo-0 to member B. This logs a warning and does not change the assignment.
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 11, 0, 0));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(groupId, memberIdB,
-        //     TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-        //     TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0)
-        // )));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 12));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, memberB));
-
-        // // Unassign task foo-0 from member B.
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 11, 0, 0));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 11));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, new StreamsGroupMember.Builder(memberB)
-        //     .setMemberEpoch(11)
-        //     .setPreviousMemberEpoch(10)
-        //     .setTasksPendingRevocation(
-        //         TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-        //         TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0))
-        //     )
-        //     .build()));
-
-        // // Then assign task bar-0 to member A. 
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 13, 0, 0));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(groupId, memberIdA,
-        //     TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
-        //     TaskAssignmentTestUtil.mkTasks(subtopologyBar, 0)
-        // )));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 14));
-        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, memberA));
-
-        // // Verify member A has ownership of task bar-0
-        // CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
-        //     new StreamsGroupHeartbeatRequestData()
-        //         .setGroupId(groupId)
-        //         .setMemberId(memberIdA)
-        //         .setMemberEpoch(11)
-        //         .setRebalanceTimeoutMs(1500)
-        //         .setActiveTasks(List.of(new StreamsGroupHeartbeatRequestData.TaskIds()
-        //             .setSubtopologyId(subtopologyBar)
-        //             .setPartitions(List.of(0))))
-        //         .setStandbyTasks(List.of())
-        //         .setWarmupTasks(List.of()));
-        
-        // assertResponseEquals(
-        //     new StreamsGroupHeartbeatResponseData()
-        //         .setMemberId(memberIdA)
-        //         .setMemberEpoch(14)
-        //         .setHeartbeatIntervalMs(5000)
-        //         .setActiveTasks(List.of(
-        //             new StreamsGroupHeartbeatResponseData.TaskIds()
-        //                 .setSubtopologyId(subtopologyBar)
-        //                 .setPartitions(List.of(0))
-        //         ))
-        //         .setStandbyTasks(List.of())
-        //         .setWarmupTasks(List.of()),
-        //     result.response().data());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24388,7 +24388,7 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testConsumerGroupAssignmentResolvesWithCompaction() {
+    public void testReplayConsumerGroupCurrentMemberAssignmentWithCompaction() {
         String groupId = "fooup";
         String memberA = "memberA";
         String memberB = "memberB";
@@ -24396,20 +24396,11 @@ public class GroupMetadataManagerTest {
         Uuid topicId = Uuid.randomUuid();
         String topicName = "foo";
 
-        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
-            .addTopic(topicId, topicName, 2)
-            .addRacks()
-            .buildCoordinatorMetadataImage();
-        long topicHash = computeTopicHash(topicName, metadataImage);
-
-        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
-            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                .withMetadataHash(topicHash))
+            .withMetadataImage(new MetadataImageBuilder()
+            .addTopic(topicId, topicName, 2)
+            .buildCoordinatorMetadataImage())
             .build();
-
-        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
 
         // This test enacts the following scenario:
         // 1. Member A is assigned partition 0.
@@ -24427,6 +24418,7 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
             .build()));
 
+        // Partition 0's owner is replaced by member B at epoch 12.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(12)
@@ -24434,6 +24426,7 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
             .build()));
 
+        // Partition 0 must remain with member B at epoch 12 even though member A just been unassigned partition 0.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(13)
@@ -24442,12 +24435,13 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Verify partition epochs.
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
         assertEquals(12, group.currentPartitionEpoch(topicId, 0));
         assertEquals(13, group.currentPartitionEpoch(topicId, 1));
     }
 
     @Test
-    public void testConsumerGroupUnassignmentResolvesWithCompaction() {
+    public void testReplayConsumerGroupUnassignmentRecordSkippedWithCompaction() {
         String groupId = "fooup";
         String memberA = "memberA";
         String memberB = "memberB";
@@ -24457,22 +24451,12 @@ public class GroupMetadataManagerTest {
         Uuid barTopicId = Uuid.randomUuid();
         String barTopicName = "bar";
 
-        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
-            .addTopic(fooTopicId, fooTopicName, 3)
-            .addTopic(barTopicId, barTopicName, 2)
-            .addRacks()
-            .buildCoordinatorMetadataImage();
-        long fooTopicHash = computeTopicHash(fooTopicName, metadataImage);
-        long barTopicHash = computeTopicHash(barTopicName, metadataImage);
-
-        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
-            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                .withMetadataHash(computeGroupHash(Map.of(fooTopicName, fooTopicHash, barTopicName, barTopicHash))))
+            .withMetadataImage(new MetadataImageBuilder()
+            .addTopic(fooTopicId, fooTopicName, 3)
+            .addTopic(barTopicId, barTopicName, 1)
+            .buildCoordinatorMetadataImage())
             .build();
-
-        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
 
         // This test enacts the following scenario:
         // 1. Member A is assigned partition foo-1.
@@ -24493,32 +24477,89 @@ public class GroupMetadataManagerTest {
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
             .setState(MemberState.STABLE)
-            .setMemberEpoch(13)
-            .setPreviousMemberEpoch(12)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2)))
             .build()));
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
             .setState(MemberState.STABLE)
-            .setMemberEpoch(14)
-            .setPreviousMemberEpoch(13)
-            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 2)))
+            .setMemberEpoch(13)
+            .setPreviousMemberEpoch(12)
             .build()));
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
             .setState(MemberState.STABLE)
-            .setMemberEpoch(15)
-            .setPreviousMemberEpoch(11)
+            .setMemberEpoch(14)
+            .setPreviousMemberEpoch(13)
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(barTopicId, 0)))
             .build()));
 
         // Verify member A only has ownership of partition bar-0. Member B has no partitions.
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
         assertEquals(mkAssignment(mkTopicAssignment(barTopicId, 0)), group.members().get(memberA).assignedPartitions());
-        assertEquals(15, group.currentPartitionEpoch(barTopicId, 0));
+        assertEquals(14, group.currentPartitionEpoch(barTopicId, 0));
     }
 
     @Test
-    public void testStreamsGroupAssignmentResolvesWithCompaction() {
+    public void testReplayConsumerGroupCurrentMemberAssignmentSameEpochWithCompaction() {
+        String groupId = "fooup";
+        String memberA = "memberA";
+        String memberB = "memberB";
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withMetadataImage(new MetadataImageBuilder()
+            .addTopic(fooTopicId, fooTopicName, 1)
+            .addTopic(barTopicId, barTopicName, 1)
+            .buildCoordinatorMetadataImage())
+            .build();
+
+        // This test enacts the following scenario:
+        // 1. Member A unsubscribes from topic bar at epoch 10: Member A { epoch: 10, assigned partitions: [foo], pending revocations: [bar] }
+        // 2. A new assignment is available at epoch 11 with member A unsubscribing from topic foo.
+        // 3. Member A yields bar. The epoch is bumped to 11: Member A { epoch: 11, assigned partitions: [], pending revocations: [foo] }
+        // 4. Member A yields topic foo. Member A { epoch: 11, assigned partitions: [], pending revocations: [] } [removed by compaction]
+        // 5. Member B is assigned topic foo. Member B { epoch: 11, assigned partitions: [foo], pending revocations: [] }
+        // When record 4 is dropped by compaction, we want member B's assignment to be accepted with the same epoch. 
+
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
+            .setPartitionsPendingRevocation(mkAssignment(mkTopicAssignment(barTopicId, 0)))
+            .build()));
+
+        // Member A yields bar at epoch 11.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setPartitionsPendingRevocation(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
+            .build()));
+
+        // Member A yields foo. [record removed by compaction]
+        // Member B is assigned foo at epoch 11.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
+            .build()));
+
+        // Verify partition foo-0 is assigned to member B at epoch 11.
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+        assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 0)), group.members().get(memberB).assignedPartitions());
+        assertEquals(11, group.currentPartitionEpoch(fooTopicId, 0));
+    }
+
+    @Test
+    public void testReplayStreamsGroupCurrentMemberAssignmentWithCompaction() {
         String groupId = "fooup";
         String memberA = "memberA";
         String memberB = "memberB";
@@ -24527,17 +24568,11 @@ public class GroupMetadataManagerTest {
         String topicName = "foo";
         Uuid topicId = Uuid.randomUuid();
 
-        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10))
-            .withStreamsGroupTaskAssignors(List.of(assignor))
             .withMetadataImage(new MetadataImageBuilder()
                 .addTopic(topicId, topicName, 2)
                 .buildCoordinatorMetadataImage())
             .build();
-        assignor.prepareGroupAssignment(Map.of(memberA, TasksTuple.EMPTY));
-
-        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
 
         // This test enacts the following scenario:
         // 1. Member A is assigned task 0.
@@ -24556,6 +24591,7 @@ public class GroupMetadataManagerTest {
                     TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 11))))
             .build()));
 
+        // Task 0's owner is replaced by member B at epoch 12.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
@@ -24563,6 +24599,7 @@ public class GroupMetadataManagerTest {
                     TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))))
             .build()));
 
+        // Task 0 must remain with member B at epoch 12 even though member A just been unassigned task 0.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
@@ -24571,6 +24608,7 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Check task 1 is assigned to member A and task 0 to member B.
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
         assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
             TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))), group.members().get(memberA).assignedTasks());
         assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
@@ -24578,7 +24616,7 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testStreamsGroupUnassignmentResolvesWithCompaction() {
+    public void testReplayStreamsGroupUnassignmentRecordSkippedWithCompaction() {
         String groupId = "fooup";
         String memberA = "memberA";
         String memberB = "memberB";
@@ -24590,18 +24628,12 @@ public class GroupMetadataManagerTest {
         String barTopicName = "bar";
         Uuid barTopicId = Uuid.randomUuid();
 
-        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10))
-            .withStreamsGroupTaskAssignors(List.of(assignor))
             .withMetadataImage(new MetadataImageBuilder()
                 .addTopic(fooTopicId, fooTopicName, 2)
-                .addTopic(barTopicId, barTopicName, 2)
+                .addTopic(barTopicId, barTopicName, 1)
                 .buildCoordinatorMetadataImage())
             .build();
-        assignor.prepareGroupAssignment(Map.of(memberA, TasksTuple.EMPTY));
-
-        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
 
         // This test enacts the following scenario:
         // 1. Member A is assigned task foo-1.
@@ -24631,8 +24663,6 @@ public class GroupMetadataManagerTest {
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))))
             .build()));
 
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
@@ -24642,13 +24672,11 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))))
             .build()));
 
-        // Check task bar-0 is assigned to member A and task foo-2 is assigned to member B.
+        // Check task bar-0 is assigned to member A. Member B has no tasks.
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
         assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
             TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))), group.members().get(memberA).assignedTasks());
-        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))), group.members().get(memberB).assignedTasks());
     }
-
     private record PendingAssignmentCase(
         String description,
         String groupId,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24705,4 +24705,157 @@ public class GroupMetadataManagerTest {
         // Use the same default value as GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT
         return Map.of("num.standby.replicas", String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT));
     }
+
+    @Test
+    public void testStreamsGroupResolvesWithConcurrentCompactionAndUnassignment() {
+        String groupId = "fooup";
+        String memberIdA = "memberA";
+        String memberIdB = "memberB";
+
+        String subtopologyFoo = "subtopology";
+        String subtopologyBar = "subtopologyBar";
+        String fooTopicName = "foo";
+        Uuid fooTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+        Uuid barTopicId = Uuid.randomUuid();
+        Topology topology = new Topology().setSubtopologies(List.of(
+            new Subtopology().setSubtopologyId(subtopologyFoo).setSourceTopics(List.of(fooTopicName)),
+            new Subtopology().setSubtopologyId(subtopologyBar).setSourceTopics(List.of(barTopicName))
+        ));
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 3)
+                .addTopic(barTopicId, barTopicName, 3)
+                .buildCoordinatorMetadataImage())
+            .build();
+        assignor.prepareGroupAssignment(Map.of(memberIdA, TasksTuple.EMPTY));
+
+        StreamsGroupMember memberA = streamsGroupMemberBuilderWithDefaults(memberIdA)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .build();
+
+        StreamsGroupMember memberB = streamsGroupMemberBuilderWithDefaults(memberIdB)
+            .setMemberEpoch(11)
+            .setPreviousMemberEpoch(10)
+            .build();
+
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, memberA));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, memberB));
+
+        // Assign task foo-0 to member A
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 11, 0, 0));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(groupId, memberIdA,
+            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+            TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0)
+        )));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 12));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, memberA));
+
+        // Unassign task foo-0 from member A.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 12, 0, 0));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 12));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, new StreamsGroupMember.Builder(memberA)
+            .setMemberEpoch(12)
+            .setPreviousMemberEpoch(11)
+            .setTasksPendingRevocation(
+                TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+                TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0))
+            )
+            .build()));
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberIdA)
+                .setMemberEpoch(12)
+                .setRebalanceTimeoutMs(1500)
+                .setActiveTasks(List.of(new StreamsGroupHeartbeatRequestData.TaskIds()
+                    .setSubtopologyId(subtopologyFoo)
+                    .setPartitions(List.of()),
+                    new StreamsGroupHeartbeatRequestData.TaskIds()
+                    .setSubtopologyId(subtopologyBar)
+                    .setPartitions(List.of())))
+                .setStandbyTasks(List.of())
+                .setWarmupTasks(List.of()));
+        
+        assertResponseEquals(
+            new StreamsGroupHeartbeatResponseData()
+                .setMemberId(memberIdA)
+                .setMemberEpoch(14)
+                .setHeartbeatIntervalMs(5000)
+                .setActiveTasks(List.of(
+                    new StreamsGroupHeartbeatResponseData.TaskIds()
+                        .setSubtopologyId(subtopologyFoo)
+                        .setPartitions(List.of(0, 1))
+                ))
+                .setStandbyTasks(List.of())
+                .setWarmupTasks(List.of()),
+            result.response().data());
+
+        // // Assign task foo-0 to member B. This logs a warning and does not change the assignment.
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 11, 0, 0));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(groupId, memberIdB,
+        //     TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+        //     TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0)
+        // )));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 12));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, memberB));
+
+        // // Unassign task foo-0 from member B.
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 11, 0, 0));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 11));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, new StreamsGroupMember.Builder(memberB)
+        //     .setMemberEpoch(11)
+        //     .setPreviousMemberEpoch(10)
+        //     .setTasksPendingRevocation(
+        //         TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+        //         TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0))
+        //     )
+        //     .build()));
+
+        // // Then assign task bar-0 to member A. 
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(groupId, 13, 0, 0));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecord(groupId, topology));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(groupId, memberIdA,
+        //     TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE,
+        //     TaskAssignmentTestUtil.mkTasks(subtopologyBar, 0)
+        // )));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentEpochRecord(groupId, 14));
+        // context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, memberA));
+
+        // // Verify member A has ownership of task bar-0
+        // CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+        //     new StreamsGroupHeartbeatRequestData()
+        //         .setGroupId(groupId)
+        //         .setMemberId(memberIdA)
+        //         .setMemberEpoch(11)
+        //         .setRebalanceTimeoutMs(1500)
+        //         .setActiveTasks(List.of(new StreamsGroupHeartbeatRequestData.TaskIds()
+        //             .setSubtopologyId(subtopologyBar)
+        //             .setPartitions(List.of(0))))
+        //         .setStandbyTasks(List.of())
+        //         .setWarmupTasks(List.of()));
+        
+        // assertResponseEquals(
+        //     new StreamsGroupHeartbeatResponseData()
+        //         .setMemberId(memberIdA)
+        //         .setMemberEpoch(14)
+        //         .setHeartbeatIntervalMs(5000)
+        //         .setActiveTasks(List.of(
+        //             new StreamsGroupHeartbeatResponseData.TaskIds()
+        //                 .setSubtopologyId(subtopologyBar)
+        //                 .setPartitions(List.of(0))
+        //         ))
+        //         .setStandbyTasks(List.of())
+        //         .setWarmupTasks(List.of()),
+        //     result.response().data());
+    }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24390,16 +24390,16 @@ public class GroupMetadataManagerTest {
     @Test
     public void testReplayConsumerGroupCurrentMemberAssignmentWithCompaction() {
         String groupId = "fooup";
-        String memberA = "memberA";
-        String memberB = "memberB";
+        String memberIdA = "memberIdA";
+        String memberIdB = "memberIdB";
 
         Uuid topicId = Uuid.randomUuid();
         String topicName = "foo";
 
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withMetadataImage(new MetadataImageBuilder()
-            .addTopic(topicId, topicName, 2)
-            .buildCoordinatorMetadataImage())
+                .addTopic(topicId, topicName, 2)
+                .buildCoordinatorMetadataImage())
             .build();
 
         // This test enacts the following scenario:
@@ -24411,7 +24411,7 @@ public class GroupMetadataManagerTest {
         // unassignment records are removed. We would like to not fail in these cases.
         // Therefore we will allow assignments to owned partitions as long as the epoch is larger. 
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
@@ -24419,15 +24419,15 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Partition 0's owner is replaced by member B at epoch 12.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
             .build()));
 
-        // Partition 0 must remain with member B at epoch 12 even though member A just been unassigned partition 0.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+        // Partition 0 must remain with member B at epoch 12 even though member A has just been unassigned partition 0.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
@@ -24443,8 +24443,8 @@ public class GroupMetadataManagerTest {
     @Test
     public void testReplayConsumerGroupUnassignmentRecordSkippedWithCompaction() {
         String groupId = "fooup";
-        String memberA = "memberA";
-        String memberB = "memberB";
+        String memberIdA = "memberIdA";
+        String memberIdB = "memberIdB";
 
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
@@ -24453,9 +24453,9 @@ public class GroupMetadataManagerTest {
 
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withMetadataImage(new MetadataImageBuilder()
-            .addTopic(fooTopicId, fooTopicName, 3)
-            .addTopic(barTopicId, barTopicName, 1)
-            .buildCoordinatorMetadataImage())
+                .addTopic(fooTopicId, fooTopicName, 1)
+                .addTopic(barTopicId, barTopicName, 1)
+                .buildCoordinatorMetadataImage())
             .build();
 
         // This test enacts the following scenario:
@@ -24465,30 +24465,30 @@ public class GroupMetadataManagerTest {
         // 4. Member B is unassigned partition foo-1. 
         // 5. Member A is assigned partition bar-0. 
         // This is a legitimate set of assignments but with compaction the unassignment record can be skipped.
-        // We would like to not fail in these cases and allow both the assignment of member B to foo-1 and 
-        // member A to bar-0 to succeed because the epochs are larger. 
+        // This can lead to conflicts from updating an owned partition in step 3 and attempting to remove
+        // nonexistent ownership in step 5. We want to ensure both assignments are allowed.  
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0, 1)))
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
             .build()));
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
-            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2)))
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
             .build()));
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
             .build()));
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(14)
             .setPreviousMemberEpoch(13)
@@ -24497,15 +24497,15 @@ public class GroupMetadataManagerTest {
 
         // Verify member A only has ownership of partition bar-0. Member B has no partitions.
         ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
-        assertEquals(mkAssignment(mkTopicAssignment(barTopicId, 0)), group.members().get(memberA).assignedPartitions());
+        assertEquals(mkAssignment(mkTopicAssignment(barTopicId, 0)), group.members().get(memberIdA).assignedPartitions());
         assertEquals(14, group.currentPartitionEpoch(barTopicId, 0));
     }
 
     @Test
     public void testReplayConsumerGroupCurrentMemberAssignmentSameEpochWithCompaction() {
         String groupId = "fooup";
-        String memberA = "memberA";
-        String memberB = "memberB";
+        String memberIdA = "memberIdA";
+        String memberIdB = "memberIdB";
 
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
@@ -24514,9 +24514,9 @@ public class GroupMetadataManagerTest {
 
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withMetadataImage(new MetadataImageBuilder()
-            .addTopic(fooTopicId, fooTopicName, 1)
-            .addTopic(barTopicId, barTopicName, 1)
-            .buildCoordinatorMetadataImage())
+                .addTopic(fooTopicId, fooTopicName, 1)
+                .addTopic(barTopicId, barTopicName, 1)
+                .buildCoordinatorMetadataImage())
             .build();
 
         // This test enacts the following scenario:
@@ -24527,7 +24527,7 @@ public class GroupMetadataManagerTest {
         // 5. Member B is assigned topic foo. Member B { epoch: 11, assigned partitions: [foo], pending revocations: [] }
         // When record 4 is dropped by compaction, we want member B's assignment to be accepted with the same epoch. 
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(9)
@@ -24536,7 +24536,7 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Member A yields bar at epoch 11.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
@@ -24545,7 +24545,7 @@ public class GroupMetadataManagerTest {
 
         // Member A yields foo. [record removed by compaction]
         // Member B is assigned foo at epoch 11.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
@@ -24554,25 +24554,29 @@ public class GroupMetadataManagerTest {
 
         // Verify partition foo-0 is assigned to member B at epoch 11.
         ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
-        assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 0)), group.members().get(memberB).assignedPartitions());
+        assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 0)), group.members().get(memberIdB).assignedPartitions());
         assertEquals(11, group.currentPartitionEpoch(fooTopicId, 0));
     }
 
     @Test
     public void testReplayStreamsGroupCurrentMemberAssignmentWithCompaction() {
         String groupId = "fooup";
-        String memberA = "memberA";
-        String memberB = "memberB";
+        String memberIdA = "memberIdA";
+        String memberIdB = "memberIdB";
+        String processIdA = "processIdA";
+        String processIdB = "processIdB";
 
-        String subtopology = "subtopology";
-        String topicName = "foo";
-        Uuid topicId = Uuid.randomUuid();
+        String subtopologyId = "subtopology";
 
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(topicId, topicName, 2)
-                .buildCoordinatorMetadataImage())
-            .build();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
+
+        // Initialize members with process Ids.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
+            .setProcessId(processIdA)
+            .build()));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
+            .setProcessId(processIdB)
+            .build()));
 
         // This test enacts the following scenario:
         // 1. Member A is assigned task 0.
@@ -24581,59 +24585,59 @@ public class GroupMetadataManagerTest {
         // 4. Member A is assigned task 1. 
         // If record 2 is processed, there are no issues, however with compaction it is possible that 
         // unassignment records are removed. We would like to not fail in these cases.
-        // Therefore we will allow assignments to owned tasks as long as the epoch is larger. 
+        // Therefore we will allow assignments to owned tasks as long as the epoch is larger.
 
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+        // Assign task 0 to member A.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 11))))
+                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyId, Map.of(0, 11))))
             .build()));
 
         // Task 0's owner is replaced by member B at epoch 12.
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))))
+                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyId, Map.of(0, 12))))
             .build()));
 
-        // Task 0 must remain with member B at epoch 12 even though member A just been unassigned task 0.
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+        // Task 0 must remain with member B at epoch 12 even though member A has just been unassigned task 1.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))))
+                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyId, Map.of(1, 13))))
             .build()));
 
         // Check task 1 is assigned to member A and task 0 to member B.
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
-        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))), group.members().get(memberA).assignedTasks());
-        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))), group.members().get(memberB).assignedTasks());
+        assertEquals(processIdA, group.currentActiveTaskProcessId(subtopologyId, 1));
+        assertEquals(processIdB, group.currentActiveTaskProcessId(subtopologyId, 0));
     }
 
     @Test
     public void testReplayStreamsGroupUnassignmentRecordSkippedWithCompaction() {
         String groupId = "fooup";
-        String memberA = "memberA";
-        String memberB = "memberB";
+        String memberIdA = "memberIdA";
+        String memberIdB = "memberIdB";
+        String processIdA = "processIdA";
+        String processIdB = "processIdB";
 
         String subtopologyFoo = "subtopologyFoo";
-        String fooTopicName = "foo";
-        Uuid fooTopicId = Uuid.randomUuid();
         String subtopologyBar = "subtopologyBar";
-        String barTopicName = "bar";
-        Uuid barTopicId = Uuid.randomUuid();
 
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(fooTopicId, fooTopicName, 2)
-                .addTopic(barTopicId, barTopicName, 1)
-                .buildCoordinatorMetadataImage())
-            .build();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
+
+        // Initialize members with process Ids.
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
+            .setProcessId(processIdA)
+            .build()));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
+            .setProcessId(processIdB)
+            .build()));
 
         // This test enacts the following scenario:
         // 1. Member A is assigned task foo-1.
@@ -24645,7 +24649,7 @@ public class GroupMetadataManagerTest {
         // We would like to not fail in these cases and allow both the assignment of member B to foo-1 and 
         // member A to bar-0 to succeed because the epochs are larger. 
 
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
@@ -24653,30 +24657,30 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11, 1, 11))))
             .build()));
 
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
-            .setMemberEpoch(11)
-            .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11))))
-            .build()));
-
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 12))))
             .build()));
 
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
+            .build()));
+
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
+            .setMemberEpoch(14)
+            .setPreviousMemberEpoch(13)
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))))
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 14))))
             .build()));
 
         // Check task bar-0 is assigned to member A. Member B has no tasks.
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
-        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))), group.members().get(memberA).assignedTasks());
+        assertEquals(processIdA, group.currentActiveTaskProcessId(subtopologyBar, 0));
     }
+
     private record PendingAssignmentCase(
         String description,
         String groupId,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24540,28 +24540,31 @@ public class GroupMetadataManagerTest {
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 0)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 11))))
             .build()));
 
         // Assign task 0 to member B.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 0)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))))
             .build()));
 
         // Then assign task 1 as well to member A.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 1)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                    TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))))
             .build()));
 
         // Check task 1 is assigned to member A and task 0 to member B.
-        assertEquals(group.members().get(memberA).assignedTasks(), 
-            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 1)));
-        assertEquals(group.members().get(memberB).assignedTasks(), 
-            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology, 0)));
+        assertEquals(group.members().get(memberA).assignedTasks(), TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))));
+        assertEquals(group.members().get(memberB).assignedTasks(), TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))));
     }
 
     @Test
@@ -24595,7 +24598,8 @@ public class GroupMetadataManagerTest {
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0, 1)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11, 1, 11))))
             .build()));
 
         // Unassign task foo-0 from member A.
@@ -24603,34 +24607,41 @@ public class GroupMetadataManagerTest {
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 1)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(1, 12))))
             .build()));
 
         // Assign task foo-0,2 to member B
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 0)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11))))
             .build()));
 
         // Unassign task foo-0 from member B.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 2)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))))
             .build()));
 
         // Assign task bar-0 to member A. 
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyBar, 0)))
+            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))))
             .build()));
 
         // Check task bar-0 is assigned to member A and task foo-2 is assigned to member B.
         assertEquals(group.members().get(memberA).assignedTasks(), 
-            TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyBar, 0)));
-        assertEquals(group.members().get(memberB).assignedTasks(), TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopologyFoo, 2)));
+            TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))));
+        assertEquals(group.members().get(memberB).assignedTasks(), 
+            TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))));
     }
 
     private record PendingAssignmentCase(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24411,7 +24411,15 @@ public class GroupMetadataManagerTest {
 
         ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
 
-        // Assign partition 0 to member A
+        // This test enacts the following scenario:
+        // 1. Member A is assigned partition 0.
+        // 2. Member A is unassigned partition 0 [record removed by compaction].
+        // 3. Member B is assigned partition 0. 
+        // 4. Member A is assigned partition 1. 
+        // If record 2 is processed, there are no issues, however with compaction it is possible that 
+        // unassignment records are removed. We would like to not fail in these cases.
+        // Therefore we will allow assignments to owned partitions as long as the epoch is larger. 
+
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
@@ -24419,7 +24427,6 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
             .build()));
 
-        // Assign partition 0 to member B. This is allowed even though partition 0 is already owned by member A.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(12)
@@ -24427,7 +24434,6 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(topicId, 0)))
             .build()));
 
-        // Now assign partition 1 to member A.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(13)
@@ -24436,8 +24442,8 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Verify partition epochs.
-        assertEquals(group.currentPartitionEpoch(topicId, 0), 12);
-        assertEquals(group.currentPartitionEpoch(topicId, 1), 13);
+        assertEquals(12, group.currentPartitionEpoch(topicId, 0));
+        assertEquals(13, group.currentPartitionEpoch(topicId, 1));
     }
 
     @Test
@@ -24468,7 +24474,16 @@ public class GroupMetadataManagerTest {
 
         ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
 
-        // Assign partition foo-1 to member A
+        // This test enacts the following scenario:
+        // 1. Member A is assigned partition foo-1.
+        // 2. Member A is unassigned partition foo-1 [record removed by compaction].
+        // 3. Member B is assigned partition foo-1.
+        // 4. Member B is unassigned partition foo-1. 
+        // 5. Member A is assigned partition bar-0. 
+        // This is a legitimate set of assignments but with compaction the unassignment record can be skipped.
+        // We would like to not fail in these cases and allow both the assignment of member B to foo-1 and 
+        // member A to bar-0 to succeed because the epochs are larger. 
+
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(11)
@@ -24476,16 +24491,6 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0, 1)))
             .build()));
 
-
-        // Unassign partition foo-1 from member A.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
-            .setState(MemberState.STABLE)
-            .setMemberEpoch(12)
-            .setPreviousMemberEpoch(11)
-            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
-            .build()));
-
-        // Assign partition foo-1 to member B.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(13)
@@ -24493,7 +24498,6 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2)))
             .build()));
 
-        // Unassign partition foo-1 to member B.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(14)
@@ -24501,7 +24505,6 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 2)))
             .build()));
 
-        // Assign partition bar-0 to member A.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(15)
@@ -24509,8 +24512,9 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(barTopicId, 0)))
             .build()));
 
-        // Verify member A has ownership of partition bar-0. member B has no partitions.
-        assertEquals(group.currentPartitionEpoch(barTopicId, 0), 15);
+        // Verify member A only has ownership of partition bar-0. Member B has no partitions.
+        assertEquals(mkAssignment(mkTopicAssignment(barTopicId, 0)), group.members().get(memberA).assignedPartitions());
+        assertEquals(15, group.currentPartitionEpoch(barTopicId, 0));
     }
 
     @Test
@@ -24535,7 +24539,15 @@ public class GroupMetadataManagerTest {
 
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
 
-        // Assign task 0 to member A
+        // This test enacts the following scenario:
+        // 1. Member A is assigned task 0.
+        // 2. Member A is unassigned task 0 [record removed by compaction].
+        // 3. Member B is assigned task 0. 
+        // 4. Member A is assigned task 1. 
+        // If record 2 is processed, there are no issues, however with compaction it is possible that 
+        // unassignment records are removed. We would like to not fail in these cases.
+        // Therefore we will allow assignments to owned tasks as long as the epoch is larger. 
+
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
@@ -24544,7 +24556,6 @@ public class GroupMetadataManagerTest {
                     TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 11))))
             .build()));
 
-        // Assign task 0 to member B.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
@@ -24552,7 +24563,6 @@ public class GroupMetadataManagerTest {
                     TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))))
             .build()));
 
-        // Then assign task 1 as well to member A.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
@@ -24561,10 +24571,10 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Check task 1 is assigned to member A and task 0 to member B.
-        assertEquals(group.members().get(memberA).assignedTasks(), TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))));
-        assertEquals(group.members().get(memberB).assignedTasks(), TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))));
+        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(1, 13))), group.members().get(memberA).assignedTasks());
+        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopology, Map.of(0, 12))), group.members().get(memberB).assignedTasks());
     }
 
     @Test
@@ -24593,7 +24603,16 @@ public class GroupMetadataManagerTest {
 
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
 
-        // Assign task foo-0,1 to member A
+        // This test enacts the following scenario:
+        // 1. Member A is assigned task foo-1.
+        // 2. Member A is unassigned task foo-1 [record removed by compaction].
+        // 3. Member B is assigned task foo-1.
+        // 4. Member B is unassigned task foo-1. 
+        // 5. Member A is assigned task bar-0. 
+        // This is a legitimate set of assignments but with compaction the unassignment record can be skipped.
+        // We would like to not fail in these cases and allow both the assignment of member B to foo-1 and 
+        // member A to bar-0 to succeed because the epochs are larger. 
+
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
@@ -24602,16 +24621,6 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11, 1, 11))))
             .build()));
 
-        // Unassign task foo-0 from member A.
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
-            .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
-            .setMemberEpoch(12)
-            .setPreviousMemberEpoch(11)
-            .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(1, 12))))
-            .build()));
-
-        // Assign task foo-0,2 to member B
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
@@ -24619,7 +24628,6 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11))))
             .build()));
 
-        // Unassign task foo-0 from member B.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
@@ -24627,7 +24635,6 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))))
             .build()));
 
-        // Assign task bar-0 to member A. 
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
@@ -24636,12 +24643,10 @@ public class GroupMetadataManagerTest {
             .build()));
 
         // Check task bar-0 is assigned to member A and task foo-2 is assigned to member B.
-        assertEquals(group.members().get(memberA).assignedTasks(), 
-            TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))));
-        assertEquals(group.members().get(memberB).assignedTasks(), 
-            TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))));
+        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+            TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 13))), group.members().get(memberA).assignedTasks());
+        assertEquals(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(2, 12))), group.members().get(memberB).assignedTasks());
     }
 
     private record PendingAssignmentCase(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24392,15 +24392,9 @@ public class GroupMetadataManagerTest {
         String groupId = "fooup";
         String memberIdA = "memberIdA";
         String memberIdB = "memberIdB";
-
         Uuid topicId = Uuid.randomUuid();
-        String topicName = "foo";
 
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(topicId, topicName, 2)
-                .buildCoordinatorMetadataImage())
-            .build();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
 
         // This test enacts the following scenario:
         // 1. Member A is assigned partition 0.
@@ -24441,32 +24435,25 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testReplayConsumerGroupUnassignmentRecordSkippedWithCompaction() {
+    public void testReplayConsumerGroupCurrentMemberAssignmentUnownedTopicWithCompaction() {
         String groupId = "fooup";
         String memberIdA = "memberIdA";
         String memberIdB = "memberIdB";
-
         Uuid fooTopicId = Uuid.randomUuid();
-        String fooTopicName = "foo";
         Uuid barTopicId = Uuid.randomUuid();
-        String barTopicName = "bar";
 
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(fooTopicId, fooTopicName, 1)
-                .addTopic(barTopicId, barTopicName, 1)
-                .buildCoordinatorMetadataImage())
-            .build();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
 
         // This test enacts the following scenario:
-        // 1. Member A is assigned partition foo-1.
-        // 2. Member A is unassigned partition foo-1 [record removed by compaction].
-        // 3. Member B is assigned partition foo-1.
-        // 4. Member B is unassigned partition foo-1. 
+        // 1. Member A is assigned partition foo-0.
+        // 2. Member A is unassigned partition foo-0 [record removed by compaction].
+        // 3. Member B is assigned partition foo-0.
+        // 4. Member B is unassigned partition foo-0. 
         // 5. Member A is assigned partition bar-0. 
         // This is a legitimate set of assignments but with compaction the unassignment record can be skipped.
-        // This can lead to conflicts from updating an owned partition in step 3 and attempting to remove
-        // nonexistent ownership in step 5. We want to ensure both assignments are allowed.  
+        // This can lead to conflicts from updating an owned partition in step 3 and attempting 
+        // to remove nonexistent ownership in step 5. We want to ensure removing ownership from a 
+        // completely unowned partition in step 5 is allowed.  
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
@@ -24475,6 +24462,7 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
             .build()));
 
+        // foo-0's owner is replaced by member B at epoch 12.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(12)
@@ -24482,12 +24470,14 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
             .build()));
 
+        // foo becomes unowned.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
             .setState(MemberState.STABLE)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
             .build()));
 
+        // Member A is unassigned foo-0.
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
             .setState(MemberState.STABLE)
             .setMemberEpoch(14)
@@ -24495,9 +24485,9 @@ public class GroupMetadataManagerTest {
             .setAssignedPartitions(mkAssignment(mkTopicAssignment(barTopicId, 0)))
             .build()));
 
-        // Verify member A only has ownership of partition bar-0. Member B has no partitions.
+        // Verify foo-0 is unowned and bar-0 is owned by member A at epoch 14.
         ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
-        assertEquals(mkAssignment(mkTopicAssignment(barTopicId, 0)), group.members().get(memberIdA).assignedPartitions());
+        assertEquals(-1, group.currentPartitionEpoch(fooTopicId, 0));
         assertEquals(14, group.currentPartitionEpoch(barTopicId, 0));
     }
 
@@ -24506,18 +24496,10 @@ public class GroupMetadataManagerTest {
         String groupId = "fooup";
         String memberIdA = "memberIdA";
         String memberIdB = "memberIdB";
-
         Uuid fooTopicId = Uuid.randomUuid();
-        String fooTopicName = "foo";
         Uuid barTopicId = Uuid.randomUuid();
-        String barTopicName = "bar";
 
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(fooTopicId, fooTopicName, 1)
-                .addTopic(barTopicId, barTopicName, 1)
-                .buildCoordinatorMetadataImage())
-            .build();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
 
         // This test enacts the following scenario:
         // 1. Member A unsubscribes from topic bar at epoch 10: Member A { epoch: 10, assigned partitions: [foo], pending revocations: [bar] }
@@ -24565,18 +24547,18 @@ public class GroupMetadataManagerTest {
         String memberIdB = "memberIdB";
         String processIdA = "processIdA";
         String processIdB = "processIdB";
-
         String subtopologyId = "subtopology";
 
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
-
         // Initialize members with process Ids.
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
-            .setProcessId(processIdA)
-            .build()));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
-            .setProcessId(processIdB)
-            .build()));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, 
+            streamsGroupMemberBuilderWithDefaults(memberIdA)
+                .setProcessId(processIdA)
+                .build()));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, 
+            streamsGroupMemberBuilderWithDefaults(memberIdB)
+                .setProcessId(processIdB)
+                .build()));
 
         // This test enacts the following scenario:
         // 1. Member A is assigned task 0.
@@ -24604,7 +24586,7 @@ public class GroupMetadataManagerTest {
                     TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyId, Map.of(0, 12))))
             .build()));
 
-        // Task 0 must remain with member B at epoch 12 even though member A has just been unassigned task 1.
+        // Task 0 must remain with member B at epoch 12 even though member A has just been unassigned task 0.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
@@ -24619,44 +24601,46 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testReplayStreamsGroupUnassignmentRecordSkippedWithCompaction() {
+    public void testReplayStreamsGroupCurrentMemberAssignmentUnownedTopologyWithCompaction() {
         String groupId = "fooup";
         String memberIdA = "memberIdA";
         String memberIdB = "memberIdB";
         String processIdA = "processIdA";
         String processIdB = "processIdB";
-
         String subtopologyFoo = "subtopologyFoo";
         String subtopologyBar = "subtopologyBar";
 
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
-
         // Initialize members with process Ids.
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
-            .setProcessId(processIdA)
-            .build()));
-        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
-            .setProcessId(processIdB)
-            .build()));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, 
+            streamsGroupMemberBuilderWithDefaults(memberIdA)
+                .setProcessId(processIdA)
+                .build()));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberRecord(groupId, 
+            streamsGroupMemberBuilderWithDefaults(memberIdB)
+                .setProcessId(processIdB)
+                .build()));
 
         // This test enacts the following scenario:
-        // 1. Member A is assigned task foo-1.
-        // 2. Member A is unassigned task foo-1 [record removed by compaction].
-        // 3. Member B is assigned task foo-1.
-        // 4. Member B is unassigned task foo-1. 
+        // 1. Member A is assigned task foo-0.
+        // 2. Member A is unassigned task foo-0 [record removed by compaction].
+        // 3. Member B is assigned task foo-0.
+        // 4. Member B is unassigned task foo-0. 
         // 5. Member A is assigned task bar-0. 
         // This is a legitimate set of assignments but with compaction the unassignment record can be skipped.
-        // We would like to not fail in these cases and allow both the assignment of member B to foo-1 and 
-        // member A to bar-0 to succeed because the epochs are larger. 
+        // This can lead to conflicts from updating an owned subtopology in step 3 and attempting to remove
+        // nonexistent ownership in step 5. We want to ensure removing ownership from a 
+        // completely unowned subtopology in step 5 is allowed.  
 
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
             .setState(org.apache.kafka.coordinator.group.streams.MemberState.STABLE)
             .setMemberEpoch(11)
             .setPreviousMemberEpoch(10)
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithEpochs(TaskRole.ACTIVE, 
-                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11, 1, 11))))
+                TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 11))))
             .build()));
 
+        // foo-0's owner is replaced by member B at epoch 12.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
             .setMemberEpoch(12)
             .setPreviousMemberEpoch(11)
@@ -24664,11 +24648,13 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyFoo, Map.of(0, 12))))
             .build()));
 
+        // foo becomes unowned
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdB)
             .setMemberEpoch(13)
             .setPreviousMemberEpoch(12)
             .build()));
 
+        // Member A is unassigned foo-0.
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, streamsGroupMemberBuilderWithDefaults(memberIdA)
             .setMemberEpoch(14)
             .setPreviousMemberEpoch(13)
@@ -24676,8 +24662,9 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyBar, Map.of(0, 14))))
             .build()));
 
-        // Check task bar-0 is assigned to member A. Member B has no tasks.
+        // Verify foo-0 is unassigned and bar-0 is assigned to member A.
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
+        assertEquals(null, group.currentActiveTaskProcessId(subtopologyFoo, 0));
         assertEquals(processIdA, group.currentActiveTaskProcessId(subtopologyBar, 0));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -24492,55 +24492,6 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testReplayConsumerGroupCurrentMemberAssignmentSameEpochWithCompaction() {
-        String groupId = "fooup";
-        String memberIdA = "memberIdA";
-        String memberIdB = "memberIdB";
-        Uuid fooTopicId = Uuid.randomUuid();
-        Uuid barTopicId = Uuid.randomUuid();
-
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
-
-        // This test enacts the following scenario:
-        // 1. Member A unsubscribes from topic bar at epoch 10: Member A { epoch: 10, assigned partitions: [foo], pending revocations: [bar] }
-        // 2. A new assignment is available at epoch 11 with member A unsubscribing from topic foo.
-        // 3. Member A yields bar. The epoch is bumped to 11: Member A { epoch: 11, assigned partitions: [], pending revocations: [foo] }
-        // 4. Member A yields topic foo. Member A { epoch: 11, assigned partitions: [], pending revocations: [] } [removed by compaction]
-        // 5. Member B is assigned topic foo. Member B { epoch: 11, assigned partitions: [foo], pending revocations: [] }
-        // When record 4 is dropped by compaction, we want member B's assignment to be accepted with the same epoch. 
-
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
-            .setState(MemberState.STABLE)
-            .setMemberEpoch(10)
-            .setPreviousMemberEpoch(9)
-            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
-            .setPartitionsPendingRevocation(mkAssignment(mkTopicAssignment(barTopicId, 0)))
-            .build()));
-
-        // Member A yields bar at epoch 11.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdA)
-            .setState(MemberState.STABLE)
-            .setMemberEpoch(11)
-            .setPreviousMemberEpoch(10)
-            .setPartitionsPendingRevocation(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
-            .build()));
-
-        // Member A yields foo. [record removed by compaction]
-        // Member B is assigned foo at epoch 11.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberIdB)
-            .setState(MemberState.STABLE)
-            .setMemberEpoch(11)
-            .setPreviousMemberEpoch(10)
-            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 0)))
-            .build()));
-
-        // Verify partition foo-0 is assigned to member B at epoch 11.
-        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
-        assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 0)), group.members().get(memberIdB).assignedPartitions());
-        assertEquals(11, group.currentPartitionEpoch(fooTopicId, 0));
-    }
-
-    @Test
     public void testReplayStreamsGroupCurrentMemberAssignmentWithCompaction() {
         String groupId = "fooup";
         String memberIdA = "memberIdA";
@@ -24594,7 +24545,7 @@ public class GroupMetadataManagerTest {
                     TaskAssignmentTestUtil.mkTasksWithEpochs(subtopologyId, Map.of(1, 13))))
             .build()));
 
-        // Check task 1 is assigned to member A and task 0 to member B.
+        // Verify task 1 is assigned to member A and task 0 to member B.
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
         assertEquals(processIdA, group.currentActiveTaskProcessId(subtopologyId, 1));
         assertEquals(processIdB, group.currentActiveTaskProcessId(subtopologyId, 0));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
@@ -1380,6 +1380,7 @@ public class ClassicGroupTest {
             .build();
 
         ConsumerGroup consumerGroup = new ConsumerGroup(
+            logContext,
             new SnapshotRegistry(logContext),
             groupId
         );
@@ -1532,6 +1533,7 @@ public class ClassicGroupTest {
             .build();
 
         ConsumerGroup consumerGroup = new ConsumerGroup(
+            logContext,
             new SnapshotRegistry(logContext),
             groupId
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1290,6 +1290,7 @@ public class ConsumerGroupTest {
         classicGroup.add(member);
 
         ConsumerGroup consumerGroup = ConsumerGroup.fromClassicGroup(
+            logContext,
             new SnapshotRegistry(logContext),
             classicGroup,
             new HashMap<>(),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -289,21 +289,16 @@ public class ConsumerGroupTest {
 
         // m2 should not be able to acquire foo-1 because the partition is
         // still owned by another member.
-        assertThrows(IllegalStateException.class, () -> consumerGroup.updateMember(m2));
+        consumerGroup.updateMember(m2);
+        assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 1)), 
+            consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions()
+        );
     }
 
     @Test
     public void testRemovePartitionEpochs() {
         Uuid fooTopicId = Uuid.randomUuid();
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
-
-        // Removing should fail because there is no epoch set.
-        assertThrows(IllegalStateException.class, () -> consumerGroup.removePartitionEpochs(
-            mkAssignment(
-                mkTopicAssignment(fooTopicId, 1)
-            ),
-            10
-        ));
 
         ConsumerGroupMember m1 = new ConsumerGroupMember.Builder("m1")
             .setMemberEpoch(10)
@@ -313,13 +308,18 @@ public class ConsumerGroupTest {
 
         consumerGroup.updateMember(m1);
 
-        // Removing should fail because the expected epoch is incorrect.
-        assertThrows(IllegalStateException.class, () -> consumerGroup.removePartitionEpochs(
+        // Removing with incorrect epoch should fail. 
+        // A debug message is logged but no exception is thrown.
+        consumerGroup.removePartitionEpochs(
             mkAssignment(
                 mkTopicAssignment(fooTopicId, 1)
             ),
             11
-        ));
+        );
+        assertEquals(
+            consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions(), 
+            m1.assignedPartitions()
+        );
     }
 
     @Test
@@ -336,12 +336,14 @@ public class ConsumerGroupTest {
 
         // Changing the epoch should fail because the owner of the partition
         // should remove it first.
-        assertThrows(IllegalStateException.class, () -> consumerGroup.addPartitionEpochs(
+        // A debug message is logged but no exception is thrown.
+        consumerGroup.addPartitionEpochs(
             mkAssignment(
                 mkTopicAssignment(fooTopicId, 1)
             ),
             11
-        ));
+        );
+        assertEquals(11, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -333,10 +333,6 @@ public class ConsumerGroupTest {
             ),
             11
         );
-        assertEquals(
-            mkAssignment(mkTopicAssignment(fooTopicId, 1)),
-            consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions()
-        );
         assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -320,6 +320,7 @@ public class ConsumerGroupTest {
             consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions(), 
             m1.assignedPartitions()
         );
+        assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
     }
 
     @Test
@@ -334,9 +335,7 @@ public class ConsumerGroupTest {
             10
         );
 
-        // Changing the epoch should fail because the owner of the partition
-        // should remove it first.
-        // A debug message is logged but no exception is thrown.
+        // Updating to a larger epoch should succeed.
         consumerGroup.addPartitionEpochs(
             mkAssignment(
                 mkTopicAssignment(fooTopicId, 1)
@@ -344,6 +343,16 @@ public class ConsumerGroupTest {
             11
         );
         assertEquals(11, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
+
+        // Updating to a smaller epoch should fail.
+        assertThrows(IllegalStateException.class, () -> {
+            consumerGroup.addPartitionEpochs(
+                mkAssignment(
+                    mkTopicAssignment(fooTopicId, 1)
+                ),
+                10
+            );
+        });
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -287,18 +287,37 @@ public class ConsumerGroupTest {
                 mkTopicAssignment(fooTopicId, 1)))
             .build();
 
-        // m2 should not be able to acquire foo-1 because the partition is
-        // still owned by another member.
+        // m2 can acquire foo-1 because the epoch is at least as large as m1's epoch.
         consumerGroup.updateMember(m2);
         assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 1)), 
             consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions()
         );
+
+        ConsumerGroupMember m3 = new ConsumerGroupMember.Builder("m3")
+            .setMemberEpoch(9)
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 1)))
+            .build();
+
+        // m3 should not be able to acquire foo-1 because the epoch is smaller 
+        // than the current partition epoch (10).
+        assertThrows(IllegalStateException.class, () -> {
+            consumerGroup.updateMember(m3);
+        });
     }
 
     @Test
     public void testRemovePartitionEpochs() {
         Uuid fooTopicId = Uuid.randomUuid();
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        // Removing should be a no-op when there is no epoch set.
+        consumerGroup.removePartitionEpochs(
+            mkAssignment(
+                mkTopicAssignment(fooTopicId, 1)
+            ),
+            10
+        );
 
         ConsumerGroupMember m1 = new ConsumerGroupMember.Builder("m1")
             .setMemberEpoch(10)
@@ -308,8 +327,8 @@ public class ConsumerGroupTest {
 
         consumerGroup.updateMember(m1);
 
-        // Removing with incorrect epoch should fail. 
-        // A debug message is logged but no exception is thrown.
+        // Removing with incorrect epoch should do nothing. 
+        // A debug message is logged, no exception is thrown.
         consumerGroup.removePartitionEpochs(
             mkAssignment(
                 mkTopicAssignment(fooTopicId, 1)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -87,6 +87,7 @@ public class ConsumerGroupTest {
     private ConsumerGroup createConsumerGroup(String groupId) {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         return new ConsumerGroup(
+            new LogContext(),
             snapshotRegistry,
             groupId
         );
@@ -696,7 +697,7 @@ public class ConsumerGroupTest {
     @Test
     public void testUpdateInvertedAssignment() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup consumerGroup = new ConsumerGroup(snapshotRegistry, "test-group");
+        ConsumerGroup consumerGroup = new ConsumerGroup(new LogContext(), snapshotRegistry, "test-group");
         Uuid topicId = Uuid.randomUuid();
         String memberId1 = "member1";
         String memberId2 = "member2";
@@ -911,7 +912,7 @@ public class ConsumerGroupTest {
     @Test
     public void testAsListedGroup() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup group = new ConsumerGroup(snapshotRegistry, "group-foo");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo");
         snapshotRegistry.idempotentCreateSnapshot(0);
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY.toString(), group.stateAsString(0));
         group.updateMember(new ConsumerGroupMember.Builder("member1")
@@ -926,6 +927,7 @@ public class ConsumerGroupTest {
     public void testValidateOffsetFetch() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         ConsumerGroup group = new ConsumerGroup(
+            new LogContext(), 
             snapshotRegistry,
             "group-foo"
         );
@@ -986,7 +988,7 @@ public class ConsumerGroupTest {
         long commitTimestamp = 20000L;
         long offsetsRetentionMs = 10000L;
         OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(15000L, OptionalInt.empty(), "", commitTimestamp, OptionalLong.empty(), Uuid.ZERO_UUID);
-        ConsumerGroup group = new ConsumerGroup(new SnapshotRegistry(new LogContext()), "group-id");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), new SnapshotRegistry(new LogContext()), "group-id");
 
         Optional<OffsetExpirationCondition> offsetExpirationCondition = group.offsetExpirationCondition();
         assertTrue(offsetExpirationCondition.isPresent());
@@ -1023,7 +1025,7 @@ public class ConsumerGroupTest {
     @Test
     public void testAsDescribedGroup() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup group = new ConsumerGroup(snapshotRegistry, "group-id-1");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id-1");
         snapshotRegistry.idempotentCreateSnapshot(0);
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY.toString(), group.stateAsString(0));
 
@@ -1060,7 +1062,7 @@ public class ConsumerGroupTest {
     @Test
     public void testIsInStatesCaseInsensitive() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup group = new ConsumerGroup(snapshotRegistry, "group-foo");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo");
         snapshotRegistry.idempotentCreateSnapshot(0);
         assertTrue(group.isInStates(Set.of("empty"), 0));
         assertFalse(group.isInStates(Set.of("Empty"), 0));
@@ -1298,6 +1300,7 @@ public class ConsumerGroupTest {
         );
 
         ConsumerGroup expectedConsumerGroup = new ConsumerGroup(
+            new LogContext(), 
             new SnapshotRegistry(logContext),
             groupId
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -317,8 +317,8 @@ public class ConsumerGroupTest {
             11
         );
         assertEquals(
-            consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions(), 
-            m1.assignedPartitions()
+            mkAssignment(mkTopicAssignment(fooTopicId, 1)),
+            consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions()
         );
         assertEquals(10, consumerGroup.currentPartitionEpoch(fooTopicId, 1));
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -288,10 +288,8 @@ public class ConsumerGroupTest {
             .build();
 
         // m2 can acquire foo-1 because the epoch is at least as large as m1's epoch.
+        // This should not throw IllegalStateException.
         consumerGroup.updateMember(m2);
-        assertEquals(mkAssignment(mkTopicAssignment(fooTopicId, 1)), 
-            consumerGroup.getOrMaybeCreateMember("m1", false).assignedPartitions()
-        );
 
         ConsumerGroupMember m3 = new ConsumerGroupMember.Builder("m3")
             .setMemberEpoch(9)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -282,23 +282,23 @@ public class ConsumerGroupTest {
         consumerGroup.updateMember(m1);
 
         ConsumerGroupMember m2 = new ConsumerGroupMember.Builder("m2")
+            .setMemberEpoch(11)
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 1)))
+            .build();
+
+        // m2 can acquire foo-1 because the epoch is larger than m1's epoch.
+        // This should not throw IllegalStateException.
+        consumerGroup.updateMember(m2);
+
+        ConsumerGroupMember m3 = new ConsumerGroupMember.Builder("m3")
             .setMemberEpoch(10)
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(fooTopicId, 1)))
             .build();
 
-        // m2 can acquire foo-1 because the epoch is at least as large as m1's epoch.
-        // This should not throw IllegalStateException.
-        consumerGroup.updateMember(m2);
-
-        ConsumerGroupMember m3 = new ConsumerGroupMember.Builder("m3")
-            .setMemberEpoch(9)
-            .setAssignedPartitions(mkAssignment(
-                mkTopicAssignment(fooTopicId, 1)))
-            .build();
-
         // m3 should not be able to acquire foo-1 because the epoch is smaller 
-        // than the current partition epoch (10).
+        // than the current partition epoch (11).
         assertThrows(IllegalStateException.class, () -> {
             consumerGroup.updateMember(m3);
         });

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -375,6 +375,12 @@ public class StreamsGroupTest {
         String fooSubtopologyId = "foo-sub";
         StreamsGroup streamsGroup = createStreamsGroup("foo");
 
+        // Removing should be a no-op when there is no epoch set.
+        streamsGroup.removeTaskProcessIds(
+            TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
+            "process"
+        );
+
         StreamsGroupMember m1 = new StreamsGroupMember.Builder("m1")
             .setProcessId("process")
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)))
@@ -382,13 +388,17 @@ public class StreamsGroupTest {
 
         streamsGroup.updateMember(m1);
 
-        // Removing with incorrect epoch should fail. 
-        // A debug message is logged but no exception is thrown.
+        // Removing with incorrect epoch should do nothing. 
+        // A debug message is logged, no exception is thrown.
         streamsGroup.removeTaskProcessIds(
-            TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
+            TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 9, mkTasks(fooSubtopologyId, 1)),
             "process1"
         );
         assertEquals(m1.assignedTasks(), streamsGroup.getMemberOrThrow("m1").assignedTasks());
+        if (taskRole == TaskRole.ACTIVE) {
+            assertEquals(10, streamsGroup.getMemberOrThrow("m1").assignedTasks().activeTasksWithEpochs()
+                .get(fooSubtopologyId).get(1));
+        }
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -388,7 +388,7 @@ public class StreamsGroupTest {
             TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
             "process1"
         );
-        assertEquals(streamsGroup.getMemberOrThrow("m1").assignedTasks(), m1.assignedTasks());
+        assertEquals(m1.assignedTasks(), streamsGroup.getMemberOrThrow("m1").assignedTasks());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -395,7 +395,6 @@ public class StreamsGroupTest {
             TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 9, mkTasks(fooSubtopologyId, 1)),
             "process1"
         );
-        assertEquals(m1.assignedTasks(), streamsGroup.getMemberOrThrow("m1").assignedTasks());
         if (taskRole == TaskRole.ACTIVE) {
             assertEquals("process", streamsGroup.currentActiveTaskProcessId(fooSubtopologyId, 1));
         }
@@ -415,17 +414,17 @@ public class StreamsGroupTest {
             "process"
         );
 
-        // We allow changing the epoch with the same process id. 
+        // We allow replacing with a different process id.
         streamsGroup.addTaskProcessId(
             new TasksTupleWithEpochs(
                 mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 2)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 3))
             ),
-            "process"
+            "process2"
         );
 
-        assertEquals("process", streamsGroup.currentActiveTaskProcessId(fooSubtopologyId, 1));
+        assertEquals("process2", streamsGroup.currentActiveTaskProcessId(fooSubtopologyId, 1));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -340,7 +340,7 @@ public class StreamsGroupTest {
         StreamsGroup streamsGroup = createStreamsGroup("foo");
 
         StreamsGroupMember m1 = new StreamsGroupMember.Builder("m1")
-            .setProcessId("process")
+            .setProcessId("process1")
             .setAssignedTasks(
                 new TasksTupleWithEpochs(
                     mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
@@ -353,18 +353,17 @@ public class StreamsGroupTest {
         streamsGroup.updateMember(m1);
 
         StreamsGroupMember m2 = new StreamsGroupMember.Builder("m2")
-            .setProcessId("process")
+            .setProcessId("process2")
             .setAssignedTasks(
                 new TasksTupleWithEpochs(
-                    mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
+                    mkTasksPerSubtopologyWithCommonEpoch(9, mkTasks(fooSubtopologyId, 1)),
                     Map.of(),
                     Map.of()
                 )
             )
             .build();
 
-        // m2 should not be able to acquire foo-1 because the partition is
-        // still owned by another member.
+        // m1 should retain ownership of the task since m2 has a smaller epoch.
         assertThrows(IllegalStateException.class, () -> streamsGroup.updateMember(m2));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -363,8 +363,10 @@ public class StreamsGroupTest {
             )
             .build();
 
-        // m1 should retain ownership of the task since m2 has a smaller epoch.
-        assertThrows(IllegalStateException.class, () -> streamsGroup.updateMember(m2));
+        // We allow m2 to acquire foo-1 despite the fact that m1 has ownership because the processId is different.
+        streamsGroup.updateMember(m2);
+
+        assertEquals("process2", streamsGroup.currentActiveTaskProcessId(fooSubtopologyId, 1));
     }
 
 
@@ -374,7 +376,7 @@ public class StreamsGroupTest {
         String fooSubtopologyId = "foo-sub";
         StreamsGroup streamsGroup = createStreamsGroup("foo");
 
-        // Removing should be a no-op when there is no epoch set.
+        // Removing should be a no-op when there is no process id set.
         streamsGroup.removeTaskProcessIds(
             TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
             "process"
@@ -387,7 +389,7 @@ public class StreamsGroupTest {
 
         streamsGroup.updateMember(m1);
 
-        // Removing with incorrect epoch should do nothing. 
+        // Removing with incorrect process id should do nothing. 
         // A debug message is logged, no exception is thrown.
         streamsGroup.removeTaskProcessIds(
             TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 9, mkTasks(fooSubtopologyId, 1)),
@@ -395,8 +397,7 @@ public class StreamsGroupTest {
         );
         assertEquals(m1.assignedTasks(), streamsGroup.getMemberOrThrow("m1").assignedTasks());
         if (taskRole == TaskRole.ACTIVE) {
-            assertEquals(10, streamsGroup.getMemberOrThrow("m1").assignedTasks().activeTasksWithEpochs()
-                .get(fooSubtopologyId).get(1));
+            assertEquals("process", streamsGroup.currentActiveTaskProcessId(fooSubtopologyId, 1));
         }
     }
 
@@ -414,16 +415,17 @@ public class StreamsGroupTest {
             "process"
         );
 
-        // Changing the epoch should fail because the owner of the partition
-        // should remove it first.
-        assertThrows(IllegalStateException.class, () -> streamsGroup.addTaskProcessId(
+        // We allow changing the epoch with the same process id. 
+        streamsGroup.addTaskProcessId(
             new TasksTupleWithEpochs(
                 mkTasksPerSubtopologyWithCommonEpoch(10, mkTasks(fooSubtopologyId, 1)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 2)),
                 mkTasksPerSubtopology(mkTasks(fooSubtopologyId, 3))
             ),
             "process"
-        ));
+        );
+
+        assertEquals("process", streamsGroup.currentActiveTaskProcessId(fooSubtopologyId, 1));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -375,12 +375,6 @@ public class StreamsGroupTest {
         String fooSubtopologyId = "foo-sub";
         StreamsGroup streamsGroup = createStreamsGroup("foo");
 
-        // Removing should fail because there is no epoch set.
-        assertThrows(IllegalStateException.class, () -> streamsGroup.removeTaskProcessIds(
-            TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
-            "process"
-        ));
-
         StreamsGroupMember m1 = new StreamsGroupMember.Builder("m1")
             .setProcessId("process")
             .setAssignedTasks(TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)))
@@ -388,11 +382,13 @@ public class StreamsGroupTest {
 
         streamsGroup.updateMember(m1);
 
-        // Removing should fail because the expected epoch is incorrect.
-        assertThrows(IllegalStateException.class, () -> streamsGroup.removeTaskProcessIds(
+        // Removing with incorrect epoch should fail. 
+        // A debug message is logged but no exception is thrown.
+        streamsGroup.removeTaskProcessIds(
             TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch(taskRole, 10, mkTasks(fooSubtopologyId, 1)),
             "process1"
-        ));
+        );
+        assertEquals(streamsGroup.getMemberOrThrow("m1").assignedTasks(), m1.assignedTasks());
     }
 
     @Test


### PR DESCRIPTION
When the group coordinator loads with concurrent compaction, the record
unassigning a partition/task can be missed which leads to an
IllegalStateException being thrown, however the records self-resolve by
the time loading is finished. This PR makes the change to log a warning
and proceed with loading instead of throwing an IllegalStateException.

Testing: Added unit tests for Consumer and Streams groups to ensure this
change does not impact loading success.

Reviewers: Sean Quah <squah@confluent.io>, Lucas Brutschy
 <lbrutschy@confluent.io>, David Jacot <djacot@confluent.io>
