### PR TITLE
KAFKA-19974: Do not bump member epoch when exiting UNREVOKED_PARTITIONS

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/CurrentAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/CurrentAssignmentBuilder.java
@@ -220,14 +220,10 @@ public class CurrentAssignmentBuilder {
                     }
                 }
 
-                // When the member has revoked all the pending partitions, it can
-                // transition to the next epoch (current + 1) and we can reconcile
-                // its state towards the latest target assignment.
+                // When the member has revoked all the pending partitions, we can
+                // reconcile its state towards the latest target assignment.
                 return computeNextAssignment(
-                    // When we enter UNREVOKED_PARTITIONS due to a subscription change,
-                    // we must not advance the member epoch when the new target
-                    // assignment is not available yet.
-                    Math.min(member.memberEpoch() + 1, targetAssignmentEpoch),
+                    member.memberEpoch(),
                     member.assignedPartitions()
                 );
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/CurrentAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/CurrentAssignmentBuilderTest.java
@@ -386,12 +386,8 @@ public class CurrentAssignmentBuilderTest {
         );
     }
 
-    @ParameterizedTest
-    @CsvSource({
-        "10, 12, 11",
-        "10, 10, 10", // The member epoch must not advance past the target assignment epoch.
-    })
-    public void testUnrevokedPartitionsToUnrevokedPartitions(int memberEpoch, int targetAssignmentEpoch, int expectedMemberEpoch) {
+    @Test
+    public void testUnrevokedPartitionsToUnrevokedPartitions() {
         String topic1 = "topic1";
         String topic2 = "topic2";
         Uuid topicId1 = Uuid.randomUuid();
@@ -404,8 +400,8 @@ public class CurrentAssignmentBuilderTest {
 
         ConsumerGroupMember member = new ConsumerGroupMember.Builder("member")
             .setState(MemberState.UNREVOKED_PARTITIONS)
-            .setMemberEpoch(memberEpoch)
-            .setPreviousMemberEpoch(memberEpoch)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
             .setSubscribedTopicNames(List.of(topic1, topic2))
             .setAssignedPartitions(mkAssignment(
                 mkTopicAssignment(topicId1, 2, 3),
@@ -417,7 +413,7 @@ public class CurrentAssignmentBuilderTest {
 
         ConsumerGroupMember updatedMember = new CurrentAssignmentBuilder(member)
             .withMetadataImage(metadataImage)
-            .withTargetAssignment(targetAssignmentEpoch, new Assignment(mkAssignment(
+            .withTargetAssignment(12, new Assignment(mkAssignment(
                 mkTopicAssignment(topicId1, 3),
                 mkTopicAssignment(topicId2, 6))))
             .withCurrentPartitionEpoch((topicId, partitionId) -> -1)
@@ -433,8 +429,8 @@ public class CurrentAssignmentBuilderTest {
         assertEquals(
             new ConsumerGroupMember.Builder("member")
                 .setState(MemberState.UNREVOKED_PARTITIONS)
-                .setMemberEpoch(expectedMemberEpoch)
-                .setPreviousMemberEpoch(memberEpoch)
+                .setMemberEpoch(10)
+                .setPreviousMemberEpoch(10)
                 .setSubscribedTopicNames(List.of(topic1, topic2))
                 .setAssignedPartitions(mkAssignment(
                     mkTopicAssignment(topicId1, 3),


### PR DESCRIPTION
Previously, when transitioning from UNREVOKED_PARTITIONS to
UNREVOKED_PARTITIONS, we bumped the member epoch by 1. After the change
for KAFKA-19431, we could also enter UNREVOKED_PARTITIONS due to
unsubscribing from a topic. This introduced a new class of epoch bumps,
which allowed a partition to be owned by different members at the same
epoch (though not at the same time). We would like to preserve the
invariant that partitions can only be owned by a single member at any
given epoch, so we remove the partition bump entirely.

After this patch, when transitioning from UNREVOKED_PARTITIONS to
UNREVOKED_PARTITIONS, the member epoch is not bumped. When transitioning
from UNREVOKED_PARTIIONS to any other state, the member epoch is updated
to match the target assignment epoch.

Reviewers: David Jacot <djacot@confluent.io>
