### PR TITLE
MINOR Clarified maximum length of COMPACT_STRING

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -549,7 +549,8 @@ public abstract class Type {
         @Override
         public String documentation() {
             return "Represents a sequence of characters. First the length N + 1 is given as an UNSIGNED_VARINT " +
-                    ". Then N bytes follow which are the UTF-8 encoding of the character sequence.";
+                    ". Then N bytes follow which are the UTF-8 encoding of the character sequence. " +
+                    "The size of the string may not be more than 32767 bytes.";
         }
     };
 


### PR DESCRIPTION
This is a minor documentation change. Related to mailing list discussion [here](https://lists.apache.org/thread/d6lpwtqqzok69twndwzxx2zp09dmvjq8)