### PR TITLE
KAFKA-19897: Document support for testing with java 25 (3.9)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,24 +181,6 @@ pipeline {
           }
         }
 
-        stage('JDK 23 and Scala 2.13') {
-          agent { label 'ubuntu' }
-          tools {
-            jdk 'jdk_23_latest'
-          }
-          options {
-            timeout(time: 8, unit: 'HOURS')
-            timestamps()
-          }
-          environment {
-            SCALA_VERSION=2.13
-          }
-          steps {
-            doValidation()
-            doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 23'
-          }
-        }
         stage('JDK 25 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew test # runs both unit and integration tests
     ./gradlew unitTest
     ./gradlew integrationTest
+
+### Run tests with Java 25
+    ./gradlew testWithJava25
     
 ### Force re-running tests without code change ###
     ./gradlew test --rerun

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Build and test Apache Kafka with Java 8, 11, 17, 21 and 23. Note that Java 23 has reached End-of-Life (EOL). Java 25 is supported for testing only.
+  Build and test Apache Kafka with Java 8, 11, 17, 21 and 23. Java 25 is supported for testing only.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, 11, 17, 21, and 23 are fully supported while Java 25 is supported for unit and integration tests only.
+  Java 8, 11, 17, and 21 are fully supported while Java 25 has received limited validation and support is best-effort.
   Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
   most recent non LTS version.
   <p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1250,8 +1250,6 @@ queued.max.requests=[number of concurrent requests]</code></pre>
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
   Java 8, 11, 17, and 21 are fully supported while Java 25 has received limited validation and support is best-effort.
-  Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
-  most recent non LTS version.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,9 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Apache Kafka can be built and tested with Java 8, 11, 17, 21, and 23. Java 25 is supported for testing only.
+  Java 8, 11, 17, 21, and 23 are fully supported while Java 25 is supported for unit and integration tests only.
+  Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
+  most recent non LTS version.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Build and test Apache Kafka with Java 8, 11, 17, 21 and 23. Java 25 is supported for testing only.
+  Apache Kafka can be built and tested with Java 8, 11, 17, 21, and 23. Java 25 is supported for testing only.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, Java 11, Java 17, Java 21 and Java 23 are supported.
+  Build and test Apache Kafka with Java 8, 11, 17, 21 and 23. Note that Java 23 has reached End-of-Life (EOL). Java 25 is supported for testing only.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.


### PR DESCRIPTION
With #21026 completed, we can update the documentation to indicate support for testing with Java 25 in AK 3.9.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>