### PR TITLE
KAFKA-19876: Replace the base image since openjdk image is deprecated (trunk)

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -149,9 +149,12 @@ RUN useradd -u $UID -ms /bin/bash ducker \
   && mkdir -p /home/ducker/ \
   && rsync -aiq /root/.ssh/ /home/ducker/.ssh \
   && chown -R ducker /home/ducker/ /mnt/ /var/log/ \
-  && echo "PATH=$(runuser -l ducker -c 'echo $PATH'):$JAVA_HOME/bin" >> /home/ducker/.ssh/environment \
-  && echo 'PATH=$PATH:'"$JAVA_HOME/bin" >> /home/ducker/.profile \
   && echo 'ducker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+# Symlink all JDK binaries (java, jcmd, jps, etc.) to /usr/bin.
+# We don't add PATH env to ~/.ssh/environment because on some Linux distributions,
+# PAM (Pluggable Authentication Modules) may re-read /etc/environment, overwriting PATH.
+RUN cp -sn $JAVA_HOME/bin/* /usr/bin/
 
 USER ducker
 

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -46,7 +46,7 @@ default_num_nodes=14
 
 # The default JDK base image with apt-get support.
 # The openjdk image has been officially deprecated. For more information, see: https://hub.docker.com/_/openjdk
-default_jdk="sapmachine:17-jdk-ubuntu-jammy"
+default_jdk="eclipse-temurin:17-jdk-jammy"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"


### PR DESCRIPTION
`sapmachine` doesn't support JDK 8, so we switched to use
`eclipse-temurin` so that previous AK versions such as AK 3.9 (#20897)
can use  the same image provider.

We also use symlinks to fix the java path  problem for
`eclipse-temurin`, based on a solution proposed by  @unknowntpo.

# Java path problem and its solution
After switching to `eclipse-temurin`, we encountered a `java not found`
problem.
This was unexpected because we had already written PATH to
`~/.ssh/environment` and set `PermitUserEnvironment yes` in
`sshd_config`.

It turns out that the `PAM (Pluggable Authentication Modules)` re-reads
`/etc/environment` after `~/.ssh/environment`. Unfortunately, there is a
`PATH` variable in `/etc/environment` in ubuntu, which overwrites the
`PATH`  from `~/.ssh/environment`. Some images didn't have this problem
because  the java path was already in `PATH` before we changed it.

The possible solutions are:
* Prevent PAM from reading `/etc/environment` by editing
`/etc/pam.d/sshd`
* Write PATH to `~/.pam_environment` (ref: [help.ubuntu
article](https://help.ubuntu.com/community/EnvironmentVariables#A.2BAH4-.2F.pam_environment))
* Write PATH to `/etc/environment/`
* Add a symlink so that java can be found without changing PATH

However, we think first two solutions are prone to being
distribution-specific.  Modifying `/etc/environment` affects all users'
`PATH`, which is not ideal.  Therefore, we adopt the symlink solution
suggested by @unknowntpo

Passed `pluggable_test` on my local mac with image
`eclipse-temurin:17-jdk-jammy`
```
> TC_PATHS="tests/kafkatest/tests/client/pluggable_test.py" bash
tests/docker/run_tests.sh
...
docker build --memory=3200m --build-arg ducker_creator= --build-arg
jdk_version=eclipse-temurin:17-jdk-jammy --build-arg UID=501 --build-arg
KAFKA_MODE=jvm -t ducker-ak-eclipse-temurin-17-jdk-jammy -f
/Users/ming/code/kafka/tests/docker/Dockerfile -- .
...
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-11-21--001
run time:         15.249 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:
kafkatest.tests.client.pluggable_test.PluggableConsumerTest.test_start_stop.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   15.103 seconds
--------------------------------------------------------------------------------
```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
