### PR TITLE
MINOR: Fix typo in MemberAssignmentImplTest

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/MemberAssignmentImplTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/MemberAssignmentImplTest.java
@@ -30,7 +30,7 @@ public class MemberAssignmentImplTest {
 
     @Test
     public void testPartitionsMutable() {
-        // We depend on the the map inside MemberAssignmentImpl remaining mutable in the server-side
+        // We depend on the map inside MemberAssignmentImpl remaining mutable in the server-side
         // assignors, otherwise we end up deep copying the map unnecessarily.
         Uuid topicId1 = Uuid.randomUuid();
         Uuid topicId2 = Uuid.randomUuid();


### PR DESCRIPTION
Fix typo in MemberAssignmentImplTest comment.

Reviewers: David Jacot <djacot@confluent.io>