### PR TITLE
MINOR: Rename OptimizedUniformAssignmentBuilderTest

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/UniformHomogeneousAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/UniformHomogeneousAssignmentBuilderTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OptimizedUniformAssignmentBuilderTest {
+public class UniformHomogeneousAssignmentBuilderTest {
     private final UniformAssignor assignor = new UniformAssignor();
     private final Uuid topic1Uuid = Uuid.fromString("T1-A4s3VTwiI5CTbEp6POw");
     private final Uuid topic2Uuid = Uuid.fromString("T2-B4s3VTwiI5YHbPp6YUe");


### PR DESCRIPTION
Rename OptimizedUniformAssignmentBuilderTest to
UniformHomogeneousAssignmentBuilderTest, since the class being tested is
named UniformHomogeneousAssignmentBuilder.

Reviewers: David Jacot <djacot@confluent.io>
