### PR TITLE
MINOR: Document Java 25 as a supported Java version

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1314,12 +1314,12 @@ $ bin/kafka-acls.sh \
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.5 Java Version</a></h3>
 
-  Java 17 and Java 21 are fully supported while Java 11 is supported for a subset of modules (clients, streams and related).
+  Java 17, Java 21, and Java 25 are fully supported while Java 11 is supported for a subset of modules (clients, streams and related).
   Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
   most recent non LTS version.
 
   <p>
-  We generally recommend running Apache Kafka with the most recent LTS release (Java 21 at the time of writing) for performance,
+  We generally recommend running Apache Kafka with the most recent LTS release (Java 25 at the time of writing) for performance,
   efficiency and support reasons. From a security perspective, we recommend the latest released patch version as older versions
   typically have disclosed security vulnerabilities.
   <p>


### PR DESCRIPTION
Document Java 25 as a fully supported and recommended Java version in
the ops documentation.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
