### PR TITLE
MINOR: Update docs version to 4.1

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -33,7 +33,7 @@
     <!--//#include virtual="../includes/_docs_banner.htm" -->
     
     <h1>Documentation</h1>
-    <h3>Kafka 4.0 Documentation</h3>
+    <h3>Kafka 4.1 Documentation</h3>
     Prior releases: <a href="/07/documentation.html">0.7.x</a>, 
                     <a href="/08/documentation.html">0.8.0</a>, 
                     <a href="/081/documentation.html">0.8.1.X</a>, 
@@ -63,7 +63,8 @@
                     <a href="/36/documentation.html">3.6.X</a>,
                     <a href="/37/documentation.html">3.7.X</a>,
                     <a href="/38/documentation.html">3.8.X</a>,
-                    <a href="/39/documentation.html">3.9.X</a>.
+                    <a href="/39/documentation.html">3.9.X</a>,
+                    <a href="/40/documentation.html">4.0.X</a>.
 
    <h2 class="anchor-heading"><a id="gettingStarted" class="anchor-link"></a><a href="#gettingStarted">1. Getting Started</a></h2>
       <h3 class="anchor-heading"><a id="introduction" class="anchor-link"></a><a href="#introduction">1.1 Introduction</a></h3>


### PR DESCRIPTION
We only updated docs version in `4.1` branch, but not in `trunk`.

Cf https://github.com/apache/kafka/commit/abeebb3b3ff6c701379430ea72fca9aff17e995a

Reviewers: Matthias J. Sax <matthias@confluent.io>