### PR TITLE
MINOR: Use SHA256withRSA instead of SHA1withRSA when running SslTransportLayerTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -111,7 +111,7 @@ public class TestSslUtils {
      * @param dn the X.509 Distinguished Name, eg "CN=Test, L=London, C=GB"
      * @param pair the KeyPair
      * @param days how many days from now the Certificate is valid for, or - for negative values - how many days before now
-     * @param algorithm the signing algorithm, eg "SHA1withRSA"
+     * @param algorithm the signing algorithm, eg "SHA256withRSA"
      * @return the self-signed certificate
      * @throws CertificateException thrown if a security error or an IO error occurred.
      */
@@ -132,7 +132,7 @@ public class TestSslUtils {
      *        CA.
      * @param parentKeyPair The key pair of the issuer. Leave null if you want to generate a root
      *        CA.
-     * @param algorithm the signing algorithm, eg "SHA1withRSA"
+     * @param algorithm the signing algorithm, eg "SHA256withRSA"
      * @return the signed certificate
      * @throws CertificateException
      */
@@ -399,7 +399,7 @@ public class TestSslUtils {
         private byte[] subjectAltName;
 
         public CertificateBuilder() {
-            this(30, "SHA1withRSA");
+            this(30, "SHA256withRSA");
         }
 
         public CertificateBuilder(int days, String algorithm) {


### PR DESCRIPTION
`SHA1withRSA` is disabled in some linux distribution, such as Fedora 43 server, which results in the following error. Hence, this PR adopts the solution suggested by @gaurav-narula in https://github.com/apache/kafka/pull/20561#issuecomment-3378701638, which is to use `SHA256withRSA` instead of `SHA1withRSA`

```
Gradle Test Run :clients:test > Gradle Test Executor 28 > Tls13SslFactoryTest > testSslFactoryConfiguration() FAILED
    org.apache.kafka.common.config.ConfigException: Invalid value javax.net.ssl.SSLHandshakeException: (handshake_failure) No available authentication scheme for configuration A client SSLEngine created with the provided settings can't connect to a server SSLEngine created with those settings.
        at app//org.apache.kafka.common.security.ssl.SslFactory.configure(SslFactory.java:105)
        at app//org.apache.kafka.common.security.ssl.SslFactoryTest.testSslFactoryConfiguration(SslFactoryTest.java:80)
        at java.base@21.0.9/java.lang.reflect.Method.invoke(Method.java:580)
        at java.base@21.0.9/java.util.ArrayList.forEach(ArrayList.java:1596)
        at java.base@21.0.9/java.util.ArrayList.forEach(ArrayList.java:1596)
```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
