### PR TITLE
MINOR: Clean up TopicCommand

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -119,7 +119,7 @@ public class TopicCommandTest {
         TopicCommand.PartitionDescription partitionDescription = new TopicCommand.PartitionDescription("test-topic",
                 new TopicPartitionInfo(0, new Node(1, "localhost", 9091), replicas,
                         List.of(new Node(1, "localhost", 9091))),
-                null, false,
+                null,
                 new PartitionReassignment(replicaIds, List.of(2), List.of())
         );
 


### PR DESCRIPTION
Changes in this PR:
- Cleared out obsolete boolean fields (always false) from classes.
- Revised method access modifiers for better encapsulation.
- Simplified code by inlining one‑time‑use methods.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
