### PR TITLE
MINOR: Fix em-dash in command option documentation

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ShareGroupCommandOptions.java
@@ -50,7 +50,7 @@ public class ShareGroupCommandOptions extends CommandDefaultOptions {
         "Has 2 execution options: --dry-run to plan which offsets to reset, and --execute to reset the offsets. " + NL +
         "You must choose one of the following reset specifications: --to-datetime, --to-earliest, --to-latest." + NL +
         "To define the scope use --all-topics or --topic." + NL +
-        "Fails if neither '--dry-run' nor '–execute' is specified.";
+        "Fails if neither '--dry-run' nor '--execute' is specified.";
     private static final String DRY_RUN_DOC = "Only show results without executing changes on share groups. Supported operations: reset-offsets.";
     private static final String EXECUTE_DOC = "Execute operation. Supported operations: reset-offsets.";
     private static final String RESET_TO_DATETIME_DOC = "Reset offsets to offset from datetime. Format: 'YYYY-MM-DDThh:mm:ss.sss'";

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommandOptions.java
@@ -56,7 +56,7 @@ public class StreamsGroupCommandOptions extends CommandDefaultOptions {
         "You must choose one of the following reset specifications: --to-datetime, --by-duration, --to-earliest, " +
         "--to-latest, --shift-by, --from-file, --to-current, --to-offset." + NL +
         "To define the scope use --all-input-topics or --input-topic. One scope must be specified unless you use '--from-file'." + NL +
-        "Fails if neither '--dry-run' nor '–execute' is specified.";
+        "Fails if neither '--dry-run' nor '--execute' is specified.";
     private static final String DRY_RUN_DOC = "Only show results without executing changes on streams group. Supported operations: reset-offsets.";
     private static final String EXECUTE_DOC = "Execute operation. Supported operations: reset-offsets.";
     private static final String EXPORT_DOC = "Export operation execution to a CSV file. Supported operations: reset-offsets.";


### PR DESCRIPTION
Replace em-dash (–) with double hyphen (--) in '--execute' option
documentation for both ShareGroupCommandOptions and
StreamsGroupCommandOptions to ensure proper display and consistency.

Introduced in commit ffab7e6a5d5.

Reviewers: Ming-Yen Chung <mingyen066@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
