### PR TITLE
MINOR: remove the hardcoded topic name from `GroupCoordinatorBaseRequestTest`

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
@@ -277,7 +277,7 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
     val groupId = "grp"
 
     // Consumer member 1 joins the group.
-    val (memberId1, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString)
+    val (memberId1, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString, List("foo"))
 
     // Classic member 2 joins the group.
     val joinGroupResponseData = sendJoinRequest(
@@ -415,7 +415,7 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
     val groupId = "grp"
 
     // Consumer member 1 joins the group.
-    val (memberId1, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString)
+    val (memberId1, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString, List("foo"))
 
     // Classic member 2 joins the group.
     val joinGroupResponseData = sendJoinRequest(
@@ -639,7 +639,7 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
 
     // Create a consumer group by joining a member.
     val groupId = "grp"
-    val (memberId, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString)
+    val (memberId, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString, List("foo"))
 
     // The member leaves the group.
     leaveGroup(

--- a/core/src/test/scala/unit/kafka/server/DeleteGroupsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteGroupsRequestTest.scala
@@ -58,7 +58,8 @@ class DeleteGroupsRequestTest(cluster: ClusterInstance) extends GroupCoordinator
     // We test DeleteGroups on empty and non-empty groups. Here we create the non-empty group.
     joinConsumerGroup(
       groupId = "grp-non-empty",
-      useNewProtocol = useNewProtocol
+      useNewProtocol = useNewProtocol,
+      topic = "foo"
     )
 
     for (version <- ApiKeys.DELETE_GROUPS.oldestVersion() to ApiKeys.DELETE_GROUPS.latestVersion(isUnstableApiEnabled)) {
@@ -66,7 +67,8 @@ class DeleteGroupsRequestTest(cluster: ClusterInstance) extends GroupCoordinator
       // a session long enough for the duration of the test.
       val (memberId, memberEpoch) = joinConsumerGroup(
         groupId = "grp",
-        useNewProtocol = useNewProtocol
+        useNewProtocol = useNewProtocol,
+        topic = "foo"
       )
 
       // The member leaves the group so that grp is empty and ready to be deleted.

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -683,22 +683,22 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
     (joinGroupResponseData.memberId, joinGroupResponseData.generationId)
   }
 
-  protected def joinConsumerGroupWithNewProtocol(groupId: String, memberId: String = ""): (String, Int) = {
+  protected def joinConsumerGroupWithNewProtocol(groupId: String, memberId: String = "", subscribedTopicNames: List[String]): (String, Int) = {
     val consumerGroupHeartbeatResponseData = consumerGroupHeartbeat(
       groupId = groupId,
       memberId = memberId,
       rebalanceTimeoutMs = 5 * 60 * 1000,
-      subscribedTopicNames = List("foo"),
+      subscribedTopicNames = subscribedTopicNames,
       topicPartitions = List.empty
     )
     (consumerGroupHeartbeatResponseData.memberId, consumerGroupHeartbeatResponseData.memberEpoch)
   }
 
-  protected def joinConsumerGroup(groupId: String, useNewProtocol: Boolean): (String, Int) = {
+  protected def joinConsumerGroup(groupId: String, useNewProtocol: Boolean, topic: String): (String, Int) = {
     if (useNewProtocol) {
       // Note that we heartbeat only once to join the group and assume
       // that the test will complete within the session timeout.
-      joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid().toString)
+      joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid().toString, List(topic))
     } else {
       // Note that we don't heartbeat and assume that the test will
       // complete within the session timeout.

--- a/core/src/test/scala/unit/kafka/server/ListGroupsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListGroupsRequestTest.scala
@@ -91,7 +91,7 @@ class ListGroupsRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBa
 
       if (useNewProtocol) {
         // Create grp-4 in new protocol. Grp-4 is in STABLE state.
-        memberId1InGroup4 = joinConsumerGroup("grp-4", useNewProtocol = true)._1
+        memberId1InGroup4 = joinConsumerGroup("grp-4", useNewProtocol = true, topic = "foo")._1
         response4 = new ListGroupsResponseData.ListedGroup()
           .setGroupId("grp-4")
           .setProtocolType("consumer")
@@ -99,8 +99,8 @@ class ListGroupsRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBa
           .setGroupType(if (version >= 5) Group.GroupType.CONSUMER.toString else "")
 
         // Create grp-5 in new protocol. Then member 2 joins grp-5, triggering a rebalance. Grp-5 is in RECONCILING state.
-        memberId1InGroup5 = joinConsumerGroup("grp-5", useNewProtocol = true)._1
-        memberId2InGroup5 = joinConsumerGroup("grp-5", useNewProtocol = true)._1
+        memberId1InGroup5 = joinConsumerGroup("grp-5", useNewProtocol = true, topic = "foo")._1
+        memberId2InGroup5 = joinConsumerGroup("grp-5", useNewProtocol = true, topic = "foo")._1
         response5 = new ListGroupsResponseData.ListedGroup()
           .setGroupId("grp-5")
           .setProtocolType("consumer")
@@ -108,7 +108,7 @@ class ListGroupsRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBa
           .setGroupType(if (version >= 5) Group.GroupType.CONSUMER.toString else "")
 
         // Create grp-6 in new protocol. Then member 1 leaves grp-6. Grp-6 is in Empty state.
-        memberId1InGroup6 = joinConsumerGroup("grp-6", useNewProtocol = true)._1
+        memberId1InGroup6 = joinConsumerGroup("grp-6", useNewProtocol = true, topic = "foo")._1
         leaveGroup(groupId = "grp-6", memberId = memberId1InGroup6, useNewProtocol = true, ApiKeys.LEAVE_GROUP.latestVersion(isUnstableApiEnabled))
         response6 = new ListGroupsResponseData.ListedGroup()
           .setGroupId("grp-6")

--- a/core/src/test/scala/unit/kafka/server/OffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetCommitRequestTest.scala
@@ -54,7 +54,7 @@ class OffsetCommitRequestTest(cluster: ClusterInstance) extends GroupCoordinator
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol)
+    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol, "foo")
 
     for (version <- ApiKeys.OFFSET_COMMIT.oldestVersion to ApiKeys.OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
       // Commit offset.

--- a/core/src/test/scala/unit/kafka/server/OffsetDeleteRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetDeleteRequestTest.scala
@@ -55,7 +55,8 @@ class OffsetDeleteRequestTest(cluster: ClusterInstance) extends GroupCoordinator
       // a session long enough for the duration of the test.
       val (memberId, memberEpoch) = joinConsumerGroup(
         groupId = "grp",
-        useNewProtocol = useNewProtocol
+        useNewProtocol = useNewProtocol,
+        topic = "foo"
       )
 
       // Commit offsets.

--- a/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
@@ -80,7 +80,7 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol)
+    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol, "foo")
 
     // Commit offsets.
     for (partitionId <- 0 to 2) {
@@ -301,7 +301,7 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol)
+    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol, "foo")
 
     // Commit offsets.
     for (partitionId <- 0 to 2) {
@@ -420,7 +420,7 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
     List("grp-0", "grp-1", "grp-2").foreach { groupId =>
       // Join the consumer group. Note that we don't heartbeat here so we must use
       // a session long enough for the duration of the test.
-      val (memberId, memberEpoch) = joinConsumerGroup(groupId, useNewProtocol)
+      val (memberId, memberEpoch) = joinConsumerGroup(groupId, useNewProtocol, "foo")
 
       for (partitionId <- 0 to 2) {
         commitOffset(
@@ -585,7 +585,7 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId, memberEpoch) = joinConsumerGroup("grp", true)
+    val (memberId, memberEpoch) = joinConsumerGroup("grp", true, "foo")
 
     // Commit offsets.
     for (partitionId <- 0 to 2) {

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -71,7 +71,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol)
+    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol, topic)
     assertNotEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, memberId)
     assertNotEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, memberEpoch)
 
@@ -235,7 +235,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol)
+    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol, topic)
     assertNotEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, memberId)
     assertNotEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, memberEpoch)
 

--- a/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
@@ -60,7 +60,7 @@ class WriteTxnMarkersRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     // Join the consumer group. Note that we don't heartbeat here so we must use
     // a session long enough for the duration of the test.
-    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol)
+    val (memberId: String, memberEpoch: Int) = joinConsumerGroup(groupId, useNewProtocol, topic)
     assertNotEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, memberId)
     assertNotEquals(JoinGroupRequest.UNKNOWN_GENERATION_ID, memberEpoch)
 


### PR DESCRIPTION
This PR removes the hardcoded topic name from the helper method used in
`GroupCoordinatorBaseRequestTest`.
