### PR TITLE
MINOR: Rename CoordinatorShard#onNewMetadataImage to onMetadataUpdate

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -2559,7 +2559,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                             // The new image can be applied to the coordinator only if the coordinator
                             // exists and is in the active state.
                             log.debug("Applying new metadata image with version {} to {}.", newImage.version(), tp);
-                            context.coordinator.onNewMetadataImage(newImage, delta);
+                            context.coordinator.onMetadataUpdate(delta, newImage);
                         } else {
                             log.debug("Ignored new metadata image with version {} for {} because the coordinator is not active.",
                                 newImage.version(), tp);

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorShard.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorShard.java
@@ -36,10 +36,10 @@ public interface CoordinatorShard<U> {
      * A new metadata image is available. This is only called after {@link CoordinatorShard#onLoaded(CoordinatorMetadataImage)}
      * is called to signal that the coordinator has been fully loaded.
      *
-     * @param newImage  The new metadata image.
-     * @param delta     The delta image.
+     * @param delta    The delta image.
+     * @param newImage The new metadata image.
      */
-    default void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {}
+    default void onMetadataUpdate(CoordinatorMetadataDelta delta, CoordinatorMetadataImage newImage) {}
 
     /**
      * The coordinator has been unloaded. This is used to apply

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/SnapshottableCoordinator.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/SnapshottableCoordinator.java
@@ -19,7 +19,6 @@ package org.apache.kafka.coordinator.common.runtime;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.slf4j.Logger;
@@ -200,14 +199,17 @@ public class SnapshottableCoordinator<S extends CoordinatorShard<U>, U> implemen
     }
 
     /**
-     * A new metadata image is available. This is only called after {@link SnapshottableCoordinator#onLoaded(MetadataImage)}
+     * A new metadata image is available. This is only called after {@link SnapshottableCoordinator#onLoaded(CoordinatorMetadataImage)}
      * is called to signal that the coordinator has been fully loaded.
      *
-     * @param newImage  The new metadata image.
-     * @param delta     The delta image.
+     * @param delta    The delta image.
+     * @param newImage The new metadata image.
      */
-    synchronized void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {
-        this.coordinator.onNewMetadataImage(newImage, delta);
+    synchronized void onMetadataUpdate(
+        CoordinatorMetadataDelta delta,
+        CoordinatorMetadataImage newImage
+    ) {
+        this.coordinator.onMetadataUpdate(delta, newImage);
     }
 
     /**

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -2032,7 +2032,7 @@ public class CoordinatorRuntimeTest {
         runtime.onMetadataUpdate(delta, newImage);
 
         // Coordinator 0 should be notified about it.
-        verify(coordinator0).onNewMetadataImage(newImage, delta);
+        verify(coordinator0).onMetadataUpdate(delta, newImage);
 
         // Coordinator 1 is loaded. It should get the current image
         // that is the new image.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -1064,7 +1064,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     @Override
     public void onLoaded(CoordinatorMetadataImage newImage) {
         CoordinatorMetadataDelta emptyDelta = newImage.emptyDelta();
-        groupMetadataManager.onNewMetadataImage(newImage, emptyDelta);
+        groupMetadataManager.onMetadataUpdate(emptyDelta, newImage);
         coordinatorMetrics.activateMetricsShard(metricsShard);
 
         groupMetadataManager.onLoaded();
@@ -1083,12 +1083,12 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     /**
      * A new metadata image is available.
      *
-     * @param newImage  The new metadata image.
-     * @param delta     The delta image.
+     * @param delta    The delta image.
+     * @param newImage The new metadata image.
      */
     @Override
-    public void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {
-        groupMetadataManager.onNewMetadataImage(newImage, delta);
+    public void onMetadataUpdate(CoordinatorMetadataDelta delta, CoordinatorMetadataImage newImage) {
+        groupMetadataManager.onMetadataUpdate(delta, newImage);
     }
 
     private static OffsetCommitKey convertLegacyOffsetCommitKey(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -6021,10 +6021,10 @@ public class GroupMetadataManager {
     /**
      * A new metadata image is available.
      *
-     * @param newImage  The new metadata image.
-     * @param delta     The delta image.
+     * @param delta    The delta image.
+     * @param newImage The new metadata image.
      */
-    public void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {
+    public void onMetadataUpdate(CoordinatorMetadataDelta delta, CoordinatorMetadataImage newImage) {
         metadataImage = newImage;
 
         // Initialize the last version if it was not yet.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -1268,9 +1268,8 @@ public class GroupCoordinatorShardTest {
 
         coordinator.onLoaded(image);
 
-        verify(groupMetadataManager, times(1)).onNewMetadataImage(
-            eq(image),
-            any()
+        verify(groupMetadataManager, times(1)).onMetadataUpdate(
+            any(), eq(image)
         );
 
         verify(groupMetadataManager, times(1)).onLoaded();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -825,9 +825,8 @@ public class GroupMetadataManagerTest {
             .addRacks()
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(
-            newMetadataImage,
-            newMetadataImage.emptyDelta()
+        context.groupMetadataManager.onMetadataUpdate(
+            newMetadataImage.emptyDelta(), newMetadataImage
         );
         // If a topic is updated, related topic hash is cleanup.
         assertEquals(Map.of(), context.groupMetadataManager.topicHashCache());
@@ -916,9 +915,8 @@ public class GroupMetadataManagerTest {
         delta.replay(new RemoveTopicRecord().setTopicId(fooTopicId));
         MetadataImage newMetadataImage = delta.apply(MetadataProvenance.EMPTY);
 
-        context.groupMetadataManager.onNewMetadataImage(
-            new KRaftCoordinatorMetadataImage(newMetadataImage),
-            new KRaftCoordinatorMetadataDelta(new MetadataDelta(newMetadataImage))
+        context.groupMetadataManager.onMetadataUpdate(
+            new KRaftCoordinatorMetadataDelta(new MetadataDelta(newMetadataImage)), new KRaftCoordinatorMetadataImage(newMetadataImage)
         );
         // If a topic is removed, related topic hash is cleanup.
         assertEquals(Map.of(), context.groupMetadataManager.topicHashCache());
@@ -3408,7 +3406,7 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testOnNewMetadataImageWithEmptyDelta() {
+    public void testOnMetadataUpdateWithEmptyDelta() {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(new MockPartitionAssignor("range")))
             .build();
@@ -3416,12 +3414,12 @@ public class GroupMetadataManagerTest {
         MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
         MetadataImage image = delta.apply(MetadataProvenance.EMPTY);
 
-        context.groupMetadataManager.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(delta));
+        context.groupMetadataManager.onMetadataUpdate(new KRaftCoordinatorMetadataDelta(delta), new KRaftCoordinatorMetadataImage(image));
         assertEquals(new KRaftCoordinatorMetadataImage(image), context.groupMetadataManager.image());
     }
 
     @Test
-    public void testOnNewMetadataImage() {
+    public void testOnMetadataUpdate() {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
 
@@ -3490,7 +3488,7 @@ public class GroupMetadataManagerTest {
         image = delta.apply(MetadataProvenance.EMPTY);
 
         // Update metadata image with the delta.
-        context.groupMetadataManager.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(delta));
+        context.groupMetadataManager.onMetadataUpdate(new KRaftCoordinatorMetadataDelta(delta), new KRaftCoordinatorMetadataImage(image));
 
         // Verify the groups.
         List.of("group1", "group2", "group3", "group4").forEach(groupId -> {
@@ -15453,7 +15451,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId, topicName, 1)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result = context.shareGroupHeartbeat(
             new ShareGroupHeartbeatRequestData()
@@ -15531,7 +15529,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 1)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result = context.shareGroupHeartbeat(
             new ShareGroupHeartbeatRequestData()
@@ -15610,7 +15608,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 1)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         // A first member joins to create the group.
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result = context.shareGroupHeartbeat(
@@ -15685,7 +15683,7 @@ public class GroupMetadataManagerTest {
             .setImage(image)
             .build();
 
-        context.groupMetadataManager.onNewMetadataImage(coordinatorMetadataImage, new KRaftCoordinatorMetadataDelta(delta));
+        context.groupMetadataManager.onMetadataUpdate(new KRaftCoordinatorMetadataDelta(delta), coordinatorMetadataImage);
 
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result = context.shareGroupHeartbeat(
             new ShareGroupHeartbeatRequestData()
@@ -15906,7 +15904,7 @@ public class GroupMetadataManagerTest {
             .addTopic(barTopicId, barTopicName, 1)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         // Member 1 joins the group.
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result = context.shareGroupHeartbeat(
@@ -18849,7 +18847,7 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testStreamsOnNewMetadataImage() {
+    public void testStreamsOnMetadataUpdate() {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
 
         // Topology of group 1 uses a and b.
@@ -18929,7 +18927,7 @@ public class GroupMetadataManagerTest {
         image = delta.apply(MetadataProvenance.EMPTY);
 
         // Update metadata image with the delta.
-        context.groupMetadataManager.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), new KRaftCoordinatorMetadataDelta(delta));
+        context.groupMetadataManager.onMetadataUpdate(new KRaftCoordinatorMetadataDelta(delta), new KRaftCoordinatorMetadataImage(image));
 
         // Verify the groups.
         List.of("group1", "group2", "group3", "group4").forEach(groupId -> {
@@ -19478,7 +19476,7 @@ public class GroupMetadataManagerTest {
             .addTopic(fooTopicId, fooTopicName, 6)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         // Session timer is scheduled on first heartbeat.
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result =
@@ -21477,9 +21475,8 @@ public class GroupMetadataManagerTest {
             .addTopic(foooTopicId, foooTopicName, 1)
             .build(2L);
 
-        context.groupMetadataManager.onNewMetadataImage(
-            new KRaftCoordinatorMetadataImage(newImage),
-            new KRaftCoordinatorMetadataDelta(new MetadataDelta(newImage))
+        context.groupMetadataManager.onMetadataUpdate(
+            new KRaftCoordinatorMetadataDelta(new MetadataDelta(newImage)), new KRaftCoordinatorMetadataImage(newImage)
         );
 
         // A member heartbeats.
@@ -22794,7 +22791,7 @@ public class GroupMetadataManagerTest {
             .addTopic(t2Uuid, t2Name, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -22860,7 +22857,7 @@ public class GroupMetadataManagerTest {
             .addTopic(t3Uuid, t3Name, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -22928,7 +22925,7 @@ public class GroupMetadataManagerTest {
             .buildCoordinatorMetadataImage();
 
         CoordinatorMetadataDelta delta = image.emptyDelta();
-        context.groupMetadataManager.onNewMetadataImage(image, delta);
+        context.groupMetadataManager.onMetadataUpdate(delta, image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -22990,7 +22987,7 @@ public class GroupMetadataManagerTest {
 
         CoordinatorMetadataImage image = CoordinatorMetadataImage.EMPTY;
         CoordinatorMetadataDelta delta = image.emptyDelta();
-        context.groupMetadataManager.onNewMetadataImage(image, delta);
+        context.groupMetadataManager.onMetadataUpdate(delta, image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23049,7 +23046,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23142,7 +23139,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId4, topicName4, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23249,7 +23246,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId1, topicName1, 3)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23333,7 +23330,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23418,7 +23415,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23508,7 +23505,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23581,7 +23578,7 @@ public class GroupMetadataManagerTest {
             .addTopic(topicId2, topicName2, 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         context.replay(GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 0, 0));
 
@@ -23622,7 +23619,7 @@ public class GroupMetadataManagerTest {
 
         String groupId = "share-group";
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         Uuid memberId = Uuid.randomUuid();
         CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result = context.shareGroupHeartbeat(
@@ -23684,7 +23681,7 @@ public class GroupMetadataManagerTest {
             .addTopic(t2Uuid, "t2", 2)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
 
         assignor.prepareGroupAssignment(new GroupAssignment(
             Map.of(
@@ -23760,7 +23757,7 @@ public class GroupMetadataManagerTest {
 
         String groupId = "share-group";
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
         context.groupMetadataManager.replay(
             new ShareGroupMetadataKey()
                 .setGroupId(groupId),
@@ -23866,7 +23863,7 @@ public class GroupMetadataManagerTest {
 
         String groupId = "share-group";
 
-        context.groupMetadataManager.onNewMetadataImage(image, mock(CoordinatorMetadataDelta.class));
+        context.groupMetadataManager.onMetadataUpdate(mock(CoordinatorMetadataDelta.class), image);
         context.groupMetadataManager.replay(
             new ShareGroupMetadataKey()
                 .setGroupId(groupId),
@@ -24082,7 +24079,7 @@ public class GroupMetadataManagerTest {
             .addTopic(t3Id, t3Name, 3)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(metadataImage, metadataImage.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(metadataImage.emptyDelta(), metadataImage);
 
         // Since t1 is initializing and t2 is initialized due to replay above.
         timeNow = timeNow + initRetryTimeoutMs + 1;
@@ -24128,7 +24125,7 @@ public class GroupMetadataManagerTest {
             .addTopic(t2Id, t2Name, 3)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         // Cleanup happens from initialzing state only.
         context.groupMetadataManager.replay(
@@ -24213,7 +24210,7 @@ public class GroupMetadataManagerTest {
             .addTopic(t6Id, t6Name, 3)
             .buildCoordinatorMetadataImage();
 
-        context.groupMetadataManager.onNewMetadataImage(image, image.emptyDelta());
+        context.groupMetadataManager.onMetadataUpdate(image.emptyDelta(), image);
 
         context.groupMetadataManager.replay(
             new ShareGroupMetadataKey()

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -212,7 +212,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     }
 
     @Override
-    public void onNewMetadataImage(CoordinatorMetadataImage newImage, CoordinatorMetadataDelta delta) {
+    public void onMetadataUpdate(CoordinatorMetadataDelta delta, CoordinatorMetadataImage newImage) {
         this.metadataImage = newImage;
     }
 

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -122,7 +122,7 @@ class ShareCoordinatorShardTest {
             var topicMetadata = mock(CoordinatorMetadataImage.TopicMetadata.class);
             when(topicMetadata.partitionCount()).thenReturn(PARTITION + 1);
             when(metadataImage.topicMetadata((Uuid) any())).thenReturn(Optional.of(topicMetadata));
-            shard.onNewMetadataImage(metadataImage, null);
+            shard.onMetadataUpdate(null, metadataImage);
             return shard;
         }
 
@@ -446,7 +446,7 @@ class ShareCoordinatorShardTest {
     public void testWriteNullMetadataImage() {
         initSharePartition(shard, SHARE_PARTITION_KEY);
 
-        shard.onNewMetadataImage(null, null);
+        shard.onMetadataUpdate(null, null);
 
         WriteShareGroupStateRequestData request = new WriteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -676,7 +676,7 @@ class ShareCoordinatorShardTest {
         initSharePartition(shard, SHARE_PARTITION_KEY);
         writeAndReplayDefaultRecord(shard);
 
-        shard.onNewMetadataImage(null, null);
+        shard.onMetadataUpdate(null, null);
 
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1081,7 +1081,7 @@ class ShareCoordinatorShardTest {
 
     @Test
     public void testDeleteNullMetadataImage() {
-        shard.onNewMetadataImage(null, null);
+        shard.onMetadataUpdate(null, null);
 
         DeleteShareGroupStateRequestData request = new DeleteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1103,7 +1103,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testDeleteTopicIdNonExistentInMetadataImage() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
 
         DeleteShareGroupStateRequestData request = new DeleteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1135,7 +1135,7 @@ class ShareCoordinatorShardTest {
     public void testDeletePartitionIdNonExistentInMetadataImage() {
         MetadataImage image = mock(MetadataImage.class);
         when(image.cluster()).thenReturn(mock(ClusterImage.class));
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
 
         DeleteShareGroupStateRequestData request = new DeleteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1252,7 +1252,7 @@ class ShareCoordinatorShardTest {
 
     @Test
     public void testInitializeNullMetadataImage() {
-        shard.onNewMetadataImage(null, null);
+        shard.onMetadataUpdate(null, null);
 
         InitializeShareGroupStateRequestData request = new InitializeShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1276,7 +1276,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testInitializeTopicIdNonExistentInMetadataImage() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
 
         InitializeShareGroupStateRequestData request = new InitializeShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1306,7 +1306,7 @@ class ShareCoordinatorShardTest {
     public void testInitializePartitionIdNonExistentInMetadataImage() {
         MetadataImage image = mock(MetadataImage.class);
         when(image.cluster()).thenReturn(mock(ClusterImage.class));
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
 
         InitializeShareGroupStateRequestData request = new InitializeShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
@@ -1341,7 +1341,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testSnapshotColdPartitionsNoEligiblePartitions() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
         int offset = 0;
         int producerId = 0;
         short producerEpoch = 0;
@@ -1411,7 +1411,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testSnapshotColdPartitionsSnapshotUpdateNotConsidered() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
         int offset = 0;
         int producerId = 0;
         short producerEpoch = 0;
@@ -1514,7 +1514,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testSnapshotColdPartitionsDoesNotPerpetuallySnapshot() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
         int offset = 0;
         int producerId = 0;
         short producerEpoch = 0;
@@ -1592,7 +1592,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testSnapshotColdPartitionsPartialEligiblePartitions() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
         int offset = 0;
         int producerId = 0;
         short producerEpoch = 0;
@@ -1712,7 +1712,7 @@ class ShareCoordinatorShardTest {
     @Test
     public void testOnTopicsDeletedTopicIds() {
         MetadataImage image = mock(MetadataImage.class);
-        shard.onNewMetadataImage(new KRaftCoordinatorMetadataImage(image), null);
+        shard.onMetadataUpdate(null, new KRaftCoordinatorMetadataImage(image));
 
         int offset = 0;
         int producerId = 0;


### PR DESCRIPTION
This patch is a continuation of
https://github.com/apache/kafka/pull/21008. It applies the same naming
convention within the `CoordinatorRuntime`.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
