### PR TITLE
KAFKA-19987: Add metrics from KIP-1216 to ops.html

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3231,6 +3231,36 @@ All the following metrics have a recording level of <code>info</code>:
         <td>The system timestamp in ms that the thread was started.</td>
         <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
       </tr>
+      <tr>
+        <td>tasks-revoked-latency-avg</td>
+        <td>The average time in ms taken for tasks-revoked rebalance listener callback.</td>
+        <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>tasks-revoked-latency-max</td>
+        <td>The maximum time in ms taken for tasks-revoked rebalance listener callback.</td>
+        <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>tasks-assigned-latency-avg</td>
+        <td>The average time in ms taken for tasks-assigned rebalance listener callback.</td>
+        <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>tasks-assigned-latency-max</td>
+        <td>The maximum time in ms taken for tasks-assigned rebalance listener callback.</td>
+        <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>tasks-lost-latency-avg</td>
+        <td>The average time in ms taken for tasks-lost rebalance listener callback.</td>
+        <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
+      </tr>
+      <tr>
+        <td>tasks-lost-latency-max</td>
+        <td>The maximum time in ms taken for tasks-lost rebalance listener callback.</td>
+        <td>kafka.streams:type=stream-thread-metrics,thread-id=([-.\w]+)</td>
+      </tr>
  </tbody>
 </table>
 


### PR DESCRIPTION
This commit adds the new thread-level rebalance listener callback
metrics from KIP-1216 to the Streams Monitoring section in ops.html:

- tasks-revoked-latency-avg and tasks-revoked-latency-max
- tasks-assigned-latency-avg and tasks-assigned-latency-max
- tasks-lost-latency-avg and tasks-lost-latency-max

All metrics are at the INFO recording level and measure time in
milliseconds.

Reviewers: Matthias J. Sax <matthias@confluent.io>
