### PR TITLE
KAFKA-19212: Correct the unclean leader election metric calculation for 3.9

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -344,11 +344,11 @@ public class PartitionChangeBuilder {
                 targetIsr = Collections.singletonList(electionResult.node);
                 targetElr = targetElr.stream().filter(replica -> replica != electionResult.node)
                     .collect(Collectors.toList());
-                log.trace("Setting new leader for topicId {}, partition {} to {} using ELR",
-                        topicId, partitionId, electionResult.node);
+                log.info("Setting new leader for topicId {}, partition {} to {} using ELR. Previous partition: {}, change record: {}",
+                        topicId, partitionId, electionResult.node, partition, record);
             } else if (electionResult.unclean) {
-                log.info("Setting new leader for topicId {}, partition {} to {} using an unclean election",
-                    topicId, partitionId, electionResult.node);
+                log.info("Setting new leader for topicId {}, partition {} to {} using an unclean election. Previous partition: {}, change record: {}",
+                    topicId, partitionId, electionResult.node, partition, record);
             } else {
                 log.trace("Setting new leader for topicId {}, partition {} to {} using a clean election",
                     topicId, partitionId, electionResult.node);

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -74,6 +74,10 @@ class ControllerMetricsChanges {
         return offlinePartitionsChange;
     }
 
+    public int uncleanLeaderElection() {
+        return uncleanLeaderElection;
+    }
+
     public int partitionsWithoutPreferredLeaderChange() {
         return partitionsWithoutPreferredLeaderChange;
     }
@@ -114,10 +118,12 @@ class ControllerMetricsChanges {
         } else {
             for (Entry<Integer, PartitionRegistration> entry : topicDelta.partitionChanges().entrySet()) {
                 int partitionId = entry.getKey();
+                PartitionRegistration prevPartition = prev.partitions().get(partitionId);
                 PartitionRegistration nextPartition = entry.getValue();
-                handlePartitionChange(prev.partitions().get(partitionId), nextPartition);
+                handlePartitionChange(prevPartition, nextPartition);
             }
         }
+        topicDelta.partitionToUncleanLeaderElectionCount().forEach((partitionId, count) -> uncleanLeaderElection += count);
     }
 
     void handlePartitionChange(PartitionRegistration prev, PartitionRegistration next) {
@@ -136,11 +142,6 @@ class ControllerMetricsChanges {
             isPresent = true;
             isOffline = !next.hasLeader();
             isWithoutPreferredLeader = !next.hasPreferredLeader();
-            // take current all replicas as ISR if prev is null (new created partition), so we won't treat it as unclean election.
-            int[] prevIsr = prev != null ? prev.isr : next.replicas;
-            if (!PartitionRegistration.electionWasClean(next.leader, prevIsr)) {
-                uncleanLeaderElection++;
-            }
         }
         globalPartitionsChange += delta(wasPresent, isPresent);
         offlinePartitionsChange += delta(wasOffline, isOffline);

--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 public final class TopicDelta {
     private final TopicImage image;
     private final Map<Integer, PartitionRegistration> partitionChanges = new HashMap<>();
+    private Map<Integer, Integer> partitionToUncleanLeaderElectionCount = new HashMap<>();
 
     public TopicDelta(TopicImage image) {
         this.image = image;
@@ -67,20 +68,40 @@ public final class TopicDelta {
         return image.id();
     }
 
+    public Map<Integer, Integer> partitionToUncleanLeaderElectionCount() {
+        return partitionToUncleanLeaderElectionCount;
+    }
+
     public void replay(PartitionRecord record) {
+        int partitionId = record.partitionId();
+        PartitionRegistration prevPartition = partitionChanges.get(partitionId);
+        if (prevPartition == null) {
+            prevPartition = image.partitions().get(partitionId);
+        }
+        if (prevPartition != null) {
+            updateElectionStats(partitionId, prevPartition, record.leader(), record.leaderRecoveryState());
+        }
         partitionChanges.put(record.partitionId(), new PartitionRegistration(record));
     }
 
     public void replay(PartitionChangeRecord record) {
-        PartitionRegistration partition = partitionChanges.get(record.partitionId());
-        if (partition == null) {
-            partition = image.partitions().get(record.partitionId());
-            if (partition == null) {
+        int partitionId = record.partitionId();
+        PartitionRegistration prevPartition = partitionChanges.get(partitionId);
+        if (prevPartition == null) {
+            prevPartition = image.partitions().get(partitionId);
+            if (prevPartition == null) {
                 throw new RuntimeException("Unable to find partition " +
-                    record.topicId() + ":" + record.partitionId());
+                    record.topicId() + ":" + partitionId);
             }
         }
-        partitionChanges.put(record.partitionId(), partition.merge(record));
+        updateElectionStats(partitionId, prevPartition, record.leader(), record.leaderRecoveryState());
+        partitionChanges.put(record.partitionId(), prevPartition.merge(record));
+    }
+
+    private void updateElectionStats(int partitionId, PartitionRegistration prevPartition, int newLeader, byte newLeaderRecoveryState) {
+        if (PartitionRegistration.electionWasUnclean(newLeaderRecoveryState)) {
+            partitionToUncleanLeaderElectionCount.put(partitionId, partitionToUncleanLeaderElectionCount.getOrDefault(partitionId, 0) + 1);
+        }
     }
 
     public TopicImage apply() {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 
 
@@ -165,8 +164,8 @@ public class PartitionRegistration {
     public final int leaderEpoch;
     public final int partitionEpoch;
 
-    public static boolean electionWasClean(int newLeader, int[] isr) {
-        return newLeader == NO_LEADER || Replicas.contains(isr, newLeader);
+    public static boolean electionWasUnclean(byte leaderRecoveryState) {
+        return leaderRecoveryState == LeaderRecoveryState.RECOVERING.value();
     }
 
     private static List<Uuid> checkDirectories(PartitionRecord record) {
@@ -347,7 +346,7 @@ public class PartitionRegistration {
     }
 
     public void maybeLogPartitionChange(Logger log, String description, PartitionRegistration prev) {
-        if (!electionWasClean(leader, prev.isr)) {
+        if (electionWasUnclean(this.leaderRecoveryState.value())) {
             log.info("UNCLEAN partition change for {}: {}", description, diff(prev));
         } else if (log.isDebugEnabled()) {
             log.debug("partition change for {}: {}", description, diff(prev));

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
@@ -24,11 +24,13 @@ import org.apache.kafka.image.TopicDelta;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.common.MetadataVersion;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -197,5 +199,17 @@ public class ControllerMetricsChangesTest {
         assertEquals(1, changes.globalPartitionsChange());
         assertEquals(0, changes.offlinePartitionsChange());
         assertEquals(1, changes.partitionsWithoutPreferredLeaderChange());
+    }
+
+    @Test
+    public void testTopicElectionResult() {
+        ControllerMetricsChanges changes = new ControllerMetricsChanges();
+        TopicImage image = new TopicImage("foo", FOO_ID, Collections.emptyMap());
+        TopicDelta delta = new TopicDelta(image);
+        delta.replay(new PartitionRecord().setPartitionId(0).setLeader(0).setIsr(Arrays.asList(0, 1)).setReplicas(Arrays.asList(0, 1, 2)));
+        delta.replay(new PartitionChangeRecord().setPartitionId(0).setLeader(2).setIsr(Arrays.asList(2)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));
+
+        changes.handleTopicChange(image, delta);
+        assertEquals(1, changes.uncleanLeaderElection());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -353,6 +353,32 @@ public class TopicsImageTest {
     }
 
     @Test
+    public void testTopicDeltaElectionStatsWithEmptyImage() {
+        TopicImage image = new TopicImage("topic", Uuid.randomUuid(), Collections.emptyMap());
+        TopicDelta delta = new TopicDelta(image);
+        delta.replay(new PartitionRecord().setPartitionId(0).setLeader(0).setIsr(Arrays.asList(0, 1)).setReplicas(Arrays.asList(0, 1, 2)));
+        delta.replay(new PartitionChangeRecord().setPartitionId(0).setLeader(2).setIsr(Arrays.asList(2)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));
+        assertEquals(1, delta.partitionToUncleanLeaderElectionCount().get(0));
+        delta.replay(new PartitionChangeRecord().setPartitionId(0).setIsr(Arrays.asList(1, 2)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()));
+        assertEquals(1, delta.partitionToUncleanLeaderElectionCount().get(0));
+        delta.replay(new PartitionChangeRecord().setPartitionId(0).setLeader(0).setIsr(Arrays.asList(0)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));
+        assertEquals(2, delta.partitionToUncleanLeaderElectionCount().get(0));
+        delta.replay(new PartitionChangeRecord().setPartitionId(0).setLeader(1).setIsr(Arrays.asList(1)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));
+        assertEquals(3, delta.partitionToUncleanLeaderElectionCount().get(0));
+    }
+
+    @Test
+    public void testTopicDeltaElectionStatsWithNonEmptyImage() {
+        Map<Integer, PartitionRegistration> partitions = new HashMap<>();
+        partitions.put(0, new PartitionRegistration(new PartitionRecord().setPartitionId(0).setLeader(0).setIsr(Arrays.asList(0, 1)).setReplicas(Arrays.asList(0, 1, 2))));
+        partitions.put(1, new PartitionRegistration(new PartitionRecord().setPartitionId(1).setLeader(-1).setIsr(Arrays.asList()).setEligibleLeaderReplicas(Arrays.asList(0, 1)).setReplicas(Arrays.asList(0, 1, 2))));
+        TopicImage image = new TopicImage("topic", Uuid.randomUuid(), partitions);
+        TopicDelta delta = new TopicDelta(image);
+        delta.replay(new PartitionRecord().setPartitionId(0).setLeader(2).setIsr(Arrays.asList(2)).setReplicas(Arrays.asList(0, 1, 2)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()));
+        assertEquals(1, delta.partitionToUncleanLeaderElectionCount().get(0));
+    }
+
+    @Test
     public void testLocalReassignmentChanges() {
         int localId = 3;
         Uuid zooId = Uuid.fromString("0hHJ3X5ZQ-CFfQ5xgpj90w");

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -57,11 +57,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Timeout(40)
 public class PartitionRegistrationTest {
     @Test
-    public void testElectionWasClean() {
-        assertTrue(PartitionRegistration.electionWasClean(1, new int[]{1, 2}));
-        assertFalse(PartitionRegistration.electionWasClean(1, new int[]{0, 2}));
-        assertFalse(PartitionRegistration.electionWasClean(1, new int[]{}));
-        assertTrue(PartitionRegistration.electionWasClean(3, new int[]{1, 2, 3, 4, 5, 6}));
+    public void testElectionWasUnclean() {
+        assertFalse(PartitionRegistration.electionWasUnclean(LeaderRecoveryState.RECOVERED.value()));
+        assertTrue(PartitionRegistration.electionWasUnclean(LeaderRecoveryState.RECOVERING.value()));
     }
 
     @Test


### PR DESCRIPTION
This is attempt of backport https://github.com/apache/kafka/pull/19590 specific for Kafka 3.9. Copying description from that PR:

"""
The current ElectionWasClean checks if the new leader is in the previous
ISR. However, there is a corner case in the partition reassignment. The
partition reassignment can change the partition replicas. If the new
preferred leader (the first one in the new replicas) is the last one to
join ISR, this preferred leader will be elected in the same partition
change.

For example: In the previous state, the partition is Leader: 0,
Replicas (2,1,0), ISR (1,0), Adding(2), removing(0). Then replica 2
joins the ISR. The new partition would be like: Leader: 2, Replicas
(2,1), ISR(1,2). The new leader 2 is not in the previous ISR (1,0) but
it is still a clean election.
"""

The original fix depends on ELR, however, AFAIK ELR's are valid for Kafka 4.0 and 4.1, not for 3.9. I prepared a simpler fix for 3.9 (we have encountered such problem under 3.9, and Confluent confirmed it is an issue).

Note: this is my first Apache contribution, I signed the ICLA, I read the contributing guidelines, sorry if I did something incorrectly :) 
Let me also mention author of the original fix for 4.x - @CalvinConfluent 

Thank you!