### PR TITLE
MINOR: Improve JavaDoc for LEAVING state transition in AbstractHeartbeatRequestManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -635,9 +635,9 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
     }
 
     /**
-     * Reset member epoch to the value required for the leave the group heartbeat request, and
-     * transition to the {@link MemberState#LEAVING} state so that a heartbeat request is sent
-     * out with it.
+     * Reset the member epoch to the value required for the leave-group heartbeat and transition to
+     * {@link MemberState#LEAVING} so the next heartbeat notifies the coordinator that the member is
+     * leaving the group.
      *
      * @param dueToExpiredPollTimer True if the leave group is due to an expired poll timer. This
      *                              will indicate that the member must remain STALE after leaving,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -636,8 +636,8 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
 
     /**
      * Reset the member epoch to the value required for the leave-group heartbeat and transition to
-     * {@link MemberState#LEAVING} so the next heartbeat notifies the coordinator that the member is
-     * leaving the group.
+     * {@link MemberState#LEAVING} so the next heartbeat notifies the coordinator that the member
+     * is leaving the group.
      *
      * @param dueToExpiredPollTimer True if the leave group is due to an expired poll timer. This
      *                              will indicate that the member must remain STALE after leaving,


### PR DESCRIPTION
This PR improves the JavaDoc explaining the transition to MemberState.LEAVING in AbstractHeartbeatRequestManager.

The previous wording was grammatically unclear and made it difficult to understand when and why the leave-group heartbeat is sent. The updated JavaDoc clarifies that:

the member epoch is reset for the leave-group heartbeat, and

transitioning to MemberState.LEAVING ensures that the next heartbeat notifies the coordinator that the member is leaving the group.