### PR TITLE
HOTFIX: Add 4.2 branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches:
       - 'trunk'
-      - '4.0'
+      - '4.2'
 
   schedule:
     - cron: '0 0 * * 6,0'    # Run on Saturday and Sunday at midnight UTC
@@ -28,7 +28,7 @@ on:
     types: [ opened, synchronize, ready_for_review, reopened ]
     branches:
       - 'trunk'
-      - '4.0'
+      - '4.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Add 4.2 branch to CI, as discussed in
https://github.com/apache/kafka/pull/20948#pullrequestreview-3495483828

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
