### PR TITLE
MINOR: Update `GroupCoordinator` interface to received `MetadataImage/Delta` directly

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -2538,7 +2538,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param newImage  The new metadata image.
      * @param delta     The metadata delta.
      */
-    public void onNewMetadataImage(
+    public void onMetadataUpdate(
         CoordinatorMetadataImage newImage,
         CoordinatorMetadataDelta delta
     ) {

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -2535,12 +2535,12 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     /**
      * A new metadata image is available.
      *
-     * @param newImage  The new metadata image.
-     * @param delta     The metadata delta.
+     * @param delta    The metadata delta.
+     * @param newImage The new metadata image.
      */
     public void onMetadataUpdate(
-        CoordinatorMetadataImage newImage,
-        CoordinatorMetadataDelta delta
+        CoordinatorMetadataDelta delta,
+        CoordinatorMetadataImage newImage
     ) {
         throwIfNotRunning();
         log.debug("Scheduling applying of a new metadata image with version {}.", newImage.version());

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -2029,7 +2029,7 @@ public class CoordinatorRuntimeTest {
         // Publish a new image.
         CoordinatorMetadataDelta delta = new KRaftCoordinatorMetadataDelta(new MetadataDelta(MetadataImage.EMPTY));
         CoordinatorMetadataImage newImage = CoordinatorMetadataImage.EMPTY;
-        runtime.onMetadataUpdate(newImage, delta);
+        runtime.onMetadataUpdate(delta, newImage);
 
         // Coordinator 0 should be notified about it.
         verify(coordinator0).onNewMetadataImage(newImage, delta);

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -1968,7 +1968,7 @@ public class CoordinatorRuntimeTest {
     }
 
     @Test
-    public void testOnNewMetadataImage() {
+    public void testOnMetadataUpdate() {
         TopicPartition tp0 = new TopicPartition("__consumer_offsets", 0);
         TopicPartition tp1 = new TopicPartition("__consumer_offsets", 1);
 
@@ -2029,7 +2029,7 @@ public class CoordinatorRuntimeTest {
         // Publish a new image.
         CoordinatorMetadataDelta delta = new KRaftCoordinatorMetadataDelta(new MetadataDelta(MetadataImage.EMPTY));
         CoordinatorMetadataImage newImage = CoordinatorMetadataImage.EMPTY;
-        runtime.onNewMetadataImage(newImage, delta);
+        runtime.onMetadataUpdate(newImage, delta);
 
         // Coordinator 0 should be notified about it.
         verify(coordinator0).onNewMetadataImage(newImage, delta);

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -234,7 +234,7 @@ class BrokerMetadataPublisher(
 
       try {
         // Propagate the new image to the group coordinator.
-        groupCoordinator.onNewMetadataImage(new KRaftCoordinatorMetadataImage(newImage), new KRaftCoordinatorMetadataDelta(delta))
+        groupCoordinator.onMetadataUpdate(new KRaftCoordinatorMetadataImage(newImage), new KRaftCoordinatorMetadataDelta(delta))
       } catch {
         case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating group " +
           s"coordinator with local changes in $deltaName", t)
@@ -242,7 +242,7 @@ class BrokerMetadataPublisher(
 
       try {
         // Propagate the new image to the share coordinator.
-        shareCoordinator.onNewMetadataImage(new KRaftCoordinatorMetadataImage(newImage), newImage.features(), new KRaftCoordinatorMetadataDelta(delta))
+        shareCoordinator.onMetadataUpdate(new KRaftCoordinatorMetadataImage(newImage), newImage.features(), new KRaftCoordinatorMetadataDelta(delta))
       } catch {
         case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating share " +
           s"coordinator with local changes in $deltaName", t)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -234,7 +234,7 @@ class BrokerMetadataPublisher(
 
       try {
         // Propagate the new image to the group coordinator.
-        groupCoordinator.onMetadataUpdate(new KRaftCoordinatorMetadataImage(newImage), new KRaftCoordinatorMetadataDelta(delta))
+        groupCoordinator.onMetadataUpdate(delta, newImage)
       } catch {
         case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating group " +
           s"coordinator with local changes in $deltaName", t)
@@ -242,7 +242,7 @@ class BrokerMetadataPublisher(
 
       try {
         // Propagate the new image to the share coordinator.
-        shareCoordinator.onMetadataUpdate(new KRaftCoordinatorMetadataImage(newImage), newImage.features(), new KRaftCoordinatorMetadataDelta(delta))
+        shareCoordinator.onNewMetadataImage(new KRaftCoordinatorMetadataImage(newImage), newImage.features(), new KRaftCoordinatorMetadataDelta(delta))
       } catch {
         case t: Throwable => metadataPublishingFaultHandler.handleFault("Error updating share " +
           s"coordinator with local changes in $deltaName", t)

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -35,7 +35,6 @@ import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.metadata.{FeatureLevelRecord, PartitionRecord, RemoveTopicRecord, TopicRecord}
 import org.apache.kafka.common.test.{KafkaClusterTestKit, TestKitNodes}
 import org.apache.kafka.common.utils.Exit
-import org.apache.kafka.coordinator.common.runtime.{KRaftCoordinatorMetadataDelta, KRaftCoordinatorMetadataImage}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.coordinator.share.ShareCoordinator
 import org.apache.kafka.image.{AclsImage, ClientQuotasImage, ClusterImageTest, ConfigurationsImage, DelegationTokenImage, FeaturesImage, MetadataDelta, MetadataImage, MetadataImageTest, MetadataProvenance, ProducerIdsImage, ScramImage, TopicsImage}

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -292,7 +292,7 @@ class BrokerMetadataPublisherTest {
         .numBytes(42)
         .build())
 
-    verify(groupCoordinator).onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(delta))
+    verify(groupCoordinator).onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(delta))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -292,7 +292,7 @@ class BrokerMetadataPublisherTest {
         .numBytes(42)
         .build())
 
-    verify(groupCoordinator).onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(delta))
+    verify(groupCoordinator).onMetadataUpdate(delta, image)
   }
 
   @Test

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -470,7 +470,7 @@ public interface GroupCoordinator {
      * @param newImage  The new metadata image.
      * @param delta     The metadata delta.
      */
-    void onNewMetadataImage(
+    void onMetadataUpdate(
         CoordinatorMetadataImage newImage,
         CoordinatorMetadataDelta delta
     );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -53,9 +53,9 @@ import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.BufferSupplier;
-import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataDelta;
-import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
+import org.apache.kafka.image.MetadataDelta;
+import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 
 import java.time.Duration;
@@ -467,12 +467,12 @@ public interface GroupCoordinator {
     /**
      * A new metadata image is available.
      *
-     * @param newImage  The new metadata image.
      * @param delta     The metadata delta.
+     * @param newImage  The new metadata image.
      */
     void onMetadataUpdate(
-        CoordinatorMetadataImage newImage,
-        CoordinatorMetadataDelta delta
+        MetadataDelta delta,
+        MetadataImage newImage
     );
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -84,18 +84,21 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorLoader;
-import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataDelta;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorResult;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetrics;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorShardBuilderSupplier;
+import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataDelta;
+import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MultiThreadedEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
+import org.apache.kafka.image.MetadataDelta;
+import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.authorizer.Authorizer;
 import org.apache.kafka.server.record.BrokerCompressionType;
@@ -343,9 +346,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
 
     /**
      * The metadata image to extract topic id to names map.
-     * This is initialised when the {@link GroupCoordinator#onMetadataUpdate(CoordinatorMetadataImage, CoordinatorMetadataDelta)} is called
+     * This is initialised when the {@link GroupCoordinator#onMetadataUpdate(MetadataDelta, MetadataImage)} is called
      */
-    private CoordinatorMetadataImage metadataImage = null;
+    private volatile CoordinatorMetadataImage metadataImage = null;
 
     /**
      *
@@ -2354,16 +2357,16 @@ public class GroupCoordinatorService implements GroupCoordinator {
     }
 
     /**
-     * See {@link GroupCoordinator#onMetadataUpdate(CoordinatorMetadataImage, CoordinatorMetadataDelta)}.
+     * See {@link GroupCoordinator#onMetadataUpdate(MetadataDelta, MetadataImage)}.
      */
     @Override
     public void onMetadataUpdate(
-        CoordinatorMetadataImage newImage,
-        CoordinatorMetadataDelta delta
+        MetadataDelta delta,
+        MetadataImage newImage
     ) {
         throwIfNotActive();
-        metadataImage = newImage;
-        runtime.onNewMetadataImage(newImage, delta);
+        metadataImage = newImage == null ? null : new KRaftCoordinatorMetadataImage(newImage);
+        runtime.onNewMetadataImage(metadataImage, new KRaftCoordinatorMetadataDelta(delta));
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -2365,8 +2365,10 @@ public class GroupCoordinatorService implements GroupCoordinator {
         MetadataImage newImage
     ) {
         throwIfNotActive();
-        metadataImage = newImage == null ? null : new KRaftCoordinatorMetadataImage(newImage);
-        runtime.onNewMetadataImage(metadataImage, new KRaftCoordinatorMetadataDelta(delta));
+        var wrappedImage = newImage == null ? null : new KRaftCoordinatorMetadataImage(newImage);
+        var wrappedDelta = delta == null ? null : new KRaftCoordinatorMetadataDelta(delta);
+        metadataImage = wrappedImage;
+        runtime.onNewMetadataImage(wrappedImage, wrappedDelta);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -343,7 +343,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
 
     /**
      * The metadata image to extract topic id to names map.
-     * This is initialised when the {@link GroupCoordinator#onNewMetadataImage(CoordinatorMetadataImage, CoordinatorMetadataDelta)} is called
+     * This is initialised when the {@link GroupCoordinator#onMetadataUpdate(CoordinatorMetadataImage, CoordinatorMetadataDelta)} is called
      */
     private CoordinatorMetadataImage metadataImage = null;
 
@@ -2354,10 +2354,10 @@ public class GroupCoordinatorService implements GroupCoordinator {
     }
 
     /**
-     * See {@link GroupCoordinator#onNewMetadataImage(CoordinatorMetadataImage, CoordinatorMetadataDelta)}.
+     * See {@link GroupCoordinator#onMetadataUpdate(CoordinatorMetadataImage, CoordinatorMetadataDelta)}.
      */
     @Override
-    public void onNewMetadataImage(
+    public void onMetadataUpdate(
         CoordinatorMetadataImage newImage,
         CoordinatorMetadataDelta delta
     ) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -2368,7 +2368,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         var wrappedImage = newImage == null ? null : new KRaftCoordinatorMetadataImage(newImage);
         var wrappedDelta = delta == null ? null : new KRaftCoordinatorMetadataDelta(delta);
         metadataImage = wrappedImage;
-        runtime.onMetadataUpdate(wrappedImage, wrappedDelta);
+        runtime.onMetadataUpdate(wrappedDelta, wrappedImage);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -2368,7 +2368,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         var wrappedImage = newImage == null ? null : new KRaftCoordinatorMetadataImage(newImage);
         var wrappedDelta = delta == null ? null : new KRaftCoordinatorMetadataDelta(delta);
         metadataImage = wrappedImage;
-        runtime.onNewMetadataImage(wrappedImage, wrappedDelta);
+        runtime.onMetadataUpdate(wrappedImage, wrappedDelta);
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -88,11 +88,8 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
-import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataDelta;
-import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
@@ -3163,7 +3160,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(Uuid.randomUuid(), "foo", 1)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(new MetadataDelta(image)));
+        service.onMetadataUpdate(new MetadataDelta(image), image);
 
         when(runtime.scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-partition-deleted"),
@@ -3221,7 +3218,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(Uuid.randomUuid(), "foo", 1)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(new MetadataDelta(image)));
+        service.onMetadataUpdate(new MetadataDelta(image), image);
 
         // No error in partition deleted callback
         when(runtime.scheduleWriteAllOperation(
@@ -3268,10 +3265,10 @@ public class GroupCoordinatorServiceTest {
             .build();
         service.startup(() -> 3);
 
-        CoordinatorMetadataImage image = new MetadataImageBuilder()
+        MetadataImage image = new MetadataImageBuilder()
             .addTopic(Uuid.randomUuid(), "bar", 1)
-            .buildCoordinatorMetadataImage();
-        service.onMetadataUpdate(image, image.emptyDelta());
+            .build();
+        service.onMetadataUpdate(new MetadataDelta(image), image);
 
         // No error in partition deleted callback
         when(runtime.scheduleWriteAllOperation(
@@ -3318,8 +3315,8 @@ public class GroupCoordinatorServiceTest {
             .build();
         service.startup(() -> 3);
 
-        CoordinatorMetadataImage image = CoordinatorMetadataImage.EMPTY;
-        service.onMetadataUpdate(image, image.emptyDelta());
+        MetadataImage image = MetadataImage.EMPTY;
+        service.onMetadataUpdate(new MetadataDelta(image), image);
 
         // No error in partition deleted callback
         when(runtime.scheduleWriteAllOperation(
@@ -4146,7 +4143,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new MetadataDelta(image), image);
 
         int partition = 1;
 
@@ -4273,7 +4270,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         int partition = 1;
 
@@ -4344,7 +4341,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         int partition = 1;
 
@@ -4380,7 +4377,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         int partition = 1;
 
@@ -4417,7 +4414,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         int partition = 1;
 
@@ -5581,7 +5578,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(topicId, "topic-name", 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         when(mockPersister.initializeState(ArgumentMatchers.any())).thenReturn(CompletableFuture.completedFuture(
             new InitializeShareGroupStateResult.Builder()
@@ -5756,7 +5753,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(topicId, "topic-name", 3)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         when(mockPersister.initializeState(ArgumentMatchers.any())).thenReturn(CompletableFuture.completedFuture(
             new InitializeShareGroupStateResult.Builder()
@@ -5974,7 +5971,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(topicId, "topic-name", 1)
             .build();
 
-        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(null, image);
 
         when(mockPersister.initializeState(ArgumentMatchers.any())).thenReturn(CompletableFuture.completedFuture(
             new InitializeShareGroupStateResult.Builder()
@@ -6023,7 +6020,7 @@ public class GroupCoordinatorServiceTest {
         private CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime;
         private GroupCoordinatorMetrics metrics = new GroupCoordinatorMetrics();
         private Persister persister = new NoOpStatePersister();
-        private CoordinatorMetadataImage metadataImage = null;
+        private MetadataImage metadataImage = null;
         private PartitionMetadataClient partitionMetadataClient = null;
 
         GroupCoordinatorService build() {
@@ -6032,7 +6029,9 @@ public class GroupCoordinatorServiceTest {
 
         GroupCoordinatorService build(boolean serviceStartup) {
             if (metadataImage == null) {
-                metadataImage = mock(CoordinatorMetadataImage.class);
+                metadataImage = new MetadataImageBuilder()
+                    .addTopic(TOPIC_ID, TOPIC_NAME, 1)
+                    .build();
             }
 
             GroupCoordinatorService service = new GroupCoordinatorService(
@@ -6048,14 +6047,8 @@ public class GroupCoordinatorServiceTest {
 
             if (serviceStartup) {
                 service.startup(() -> 1);
-                service.onMetadataUpdate(metadataImage, null);
+                service.onMetadataUpdate(null, metadataImage);
             }
-            when(metadataImage.topicNames()).thenReturn(Set.of(TOPIC_NAME));
-            var topicMetadata = mock(CoordinatorMetadataImage.TopicMetadata.class);
-            when(topicMetadata.name()).thenReturn(TOPIC_NAME);
-            when(topicMetadata.id()).thenReturn(TOPIC_ID);
-            when(metadataImage.topicMetadata(TOPIC_ID)).thenReturn(Optional.of(topicMetadata));
-            when(metadataImage.topicMetadata(TOPIC_NAME)).thenReturn(Optional.of(topicMetadata));
 
             return service;
         }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -3163,7 +3163,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(Uuid.randomUuid(), "foo", 1)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(new MetadataDelta(image)));
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(new MetadataDelta(image)));
 
         when(runtime.scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-partition-deleted"),
@@ -3221,7 +3221,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(Uuid.randomUuid(), "foo", 1)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(new MetadataDelta(image)));
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(new MetadataDelta(image)));
 
         // No error in partition deleted callback
         when(runtime.scheduleWriteAllOperation(
@@ -3271,7 +3271,7 @@ public class GroupCoordinatorServiceTest {
         CoordinatorMetadataImage image = new MetadataImageBuilder()
             .addTopic(Uuid.randomUuid(), "bar", 1)
             .buildCoordinatorMetadataImage();
-        service.onNewMetadataImage(image, image.emptyDelta());
+        service.onMetadataUpdate(image, image.emptyDelta());
 
         // No error in partition deleted callback
         when(runtime.scheduleWriteAllOperation(
@@ -3319,7 +3319,7 @@ public class GroupCoordinatorServiceTest {
         service.startup(() -> 3);
 
         CoordinatorMetadataImage image = CoordinatorMetadataImage.EMPTY;
-        service.onNewMetadataImage(image, image.emptyDelta());
+        service.onMetadataUpdate(image, image.emptyDelta());
 
         // No error in partition deleted callback
         when(runtime.scheduleWriteAllOperation(
@@ -4146,7 +4146,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         int partition = 1;
 
@@ -4229,7 +4229,7 @@ public class GroupCoordinatorServiceTest {
             .build(true);
 
         // Forcing a null Metadata Image
-        service.onNewMetadataImage(null, null);
+        service.onMetadataUpdate(null, null);
 
         int partition = 1;
         DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup requestData = new DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup()
@@ -4273,7 +4273,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         int partition = 1;
 
@@ -4344,7 +4344,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         int partition = 1;
 
@@ -4380,7 +4380,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         int partition = 1;
 
@@ -4417,7 +4417,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(TOPIC_ID, TOPIC_NAME, 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         int partition = 1;
 
@@ -4507,7 +4507,7 @@ public class GroupCoordinatorServiceTest {
             .build(true);
 
         // Forcing a null Metadata Image
-        service.onNewMetadataImage(null, null);
+        service.onMetadataUpdate(null, null);
 
         DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup requestData = new DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup()
             .setGroupId("share-group-id")
@@ -4704,7 +4704,7 @@ public class GroupCoordinatorServiceTest {
             .build(true);
 
         // Forcing a null Metadata Image
-        service.onNewMetadataImage(null, null);
+        service.onMetadataUpdate(null, null);
 
         DeleteShareGroupOffsetsRequestData requestData = new DeleteShareGroupOffsetsRequestData()
             .setGroupId("share-group-id")
@@ -5581,7 +5581,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(topicId, "topic-name", 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         when(mockPersister.initializeState(ArgumentMatchers.any())).thenReturn(CompletableFuture.completedFuture(
             new InitializeShareGroupStateResult.Builder()
@@ -5756,7 +5756,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(topicId, "topic-name", 3)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         when(mockPersister.initializeState(ArgumentMatchers.any())).thenReturn(CompletableFuture.completedFuture(
             new InitializeShareGroupStateResult.Builder()
@@ -5818,7 +5818,7 @@ public class GroupCoordinatorServiceTest {
             .build(true);
 
         // Forcing a null Metadata Image
-        service.onNewMetadataImage(null, null);
+        service.onMetadataUpdate(null, null);
 
         String groupId = "share-group";
         AlterShareGroupOffsetsRequestData request = new AlterShareGroupOffsetsRequestData()
@@ -5974,7 +5974,7 @@ public class GroupCoordinatorServiceTest {
             .addTopic(topicId, "topic-name", 1)
             .build();
 
-        service.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        service.onMetadataUpdate(new KRaftCoordinatorMetadataImage(image), null);
 
         when(mockPersister.initializeState(ArgumentMatchers.any())).thenReturn(CompletableFuture.completedFuture(
             new InitializeShareGroupStateResult.Builder()
@@ -6048,7 +6048,7 @@ public class GroupCoordinatorServiceTest {
 
             if (serviceStartup) {
                 service.startup(() -> 1);
-                service.onNewMetadataImage(metadataImage, null);
+                service.onMetadataUpdate(metadataImage, null);
             }
             when(metadataImage.topicNames()).thenReturn(Set.of(TOPIC_NAME));
             var topicMetadata = mock(CoordinatorMetadataImage.TopicMetadata.class);

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -1100,7 +1100,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     @Override
     public void onNewMetadataImage(CoordinatorMetadataImage newImage, FeaturesImage newFeaturesImage, CoordinatorMetadataDelta delta) {
         throwIfNotActive();
-        this.runtime.onNewMetadataImage(newImage, delta);
+        this.runtime.onMetadataUpdate(newImage, delta);
         boolean enabled = isShareGroupsEnabled(newFeaturesImage);
         // enabled    shouldRunJob         result (XOR)
         // 0            0               no op on flag, do not call jobs

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -1100,7 +1100,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     @Override
     public void onNewMetadataImage(CoordinatorMetadataImage newImage, FeaturesImage newFeaturesImage, CoordinatorMetadataDelta delta) {
         throwIfNotActive();
-        this.runtime.onMetadataUpdate(newImage, delta);
+        this.runtime.onMetadataUpdate(delta, newImage);
         boolean enabled = isShareGroupsEnabled(newFeaturesImage);
         // enabled    shouldRunJob         result (XOR)
         // 0            0               no op on flag, do not call jobs


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/20061, we introduced the
`CoordinatorMetadataImage` and `CoordinatorMetadataDelta` interfaces to
basically contain/control how metadata is used within the
`GroupCoordinatorService`, more precisely within the
`GroupCoordinatorShard`. When we did the change, we directly changed the
`GroupCoordinator` interface to take implementation of those interfaces,
requiring to wrap the `MetadataImage` and the `MetadataDelta` in the
`BrokerMetadataPublisher`. While looking at it now, I find this not idea
for a couple a reasons:
1) From a `BrokerMetadataPublisher` perspective, propagating metadata
should be standardized. Basically, all the internal components should
work the same from his point of view. If a component wants to be more
restrictive within his scope, it is fine but the publisher should not be
aware of this.
2) From a `GroupCoordinator` perspective, requiring
`CoordinatorMetadataImage` and `CoordinatorMetadataDelta` limits what we
can do. For instance, we could move more functionality such as electing
shards from the `BrokerMetadataPublisher` to the
`GroupCoordinatorService` to further simplify the metadata publishing
and improving the encapsulation of the components.
3) From a `ShareCoordinator` perspective, the abstraction failed short
as we require `CoordinatorMetadataImage` and `CoordinatorMetadataDelta`
in the interface but we still require `FeaturesImage` as well. The
abstraction fails short here.

This patch is an attempt to change this by moving back to requiring
`MetadataImage` and `MetadataDelta` in the `GroupCoordinator` interface
and to wrap them within the service itself. It does not change the
`ShareCoordinator` yet. I will do this as a follow-up if people agree
with the general approach.

Reviewers: Sean Quah <squah@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>
