### PR TITLE
KAFKA-19965: Increasing batch size to fix throttled delivery test

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -3492,7 +3492,11 @@ public class ShareConsumerTest {
         try (Producer<byte[], byte[]> producer = createProducer();
             ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(
                 "group1",
-                Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT))
+                Map.of(
+                    ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT,
+                    ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 512
+                )
+            )
         ) {
             // Produce records in complete power of 2 to fully test the throttling behavior.
             int producedMessageCount = 512;


### PR DESCRIPTION
The PR increases the max.poll.records config to 512 as the produced
batch is of 512 records. SharePartition creates batches as per `share
fetch` request batch-size config, which is currently controlled by
max.poll.records. Drfault max.poll.records config is 500 and If producer
generates multiple batches on log then there will be multiple batches in
share partition. The throttled response in fetch is based on batch size
in share partition hence subsequent throttles fetch calls can have
different sizes as per the produces batches. To make sure the batch is
of correct size in share partition increase the max.poll.records to 512.

The same has been done in other test but missed in the current PR test:
https://github.com/apache/kafka/blob/a8b1fb9203133a356732bf069aa3e0dd9b1716b7/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java#L3707

Reviewers: Andrew Schofield <aschofield@confluent.io>, Lan Ding
 <isDing_L@163.com>
