### PR TITLE
KAFKA-19926: Apply rebalance delay also for later epochs if the group is empty

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2065,7 +2065,7 @@ public class GroupMetadataManager {
             boolean initialDelayActive = timer.isScheduled(streamsInitialRebalanceKey(groupId));
             if (initialDelayActive) {
                 // During initial rebalance delay, return empty assignment to first joining members.
-                targetAssignmentEpoch = 1;
+                targetAssignmentEpoch = Math.max(1, group.assignmentEpoch());
                 targetAssignment = TasksTuple.EMPTY;
             } else {
                 targetAssignment = updateStreamsTargetAssignment(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2043,8 +2043,7 @@ public class GroupMetadataManager {
         }
 
         // Schedule initial rebalance delay for new streams groups to coalesce joins.
-        boolean isInitialRebalance = (group.groupEpoch() == 0);
-        if (isInitialRebalance) {
+        if (group.isEmpty()) {
             int initialDelayMs = streamsGroupInitialRebalanceDelayMs(groupId);
             if (initialDelayMs > 0) {
                 timer.scheduleIfAbsent(
@@ -2064,7 +2063,7 @@ public class GroupMetadataManager {
         TasksTuple targetAssignment;
         if (groupEpoch > group.assignmentEpoch()) {
             boolean initialDelayActive = timer.isScheduled(streamsInitialRebalanceKey(groupId));
-            if (initialDelayActive && group.assignmentEpoch() == 0) {
+            if (initialDelayActive) {
                 // During initial rebalance delay, return empty assignment to first joining members.
                 targetAssignmentEpoch = 1;
                 targetAssignment = TasksTuple.EMPTY;


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/20755 we introduce a initial
rebalance delay for streams group, now we would like to expand it to all
rebalance when group is empty to avoid frequent rebalance in a small
time period

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
