### PR TITLE
MINOR: Bump LATEST_PRODUCTION to 4.2-IV1

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -34,6 +34,8 @@ import org.apache.kafka.server.common.Feature;
 import org.apache.kafka.server.common.GroupVersion;
 import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.server.common.ShareVersion;
+import org.apache.kafka.server.common.StreamsVersion;
 import org.apache.kafka.server.common.TestFeatureVersion;
 import org.apache.kafka.server.common.TransactionVersion;
 import org.apache.kafka.test.TestUtils;
@@ -391,6 +393,12 @@ public class FormatterTest {
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(GroupVersion.FEATURE_NAME).
                 setFeatureLevel(GroupVersion.GV_1.featureLevel()), (short) 0));
+            expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(ShareVersion.FEATURE_NAME).
+                setFeatureLevel(ShareVersion.SV_1.featureLevel()), (short) 0));
+            expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(StreamsVersion.FEATURE_NAME).
+                setFeatureLevel(StreamsVersion.SV_1.featureLevel()), (short) 0));
             if (version > 0) {
                 expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                     setName(TestFeatureVersion.FEATURE_NAME).

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -114,6 +114,12 @@ public enum MetadataVersion {
     // Send FETCH version 18 in the replica fetcher (KIP-1166)
     IBP_4_1_IV1(27, "4.1", "IV1", false),
 
+    // Enables share groups by default for new clusters (KIP-932).
+    IBP_4_2_IV0(28, "4.2", "IV0", false),
+
+    // Enables "streams" groups by default for new clusters (KIP-1071).
+    IBP_4_2_IV1(29, "4.2", "IV1", false),
+
     //
     // NOTE: MetadataVersions after this point are unstable and may be changed.
     // If users attempt to use an unstable MetadataVersion, they will get an error unless
@@ -121,11 +127,8 @@ public enum MetadataVersion {
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 
-    // Enables share groups by default for new clusters (KIP-932).
-    IBP_4_2_IV0(28, "4.2", "IV0", false),
-
-    // Enables "streams" groups by default for new clusters (KIP-1071).
-    IBP_4_2_IV1(29, "4.2", "IV1", false);
+    // New version for the Kafka 4.3.0 release.
+    IBP_4_3_IV0(30, "4.3", "IV0", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -145,7 +148,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_1_IV1;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_2_IV1;
     // If you change the value above please also update
     // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -90,16 +90,17 @@ class MetadataVersionTest {
         assertEquals(IBP_4_1_IV0, MetadataVersion.fromVersionString("4.1-IV0", true));
         assertEquals(IBP_4_1_IV1, MetadataVersion.fromVersionString("4.1-IV1", true));
 
+        // 4.2-IV1 is the latest production version in the 4.2 line
+        assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2", true));
         assertEquals(IBP_4_2_IV0, MetadataVersion.fromVersionString("4.2-IV0", true));
         assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2-IV1", true));
 
+        assertEquals(IBP_4_3_IV0, MetadataVersion.fromVersionString("4.3-IV0", true));
+
         // Throws exception when unstableFeatureVersionsEnabled is false
-        assertEquals("Unknown metadata.version '4.2-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
-            + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, 4.1-IV1",
-            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.2-IV0", false)).getMessage());
-        assertEquals("Unknown metadata.version '4.2-IV1'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
-                + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, 4.1-IV1",
-            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.2-IV1", false)).getMessage());
+        assertEquals("Unknown metadata.version '4.3-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
+            + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, 4.1-IV1, 4.2-IV0, 4.2-IV1",
+            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.3-IV0", false)).getMessage());
     }
 
     @Test
@@ -133,6 +134,7 @@ class MetadataVersionTest {
         assertEquals("4.1", IBP_4_1_IV1.shortVersion());
         assertEquals("4.2", IBP_4_2_IV0.shortVersion());
         assertEquals("4.2", IBP_4_2_IV1.shortVersion());
+        assertEquals("4.3", IBP_4_3_IV0.shortVersion());
     }
 
     @Test
@@ -160,6 +162,7 @@ class MetadataVersionTest {
         assertEquals("4.1-IV1", IBP_4_1_IV1.version());
         assertEquals("4.2-IV0", IBP_4_2_IV0.version());
         assertEquals("4.2-IV1", IBP_4_2_IV1.version());
+        assertEquals("4.3-IV0", IBP_4_3_IV0.version());
     }
 
     @Test

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
@@ -52,7 +52,7 @@ public @interface ClusterTest {
     String brokerListener() default DEFAULT_BROKER_LISTENER_NAME;
     SecurityProtocol controllerSecurityProtocol() default SecurityProtocol.PLAINTEXT;
     String controllerListener() default DEFAULT_CONTROLLER_LISTENER_NAME;
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_2_IV1;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_3_IV0;
     ClusterConfigProperty[] serverProperties() default {};
     // users can add tags that they want to display in test
     String[] tags() default {};

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -248,9 +248,4 @@ LATEST_4_1 = V_4_1_1
 
 # 4.2.x version
 V_4_2_0 = KafkaVersion("4.2.0")
-V_4_2_1 = KafkaVersion("4.2.1")
-LATEST_4_2 = V_4_2_1
-
-# 4.3.x version
-V_4_3_0 = KafkaVersion("4.3.0")
-LATEST_4_3 = V_4_3_0
+LATEST_4_2 = V_4_2_0

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -132,7 +132,7 @@ DEV_VERSION = KafkaVersion("4.3.0-SNAPSHOT")
 
 LATEST_STABLE_TRANSACTION_VERSION = 2
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
-LATEST_STABLE_METADATA_VERSION = "4.1-IV1"
+LATEST_STABLE_METADATA_VERSION = "4.2-IV1"
 
 # 2.1.x versions
 V_2_1_0 = KafkaVersion("2.1.0")
@@ -248,4 +248,9 @@ LATEST_4_1 = V_4_1_1
 
 # 4.2.x version
 V_4_2_0 = KafkaVersion("4.2.0")
-LATEST_4_2 = V_4_2_0
+V_4_2_1 = KafkaVersion("4.2.1")
+LATEST_4_2 = V_4_2_1
+
+# 4.3.x version
+V_4_3_0 = KafkaVersion("4.3.0")
+LATEST_4_3 = V_4_3_0

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -60,7 +60,7 @@ public class FeatureCommandTest {
         assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-                "SupportedMaxVersion: 4.2-IV1\tFinalizedVersionLevel: 3.3-IV3\t", outputWithoutEpoch(features.get(3)));
+                "SupportedMaxVersion: 4.3-IV0\tFinalizedVersionLevel: 3.3-IV3\t", outputWithoutEpoch(features.get(3)));
         assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(4)));
         assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
@@ -86,7 +86,7 @@ public class FeatureCommandTest {
         assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-                "SupportedMaxVersion: 4.2-IV1\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(3)));
+                "SupportedMaxVersion: 4.3-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(3)));
         assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
                 "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(4)));
         assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +


### PR DESCRIPTION
Bump latest production metadata version to 4.2-IV1 to enable share
groups and streams groups by default.

Reviewers: Matthias J. Sax <mjsax@apache.org>
