### PR TITLE
KAFKA-17251: Avoid WARN on cleanup when state directory only contains process metadata.

### DIFF
--- a/docs/streams/developer-guide/app-reset-tool.md
+++ b/docs/streams/developer-guide/app-reset-tool.md
@@ -131,7 +131,7 @@ All the other parameters can be combined as needed. For example, if you want to 
 
 For a complete application reset, you must delete the application's local state directory on any machines where the application instance was run. You must do this before restarting an application instance on the same machine. You can use either of these methods:
 
-  * The API method `KafkaStreams#cleanUp()` in your application code.
+  * The API method `KafkaStreams#cleanUp()` removes local state, but it may retain the application state directory if only expected metadata files remain, such as `kafka-streams-process-metadata` and/or `.lock`.
   * Manually delete the corresponding local state directory (default location: `/${java.io.tmpdir}/kafka-streams/<application.id>`). For more information, see [Streams](/{version}/javadoc/org/apache/kafka/streams/StreamsConfig.html#STATE_DIR_CONFIG) javadocs.
 
 

--- a/docs/streams/upgrade-guide.md
+++ b/docs/streams/upgrade-guide.md
@@ -65,6 +65,10 @@ Starting in Kafka Streams 2.6.x, a new processing mode is available, named EOS v
 
 Since 2.6.0 release, Kafka Streams depends on a RocksDB version that requires MacOS 10.14 or higher.
 
+## Streams API changes in 4.4.0
+
+Kafka Streams no longer emits a WARN from `KafkaStreams#cleanUp()` when the application state directory cannot be deleted only because expected metadata files remain, such as `kafka-streams-process-metadata` and/or `.lock`. In this case, the local state cleanup is considered successful and the application state directory may be retained. Users who require a full local reset including persisted process metadata should manually delete the application state directory after the Kafka Streams instance has been closed. More details can be found in [KIP-1283](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1283:+Clarify+KafkaStreams+cleanUp+semantics+to+preserve+process+metadata+and+state+directory+lock+file)
+
 ## Streams API changes in 4.3.0
 
 **Note:** Kafka Streams 4.3.0 contains a critical native memory leak in the RocksDB state store layer ([KAFKA-20616](https://issues.apache.org/jira/browse/KAFKA-20616)). The `ColumnFamilyOptions` for the offsets column family is not closed, and column family handles can leak on close-path exceptions, which under cascading task closes (e.g., rebalances or error-triggered recoveries) leads to unbounded off-heap memory growth and eventual OOM. Users running Kafka Streams should consider upgrading directly to 4.3.1, which includes the fix for it.

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1690,6 +1690,15 @@ public class KafkaStreams implements AutoCloseable {
      * instance is {@link #close() closed}.
      * <p>
      * Calling this method triggers a restore of local {@link StateStore}s on the next {@link #start() application start}.
+     * <p>
+     * As a final step, this method attempts to delete the application's state directory.
+     * If only expected metadata files remain, such as {@code kafka-streams-process-metadata}
+     * and/or {@code .lock}, the directory itself may be retained. This is not considered
+     * a cleanup failure.
+     * 
+     * <p>
+     * If a full local reset is required, including removal of persisted process metadata,
+     * manually delete the application's state directory after this instance has been closed.
      *
      * @throws IllegalStateException if this {@code KafkaStreams} instance has been started and hasn't fully shut down
      * @throws StreamsException if cleanup failed

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -585,7 +585,7 @@ public class StateDirectory implements AutoCloseable {
             if (hasPersistentStores && stateDir.exists() && !stateDir.delete()) {
                 final File[] remainingFiles = stateDir.listFiles();
                 if (remainingFiles == null) {
-                    log.warn("{} Failed to delete state store directory of {}. It is not a directory, or is inaccessible.",
+                    log.warn("{} Failed to delete state store directory {}. It is not a directory, or it is inaccessible.",
                             logPrefix(), stateDir.getAbsolutePath());
                     return;
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -608,7 +608,7 @@ public class StateDirectory implements AutoCloseable {
                     // processId stable across restarts. Removing it would cause a new processId to be
                     // generated and may lead to unnecessary task movements during rebalances.
                     log.debug(
-                            "{} State store directory {} was not deleted because it still contains only expected metadata files ({} and/or {}).",
+                            "{} State store directory {} was not deleted because it still contains expected metadata files ({} and/or {}).",
                             logPrefix(), stateDir.getAbsolutePath(), PROCESS_FILE_NAME, LOCK_FILE_NAME
                     );
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -585,7 +585,7 @@ public class StateDirectory implements AutoCloseable {
             if (hasPersistentStores && stateDir.exists() && !stateDir.delete()) {
                 final File[] remainingFiles = stateDir.listFiles();
                 if (remainingFiles == null) {
-                    log.warn("{} Failed to delete state store directory of {} for it is not empty",
+                    log.warn("{} Failed to delete state store directory of {}. It is not a directory, or is inaccessible.",
                             logPrefix(), stateDir.getAbsolutePath());
                     return;
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -591,7 +591,7 @@ public class StateDirectory implements AutoCloseable {
                 }
 
                 boolean hasProcessOrLockFiles = false;
-                boolean hasNonProcessOrLockFiles = false;
+                boolean hasUnexpectedFiles = false;
 
                 for (final File file : remainingFiles) {
                     final String name = file.getName();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -590,32 +590,32 @@ public class StateDirectory implements AutoCloseable {
                     return;
                 }
 
-                boolean hasProcessFiles = false;
-                boolean hasNonProcessFiles = false;
+                boolean hasProcessOrLockFiles = false;
+                boolean hasNonProcessOrLockFiles = false;
 
                 for (final File file : remainingFiles) {
                     final String name = file.getName();
-                    if (PROCESS_FILE_NAME.equals(name)) {
-                        hasProcessFiles = true;
+                    if (PROCESS_FILE_NAME.equals(name) || LOCK_FILE_NAME.equals(name)) {
+                        hasProcessOrLockFiles = true;
                     } else {
-                        hasNonProcessFiles = true;
+                        hasNonProcessOrLockFiles = true;
                         break;
                     }
                 }
                 
-                if (hasProcessFiles && !hasNonProcessFiles) {
+                if (hasProcessOrLockFiles && !hasNonProcessOrLockFiles) {
                     // KAFKA-10716: The processId file is persisted in the state directory to keep the
                     // processId stable across restarts. Removing it would cause a new processId to be
                     // generated and may lead to unnecessary task movements during rebalances.
                     log.debug(
-                            "{} State store directory {} was not deleted because it still contains the " +
-                            "process metadata file {} that is required for stable task assignment across restarts.",
-                            logPrefix(), stateDir.getAbsolutePath(), PROCESS_FILE_NAME
+                            "{} State store directory {} was not deleted because it still contains only expected metadata files ({} and/or {}).",
+                            logPrefix(), stateDir.getAbsolutePath(), PROCESS_FILE_NAME, LOCK_FILE_NAME
                     );
                 } else {
                     log.warn(
-                            String.format("%s Failed to delete state store directory of %s for it is not empty",
-                                    logPrefix(), stateDir.getAbsolutePath())
+                            "{} Failed to fully clean up state store directory {} because unexpected files remain.",
+                            logPrefix(),
+                            stateDir.getAbsolutePath()
                     );
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -598,12 +598,12 @@ public class StateDirectory implements AutoCloseable {
                     if (PROCESS_FILE_NAME.equals(name) || LOCK_FILE_NAME.equals(name)) {
                         hasProcessOrLockFiles = true;
                     } else {
-                        hasNonProcessOrLockFiles = true;
+                        hasUnexpectedFiles = true;
                         break;
                     }
                 }
                 
-                if (hasProcessOrLockFiles && !hasNonProcessOrLockFiles) {
+                if (hasProcessOrLockFiles && !hasUnexpectedFiles) {
                     // KAFKA-10716: The processId file is persisted in the state directory to keep the
                     // processId stable across restarts. Removing it would cause a new processId to be
                     // generated and may lead to unnecessary task movements during rebalances.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -583,10 +583,41 @@ public class StateDirectory implements AutoCloseable {
 
         try {
             if (hasPersistentStores && stateDir.exists() && !stateDir.delete()) {
-                log.warn(
-                    String.format("%s Failed to delete state store directory of %s for it is not empty",
-                        logPrefix(), stateDir.getAbsolutePath())
-                );
+                final File[] remainingFiles = stateDir.listFiles();
+                if (remainingFiles == null) {
+                    log.warn("{} Failed to delete state store directory of {} for it is not empty",
+                            logPrefix(), stateDir.getAbsolutePath());
+                    return;
+                }
+
+                boolean hasProcessFiles = false;
+                boolean hasNonProcessFiles = false;
+
+                for (final File file : remainingFiles) {
+                    final String name = file.getName();
+                    if (PROCESS_FILE_NAME.equals(name)) {
+                        hasProcessFiles = true;
+                    } else {
+                        hasNonProcessFiles = true;
+                        break;
+                    }
+                }
+                
+                if (hasProcessFiles && !hasNonProcessFiles) {
+                    // KAFKA-10716: The processId file is persisted in the state directory to keep the
+                    // processId stable across restarts. Removing it would cause a new processId to be
+                    // generated and may lead to unnecessary task movements during rebalances.
+                    log.debug(
+                            "{} State store directory {} was not deleted because it still contains the " +
+                            "process metadata file {} that is required for stable task assignment across restarts.",
+                            logPrefix(), stateDir.getAbsolutePath(), PROCESS_FILE_NAME
+                    );
+                } else {
+                    log.warn(
+                            String.format("%s Failed to delete state store directory of %s for it is not empty",
+                                    logPrefix(), stateDir.getAbsolutePath())
+                    );
+                }
             }
         } catch (final SecurityException exception) {
             log.error(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -72,6 +72,7 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.processor.internals.StateDirectory.LOCK_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateDirectory.PROCESS_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.toTaskDirString;
@@ -601,7 +602,7 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldNotDeleteAppDirWhenCleanUpIfNotEmpty() throws IOException {
+    public void shouldWarnWhenUnexpectedFilesRemainDuringClean() throws IOException {
         final TaskId taskId = new TaskId(0, 0);
         final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
@@ -615,9 +616,10 @@ public class StateDirectoryTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             // call StateDirectory#clean
             directory.clean();
+            assertTrue(appDir.exists());
             assertThat(
                 appender.getMessages(),
-                hasItem(endsWith(String.format("Failed to delete state store directory of %s for it is not empty", appDir.getAbsolutePath())))
+                hasItem(containsString("unexpected files remain"))
             );
         }
     }
@@ -957,7 +959,7 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldLogDebugAndNotWarnWhenOnlyProcessFileRemainsDuringClean() throws IOException {
+    public void shouldRetainAppDirAndNotWarnWhenOnlyProcessFileRemainsDuringClean() throws IOException {
         // GIVEN
         final File stateDir = TestUtils.tempDirectory();
         final StateDirectory stateDirectory = new StateDirectory(
@@ -972,28 +974,106 @@ public class StateDirectoryTest {
                 true,
                 false);
 
-        final File processFile = new File(stateDir.getPath() + "/" + applicationId, PROCESS_FILE_NAME);
+        final File appStateDir = new File(stateDir, applicationId);
+        final File processFile = new File(appStateDir, PROCESS_FILE_NAME);
         processFile.createNewFile();
         stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0));
-        
+
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             appender.setClassLogger(StateDirectory.class, Level.DEBUG);
-            
+
             // WHEN
             stateDirectory.clean();
 
             // THEN
             assertTrue(processFile.exists());
-            assertTrue(stateDir.exists());
-            
+            assertTrue(appStateDir.exists());
+
             final List<String> messages = appender.getMessages();
             final boolean hasWarnLog = messages.stream()
-                    .anyMatch(msg -> msg.contains("Failed to delete state store directory") && msg.contains("it is not empty"));
+                    .anyMatch(msg -> msg.contains("Failed to fully clean up state store directory")
+                                        || msg.contains("Failed to delete state store directory"));
             assertFalse(hasWarnLog);
+        }
+    }
 
-            final boolean hasDebugLog = messages.stream()
-                    .anyMatch(msg -> msg.contains("process metadata file") && msg.contains("required for stable task assignment"));
-            assertTrue(hasDebugLog);
+    @Test
+    public void shouldRetainAppDirAndNotWarnWhenOnlyLockFileRemainsDuringClean() throws IOException {
+        // GIVEN
+        final File stateDir = TestUtils.tempDirectory();
+        final StateDirectory stateDirectory = new StateDirectory(
+                new StreamsConfig(new Properties() {
+                    {
+                        put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+                        put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+                        put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+                    }
+                }),
+                time,
+                true,
+                false);
+
+        final File appStateDir = new File(stateDir, applicationId);
+        final File lockFile = new File(appStateDir, LOCK_FILE_NAME);
+        lockFile.createNewFile();
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
+            appender.setClassLogger(StateDirectory.class, Level.DEBUG);
+
+            // WHEN
+            stateDirectory.clean();
+
+            // THEN
+            assertTrue(lockFile.exists());
+            assertTrue(appStateDir.exists());
+
+            final List<String> messages = appender.getMessages();
+            final boolean hasWarnLog = messages.stream()
+                    .anyMatch(msg -> msg.contains("Failed to fully clean up state store directory")
+                                        || msg.contains("Failed to delete state store directory"));
+            assertFalse(hasWarnLog);
+        }
+    }
+
+    @Test
+    public void shouldRetainAppDirAndNotWarnWhenOnlyExpectedMetadataFilesRemainDuringClean() throws IOException {
+        // GIVEN
+        final File stateDir = TestUtils.tempDirectory();
+        final StateDirectory stateDirectory = new StateDirectory(
+                new StreamsConfig(new Properties() {
+                    {
+                        put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+                        put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+                        put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+                    }
+                }),
+                time,
+                true,
+                false);
+
+        final File appStateDir = new File(stateDir, applicationId);
+        final File processFile = new File(appStateDir, PROCESS_FILE_NAME);
+        final File lockFile = new File(appStateDir, LOCK_FILE_NAME);
+        processFile.createNewFile();
+        lockFile.createNewFile();
+        stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0));
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
+            appender.setClassLogger(StateDirectory.class, Level.DEBUG);
+
+            // WHEN
+            stateDirectory.clean();
+
+            // THEN
+            assertTrue(processFile.exists());
+            assertTrue(lockFile.exists());
+            assertTrue(appStateDir.exists());
+
+            final List<String> messages = appender.getMessages();
+            final boolean hasWarnLog = messages.stream()
+                    .anyMatch(msg -> msg.contains("Failed to fully clean up state store directory")
+                                        || msg.contains("Failed to delete state store directory"));
+            assertFalse(hasWarnLog);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.test.TestUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -953,6 +954,47 @@ public class StateDirectoryTest {
         assertEquals(Set.of(dir2), new HashSet<>(files));
         files = directory.listNonEmptyTaskDirectories();
         assertEquals(Set.of(dir2), new HashSet<>(files));
+    }
+
+    @Test
+    public void shouldLogDebugAndNotWarnWhenOnlyProcessFileRemainsDuringClean() throws IOException {
+        // GIVEN
+        final File stateDir = TestUtils.tempDirectory();
+        final StateDirectory stateDirectory = new StateDirectory(
+                new StreamsConfig(new Properties() {
+                    {
+                        put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+                        put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+                        put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+                    }
+                }),
+                time,
+                true,
+                false);
+
+        final File processFile = new File(stateDir.getPath() + "/" + applicationId , PROCESS_FILE_NAME);
+        processFile.createNewFile();
+        stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0));
+        
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
+            appender.setClassLogger(StateDirectory.class, Level.DEBUG);
+            
+            // WHEN
+            stateDirectory.clean();
+
+            // THEN
+            assertTrue(processFile.exists());
+            assertTrue(stateDir.exists());
+            
+            final List<String> messages = appender.getMessages();
+            final boolean hasWarnLog = messages.stream()
+                    .anyMatch(msg -> msg.contains("Failed to delete state store directory") && msg.contains("it is not empty"));
+            assertFalse(hasWarnLog);
+
+            final boolean hasDebugLog = messages.stream()
+                    .anyMatch(msg -> msg.contains("process metadata file") && msg.contains("required for stable task assignment"));
+            assertTrue(hasDebugLog);
+        }
     }
 
     private StateStore initializeStartupStores(final TaskId taskId, final boolean createTaskDir) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -972,7 +972,7 @@ public class StateDirectoryTest {
                 true,
                 false);
 
-        final File processFile = new File(stateDir.getPath() + "/" + applicationId , PROCESS_FILE_NAME);
+        final File processFile = new File(stateDir.getPath() + "/" + applicationId, PROCESS_FILE_NAME);
         processFile.createNewFile();
         stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0));
         


### PR DESCRIPTION
`KafkaStreams#cleanup(...)` currently logs a `WARN` when the state
directory cannot be deleted because it is not empty. Since KAFKA-10716,
the `processId` file is persisted in state directory and is expected to
remain across restarts, so this WARN can be misleading when the process
metadata file is the only remaining entry.

As agree on in KIP-1238, in `StateDirectory#clean(...)`, if the
directory contains only the `process metadata` file, a debug message is
logged explaining that the directory was not deleted because it still
contains the process metadata file required for stable task assignment
across restarts, and no WARN is emitted. If any other file remains, the
existing WARN is logged as before.

Reviewers: Lucy Liu <lucliu@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
