### PR TITLE
KAFKA-15700: FetchFromFollowerIntegrationTest is flaky

### DIFF
--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -234,7 +234,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
         val records = future.get(30, TimeUnit.SECONDS)
         assertEquals(assignments(i), records.map(r => new TopicPartition(r.topic, r.partition)).toSet)
       }
-      consumers.foreach{ consumer => consumer.commitSync() }
+      consumers.foreach{ _.commitSync() }
     }
 
 

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -200,6 +200,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
       consumerConfig.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, server.config.rack.orNull)
       consumerConfig.setProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, s"instance-${server.config.brokerId}")
       consumerConfig.setProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "1000")
+      consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
       createConsumer()
     }
 

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -27,9 +27,9 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.server.config.ServerLogConfigs
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.{Disabled, Timeout}
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.{MethodSource, ValueSource}
 
 import java.util
 import java.util.Properties
@@ -181,9 +181,8 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
     }
   }
 
-  @Disabled
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
-  @MethodSource(Array("getTestGroupProtocolParametersAll"))
+  @ValueSource(strings = Array("classic"))
   def testRackAwareRangeAssignor(groupProtocol: String): Unit = {
     val partitionList = brokers.indices.toList
 
@@ -235,6 +234,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
         val records = future.get(30, TimeUnit.SECONDS)
         assertEquals(assignments(i), records.map(r => new TopicPartition(r.topic, r.partition)).toSet)
       }
+      consumers.foreach{ consumer => consumer.commitSync() }
     }
 
 


### PR DESCRIPTION
# Description
This PR fixes the flakiness in `testRackAwareRangeAssignor`.  Currently,
it fails during the verification after `alterPartitionReassignments`,
and also during `groupProtocol = consumer`.

## Using CLASSIC Group Protocol
The test relies on auto-commit, which is not deterministic during the
rebalance triggered by `alterPartitionReassignments`. Consequently, the
consumer may fail to commit offsets before the rebalance completes. When
the partition is re-assigned, the consumer fetches previously consumed
messages (duplicate consumption). Since `verifyAssignments` polls for a
fixed number of records, these duplicate messages cause the assertion to
fail (as it expects records from specific new partitions, not old ones).

A `Consumer#commitSync` is added after each verification to ensure the
next verification won't consume old data.

## Using CONSUMER Group Protocol
`PARTITION_ASSIGNMENT_STRATEGY_CONFIG` is invalid when using the
CONSUMER group protocol, so we can't use the `RangeAssignor` here.

Now the test is restricted to run only with `groupProtocol = classic`.

# Result
Successfully run 500 times in local:
<img width="924" height="399" alt="Screenshot 2025-11-24 at 6 56 00 PM"
src="https://github.com/user-attachments/assets/92e9cdd7-0726-4711-9f0e-c69568432663"
/>

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Kirk True
 <ktrue@confluent.io>


