### PR TITLE
MINOR: Extend streams quickstart with new protocol

### DIFF
--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -166,6 +166,11 @@ and continuously write its current results to the output topic <b>streams-wordco
 Hence there won't be any STDOUT output except log entries as the results are written back into in Kafka.
 </p>
 
+Optionally, pass in a configuration file containing <code>group.protocol=streams</code> to enable the new rebalancing protocol introduced in KIP-1071. 
+This shifts task assignment logic from the client to the broker, reducing rebalance times and eliminating stop-the-world rebalances.
+
+<pre><code class="language-bash">$ bin/kafka-run-class.sh org.apache.kafka.streams.examples.wordcount.WordCountDemo streams.properties</code></pre>
+
 Now we can start the console producer in a separate terminal to write some input data to this topic:
 
 <pre><code class="language-bash">$ bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic streams-plaintext-input</code></pre>

--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -166,10 +166,11 @@ and continuously write its current results to the output topic <b>streams-wordco
 Hence there won't be any STDOUT output except log entries as the results are written back into in Kafka.
 </p>
 
-Optionally, pass in a configuration file containing <code>group.protocol=streams</code> to enable the new rebalancing protocol introduced in KIP-1071. 
+Optionally, use <code>group.protocol=streams</code> to enable the new rebalancing protocol introduced in KIP-1071. 
 This shifts task assignment logic from the client to the broker, reducing rebalance times and eliminating stop-the-world rebalances.
 
-<pre><code class="language-bash">$ bin/kafka-run-class.sh org.apache.kafka.streams.examples.wordcount.WordCountDemo streams.properties</code></pre>
+<pre><code class="language-bash">$ echo "group.protocol=streams" > streams.properties
+$ bin/kafka-run-class.sh org.apache.kafka.streams.examples.wordcount.WordCountDemo streams.properties</code></pre>
 
 Now we can start the console producer in a separate terminal to write some input data to this topic:
 


### PR DESCRIPTION
This PR adds a section in the Kafka Streams quickstart for enabling the
new `streams` protocol.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
