### PR TITLE
MINOR: improve logging for Kafka Streams stateful task management

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -147,7 +147,7 @@ final class StateManagerUtil {
                     }
                 }
             } else {
-                log.error("Failed to acquire lock while closing the state store for {} task {}", taskType, id);
+                log.warn("Failed to acquire lock while closing the state store for {} task {}", taskType, id);
             }
         } catch (final IOException e) {
             final ProcessorStateException exception = new ProcessorStateException(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -147,7 +147,7 @@ final class StateManagerUtil {
                     }
                 }
             } else {
-                log.warn("Failed to acquire lock while closing the state store for {} task {}", taskType, id);
+                log.warn("Unable to acquire lock while closing the state store for {} task {}", taskType, id);
             }
         } catch (final IOException e) {
             final ProcessorStateException exception = new ProcessorStateException(


### PR DESCRIPTION
Changing log level from ERROR to WARN, as it's expected that this can
happen, and we should not incorrectly make users worry about it.

Reviewers: PoAn Yang <payang@apache.org>, Colt McNealy
 <colt@littlehorse.io>, Lucas Brutschy <lbrutschy@confluent.io>,
 Chia-Ping Tsai <chia7712@gmail.com>
