### PR TITLE
KAFKA-19950: Removing connection from session in ShareSessionCache on eviction

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartitionManager.java
+++ b/core/src/main/java/kafka/server/share/SharePartitionManager.java
@@ -360,7 +360,7 @@ public class SharePartitionManager implements AutoCloseable {
             groupId, memberId);
         // Remove the share session from the cache.
         ShareSessionKey key = shareSessionKey(groupId, memberId);
-        if (cache.remove(key) == null) {
+        if (cache.removeAndNotifyListener(key) == null) {
             log.error("Share session error for {}: no such share session found", key);
             return FutureUtils.failedFuture(Errors.SHARE_SESSION_NOT_FOUND.exception());
         } else {
@@ -377,7 +377,12 @@ public class SharePartitionManager implements AutoCloseable {
             SharePartitionKey sharePartitionKey = sharePartitionKey(groupId, topicIdPartition);
             SharePartition sharePartition = partitionCache.get(sharePartitionKey);
             if (sharePartition == null) {
-                log.error("No share partition found for groupId {} topicPartition {} while releasing acquired topic partitions", groupId, topicIdPartition);
+                // During release session, if share group becomes empty i.e. no members then onGroupEmpty
+                // listener callback will remove the share partition from cache. So it is possible that
+                // the share partition is not found here. Hence, just log it at debug level.
+                log.debug("No share partition found for groupId {} topicPartition {} while releasing acquired topic partitions", groupId, topicIdPartition);
+                // Complete the future with UNKNOWN_TOPIC_OR_PARTITION, the result is ignored while
+                // releasing the session and should not fail the release session request.
                 futuresMap.put(topicIdPartition, CompletableFuture.completedFuture(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception()));
             } else {
                 CompletableFuture<Throwable> future = new CompletableFuture<>();
@@ -478,7 +483,11 @@ public class SharePartitionManager implements AutoCloseable {
                     log.error("Acknowledge data present in Initial Fetch Request for group {} member {}", groupId, memberId);
                     throw Errors.INVALID_REQUEST.exception();
                 }
-                if (cache.remove(key) != null) {
+                // Try removing the existing session if any. Do not notify the listener as another
+                // session will be created immediately after. Incase there is a single member share group,
+                // then re-creation of session should not trigger onGroupEmpty which will remove the
+                // share partitions from cache.
+                if (cache.removeAndMaybeNotifyListener(key, false) != null) {
                     log.debug("Removed share session with key {}", key);
                 }
                 ImplicitLinkedHashCollection<CachedSharePartition> cachedSharePartitions = new

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3370,7 +3370,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                   error(s"Releasing share session close with correlation from client ${request.header.clientId}  " +
                     s"failed with error ${throwable.getMessage}")
                 } else {
-                  info(s"Releasing share session close $releaseAcquiredRecordsData succeeded")
+                  info(s"Releasing share session for client id ${request.header.clientId} succeeded, response: $releaseAcquiredRecordsData")
                 }
               )
           }
@@ -3594,7 +3594,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                   debug(s"Releasing share session close with correlation from client ${request.header.clientId}  " +
                     s"failed with error ${throwable.getMessage}")
                 } else {
-                  info(s"Releasing share session close $releaseAcquiredRecordsData succeeded")
+                  info(s"Releasing share session for client id ${request.header.clientId} succeeded, response: $releaseAcquiredRecordsData")
                 }
               }
           }

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -1283,7 +1283,7 @@ public class SharePartitionManagerTest {
         ShareSessionCache cache = mock(ShareSessionCache.class);
         ShareSession shareSession = mock(ShareSession.class);
         when(cache.get(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
-        when(cache.remove(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
+        when(cache.removeAndNotifyListener(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
 
         ImplicitLinkedHashCollection<CachedSharePartition> partitionMap = new ImplicitLinkedHashCollection<>(3);
         partitionMap.add(new CachedSharePartition(tp1));
@@ -1389,7 +1389,7 @@ public class SharePartitionManagerTest {
         ShareSessionCache cache = mock(ShareSessionCache.class);
         ShareSession shareSession = mock(ShareSession.class);
         when(cache.get(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
-        when(cache.remove(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
+        when(cache.removeAndNotifyListener(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
         when(shareSession.partitionMap()).thenReturn(new ImplicitLinkedHashCollection<>());
 
         sharePartitionManager = SharePartitionManagerBuilder.builder()
@@ -1412,7 +1412,7 @@ public class SharePartitionManagerTest {
         // Null share session in get response so empty topic partitions should be returned.
         when(cache.get(new ShareSessionKey(groupId, memberId))).thenReturn(null);
         // Make the response not null for remove so can further check for the return value from topic partitions.
-        when(cache.remove(new ShareSessionKey(groupId, memberId))).thenReturn(mock(ShareSession.class));
+        when(cache.removeAndNotifyListener(new ShareSessionKey(groupId, memberId))).thenReturn(mock(ShareSession.class));
 
         sharePartitionManager = SharePartitionManagerBuilder.builder()
             .withCache(cache)
@@ -1926,7 +1926,7 @@ public class SharePartitionManagerTest {
 
         ShareSessionCache cache = mock(ShareSessionCache.class);
         ShareSession shareSession = mock(ShareSession.class);
-        when(cache.remove(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
+        when(cache.removeAndNotifyListener(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
 
         // mocked share partitions sp1 and sp2 can be acquired once there is a release acquired records on session close request for it.
         doAnswer(invocation -> {
@@ -2030,7 +2030,7 @@ public class SharePartitionManagerTest {
 
         ShareSessionCache cache = mock(ShareSessionCache.class);
         ShareSession shareSession = mock(ShareSession.class);
-        when(cache.remove(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
+        when(cache.removeAndNotifyListener(new ShareSessionKey(groupId, memberId))).thenReturn(shareSession);
 
         // mocked share partitions sp1, sp2 and sp3 can be acquired once there is a release acquired records on session close for it.
         doAnswer(invocation -> {
@@ -3009,7 +3009,7 @@ public class SharePartitionManagerTest {
         SharePartition sp0 = mock(SharePartition.class);
 
         ShareSessionCache cache = new ShareSessionCache(10);
-        cache.maybeCreateSession(groupId, memberId1, new ImplicitLinkedHashCollection<>(), CONNECTION_ID);
+        ShareSessionKey key = cache.maybeCreateSession(groupId, memberId1, new ImplicitLinkedHashCollection<>(), CONNECTION_ID);
 
         SharePartitionCache partitionCache = spy(new SharePartitionCache());
         partitionCache.computeIfAbsent(new SharePartitionKey(groupId, tp0), k -> sp0);
@@ -3032,11 +3032,13 @@ public class SharePartitionManagerTest {
         Mockito.verify(mockReplicaManager, times(1)).removeListener(any(), any());
         Mockito.verify(partitionCache, times(0)).topicIdPartitionsForGroup(groupId);
 
-        // Invoke listeners by simulating connection disconnect for member. As the group is empty,
-        // hence onGroupEmpty method should be invoked and should complete without any exception.
+        // The invocation of connection disconnect listener after the cache is already empty should
+        // not trigger any additional on group empty calls.
         cache.connectionDisconnectListener().onDisconnect(CONNECTION_ID);
-        // Verify that the listener is called for the group.
-        Mockito.verify(partitionCache, times(1)).topicIdPartitionsForGroup(groupId);
+        // The invocation of connection disconnect listener should not have any effect as the cache is already empty.
+        // The share version toggle cleared the cache and is responsible to fence the share partitions.
+        // Hence, no additional on group empty calls should be made.
+        Mockito.verify(partitionCache, times(0)).topicIdPartitionsForGroup(groupId);
     }
 
     private Timer systemTimerReaper() {

--- a/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionManagerTest.java
@@ -3009,7 +3009,7 @@ public class SharePartitionManagerTest {
         SharePartition sp0 = mock(SharePartition.class);
 
         ShareSessionCache cache = new ShareSessionCache(10);
-        ShareSessionKey key = cache.maybeCreateSession(groupId, memberId1, new ImplicitLinkedHashCollection<>(), CONNECTION_ID);
+        cache.maybeCreateSession(groupId, memberId1, new ImplicitLinkedHashCollection<>(), CONNECTION_ID);
 
         SharePartitionCache partitionCache = spy(new SharePartitionCache());
         partitionCache.computeIfAbsent(new SharePartitionKey(groupId, tp0), k -> sp0);

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4777,12 +4777,6 @@ class KafkaApisTest extends Logging {
     cachedSharePartitions.mustAdd(new CachedSharePartition(
       new TopicIdPartition(topicId, partitionIndex, topicName), false))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenThrow(
-      Errors.INVALID_REQUEST.exception()
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2
-    )))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -4806,6 +4800,13 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenThrow(
+      Errors.INVALID_REQUEST.exception()
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId)
+    ))
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
@@ -5024,11 +5025,6 @@ class KafkaApisTest extends Logging {
     cachedSharePartitions.mustAdd(new CachedSharePartition(
       new TopicIdPartition(topicId, partitionIndex, topicName), false))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
-      .thenReturn(new ShareSessionContext(1, new ShareSession(
-        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-      )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -5052,6 +5048,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
+      .thenReturn(new ShareSessionContext(1, new ShareSession(
+        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+      )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     val response = verifyNoThrottling[ShareFetchResponse](request)
@@ -5083,11 +5085,6 @@ class KafkaApisTest extends Logging {
     cachedSharePartitions.mustAdd(new CachedSharePartition(
       new TopicIdPartition(topicId, partitionIndex, topicName), false))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
-      .thenReturn(new ShareSessionContext(1, new ShareSession(
-        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-      )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -5111,6 +5108,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
+      .thenReturn(new ShareSessionContext(1, new ShareSession(
+        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+      )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     val response = verifyNoThrottling[ShareFetchResponse](request)
@@ -5460,16 +5463,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, partitionIndex, topicName), false)
     )
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    ).thenReturn(new ShareSessionContext(2, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 3))
-    )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -5485,6 +5478,16 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    ).thenReturn(new ShareSessionContext(2, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 3, request.context.connectionId))
+    )
 
     // First share fetch request is to establish the share session with the broker.
     kafkaApis = createKafkaApis()
@@ -5725,19 +5728,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId4, 0, topicName4), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
-        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 1)),
-        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 0)),
-        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 1))
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions1, 2))
-    ).thenReturn(new ShareSessionContext(2, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions2, 3))
-    ).thenReturn(new FinalContext())
-
     when(sharePartitionManager.releaseSession(any(), any())).thenReturn(
       CompletableFuture.completedFuture(util.Map.of[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
         new TopicIdPartition(topicId3, new TopicPartition(topicName3, 0)),
@@ -5808,6 +5798,20 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
+        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 1)),
+        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 0)),
+        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 1))
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions1, 2, request.context.connectionId))
+    ).thenReturn(new ShareSessionContext(2, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions2, 3, request.context.connectionId))
+    ).thenReturn(new FinalContext())
+
     // First share fetch request is to establish the share session with the broker.
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
@@ -6688,14 +6692,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, 0, topicName), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -6720,6 +6716,15 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
@@ -6807,14 +6812,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, 0, topicName), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    )
-
     when(sharePartitionManager.acknowledge(any(), any(), any())).thenReturn(
       CompletableFuture.completedFuture(util.Map.of[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
         new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
@@ -6837,6 +6834,15 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
@@ -14299,14 +14305,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, 0, topicName), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -14331,6 +14329,15 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSession.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSession.java
@@ -38,6 +38,7 @@ public class ShareSession {
 
     private final ShareSessionKey key;
     private final ImplicitLinkedHashCollection<CachedSharePartition> partitionMap;
+    private final String connectionId;
 
     // visible for testing
     public int epoch;
@@ -48,16 +49,23 @@ public class ShareSession {
     /**
      * The share session.
      * Each share session is protected by its own lock, which must be taken before mutable
-     * fields are read or modified.  This includes modification of the share session partition map.
+     * fields are read or modified. This includes modification of the share session partition map.
      *
      * @param key                The share session key to identify the share session uniquely.
      * @param partitionMap       The CachedPartitionMap.
      * @param epoch              The share session sequence number.
+     * @param connectionId       The connection id associated with this share session.
      */
-    public ShareSession(ShareSessionKey key, ImplicitLinkedHashCollection<CachedSharePartition> partitionMap, int epoch) {
+    public ShareSession(
+        ShareSessionKey key,
+        ImplicitLinkedHashCollection<CachedSharePartition> partitionMap,
+        int epoch,
+        String connectionId
+    ) {
         this.key = key;
         this.partitionMap = partitionMap;
         this.epoch = epoch;
+        this.connectionId = connectionId;
     }
 
     public ShareSessionKey key() {
@@ -83,6 +91,10 @@ public class ShareSession {
 
     public synchronized Boolean isEmpty() {
         return partitionMap.isEmpty();
+    }
+
+    public synchronized String connectionId() {
+        return connectionId;
     }
 
     // Update the cached partition data based on the request.
@@ -138,6 +150,7 @@ public class ShareSession {
                 ", partitionMap=" + partitionMap +
                 ", epoch=" + epoch +
                 ", cachedSize=" + cachedSize +
+                ", connectionId=" + connectionId +
                 ")";
     }
 }

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSession.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSession.java
@@ -93,7 +93,7 @@ public class ShareSession {
         return partitionMap.isEmpty();
     }
 
-    public synchronized String connectionId() {
+    public String connectionId() {
         return connectionId;
     }
 

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -107,7 +107,7 @@ public class ShareSessionCache {
     }
 
     /**
-     * Remove all the share sessions from cache. The method do not notify the share group listener
+     * Remove all the share sessions from cache. The method does not notify the share group listener
      * and expects the caller to handle the cleanup for share partitions.
      */
     public synchronized void removeAllSessions() {
@@ -121,10 +121,28 @@ public class ShareSessionCache {
         return numPartitions;
     }
 
-    public synchronized ShareSession remove(ShareSessionKey key) {
+    /**
+     * Remove an entry from the session cache and notify the share group listener if registered.
+     *
+     * @param key The session key.
+     * @return The removed session, or None if there was no such session.
+     */
+    public synchronized ShareSession removeAndNotifyListener(ShareSessionKey key) {
+        return removeAndMaybeNotifyListener(key, true);
+    }
+
+    /**
+     * Remove an entry from the session cache. Maybe invoke the share group listener if registered
+     * and notifyListener is true.
+     *
+     * @param key The session key.
+     * @param notifyListener Whether to notify the share group listener.
+     * @return The removed session, or None if there was no such session.
+     */
+    public synchronized ShareSession removeAndMaybeNotifyListener(ShareSessionKey key, boolean notifyListener) {
         ShareSession session = get(key);
         if (session != null)
-            return remove(session);
+            return removeAndMaybeNotifyListener(session, notifyListener);
         return null;
     }
 
@@ -148,8 +166,9 @@ public class ShareSessionCache {
             // update the evictions metric.
             evictionsMeter.mark();
             // Try removing session if not already removed. The listener might have removed the session
-            // already.
-            remove(session);
+            // already. Don't notify the share group listener as it should be notified later. Notify
+            // the listener only once per removal.
+            removeAndMaybeNotifyListener(session, false);
         }
         // Notify the share group listener if the group is empty. This should be checked regardless
         // session is evicted by connection disconnect or client's final epoch.
@@ -173,18 +192,22 @@ public class ShareSessionCache {
     }
 
     /**
-     * Remove an entry from the session cache. Invoke the share group listener if registered.
+     * Remove an entry from the session cache. Maybe invoke the share group listener if registered
+     * and notifyListener is true.
      *
      * @param session The session.
+     * @param notifyListener Whether to notify the share group listener.
      * @return The removed session, or None if there was no such session.
      */
-    public synchronized ShareSession remove(ShareSession session) {
+    private synchronized ShareSession removeAndMaybeNotifyListener(ShareSession session, boolean notifyListener) {
         ShareSession removeResult = sessions.remove(session.key());
         if (removeResult != null) {
             numPartitions = numPartitions - session.cachedSize();
             numMembersPerGroup.compute(session.key().groupId(), (k, v) -> v != null ? v - 1 : 0);
             maybeRemoveConnectionFromSession(removeResult.connectionId());
-            checkAndNotifyGroupListener(session.key().groupId());
+            if (notifyListener) {
+                checkAndNotifyGroupListener(session.key().groupId());
+            }
         }
         return removeResult;
     }

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -107,12 +107,14 @@ public class ShareSessionCache {
     }
 
     /**
-     * Remove all the share sessions from cache.
+     * Remove all the share sessions from cache. The method do not notify the share group listener
+     * and expects the caller to handle the cleanup for share partitions.
      */
     public synchronized void removeAllSessions() {
         sessions.clear();
         numMembersPerGroup.clear();
         numPartitions = 0;
+        connectionIdToSessionMap.clear();
     }
 
     public synchronized long totalPartitions() {
@@ -127,13 +129,13 @@ public class ShareSessionCache {
     }
 
     /**
-     * Maybe remove the session and notify listeners. This is called when the connection is disconnected
+     * Maybe remove the session for the client. This is called when the connection is disconnected
      * for the client. The session may have already been removed by the client as part of final epoch,
      * hence check if the session is still present in the cache.
      *
      * @param key The share session key.
      */
-    public synchronized void maybeRemoveAndNotifyListeners(ShareSessionKey key) {
+    private synchronized void maybeRemoveSession(ShareSessionKey key) {
         ShareSession session = get(key);
         if (session != null) {
             // Notify the share group listener that member has left the group. Notify listener prior
@@ -151,18 +153,27 @@ public class ShareSessionCache {
         }
         // Notify the share group listener if the group is empty. This should be checked regardless
         // session is evicted by connection disconnect or client's final epoch.
-        int numMembers = numMembersPerGroup.getOrDefault(key.groupId(), 0);
+        checkAndNotifyGroupListener(key.groupId());
+    }
+
+    /**
+     * Check if the share group is empty and notify the share group listener.
+     *
+     * @param groupId The share group id.
+     */
+    private synchronized void checkAndNotifyGroupListener(String groupId) {
+        int numMembers = numMembersPerGroup.getOrDefault(groupId, 0);
         if (numMembers == 0) {
             // Remove the group from the map as it is empty.
-            numMembersPerGroup.remove(key.groupId());
+            numMembersPerGroup.remove(groupId);
             if (shareGroupListener != null) {
-                shareGroupListener.onGroupEmpty(key.groupId());
+                shareGroupListener.onGroupEmpty(groupId);
             }
         }
     }
 
     /**
-     * Remove an entry from the session cache.
+     * Remove an entry from the session cache. Invoke the share group listener if registered.
      *
      * @param session The session.
      * @return The removed session, or None if there was no such session.
@@ -172,6 +183,8 @@ public class ShareSessionCache {
         if (removeResult != null) {
             numPartitions = numPartitions - session.cachedSize();
             numMembersPerGroup.compute(session.key().groupId(), (k, v) -> v != null ? v - 1 : 0);
+            maybeRemoveConnectionFromSession(removeResult.connectionId());
+            checkAndNotifyGroupListener(session.key().groupId());
         }
         return removeResult;
     }
@@ -201,7 +214,7 @@ public class ShareSessionCache {
     ) {
         if (sessions.size() < maxEntries) {
             ShareSession session = new ShareSession(new ShareSessionKey(groupId, memberId), partitionMap,
-                ShareRequestMetadata.nextEpoch(ShareRequestMetadata.INITIAL_EPOCH));
+                ShareRequestMetadata.nextEpoch(ShareRequestMetadata.INITIAL_EPOCH), clientConnectionId);
             sessions.put(session.key(), session);
             updateNumPartitions(session);
             numMembersPerGroup.compute(session.key().groupId(), (k, v) -> v != null ? v + 1 : 1);
@@ -219,6 +232,19 @@ public class ShareSessionCache {
         this.shareGroupListener = shareGroupListener;
     }
 
+    /**
+     * Remove the connection id to session mapping when the connection is closed. The removal is not
+     * guaranteed always as the connection can be removed as part of final epoch from client or disconnect,
+     * hence the method returns the session key if present. The invocation to the method is idempotent
+     * and shall always at least be called once for every connection id.
+     *
+     * @param connectionId The client connection id.
+     * @return The share session key if present, null otherwise.
+     */
+    public synchronized ShareSessionKey maybeRemoveConnectionFromSession(String connectionId) {
+        return connectionIdToSessionMap.remove(connectionId);
+    }
+
     // Visible for testing.
     Meter evictionsMeter() {
         return evictionsMeter;
@@ -234,12 +260,12 @@ public class ShareSessionCache {
         // When the client disconnects, the corresponding session should be removed from the cache.
         @Override
         public void onDisconnect(String connectionId) {
-            ShareSessionKey shareSessionKey = connectionIdToSessionMap.remove(connectionId);
+            ShareSessionKey shareSessionKey = maybeRemoveConnectionFromSession(connectionId);
             if (shareSessionKey != null) {
                 // Try removing session and notify listeners. The session might already be removed
                 // as part of final epoch from client, so we need to check if the session is still
                 // present in the cache.
-                maybeRemoveAndNotifyListeners(shareSessionKey);
+                maybeRemoveSession(shareSessionKey);
             }
         }
     }

--- a/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
@@ -88,7 +88,7 @@ public class ShareSessionCacheTest {
         assertShareCacheContains(cache, List.of(key1, key2));
         assertEquals(6, cache.totalPartitions());
         assertEquals(2, cache.size());
-        cache.remove(key1);
+        cache.removeAndNotifyListener(key1);
         assertShareCacheContains(cache, List.of(key2));
         assertEquals(1, cache.size());
         assertEquals(4, cache.totalPartitions());
@@ -163,21 +163,21 @@ public class ShareSessionCacheTest {
         assertEquals(6, cache.totalPartitions());
         assertMetricsValues(3, 6, 0, cache);
 
-        cache.remove(key1);
+        cache.removeAndNotifyListener(key1);
         assertEquals(2, cache.size());
         assertEquals(5, cache.totalPartitions());
         assertMetricsValues(2, 5, 0, cache);
         Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(key1.groupId(), key1.memberId());
         Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(key1.groupId());
 
-        cache.remove(key2);
+        cache.removeAndNotifyListener(key2);
         assertEquals(1, cache.size());
         assertEquals(3, cache.totalPartitions());
         assertMetricsValues(1, 3, 0, cache);
         Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(key1.groupId(), key1.memberId());
         Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(key1.groupId());
 
-        cache.remove(key3);
+        cache.removeAndNotifyListener(key3);
         assertEquals(0, cache.size());
         assertEquals(0, cache.totalPartitions());
         assertMetricsValues(0, 0, 0, cache);
@@ -220,7 +220,7 @@ public class ShareSessionCacheTest {
 
         // Remove session and verify listener are not called as connection disconnect listener didn't
         // remove the session.
-        cache.remove(key1);
+        cache.removeAndNotifyListener(key1);
         Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(groupId, memberId1);
         Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(groupId);
         // Verify member count is updated
@@ -244,9 +244,7 @@ public class ShareSessionCacheTest {
         // leave event count should be same as before.
         Mockito.verify(mockListener, Mockito.times(1)).onMemberLeave(groupId, memberId1);
         Mockito.verify(mockListener, Mockito.times(1)).onMemberLeave(groupId, memberId2);
-        // Empty group event should be triggered now but would be called twice as the code path
-        // is same when the last member leaves via connection disconnect listener or remove session.
-        Mockito.verify(mockListener, Mockito.times(2)).onGroupEmpty(groupId);
+        Mockito.verify(mockListener, Mockito.times(1)).onGroupEmpty(groupId);
         assertNull(cache.numMembers(groupId));
     }
 
@@ -273,7 +271,7 @@ public class ShareSessionCacheTest {
         // Remove session for group1 and verify listeners are only called for group1.
         cache.connectionDisconnectListener().onDisconnect("conn-1");
         Mockito.verify(mockListener, Mockito.times(1)).onMemberLeave(groupId1, memberId1);
-        Mockito.verify(mockListener, Mockito.times(2)).onGroupEmpty(groupId1);
+        Mockito.verify(mockListener, Mockito.times(1)).onGroupEmpty(groupId1);
         // Listener should not be called for group2.
         Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(groupId2, memberId2);
         Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(groupId2);

--- a/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
+++ b/server/src/test/java/org/apache/kafka/server/share/session/ShareSessionCacheTest.java
@@ -113,7 +113,10 @@ public class ShareSessionCacheTest {
 
     @Test
     public void testRemoveConnection() throws InterruptedException {
+        ShareGroupListener mockListener = Mockito.mock(ShareGroupListener.class);
         ShareSessionCache cache = new ShareSessionCache(3);
+        cache.registerShareGroupListener(mockListener);
+
         assertEquals(0, cache.size());
         ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid().toString(), mockedSharePartitionMap(1), "conn-1");
         ShareSessionKey key2 = cache.maybeCreateSession("grp", Uuid.randomUuid().toString(), mockedSharePartitionMap(2), "conn-2");
@@ -127,10 +130,12 @@ public class ShareSessionCacheTest {
         assertShareCacheContains(cache, List.of(key1, key2, key3));
 
         assertMetricsValues(3, 6, 0, cache);
+        Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty("grp");
 
         // Simulating the disconnection of client with connection id conn-1
         cache.connectionDisconnectListener().onDisconnect("conn-1");
         assertShareCacheContains(cache, List.of(key2, key3));
+        Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty("grp");
 
         assertMetricsValues(2, 5, 1, cache);
 
@@ -139,6 +144,45 @@ public class ShareSessionCacheTest {
         assertShareCacheContains(cache, List.of(key2, key3, key4));
 
         assertMetricsValues(3, 9, 1, cache);
+    }
+
+    @Test
+    public void testRemoveSession() throws InterruptedException {
+        ShareGroupListener mockListener = Mockito.mock(ShareGroupListener.class);
+        ShareSessionCache cache = new ShareSessionCache(3);
+        cache.registerShareGroupListener(mockListener);
+
+        assertEquals(0, cache.size());
+        assertEquals(0, cache.totalPartitions());
+
+        ShareSessionKey key1 = cache.maybeCreateSession("grp", Uuid.randomUuid().toString(), mockedSharePartitionMap(1), "conn-1");
+        ShareSessionKey key2 = cache.maybeCreateSession("grp", Uuid.randomUuid().toString(), mockedSharePartitionMap(2), "conn-2");
+        ShareSessionKey key3 = cache.maybeCreateSession("grp", Uuid.randomUuid().toString(), mockedSharePartitionMap(3), "conn-3");
+
+        assertEquals(3, cache.size());
+        assertEquals(6, cache.totalPartitions());
+        assertMetricsValues(3, 6, 0, cache);
+
+        cache.remove(key1);
+        assertEquals(2, cache.size());
+        assertEquals(5, cache.totalPartitions());
+        assertMetricsValues(2, 5, 0, cache);
+        Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(key1.groupId(), key1.memberId());
+        Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(key1.groupId());
+
+        cache.remove(key2);
+        assertEquals(1, cache.size());
+        assertEquals(3, cache.totalPartitions());
+        assertMetricsValues(1, 3, 0, cache);
+        Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(key1.groupId(), key1.memberId());
+        Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(key1.groupId());
+
+        cache.remove(key3);
+        assertEquals(0, cache.size());
+        assertEquals(0, cache.totalPartitions());
+        assertMetricsValues(0, 0, 0, cache);
+        Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(key1.groupId(), key1.memberId());
+        Mockito.verify(mockListener, Mockito.times(1)).onGroupEmpty(key1.groupId());
     }
 
     @Test
@@ -196,10 +240,13 @@ public class ShareSessionCacheTest {
 
         // Simulate connection disconnect for memberId2.
         cache.connectionDisconnectListener().onDisconnect("conn-2");
-        // Verify both member leave event and empty group event should be triggered.
+        // Verify member leave for memberId2 has triggered along with empty group event. The memberId1
+        // leave event count should be same as before.
         Mockito.verify(mockListener, Mockito.times(1)).onMemberLeave(groupId, memberId1);
         Mockito.verify(mockListener, Mockito.times(1)).onMemberLeave(groupId, memberId2);
-        Mockito.verify(mockListener, Mockito.times(1)).onGroupEmpty(groupId);
+        // Empty group event should be triggered now but would be called twice as the code path
+        // is same when the last member leaves via connection disconnect listener or remove session.
+        Mockito.verify(mockListener, Mockito.times(2)).onGroupEmpty(groupId);
         assertNull(cache.numMembers(groupId));
     }
 
@@ -226,7 +273,7 @@ public class ShareSessionCacheTest {
         // Remove session for group1 and verify listeners are only called for group1.
         cache.connectionDisconnectListener().onDisconnect("conn-1");
         Mockito.verify(mockListener, Mockito.times(1)).onMemberLeave(groupId1, memberId1);
-        Mockito.verify(mockListener, Mockito.times(1)).onGroupEmpty(groupId1);
+        Mockito.verify(mockListener, Mockito.times(2)).onGroupEmpty(groupId1);
         // Listener should not be called for group2.
         Mockito.verify(mockListener, Mockito.times(0)).onMemberLeave(groupId2, memberId2);
         Mockito.verify(mockListener, Mockito.times(0)).onGroupEmpty(groupId2);


### PR DESCRIPTION
The PR fixes couple of issues:
1. Thread safe access to the connection id map.
2. Invoke empty group listener on both code paths i.e. connection
disconnect or session removal on final epoch.
3. Clean up connection map when client sends the initial epoch again on
existing session.

The ShareSessionCache has following paths:

1. Connection Disconnection Listener - Triggers on connection
disconnection. However, if `releaseSession` is triggered on final epoch
then the disconnect listener invocation will not yeild anything as the
connection would have been removed. If the session is not yet released
then the listener removes the session and invokes onMemberLeave and also
invokes onGroupEmpty, if group is empty.

2. `removeAndNotifyListener(ShareSessionKey key)` - Used by
`releaseSession`, invoked on final epoch then that will also remove the
connectionId from connection map along the session cache. Which means
when connection is removed then the connection disconnet listener will
be a no-op. Hence this method also check and triggers group related
triggers i.e. onGroupEmpty.

3. `removeAndMaybeNotifyListener(ShareSessionKey key, boolean
notifyListener)` - Used by `nexContext` which removes old session when
initial epoch from client is received. The method is invoked with
`notifyListener` as false to not trigger onGroupEmpty listener. As there
will be a new session created just after the prior session removal hence
do not remove the repsective share partitions. This is helpful for 1
member share group, do not unneccessary clean up share partitions.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Abhinav Dixit
 <adixit@confluent.io>
