### PR TITLE
MINOR: Fix typo in JavaDoc in AbstractHeartbeatRequestManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -53,7 +53,7 @@ import static org.apache.kafka.clients.consumer.internals.RequestState.RETRY_BAC
  * <p>If the member got kicked out of a group, it will try to give up the current assignment by invoking {@code
  * OnPartitionsLost} before attempting to join again with a zero epoch.
  *
- * <p>If the coordinator not is not found, we will skip sending the heartbeat and try to find a coordinator first.
+ * <p>If the coordinator is not found, we will skip sending the heartbeat and try to find a coordinator first.
  *
  * <p>When the member completes the assignment reconciliation, the {@link HeartbeatRequestState} will be reset so
  * that a heartbeat will be sent in the next event loop.


### PR DESCRIPTION
This PR fixes a small typo in the JavaDoc of
AbstractHeartbeatRequestManager:
- "coordinator not is not found" → "coordinator is not found"

No functional changes.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
