### PR TITLE
KAFKA-19929: Fix polling delay for share consumer in record-limit mode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumeRequestManager.java
@@ -769,15 +769,6 @@ public class ShareConsumeRequestManager implements RequestManager, MemberStateLi
         return false;
     }
 
-    @Override
-    public long maximumTimeToWait(long currentTimeMs) {
-        // When fetching records and there is no chosen node for fetching, we do not want to wait for the next poll in record_limit mode.
-        if (isShareAcquireModeRecordLimit() && fetchMoreRecords && subscriptions.numAssignedPartitions() > 0 && fetchRecordsNodeId.get() == -1) {
-            return 0L;
-        }
-        return Long.MAX_VALUE;
-    }
-
     private void handleShareFetchSuccess(Node fetchTarget,
                                          ShareFetchRequestData requestData,
                                          ClientResponse resp) {


### PR DESCRIPTION
In record-limit mode, the share consume request manager was varying the
time to wait between polls depending on whether there might be more
requests to send in the future. However, this was based on a mistaken
understanding of how the polling logic works.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
