### PR TITLE
KAFKA-19715: Consider bumping 3rd party Github Actions

### DIFF
--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
     - name: Login to Docker Hub

--- a/.github/workflows/docker_rc_release.yml
+++ b/.github/workflows/docker_rc_release.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r docker/requirements.txt
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
     - name: Login to Docker Hub


### PR DESCRIPTION
This PR bumps the versions of docker/setup-qemu-action from 3.6 to 3.7.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
