### PR TITLE
KAFKA-19946: Simplify skipping of empty ShareFetch requests

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -774,7 +774,7 @@ public class SharePartition {
                 // check for the floor entry and adjust the base offset accordingly.
                 if (baseOffset < startOffset) {
                     log.info("Adjusting base offset for the fetch as it's prior to start offset: {}-{}"
-                            + "from {} to {}", groupId, topicIdPartition, baseOffset, startOffset);
+                            + " from {} to {}", groupId, topicIdPartition, baseOffset, startOffset);
                     baseOffset = startOffset;
                 }
             } else if (floorEntry.getValue().lastOffset() >= baseOffset) {


### PR DESCRIPTION
ShareFetch requests can be used to fetch records for share consumers,
but in some cases, no records are required and the request is just being
used to update the share session or send acknowledgements. As a result,
there are situations in which a ShareFetch request would be built, only
for it to be entirely empty (no fetch, no asks, no share session
update). This PR simplifies the logic for detecting when the request is
empty and then to avoid building it entirely. It also adds some tests
for this case.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
