### PR TITLE
KAFKA-16366: Refactor KTable source optimization

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/Topology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/Topology.java
@@ -814,21 +814,16 @@ public class Topology {
         final String processorName,
         final ProcessorSupplier<K, V, Void, Void> stateUpdateSupplier
     ) {
-        internalTopologyBuilder.addSource(
-            new AutoOffsetResetInternal(org.apache.kafka.streams.AutoOffsetReset.earliest()),
-            sourceName,
-            timestampExtractor,
-            keyDeserializer,
-            valueDeserializer,
-            topic
+        internalTopologyBuilder.addReadOnlyStateStore(
+                storeBuilder,
+                sourceName,
+                timestampExtractor,
+                keyDeserializer,
+                valueDeserializer,
+                topic,
+                processorName,
+                stateUpdateSupplier
         );
-        internalTopologyBuilder.addProcessor(processorName, stateUpdateSupplier, sourceName);
-        internalTopologyBuilder.addStateStore(storeBuilder, processorName);
-
-        // connect the source topic as (read-only) changelog topic for fault-tolerance
-        storeBuilder.withLoggingDisabled();
-        internalTopologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topic);
-
         return this;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
@@ -58,6 +58,11 @@ public class ProcessorParameters<KIn, VIn, KOut, VOut> {
     public ProcessorSupplier<KIn, VIn, KOut, VOut> processorSupplier() {
         return processorSupplier;
     }
+    
+    public ProcessorSupplier<KIn, VIn, KOut, VOut> wrappedProcessSupplier(final InternalTopologyBuilder topologyBuilder) {
+        ApiUtils.checkSupplier(processorSupplier);
+        return topologyBuilder.wrapProcessorSupplier(processorName, processorSupplier);
+    }
 
     public FixedKeyProcessorSupplier<KIn, VIn, VOut> fixedKeyProcessorSupplier() {
         return fixedKeyProcessorSupplier;
@@ -69,7 +74,7 @@ public class ProcessorParameters<KIn, VIn, KOut, VOut> {
 
             final ProcessorSupplier<KIn, VIn, KOut, VOut> wrapped =
                 topologyBuilder.wrapProcessorSupplier(processorName, processorSupplier);
-
+            
             topologyBuilder.addProcessor(processorName, wrapped, parentNodeNames);
             final Set<StoreBuilder<?>> stores = wrapped.stores();
             if (stores != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorParameters.java
@@ -59,7 +59,7 @@ public class ProcessorParameters<KIn, VIn, KOut, VOut> {
         return processorSupplier;
     }
     
-    public ProcessorSupplier<KIn, VIn, KOut, VOut> wrappedProcessSupplier(final InternalTopologyBuilder topologyBuilder) {
+    ProcessorSupplier<KIn, VIn, KOut, VOut> wrappedProcessorSupplier(final InternalTopologyBuilder topologyBuilder) {
         ApiUtils.checkSupplier(processorSupplier);
         return topologyBuilder.wrapProcessorSupplier(processorName, processorSupplier);
     }
@@ -70,11 +70,8 @@ public class ProcessorParameters<KIn, VIn, KOut, VOut> {
 
     public void addProcessorTo(final InternalTopologyBuilder topologyBuilder, final String... parentNodeNames) {
         if (processorSupplier != null) {
-            ApiUtils.checkSupplier(processorSupplier);
+            final ProcessorSupplier<KIn, VIn, KOut, VOut> wrapped = wrappedProcessorSupplier(topologyBuilder);
 
-            final ProcessorSupplier<KIn, VIn, KOut, VOut> wrapped =
-                topologyBuilder.wrapProcessorSupplier(processorName, processorSupplier);
-            
             topologyBuilder.addProcessor(processorName, wrapped, parentNodeNames);
             final Set<StoreBuilder<?>> stores = wrapped.stores();
             if (stores != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -21,9 +21,11 @@ import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Set;
 
 /**
  * Used to represent either a KTable source or a GlobalKTable source. A boolean flag is used to indicate if this represents a GlobalKTable a {@link
@@ -96,27 +98,38 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
                 false
             );
         } else {
-            topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
-                                      sourceName,
-                                      consumedInternal().timestampExtractor(),
-                                      consumedInternal().keyDeserializer(),
-                                      consumedInternal().valueDeserializer(),
-                                      topicName);
-
-            processorParameters.addProcessorTo(topologyBuilder, sourceName);
-
-            // if the KTableSource should not be materialized, stores will be null or empty
             final KTableSource<K, V> tableSource = (KTableSource<K, V>) processorParameters.processorSupplier();
-            if (tableSource.stores() != null) {
-                if (shouldReuseSourceTopicForChangelog) {
-                    // TODO: rewrite this part to use Topology.addReadOnlyStateStore() instead
-                    // should allow to move off using `InternalTopologyBuilder` in favor of the public `Topology` API
-                    tableSource.stores().forEach(store -> {
-                        // connect the source topic as (read-only) changelog topic for fault-tolerance
-                        store.withLoggingDisabled();
-                        topologyBuilder.connectSourceStoreAndTopic(store.name(), topicName);
-                    });
-                }
+            if (tableSource.stores() != null && shouldReuseSourceTopicForChangelog) {
+                // The DSL topology uses a serial pipeline, 
+                // whereas the PAPI optimization assumes a parallel structure.
+                // We use a wildcard supplier to support the DSL's forwarding behavior.
+                final ProcessorSupplier<K, V, ?, ?> stateUpdater = 
+                        processorParameters.wrappedProcessSupplier(topologyBuilder);
+
+                // TableSourceNode is backed by KTableSource, which maintains a single state store. 
+                // Therefore, we are guaranteed to have exactly one store.
+                assert tableSource.stores().size() == 1;
+
+                topologyBuilder.addReadOnlyStateStore(
+                        consumedInternal().offsetResetPolicy(),
+                        tableSource.stores().iterator().next(),
+                        sourceName,
+                        consumedInternal().timestampExtractor(),
+                        consumedInternal().keyDeserializer(),
+                        consumedInternal().valueDeserializer(),
+                        topicName,
+                        processorParameters.processorName(),
+                        stateUpdater
+                );
+            } else {
+                topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
+                        sourceName,
+                        consumedInternal().timestampExtractor(),
+                        consumedInternal().keyDeserializer(),
+                        consumedInternal().valueDeserializer(),
+                        topicName);
+
+                processorParameters.addProcessorTo(topologyBuilder, sourceName);    
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -98,21 +98,25 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
                 false
             );
         } else {
+            // if the KTableSource should not be materialized, stores will be null or empty
             final KTableSource<K, V> tableSource = (KTableSource<K, V>) processorParameters.processorSupplier();
             if (tableSource.stores() != null && shouldReuseSourceTopicForChangelog) {
                 // The DSL topology uses a serial pipeline, 
                 // whereas the PAPI optimization assumes a parallel structure.
                 // We use a wildcard supplier to support the DSL's forwarding behavior.
                 final ProcessorSupplier<K, V, ?, ?> stateUpdater = 
-                        processorParameters.wrappedProcessSupplier(topologyBuilder);
+                        processorParameters.wrappedProcessorSupplier(topologyBuilder);
 
-                // TableSourceNode is backed by KTableSource, which maintains a single state store. 
-                // Therefore, we are guaranteed to have exactly one store.
-                assert tableSource.stores().size() == 1;
+                final Set<StoreBuilder<?>> stores = stateUpdater.stores();
+                if (stores.size() != 1) {
+                    // TableSourceNode is backed by KTableSource, which maintains a single state store. 
+                    // Therefore, we are guaranteed to have exactly one store.
+                    throw new IllegalStateException("Expected exactly one store for optimized KTable source");
+                }
 
                 topologyBuilder.addReadOnlyStateStore(
                         consumedInternal().offsetResetPolicy(),
-                        tableSource.stores().iterator().next(),
+                        stores.iterator().next(),
                         sourceName,
                         consumedInternal().timestampExtractor(),
                         consumedInternal().keyDeserializer(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -744,6 +744,64 @@ public class InternalTopologyBuilder {
         return changelogTopicToStore.get(topicName);
     }
 
+    public synchronized <K, V, S extends StateStore> void addReadOnlyStateStore(
+            final StoreBuilder<S> storeBuilder,
+            final String sourceName,
+            final TimestampExtractor timestampExtractor,
+            final Deserializer<K> keyDeserializer,
+            final Deserializer<V> valueDeserializer,
+            final String topic,
+            final String processorName,
+            final ProcessorSupplier<K, V, Void, Void> stateUpdateSupplier
+    ) {
+        addReadOnlyStateStore(
+                new AutoOffsetResetInternal(org.apache.kafka.streams.AutoOffsetReset.earliest()),
+                storeBuilder,
+                sourceName,
+                timestampExtractor,
+                keyDeserializer,
+                valueDeserializer,
+                topic,
+                processorName,
+                stateUpdateSupplier
+        );
+    }
+
+    // This method is used both by the Processor API and the DSL.
+    // - In the Processor API, stateUpdateSupplier has type ProcessorSupplier<K, V, Void, Void>
+    //   and only updates the state store.
+    // - In the DSL, KTableSource uses ProcessorSupplier<K, V, K, Change<V>> so that it can
+    //   both update the state store and forward a change stream downstream.
+    // For wiring the topology we only depend on the input key and value types,
+    // so the output key and value types are modelled as wildcards here.
+    public synchronized <K, V, S extends StateStore> void addReadOnlyStateStore(
+            final AutoOffsetResetInternal autoOffsetReset,
+            final StoreBuilder<S> storeBuilder,
+            final String sourceName,
+            final TimestampExtractor timestampExtractor,
+            final Deserializer<K> keyDeserializer,
+            final Deserializer<V> valueDeserializer,
+            final String topic,
+            final String processorName,
+            final ProcessorSupplier<K, V, ?, ?> stateUpdateSupplier
+    ) {
+        addSource(
+                autoOffsetReset,
+                sourceName,
+                timestampExtractor,
+                keyDeserializer,
+                valueDeserializer,
+                topic
+        );
+        addProcessor(processorName, stateUpdateSupplier, sourceName);
+        addStateStore(storeBuilder, processorName);
+
+        // connect the source topic as (read-only) changelog topic for fault-tolerance
+        storeBuilder.withLoggingDisabled();
+        connectSourceStoreAndTopic(storeBuilder.name(), topic);
+    }
+    
+    
     public void connectSourceStoreAndTopic(final String sourceStoreName,
                                            final String topic) {
         if (storeToChangelogTopic.containsKey(sourceStoreName)) {

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -715,6 +715,101 @@ public class StreamsBuilderTest {
     }
 
     @Test
+    public void shouldReuseSourceTopicAsChangelogsWithOptimization20AndKeepWrapperStoreWiring() {
+        // GIVEN
+        final String topic = "topic";
+        final String sourceName = "source-table";
+
+        final Properties props = StreamsTestUtils.getStreamsConfig();
+        props.put(TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS);
+
+        final WrapperRecorder counter = new WrapperRecorder();
+        props.put(PROCESSOR_WRAPPER_CLASS_CONFIG, RecordingProcessorWrapper.class);
+        props.put(PROCESSOR_WRAPPER_COUNTER_CONFIG, counter);
+
+        final StreamsBuilder builder =
+                new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
+
+        builder.table(
+                topic,
+                Consumed.as(sourceName),
+                Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store")
+        );
+
+        // WHEN
+        final Topology topology = builder.build(props);
+        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
+        internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
+
+        // THEN
+        assertThat(
+                internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
+                equalTo(Collections.singletonMap("store", topic)));
+        assertThat(
+                internalTopologyBuilder.stateStores().keySet(),
+                equalTo(Collections.singleton("store")));
+        assertThat(
+                internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
+                equalTo(false));
+        assertThat(
+                internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_0).nonSourceChangelogTopics().isEmpty(),
+                equalTo(true));
+
+        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(sourceName));
+        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(1));
+        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
+        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+    }
+
+    @Test
+    public void shouldNotReuseSourceTopicAsChangelogsWhenOptimizationOffAndKeepWrapperStoreWiring() {
+        // GIVEN
+        final String topic = "topic";
+        final String sourceName = "source-table";
+
+        final Properties props = StreamsTestUtils.getStreamsConfig("appId");
+
+        final WrapperRecorder counter = new WrapperRecorder();
+        props.put(PROCESSOR_WRAPPER_CLASS_CONFIG, RecordingProcessorWrapper.class);
+        props.put(PROCESSOR_WRAPPER_COUNTER_CONFIG, counter);
+
+        final StreamsBuilder builder =
+                new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
+
+        builder.table(
+                topic,
+                Consumed.as(sourceName),
+                Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store")
+        );
+
+        // WHEN
+        final Topology topology = builder.build(props);
+        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
+        internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
+
+        // THEN
+        assertThat(
+                internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
+                equalTo(Collections.singletonMap("store", "appId-store-changelog")));
+        assertThat(
+                internalTopologyBuilder.stateStores().keySet(),
+                equalTo(Collections.singleton("store")));
+        assertThat(
+                internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
+                equalTo(true));
+        assertThat(
+                internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_0).stateChangelogTopics.keySet(),
+                equalTo(Collections.singleton("appId-store-changelog")));
+
+        // Wrapper regression check (optimization OFF)
+        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(sourceName));
+        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(1));
+        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
+        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+    }
+
+
+    @Test
     public void shouldNotReuseRepartitionTopicAsChangelogs() {
         final String topic = "topic";
         builder.<Long, String>stream(topic).repartition().toTable(Materialized.as("store"));

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -2439,6 +2439,64 @@ public class TopologyTest {
     }
 
     @Test
+    public void whenKTableSourceIsOptimizedThenTopologyShouldBeSerialPipeline() {
+        // Given
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table("input-topic")
+                .groupBy((key, value) -> null)
+                .count();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        
+        // When
+        final Topology topology = builder.build(props);
+        
+        // Then
+        final String expectedTopologyDescription = "Topologies:\n" +
+                "   Sub-topology: 0\n" +
+                "    Source: KSTREAM-SOURCE-0000000001 (topics: [input-topic])\n" +
+                "      --> KTABLE-SOURCE-0000000002\n" +
+                "    Processor: KTABLE-SOURCE-0000000002 (stores: [input-topic-STATE-STORE-0000000000])\n" +
+                "      --> KTABLE-SELECT-0000000003\n" +
+                "      <-- KSTREAM-SOURCE-0000000001\n" +
+                "    Processor: KTABLE-SELECT-0000000003 (stores: [])\n" +
+                "      --> KSTREAM-SINK-0000000005\n" +
+                "      <-- KTABLE-SOURCE-0000000002\n" +
+                "    Sink: KSTREAM-SINK-0000000005 (topic: KTABLE-AGGREGATE-STATE-STORE-0000000004-repartition)\n" +
+                "      <-- KTABLE-SELECT-0000000003\n" +
+                "\n" +
+                "  Sub-topology: 1\n" +
+                "    Source: KSTREAM-SOURCE-0000000006 (topics: [KTABLE-AGGREGATE-STATE-STORE-0000000004-repartition])\n" +
+                "      --> KTABLE-AGGREGATE-0000000007\n" +
+                "    Processor: KTABLE-AGGREGATE-0000000007 (stores: [KTABLE-AGGREGATE-STATE-STORE-0000000004])\n" +
+                "      --> none\n" +
+                "      <-- KSTREAM-SOURCE-0000000006\n\n";
+        assertEquals(
+                expectedTopologyDescription, 
+                topology.describe().toString()
+        );
+    }
+
+    @Test
+    public void whenKTableSourceIsOptimizedThenItsStateStoreShouldNotLog() {
+        // Given
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table("input-topic")
+                .groupBy((key, value) -> null)
+                .count();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        
+        // When
+        final Topology topology = builder.build(props);
+
+        // Then
+        final StoreFactory stateStoreFactory = topology.internalTopologyBuilder.stateStores().get("input-topic-STATE-STORE-0000000000");
+        assertThat(stateStoreFactory.loggingEnabled(), equalTo(false));
+    }
+    
+
+    @Test
     public void shouldWrapProcessors() {
         final Map<Object, Object> props = dummyStreamsConfigMap();
         props.put(PROCESSOR_WRAPPER_CLASS_CONFIG, RecordingProcessorWrapper.class);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
@@ -35,6 +35,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -46,6 +48,8 @@ public class TableSourceNodeTest {
 
     private static final String STORE_NAME = "store-name";
     private static final String TOPIC = "input-topic";
+    private static final String SOURCE_NAME = "source-name";
+    private static final String PROCESSOR_NAME = "processor-name";
 
     private InternalTopologyBuilder topologyBuilder = mock(InternalTopologyBuilder.class);
 
@@ -59,7 +63,18 @@ public class TableSourceNodeTest {
     public void shouldConnectStateStoreToInputTopicIfInputTopicIsUsedAsChangelog() {
         final boolean shouldReuseSourceTopicForChangelog = true;
         buildTableSourceNode(shouldReuseSourceTopicForChangelog);
-        verify(topologyBuilder).connectSourceStoreAndTopic(STORE_NAME, TOPIC);
+        verify(topologyBuilder).addReadOnlyStateStore(
+                any(),
+                argThat(store -> STORE_NAME.equals(store.name())),
+                eq(SOURCE_NAME),
+                any(),
+                any(),
+                any(),
+                eq(TOPIC),
+                eq(PROCESSOR_NAME),
+                any()
+        );
+        verify(topologyBuilder, never()).connectSourceStoreAndTopic(any(), any());
     }
 
     @Test
@@ -67,6 +82,7 @@ public class TableSourceNodeTest {
         final boolean shouldReuseSourceTopicForChangelog = false;
         buildTableSourceNode(shouldReuseSourceTopicForChangelog);
         verify(topologyBuilder, never()).connectSourceStoreAndTopic(STORE_NAME, TOPIC);
+        verify(topologyBuilder, never()).addReadOnlyStateStore(any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     private void buildTableSourceNode(final boolean shouldReuseSourceTopicForChangelog) {
@@ -75,9 +91,10 @@ public class TableSourceNodeTest {
                 materializedInternal = new MaterializedInternal<>(Materialized.as(STORE_NAME));
         final TableSourceNode<String, String> tableSourceNode = tableSourceNodeBuilder
             .withTopic(TOPIC)
+            .withSourceName(SOURCE_NAME)
             .withConsumedInternal(new ConsumedInternal<>(Consumed.as("node-name")))
             .withProcessorParameters(
-                    new ProcessorParameters<>(new KTableSource<>(materializedInternal), null))
+                    new ProcessorParameters<>(new KTableSource<>(materializedInternal), PROCESSOR_NAME))
             .build();
         tableSourceNode.reuseSourceTopicForChangeLog(shouldReuseSourceTopicForChangelog);
 


### PR DESCRIPTION
### Description

This PR refactors the `DSL`'s optimization logic (reusing the input topic as the changelog) to leverage the public `Topology#addReadOnlyStateStore` API introduced in KIP-813, replacing the previous usage of internal builder methods.

### Key Changes:
- Refactored `TableSourceNode`
  - Replaced the manual wiring of sources and stores (via `addSource`, `addProcessor`, `connectSourceStoreAndTopic`) with a call to `topologyBuilder.addReadOnlyStateStore`.
- Updated `InternalTopologyBuilder`:
  - Added an overloaded `addReadOnlyStateStore` method accepting a `ProcessorSupplier` with wildcard output types `(?, ?)`.
  - Reasoning: The public PAPI `addReadOnlyStateStore` enforces `Void, Void` output types. However, the `DSL`'s `KTableSource` needs to forward records downstream (emitting K, Change<V>). The internal overload allows the `DSL` to reuse the "read-only" wiring logic while maintaining its forwarding behavior.
- Added Regression Tests:
  - Added `TopologyTest#whenKTableSourceIsOptimizedThenTopologyShouldBeSerialPipeline` - Verifies that the generated topology description remains identical to the pre-refactoring structure, ensuring strict backward compatibility.
  - Added `TopologyTest#whenKTableSourceIsOptimizedThenItsStateStoreShouldNotLog` - Confirms that the optimization is correctly applied (changelog logging is disabled).

### Result
- Fixes https://issues.apache.org/jira/browse/KAFKA-16366