### PR TITLE
MINOR: Ensure proper visibility of attribute accesses across threads

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -578,7 +578,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         /**
          * The current state.
          */
-        CoordinatorState state;
+        volatile CoordinatorState state;
 
         /**
          * The current epoch of the coordinator. This represents

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -345,7 +345,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
      * The metadata image to extract topic id to names map.
      * This is initialised when the {@link GroupCoordinator#onNewMetadataImage(CoordinatorMetadataImage, CoordinatorMetadataDelta)} is called
      */
-    private CoordinatorMetadataImage metadataImage = null;
+    private volatile CoordinatorMetadataImage metadataImage = null;
 
     /**
      *


### PR DESCRIPTION
I found those two cases while working in this area. In both cases, they
are read by multiple threads so they must either be volatile or
acquiring the appropriate lock. Using volatile is fine here.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
