### PR TITLE
KAFKA-19967: Reduce GC pressure in tiered storage read path using direct memory buffers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/RemoteLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RemoteLogInputStream.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.errors.CorruptRecordException;
+import org.apache.kafka.common.utils.DirectBufferPool;
 import org.apache.kafka.common.utils.Utils;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -28,13 +30,16 @@ import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
 import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
 import static org.apache.kafka.common.record.Records.SIZE_OFFSET;
 
-public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
+public class RemoteLogInputStream implements LogInputStream<RecordBatch>, Closeable {
     private final InputStream inputStream;
+    private final DirectBufferPool bufferPool;
     // LogHeader buffer up to magic.
     private final ByteBuffer logHeaderBuffer = ByteBuffer.allocate(HEADER_SIZE_UP_TO_MAGIC);
+    private ByteBuffer currentBuffer = null;
 
-    public RemoteLogInputStream(InputStream inputStream) {
+    public RemoteLogInputStream(InputStream inputStream, DirectBufferPool bufferPool) {
         this.inputStream = inputStream;
+        this.bufferPool = bufferPool;
     }
 
     @Override
@@ -53,10 +58,17 @@ public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
             throw new CorruptRecordException(String.format("Found record size %d smaller than minimum record " +
                                                                    "overhead (%d).", size, LegacyRecord.RECORD_OVERHEAD_V0));
 
+        // Release previous buffer before allocating new one to avoid accumulation
+        if (currentBuffer != null) {
+            bufferPool.release(currentBuffer);
+            currentBuffer = null;
+        }
+
         // Total size is: "LOG_OVERHEAD + the size of the rest of the content"
         int bufferSize = LOG_OVERHEAD + size;
         // buffer contains the complete payload including header and records.
-        ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+        ByteBuffer buffer = bufferPool.allocate(bufferSize);
+        currentBuffer = buffer;
 
         // write log header into buffer
         buffer.put(logHeaderBuffer);
@@ -75,5 +87,13 @@ public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
             batch = new AbstractLegacyRecordBatch.ByteBufferLegacyRecordBatch(buffer);
 
         return batch;
+    }
+
+    @Override
+    public void close() {
+        if (currentBuffer != null) {
+            bufferPool.release(currentBuffer);
+            currentBuffer = null;
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/DirectBufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/DirectBufferPool.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.Cleaner;
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Pool for direct ByteBuffers used in remote storage reads.
+ * Uses WeakReferences so GC can reclaim buffers under memory pressure.
+ */
+public class DirectBufferPool {
+    private static final Logger log = LoggerFactory.getLogger(DirectBufferPool.class);
+    private static final Cleaner CLEANER = Cleaner.create();
+
+    private final ConcurrentMap<Integer, Queue<WeakReference<ByteBuffer>>> buffersBySize;
+    private final AtomicLong allocations = new AtomicLong(0);
+    private final AtomicLong poolHits = new AtomicLong(0);
+    private final AtomicLong directAllocFailures = new AtomicLong(0);
+    private final AtomicLong autoReleases = new AtomicLong(0);
+    private final boolean poolingEnabled;
+
+    public DirectBufferPool(boolean poolingEnabled) {
+        this.poolingEnabled = poolingEnabled;
+        this.buffersBySize = new ConcurrentHashMap<>();
+    }
+
+    public ByteBuffer allocate(int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("size must be positive");
+        }
+
+        allocations.incrementAndGet();
+
+        if (!poolingEnabled) {
+            return allocateDirect(size);
+        }
+
+        Queue<WeakReference<ByteBuffer>> queue = buffersBySize.get(size);
+        if (queue != null) {
+            WeakReference<ByteBuffer> ref;
+            while ((ref = queue.poll()) != null) {
+                ByteBuffer buf = ref.get();
+                if (buf != null) {
+                    poolHits.incrementAndGet();
+                    buf.clear();
+                    return buf;
+                }
+            }
+        }
+
+        return allocateDirect(size);
+    }
+
+    public void release(ByteBuffer buffer) {
+        doRelease(buffer, false);
+    }
+
+    public void registerForAutoRelease(Object ref, ByteBuffer buffer) {
+        if (ref == null || buffer == null || !poolingEnabled || !buffer.isDirect()) {
+            return;
+        }
+        CLEANER.register(ref, () -> doRelease(buffer, true));
+    }
+
+    private void doRelease(ByteBuffer buffer, boolean auto) {
+        if (buffer == null || !poolingEnabled || !buffer.isDirect()) {
+            return;
+        }
+
+        if (auto) {
+            autoReleases.incrementAndGet();
+        }
+
+        buffer.clear();
+        int size = buffer.capacity();
+
+        Queue<WeakReference<ByteBuffer>> queue = buffersBySize.get(size);
+        if (queue == null) {
+            queue = new ConcurrentLinkedQueue<>();
+            Queue<WeakReference<ByteBuffer>> existing = buffersBySize.putIfAbsent(size, queue);
+            if (existing != null) {
+                queue = existing;
+            }
+        }
+
+        queue.add(new WeakReference<>(buffer));
+    }
+
+    public void close() {
+        buffersBySize.clear();
+    }
+
+    public long allocations() {
+        return allocations.get();
+    }
+
+    public long poolHits() {
+        return poolHits.get();
+    }
+
+    public long directAllocFailures() {
+        return directAllocFailures.get();
+    }
+
+    public long autoReleases() {
+        return autoReleases.get();
+    }
+
+    public double poolHitRate() {
+        long total = allocations.get();
+        return total > 0 ? (double) poolHits.get() / total : 0.0;
+    }
+
+    int countBuffersOfSize(int size) {
+        Queue<WeakReference<ByteBuffer>> queue = buffersBySize.get(size);
+        if (queue == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (WeakReference<ByteBuffer> ref : queue) {
+            if (ref.get() != null) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private ByteBuffer allocateDirect(int size) {
+        try {
+            return ByteBuffer.allocateDirect(size);
+        } catch (OutOfMemoryError e) {
+            directAllocFailures.incrementAndGet();
+            log.warn("Failed to allocate direct buffer of {} bytes, using heap", size);
+            return ByteBuffer.allocate(size);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1278,25 +1278,51 @@ public final class Utils {
      * end of the stream has been reached.
      *
      * @param inputStream       Input stream to read from
-     * @param destinationBuffer The buffer into which bytes are to be transferred (it must be backed by an array)
+     * @param destinationBuffer The buffer into which bytes are to be transferred (can be heap or direct buffer)
      * @return number of byte read from the input stream
      * @throws IOException If an I/O error occurs
+     * @throws IllegalArgumentException if buffer is read-only or unsupported buffer type
      */
     public static int readFully(InputStream inputStream, ByteBuffer destinationBuffer) throws IOException {
-        if (!destinationBuffer.hasArray())
-            throw new IllegalArgumentException("destinationBuffer must be backed by an array");
-        int initialOffset = destinationBuffer.arrayOffset() + destinationBuffer.position();
-        byte[] array = destinationBuffer.array();
+        if (destinationBuffer.isReadOnly()) {
+            throw new IllegalArgumentException("Cannot read into read-only ByteBuffer (destinationBuffer must be writable)");
+        }
+
         int length = destinationBuffer.remaining();
-        int totalBytesRead = 0;
-        do {
-            int bytesRead = inputStream.read(array, initialOffset + totalBytesRead, length - totalBytesRead);
-            if (bytesRead == -1)
-                break;
-            totalBytesRead += bytesRead;
-        } while (length > totalBytesRead);
-        destinationBuffer.position(destinationBuffer.position() + totalBytesRead);
-        return totalBytesRead;
+
+        if (destinationBuffer.isDirect()) {
+            int totalBytesRead = 0;
+            byte[] tempBuffer = new byte[Math.min(8192, length)];
+            while (totalBytesRead < length) {
+                int toRead = Math.min(tempBuffer.length, length - totalBytesRead);
+                int bytesRead = inputStream.read(tempBuffer, 0, toRead);
+                if (bytesRead == -1) {
+                    break;
+                }
+                destinationBuffer.put(tempBuffer, 0, bytesRead);
+                totalBytesRead += bytesRead;
+            }
+            return totalBytesRead;
+        } else if (destinationBuffer.hasArray()) {
+            int initialOffset = destinationBuffer.arrayOffset() + destinationBuffer.position();
+            byte[] array = destinationBuffer.array();
+            int totalBytesRead = 0;
+            do {
+                int bytesRead = inputStream.read(array, initialOffset + totalBytesRead, length - totalBytesRead);
+                if (bytesRead == -1) {
+                    break;
+                }
+                totalBytesRead += bytesRead;
+            } while (length > totalBytesRead);
+            destinationBuffer.position(destinationBuffer.position() + totalBytesRead);
+            return totalBytesRead;
+        } else {
+            throw new IllegalArgumentException(
+                "Unsupported ByteBuffer type. Buffer must be either direct (isDirect=true) " +
+                "or heap-backed with array access (hasArray=true). Current buffer: isDirect=" +
+                destinationBuffer.isDirect() + ", hasArray=" + destinationBuffer.hasArray() +
+                ", isReadOnly=" + destinationBuffer.isReadOnly());
+        }
     }
 
     public static void writeFully(FileChannel channel, ByteBuffer sourceBuffer) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
@@ -19,8 +19,10 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.utils.DirectBufferPool;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -98,8 +100,9 @@ public class RemoteLogInputStreamTest {
             fileRecords.flush();
         }
 
-        try (FileInputStream is = new FileInputStream(file)) {
-            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+        DirectBufferPool bufferPool = new DirectBufferPool(true);
+        try (FileInputStream is = new FileInputStream(file);
+             RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, bufferPool)) {
 
             RecordBatch firstBatch = logInputStream.nextBatch();
             assertGenericRecordBatchData(args, firstBatch, 0L, 3241324L, firstBatchRecord);
@@ -142,8 +145,9 @@ public class RemoteLogInputStreamTest {
             fileRecords.flush();
         }
 
-        try (FileInputStream is = new FileInputStream(file)) {
-            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+        DirectBufferPool bufferPool = new DirectBufferPool(true);
+        try (FileInputStream is = new FileInputStream(file);
+             RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, bufferPool)) {
 
             RecordBatch firstBatch = logInputStream.nextBatch();
             assertNoProducerData(firstBatch);
@@ -193,8 +197,9 @@ public class RemoteLogInputStreamTest {
             fileRecords.flush();
         }
 
-        try (FileInputStream is = new FileInputStream(file)) {
-            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+        DirectBufferPool bufferPool = new DirectBufferPool(true);
+        try (FileInputStream is = new FileInputStream(file);
+             RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, bufferPool)) {
 
             RecordBatch firstBatch = logInputStream.nextBatch();
             assertProducerData(firstBatch, producerId, producerEpoch, baseSequence, false, firstBatchRecords);
@@ -235,6 +240,38 @@ public class RemoteLogInputStreamTest {
             assertGenericRecordBatchData(args, firstBatch, 0L, 100L, firstBatchRecord);
 
             assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @Test
+    public void testCloseReleasesBuffersToPool() throws IOException {
+        SimpleRecord record = new SimpleRecord(100L, "key".getBytes(), "value".getBytes());
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withRecords(MAGIC_VALUE_V2, 0L,
+                    Compression.NONE, CREATE_TIME, record));
+            fileRecords.append(MemoryRecords.withRecords(MAGIC_VALUE_V2, 1L,
+                    Compression.NONE, CREATE_TIME, record));
+            fileRecords.flush();
+        }
+
+        DirectBufferPool bufferPool = new DirectBufferPool(true);
+
+        try (FileInputStream is = new FileInputStream(file);
+             RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, bufferPool)) {
+            logInputStream.nextBatch();
+            logInputStream.nextBatch();
+            assertEquals(2, bufferPool.allocations());
+            assertEquals(1, bufferPool.poolHits());
+        }
+
+        try (FileInputStream is = new FileInputStream(file);
+             RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, bufferPool)) {
+            logInputStream.nextBatch();
+            logInputStream.nextBatch();
+            assertEquals(4, bufferPool.allocations());
+            assertEquals(3, bufferPool.poolHits());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/DirectBufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/DirectBufferPoolTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DirectBufferPoolTest {
+
+    private DirectBufferPool pool;
+
+    @AfterEach
+    public void tearDown() {
+        if (pool != null) {
+            pool.close();
+        }
+    }
+
+    @Test
+    public void testBasics() {
+        pool = new DirectBufferPool(true);
+
+        ByteBuffer a = pool.allocate(100);
+        assertEquals(100, a.capacity());
+        assertEquals(100, a.remaining());
+        pool.release(a);
+
+        ByteBuffer b = pool.allocate(100);
+        assertSame(a, b);
+
+        ByteBuffer c = pool.allocate(100);
+        assertNotSame(b, c);
+        pool.release(b);
+        pool.release(c);
+    }
+
+    @Test
+    public void testBuffersAreCleared() {
+        pool = new DirectBufferPool(true);
+
+        ByteBuffer a = pool.allocate(100);
+        a.putInt(0xdeadbeef);
+        assertEquals(96, a.remaining());
+        pool.release(a);
+
+        ByteBuffer b = pool.allocate(100);
+        assertSame(a, b);
+        assertEquals(100, a.remaining());
+        pool.release(b);
+    }
+
+    @Test
+    public void testWeakRefClearing() {
+        pool = new DirectBufferPool(true);
+
+        List<ByteBuffer> bufs = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            ByteBuffer buf = pool.allocate(100);
+            bufs.add(buf);
+        }
+
+        for (ByteBuffer buf : bufs) {
+            pool.release(buf);
+        }
+
+        assertEquals(10, pool.countBuffersOfSize(100));
+
+        bufs.clear();
+        bufs = null;
+        for (int i = 0; i < 3; i++) {
+            System.gc();
+        }
+
+        ByteBuffer buf = pool.allocate(100);
+        assertEquals(0, pool.countBuffersOfSize(100));
+        pool.release(buf);
+    }
+
+    @Test
+    public void testPoolingDisabled() {
+        pool = new DirectBufferPool(false);
+
+        ByteBuffer a = pool.allocate(100);
+        pool.release(a);
+
+        ByteBuffer b = pool.allocate(100);
+        assertNotSame(a, b);
+    }
+
+    @Test
+    public void testInvalidSize() {
+        pool = new DirectBufferPool(false);
+        assertThrows(IllegalArgumentException.class, () -> pool.allocate(0));
+        assertThrows(IllegalArgumentException.class, () -> pool.allocate(-1));
+    }
+
+    @Test
+    public void testAllocationFailure() {
+        pool = new DirectBufferPool(false);
+
+        ByteBuffer buf = pool.allocate(1024);
+        assertTrue(buf.isDirect());
+        assertEquals(0, pool.directAllocFailures());
+    }
+
+    @Test
+    public void testAutoReleaseOnGC() throws Exception {
+        pool = new DirectBufferPool(true);
+
+        ByteBuffer buffer = pool.allocate(256);
+        Object ref = new Object();
+        pool.registerForAutoRelease(ref, buffer);
+
+        assertEquals(1, pool.allocations());
+        assertEquals(0, pool.autoReleases());
+
+        ref = null;
+        for (int i = 0; i < 10 && pool.autoReleases() == 0; i++) {
+            System.gc();
+            Thread.sleep(50);
+        }
+
+        assertEquals(1, pool.autoReleases());
+
+        ByteBuffer reused = pool.allocate(256);
+        assertEquals(1, pool.poolHits());
+        assertSame(buffer, reused);
+    }
+
+    @Test
+    public void testAutoReleaseNullHandling() {
+        pool = new DirectBufferPool(true);
+
+        pool.registerForAutoRelease(null, pool.allocate(100));
+        pool.registerForAutoRelease(new Object(), null);
+
+        DirectBufferPool disabledPool = new DirectBufferPool(false);
+        disabledPool.registerForAutoRelease(new Object(), disabledPool.allocate(100));
+        assertEquals(0, disabledPool.autoReleases());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -1341,4 +1341,134 @@ public class UtilsTest {
             return key.hashCode();
         }
     }
+
+    @Test
+    public void testReadFullyInputStreamWithHeapBuffer() throws IOException {
+        byte[] testData = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocate(testData.length);
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(testData)) {
+            int bytesRead = Utils.readFully(inputStream, buffer);
+
+            assertEquals(testData.length, bytesRead, "Should read all bytes");
+            assertEquals(testData.length, buffer.position(), "Buffer position should be at end");
+            assertFalse(buffer.hasRemaining(), "Buffer should be full");
+
+            buffer.flip();
+            byte[] result = new byte[buffer.remaining()];
+            buffer.get(result);
+            assertArrayEquals(testData, result, "Data should match");
+        }
+    }
+
+    @Test
+    public void testReadFullyInputStreamWithDirectBuffer() throws IOException {
+        byte[] testData = "Hello, Direct Buffer!".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(testData.length);
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(testData)) {
+            int bytesRead = Utils.readFully(inputStream, buffer);
+
+            assertEquals(testData.length, bytesRead, "Should read all bytes");
+            assertEquals(testData.length, buffer.position(), "Buffer position should be at end");
+            assertFalse(buffer.hasRemaining(), "Buffer should be full");
+            assertTrue(buffer.isDirect(), "Buffer should be direct");
+
+            buffer.flip();
+            byte[] result = new byte[buffer.remaining()];
+            buffer.get(result);
+            assertArrayEquals(testData, result, "Data should match");
+        }
+    }
+
+    @Test
+    public void testReadFullyInputStreamWithLargeDirectBuffer() throws IOException {
+        // Test with buffer larger than 8KB chunk size
+        byte[] testData = new byte[16384]; // 16 KB
+        for (int i = 0; i < testData.length; i++) {
+            testData[i] = (byte) (i % 256);
+        }
+        ByteBuffer buffer = ByteBuffer.allocateDirect(testData.length);
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(testData)) {
+            int bytesRead = Utils.readFully(inputStream, buffer);
+
+            assertEquals(testData.length, bytesRead, "Should read all bytes");
+            assertFalse(buffer.hasRemaining(), "Buffer should be full");
+
+            buffer.flip();
+            byte[] result = new byte[buffer.remaining()];
+            buffer.get(result);
+            assertArrayEquals(testData, result, "Data should match");
+        }
+    }
+
+    @Test
+    public void testReadFullyInputStreamWithPartialData() throws IOException {
+        byte[] testData = "Short".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(100); // Buffer larger than data
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(testData)) {
+            int bytesRead = Utils.readFully(inputStream, buffer);
+
+            assertEquals(testData.length, bytesRead, "Should read available bytes");
+            assertEquals(testData.length, buffer.position(), "Buffer position should match bytes read");
+            assertTrue(buffer.hasRemaining(), "Buffer should have remaining capacity");
+
+            buffer.flip();
+            byte[] result = new byte[buffer.remaining()];
+            buffer.get(result);
+            assertArrayEquals(testData, result, "Data should match");
+        }
+    }
+
+    @Test
+    public void testReadFullyInputStreamWithReadOnlyBuffer() {
+        byte[] testData = "Test".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocate(testData.length).asReadOnlyBuffer();
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(testData)) {
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> Utils.readFully(inputStream, buffer),
+                "Should throw exception for read-only buffer");
+            assertTrue(exception.getMessage().contains("read-only") || exception.getMessage().contains("writable"),
+                "Exception should mention read-only or writable: " + exception.getMessage());
+        } catch (IOException e) {
+            fail("Should not throw IOException: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testReadFullyInputStreamWithEmptyStream() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(100);
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(new byte[0])) {
+            int bytesRead = Utils.readFully(inputStream, buffer);
+
+            assertEquals(0, bytesRead, "Should read zero bytes from empty stream");
+            assertEquals(0, buffer.position(), "Buffer position should remain at 0");
+        }
+    }
+
+    @Test
+    public void testReadFullyInputStreamMultipleChunks() throws IOException {
+        // Test that direct buffer path correctly handles multiple 8KB chunks
+        byte[] testData = new byte[25000]; // More than 3 chunks of 8KB
+        for (int i = 0; i < testData.length; i++) {
+            testData[i] = (byte) (i % 256);
+        }
+        ByteBuffer buffer = ByteBuffer.allocateDirect(testData.length);
+
+        try (java.io.ByteArrayInputStream inputStream = new java.io.ByteArrayInputStream(testData)) {
+            int bytesRead = Utils.readFully(inputStream, buffer);
+
+            assertEquals(testData.length, bytesRead, "Should read all bytes");
+            assertEquals(0, buffer.remaining(), "Buffer should be full");
+
+            buffer.flip();
+            for (int i = 0; i < testData.length; i++) {
+                assertEquals(testData[i], buffer.get(), "Byte at position " + i + " should match");
+            }
+        }
+    }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ChildFirstClassLoader;
 import org.apache.kafka.common.utils.CloseableIterator;
+import org.apache.kafka.common.utils.DirectBufferPool;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
@@ -190,6 +191,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     // The endpoint for remote log metadata manager to connect to
     private final Optional<Endpoint> endpoint;
     private final Timer remoteReadTimer;
+    private final DirectBufferPool directBufferPool;
 
     private boolean closed = false;
 
@@ -253,6 +255,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         metricsGroup.newGauge(REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC, rlmCopyThreadPool::getIdlePercent);
         remoteReadTimer = metricsGroup.newTimer(REMOTE_LOG_READER_FETCH_RATE_AND_TIME_METRIC,
                 TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+
+        directBufferPool = new DirectBufferPool(rlmConfig.remoteLogDirectBufferPoolEnabled());
 
         remoteStorageReaderThreadPool = new RemoteStorageThreadPool(
                 REMOTE_LOG_READER_THREAD_NAME_PATTERN,
@@ -637,7 +641,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         try {
             // Search forward for the position of the last offset that is greater than or equal to the startingOffset
             remoteSegInputStream = remoteStorageManagerPlugin.get().fetchLogSegment(rlsMetadata, startPos);
-            RemoteLogInputStream remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream);
+            RemoteLogInputStream remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream, directBufferPool);
 
             while (true) {
                 RecordBatch batch = remoteLogInputStream.nextBatch();
@@ -1715,7 +1719,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             int updatedFetchSize =
                     remoteStorageFetchInfo.minOneMessage() && firstBatchSize > maxBytes ? firstBatchSize : maxBytes;
 
-            ByteBuffer buffer = ByteBuffer.allocate(updatedFetchSize);
+            ByteBuffer buffer = directBufferPool.allocate(updatedFetchSize);
             int remainingBytes = updatedFetchSize;
 
             firstBatch.writeTo(buffer);
@@ -1728,9 +1732,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             buffer.flip();
 
             startPos = startPos + enrichedRecordBatch.skippedBytes;
+            MemoryRecords records = MemoryRecords.readableRecords(buffer);
+            directBufferPool.registerForAutoRelease(records, buffer);
+
             FetchDataInfo fetchDataInfo = new FetchDataInfo(
                     new LogOffsetMetadata(firstBatch.baseOffset(), remoteLogSegmentMetadata.startOffset(), startPos),
-                    MemoryRecords.readableRecords(buffer));
+                    records);
             if (includeAbortedTxns) {
                 fetchDataInfo = addAbortedTransactions(firstBatch.baseOffset(), remoteLogSegmentMetadata, fetchDataInfo, logOptional.get());
             }
@@ -1744,7 +1751,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     }
     // for testing
     RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
-        return new RemoteLogInputStream(in);
+        return new RemoteLogInputStream(in, directBufferPool);
     }
 
     // Visible for testing
@@ -2052,6 +2059,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                     followerRLMTasks.clear();
 
                     Utils.closeQuietly(indexCache, "RemoteIndexCache");
+                    directBufferPool.close();
                     Utils.closeQuietly(remoteLogMetadataManagerPlugin, "remoteLogMetadataManagerPlugin");
                     Utils.closeQuietly(remoteStorageManagerPlugin, "remoteStorageManagerPlugin");
                     closed = true;

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -200,6 +200,12 @@ public final class RemoteLogManagerConfig {
     public static final String REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_DOC = "The maximum amount of time the server will wait for the remote list offsets request to complete.";
     public static final long DEFAULT_REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS = 30000L;
 
+    public static final String REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED_PROP = "remote.log.direct.buffer.pool.enabled";
+    public static final String REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED_DOC = "Enable direct buffer pooling for remote storage reads. " +
+            "Uses weak references to allow GC-driven cleanup. Disabled by default since buffers cannot currently be " +
+            "returned to the pool (passed to MemoryRecords and lost). Enable for future compatibility.";
+    public static final boolean DEFAULT_REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED = false;
+
     private final AbstractConfig config;
 
     public static ConfigDef configDef() {
@@ -379,7 +385,13 @@ public final class RemoteLogManagerConfig {
                         DEFAULT_REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS,
                         atLeast(1),
                         MEDIUM,
-                        REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_DOC);
+                        REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_DOC)
+                .defineInternal(REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED_PROP,
+                        BOOLEAN,
+                        DEFAULT_REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED,
+                        null,
+                        LOW,
+                        REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED_DOC);
     }
     
     public RemoteLogManagerConfig(AbstractConfig config) {
@@ -547,6 +559,10 @@ public final class RemoteLogManagerConfig {
 
     public long remoteListOffsetsRequestTimeoutMs() {
         return config.getLong(REMOTE_LIST_OFFSETS_REQUEST_TIMEOUT_MS_PROP);
+    }
+
+    public boolean remoteLogDirectBufferPoolEnabled() {
+        return config.getBoolean(REMOTE_LOG_DIRECT_BUFFER_POOL_ENABLED_PROP);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
This change addresses high GC pressure by allocating tiered storage fetch buffers in direct (off-heap) memory instead of the JVM heap. When direct memory is exhausted, the system gracefully falls back to heap allocation with a warning.

Problem:
During tiered storage reads, heap-allocated buffers bypass young generation and go directly to old generation (humongous allocations). Under high read load, these accumulate rapidly and trigger frequent, expensive G1 Old Generation collections causing significant GC pause times.

Solution:
- Introduced DirectBufferPool that pools direct buffers using WeakReferences, allowing GC to reclaim buffers under memory pressure
- Modified RemoteLogInputStream to use pooled direct buffers instead of per-request heap allocation
- Graceful fallback to heap allocation when direct memory is exhausted
