### PR TITLE
KAFKA-19970: Add configurable TTL for tiered storage index cache eviction

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1016,6 +1016,7 @@ class KafkaConfigTest {
         case RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP => // ignore string
         case RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP => // ignore string
         case RemoteLogManagerConfig.REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
+        case RemoteLogManagerConfig.REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS_PROP => assertPropertyInvalid(baseProperties, name, "not_a_number", -2)
         case RemoteLogManagerConfig.REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_PROP => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case RemoteLogManagerConfig.REMOTE_LOG_MANAGER_FOLLOWER_THREAD_POOL_SIZE_PROP => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case RemoteLogManagerConfig.REMOTE_LOG_MANAGER_COPIER_THREAD_POOL_SIZE_PROP => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1, -2)

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -241,7 +241,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         copyQuotaMetrics = new RLMQuotaMetrics(metrics, "remote-copy-throttle-time", RemoteLogManager.class.getSimpleName(),
             "The %s time in millis remote copies was throttled by a broker", INACTIVE_SENSOR_EXPIRATION_TIME_SECONDS);
 
-        indexCache = new RemoteIndexCache(rlmConfig.remoteLogIndexFileCacheTotalSizeBytes(), remoteStorageManagerPlugin.get(), logDir);
+        indexCache = new RemoteIndexCache(
+            rlmConfig.remoteLogIndexFileCacheTotalSizeBytes(),
+            rlmConfig.remoteLogIndexFileCacheTtlMs(),
+            false,
+            remoteStorageManagerPlugin.get(),
+            logDir);
         delayInMs = rlmConfig.remoteLogManagerTaskIntervalMs();
         rlmCopyThreadPool = new RLMScheduledThreadPool(rlmConfig.remoteLogManagerCopierThreadPoolSize(),
             "RLMCopyThreadPool", "kafka-rlm-copy-thread-pool-%d");

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -92,6 +92,15 @@ public final class RemoteLogManagerConfig {
             "from remote storage in the local storage.";
     public static final long DEFAULT_REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES = 1024 * 1024 * 1024L;
 
+    public static final String REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS_PROP = "remote.log.index.file.cache.ttl.ms";
+    public static final String REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS_DOC = "The maximum time in milliseconds an index file entry can remain in the cache " +
+            "after its last access. After this duration, the entry will be evicted even if there is available space. " +
+            "This helps prevent stale index files from remaining in cache indefinitely, particularly when a broker is no longer the leader " +
+            "for a partition or when read-from-replica is enabled. Evicted index files are automatically re-fetched from remote storage when needed. " +
+            "Default is 15 minutes (900000 ms), which provides sufficient time for clients to read a partition/segment while ensuring stale entries " +
+            "don't accumulate. Set to -1 to disable time-based eviction and use only size-based eviction.";
+    public static final long DEFAULT_REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS = 900000L; // 15 minutes
+
     public static final String REMOTE_LOG_MANAGER_FOLLOWER_THREAD_POOL_SIZE_PROP = "remote.log.manager.follower.thread.pool.size";
     public static final String REMOTE_LOG_MANAGER_FOLLOWER_THREAD_POOL_SIZE_DOC = "Size of the thread pool used in scheduling follower tasks to read " +
             "the highest-uploaded remote-offset for follower partitions.";
@@ -261,6 +270,12 @@ public final class RemoteLogManagerConfig {
                         atLeast(1),
                         LOW,
                         REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_DOC)
+                .defineInternal(REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS_PROP,
+                        LONG,
+                        DEFAULT_REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS,
+                        atLeast(-1),
+                        LOW,
+                        REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS_DOC)
                 .define(REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_PROP,
                         INT,
                         DEFAULT_REMOTE_LOG_MANAGER_THREAD_POOL_SIZE,
@@ -523,6 +538,10 @@ public final class RemoteLogManagerConfig {
 
     public long remoteLogIndexFileCacheTotalSizeBytes() {
         return config.getLong(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP);
+    }
+
+    public long remoteLogIndexFileCacheTtlMs() {
+        return config.getLong(REMOTE_LOG_INDEX_FILE_CACHE_TTL_MS_PROP);
     }
 
     public long remoteLogManagerCopyMaxBytesPerSecond() {


### PR DESCRIPTION
Caffeine cache currently only uses size-based eviction with frequency
buckets. Within same frequency bucket,
larger entries are always evicted. This causes old (smaller) index files
to stay in cache indefinitely while
newer indices thrash, resulting in:
- Poor cache utilization for backfill workloads
- Higher fetch errors
- Suboptimal memory usage

This problem is exacerbated when a broker is no longer the leader for a
partition  or when read-from-replica is enabled, as stale indexes can
accumulate without  being cleared.

Solution:
---------
Add time-based eviction (expireAfterAccess) via a new internal config
remote.log.index.file.cache.ttl.ms (default: 1 hour). This ensures
entries are
evicted after last access time expires, preventing indefinite
accumulation.
Evicted index files are automatically re-fetched from remote storage
when needed.

Reviewers: Luke Chen <showuon@gmail.com>, Kamal Chandraprakash
 <kamal.chandraprakash@gmail.com>
