### PR TITLE
KAFKA-19941: Improved property spacing/readability of kafka-features.sh output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -241,7 +241,7 @@ public class FeatureCommand {
         featureMetadata.supportedFeatures().keySet().stream().sorted().forEach(feature -> {
             short finalizedLevel = (featureMetadata.finalizedFeatures().get(feature) == null) ? 0 : featureMetadata.finalizedFeatures().get(feature).maxVersionLevel();
             SupportedVersionRange range = featureMetadata.supportedFeatures().get(feature);
-            System.out.printf("Feature: %s\t\tSupportedMinVersion: %s\t\tSupportedMaxVersion: %s\t\tFinalizedVersionLevel: %s\t\tEpoch: %s%n",
+            System.out.printf("Feature: %-40s  SupportedMinVersion: %-15s  SupportedMaxVersion: %-15s  FinalizedVersionLevel: %-15s  Epoch: %s%n",
                     feature,
                     levelToString(feature, range.minVersion()),
                     levelToString(feature, range.maxVersion()),

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -241,7 +241,7 @@ public class FeatureCommand {
         featureMetadata.supportedFeatures().keySet().stream().sorted().forEach(feature -> {
             short finalizedLevel = (featureMetadata.finalizedFeatures().get(feature) == null) ? 0 : featureMetadata.finalizedFeatures().get(feature).maxVersionLevel();
             SupportedVersionRange range = featureMetadata.supportedFeatures().get(feature);
-            System.out.printf("Feature: %s\tSupportedMinVersion: %s\tSupportedMaxVersion: %s\tFinalizedVersionLevel: %s\tEpoch: %s%n",
+            System.out.printf("Feature: %s\t\tSupportedMinVersion: %s\t\tSupportedMaxVersion: %s\t\tFinalizedVersionLevel: %s\t\tEpoch: %s%n",
                     feature,
                     levelToString(feature, range.minVersion()),
                     levelToString(feature, range.maxVersion()),

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -151,20 +151,34 @@ public class FeatureCommandTest {
         List<String> featuresWithUnstable = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: eligible.leader.replicas.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(0)));
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(1)));
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(2)));
-        assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-            "SupportedMaxVersion: 4.3-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(featuresWithUnstable.get(3)));
-        assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(4)));
-        assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(5)));
-        assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(6)));
+        assertFeatureOutput(
+                "eligible.leader.replicas.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(0))
+        );
+        assertFeatureOutput(
+                "group.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(1))
+        );
+        assertFeatureOutput(
+                "kraft.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(2))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "4.3-IV0", "3.7-IV0",
+                outputWithoutEpoch(featuresWithUnstable.get(3))
+        );
+        assertFeatureOutput(
+                "share.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(4))
+        );
+        assertFeatureOutput(
+                "streams.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(5))
+        );
+        assertFeatureOutput(
+                "transaction.version", "0", "2", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(6))
+        );
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
             assertEquals(
@@ -174,20 +188,34 @@ public class FeatureCommandTest {
         );
         List<String> featuresWithoutUnstable = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
-        assertEquals("Feature: eligible.leader.replicas.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(0)));
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(1)));
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(2)));
-        assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-            "SupportedMaxVersion: 4.2-IV1\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(featuresWithoutUnstable.get(3)));
-        assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(4)));
-        assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(5)));
-        assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(6)));
+        assertFeatureOutput(
+                "eligible.leader.replicas.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(0))
+        );
+        assertFeatureOutput(
+                "group.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(1))
+        );
+        assertFeatureOutput(
+                "kraft.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(2))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "4.2-IV1", "3.7-IV0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(3))
+        );
+        assertFeatureOutput(
+                "share.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(4))
+        );
+        assertFeatureOutput(
+                "streams.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(5))
+        );
+        assertFeatureOutput(
+                "transaction.version", "0", "2", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(6))
+        );
     }
 
     @ClusterTest(
@@ -217,20 +245,34 @@ public class FeatureCommandTest {
         List<String> featuresWithUnstable = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: eligible.leader.replicas.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(0)));
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(1)));
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(2)));
-        assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-            "SupportedMaxVersion: 4.3-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(featuresWithUnstable.get(3)));
-        assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(4)));
-        assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(5)));
-        assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(6)));
+        assertFeatureOutput(
+                "eligible.leader.replicas.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(0))
+        );
+        assertFeatureOutput(
+                "group.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(1))
+        );
+        assertFeatureOutput(
+                "kraft.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(2))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "4.3-IV0", "3.7-IV0",
+                outputWithoutEpoch(featuresWithUnstable.get(3))
+        );
+        assertFeatureOutput(
+                "share.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(4))
+        );
+        assertFeatureOutput(
+                "streams.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(5))
+        );
+        assertFeatureOutput(
+                "transaction.version", "0", "2", "0",
+                outputWithoutEpoch(featuresWithUnstable.get(6))
+        );
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
             assertEquals(
@@ -240,20 +282,34 @@ public class FeatureCommandTest {
         );
         List<String> featuresWithoutUnstable = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
-        assertEquals("Feature: eligible.leader.replicas.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(0)));
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(1)));
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(2)));
-        assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-            "SupportedMaxVersion: 4.2-IV1\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(featuresWithoutUnstable.get(3)));
-        assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(4)));
-        assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithUnstable.get(5)));
-        assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-            "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(featuresWithoutUnstable.get(6)));
+        assertFeatureOutput(
+                "eligible.leader.replicas.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(0))
+        );
+        assertFeatureOutput(
+                "group.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(1))
+        );
+        assertFeatureOutput(
+                "kraft.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(2))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "4.2-IV1", "3.7-IV0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(3))
+        );
+        assertFeatureOutput(
+                "share.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(4))
+        );
+        assertFeatureOutput(
+                "streams.version", "0", "1", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(5))
+        );
+        assertFeatureOutput(
+                "transaction.version", "0", "2", "0",
+                outputWithoutEpoch(featuresWithoutUnstable.get(6))
+        );
     }
 
     @ClusterTest(types = {Type.KRAFT}, metadataVersion = MetadataVersion.IBP_3_3_IV3)

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static org.apache.kafka.clients.admin.FeatureUpdate.UpgradeType.SAFE_DOWNGRADE;
@@ -53,21 +54,34 @@ public class FeatureCommandTest {
 
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
-        // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: eligible.leader.replicas.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(0)));
-        assertEquals("Feature: group.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(1)));
-        assertEquals("Feature: kraft.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(2)));
-        assertEquals("Feature: metadata.version\t\tSupportedMinVersion: 3.3-IV3\t\t" +
-                "SupportedMaxVersion: 4.3-IV0\t\tFinalizedVersionLevel: 3.3-IV3\t\t", outputWithoutEpoch(features.get(3)));
-        assertEquals("Feature: share.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(4)));
-        assertEquals("Feature: streams.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(5)));
-        assertEquals("Feature: transaction.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 2\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(6)));
+        assertFeatureOutput(
+                "eligible.leader.replicas.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(0))
+        );
+        assertFeatureOutput(
+                "group.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(1))
+        );
+        assertFeatureOutput(
+                "kraft.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(2))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "4.3-IV0", "3.3-IV3",
+                outputWithoutEpoch(features.get(3))
+        );
+        assertFeatureOutput(
+                "share.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(4))
+        );
+        assertFeatureOutput(
+                "streams.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(5))
+        );
+        assertFeatureOutput(
+                "transaction.version", "0", "2", "0",
+                outputWithoutEpoch(features.get(6))
+        );
     }
 
     // Use the first MetadataVersion that supports KIP-919
@@ -80,20 +94,34 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: eligible.leader.replicas.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(0)));
-        assertEquals("Feature: group.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(1)));
-        assertEquals("Feature: kraft.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(2)));
-        assertEquals("Feature: metadata.version\t\tSupportedMinVersion: 3.3-IV3\t\t" +
-                "SupportedMaxVersion: 4.3-IV0\t\tFinalizedVersionLevel: 3.7-IV0\t\t", outputWithoutEpoch(features.get(3)));
-        assertEquals("Feature: share.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(4)));
-        assertEquals("Feature: streams.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(5)));
-        assertEquals("Feature: transaction.version\t\tSupportedMinVersion: 0\t\t" +
-                "SupportedMaxVersion: 2\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(6)));
+        assertFeatureOutput(
+                "eligible.leader.replicas.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(0))
+        );
+        assertFeatureOutput(
+                "group.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(1))
+        );
+        assertFeatureOutput(
+                "kraft.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(2))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "4.3-IV0", "3.7-IV0",
+                outputWithoutEpoch(features.get(3))
+        );
+        assertFeatureOutput(
+                "share.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(4))
+        );
+        assertFeatureOutput(
+                "streams.version", "0", "1", "0",
+                outputWithoutEpoch(features.get(5))
+        );
+        assertFeatureOutput(
+                "transaction.version", "0", "2", "0",
+                outputWithoutEpoch(features.get(6))
+        );
     }
 
     @ClusterTest(
@@ -390,8 +418,16 @@ public class FeatureCommandTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals(format("Feature: foo.bar\t\tSupportedMinVersion: 0\t\tSupportedMaxVersion: 10\t\tFinalizedVersionLevel: 5\t\tEpoch: 123%n" +
-            "Feature: metadata.version\t\tSupportedMinVersion: 3.3-IV3\t\tSupportedMaxVersion: 3.5-IV0\t\tFinalizedVersionLevel: 3.4-IV0\t\tEpoch: 123"), describeResult);
+
+        List<String> features = Arrays.stream(describeResult.split("\n")).sorted().toList();
+        assertFeatureOutput(
+                "foo.bar", "0", "10", "5",
+                outputWithoutEpoch(features.get(0))
+        );
+        assertFeatureOutput(
+                "metadata.version", "3.3-IV3", "3.5-IV0", "3.4-IV0",
+                outputWithoutEpoch(features.get(1))
+        );
     }
 
     @Test
@@ -710,5 +746,23 @@ public class FeatureCommandTest {
         );
 
         assertEquals(expectedOutput.trim(), output.trim());
+    }
+
+    private static void assertFeatureOutput(
+            String expectedFeature,
+            String expectedMinVersion,
+            String expectedMaxVersion,
+            String expectedFinalizedVersion,
+            String actualFeature
+    ) {
+        String featureFormattingRegex = String.format(
+                "Feature:\\s+%s\\s+SupportedMinVersion:\\s+%s\\s+SupportedMaxVersion:\\s+%s\\s+FinalizedVersionLevel:\\s+%s\\s*$",
+                Pattern.quote(expectedFeature),
+                Pattern.quote(expectedMinVersion),
+                Pattern.quote(expectedMaxVersion),
+                Pattern.quote(expectedFinalizedVersion)
+        );
+
+        assertTrue(actualFeature.matches(featureFormattingRegex));
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -54,20 +54,20 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: eligible.leader.replicas.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(1)));
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
-        assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-                "SupportedMaxVersion: 4.3-IV0\tFinalizedVersionLevel: 3.3-IV3\t", outputWithoutEpoch(features.get(3)));
-        assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(4)));
-        assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(5)));
-        assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(6)));
+        assertEquals("Feature: eligible.leader.replicas.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(0)));
+        assertEquals("Feature: group.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(1)));
+        assertEquals("Feature: kraft.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(2)));
+        assertEquals("Feature: metadata.version\t\tSupportedMinVersion: 3.3-IV3\t\t" +
+                "SupportedMaxVersion: 4.3-IV0\t\tFinalizedVersionLevel: 3.3-IV3\t\t", outputWithoutEpoch(features.get(3)));
+        assertEquals("Feature: share.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(4)));
+        assertEquals("Feature: streams.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(5)));
+        assertEquals("Feature: transaction.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 2\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(6)));
     }
 
     // Use the first MetadataVersion that supports KIP-919
@@ -80,20 +80,20 @@ public class FeatureCommandTest {
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
-        assertEquals("Feature: eligible.leader.replicas.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(0)));
-        assertEquals("Feature: group.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(1)));
-        assertEquals("Feature: kraft.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(2)));
-        assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\t" +
-                "SupportedMaxVersion: 4.3-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(features.get(3)));
-        assertEquals("Feature: share.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(4)));
-        assertEquals("Feature: streams.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 1\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(5)));
-        assertEquals("Feature: transaction.version\tSupportedMinVersion: 0\t" +
-                "SupportedMaxVersion: 2\tFinalizedVersionLevel: 0\t", outputWithoutEpoch(features.get(6)));
+        assertEquals("Feature: eligible.leader.replicas.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(0)));
+        assertEquals("Feature: group.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(1)));
+        assertEquals("Feature: kraft.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(2)));
+        assertEquals("Feature: metadata.version\t\tSupportedMinVersion: 3.3-IV3\t\t" +
+                "SupportedMaxVersion: 4.3-IV0\t\tFinalizedVersionLevel: 3.7-IV0\t\t", outputWithoutEpoch(features.get(3)));
+        assertEquals("Feature: share.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(4)));
+        assertEquals("Feature: streams.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 1\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(5)));
+        assertEquals("Feature: transaction.version\t\tSupportedMinVersion: 0\t\t" +
+                "SupportedMaxVersion: 2\t\tFinalizedVersionLevel: 0\t\t", outputWithoutEpoch(features.get(6)));
     }
 
     @ClusterTest(
@@ -390,8 +390,8 @@ public class FeatureCommandTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals(format("Feature: foo.bar\tSupportedMinVersion: 0\tSupportedMaxVersion: 10\tFinalizedVersionLevel: 5\tEpoch: 123%n" +
-            "Feature: metadata.version\tSupportedMinVersion: 3.3-IV3\tSupportedMaxVersion: 3.5-IV0\tFinalizedVersionLevel: 3.4-IV0\tEpoch: 123"), describeResult);
+        assertEquals(format("Feature: foo.bar\t\tSupportedMinVersion: 0\t\tSupportedMaxVersion: 10\t\tFinalizedVersionLevel: 5\t\tEpoch: 123%n" +
+            "Feature: metadata.version\t\tSupportedMinVersion: 3.3-IV3\t\tSupportedMaxVersion: 3.5-IV0\t\tFinalizedVersionLevel: 3.4-IV0\t\tEpoch: 123"), describeResult);
     }
 
     @Test


### PR DESCRIPTION
### Description

Closes: [KAFKA-19941](https://issues.apache.org/jira/browse/KAFKA-19941)

The goal of this minor pull request was to improve the existing
readability for the `kafka-features.sh` output which could be difficult
to decipher due to the inadequate spacing between properties. This
change improves that spacing by replacing the previous tab-based spacing
with a fixed-width approach to standardize property alignment.

In addition to these changes all of the affected tests within the
`FeatureCommandTest` suite were updated to ensure all of the existing
tests were passing after the changes were made.

### Discussion and Rationale

These changes were discussed briefly within [this mailing list
thread](https://lists.apache.org/thread/jwcn88o4f4c19x1onymxmkddk3dcsckf),
however the conversation was primarily about if adjusting output would
equate to changing a public interface -- thus requiring a KIP.

While there were several possible options to improve the readability or
to support multiple formats potentially via an output parameter (e.g.
`--output=table` to table-formatted output, similarly with JSON, etc.),
these would be much larger bodies of work. The simplest approach in this
case was to just improve the spacing and allow the end-user to adopt
their preferred transformation from the existing format.

### Example Output

<img width="1381" height="163" alt="kafka-features-alignment-output"
src="https://github.com/user-attachments/assets/0266bbd8-ea91-498f-a0b7-d3f573fdf442"
/>

### Mentions

Tagging @chia7712 for review (as the initial creator of the JIRA)

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
