### PR TITLE
MINOR: Fix Formatting in `ConsumerGroupHeartbeatRequestTest.scala`

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -157,7 +157,8 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
     // in this test because it does not use FindCoordinator API.
     createOffsetsTopic()
 
-    try {// Heartbeat request to join the group. Note that the member subscribes
+    try {
+      // Heartbeat request to join the group. Note that the member subscribes
       // to a nonexistent topic.
       var consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequest.Builder(
         new ConsumerGroupHeartbeatRequestData()


### PR DESCRIPTION
Minor PR to fix formatting in the
[ConsumerGroupHeartbeatRequestTest.scala](https://github.com/apache/kafka/compare/trunk...AnGg98:kafka:minor-fix-formatting?expand=1#diff-68a3ea4636720b88bf7cffa347f40af0bd0a51b3256e7ef5aa60deb107dc309e)

Reviewers: David Jacot <djacot@confluent.io>
