### PR TITLE
MINOR: Fix a typo in connect.html

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -198,7 +198,7 @@ transforms.InsertSource.static.value=test-file-source</code></pre>
         <li><code>predicates.$alias.$predicateSpecificConfig</code> - Configuration properties for the predicate.</li>
     </ul>
 
-    <p>All transformations have the implicit config properties <code>predicate</code> and <code>negate</code>. A predicular predicate is associated with a transformation by setting the transformation's <code>predicate</code> config to the predicate's alias. The predicate's value can be reversed using the <code>negate</code> configuration property.</p>
+    <p>All transformations have the implicit config properties <code>predicate</code> and <code>negate</code>. A particular predicate is associated with a transformation by setting the transformation's <code>predicate</code> config to the predicate's alias. The predicate's value can be reversed using the <code>negate</code> configuration property.</p>
 
     <p>For example, suppose you have a source connector which produces messages to many different topics and you want to:</p>
     <ul>


### PR DESCRIPTION
Fixes a small typo in connect.html.

Reviewers: Andrew Schofield <aschofield@confluent.io>
