### PR TITLE
KAFKA-19966: Upgrade commons-validator to 1.10.1 (3.9)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -214,7 +214,7 @@ commons-digester-2.1
 commons-io-2.14.0
 commons-lang3-3.18.0
 commons-logging-1.3.5
-commons-validator-1.7
+commons-validator-1.10.1
 error_prone_annotations-2.10.0
 jackson-annotations-2.16.2
 jackson-core-2.16.2

--- a/build.gradle
+++ b/build.gradle
@@ -163,8 +163,6 @@ allprojects {
           libs.nettyTransportNativeEpoll,
           // be explicit about the reload4j version instead of relying on the transitive versions
           libs.reload4j,
-          // Workaround before `commons-validator` has new release. See KAFKA-19359.
-          libs.commonsBeanutils,
           libs.commonsLang
         )
       }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -91,9 +91,8 @@ versions += [
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   commonsIo: "2.14.0", // ZooKeeper dependency. Do not use, this is going away.
-  commonsBeanutils: "1.11.0",
   commonsLang: "3.18.0",
-  commonsValidator: "1.7",
+  commonsValidator: "1.10.1",
   dropwizardMetrics: "4.1.12.1",
   gradle: "8.10.2",
   grgit: "4.1.1",
@@ -184,7 +183,6 @@ libs += [
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsIo: "commons-io:commons-io:$versions.commonsIo",
-  commonsBeanutils: "commons-beanutils:commons-beanutils:$versions.commonsBeanutils",
   commonsLang: "org.apache.commons:commons-lang3:$versions.commonsLang",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",


### PR DESCRIPTION
Upgrade commons-validator to 1.10.1 and remove the workarounds
introduced by KAFKA-19359

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>