### PR TITLE
KAFKA-19968: Fix tiered storage quota enforcement issues

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -286,6 +286,9 @@ class BrokerServer(
 
       remoteLogManagerOpt = createRemoteLogManager(listenerInfo)
 
+      // Eagerly apply tiered storage quota configurations to prevent startup race condition
+      remoteLogManagerOpt.foreach(applyRemoteLogQuotas)
+
       alterPartitionManager = AlterPartitionManager(
         config,
         scheduler = kafkaScheduler,
@@ -760,6 +763,32 @@ class BrokerServer(
       Some(rlm)
     } else {
       None
+    }
+  }
+
+  /**
+   * Eagerly applies tiered storage quota configurations to RemoteLogManager.
+   * This prevents a startup race condition where RemoteLogManager would otherwise start with
+   * default quotas (unlimited) until dynamic config updates apply the correct values.
+   *
+   * In KRaft mode, configs are read directly from the broker configuration which is already
+   * loaded from the controller metadata at startup.
+   *
+   * @param remoteLogManager The RemoteLogManager instance to configure
+   */
+  private def applyRemoteLogQuotas(remoteLogManager: RemoteLogManager): Unit = {
+    val fetchQuota = config.remoteLogManagerConfig.remoteLogManagerFetchMaxBytesPerSecond()
+    val copyQuota = config.remoteLogManagerConfig.remoteLogManagerCopyMaxBytesPerSecond()
+
+    // Only apply if not using default (unlimited) values
+    if (fetchQuota != RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_FETCH_MAX_BYTES_PER_SECOND) {
+      remoteLogManager.updateFetchQuota(fetchQuota)
+      info(s"Initialized RemoteLogManager fetch quota from configuration: $fetchQuota bytes/sec")
+    }
+
+    if (copyQuota != RemoteLogManagerConfig.DEFAULT_REMOTE_LOG_MANAGER_COPY_MAX_BYTES_PER_SECOND) {
+      remoteLogManager.updateCopyQuota(copyQuota)
+      info(s"Initialized RemoteLogManager copy quota from configuration: $copyQuota bytes/sec")
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1925,8 +1925,14 @@ class ReplicaManager(val config: KafkaConfig,
         createLogReadResult(highWatermark, leaderLogStartOffset, leaderLogEndOffset,
           new OffsetMovedToTieredStorageException("Given offset" + offset + " is moved to tiered storage"))
       } else {
-        val throttleTimeMs = remoteLogManager.get.getFetchThrottleTimeMs
+        // Reserve quota atomically before dispatching to prevent concurrent bypass
+        // This records the estimated fetch size and checks quota in one atomic operation
+        val quotaCheckResult = remoteLogManager.get.recordAndCheckFetchQuota(adjustedMaxBytes)
+        val throttleTimeMs = quotaCheckResult
         val fetchDataInfo = if (throttleTimeMs > 0) {
+          // Quota exceeded - release the reservation immediately since we're not fetching
+          remoteLogManager.get.releaseFetchQuota(adjustedMaxBytes)
+
           // Record the throttle time for the remote log fetches
           remoteLogManager.get.fetchThrottleTimeSensor().record(throttleTimeMs, time.milliseconds())
 
@@ -1945,7 +1951,7 @@ class ReplicaManager(val config: KafkaConfig,
           val remoteStorageFetchInfoOpt = if (adjustedMaxBytes > 0) {
             // For consume fetch requests, create a dummy FetchDataInfo with the remote storage fetch information.
             // For the topic-partitions that need remote data, we will use this information to read the data in another thread.
-            Optional.of(new RemoteStorageFetchInfo(adjustedMaxBytes, minOneMessage, tp, fetchInfo, params.isolation))
+            Optional.of(new RemoteStorageFetchInfo(adjustedMaxBytes, minOneMessage, tp, fetchInfo, params.isolation, adjustedMaxBytes))
           } else {
             Optional.empty[RemoteStorageFetchInfo]()
           }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5746,7 +5746,8 @@ class ReplicaManagerTest {
 
   @Test
   def testRemoteReadQuotaExceeded(): Unit = {
-    when(mockRemoteLogManager.getFetchThrottleTimeMs).thenReturn(quotaExceededThrottleTime)
+    when(mockRemoteLogManager.recordAndCheckFetchQuota(anyInt())).thenReturn(quotaExceededThrottleTime)
+    doNothing().when(mockRemoteLogManager).releaseFetchQuota(anyInt())
 
     val tp0 = new TopicPartition(topic, 0)
     val tpId0 = new TopicIdPartition(topicId, tp0)
@@ -5770,7 +5771,7 @@ class ReplicaManagerTest {
 
   @Test
   def testRemoteReadQuotaNotExceeded(): Unit = {
-    when(mockRemoteLogManager.getFetchThrottleTimeMs).thenReturn(quotaAvailableThrottleTime)
+    when(mockRemoteLogManager.recordAndCheckFetchQuota(anyInt())).thenReturn(quotaAvailableThrottleTime)
 
     val tp0 = new TopicPartition(topic, 0)
     val tpId0 = new TopicIdPartition(topicId, tp0)

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManager.java
@@ -93,6 +93,48 @@ public class RLMQuotaManager {
         sensor().record(value, time.milliseconds(), false);
     }
 
+    /**
+     * Record usage and immediately check quota. This ensures the check sees the recorded value
+     * by using the sensor's internal synchronization.
+     *
+     * @param value The value to record
+     * @return The throttle time in milliseconds, or 0 if quota is not exceeded
+     */
+    public long recordAndGetThrottleTimeMs(double value) {
+        Sensor sensorInstance = sensor();
+        // Record with checkQuotas=false to avoid immediate exception
+        sensorInstance.record(value, time.milliseconds(), false);
+
+        // Now check quotas - this will see the value we just recorded
+        // because Sensor uses synchronized internally
+        try {
+            sensorInstance.checkQuotas();
+        } catch (QuotaViolationException qve) {
+            LOGGER.debug("Quota violated after recording {} bytes for sensor ({}), metric: ({}), metric-value: ({}), bound: ({})",
+                value, sensorInstance.name(), qve.metric().metricName(), qve.value(), qve.bound());
+            return QuotaUtils.throttleTime(qve, time.milliseconds());
+        }
+        return 0L;
+    }
+
+    /**
+     * Returns the current quota configuration.
+     * This method is thread-safe and returns a consistent snapshot of the quota.
+     *
+     * Visible for testing - allows tests to verify quota values are correctly initialized
+     * and updated without requiring indirect measurement through throttle behavior.
+     *
+     * @return the current Quota
+     */
+    public Quota quota() {
+        lock.readLock().lock();
+        try {
+            return quota;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     private MetricConfig getQuotaMetricConfig(Quota quota) {
         return new MetricConfig()
             .timeWindow(config.quotaWindowSizeSeconds(), TimeUnit.SECONDS)

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -353,6 +353,32 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         return fetchQuotaMetrics.sensor();
     }
 
+    /**
+     * Atomically records estimated fetch size and checks quota.
+     * This prevents the race condition where multiple threads check quota before any record usage.
+     */
+    public long recordAndCheckFetchQuota(int estimatedBytes) {
+        return rlmFetchQuotaManager.recordAndGetThrottleTimeMs(estimatedBytes);
+    }
+
+    /**
+     * Releases a previously reserved quota amount.
+     * Used when a fetch is throttled and not executed.
+     */
+    public void releaseFetchQuota(int bytes) {
+        rlmFetchQuotaManager.record(-bytes);
+    }
+
+    // Visible for testing
+    public RLMQuotaManager fetchQuotaManager() {
+        return rlmFetchQuotaManager;
+    }
+
+    // Visible for testing
+    public RLMQuotaManager copyQuotaManager() {
+        return rlmCopyQuotaManager;
+    }
+
     static RLMQuotaManagerConfig copyQuotaManagerConfig(RemoteLogManagerConfig rlmConfig) {
         return new RLMQuotaManagerConfig(rlmConfig.remoteLogManagerCopyMaxBytesPerSecond(),
           rlmConfig.remoteLogManagerCopyNumQuotaSamples(),

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogReader.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogReader.java
@@ -60,22 +60,51 @@ public class RemoteLogReader implements Callable<Void> {
     @Override
     public Void call() {
         RemoteLogReadResult result;
+        String topic = fetchInfo.topicIdPartition().topic();
+
+        int quotaReservedBytes = fetchInfo.quotaReservedBytes();
+
         try {
             LOGGER.debug("Reading records from remote storage for topic partition {}", fetchInfo.topicIdPartition());
             FetchDataInfo fetchDataInfo = remoteReadTimer.time(() -> rlm.read(fetchInfo));
-            brokerTopicStats.topicStats(fetchInfo.topicIdPartition().topic()).remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
-            brokerTopicStats.allTopicsStats().remoteFetchBytesRate().mark(fetchDataInfo.records.sizeInBytes());
+            int actualFetchSize = fetchDataInfo.records.sizeInBytes();
+
+            // Adjust quota: record only the DELTA between actual and reserved
+            if (quotaReservedBytes > 0) {
+                int delta = actualFetchSize - quotaReservedBytes;
+                if (delta != 0) {
+                    quotaManager.record(delta);
+                    LOGGER.debug("Adjusted quota for {}: reserved={}, actual={}, delta={}",
+                        fetchInfo.topicIdPartition(), quotaReservedBytes, actualFetchSize, delta);
+                }
+            }
+
+            brokerTopicStats.topicStats(topic).remoteFetchBytesRate().mark(actualFetchSize);
+            brokerTopicStats.allTopicsStats().remoteFetchBytesRate().mark(actualFetchSize);
+
             result = new RemoteLogReadResult(Optional.of(fetchDataInfo), Optional.empty());
         } catch (OffsetOutOfRangeException e) {
+            // Fetch failed, release the reservation
+            if (quotaReservedBytes > 0) {
+                quotaManager.record(-quotaReservedBytes);
+                LOGGER.debug("Released {} bytes reservation due to offset out of range for {}",
+                    quotaReservedBytes, fetchInfo.topicIdPartition());
+            }
             result = new RemoteLogReadResult(Optional.empty(), Optional.of(e));
         } catch (Exception e) {
-            brokerTopicStats.topicStats(fetchInfo.topicIdPartition().topic()).failedRemoteFetchRequestRate().mark();
+            // Fetch failed, release the reservation
+            if (quotaReservedBytes > 0) {
+                quotaManager.record(-quotaReservedBytes);
+                LOGGER.debug("Released {} bytes reservation due to error for {}",
+                    quotaReservedBytes, fetchInfo.topicIdPartition());
+            }
+            brokerTopicStats.topicStats(topic).failedRemoteFetchRequestRate().mark();
             brokerTopicStats.allTopicsStats().failedRemoteFetchRequestRate().mark();
             LOGGER.error("Error occurred while reading the remote data for {}", fetchInfo.topicIdPartition(), e);
             result = new RemoteLogReadResult(Optional.empty(), Optional.of(e));
         }
+
         LOGGER.debug("Finished reading records from remote storage for topic partition {}", fetchInfo.topicIdPartition());
-        quotaManager.record(result.fetchDataInfo().map(fetchDataInfo -> fetchDataInfo.records.sizeInBytes()).orElse(0));
         callback.accept(result);
         return null;
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageFetchInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageFetchInfo.java
@@ -21,5 +21,5 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.server.storage.log.FetchIsolation;
 
 public record RemoteStorageFetchInfo(int fetchMaxBytes, boolean minOneMessage, TopicIdPartition topicIdPartition,
-                                     FetchRequest.PartitionData fetchInfo, FetchIsolation fetchIsolation) {
+                                     FetchRequest.PartitionData fetchInfo, FetchIsolation fetchIsolation, int quotaReservedBytes) {
 }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerTest.java
@@ -568,6 +568,55 @@ public class RLMQuotaManagerTest {
             "Final quota check should show violation after 150 bytes recorded (quota is 100)");
     }
 
+    @Test
+    public void testRecordAndGetThrottleTimeMsPreventsRaceCondition() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 10;
+        int bytesPerThread = 20;
+        Thread[] threads = new Thread[numThreads];
+        long[] throttleTimes = new long[numThreads];
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        AtomicInteger exceptions = new AtomicInteger(0);
+
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    throttleTimes[threadIndex] = quotaManager.recordAndGetThrottleTimeMs(bytesPerThread);
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    exceptions.incrementAndGet();
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals(0, exceptions.get(), "No threads should have exceptions");
+
+        moveClock(1);
+
+        int allowedCount = 0;
+        for (long throttleTime : throttleTimes) {
+            if (throttleTime == 0) {
+                allowedCount++;
+            }
+        }
+
+        assertTrue(allowedCount < numThreads, "Some threads must be throttled when quota exceeded");
+        assertTrue(allowedCount > 0, "At least one thread should succeed before quota exceeded");
+        assertTrue(quotaManager.getThrottleTimeMs() > 0, "Quota should be exceeded after all recordings");
+    }
+
     private Map<MetricName, MetricConfig> extractMetricConfig(Map<MetricName, KafkaMetric> metrics) {
         return metrics.entrySet().stream()
             .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().config()));

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/quota/RLMQuotaManagerTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -110,6 +113,459 @@ public class RLMQuotaManagerTest {
 
     private void moveClock(int secs) {
         time.setCurrentTimeMs(time.milliseconds() + secs * 1000L);
+    }
+
+    @Test
+    public void testRecordAndGetThrottleTimeMs() {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(50, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        // First request should not be throttled
+        long throttleTime = quotaManager.recordAndGetThrottleTimeMs(30);
+        assertEquals(0L, throttleTime, "First request under quota should not be throttled");
+
+        // Move clock forward to capture the rate
+        moveClock(1);
+
+        // Second request that exceeds quota should be throttled
+        throttleTime = quotaManager.recordAndGetThrottleTimeMs(30);
+        assertTrue(throttleTime > 0, "Request exceeding quota should be throttled");
+    }
+
+    @Test
+    public void testRecordAndGetThrottleTimeMsSeesRecordedValue() {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(50, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        // Record a value that exceeds quota
+        long throttleTime = quotaManager.recordAndGetThrottleTimeMs(500);
+        moveClock(1);
+
+        // The throttle time should be non-zero because recordAndGetThrottleTimeMs
+        // should see its own recorded value
+        assertTrue(throttleTime > 0, "recordAndGetThrottleTimeMs should see its own recorded value");
+    }
+
+    @Test
+    public void testRecordAndGetThrottleTimeMsMultipleRequests() {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        // Record multiple small requests
+        assertEquals(0L, quotaManager.recordAndGetThrottleTimeMs(20));
+        assertEquals(0L, quotaManager.recordAndGetThrottleTimeMs(20));
+        assertEquals(0L, quotaManager.recordAndGetThrottleTimeMs(20));
+
+        moveClock(1);
+
+        // Next request should see accumulated usage
+        assertEquals(0L, quotaManager.recordAndGetThrottleTimeMs(20));
+
+        // This one pushes over quota
+        long throttleTime = quotaManager.recordAndGetThrottleTimeMs(30);
+        assertTrue(throttleTime > 0, "Request that pushes over quota should be throttled");
+    }
+
+    @Test
+    public void testConcurrentRecordAndGetThrottleTimeMs() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 10;
+        int recordsPerThread = 5;
+        int bytesPerRecord = 30; // 10 threads * 5 records * 30 bytes = 1500 bytes total
+
+        Thread[] threads = new Thread[numThreads];
+        long[][] throttleTimes = new long[numThreads][recordsPerThread];
+
+        // Create threads that will concurrently record
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                for (int j = 0; j < recordsPerThread; j++) {
+                    throttleTimes[threadIndex][j] = quotaManager.recordAndGetThrottleTimeMs(bytesPerRecord);
+                    try {
+                        Thread.sleep(1); // Small delay to simulate real work
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        moveClock(1);
+
+        int throttledCount = 0;
+        for (int i = 0; i < numThreads; i++) {
+            for (int j = 0; j < recordsPerThread; j++) {
+                if (throttleTimes[i][j] > 0) {
+                    throttledCount++;
+                }
+            }
+        }
+
+        assertTrue(throttledCount > 0,
+            "At least some concurrent requests should have been throttled when quota is exceeded");
+    }
+
+    @Test
+    public void testConcurrentRecordAndGetThrottleTimeMsConsistency() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(50, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 5;
+        Thread[] threads = new Thread[numThreads];
+        boolean[] wasThrottled = new boolean[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                long throttleTime = quotaManager.recordAndGetThrottleTimeMs(60);
+                wasThrottled[threadIndex] = throttleTime > 0;
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        moveClock(1);
+
+        int throttledCount = 0;
+        for (boolean throttled : wasThrottled) {
+            if (throttled) {
+                throttledCount++;
+            }
+        }
+
+        assertTrue(throttledCount >= 1,
+            "At least one thread should have been throttled when all threads exceed quota");
+    }
+
+    @Test
+    public void testRecordAndGetThrottleTimeMsNegativeValue() {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        quotaManager.recordAndGetThrottleTimeMs(150);
+        moveClock(1);
+
+        assertTrue(quotaManager.getThrottleTimeMs() > 0);
+
+        quotaManager.record(-150);
+
+        assertEquals(0L, quotaManager.getThrottleTimeMs(),
+            "Quota should not be exceeded after releasing reservation");
+    }
+
+    @Test
+    public void testConcurrentDeltaAdjustments() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(200, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 20;
+        Thread[] threads = new Thread[numThreads];
+
+        // Simulate fetch scenario: reserve estimate, then adjust with actual delta
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                int estimated = 50;
+                quotaManager.recordAndGetThrottleTimeMs(estimated);
+
+                try {
+                    Thread.sleep(5);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                int actual = 30 + (threadIndex % 31);
+                int delta = actual - estimated;
+                quotaManager.record(delta);
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        moveClock(1);
+
+        long throttleTime = quotaManager.getThrottleTimeMs();
+        assertTrue(throttleTime >= 0, "Quota manager should be in consistent state after concurrent delta adjustments");
+    }
+
+    @Test
+    public void testConcurrentReservationReleases() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 15;
+        Thread[] threads = new Thread[numThreads];
+
+        // Half succeed with delta adjustment, half fail and release
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                int estimated = 40;
+                quotaManager.recordAndGetThrottleTimeMs(estimated);
+
+                try {
+                    Thread.sleep(2);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                if (threadIndex % 2 == 0) {
+                    int actual = 35;
+                    int delta = actual - estimated;
+                    quotaManager.record(delta);
+                } else {
+                    quotaManager.record(-estimated);
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        moveClock(1);
+
+        long throttleTime = quotaManager.getThrottleTimeMs();
+        assertTrue(throttleTime >= 0, "Quota manager should handle mixed success/failure scenarios");
+    }
+
+    @Test
+    public void testHighConcurrencyStressTest() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(500, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 50;
+        Thread[] threads = new Thread[numThreads];
+        boolean[] completed = new boolean[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    int estimated = 20 + (threadIndex % 30);
+                    long throttleTime = quotaManager.recordAndGetThrottleTimeMs(estimated);
+
+                    if (throttleTime > 0) {
+                        Thread.sleep(Math.min(throttleTime, 10));
+                    }
+
+                    Thread.sleep(1);
+
+                    if (threadIndex % 3 == 0) {
+                        quotaManager.record(-estimated);
+                    } else {
+                        int actual = estimated + (threadIndex % 10) - 5;
+                        quotaManager.record(actual - estimated);
+                    }
+
+                    completed[threadIndex] = true;
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join(5000);
+        }
+
+        int completedCount = 0;
+        for (boolean c : completed) {
+            if (c) {
+                completedCount++;
+            }
+        }
+
+        assertTrue(completedCount >= numThreads * 0.95,
+            "At least 95% of threads should complete under high concurrency");
+
+        moveClock(1);
+
+        long throttleTime = quotaManager.getThrottleTimeMs();
+        assertTrue(throttleTime >= 0, "Quota manager should remain consistent under stress");
+    }
+
+    @Test
+    public void testConcurrentRecordAndCheckRace() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 20;
+        Thread[] threads = new Thread[numThreads];
+        long[] throttleTimes = new long[numThreads];
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        AtomicInteger exceptions = new AtomicInteger(0);
+
+        // Use barrier to ensure true concurrent execution
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    throttleTimes[threadIndex] = quotaManager.recordAndGetThrottleTimeMs(10);
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    exceptions.incrementAndGet();
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals(0, exceptions.get(), "No threads should have exceptions");
+
+        moveClock(1);
+
+        int throttledCount = 0;
+        for (long throttleTime : throttleTimes) {
+            if (throttleTime > 0) {
+                throttledCount++;
+            }
+        }
+
+        assertTrue(throttledCount > 0,
+            "With 20 threads recording 10 bytes each (200 total), some should be throttled (quota is 100)");
+
+        long finalThrottleTime = quotaManager.getThrottleTimeMs();
+        assertTrue(finalThrottleTime > 0,
+            "After recording 200 bytes with 100 bytes/sec quota, should be throttled");
+    }
+
+    @Test
+    public void testConcurrentRecordAndReleaseInterleaved() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(150, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 30;
+        Thread[] threads = new Thread[numThreads];
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        AtomicInteger exceptions = new AtomicInteger(0);
+
+        // Use barrier to ensure true concurrent execution
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+
+                    if (threadIndex % 3 == 0) {
+                        quotaManager.recordAndGetThrottleTimeMs(30);
+                    } else if (threadIndex % 3 == 1) {
+                        quotaManager.record(-30);
+                    } else {
+                        quotaManager.record(5);
+                    }
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    exceptions.incrementAndGet();
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals(0, exceptions.get(), "No threads should have exceptions");
+
+        moveClock(1);
+
+        long throttleTime = quotaManager.getThrottleTimeMs();
+        assertTrue(throttleTime >= 0,
+            "Quota manager should handle interleaved record/release operations");
+    }
+
+    @Test
+    public void testRecordCheckInterleavingRace() throws InterruptedException {
+        RLMQuotaManager quotaManager = new RLMQuotaManager(
+            new RLMQuotaManagerConfig(100, 11, 1), metrics, QUOTA_TYPE, DESCRIPTION, time);
+
+        int numThreads = 10;
+        Thread[] threads = new Thread[numThreads];
+        long[] throttleTimes = new long[numThreads];
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        AtomicInteger exceptions = new AtomicInteger(0);
+
+        // Use barrier to ensure true concurrent execution
+        for (int i = 0; i < numThreads; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    throttleTimes[threadIndex] = quotaManager.recordAndGetThrottleTimeMs(15);
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    exceptions.incrementAndGet();
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals(0, exceptions.get(), "No threads should have exceptions");
+
+        moveClock(1);
+
+        int throttledCount = 0;
+        for (long throttleTime : throttleTimes) {
+            if (throttleTime > 0) {
+                throttledCount++;
+            }
+        }
+
+        assertTrue(throttledCount > 0,
+            "With 10 threads recording 15 bytes each (150 total), exceeding 100 quota, some should be throttled");
+
+        long finalThrottleTime = quotaManager.getThrottleTimeMs();
+        assertTrue(finalThrottleTime > 0,
+            "Final quota check should show violation after 150 bytes recorded (quota is 100)");
     }
 
     private Map<MetricName, MetricConfig> extractMetricConfig(Map<MetricName, KafkaMetric> metrics) {

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -3120,7 +3120,7 @@ public class RemoteLogManagerTest {
         );
 
         RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(
-                0, false, tpId, partitionData, FetchIsolation.TXN_COMMITTED
+                0, false, tpId, partitionData, FetchIsolation.TXN_COMMITTED, 0
         );
 
         try (RemoteLogManager remoteLogManager = new RemoteLogManager(
@@ -3200,7 +3200,7 @@ public class RemoteLogManagerTest {
         );
 
         RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(
-                0, minOneMessage, tpId, partitionData, FetchIsolation.HIGH_WATERMARK
+                0, minOneMessage, tpId, partitionData, FetchIsolation.HIGH_WATERMARK, 0
         );
 
         try (RemoteLogManager remoteLogManager = new RemoteLogManager(
@@ -3286,7 +3286,7 @@ public class RemoteLogManagerTest {
         when(firstBatch.sizeInBytes()).thenReturn(recordBatchSizeInBytes);
         doNothing().when(firstBatch).writeTo(capture.capture());
         RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(
-                0, true, tpId, partitionData, FetchIsolation.HIGH_WATERMARK
+                0, true, tpId, partitionData, FetchIsolation.HIGH_WATERMARK, 0
         );
 
 
@@ -3677,7 +3677,7 @@ public class RemoteLogManagerTest {
                 Uuid.randomUuid(), fetchOffset, 0, 100, Optional.empty());
         RemoteStorageFetchInfo remoteStorageFetchInfo = new RemoteStorageFetchInfo(
                 1048576, true, leaderTopicIdPartition,
-                partitionData, FetchIsolation.HIGH_WATERMARK);
+                partitionData, FetchIsolation.HIGH_WATERMARK, 0);
         FetchDataInfo fetchDataInfo = remoteLogManager.read(remoteStorageFetchInfo);
         // firstBatch baseOffset may not be equal to the fetchOffset
         assertEquals(9, fetchDataInfo.fetchOffsetMetadata.messageOffset);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -3808,6 +3808,38 @@ public class RemoteLogManagerTest {
         assertEquals(4, remoteLogManager.followerThreadPoolSize());
     }
 
+    @Test
+    void testQuotaStartsUnlimitedWithoutExplicitConfig() throws Exception {
+        Properties props = brokerConfig;
+        props.setProperty(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true");
+        appendRLMConfig(props);
+
+        RemoteLogManagerConfig rlmConfig = configs(props);
+        RemoteLogManager rlm = new RemoteLogManager(
+            rlmConfig, brokerId, logDir, clusterId, time,
+            tp -> Optional.empty(),
+            (topicPartition, offset) -> { },
+            brokerTopicStats, metrics, endPoint
+        );
+
+        try {
+            assertEquals(Long.MAX_VALUE, (long) rlm.fetchQuotaManager().quota().bound());
+            assertEquals(Long.MAX_VALUE, (long) rlm.copyQuotaManager().quota().bound());
+
+            long throttleTime = rlm.recordAndCheckFetchQuota(100_000_000);
+            assertEquals(0L, throttleTime);
+
+            long fetchQuota = 1_000_000L;
+            rlm.updateFetchQuota(fetchQuota);
+            assertEquals(fetchQuota, (long) rlm.fetchQuotaManager().quota().bound());
+
+            throttleTime = rlm.recordAndCheckFetchQuota(50_000);
+            assertTrue(throttleTime > 0);
+        } finally {
+            rlm.close();
+        }
+    }
+
     private void appendRecordsToFile(File file, int nRecords, int nRecordsPerBatch) throws IOException {
         byte magic = RecordBatch.CURRENT_MAGIC_VALUE;
         Compression compression = Compression.NONE;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogReaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogReaderTest.java
@@ -70,7 +70,7 @@ public class RemoteLogReaderTest {
         when(mockRLM.read(any(RemoteStorageFetchInfo.class))).thenReturn(fetchDataInfo);
 
         Consumer<RemoteLogReadResult> callback = mock(Consumer.class);
-        RemoteStorageFetchInfo remoteStorageFetchInfo = new RemoteStorageFetchInfo(0, false, new TopicIdPartition(Uuid.randomUuid(), 0, TOPIC), null, null);
+        RemoteStorageFetchInfo remoteStorageFetchInfo = new RemoteStorageFetchInfo(0, false, new TopicIdPartition(Uuid.randomUuid(), 0, TOPIC), null, null, 0);
         RemoteLogReader remoteLogReader =
                 new RemoteLogReader(remoteStorageFetchInfo, mockRLM, callback, brokerTopicStats, mockQuotaManager, timer);
         remoteLogReader.call();
@@ -83,10 +83,8 @@ public class RemoteLogReaderTest {
         assertTrue(actualRemoteLogReadResult.fetchDataInfo().isPresent());
         assertEquals(fetchDataInfo, actualRemoteLogReadResult.fetchDataInfo().get());
 
-        // verify the record method on quota manager was called with the expected value
-        ArgumentCaptor<Double> recordedArg = ArgumentCaptor.forClass(Double.class);
-        verify(mockQuotaManager, times(1)).record(recordedArg.capture());
-        assertEquals(100, recordedArg.getValue());
+        // With quotaReservedBytes=0, quota manager record() is not called
+        verify(mockQuotaManager, times(0)).record(any(Double.class));
 
         // Verify metrics for remote reads are updated correctly
         assertEquals(1, brokerTopicStats.topicStats(TOPIC).remoteFetchRequestRate().count());
@@ -103,7 +101,7 @@ public class RemoteLogReaderTest {
         when(mockRLM.read(any(RemoteStorageFetchInfo.class))).thenThrow(new RuntimeException("error"));
 
         Consumer<RemoteLogReadResult> callback = mock(Consumer.class);
-        RemoteStorageFetchInfo remoteStorageFetchInfo = new RemoteStorageFetchInfo(0, false, new TopicIdPartition(Uuid.randomUuid(), 0, TOPIC), null, null);
+        RemoteStorageFetchInfo remoteStorageFetchInfo = new RemoteStorageFetchInfo(0, false, new TopicIdPartition(Uuid.randomUuid(), 0, TOPIC), null, null, 0);
         RemoteLogReader remoteLogReader =
                 new RemoteLogReader(remoteStorageFetchInfo, mockRLM, callback, brokerTopicStats, mockQuotaManager, timer);
         remoteLogReader.call();
@@ -115,10 +113,8 @@ public class RemoteLogReaderTest {
         assertTrue(actualRemoteLogReadResult.error().isPresent());
         assertFalse(actualRemoteLogReadResult.fetchDataInfo().isPresent());
 
-        // verify the record method on quota manager was called with the expected value
-        ArgumentCaptor<Double> recordedArg = ArgumentCaptor.forClass(Double.class);
-        verify(mockQuotaManager, times(1)).record(recordedArg.capture());
-        assertEquals(0, recordedArg.getValue());
+        // With quotaReservedBytes=0, quota manager record() is not called
+        verify(mockQuotaManager, times(0)).record(any(Double.class));
 
         // Verify metrics for remote reads are updated correctly
         assertEquals(1, brokerTopicStats.topicStats(TOPIC).remoteFetchRequestRate().count());

--- a/storage/src/test/java/org/apache/kafka/server/purgatory/DelayedRemoteFetchTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/purgatory/DelayedRemoteFetchTest.java
@@ -92,7 +92,7 @@ public class DelayedRemoteFetchTest {
         CompletableFuture<RemoteLogReadResult> future = new CompletableFuture<>();
         future.complete(buildRemoteReadResult(Errors.NONE));
 
-        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
+        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
         long highWatermark = 100L;
         long leaderLogStartOffset = 10L;
         LogReadResult logReadInfo = buildReadResult(Errors.NONE, highWatermark, leaderLogStartOffset);
@@ -129,7 +129,7 @@ public class DelayedRemoteFetchTest {
 
         CompletableFuture<RemoteLogReadResult> future = new CompletableFuture<>();
         future.complete(buildRemoteReadResult(Errors.NONE));
-        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
+        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
         LogReadResult logReadInfo = buildReadResult(Errors.NONE, 100L, 10L);
 
         assertThrows(IllegalStateException.class, () ->
@@ -163,7 +163,7 @@ public class DelayedRemoteFetchTest {
             .when(partitionOrException).accept(topicIdPartition.topicPartition());
 
         CompletableFuture<RemoteLogReadResult> future = new CompletableFuture<>();
-        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
+        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
 
         LogReadResult logReadInfo = buildReadResult(Errors.NONE);
 
@@ -201,7 +201,7 @@ public class DelayedRemoteFetchTest {
         CompletableFuture<RemoteLogReadResult> future = new CompletableFuture<>();
         future.complete(buildRemoteReadResult(Errors.NONE));
 
-        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
+        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
 
         // build a read result with error
         LogReadResult logReadInfo = buildReadResult(Errors.FENCED_LEADER_EPOCH);
@@ -255,8 +255,8 @@ public class DelayedRemoteFetchTest {
         // Only complete one remote fetch
         future2.complete(buildRemoteReadResult(Errors.NONE));
 
-        RemoteStorageFetchInfo fetchInfo1 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
-        RemoteStorageFetchInfo fetchInfo2 = new RemoteStorageFetchInfo(0, false, topicIdPartition2, null, null);
+        RemoteStorageFetchInfo fetchInfo1 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
+        RemoteStorageFetchInfo fetchInfo2 = new RemoteStorageFetchInfo(0, false, topicIdPartition2, null, null, 0);
 
         long highWatermark = 100L;
         long leaderLogStartOffset = 10L;
@@ -329,8 +329,8 @@ public class DelayedRemoteFetchTest {
         // Only complete one remote fetch
         future1.complete(buildRemoteReadResult(Errors.NONE));
 
-        RemoteStorageFetchInfo fetchInfo1 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
-        RemoteStorageFetchInfo fetchInfo2 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
+        RemoteStorageFetchInfo fetchInfo1 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
+        RemoteStorageFetchInfo fetchInfo2 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
 
         long highWatermark1 = 100L;
         long leaderLogStartOffset1 = 10L;
@@ -399,8 +399,8 @@ public class DelayedRemoteFetchTest {
         future1.complete(buildRemoteReadResult(Errors.NONE));
         future2.complete(buildRemoteReadResult(Errors.UNKNOWN_SERVER_ERROR));
 
-        RemoteStorageFetchInfo fetchInfo1 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
-        RemoteStorageFetchInfo fetchInfo2 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null);
+        RemoteStorageFetchInfo fetchInfo1 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
+        RemoteStorageFetchInfo fetchInfo2 = new RemoteStorageFetchInfo(0, false, topicIdPartition, null, null, 0);
 
         LogReadResult logReadInfo1 = buildReadResult(Errors.NONE, 100, 10);
         LogReadResult logReadInfo2 = buildReadResult(Errors.NONE, 100, 10);


### PR DESCRIPTION
###Problem:
1. Race condition and quota leaks: Multiple threads could check quota before any recorded usage, allowing all to bypass limits simultaneously. Additionally, in multi-partition fetches, quota was reserved per-partition but could leak if some partitions failed or were throttled, leading to quota exhaustion over time.

2. Startup race condition: RemoteLogManager initialized with default quotas (Long.MAX_VALUE = unlimited) and relied on dynamic config updates to apply correct values, creating a window where operations could exceed configured quotas.

###Solution:
1. Atomic quota reservation
   - Added `RLMQuotaManager.recordAndGetThrottleTimeMs()` to atomically record usage and check quota in a single synchronized operation
   - Added quotaReservedBytes field to RemoteStorageFetchInfo to track per-partition reservations
   - Modified ReplicaManager to call `recordAndCheckFetchQuota()` BEFORE dispatching remote fetch, ensuring quota is reserved atomically based on adjustedMaxBytes
   - If throttled, immediately release the reservation since fetch won't execute
   - RemoteLogReader adjusts quota using delta (actual - reserved) after fetch completes
   - On error, releases the full reservation to prevent leaks

2. Eager startup quota initialization
   - Ensures quotas are correct before broker starts serving requests
   - Added `BrokerServer.applyRemoteLogQuotas()` to eagerly apply quota configs immediately after RemoteLogManager creation
