### PR TITLE
KAFKA-19953: Bug releasing acquired records when maintained per offset

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -1089,7 +1089,7 @@ public class SharePartition {
             if (!offsetState.getValue().memberId().equals(memberId) && !offsetState.getValue().memberId().equals(EMPTY_MEMBER_ID)) {
                 log.debug("Member {} is not the owner of offset: {} in batch: {} for the share"
                         + " partition: {}-{}. Skipping offset.", memberId, offsetState.getKey(), inFlightBatch, groupId, topicIdPartition);
-                return Optional.empty();
+                continue;
             }
             if (offsetState.getValue().state() == RecordState.ACQUIRED) {
                 // These records were fetched but they were not actually delivered to the client.


### PR DESCRIPTION
### About
When we have `releaseAcquiredRecords` call on SharePartition and the
batch is being maintained per offset, if we have non matching member id
while releasing acquired records, we should skip only that offset and
continue with the next offset in the batch, not skip all the offsets
after seeing the problematic offset

### Testing
Added unit tests to verify the new functionality

Reviewers: Andrew Schofield <aschofield@confluent.io>, Apoorv Mittal
 <apoorvmittal10@gmail.com>
