### PR TITLE
KAFKA-19777 : Generator | Fix order of arguments to assertEquals in unit tests - 2

### DIFF
--- a/generator/src/test/java/org/apache/kafka/message/MessageGeneratorTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/MessageGeneratorTest.java
@@ -74,8 +74,8 @@ public class MessageGeneratorTest {
 
     @Test
     public void testConstants() {
-        assertEquals(MessageGenerator.UNSIGNED_SHORT_MAX, 0xFFFF);
-        assertEquals(MessageGenerator.UNSIGNED_INT_MAX, 0xFFFFFFFFL);
+        assertEquals(0xFFFF, MessageGenerator.UNSIGNED_SHORT_MAX);
+        assertEquals(0xFFFFFFFFL, MessageGenerator.UNSIGNED_INT_MAX);
     }
 
     @Test


### PR DESCRIPTION
## Overview
This PR addresses the remaining fixes related to #20921.

>In this PR, we corrected the argument order in assertEquals within the
generator package.

## References

- sub-issue: https://issues.apache.org/jira/browse/KAFKA-19777
- issue: https://issues.apache.org/jira/browse/KAFKA-19097

Reviewers: Rion Williams, <rionmonster@gmail.com>, Lianet Magrans
 <lmagrans@confluent.io>


