### PR TITLE
MINOR: Use a separate map to store acknowledgements in ShareAcknowledgementEvent.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ShareAcknowledgementEvent.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.internals.Acknowledgements;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkThread;
 import org.apache.kafka.common.TopicIdPartition;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ public class ShareAcknowledgementEvent {
     public ShareAcknowledgementEvent(Map<TopicIdPartition, Acknowledgements> acknowledgementsMap,
                                      boolean checkForRenewAcknowledgements,
                                      Optional<Integer> acquisitionLockTimeoutMs) {
-        this.acknowledgementsMap = acknowledgementsMap;
+        this.acknowledgementsMap = new HashMap<>(acknowledgementsMap);
         this.checkForRenewAcknowledgements = checkForRenewAcknowledgements;
         this.acquisitionLockTimeoutMs = acquisitionLockTimeoutMs;
     }


### PR DESCRIPTION
*What*

- Currently we are passing down the same map in
ShareAcknowledgementEvent to the application thread for callback
processing. But this map could be modified in the
ShareConsumeRequestManager, and could result in inconsistent data.
- This was a bug in
https://github.com/apache/kafka/commit/403f6c1caa4aa63c14c8da32ad98eff3a58d5853#diff-918e750d3f1c79f14a8489b1b56b95a07528755cd4303b525eb6da13217447df
when `ShareAcknowledgementEvent` was introduced.
- This PR uses a separate map every time an event is created.

Reviewers: Andrew Schofield <aschofield@confluent.io>
