### PR TITLE
KAFKA-19777 : Generator | Fix order of arguments to assertEquals in unit tests

### DIFF
--- a/generator/src/test/java/org/apache/kafka/message/CodeBufferTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/CodeBufferTest.java
@@ -41,10 +41,11 @@ public class CodeBufferTest {
         StringWriter stringWriter = new StringWriter();
         buffer.write(stringWriter);
         assertEquals(
-            stringWriter.toString(),
             String.format("public static void main(String[] args) throws Exception {%n") +
             String.format("    System.out.println(\"hello world\");%n") +
-            String.format("}%n"));
+            String.format("}%n"), stringWriter.toString());
+
+
     }
 
     @Test

--- a/generator/src/test/java/org/apache/kafka/message/CodeBufferTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/CodeBufferTest.java
@@ -44,8 +44,6 @@ public class CodeBufferTest {
             String.format("public static void main(String[] args) throws Exception {%n") +
             String.format("    System.out.println(\"hello world\");%n") +
             String.format("}%n"), stringWriter.toString());
-
-
     }
 
     @Test

--- a/generator/src/test/java/org/apache/kafka/message/StructRegistryTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/StructRegistryTest.java
@@ -57,11 +57,11 @@ public class StructRegistryTest {
                 "}")), MessageSpec.class);
         StructRegistry structRegistry = new StructRegistry();
         structRegistry.register(testMessageSpec);
-        assertEquals(structRegistry.commonStructNames(), Collections.singleton("TestCommonStruct"));
+        assertEquals(Collections.singleton("TestCommonStruct"), structRegistry.commonStructNames());
         assertFalse(structRegistry.isStructArrayWithKeys(testMessageSpec.fields().get(1)));
         assertFalse(structRegistry.isStructArrayWithKeys(testMessageSpec.fields().get(2)));
         assertTrue(structRegistry.commonStructs().hasNext());
-        assertEquals(structRegistry.commonStructs().next().name(), "TestCommonStruct");
+        assertEquals("TestCommonStruct", structRegistry.commonStructs().next().name());
     }
 
     @Test
@@ -145,10 +145,10 @@ public class StructRegistryTest {
 
         FieldSpec field2 = testMessageSpec.fields().get(1);
         assertTrue(field2.type().isStruct());
-        assertEquals(field2.type().toString(), "TestInlineStruct");
-        assertEquals(field2.name(), "field2");
+        assertEquals("TestInlineStruct", field2.type().toString());
+        assertEquals("field2", field2.name());
 
-        assertEquals(structRegistry.findStruct(field2).name(), "TestInlineStruct");
+        assertEquals("TestInlineStruct", structRegistry.findStruct(field2).name());
         assertFalse(structRegistry.isStructArrayWithKeys(field2));
     }
 

--- a/generator/src/test/java/org/apache/kafka/message/VersionConditionalTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/VersionConditionalTest.java
@@ -35,7 +35,7 @@ public class VersionConditionalTest {
         for (String line : lines) {
             expectedStringBuilder.append(String.format(line));
         }
-        assertEquals(stringWriter.toString(), expectedStringBuilder.toString());
+        assertEquals(expectedStringBuilder.toString(), stringWriter.toString());
     }
 
     @Test


### PR DESCRIPTION
In this PR, we corrected the argument order in assertEquals within the
generator package.

Reviewers: Andrew Schofield <aschofield@confluent.io>
