### PR TITLE
MINOR: Replace ClientPropertiesBuilder with admin() factory methods in KafkaClusterTestKit

### DIFF
--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -48,7 +48,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{FileSystems, Files, Path, Paths}
 import java.util
 import java.util.concurrent.{ExecutionException, TimeUnit}
-import java.util.{Optional, OptionalLong, Properties}
+import java.util.{Optional, OptionalLong}
 import scala.collection.{Seq, mutable}
 import scala.jdk.CollectionConverters._
 import scala.util.Using
@@ -96,7 +96,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         // Create the topic.
         val assignments = new util.HashMap[Integer, util.List[Integer]]
@@ -264,7 +264,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         assertEquals(Seq(ApiError.NONE), incrementalAlter(admin, Seq(
           (new ConfigResource(Type.BROKER, ""), Seq(
@@ -321,7 +321,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         Seq(log, log2).foreach(_.debug("setting log4j"))
 
@@ -377,7 +377,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         val createResults = admin.createTopics(util.List.of(
           new NewTopic("foo", 1, 3.toShort),
@@ -399,13 +399,7 @@ class KRaftClusterTest {
   }
 
   def createAdminClient(cluster: KafkaClusterTestKit, bootstrapController: Boolean): Admin = {
-    var props: Properties = null
-    props = if (bootstrapController)
-      cluster.newClientPropertiesBuilder().setUsingBootstrapControllers(true).build()
-    else
-      cluster.clientProperties()
-    props.put(AdminClientConfig.CLIENT_ID_CONFIG, this.getClass.getName)
-    Admin.create(props)
+    cluster.admin(util.Map.of(AdminClientConfig.CLIENT_ID_CONFIG, this.getClass.getName), bootstrapController)
   }
 
   @Test
@@ -522,7 +516,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         admin.updateFeatures(
           util.Map.of(MetadataVersion.FEATURE_NAME,
@@ -551,9 +545,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.newClientPropertiesBuilder().
-        setUsingBootstrapControllers(usingBootstrapControlers).
-        build())
+      val admin = cluster.admin(util.Map.of(), usingBootstrapControlers)
       try {
         val featureMetadata = admin.describeFeatures().featureMetadata().get()
         assertEquals(new SupportedVersionRange(0, 1),
@@ -589,7 +581,7 @@ class KRaftClusterTest {
       TestUtils.waitUntilTrue(() => cluster.raftManagers().get(0).client.leaderAndEpoch().leaderId.isPresent,
         "RaftManager was not initialized.")
 
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         // Create a test topic
         val newTopic = util.List.of(new NewTopic("test-topic", 1, 1.toShort))
@@ -675,7 +667,7 @@ class KRaftClusterTest {
     try {
       cluster.format()
       cluster.startup()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         val newTopics = new util.ArrayList[NewTopic]()
         for (i <- 0 to 10000) {
@@ -757,9 +749,7 @@ class KRaftClusterTest {
     try {
       cluster.format()
       cluster.startup()
-      val admin = Admin.create(cluster.newClientPropertiesBuilder().
-        setUsingBootstrapControllers(true).
-        build())
+      val admin = cluster.admin(util.Map.of(), true)
       try {
         val exception = assertThrows(classOf[ExecutionException],
           () => admin.describeCluster().clusterId().get(1, TimeUnit.MINUTES))
@@ -813,7 +803,7 @@ class KRaftClusterTest {
     try {
       cluster.format()
       cluster.startup()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         val broker0 = cluster.brokers().get(0)
         val broker1 = cluster.brokers().get(1)
@@ -868,7 +858,7 @@ class KRaftClusterTest {
     try {
       cluster.format()
       cluster.startup()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         val broker0 = cluster.brokers().get(0)
         val broker1 = cluster.brokers().get(1)
@@ -933,7 +923,7 @@ class KRaftClusterTest {
     try {
       cluster.format()
       cluster.startup()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         val broker0 = cluster.brokers().get(0)
         val broker1 = cluster.brokers().get(1)
@@ -1006,7 +996,7 @@ class KRaftClusterTest {
       TestUtils.waitUntilTrue(() => cluster.raftManagers().get(0).client.leaderAndEpoch().leaderId.isPresent,
         "RaftManager was not initialized.")
 
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         // Create a test topic
         admin.createTopics(util.List.of(
@@ -1086,7 +1076,7 @@ class KRaftClusterTest {
       cluster.format()
       cluster.startup()
       cluster.waitForReadyBrokers()
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         admin.incrementalAlterConfigs(
           util.Map.of(new ConfigResource(Type.BROKER, ""),

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -27,7 +27,7 @@ import kafka.server.share.SharePartitionManager
 import kafka.server.{BrokerServer, KafkaConfig, ReplicaManager}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
-import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, ConfigEntry, NewTopic}
+import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry, NewTopic}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.BROKER
@@ -124,7 +124,7 @@ class BrokerMetadataPublisherTest {
           override def answer(invocation: InvocationOnMock): Unit = numTimesReloadCalled.addAndGet(1)
         })
       broker.brokerMetadataPublisher.dynamicConfigPublisher = publisher
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         assertEquals(0, numTimesReloadCalled.get())
         admin.incrementalAlterConfigs(singletonMap(
@@ -170,7 +170,7 @@ class BrokerMetadataPublisherTest {
       broker.sharedServer.loader.removeAndClosePublisher(broker.brokerMetadataPublisher).get(1, TimeUnit.MINUTES)
       broker.metadataPublishers.remove(broker.brokerMetadataPublisher)
       broker.sharedServer.loader.installPublishers(List(publisher).asJava).get(1, TimeUnit.MINUTES)
-      val admin = Admin.create(cluster.clientProperties())
+      val admin = cluster.admin()
       try {
         admin.createTopics(singletonList(new NewTopic("foo", 1, 1.toShort))).all().get()
       } finally {

--- a/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
@@ -76,7 +76,7 @@ public class ReconfigurableQuorumIntegrationTest {
         ).build()) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, () -> {
                     checkKRaftVersions(admin, KRaftVersion.KRAFT_VERSION_0.featureLevel());
                 });
@@ -94,7 +94,7 @@ public class ReconfigurableQuorumIntegrationTest {
         ).setStandalone(true).build()) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, () -> {
                     checkKRaftVersions(admin, KRaftVersion.KRAFT_VERSION_1.featureLevel());
                 });
@@ -132,7 +132,7 @@ public class ReconfigurableQuorumIntegrationTest {
         ) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
                     assertEquals(Set.of(3000, 3001, 3002), voters.keySet());
@@ -167,7 +167,7 @@ public class ReconfigurableQuorumIntegrationTest {
         ) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
                     assertEquals(Set.of(3000, 3001, 3002, 3003), voters.keySet());
@@ -206,7 +206,7 @@ public class ReconfigurableQuorumIntegrationTest {
         ) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
                     assertEquals(Set.of(3000, 3001, 3002), voters.keySet());
@@ -244,7 +244,7 @@ public class ReconfigurableQuorumIntegrationTest {
         ) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
                     assertEquals(Set.of(3000, 3001, 3002), voters.keySet());
@@ -275,7 +275,7 @@ public class ReconfigurableQuorumIntegrationTest {
         try (var cluster = new KafkaClusterTestKit.Builder(nodes).setInitialVoterSet(initialVoters).build()) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 TestUtils.retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
                     assertEquals(Set.of(3000, 3001, 3002), voters.keySet());
@@ -327,7 +327,7 @@ public class ReconfigurableQuorumIntegrationTest {
         try (var cluster = new KafkaClusterTestKit.Builder(nodes).setInitialVoterSet(initialVoters).build()) {
             cluster.format();
             cluster.startup();
-            try (var admin = Admin.create(cluster.clientProperties())) {
+            try (var admin = cluster.admin()) {
                 Uuid dirId = cluster.nodes().controllerNodes().get(3000).metadataDirectoryId();
                 var removeFuture = admin.removeRaftVoter(
                     3000,

--- a/tools/src/test/java/org/apache/kafka/tools/other/ReplicationQuotasTestRig.java
+++ b/tools/src/test/java/org/apache/kafka/tools/other/ReplicationQuotasTestRig.java
@@ -182,7 +182,7 @@ public class ReplicationQuotasTestRig {
                 throw new RuntimeException("Failed to start test Kafka cluster", e);
             }
 
-            adminClient = Admin.create(cluster.clientProperties());
+            adminClient = cluster.admin();
         }
 
         public void tearDown() {


### PR DESCRIPTION
This PR simplifies `KafkaClusterTestKit` by removing
`ClientPropertiesBuilder` and adding direct `admin()` factory methods
that align with the `ClusterInstance` style.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
