### PR TITLE
KAFKA-19922: Updated docs for start-offset in share groups (#20991)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/SharePartitionOffsetInfo.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/SharePartitionOffsetInfo.java
@@ -31,7 +31,9 @@ public class SharePartitionOffsetInfo {
     /**
      * Construct a new SharePartitionOffsetInfo.
      *
-     * @param startOffset The share-partition start offset
+     * @param startOffset The share-partition start offset. The start offset is the earliest offset
+     *                    for in-flight records being evaluated for delivery to share consumers.
+     *                    Some records after the start offset may already have completed delivery.
      * @param leaderEpoch The optional leader epoch of the share-partition
      * @param lag         The optional lag for the share-partition
      */
@@ -41,14 +43,31 @@ public class SharePartitionOffsetInfo {
         this.lag = lag;
     }
 
+    /**
+     * Get the start offset for the share-partition. The start offset is the earliest offset for
+     * in-flight records being evaluated for delivery to share consumers. Some records after the start
+     * offset may already have completed delivery.
+     *
+     * @return The start offset of the partition read by the share group.
+     */
     public long startOffset() {
         return startOffset;
     }
 
+    /**
+     * Get the leader epoch for the partition.
+     *
+     * @return The leader epoch of the partition.
+     */
     public Optional<Integer> leaderEpoch() {
         return leaderEpoch;
     }
 
+    /**
+     * Get the lag for the partition.
+     *
+     * @return The lag of the partition.
+     */
     public Optional<Long> lag() {
         return lag;
     }

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -243,6 +243,8 @@ my-share-group</code></pre>
 GROUP           TOPIC           PARTITION  START-OFFSET  LAG
 my-share-group  topic1          0          4             0</code></pre>
 
+  The start offset is the earliest offset for in-flight records being evaluated for delivery to share consumers. Some records after the start offset may already have completed delivery.
+
   NOTE: The admin client needs DESCRIBE access to all the topics used in the group.
 
   There are many --describe options that provide more detailed information about a share group:


### PR DESCRIPTION
PR to update documentation for start-offset in share groups.

Reviewers: Andrew Schofield <aschofield@confluent.io>
