### PR TITLE
MINOR: Scala, Scalafmt and Scalac SCoverage plugin version updates

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -247,9 +247,9 @@ License Version 2.0:
 - opentelemetry-proto-1.3.2-alpha
 - plexus-utils-3.6.0
 - rocksdbjni-10.1.3
-- scala-library-2.13.17
+- scala-library-2.13.18
 - scala-logging_2.13-3.9.6
-- scala-reflect-2.13.17
+- scala-reflect-2.13.18
 - snappy-java-1.1.10.7
 - snakeyaml-2.4
 - swagger-annotations-2.2.39

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -49,7 +49,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.13.17
+  SCALA_VERSION=2.13.18
   if [[ -f "$base_dir/gradle.properties" ]]; then
     SCALA_VERSION=`grep "^scalaVersion=" "$base_dir/gradle.properties" | cut -d= -f 2`
   fi

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -27,7 +27,7 @@ set BASE_DIR=%CD%
 popd
 
 IF ["%SCALA_VERSION%"] EQU [""] (
-  set SCALA_VERSION=2.13.17
+  set SCALA_VERSION=2.13.18
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (

--- a/checkstyle/.scalafmt.conf
+++ b/checkstyle/.scalafmt.conf
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-version = 3.10.0
+version = 3.10.2
 runner.dialect = scala213
 docstrings.style = Asterisk
 docstrings.wrap = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ group=org.apache.kafka
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
 version=4.3.0-SNAPSHOT
-scalaVersion=2.13.17
+scalaVersion=2.13.18
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 swaggerVersion=2.2.39
 task=build

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
 }
 
 // Add Scala version
-def defaultScala213Version = '2.13.17'
+def defaultScala213Version = '2.13.18'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.13') {
     versions["scala"] = defaultScala213Version
@@ -121,8 +121,8 @@ versions += [
   // When updating the scalafmt version please also update the version field in checkstyle/.scalafmt.conf. scalafmt now
   // has the version field as mandatory in its configuration, see
   // https://github.com/scalameta/scalafmt/releases/tag/v3.1.0.
-  scalafmt: "3.10.0",
-  scoverage: "2.4.0",
+  scalafmt: "3.10.2",
+  scoverage: "2.5.1",
   slf4j: "1.7.36",
   snappy: "1.1.10.7",
   spotbugs: "4.9.8",


### PR DESCRIPTION
details:
- Scala: 2.13.17 -->> 2.13.18 (note: Java compatible
versions: from 8 to 26)
- Scalafmt: 3.10.0 -->> 3.10.2
- scalac scoverage plugin: 2.4.0 -->> 2.5.1

release notes:

- Scala: https://github.com/scala/scala/releases/tag/v2.13.18

- Scalafmt:
  - https://github.com/scalameta/scalafmt/releases/tag/v3.10.1
  - https://github.com/scalameta/scalafmt/releases/tag/v3.10.2

- scalac scoverage plugin:
```
https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v2.4.1
https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v2.4.2
https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v2.5.0
https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v2.5.1
```

> :warning: Note: I just had to format scalac scoverage plugin links
above like`code` due to a fact that github-actions bot is overzealous
(and it constantly forcing bad formatting by adding wrong oversized
heading).

Reviewers: Matthias J. Sax <matthias@confluent.io>, Ming-Yen Chung
 <mingyen066@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
