### PR TITLE
draft

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerMetrics.java
@@ -16,7 +16,12 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Metrics;
+
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_SHARE_METRIC_GROUP_PREFIX;
@@ -30,5 +35,16 @@ public class ShareConsumerMetrics {
 
     public ShareConsumerMetrics() {
         this(new HashSet<>(), CONSUMER_SHARE_METRIC_GROUP_PREFIX);
+    }
+
+    private List<MetricNameTemplate> getAllTemplates() {
+        return new ArrayList<>(this.shareFetchMetrics.getAllTemplates());
+    }
+
+    public static void main(String[] args) {
+        Set<String> tags = new HashSet<>();
+        tags.add("client-id");
+        ShareConsumerMetrics metrics = new ShareConsumerMetrics(tags, "consumer-share");
+        System.out.println(Metrics.toHtmlTable("kafka.consumer", metrics.getAllTemplates()));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareFetchMetricsRegistry.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.common.MetricNameTemplate;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class ShareFetchMetricsRegistry {
@@ -97,5 +98,28 @@ public class ShareFetchMetricsRegistry {
                 "The average throttle time in ms", tags);
         this.fetchThrottleTimeMax = new MetricNameTemplate("fetch-throttle-time-max", groupName,
                 "The maximum throttle time in ms", tags);
+    }
+
+    public List<MetricNameTemplate> getAllTemplates() {
+        return List.of(
+            fetchSizeAvg,
+            fetchSizeMax,
+            bytesFetchedRate,
+            bytesFetchedTotal,
+            recordsPerRequestAvg,
+            recordsPerRequestMax,
+            recordsFetchedRate,
+            recordsFetchedTotal,
+            acknowledgementSendRate,
+            acknowledgementSendTotal,
+            acknowledgementErrorRate,
+            acknowledgementErrorTotal,
+            fetchLatencyAvg,
+            fetchLatencyMax,
+            fetchRequestRate,
+            fetchRequestTotal,
+            fetchThrottleTimeAvg,
+            fetchThrottleTimeMax
+        );
     }
 }

--- a/config/server.properties
+++ b/config/server.properties
@@ -70,7 +70,8 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma separated list of directories under which to store log files
-log.dirs=/tmp/kraft-combined-logs
+log.dirs=D:\\data\\kafka\\logs
+group.share.enable=true
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1927,8 +1927,8 @@ The following set of metrics are available for monitoring the group coordinator:
     </tr>
     <tr>
       <td>Group Count, per group type</td>
-      <td>kafka.server:type=group-coordinator-metrics,name=group-count,protocol={consumer|classic}</td>
-      <td>Total number of group per group type: Classic or Consumer</td>
+      <td>kafka.server:type=group-coordinator-metrics,name=group-count,protocol={consumer|classic|share}</td>
+      <td>Total number of group per group type: Classic, Consumer or Share</td>
     </tr>
     <tr>
       <td>Consumer Group Count, per state</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3980,6 +3980,8 @@ customized state stores; for built-in state stores, currently we have:
     </tbody>
  </table>
 
+  h4 class="anchor-heading"><a id="connect_monitoring" class="anchor-link"></a><a href="#connect_monitoring">Connect Monitoring</a></h4>
+
   <h4 class="anchor-heading"><a id="others_monitoring" class="anchor-link"></a><a href="#others_monitoring">Others</a></h4>
 
   We recommend monitoring GC time and other stats and various server stats such as CPU utilization, I/O service time, etc.

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -162,6 +162,7 @@
                         <li><a href="#consumer_monitoring">Consumer Monitoring</a>
                         <li><a href="#connect_monitoring">Connect Monitoring</a>
                         <li><a href="#kafka_streams_monitoring">Streams Monitoring</a>
+                        <li><a href="#kafka_share_group_monitoring">Share Group Monitoring</a>
                         <li><a href="#others_monitoring">Others</a>
                     </ul>
                 

--- a/server/src/main/java/org/apache/kafka/server/share/metrics/ShareGroupMetrics.java
+++ b/server/src/main/java/org/apache/kafka/server/share/metrics/ShareGroupMetrics.java
@@ -17,13 +17,17 @@
 package org.apache.kafka.server.share.metrics;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.Meter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,6 +65,8 @@ public class ShareGroupMetrics implements AutoCloseable {
     private final KafkaMetricsGroup metricsGroup;
     private final Time time;
 
+    private final ShareGroupMetricsRegistry shareGroupMetricsRegistry;
+
     public ShareGroupMetrics(Time time) {
         this.time = time;
         this.metricsGroup = new KafkaMetricsGroup("kafka.server", "ShareGroupMetrics");
@@ -78,6 +84,7 @@ public class ShareGroupMetrics implements AutoCloseable {
         this.partitionLoadTimeMs = metricsGroup.newHistogram(PARTITION_LOAD_TIME_MS);
         this.topicPartitionsFetchRatio = new ConcurrentHashMap<>();
         this.topicPartitionsAcquireTimeMs = new ConcurrentHashMap<>();
+        this.shareGroupMetricsRegistry = new ShareGroupMetricsRegistry();
     }
 
     public void recordAcknowledgement(byte ackType) {
@@ -141,5 +148,14 @@ public class ShareGroupMetrics implements AutoCloseable {
             return string;
         }
         return string.substring(0, 1).toUpperCase(Locale.ROOT) + string.substring(1);
+    }
+
+    private List<MetricNameTemplate> getAllTemplates() {
+        return new ArrayList<>(this.shareGroupMetricsRegistry.getAllTemplates());
+    }
+
+    public static void main(String[] args) {
+        ShareGroupMetrics metrics = new ShareGroupMetrics(null);
+        System.out.println(Metrics.toHtmlTable("kafka.server", metrics.getAllTemplates()));
     }
 }

--- a/server/src/main/java/org/apache/kafka/server/share/metrics/ShareGroupMetricsRegistry.java
+++ b/server/src/main/java/org/apache/kafka/server/share/metrics/ShareGroupMetricsRegistry.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.metrics;
+
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Metrics;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ShareGroupMetricsRegistry {
+    // KIP-932
+    public MetricNameTemplate shareGroupCount;
+    public MetricNameTemplate writeRate;
+    public MetricNameTemplate writeTotal;
+
+    // KIP-1103
+    public MetricNameTemplate totalShareFetchRequestsPerSec;
+    public MetricNameTemplate failedShareFetchRequestsPerSec;
+    public MetricNameTemplate totalShareAcknowledgementRequestsPerSec;
+    public MetricNameTemplate failedShareAcknowledgementRequestsPerSec;
+    public MetricNameTemplate recordAcknowledgementsPerSec;
+    public MetricNameTemplate partitionLoadTimeMs;
+    public MetricNameTemplate requestTopicPartitionsFetchRatio;
+    public MetricNameTemplate topicPartitionsAcquireTimeMs;
+    public MetricNameTemplate acquisitionLockTimeoutPerSec;
+    public MetricNameTemplate inFlightMessageCount;
+    public MetricNameTemplate inFlightBatchCount;
+    public MetricNameTemplate inFlightBatchMessageCount;
+    public MetricNameTemplate fetchLockTimeMs;
+    public MetricNameTemplate fetchLockRatio;
+    public MetricNameTemplate shareSessionEvictionsPerSec;
+    public MetricNameTemplate sharePartitionsCount;
+    public MetricNameTemplate shareSessionsCount;
+    public MetricNameTemplate delayedShareFetchExpiresPerSec;
+    public MetricNameTemplate shareFetchPurgatorySize;
+    public MetricNameTemplate shareFetchNumDelayedOperations;
+
+    public ShareGroupMetricsRegistry() {
+        this(new HashSet<>(), "");
+    }
+
+    public ShareGroupMetricsRegistry(String metricGrpPrefix) {
+        this(new HashSet<>(), metricGrpPrefix);
+    }
+
+    public ShareGroupMetricsRegistry(Set<String> tags, String metricGrpPrefix) {
+
+        /* BrokerTopicMetrics */
+        String brokerTopicGroupName = "BrokerTopicMetrics";
+        Set<String> topicTags = Set.of("topic");
+
+        this.totalShareFetchRequestsPerSec = new MetricNameTemplate(
+            "TotalShareFetchRequestsPerSec",
+            brokerTopicGroupName,
+            "The fetch request rate per second. ",
+            topicTags);
+
+        this.failedShareFetchRequestsPerSec = new MetricNameTemplate(
+            "FailedShareFetchRequestsPerSec",
+            brokerTopicGroupName,
+            "The share fetch request rate for requests that failed. ",
+            topicTags);
+
+        this.totalShareAcknowledgementRequestsPerSec = new MetricNameTemplate(
+            "TotalShareAcknowledgementRequestsPerSec",
+            brokerTopicGroupName,
+            "The acknowledgement request rate per second. ",
+            topicTags);
+
+        this.failedShareAcknowledgementRequestsPerSec = new MetricNameTemplate(
+            "FailedShareAcknowledgementRequestsPerSec",
+            brokerTopicGroupName,
+            "The share acknowledgement request rate for requests that failed. ",
+            topicTags);
+
+        /* Group Coordinator metrics */
+        Set<String> state = Set.of("state");
+        this.shareGroupCount = new MetricNameTemplate(
+            "ShareGroupCount",
+            "GroupCoordinator",
+            "The number of share groups in respective state.",
+            state);
+
+        /* Share Coordinator metrics */
+        String share
+        this.writeRate = new MetricNameTemplate(
+
+
+        /* ShareGroupMetrics */
+        String shareGroupMetricsName = metricGrpPrefix + "ShareGroupMetrics";
+
+        // Acknowledgement type level metrics
+        Set<String> ackTypeTags = Set.of("ackType");
+
+        this.recordAcknowledgementsPerSec = new MetricNameTemplate(
+            "RecordAcknowledgementsPerSec",
+            shareGroupMetricsName,
+            "The rate per second of records acknowledged per acknowledgement type.",
+            ackTypeTags);
+
+        // General metrics
+        this.partitionLoadTimeMs = new MetricNameTemplate(
+            "PartitionLoadTimeMs",
+            shareGroupMetricsName,
+            "The time taken to load the share partitions.",
+            tags);
+
+        // Group level metrics
+        Set<String> groupTags = Set.of("group");
+
+        this.requestTopicPartitionsFetchRatio = new MetricNameTemplate(
+            "RequestTopicPartitionsFetchRatio",
+            shareGroupMetricsName,
+            "The ratio of topic-partitions acquired to the total number of topic-partitions in share fetch request.",
+            groupTags);
+
+        this.topicPartitionsAcquireTimeMs = new MetricNameTemplate(
+            "TopicPartitionsAcquireTimeMs",
+            shareGroupMetricsName,
+            "The time elapsed (in millisecond) to acquire any topic partition for fetch.",
+            groupTags);
+
+        /* SharePartitionMetrics - Partition level */
+        String sharePartitionMetricsName = "SharePartitionMetrics";
+        Set<String> partitionTags = Set.of("group", "topic", "partition");
+
+        this.acquisitionLockTimeoutPerSec = new MetricNameTemplate(
+            "AcquisitionLockTimeoutPerSec",
+            sharePartitionMetricsName,
+            "The rate of acquisition locks for records which are not acknowledged within the timeout.",
+            partitionTags);
+
+        this.inFlightMessageCount = new MetricNameTemplate(
+            "InFlightMessageCount",
+            sharePartitionMetricsName,
+            "The number of in-flight messages for the share partition.",
+            partitionTags);
+
+        this.inFlightBatchCount = new MetricNameTemplate(
+            "InFlightBatchCount",
+            sharePartitionMetricsName,
+            "The number of in-flight batches for the share partition.",
+            partitionTags);
+
+        this.inFlightBatchMessageCount = new MetricNameTemplate(
+            "InFlightBatchMessageCount",
+            sharePartitionMetricsName,
+            "The number of messages in the in-flight batch.",
+            partitionTags);
+
+        this.fetchLockTimeMs = new MetricNameTemplate(
+            "FetchLockTimeMs",
+            sharePartitionMetricsName,
+            "The time elapsed (in milliseconds) while a share partition is held under lock for fetching messages.",
+            partitionTags);
+
+        this.fetchLockRatio = new MetricNameTemplate(
+            "FetchLockRatio",
+            sharePartitionMetricsName,
+            "The fraction of time share partition is held under lock.",
+            partitionTags);
+
+        /* ShareSessionCache metrics */
+        String shareSessionCacheName = "ShareSessionCache";
+
+        this.shareSessionEvictionsPerSec = new MetricNameTemplate(
+            "ShareSessionEvictionsPerSec",
+            shareSessionCacheName,
+            "The share session eviction rate per second.",
+            tags);
+
+        this.sharePartitionsCount = new MetricNameTemplate(
+            "SharePartitionsCount",
+            shareSessionCacheName,
+            "The number of cached share partitions.",
+            tags);
+
+        this.shareSessionsCount = new MetricNameTemplate(
+            "ShareSessionsCount",
+            shareSessionCacheName,
+            "The number of cached share sessions.",
+            tags);
+
+        /* DelayedShareFetchMetrics */
+        String delayedShareFetchMetricsName = "DelayedShareFetchMetrics";
+
+        this.delayedShareFetchExpiresPerSec = new MetricNameTemplate(
+            "ExpiresPerSec",
+            delayedShareFetchMetricsName,
+            "The expired delayed share fetch operation rate per second.",
+            tags);
+
+        /* DelayedOperationPurgatory metrics */
+        String delayedOperationPurgatoryName = "DelayedOperationPurgatory";
+        Set<String> shareFetchTags = new LinkedHashSet<>(tags);
+        shareFetchTags.add("delayedOperation");
+
+        this.shareFetchPurgatorySize = new MetricNameTemplate(
+            "PurgatorySize",
+            delayedOperationPurgatoryName,
+            "The number of requests waiting in the share fetch purgatory. This is high if share consumers use a large value for fetch.wait.max.ms",
+            shareFetchTags);
+
+        this.shareFetchNumDelayedOperations = new MetricNameTemplate(
+            "NumDelayedOperations",
+            delayedOperationPurgatoryName,
+            "The number of delayed operations for share fetch purgatory.",
+            shareFetchTags);
+    }
+
+    public List<MetricNameTemplate> getAllTemplates() {
+        return Arrays.asList(
+            shareGroupCount
+            totalShareFetchRequestsPerSec,
+            failedShareFetchRequestsPerSec,
+            totalShareAcknowledgementRequestsPerSec,
+            failedShareAcknowledgementRequestsPerSec,
+            recordAcknowledgementsPerSec,
+            partitionLoadTimeMs,
+            requestTopicPartitionsFetchRatio,
+            topicPartitionsAcquireTimeMs,
+            acquisitionLockTimeoutPerSec,
+            inFlightMessageCount,
+            inFlightBatchCount,
+            inFlightBatchMessageCount,
+            fetchLockTimeMs,
+            fetchLockRatio,
+            shareSessionEvictionsPerSec,
+            sharePartitionsCount,
+            shareSessionsCount,
+            delayedShareFetchExpiresPerSec,
+            shareFetchPurgatorySize,
+            shareFetchNumDelayedOperations
+        );
+    }
+
+    public static void main(String[] args) {
+        ShareGroupMetricsRegistry metrics = new ShareGroupMetricsRegistry();
+        System.out.println(Metrics.toHtmlTable("kafka.server", metrics.getAllTemplates()));
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/share/metrics/ShareGroupMetricsRegistry.java
+++ b/server/src/main/java/org/apache/kafka/server/share/metrics/ShareGroupMetricsRegistry.java
@@ -26,39 +26,36 @@ import java.util.List;
 import java.util.Set;
 
 public class ShareGroupMetricsRegistry {
-    // KIP-932
-    public MetricNameTemplate shareGroupCount;
-    public MetricNameTemplate writeRate;
-    public MetricNameTemplate writeTotal;
 
-    // KIP-1103
-    public MetricNameTemplate totalShareFetchRequestsPerSec;
-    public MetricNameTemplate failedShareFetchRequestsPerSec;
-    public MetricNameTemplate totalShareAcknowledgementRequestsPerSec;
-    public MetricNameTemplate failedShareAcknowledgementRequestsPerSec;
-    public MetricNameTemplate recordAcknowledgementsPerSec;
-    public MetricNameTemplate partitionLoadTimeMs;
-    public MetricNameTemplate requestTopicPartitionsFetchRatio;
-    public MetricNameTemplate topicPartitionsAcquireTimeMs;
-    public MetricNameTemplate acquisitionLockTimeoutPerSec;
-    public MetricNameTemplate inFlightMessageCount;
-    public MetricNameTemplate inFlightBatchCount;
-    public MetricNameTemplate inFlightBatchMessageCount;
-    public MetricNameTemplate fetchLockTimeMs;
-    public MetricNameTemplate fetchLockRatio;
-    public MetricNameTemplate shareSessionEvictionsPerSec;
-    public MetricNameTemplate sharePartitionsCount;
-    public MetricNameTemplate shareSessionsCount;
-    public MetricNameTemplate delayedShareFetchExpiresPerSec;
-    public MetricNameTemplate shareFetchPurgatorySize;
-    public MetricNameTemplate shareFetchNumDelayedOperations;
+    public final MetricNameTemplate shareGroupCount;
+    public final MetricNameTemplate writeRate;
+    public final MetricNameTemplate writeTotal;
+    public final MetricNameTemplate writeLatencyAvg;
+    public final MetricNameTemplate writeLatencyMax;
+    public final MetricNameTemplate lastPrunedOffset;
+    public final MetricNameTemplate totalShareFetchRequestsPerSec;
+    public final MetricNameTemplate failedShareFetchRequestsPerSec;
+    public final MetricNameTemplate totalShareAcknowledgementRequestsPerSec;
+    public final MetricNameTemplate failedShareAcknowledgementRequestsPerSec;
+    public final MetricNameTemplate recordAcknowledgementsPerSec;
+    public final MetricNameTemplate partitionLoadTimeMs;
+    public final MetricNameTemplate requestTopicPartitionsFetchRatio;
+    public final MetricNameTemplate topicPartitionsAcquireTimeMs;
+    public final MetricNameTemplate acquisitionLockTimeoutPerSec;
+    public final MetricNameTemplate inFlightMessageCount;
+    public final MetricNameTemplate inFlightBatchCount;
+    public final MetricNameTemplate inFlightBatchMessageCount;
+    public final MetricNameTemplate fetchLockTimeMs;
+    public final MetricNameTemplate fetchLockRatio;
+    public final MetricNameTemplate shareSessionEvictionsPerSec;
+    public final MetricNameTemplate sharePartitionsCount;
+    public final MetricNameTemplate shareSessionsCount;
+    public final MetricNameTemplate delayedShareFetchExpiresPerSec;
+    public final MetricNameTemplate shareFetchPurgatorySize;
+    public final MetricNameTemplate shareFetchNumDelayedOperations;
 
     public ShareGroupMetricsRegistry() {
         this(new HashSet<>(), "");
-    }
-
-    public ShareGroupMetricsRegistry(String metricGrpPrefix) {
-        this(new HashSet<>(), metricGrpPrefix);
     }
 
     public ShareGroupMetricsRegistry(Set<String> tags, String metricGrpPrefix) {
@@ -67,168 +64,118 @@ public class ShareGroupMetricsRegistry {
         String brokerTopicGroupName = "BrokerTopicMetrics";
         Set<String> topicTags = Set.of("topic");
 
-        this.totalShareFetchRequestsPerSec = new MetricNameTemplate(
-            "TotalShareFetchRequestsPerSec",
-            brokerTopicGroupName,
-            "The fetch request rate per second. ",
-            topicTags);
+        this.totalShareFetchRequestsPerSec = new MetricNameTemplate("TotalShareFetchRequestsPerSec", brokerTopicGroupName,
+            "The fetch request rate per second. ", topicTags);
 
-        this.failedShareFetchRequestsPerSec = new MetricNameTemplate(
-            "FailedShareFetchRequestsPerSec",
-            brokerTopicGroupName,
-            "The share fetch request rate for requests that failed. ",
-            topicTags);
+        this.failedShareFetchRequestsPerSec = new MetricNameTemplate("FailedShareFetchRequestsPerSec", brokerTopicGroupName,
+            "The share fetch request rate for requests that failed. ", topicTags);
 
-        this.totalShareAcknowledgementRequestsPerSec = new MetricNameTemplate(
-            "TotalShareAcknowledgementRequestsPerSec",
-            brokerTopicGroupName,
-            "The acknowledgement request rate per second. ",
-            topicTags);
+        this.totalShareAcknowledgementRequestsPerSec = new MetricNameTemplate("TotalShareAcknowledgementRequestsPerSec", brokerTopicGroupName,
+            "The acknowledgement request rate per second. ", topicTags);
 
-        this.failedShareAcknowledgementRequestsPerSec = new MetricNameTemplate(
-            "FailedShareAcknowledgementRequestsPerSec",
-            brokerTopicGroupName,
-            "The share acknowledgement request rate for requests that failed. ",
-            topicTags);
+        this.failedShareAcknowledgementRequestsPerSec = new MetricNameTemplate("FailedShareAcknowledgementRequestsPerSec", brokerTopicGroupName,
+            "The share acknowledgement request rate for requests that failed. ", topicTags);
 
         /* Group Coordinator metrics */
         Set<String> state = Set.of("state");
-        this.shareGroupCount = new MetricNameTemplate(
-            "ShareGroupCount",
-            "GroupCoordinator",
-            "The number of share groups in respective state.",
-            state);
+        this.shareGroupCount = new MetricNameTemplate("share-group-count", "GroupCoordinator",
+            "The number of share groups in respective state.", state);
 
         /* Share Coordinator metrics */
-        String share
-        this.writeRate = new MetricNameTemplate(
+        String shareCoordinatorMetrics = "share-coordinator-metrics";
+        this.writeRate = new MetricNameTemplate("write-rate", shareCoordinatorMetrics,
+            "The number of share-group state write calls per second.", tags);
 
+        this.writeTotal = new MetricNameTemplate("write-total", shareCoordinatorMetrics,
+            "The total number of share-group state write calls.", tags);
+
+        this.writeLatencyAvg = new MetricNameTemplate("write-latency-avg", shareCoordinatorMetrics,
+            "The average time taken for a share-group state write call, including the time to write to the share-group state topic.", tags);
+
+        this.writeLatencyMax = new MetricNameTemplate("write-latency-max", shareCoordinatorMetrics,
+            "The maximum time taken for a share-group state write call, including the time to write to the share-group state topic.", tags);
+
+        Set<String> topicPartitionTags = Set.of("topic", "partition");
+        this.lastPrunedOffset = new MetricNameTemplate("last-pruned-offset", shareCoordinatorMetrics,
+            "The last pruned offset in the share-group state topic.", topicPartitionTags);
 
         /* ShareGroupMetrics */
         String shareGroupMetricsName = metricGrpPrefix + "ShareGroupMetrics";
-
         // Acknowledgement type level metrics
         Set<String> ackTypeTags = Set.of("ackType");
 
-        this.recordAcknowledgementsPerSec = new MetricNameTemplate(
-            "RecordAcknowledgementsPerSec",
-            shareGroupMetricsName,
-            "The rate per second of records acknowledged per acknowledgement type.",
-            ackTypeTags);
+        this.recordAcknowledgementsPerSec = new MetricNameTemplate("RecordAcknowledgementsPerSec", shareGroupMetricsName,
+            "The rate per second of records acknowledged per acknowledgement type.", ackTypeTags);
 
         // General metrics
-        this.partitionLoadTimeMs = new MetricNameTemplate(
-            "PartitionLoadTimeMs",
-            shareGroupMetricsName,
-            "The time taken to load the share partitions.",
-            tags);
-
+        this.partitionLoadTimeMs = new MetricNameTemplate("PartitionLoadTimeMs", shareGroupMetricsName,
+            "The time taken to load the share partitions.", tags);
         // Group level metrics
         Set<String> groupTags = Set.of("group");
 
-        this.requestTopicPartitionsFetchRatio = new MetricNameTemplate(
-            "RequestTopicPartitionsFetchRatio",
-            shareGroupMetricsName,
-            "The ratio of topic-partitions acquired to the total number of topic-partitions in share fetch request.",
-            groupTags);
+        this.requestTopicPartitionsFetchRatio = new MetricNameTemplate("RequestTopicPartitionsFetchRatio", shareGroupMetricsName,
+            "The ratio of topic-partitions acquired to the total number of topic-partitions in share fetch request.", groupTags);
 
-        this.topicPartitionsAcquireTimeMs = new MetricNameTemplate(
-            "TopicPartitionsAcquireTimeMs",
-            shareGroupMetricsName,
-            "The time elapsed (in millisecond) to acquire any topic partition for fetch.",
-            groupTags);
+        this.topicPartitionsAcquireTimeMs = new MetricNameTemplate("TopicPartitionsAcquireTimeMs", shareGroupMetricsName,
+            "The time elapsed (in millisecond) to acquire any topic partition for fetch.", groupTags);
 
         /* SharePartitionMetrics - Partition level */
         String sharePartitionMetricsName = "SharePartitionMetrics";
         Set<String> partitionTags = Set.of("group", "topic", "partition");
 
-        this.acquisitionLockTimeoutPerSec = new MetricNameTemplate(
-            "AcquisitionLockTimeoutPerSec",
-            sharePartitionMetricsName,
-            "The rate of acquisition locks for records which are not acknowledged within the timeout.",
-            partitionTags);
+        this.acquisitionLockTimeoutPerSec = new MetricNameTemplate("AcquisitionLockTimeoutPerSec", sharePartitionMetricsName,
+            "The rate of acquisition locks for records which are not acknowledged within the timeout.", partitionTags);
 
-        this.inFlightMessageCount = new MetricNameTemplate(
-            "InFlightMessageCount",
-            sharePartitionMetricsName,
-            "The number of in-flight messages for the share partition.",
-            partitionTags);
+        this.inFlightMessageCount = new MetricNameTemplate("InFlightMessageCount", sharePartitionMetricsName,
+            "The number of in-flight messages for the share partition.", partitionTags);
 
-        this.inFlightBatchCount = new MetricNameTemplate(
-            "InFlightBatchCount",
-            sharePartitionMetricsName,
-            "The number of in-flight batches for the share partition.",
-            partitionTags);
+        this.inFlightBatchCount = new MetricNameTemplate("InFlightBatchCount", sharePartitionMetricsName,
+            "The number of in-flight batches for the share partition.", partitionTags);
 
-        this.inFlightBatchMessageCount = new MetricNameTemplate(
-            "InFlightBatchMessageCount",
-            sharePartitionMetricsName,
-            "The number of messages in the in-flight batch.",
-            partitionTags);
+        this.inFlightBatchMessageCount = new MetricNameTemplate("InFlightBatchMessageCount", sharePartitionMetricsName,
+            "The number of messages in the in-flight batch.", partitionTags);
 
-        this.fetchLockTimeMs = new MetricNameTemplate(
-            "FetchLockTimeMs",
-            sharePartitionMetricsName,
-            "The time elapsed (in milliseconds) while a share partition is held under lock for fetching messages.",
-            partitionTags);
+        this.fetchLockTimeMs = new MetricNameTemplate("FetchLockTimeMs", sharePartitionMetricsName,
+            "The time elapsed (in milliseconds) while a share partition is held under lock for fetching messages.", partitionTags);
 
-        this.fetchLockRatio = new MetricNameTemplate(
-            "FetchLockRatio",
-            sharePartitionMetricsName,
-            "The fraction of time share partition is held under lock.",
-            partitionTags);
+        this.fetchLockRatio = new MetricNameTemplate("FetchLockRatio", sharePartitionMetricsName,
+            "The fraction of time share partition is held under lock.", partitionTags);
 
         /* ShareSessionCache metrics */
         String shareSessionCacheName = "ShareSessionCache";
+        this.shareSessionEvictionsPerSec = new MetricNameTemplate("ShareSessionEvictionsPerSec", shareSessionCacheName,
+            "The share session eviction rate per second.", tags);
 
-        this.shareSessionEvictionsPerSec = new MetricNameTemplate(
-            "ShareSessionEvictionsPerSec",
-            shareSessionCacheName,
-            "The share session eviction rate per second.",
-            tags);
+        this.sharePartitionsCount = new MetricNameTemplate("SharePartitionsCount", shareSessionCacheName,
+            "The number of cached share partitions.", tags);
 
-        this.sharePartitionsCount = new MetricNameTemplate(
-            "SharePartitionsCount",
-            shareSessionCacheName,
-            "The number of cached share partitions.",
-            tags);
-
-        this.shareSessionsCount = new MetricNameTemplate(
-            "ShareSessionsCount",
-            shareSessionCacheName,
-            "The number of cached share sessions.",
-            tags);
+        this.shareSessionsCount = new MetricNameTemplate("ShareSessionsCount", shareSessionCacheName,
+            "The number of cached share sessions.", tags);
 
         /* DelayedShareFetchMetrics */
         String delayedShareFetchMetricsName = "DelayedShareFetchMetrics";
-
-        this.delayedShareFetchExpiresPerSec = new MetricNameTemplate(
-            "ExpiresPerSec",
-            delayedShareFetchMetricsName,
-            "The expired delayed share fetch operation rate per second.",
-            tags);
+        this.delayedShareFetchExpiresPerSec = new MetricNameTemplate("ExpiresPerSec", delayedShareFetchMetricsName,
+            "The expired delayed share fetch operation rate per second.", tags);
 
         /* DelayedOperationPurgatory metrics */
         String delayedOperationPurgatoryName = "DelayedOperationPurgatory";
         Set<String> shareFetchTags = new LinkedHashSet<>(tags);
         shareFetchTags.add("delayedOperation");
 
-        this.shareFetchPurgatorySize = new MetricNameTemplate(
-            "PurgatorySize",
-            delayedOperationPurgatoryName,
-            "The number of requests waiting in the share fetch purgatory. This is high if share consumers use a large value for fetch.wait.max.ms",
-            shareFetchTags);
+        this.shareFetchPurgatorySize = new MetricNameTemplate("PurgatorySize", delayedOperationPurgatoryName,
+            "The number of requests waiting in the share fetch purgatory. This is high if share consumers use a large value for fetch.wait.max.ms", shareFetchTags);
 
-        this.shareFetchNumDelayedOperations = new MetricNameTemplate(
-            "NumDelayedOperations",
-            delayedOperationPurgatoryName,
-            "The number of delayed operations for share fetch purgatory.",
-            shareFetchTags);
+        this.shareFetchNumDelayedOperations = new MetricNameTemplate("NumDelayedOperations", delayedOperationPurgatoryName,
+            "The number of delayed operations for share fetch purgatory.", shareFetchTags);
     }
 
     public List<MetricNameTemplate> getAllTemplates() {
         return Arrays.asList(
-            shareGroupCount
+            shareGroupCount,
+            writeRate,
+            writeTotal,
+            writeLatencyAvg,
+            writeLatencyMax,
             totalShareFetchRequestsPerSec,
             failedShareFetchRequestsPerSec,
             totalShareAcknowledgementRequestsPerSec,


### PR DESCRIPTION
This pull request adds comprehensive support for Share Group metrics in Apache Kafka, including new metric registries, documentation updates, and configuration changes. The main focus is on enabling detailed monitoring and reporting for Share Group operations, making it easier to observe and analyze Share Group behavior via metrics and documentation.

**Metrics and Registry Enhancements:**

* Introduced the new `ShareGroupMetricsRegistry` class, which defines all Share Group-related metrics and provides a method to retrieve all metric templates for reporting and monitoring purposes.
* Updated `ShareGroupMetrics` to instantiate and use the new registry, and added a method and a main function for generating HTML tables of all Share Group metrics. [[1]](diffhunk://#diff-57522e79d276c21b19376ac715ea4527e99542c7dd7f2438862ac0f92797a436R68-R69) [[2]](diffhunk://#diff-57522e79d276c21b19376ac715ea4527e99542c7dd7f2438862ac0f92797a436R87) [[3]](diffhunk://#diff-57522e79d276c21b19376ac715ea4527e99542c7dd7f2438862ac0f92797a436R152-R160)
* Enhanced `ShareConsumerMetrics` and `ShareFetchMetricsRegistry` to expose all metric templates and provide a main method for HTML reporting, improving observability for Share Consumer metrics. [[1]](diffhunk://#diff-d899978b21852fc9ca03773975dd541676618a76c97d4acac0f672cc51a915c1R19-R24) [[2]](diffhunk://#diff-d899978b21852fc9ca03773975dd541676618a76c97d4acac0f672cc51a915c1R39-R49) [[3]](diffhunk://#diff-849e16e3860a1bc6cb79db07abb4a4c3e7a908909e52fa849d898c90c93c5a36R22) [[4]](diffhunk://#diff-849e16e3860a1bc6cb79db07abb4a4c3e7a908909e52fa849d898c90c93c5a36R102-R124)

**Documentation Updates:**

* Updated the monitoring documentation to include Share Group metrics, adding references to the new metric types and descriptions in the metrics tables.
* Added a new section for Share Group Monitoring in the documentation table of contents for easier navigation and discoverability.
* Improved the documentation structure by adding a heading for Connect Monitoring.

**Configuration Changes:**

* Updated the default log directory in `server.properties` and enabled Share Group support with `group.share.enable=true`.Delete this text and replace it with a detailed description of your change. The 
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including 
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.
