### PR TITLE
KAFKA-17798: Add forbidden-apis linting to gradle build

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Please note for this to work you should create/update user maven settings (typic
     ./gradlew testJar
 
 ### Running code quality checks ###
-There are two code quality analysis tools that we regularly run, spotbugs and checkstyle.
+There are several code quality analysis tools that we regularly run: checkstyle, spotbugs, and forbidden-apis.
 
 #### Checkstyle ####
 Checkstyle enforces a consistent coding style in Kafka.
@@ -219,6 +219,14 @@ You can run spotbugs using:
 
 The spotbugs warnings will be found in `reports/spotbugs/main.html` and `reports/spotbugs/test.html` files in the subproject build
 directories.  Use -PxmlSpotBugsReport=true to generate an XML report instead of an HTML one.
+
+#### Forbidden APIs ####
+Forbidden-apis scans bytecode for invocations of unsafe or deprecated API methods (e.g., locale-dependent methods, system exit calls).
+You can run forbidden-apis using:
+
+    ./gradlew forbiddenApisMain forbiddenApisTest -x test
+
+The warnings are printed to the console. Currently configured with `ignoreFailures = true` to report issues without failing the build.
 
 ### JMH microbenchmarks ###
 We use [JMH](https://openjdk.java.net/projects/code-tools/jmh/) to write microbenchmarks that produce reliable results in the JVM.

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ plugins {
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
   id "com.github.spotbugs" version '6.4.4' apply false
+  id 'de.thetaphi.forbiddenapis' version '3.10' apply false
   id 'org.scoverage' version '8.1' apply false
   id 'com.gradleup.shadow' version '8.3.9' apply false
   id 'com.diffplug.spotless' version "8.0.0"
@@ -316,6 +317,7 @@ subprojects {
   apply plugin: 'java-library'
   apply plugin: 'checkstyle'
   apply plugin: "com.github.spotbugs"
+  apply plugin: 'de.thetaphi.forbiddenapis'
 
   // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
   // don't publish it
@@ -824,6 +826,12 @@ subprojects {
     ignoreFailures = false
   }
   test.dependsOn('spotbugsMain')
+
+  forbiddenApis {
+    bundledSignatures = ['jdk-unsafe', 'jdk-deprecated']
+    ignoreFailures = true
+  }
+  test.dependsOn('forbiddenApisMain')
 
   tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
     reports.configure {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -126,6 +126,7 @@ versions += [
   snappy: "1.1.10.7",
   spotbugs: "4.9.8",
   mockOAuth2Server: "2.2.1",
+  forbiddenApis: "3.10",
   zinc: "1.11.0",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid


### PR DESCRIPTION

  Integrates the [forbidden-apis](https://github.com/policeman-tools/forbidden-apis) Gradle plugin to scan bytecode for invocations of unsafe or deprecated API methods.

  ## Changes
  - Add forbidden-apis plugin (v3.10) to gradle build
  - Configure with `jdk-unsafe` and `jdk-deprecated` bundled signatures
  - Set `ignoreFailures = true` initially (warnings only, no build failure)
  - Hook into test task via `test.dependsOn('forbiddenApisMain')`
  - Document usage in README.md

  ## Why ignoreFailures = true?
  Running the check reveals dozens/hundreds of existing violations (mostly locale-dependent `String.format()` calls). Fixing these should be separate PRs. This PR establishes the infrastructure; follow-up issues
  [KAFKA-17799](https://issues.apache.org/jira/browse/KAFKA-17799) and [KAFKA-17800](https://issues.apache.org/jira/browse/KAFKA-17800) will add specific rules and address violations.

  ## Testing
  ./gradlew :clients:forbiddenApisMain  # runs check, reports warnings, build succeeds
  ./gradlew tasks --all | grep forbidden  # shows tasks registered for all subprojects

  ## Related
  - Blocks: KAFKA-17799, KAFKA-17800
  - Previous PR #17565 was auto-closed due to inactivity
