### PR TITLE
MINOR: Fix assignment reuse tests

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/CommonAssignorTests.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/CommonAssignorTests.java
@@ -123,7 +123,9 @@ public class CommonAssignorTests {
         );
 
         for (String memberId : members.keySet()) {
-            assertSame(firstAssignment.members().get(memberId).partitions(), secondAssignment.members().get(memberId).partitions());
+            // The assignment map from the assignor must be the same as the immutable assignment map
+            // that went in.
+            assertSame(membersWithAssignment.get(memberId).partitions(), secondAssignment.members().get(memberId).partitions());
         }
     }
 


### PR DESCRIPTION
The tests were asserting reference equality against the wrong assignment
map.

Reviewers: David Jacot <djacot@confluent.io>
