### PR TITLE
MINOR: Bump LATEST_PRODUCTION to 4.2-IV1 in 4.2 branch

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -34,6 +34,8 @@ import org.apache.kafka.server.common.Feature;
 import org.apache.kafka.server.common.GroupVersion;
 import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.server.common.ShareVersion;
+import org.apache.kafka.server.common.StreamsVersion;
 import org.apache.kafka.server.common.TestFeatureVersion;
 import org.apache.kafka.server.common.TransactionVersion;
 import org.apache.kafka.test.TestUtils;
@@ -391,6 +393,12 @@ public class FormatterTest {
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(GroupVersion.FEATURE_NAME).
                 setFeatureLevel(GroupVersion.GV_1.featureLevel()), (short) 0));
+            expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(ShareVersion.FEATURE_NAME).
+                setFeatureLevel(ShareVersion.SV_1.featureLevel()), (short) 0));
+            expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(StreamsVersion.FEATURE_NAME).
+                setFeatureLevel(StreamsVersion.SV_1.featureLevel()), (short) 0));
             if (version > 0) {
                 expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                     setName(TestFeatureVersion.FEATURE_NAME).

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.server.common.TestFeatureVersion;
 import org.apache.kafka.server.common.TransactionVersion;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -273,6 +274,8 @@ public class FormatterTest {
         }
     }
 
+    // This test is disabled because all features are stable in Apache Kafka 4.2.
+    @Disabled
     @Test
     public void testFormatWithUnstableReleaseVersionFailsWithoutEnableUnstable() throws Exception {
         try (TestEnv testEnv = new TestEnv(1)) {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -118,7 +118,7 @@ public enum MetadataVersion {
     IBP_4_2_IV0(28, "4.2", "IV0", false),
 
     // Enables "streams" groups by default for new clusters (KIP-1071).
-    IBP_4_2_IV1(29, "4.2", "IV1", false),
+    IBP_4_2_IV1(29, "4.2", "IV1", false);
 
     //
     // NOTE: MetadataVersions after this point are unstable and may be changed.
@@ -126,9 +126,6 @@ public enum MetadataVersion {
     // they have set the configuration unstable.feature.versions.enable=true.
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
-
-    // Placeholder testing level for 4.3.
-    IBP_4_3_IV0(30, "4.3", "IV0", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -375,7 +372,8 @@ public enum MetadataVersion {
 
     // Testing only
     public static MetadataVersion latestTesting() {
-        return VERSIONS[VERSIONS.length - 1];
+        // There is no separate testing version because all features are currently stable.
+        return LATEST_PRODUCTION;
     }
 
     public static MetadataVersion latestProduction() {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -114,6 +114,12 @@ public enum MetadataVersion {
     // Send FETCH version 18 in the replica fetcher (KIP-1166)
     IBP_4_1_IV1(27, "4.1", "IV1", false),
 
+    // Enables share groups by default for new clusters (KIP-932).
+    IBP_4_2_IV0(28, "4.2", "IV0", false),
+
+    // Enables "streams" groups by default for new clusters (KIP-1071).
+    IBP_4_2_IV1(29, "4.2", "IV1", false),
+
     //
     // NOTE: MetadataVersions after this point are unstable and may be changed.
     // If users attempt to use an unstable MetadataVersion, they will get an error unless
@@ -121,11 +127,8 @@ public enum MetadataVersion {
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 
-    // Enables share groups by default for new clusters (KIP-932).
-    IBP_4_2_IV0(28, "4.2", "IV0", false),
-
-    // Enables "streams" groups by default for new clusters (KIP-1071).
-    IBP_4_2_IV1(29, "4.2", "IV1", false);
+    // Placeholder testing level for 4.3.
+    IBP_4_3_IV0(30, "4.3", "IV0", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -145,7 +148,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_1_IV1;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_2_IV1;
     // If you change the value above please also update
     // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -90,16 +90,15 @@ class MetadataVersionTest {
         assertEquals(IBP_4_1_IV0, MetadataVersion.fromVersionString("4.1-IV0", true));
         assertEquals(IBP_4_1_IV1, MetadataVersion.fromVersionString("4.1-IV1", true));
 
+        // 4.2-IV1 is the latest production version in the 4.2 line
+        assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2", true));
         assertEquals(IBP_4_2_IV0, MetadataVersion.fromVersionString("4.2-IV0", true));
         assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2-IV1", true));
 
         // Throws exception when unstableFeatureVersionsEnabled is false
-        assertEquals("Unknown metadata.version '4.2-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
-            + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, 4.1-IV1",
-            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.2-IV0", false)).getMessage());
-        assertEquals("Unknown metadata.version '4.2-IV1'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
-                + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, 4.1-IV1",
-            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.2-IV1", false)).getMessage());
+        assertEquals("Unknown metadata.version '4.3-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
+            + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, 4.1-IV1, 4.2-IV0, 4.2-IV1",
+            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.3-IV0", false)).getMessage());
     }
 
     @Test

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.common;
 
 import org.apache.kafka.common.protocol.ApiKeys;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -248,6 +249,8 @@ class MetadataVersionTest {
         assertEquals(expectedVersion, metadataVersion.registerBrokerRecordVersion());
     }
 
+    // This test is disabled because all features are stable in Apache Kafka 4.2.
+    @Disabled
     @Test
     public void assertLatestProductionIsLessThanLatest() {
         assertTrue(LATEST_PRODUCTION.ordinal() < MetadataVersion.latestTesting().ordinal(),
@@ -272,6 +275,8 @@ class MetadataVersionTest {
         assertTrue(LATEST_PRODUCTION.isProduction());
     }
 
+    // This test is disabled because all features are stable in Apache Kafka 4.2.
+    @Disabled
     @Test
     public void assertLatestIsNotProduction() {
         assertFalse(MetadataVersion.latestTesting().isProduction());

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -132,7 +132,7 @@ DEV_VERSION = KafkaVersion("4.2.0-SNAPSHOT")
 
 LATEST_STABLE_TRANSACTION_VERSION = 2
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
-LATEST_STABLE_METADATA_VERSION = "4.1-IV1"
+LATEST_STABLE_METADATA_VERSION = "4.2-IV1"
 
 # 2.1.x versions
 V_2_1_0 = KafkaVersion("2.1.0")
@@ -248,4 +248,5 @@ LATEST_4_1 = V_4_1_1
 
 # 4.2.x version
 V_4_2_0 = KafkaVersion("4.2.0")
-LATEST_4_2 = V_4_2_0
+V_4_2_1 = KafkaVersion("4.2.1")
+LATEST_4_2 = V_4_2_1


### PR DESCRIPTION
Bump latest production metadata version for Apache Kafka 4.2.0 to enable
share groups and streams groups by default.
