### PR TITLE
KAFKA-19990: gracefully handle exceptions when handling AllocateProducerIdsResponse

### DIFF
--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -51,7 +51,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
     private final String logPrefix;
 
     private final int brokerId;
-    private final Time time;
+    protected final Time time;
     private final Supplier<Long> brokerEpochSupplier;
     private final NodeToControllerChannelManager controllerChannel;
 
@@ -129,9 +129,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
 
             @Override
             public void onComplete(ClientResponse response) {
-                if (response.responseBody() instanceof AllocateProducerIdsResponse) {
-                    handleAllocateProducerIdsResponse((AllocateProducerIdsResponse) response.responseBody());
-                }
+                handleAllocateProducerIdsResponse(response);
             }
 
             @Override
@@ -142,7 +140,30 @@ public class RPCProducerIdManager implements ProducerIdManager {
         });
     }
 
-    protected void handleAllocateProducerIdsResponse(AllocateProducerIdsResponse response) {
+    protected void handleUnsuccessfulResponse() {
+        // There is no need to compare and set because only one thread
+        // handles the AllocateProducerIds response.
+        backoffDeadlineMs.set(time.milliseconds() + RETRY_BACKOFF_MS);
+        requestInFlight.set(false);
+    }
+
+    protected void handleAllocateProducerIdsResponse(ClientResponse clientResponse) {
+        if (clientResponse.authenticationException() != null) {
+            log.error("{} Unable to allocate producer id because of an authentication exception", logPrefix, clientResponse.authenticationException());
+            handleUnsuccessfulResponse();
+            return;
+        }
+        if (clientResponse.versionMismatch() != null) {
+            log.error("{} Unable to allocate producer id because of a version mismatch exception", logPrefix, clientResponse.versionMismatch());
+            handleUnsuccessfulResponse();
+            return;
+        }
+        if (!clientResponse.hasResponse()) {
+            log.error("{} Unable to allocate producer id because of empty response from controller", logPrefix);
+            handleUnsuccessfulResponse();
+            return;
+        }
+        AllocateProducerIdsResponse response = (AllocateProducerIdsResponse) clientResponse.responseBody();
         var data = response.data();
         var successfulResponse = false;
         var errors = Errors.forCode(data.errorCode());
@@ -161,10 +182,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
                 log.error("{} Received error code {} from the controller.", logPrefix, errors);
         }
         if (!successfulResponse) {
-            // There is no need to compare and set because only one thread
-            // handles the AllocateProducerIds response.
-            backoffDeadlineMs.set(time.milliseconds() + RETRY_BACKOFF_MS);
-            requestInFlight.set(false);
+            handleUnsuccessfulResponse();
         }
     }
 

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -51,7 +51,8 @@ public class RPCProducerIdManager implements ProducerIdManager {
     private final String logPrefix;
 
     private final int brokerId;
-    protected final Time time;
+    // Visible for testing
+    final Time time;
     private final Supplier<Long> brokerEpochSupplier;
     private final NodeToControllerChannelManager controllerChannel;
 
@@ -140,7 +141,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
         });
     }
 
-    protected void handleUnsuccessfulResponse() {
+    private void handleUnsuccessfulResponse() {
         // There is no need to compare and set because only one thread
         // handles the AllocateProducerIds response.
         backoffDeadlineMs.set(time.milliseconds() + RETRY_BACKOFF_MS);


### PR DESCRIPTION
The handler in `RPCProducerIdManager` doesn't handle authentication
exception and version mismatch exceptions gracefully.

This change ensures we retry on such failures and adds unit tests for
these scenarios.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
