### PR TITLE
KAFKA-19956: Fix flaky testRemoteAssignorRange

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerAssignorsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerAssignorsTest.scala
@@ -269,6 +269,7 @@ class PlaintextConsumerAssignorsTest extends AbstractConsumerTest {
     this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "range-group")
     this.consumerConfig.setProperty(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG, "range")
     this.consumerConfig.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "30000")
+    this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
     val consumer = createConsumer()
 
     // create two new topics, each having 2 partitions


### PR DESCRIPTION
This has been flaky, failing with "Topic does not exist" received in a
response to a commit.

This could happen given that the test had the default auto-commit
enabled and was not explicitly closing the consumer (consumer.close
triggered as part of the test infra tear down, which does close with
timeout 0). Seems the topic could end up deleted before the auto-commit
on close was processed.

Disabling auto-commit, not needed for the test.

Reviewers: Andrew Schofield <aschofield@confluent.io>
