### PR TITLE
MINOR: Add startup-duration logging to help with Kafka startup performance tuning

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -94,8 +94,12 @@ object Kafka extends Logging {
         }
       })
 
-      try server.startup()
-      catch {
+      val startupStartTimeMs = Time.SYSTEM.milliseconds()
+      try {
+        server.startup()
+        val startupDurationMs = Time.SYSTEM.milliseconds() - startupStartTimeMs
+        info(s"Kafka startup completed in ${startupDurationMs} ms")
+      } catch {
         case e: Throwable =>
           // KafkaBroker.startup() calls shutdown() in case of exceptions, so we invoke `exit` to set the status code
           fatal("Exiting Kafka due to fatal exception during startup.", e)


### PR DESCRIPTION
Sometimes we need to know how long Kafka takes to start in order to make certain decisions—for example, tuning configuration parameters or estimating how much time operations will require. However, it’s quite inconvenient to manually look for the timestamp of the first log line and then the first log line hint the server has started, and calculate the difference.
So this PR adds a direct log output for the startup duration.

Log the total startup time after successful server startup: `"Kafka startup completed in ${startupDurationMs} ms"`

Benefits:
1. Quickly identify slow startups
2. Easily know startup duration directly in logs **without repeat manual calculation**