### PR TITLE
KAFKA-19950: Mark session stale when removed prior disconnection event

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3370,7 +3370,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                   error(s"Releasing share session close with correlation from client ${request.header.clientId}  " +
                     s"failed with error ${throwable.getMessage}")
                 } else {
-                  info(s"Releasing share session close $releaseAcquiredRecordsData succeeded")
+                  info(s"Releasing share session for client id ${request.header.clientId} succeeded, response: $releaseAcquiredRecordsData")
                 }
               )
           }
@@ -3594,7 +3594,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                   debug(s"Releasing share session close with correlation from client ${request.header.clientId}  " +
                     s"failed with error ${throwable.getMessage}")
                 } else {
-                  info(s"Releasing share session close $releaseAcquiredRecordsData succeeded")
+                  info(s"Releasing share session for client id ${request.header.clientId} succeeded, response: $releaseAcquiredRecordsData")
                 }
               }
           }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4777,12 +4777,6 @@ class KafkaApisTest extends Logging {
     cachedSharePartitions.mustAdd(new CachedSharePartition(
       new TopicIdPartition(topicId, partitionIndex, topicName), false))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenThrow(
-      Errors.INVALID_REQUEST.exception()
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2
-    )))
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -4806,6 +4800,13 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenThrow(
+      Errors.INVALID_REQUEST.exception()
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId)
+    ))
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
@@ -5024,11 +5025,6 @@ class KafkaApisTest extends Logging {
     cachedSharePartitions.mustAdd(new CachedSharePartition(
       new TopicIdPartition(topicId, partitionIndex, topicName), false))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
-      .thenReturn(new ShareSessionContext(1, new ShareSession(
-        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-      )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -5052,6 +5048,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
+      .thenReturn(new ShareSessionContext(1, new ShareSession(
+        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+      )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     val response = verifyNoThrottling[ShareFetchResponse](request)
@@ -5083,11 +5085,6 @@ class KafkaApisTest extends Logging {
     cachedSharePartitions.mustAdd(new CachedSharePartition(
       new TopicIdPartition(topicId, partitionIndex, topicName), false))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
-      .thenReturn(new ShareSessionContext(1, new ShareSession(
-        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-      )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -5111,6 +5108,12 @@ class KafkaApisTest extends Logging {
 
     val shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     val request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any()))
+      .thenReturn(new ShareSessionContext(1, new ShareSession(
+        new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+      )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     val response = verifyNoThrottling[ShareFetchResponse](request)
@@ -5460,16 +5463,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, partitionIndex, topicName), false)
     )
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    ).thenReturn(new ShareSessionContext(2, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 3))
-    )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -5485,6 +5478,16 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    ).thenReturn(new ShareSessionContext(2, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 3, request.context.connectionId))
+    )
 
     // First share fetch request is to establish the share session with the broker.
     kafkaApis = createKafkaApis()
@@ -5725,19 +5728,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId4, 0, topicName4), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
-        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 1)),
-        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 0)),
-        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 1))
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions1, 2))
-    ).thenReturn(new ShareSessionContext(2, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions2, 3))
-    ).thenReturn(new FinalContext())
-
     when(sharePartitionManager.releaseSession(any(), any())).thenReturn(
       CompletableFuture.completedFuture(util.Map.of[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
         new TopicIdPartition(topicId3, new TopicPartition(topicName3, 0)),
@@ -5808,6 +5798,20 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 0)),
+        new TopicIdPartition(topicId1, new TopicPartition(topicName1, 1)),
+        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 0)),
+        new TopicIdPartition(topicId2, new TopicPartition(topicName2, 1))
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions1, 2, request.context.connectionId))
+    ).thenReturn(new ShareSessionContext(2, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions2, 3, request.context.connectionId))
+    ).thenReturn(new FinalContext())
+
     // First share fetch request is to establish the share session with the broker.
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
@@ -6688,14 +6692,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, 0, topicName), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -6720,6 +6716,15 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
@@ -6807,14 +6812,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, 0, topicName), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    )
-
     when(sharePartitionManager.acknowledge(any(), any(), any())).thenReturn(
       CompletableFuture.completedFuture(util.Map.of[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData](
         new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
@@ -6837,6 +6834,15 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)
@@ -14299,14 +14305,6 @@ class KafkaApisTest extends Logging {
       new TopicIdPartition(topicId, 0, topicName), false
     ))
 
-    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
-      new ShareSessionContext(0, util.List.of(
-        new TopicIdPartition(topicId, partitionIndex, topicName)
-      ))
-    ).thenReturn(new ShareSessionContext(1, new ShareSession(
-      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2))
-    )
-
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
       any[Session](), anyString, anyDouble, anyLong)).thenReturn(0)
 
@@ -14331,6 +14329,15 @@ class KafkaApisTest extends Logging {
 
     var shareFetchRequest = new ShareFetchRequest.Builder(shareFetchRequestData).build(ApiKeys.SHARE_FETCH.latestVersion)
     var request = buildRequest(shareFetchRequest)
+
+    when(sharePartitionManager.newContext(any(), any(), any(), any(), any(), any(), any())).thenReturn(
+      new ShareSessionContext(0, util.List.of(
+        new TopicIdPartition(topicId, partitionIndex, topicName)
+      ))
+    ).thenReturn(new ShareSessionContext(1, new ShareSession(
+      new ShareSessionKey(groupId, memberId), cachedSharePartitions, 2, request.context.connectionId))
+    )
+
     kafkaApis = createKafkaApis()
     kafkaApis.handleShareFetchRequest(request)
     var response = verifyNoThrottling[ShareFetchResponse](request)

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSession.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSession.java
@@ -38,6 +38,7 @@ public class ShareSession {
 
     private final ShareSessionKey key;
     private final ImplicitLinkedHashCollection<CachedSharePartition> partitionMap;
+    private final String connectionId;
 
     // visible for testing
     public int epoch;
@@ -48,16 +49,23 @@ public class ShareSession {
     /**
      * The share session.
      * Each share session is protected by its own lock, which must be taken before mutable
-     * fields are read or modified.  This includes modification of the share session partition map.
+     * fields are read or modified. This includes modification of the share session partition map.
      *
      * @param key                The share session key to identify the share session uniquely.
      * @param partitionMap       The CachedPartitionMap.
      * @param epoch              The share session sequence number.
+     * @param connectionId       The connection id associated with this share session.
      */
-    public ShareSession(ShareSessionKey key, ImplicitLinkedHashCollection<CachedSharePartition> partitionMap, int epoch) {
+    public ShareSession(
+        ShareSessionKey key,
+        ImplicitLinkedHashCollection<CachedSharePartition> partitionMap,
+        int epoch,
+        String connectionId
+    ) {
         this.key = key;
         this.partitionMap = partitionMap;
         this.epoch = epoch;
+        this.connectionId = connectionId;
     }
 
     public ShareSessionKey key() {
@@ -83,6 +91,10 @@ public class ShareSession {
 
     public synchronized Boolean isEmpty() {
         return partitionMap.isEmpty();
+    }
+
+    public String connectionId() {
+        return connectionId;
     }
 
     // Update the cached partition data based on the request.
@@ -138,6 +150,7 @@ public class ShareSession {
                 ", partitionMap=" + partitionMap +
                 ", epoch=" + epoch +
                 ", cachedSize=" + cachedSize +
+                ", connectionId=" + connectionId +
                 ")";
     }
 }

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -128,13 +128,13 @@ public class ShareSessionCache {
     }
 
     /**
-     * Maybe remove the session and notify listeners. This is called when the connection is disconnected
-     * for the client. The session may have already been removed by the client as part of final epoch,
-     * hence check if the session is still present in the cache.
+     * Maybe remove the session and notify member leave listener. This is called when the connection
+     * is disconnected for the client. The session may have already been removed by the client as part
+     * of final epoch, hence check if the session is still present in the cache.
      *
      * @param key The share session key.
      */
-    private void maybeRemoveAndNotifyListeners(ShareSessionKey key) {
+    private void maybeRemoveAndNotifyListenersOnMemberLeave(ShareSessionKey key) {
         ShareSession session;
         synchronized (this) {
             session = get(key);
@@ -242,7 +242,7 @@ public class ShareSessionCache {
      *
      * @param groupId The share group id.
      */
-    private void checkAndNotifyGroupListeners(String groupId) {
+    private void checkAndNotifyListenersOnGroupEmpty(String groupId) {
         boolean notify = false;
         synchronized (this) {
             int numMembers = numMembersPerGroup.getOrDefault(groupId, 0);
@@ -287,11 +287,11 @@ public class ShareSessionCache {
                     // Try removing session and notify listeners. The session might already be removed
                     // as part of final epoch from client, so we need to check if the session is still
                     // present in the cache.
-                    maybeRemoveAndNotifyListeners(sessionKeyAndState.shareSessionKey());
+                    maybeRemoveAndNotifyListenersOnMemberLeave(sessionKeyAndState.shareSessionKey());
                 }
                 // Notify the share group listener if the group is empty. This should be checked regardless
                 // session is evicted by connection disconnect or client's final epoch.
-                checkAndNotifyGroupListeners(sessionKeyAndState.shareSessionKey().groupId());
+                checkAndNotifyListenersOnGroupEmpty(sessionKeyAndState.shareSessionKey().groupId());
             }
         }
     }

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -281,8 +281,8 @@ public class ShareSessionCache {
         @Override
         public void onDisconnect(String connectionId) {
             SessionKeyAndState sessionKeyAndState = maybeRemoveConnectionFromSession(connectionId);
-            // If the session is not stale, try removing the session and notify listeners.
             if (sessionKeyAndState != null) {
+                // If the session is not stale, try removing the session and notify listeners.
                 if (!sessionKeyAndState.stale()) {
                     // Try removing session and notify listeners. The session might already be removed
                     // as part of final epoch from client, so we need to check if the session is still

--- a/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
+++ b/server/src/main/java/org/apache/kafka/server/share/session/ShareSessionCache.java
@@ -67,7 +67,7 @@ public class ShareSessionCache {
      * The map to store the client connection id to session key. This is used to remove the session
      * from the cache when the respective client disconnects.
      */
-    private final Map<String, ShareSessionKey> connectionIdToSessionMap;
+    private final Map<String, SessionKeyAndState> connectionIdToSessionMap;
     /**
      * The listener for share group events. This is used to notify the listener when the group members
      * change.
@@ -113,6 +113,7 @@ public class ShareSessionCache {
         sessions.clear();
         numMembersPerGroup.clear();
         numPartitions = 0;
+        // Avoid cleaning up connectionIdToSessionMap as that map is cleaned when the client disconnects.
     }
 
     public synchronized long totalPartitions() {
@@ -133,8 +134,17 @@ public class ShareSessionCache {
      *
      * @param key The share session key.
      */
-    public synchronized void maybeRemoveAndNotifyListeners(ShareSessionKey key) {
-        ShareSession session = get(key);
+    private void maybeRemoveAndNotifyListeners(ShareSessionKey key) {
+        ShareSession session;
+        synchronized (this) {
+            session = get(key);
+            if (session != null) {
+                // As session is not null hence it's removed as part of connection disconnect. Hence,
+                // update the evictions metric.
+                evictionsMeter.mark();
+            }
+        }
+
         if (session != null) {
             // Notify the share group listener that member has left the group. Notify listener prior
             // removing the session from the cache to ensure that the listener has access to the session
@@ -142,22 +152,9 @@ public class ShareSessionCache {
             if (shareGroupListener != null) {
                 shareGroupListener.onMemberLeave(key.groupId(), key.memberId());
             }
-            // As session is not null hence it's removed as part of connection disconnect. Hence,
-            // update the evictions metric.
-            evictionsMeter.mark();
             // Try removing session if not already removed. The listener might have removed the session
             // already.
             remove(session);
-        }
-        // Notify the share group listener if the group is empty. This should be checked regardless
-        // session is evicted by connection disconnect or client's final epoch.
-        int numMembers = numMembersPerGroup.getOrDefault(key.groupId(), 0);
-        if (numMembers == 0) {
-            // Remove the group from the map as it is empty.
-            numMembersPerGroup.remove(key.groupId());
-            if (shareGroupListener != null) {
-                shareGroupListener.onGroupEmpty(key.groupId());
-            }
         }
     }
 
@@ -172,6 +169,17 @@ public class ShareSessionCache {
         if (removeResult != null) {
             numPartitions = numPartitions - session.cachedSize();
             numMembersPerGroup.compute(session.key().groupId(), (k, v) -> v != null ? v - 1 : 0);
+            // Mark the session as stale in the connectionIdToSessionMap to avoid removing
+            // the active session for the client. When client re-sends the initial epoch where the
+            // broker removes the prior session and establishes new session, then sometimes the connection
+            // id is changed. This leads to removal of the new session from the cache, when old connection
+            // disconnect event is processed. Marking the old connection as stale avoids this issue.
+            // If the connection id remains same for both old and new session, then the subsequent call
+            // for session creation will overwrite the prior stale mapping in the connectionIdToSessionMap.
+            SessionKeyAndState sessionKeyAndState = connectionIdToSessionMap.get(session.connectionId());
+            if (sessionKeyAndState != null) {
+                sessionKeyAndState.markStale();
+            }
         }
         return removeResult;
     }
@@ -201,11 +209,11 @@ public class ShareSessionCache {
     ) {
         if (sessions.size() < maxEntries) {
             ShareSession session = new ShareSession(new ShareSessionKey(groupId, memberId), partitionMap,
-                ShareRequestMetadata.nextEpoch(ShareRequestMetadata.INITIAL_EPOCH));
+                ShareRequestMetadata.nextEpoch(ShareRequestMetadata.INITIAL_EPOCH), clientConnectionId);
             sessions.put(session.key(), session);
             updateNumPartitions(session);
             numMembersPerGroup.compute(session.key().groupId(), (k, v) -> v != null ? v + 1 : 1);
-            connectionIdToSessionMap.put(clientConnectionId, session.key());
+            connectionIdToSessionMap.put(clientConnectionId, new SessionKeyAndState(session.key()));
             return session.key();
         }
         return null;
@@ -219,6 +227,39 @@ public class ShareSessionCache {
         this.shareGroupListener = shareGroupListener;
     }
 
+    /**
+     * Remove the connection id to session mapping when the connection is closed.
+     *
+     * @param connectionId The client connection id.
+     * @return The session key, or null if no such mapping was found.
+     */
+    private synchronized SessionKeyAndState maybeRemoveConnectionFromSession(String connectionId) {
+        return connectionIdToSessionMap.remove(connectionId);
+    }
+
+    /**
+     * Check if the share group is empty and notify the share group listener.
+     *
+     * @param groupId The share group id.
+     */
+    private void checkAndNotifyGroupListeners(String groupId) {
+        boolean notify = false;
+        synchronized (this) {
+            int numMembers = numMembersPerGroup.getOrDefault(groupId, 0);
+            if (numMembers == 0) {
+                // Remove the group from the map as it is empty.
+                numMembersPerGroup.remove(groupId);
+                if (shareGroupListener != null) {
+                    notify = true;
+                }
+            }
+        }
+        // Notify outside the synchronized block to avoid potential deadlocks.
+        if (notify) {
+            shareGroupListener.onGroupEmpty(groupId);
+        }
+    }
+
     // Visible for testing.
     Meter evictionsMeter() {
         return evictionsMeter;
@@ -229,18 +270,56 @@ public class ShareSessionCache {
         return numMembersPerGroup.get(groupId);
     }
 
+    // Visible for testing.
+    synchronized SessionKeyAndState connectionSessionKeyAndState(String connectionId) {
+        return connectionIdToSessionMap.get(connectionId);
+    }
+
     private final class ClientConnectionDisconnectListener implements ConnectionDisconnectListener {
 
         // When the client disconnects, the corresponding session should be removed from the cache.
         @Override
         public void onDisconnect(String connectionId) {
-            ShareSessionKey shareSessionKey = connectionIdToSessionMap.remove(connectionId);
-            if (shareSessionKey != null) {
-                // Try removing session and notify listeners. The session might already be removed
-                // as part of final epoch from client, so we need to check if the session is still
-                // present in the cache.
-                maybeRemoveAndNotifyListeners(shareSessionKey);
+            SessionKeyAndState sessionKeyAndState = maybeRemoveConnectionFromSession(connectionId);
+            // If the session is not stale, try removing the session and notify listeners.
+            if (sessionKeyAndState != null) {
+                if (!sessionKeyAndState.stale()) {
+                    // Try removing session and notify listeners. The session might already be removed
+                    // as part of final epoch from client, so we need to check if the session is still
+                    // present in the cache.
+                    maybeRemoveAndNotifyListeners(sessionKeyAndState.shareSessionKey());
+                }
+                // Notify the share group listener if the group is empty. This should be checked regardless
+                // session is evicted by connection disconnect or client's final epoch.
+                checkAndNotifyGroupListeners(sessionKeyAndState.shareSessionKey().groupId());
             }
+        }
+    }
+
+    /**
+     * The class records the session key and tracks if the session is stale. The session is marked stale
+     * when the session is removed from the cache prior to the client disconnect event.
+     */
+    // Visible for testing.
+    static class SessionKeyAndState {
+        private final ShareSessionKey shareSessionKey;
+        private boolean stale;
+
+        SessionKeyAndState(ShareSessionKey shareSessionKey) {
+            this.shareSessionKey = shareSessionKey;
+            this.stale = false;
+        }
+
+        ShareSessionKey shareSessionKey() {
+            return shareSessionKey;
+        }
+
+        boolean stale() {
+            return stale;
+        }
+
+        void markStale() {
+            this.stale = true;
         }
     }
 }


### PR DESCRIPTION
The PR marks the old session stale in connection listener map to avoid
triggering the member leave event. This is more often see when client
sends the share fetch request again with `initial epoch`, then broker
refreshes the connection.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Abhinav Dixit
 <adixit@confluent.io>
