### PR TITLE
refine get counter performance

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -64,7 +64,11 @@ public class RoundRobinPartitioner implements Partitioner {
     }
 
     private int nextValue(String topic) {
-        AtomicInteger counter = topicCounterMap.computeIfAbsent(topic, k -> new AtomicInteger(0));
+        AtomicInteger counter = topicCounterMap.get(topic);
+        if(counter == null) {
+            counter = new AtomicInteger(0);
+            AtomicInteger counter = topicCounterMap.putIfAbsent(topic, counter);
+        }
         return counter.getAndIncrement();
     }
 


### PR DESCRIPTION
1. use lambda will run it every time even it's not necessary.
2. this map is concurrent hashmap, so we can use putIfAbsent safely, this will let us not to use lock to make sure this will execute once and will not overwrite by the other thread.
