### PR TITLE
MINOR: Improve Streams docs for transitory states

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -241,6 +241,11 @@ public class KafkaStreams implements AutoCloseable {
      *     Any state except NOT_RUNNING, PENDING_ERROR or ERROR can go to PENDING_SHUTDOWN (whenever close is called)
      *   </li>
      *   <li>
+     *     PENDING_SHUTDOWN and PENDING_ERROR are transitory states where the Streams application gracefully closes
+     *     its existing resources before transitioning into their corresponding terminal states. These states are
+     *     not recoverable, and only a restart would get this application back to the RUNNING state.
+     *   </li>
+     *   <li>
      *     Of special importance: If the global stream thread dies, or all stream threads die (or both) then
      *     the instance will be in the ERROR state. The user will not need to close it.
      *   </li>

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -243,7 +243,7 @@ public class KafkaStreams implements AutoCloseable {
      *   <li>
      *     PENDING_SHUTDOWN and PENDING_ERROR are transitory states where the Streams application gracefully closes
      *     its existing resources before transitioning into their corresponding terminal states. These states are
-     *     not recoverable, and only a restart would get this application back to the RUNNING state.
+     *     not recoverable, and only a restart would get an application back to the RUNNING state.
      *   </li>
      *   <li>
      *     Of special importance: If the global stream thread dies, or all stream threads die (or both) then


### PR DESCRIPTION
This PR improves Kafka Streams documentation for transitory states. It
is not currently clear that the `PENDING_SHUTDOWN` and `PENDING_ERROR`
states are not recoverable, and that a restart is required to get back
to running.

Reviewers: Matthias J. Sax <matthias@confluent.io>
