### PR TITLE
MINOR: Ensure proper visibility of attribute accesses across threads

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -571,7 +571,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         /**
          * The current state.
          */
-        CoordinatorState state;
+        volatile CoordinatorState state;
 
         /**
          * The current epoch of the coordinator. This represents


### PR DESCRIPTION
backport https://github.com/apache/kafka/pull/21014.

In 4.0, `MetadataImage` has not yet been introduced into `GroupCoordinatorService`. Therefore, this patch only includes changes to `CoordinatorRuntime`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
