### PR TITLE
MINOR: Fix rare flaky behaviour in testPreferredReplicaElection

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -278,7 +278,8 @@ public class LeaderElectionCommandTest {
             assertEquals(0, LeaderElectionCommand.mainNoExit(
                     "--bootstrap-server", cluster.bootstrapServers(),
                     "--election-type", "preferred",
-                    "--all-topic-partitions"
+                    "--topic", topic,
+                    "--partition", Integer.toString(partition)
             ));
 
             TestUtils.assertLeader(client, topicPartition, broker2);


### PR DESCRIPTION
The `testPreferredReplicaElection` test shows rare  flakiness by failing
with this error `X replica(s) could not be elected`.  This occurs
because the test uses `--all-topic-partitions`, which attempts preferred
leader election on all internal topics as well as the test topic which
creates some timing issue. While the test waits for the test topic to
join the ISR, it does not wait for all internal topics to synchronize
their ISR membership after the broker restart. This fix modifies the
test to target only the specific test topic partition rather than all
partitions.

Reviewers: Jonah Hooper <jhooper@confluent.io>, kevin-wu24 <66326898+kevin-wu24@users.noreply.github.com>, David Arthur <mumrah@gmail.com>