### PR TITLE
MINOR: Correct ShareCoordinatorMetrics comments and sensor name constant

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -38,8 +38,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoCloseable {
-    //write (write-rate and write-total) Meter share-coordinator-metric The number of share-group state write calls per second.
-    //write-latency (write-latency-avg and write-latency-total) Meter share-coordinator-metrics The time taken for a share-group state write call, including the time to write to the share-group state topic.
+    // write (write-rate and write-total) Meter share-coordinator-metrics The number of share-group state write calls per second.
+    // write-latency (write-latency-avg and write-latency-max) Meter share-coordinator-metrics The time taken for a share-group state write call, including the time to write to the share-group state topic.
     public static final String METRICS_GROUP = "share-coordinator-metrics";
 
     private final Metrics metrics;
@@ -47,7 +47,7 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
     public static final String SHARE_COORDINATOR_WRITE_SENSOR_NAME = "ShareCoordinatorWrite";
     public static final String SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME = "ShareCoordinatorWriteLatency";
-    public static final String SHARE_COORDINATOR_STATE_TOPIC_PRUNE_SENSOR_NAME = "ShareCoordinatorStateTopicPruneSensorName";
+    public static final String SHARE_COORDINATOR_STATE_TOPIC_PRUNE_SENSOR_NAME = "ShareCoordinatorStateTopicPrune";
     private final Map<TopicPartition, ShareGroupPruneMetrics> pruneMetrics = new ConcurrentHashMap<>();
 
     /**


### PR DESCRIPTION
1. The comment incorrectly referenced `write-latency-total`, but the
actual
metrics are  `write-latency-max` (using Max() statistics).

<img width="564" height="633" alt="image"
src="https://github.com/user-attachments/assets/9b6b5e45-2060-453f-b7dd-49ada8c946b9"
/>

2. The `SHARE_COORDINATOR_STATE_TOPIC_PRUNE_SENSOR_NAME` constant value
had a redundant "SensorName" suffix that was inconsistent with other
sensor name constants. Removing it ensures consistent naming conventions
across all sensor name constants.

Reviewers: Sushant Mahajan <smahajan@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
