### PR TITLE
MINOR: Skip testDsaKeyPair when DSA algorithm is not supported

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -1349,14 +1349,43 @@ public class SslTransportLayerTest {
     }
 
     /**
-     * Check if DSA algorithm is supported by the JVM.
-     * @return true if DSA KeyPairGenerator is available, false otherwise
+     * Check if DSA algorithm is supported by the JVM and if there are compatible cipher suites
+     * available for TLSv1.2. This is important because even if DSA KeyPairGenerator is available,
+     * the SSL handshake may fail if no DSA-compatible cipher suites are available.
+     * @return true if DSA KeyPairGenerator is available and DSA-compatible cipher suites exist, false otherwise
      */
     private static boolean isDsaSupported() {
+        // First check if DSA KeyPairGenerator is available
         try {
             java.security.KeyPairGenerator.getInstance("DSA");
-            return true;
         } catch (java.security.NoSuchAlgorithmException e) {
+            return false;
+        }
+
+        // Check if there are DSA-compatible cipher suites available for TLSv1.2
+        // DSA algorithms are not supported for TLSv1.3, so we only check TLSv1.2
+        try {
+            SSLContext context = SSLContext.getInstance("TLSv1.2");
+            context.init(null, null, null);
+            SSLParameters params = context.getDefaultSSLParameters();
+            String[] cipherSuites = params.getCipherSuites();
+
+            // Check if any cipher suite supports DSA/DSS
+            // DSA-related cipher suites typically contain "DSS" or "DSA" in their names
+            for (String cipherSuite : cipherSuites) {
+                // Common DSA cipher suite patterns:
+                // - TLS_DHE_DSS_* (Diffie-Hellman Ephemeral with DSS)
+                // - TLS_DH_DSS_* (Diffie-Hellman with DSS)
+                // - SSL_DHE_DSS_* (legacy SSL with DSS)
+                // - SSL_DH_DSS_* (legacy SSL with DSS)
+                if (cipherSuite.contains("_DSS_") || cipherSuite.contains("_DSA_")) {
+                    return true;
+                }
+            }
+            // No DSA-compatible cipher suites found
+            return false;
+        } catch (Exception e) {
+            // If we can't check cipher suites, assume DSA is not fully supported
             return false;
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -55,6 +55,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1370,20 +1371,11 @@ public class SslTransportLayerTest {
             SSLParameters params = context.getDefaultSSLParameters();
             String[] cipherSuites = params.getCipherSuites();
 
-            // Check if any cipher suite supports DSA/DSS
-            // DSA-related cipher suites typically contain "DSS" or "DSA" in their names
-            for (String cipherSuite : cipherSuites) {
-                // Common DSA cipher suite patterns:
-                // - TLS_DHE_DSS_* (Diffie-Hellman Ephemeral with DSS)
-                // - TLS_DH_DSS_* (Diffie-Hellman with DSS)
-                // - SSL_DHE_DSS_* (legacy SSL with DSS)
-                // - SSL_DH_DSS_* (legacy SSL with DSS)
-                if (cipherSuite.contains("_DSS_") || cipherSuite.contains("_DSA_")) {
-                    return true;
-                }
-            }
-            // No DSA-compatible cipher suites found
-            return false;
+            // Check if any cipher suite supports DSA
+            // In TLS standards and JVM implementations, DSA signature cipher suites use "_DSS_" naming
+            // Common patterns: TLS_DHE_DSS_*, TLS_DH_DSS_*, SSL_DHE_DSS_*, SSL_DH_DSS_*
+            return Arrays.stream(cipherSuites)
+                    .anyMatch(suite -> suite.contains("_DSS_"));
         } catch (Exception e) {
             // If we can't check cipher suites, assume DSA is not fully supported
             return false;

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -78,6 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -476,6 +477,8 @@ public class SslTransportLayerTest {
     @ArgumentsSource(SslTransportLayerArgumentsForTLS2Provider.class)
     public void testDsaKeyPair(Args args) throws Exception {
         // DSA algorithms are not supported for TLSv1.3.
+        // Skip test if DSA is not supported by the JVM
+        assumeTrue(isDsaSupported(), "DSA algorithm is not supported by this JVM");
         args.serverCertStores = certBuilder(true, "server", args.useInlinePem).keyAlgorithm("DSA").build();
         args.clientCertStores = certBuilder(false, "client", args.useInlinePem).keyAlgorithm("DSA").build();
         args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
@@ -1343,6 +1346,19 @@ public class SslTransportLayerTest {
         return new CertStores.Builder(isServer)
                 .cn(cn)
                 .usePem(useInlinePem);
+    }
+
+    /**
+     * Check if DSA algorithm is supported by the JVM.
+     * @return true if DSA KeyPairGenerator is available, false otherwise
+     */
+    private static boolean isDsaSupported() {
+        try {
+            java.security.KeyPairGenerator.getInstance("DSA");
+            return true;
+        } catch (java.security.NoSuchAlgorithmException e) {
+            return false;
+        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
Background:
https://github.com/apache/kafka/pull/20961#issuecomment-3566975687

```
Gradle Test Run :clients:test > Gradle Test Executor 7 >
SslTransportLayerTest > testDsaKeyPair(Args) >
"testDsaKeyPair(Args).args=tlsProtocol=TLSv1.2, useInlinePem=true"
FAILED     org.opentest4j.AssertionFailedError: Channel 0 was not ready
after 30 seconds ==> expected: <true> but was: <false>         at
app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
at
app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
at app//org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
at app//org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:214)
at
app//org.apache.kafka.common.network.NetworkTestUtils.waitForChannelReady(NetworkTestUtils.java:107)
at
app//org.apache.kafka.common.network.NetworkTestUtils.checkClientConnection(NetworkTestUtils.java:70)
at
app//org.apache.kafka.common.network.SslTransportLayerTest.verifySslConfigs(SslTransportLayerTest.java:1326)
at
app//org.apache.kafka.common.network.SslTransportLayerTest.testDsaKeyPair(SslTransportLayerTest.java:483)

```

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
