### PR TITLE
KAFKA-19898: Close ConsumerNetworkThread on failed start

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventHandler.java
@@ -62,7 +62,7 @@ public class ApplicationEventHandler implements Closeable {
         this.time = time;
         this.applicationEventQueue = applicationEventQueue;
         this.asyncConsumerMetrics = asyncConsumerMetrics;
-        this.networkThread = new ConsumerNetworkThread(logContext,
+        ConsumerNetworkThread networkThread = new ConsumerNetworkThread(logContext,
                 time,
                 applicationEventQueue,
                 applicationEventReaper,
@@ -71,7 +71,18 @@ public class ApplicationEventHandler implements Closeable {
                 requestManagersSupplier,
                 asyncConsumerMetrics);
 
-        this.networkThread.start(initializationTimeoutMs);
+        try {
+            networkThread.start(initializationTimeoutMs);
+        } catch (Exception e) {
+            try {
+                networkThread.close();
+            } finally {
+                networkThread = null;
+            }
+            throw e;
+        } finally {
+            this.networkThread = networkThread;
+        }
     }
 
     /**


### PR DESCRIPTION
Client unit tests are failing because of OOM. If the
`ConsumerNetworkThread` instantiated in the constructor for
`ApplicationEventHandler` fails to start in a timely fashion, it can be
leaked.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Kirk True
 <ktrue@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
