### PR TITLE
MINOR: improve logging

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerRecord;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1078,10 +1078,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             );
         } catch (final TimeoutException timeoutException) {
             log.warn(
-                "Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop." +
-                    "\nConsider overwriting consumer config {} to a larger value to avoid timeout errors",
-                timeoutException.toString(),
-                ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+                "Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop.",
+                timeoutException.toString()
+            );
 
             // re-throw to trigger `task.timeout.ms`
             throw timeoutException;


### PR DESCRIPTION
We should not advice to increase the consumer timeout. Kafka Streams
handles the timeout gracefully and increasing the consumer timeout could
actually lead to longer blocking call resulting in undesired
rebalancing.

Reviewer: Lucas Brutschy <lbrutschy@confluent.io>
