### PR TITLE
KAFKA-19980: ConfigCommand#validatePropsKey should accept `$` symbol

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -137,6 +137,7 @@ object ConfigCommand extends Logging {
 
   private def validatePropsKey(props: Properties): Unit = {
     props.keySet.forEach { propsKey =>
+      // Allows the '$' symbol to support valid logger names for internal classes (e.g. org.apache.kafka.server.quota.ClientQuotaManager$ThrottledChannelReaper)
       if (!propsKey.toString.matches("[$a-zA-Z0-9._-]*")) {
         throw new IllegalArgumentException(
           s"Invalid character found for config key: $propsKey"

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -137,7 +137,7 @@ object ConfigCommand extends Logging {
 
   private def validatePropsKey(props: Properties): Unit = {
     props.keySet.forEach { propsKey =>
-      if (!propsKey.toString.matches("[a-zA-Z0-9._-]*")) {
+      if (!propsKey.toString.matches("[$a-zA-Z0-9._-]*")) {
         throw new IllegalArgumentException(
           s"Invalid character found for config key: $propsKey"
         )

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
@@ -295,13 +295,14 @@ public class ConfigCommandTest {
         createOpts = new ConfigCommand.ConfigCommandOptions(toArray(connectOpts1, connectOpts2,
             shortFlag, "1",
             "--alter",
-            "--add-config", "a._-c=b,c=,d=e,f="));
+            "--add-config", "a._-c=b,c=,d=e,a$b=c,f="));
         createOpts.checkArgs();
 
         Properties addedProps2 = ConfigCommand.parseConfigsToBeAdded(createOpts);
-        assertEquals(4, addedProps2.size());
+        assertEquals(5, addedProps2.size());
         assertEquals("b", addedProps2.getProperty("a._-c"));
         assertEquals("e", addedProps2.getProperty("d"));
+        assertEquals("c", addedProps2.getProperty("a$b"));
         assertTrue(addedProps2.getProperty("c").isEmpty());
         assertTrue(addedProps2.getProperty("f").isEmpty());
 


### PR DESCRIPTION
1. Enabled ConfigCommand#validatePropsKey to support the `$` symbol.
2. Added UT and IT for the change.

Reviewers: Chih-Yuan Chien <joshua2519@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
