### PR TITLE
KAFKA-18608: feat: implement private_key_jwt client authentication for OAuth 2.0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
@@ -366,6 +366,9 @@ public class SaslConfigs {
     public static final boolean DEFAULT_SASL_OAUTHBEARER_HEADER_URLENCODE = false;
     public static final String SASL_OAUTHBEARER_HEADER_URLENCODE_DOC = "The (optional) setting to enable the OAuth client to URL-encode the client_id and client_secret in the authorization header"
             + " in accordance with RFC6749, see <a href=\"https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1\">here</a> for more details. The default value is set to 'false' for backward compatibility";
+
+    public static final String SASL_OAUTHBEARER_ASSERTION_CLAIM_KID = "sasl.oauthbearer.assertion.claim.kid";
+
     public static void addClientSaslSupport(ConfigDef config) {
         config.define(SaslConfigs.SASL_KERBEROS_SERVICE_NAME, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM, SaslConfigs.SASL_KERBEROS_SERVICE_NAME_DOC)
                 .define(SaslConfigs.SASL_KERBEROS_KINIT_CMD, ConfigDef.Type.STRING, SaslConfigs.DEFAULT_KERBEROS_KINIT_CMD, ConfigDef.Importance.LOW, SaslConfigs.SASL_KERBEROS_KINIT_CMD_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/PrivateKeyJwtRetriever.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/PrivateKeyJwtRetriever.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpJwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpRequestFormatter;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.PrivateKeyRequestFormatter;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.assertion.AssertionCreator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.assertion.AssertionJwtTemplate;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.assertion.AssertionUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.assertion.DefaultAssertionCreator;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
+
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_ALGORITHM;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_FILE;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_PASSPHRASE;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE;
+
+/**
+ * {@code PrivateKeyJwtRetriever} is a {@link JwtRetriever} that performs the
+ * steps to request
+ * a JWT from an OAuth/OIDC identity provider using private key JWT
+ * authentication. This implementation
+ * creates and signs JWT assertions using a private key for client
+ * authentication, following
+ * the RFC 7523 specification for JWT Profile for OAuth 2.0 Client
+ * Authentication.
+ *
+ * <p/>
+ * 
+ * This class specifically implements the "private_key_jwt" client
+ * authentication
+ * method using the {@code client_credentials} grant type with
+ * {@code client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer}.
+ * It is closely integrated with {@link PrivateKeyRequestFormatter} to format
+ * the
+ * OAuth request with proper client assertion parameters.
+ * 
+ * <p/>
+ * 
+ * Note: This differs from {@link JwtBearerJwtRetriever} which uses the
+ * {@code jwt-bearer} grant type and mangages
+ * authorization not authentication.
+ *
+ * <p/>
+ *
+ * This {@code JwtRetriever} is enabled by specifying its class name in the
+ * Kafka configuration.
+ * For client use, specify the class name in the
+ * <code>sasl.oauthbearer.jwt.retriever.class</code>
+ * configuration like so:
+ *
+ * <pre>
+ * sasl.oauthbearer.jwt.retriever.class = org.apache.kafka.common.security.oauthbearer.PrivateKeyJwtRetriever
+ * </pre>
+ *
+ * <p/>
+ *
+ * If using this {@code JwtRetriever} on the broker side (for inter-broker
+ * communication), the configuration
+ * should be specified with a listener-based property:
+ *
+ * <pre>
+ * listener.name.&lt;listener name&gt;.oauthbearer.sasl.oauthbearer.jwt.retriever.class=org.apache.kafka.common.security.oauthbearer.PrivateKeyJwtRetriever
+ * </pre>
+ *
+ * <p/>
+ *
+ * The {@code PrivateKeyJwtRetriever} uses the following configuration options:
+ *
+ * <ul>
+ * <li><code>sasl.oauthbearer.client.credentials.client.id</code></li>
+ * <li><code>sasl.oauthbearer.assertion.algorithm</code></li>
+ * <li><code>sasl.oauthbearer.assertion.private.key.file</code></li>
+ * <li><code>sasl.oauthbearer.assertion.private.key.passphrase</code>
+ * (optional)</li>
+ * <li><code>sasl.oauthbearer.scope</code> (optional)</li>
+ * <li><code>sasl.oauthbearer.token.endpoint.url</code></li>
+ * </ul>
+ *
+ * Please refer to the official Apache Kafka documentation for more information
+ * on these, and related configuration.
+ *
+ * <p/>
+ *
+ * Note that this implementation does not support the
+ * <code>sasl.oauthbearer.assertion.file</code> configuration
+ * as it dynamically generates JWT assertions using the provided private key.
+ *
+ * <p/>
+ *
+ * Here's an example of the configuration for a Kafka client using private key
+ * JWT authentication:
+ *
+ * <pre>
+ * sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ;
+ *
+ * sasl.oauthbearer.client.credentials.client.id=my-service
+ * sasl.oauthbearer.assertion.algorithm=RS256
+ * sasl.oauthbearer.assertion.private.key.file=/path/to/private-key.pem
+ * sasl.oauthbearer.jwt.retriever.class=org.apache.kafka.common.security.oauthbearer.PrivateKeyJwtRetriever
+ * sasl.oauthbearer.scope=kafka-access
+ * sasl.oauthbearer.token.endpoint.url=https://example.com/oauth2/token
+ * </pre>
+ */
+public class PrivateKeyJwtRetriever implements JwtRetriever {
+    private final Time time;
+    private HttpJwtRetriever delegate;
+    private AssertionJwtTemplate assertionJwtTemplate;
+    private AssertionCreator assertionCreator;
+
+    public PrivateKeyJwtRetriever() {
+        this(Time.SYSTEM);
+    }
+
+    public PrivateKeyJwtRetriever(Time time) {
+        this.time = time;
+    }
+
+    @Override
+    public String retrieve() throws JwtRetrieverException {
+
+        if (delegate == null)
+            throw new IllegalStateException(
+                    "JWT retriever delegate is null; please call configure() first");
+
+        return delegate.retrieve();
+    }
+
+    @Override
+    public void close() throws IOException {
+        Utils.closeQuietly(assertionCreator, "JWT assertion creator");
+        Utils.closeQuietly(assertionJwtTemplate, "JWT assertion template");
+        Utils.closeQuietly(delegate, "JWT retriever delegate");
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        ConfigurationUtils cu = new ConfigurationUtils(configs, saslMechanism);
+
+        String scope = cu.validateString(SASL_OAUTHBEARER_SCOPE, false);
+
+        if (cu.validateString(SASL_OAUTHBEARER_ASSERTION_FILE, false) != null) {
+            throw new ConfigException(String.format("The OAuth configuration option %s value cannot be used here.",
+                    SASL_OAUTHBEARER_ASSERTION_FILE));
+        }
+
+        String algorithm = cu.validateString(SASL_OAUTHBEARER_ASSERTION_ALGORITHM);
+        File privateKeyFile = cu.validateFile(SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE);
+        Optional<String> passphrase = cu.containsKey(SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_PASSPHRASE)
+                ? Optional.of(cu.validatePassword(
+                        SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_PASSPHRASE))
+                : Optional.empty();
+
+        assertionCreator = new DefaultAssertionCreator(algorithm, privateKeyFile, passphrase);
+        assertionJwtTemplate = AssertionUtils.layeredAssertionJwtTemplate(cu, time);
+
+        Supplier<String> assertionSupplier = () -> {
+            try {
+                return assertionCreator.create(assertionJwtTemplate);
+            } catch (Exception e) {
+                throw new JwtRetrieverException(e);
+            }
+        };
+
+        Optional<String> clientId = cu.containsKey(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID)
+                ? Optional.of(cu.validateString(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID))
+                : Optional.empty();
+        HttpRequestFormatter requestFormatter = new PrivateKeyRequestFormatter(scope, assertionSupplier,
+                clientId);
+        delegate = new HttpJwtRetriever(requestFormatter);
+        delegate.configure(configs, saslMechanism, jaasConfigEntries);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/PrivateKeyRequestFormatter.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/PrivateKeyRequestFormatter.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer.internals.secured;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.apache.kafka.common.utils.Utils;
+
+public class PrivateKeyRequestFormatter implements HttpRequestFormatter {
+
+    private final String scope;
+    private final Supplier<String> assertionSupplier;
+    private final String clientId;
+
+    private static final String CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    private static final String GRANT_TYPE = "client_credentials";
+
+    public PrivateKeyRequestFormatter(String scope, Supplier<String> assertionSupplier, Optional<String> clientId) {
+        this.scope = scope;
+        this.assertionSupplier = assertionSupplier;
+        this.clientId = clientId.orElse(null);
+    }
+
+    @Override
+    public Map<String, String> formatHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("Cache-Control", "no-cache");
+        headers.put("Content-Type", "application/x-www-form-urlencoded");
+        return headers;
+    }
+
+    @Override
+    public String formatBody() {
+        String assertion = assertionSupplier.get();
+        StringBuilder requestParameters = new StringBuilder();
+        requestParameters.append("grant_type=")
+                .append(URLEncoder.encode(GRANT_TYPE, StandardCharsets.UTF_8));
+        requestParameters.append("&client_assertion=")
+                .append(URLEncoder.encode(assertion, StandardCharsets.UTF_8));
+        requestParameters.append("&client_assertion_type=")
+                .append(URLEncoder.encode(CLIENT_ASSERTION_TYPE, StandardCharsets.UTF_8));
+
+        if (clientId != null) {
+            requestParameters.append("&client_id=")
+                    .append(URLEncoder.encode(clientId, StandardCharsets.UTF_8));
+        }
+
+        if (!Utils.isBlank(scope))
+            requestParameters.append("&scope=")
+                    .append(URLEncoder.encode(scope.trim(), StandardCharsets.UTF_8));
+
+        return requestParameters.toString();
+    }
+
+    public String getGrantType() {
+        return "client_credentials";
+    }
+
+    public String getClientAssertionType() {
+        return "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/assertion/AssertionUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/assertion/AssertionUtils.java
@@ -49,6 +49,7 @@ import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERT
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_CLAIM_NBF_SECONDS;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_CLAIM_SUB;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_TEMPLATE_FILE;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_CLAIM_KID;
 
 /**
  * Set of utilities for the OAuth JWT assertion logic.
@@ -145,6 +146,15 @@ public class AssertionUtils {
         staticAssertionJwtTemplate(cu).ifPresent(templates::add);
         fileAssertionJwtTemplate(cu).ifPresent(templates::add);
         templates.add(dynamicAssertionJwtTemplate(cu, time));
+        kidAssertionJwtTemplate(cu).ifPresent(templates::add);
         return new LayeredAssertionJwtTemplate(templates);
+    }
+
+    public static Optional<KidAssertionJwtTemplate> kidAssertionJwtTemplate(ConfigurationUtils cu) {
+        if (!cu.containsKey(SASL_OAUTHBEARER_ASSERTION_CLAIM_KID)) {
+            return Optional.empty();
+        }
+        String kid = cu.validateString(SASL_OAUTHBEARER_ASSERTION_CLAIM_KID);
+        return Optional.of(new KidAssertionJwtTemplate(kid));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/assertion/KidAssertionJwtTemplate.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/assertion/KidAssertionJwtTemplate.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer.internals.secured.assertion;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KidAssertionJwtTemplate implements AssertionJwtTemplate {
+
+    private final String kid;
+
+    public KidAssertionJwtTemplate(String kid) {
+        this.kid = kid;
+    }
+
+    @Override
+    public Map<String, Object> header() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("kid", kid);
+        return Collections.unmodifiableMap(values);
+    }
+
+    @Override
+    public Map<String, Object> payload() {
+        Map<String, Object> values = new HashMap<>();
+        return Collections.unmodifiableMap(values);
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/PrivateKeyJwtRetrieverTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/PrivateKeyJwtRetrieverTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.OAuthBearerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import static org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_ASSERTION_ALGORITHM;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_ALGORITHM;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_FILE;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL;
+import static org.apache.kafka.common.config.internals.BrokerSecurityConfigs.ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG;
+import static org.apache.kafka.common.config.internals.BrokerSecurityConfigs.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+import static org.apache.kafka.test.TestUtils.tempFile;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PrivateKeyJwtRetrieverTest extends OAuthBearerTest {
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        System.clearProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG);
+        System.clearProperty(ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG);
+    }
+
+    @Test
+    public void testConfigure() throws Exception {
+        String tokenEndpointUrl = "https://www.example.com";
+        String privateKeyFile = generatePrivateKey().getPath();
+        String clientId = "test-client-id";
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, tokenEndpointUrl);
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG, privateKeyFile);
+
+        Map<String, ?> configs = getSaslConfigs(
+            Map.of(
+                SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, tokenEndpointUrl,
+                SASL_OAUTHBEARER_ASSERTION_ALGORITHM, DEFAULT_SASL_OAUTHBEARER_ASSERTION_ALGORITHM,
+                SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE, privateKeyFile,
+                SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, clientId
+            )
+        );
+
+        List<AppConfigurationEntry> jaasConfigEntries = getJaasConfigEntries();
+
+        try (PrivateKeyJwtRetriever jwtRetriever = new PrivateKeyJwtRetriever()) {
+            assertDoesNotThrow(() -> jwtRetriever.configure(configs, OAUTHBEARER_MECHANISM, jaasConfigEntries));
+        }
+    }
+
+    @Test
+    public void testConfigureWithMalformedPrivateKey() throws Exception {
+        String tokenEndpointUrl = "https://www.example.com";
+        String malformedPrivateKeyFile = tempFile().getPath();
+        String clientId = "test-client-id";
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, tokenEndpointUrl);
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG, malformedPrivateKeyFile);
+
+        Map<String, ?> configs = getSaslConfigs(
+            Map.of(
+                SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, tokenEndpointUrl,
+                SASL_OAUTHBEARER_ASSERTION_ALGORITHM, DEFAULT_SASL_OAUTHBEARER_ASSERTION_ALGORITHM,
+                SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE, malformedPrivateKeyFile,
+                SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, clientId
+            )
+        );
+
+        List<AppConfigurationEntry> jaasConfigEntries = getJaasConfigEntries();
+
+        try (PrivateKeyJwtRetriever jwtRetriever = new PrivateKeyJwtRetriever()) {
+            JwtRetrieverException e = assertThrows(JwtRetrieverException.class, () -> jwtRetriever.configure(configs, OAUTHBEARER_MECHANISM, jaasConfigEntries));
+            assertNotNull(e.getCause());
+            assertInstanceOf(GeneralSecurityException.class, e.getCause());
+        }
+    }
+
+    @Test
+    public void testConfigureWithStaticAssertionFile() throws Exception {
+        String tokenEndpointUrl = "https://www.example.com";
+        String assertionFile = tempFile(createJwt("jdoe")).getPath();
+        String clientId = "test-client-id";
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, tokenEndpointUrl);
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG, assertionFile);
+
+        Map<String, ?> configs = getSaslConfigs(
+            Map.of(
+                SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, tokenEndpointUrl,
+                SASL_OAUTHBEARER_ASSERTION_ALGORITHM, DEFAULT_SASL_OAUTHBEARER_ASSERTION_ALGORITHM,
+                SASL_OAUTHBEARER_ASSERTION_FILE, assertionFile,
+                SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, clientId
+            )
+        );
+
+        List<AppConfigurationEntry> jaasConfigEntries = getJaasConfigEntries();
+
+        try (PrivateKeyJwtRetriever jwtRetriever = new PrivateKeyJwtRetriever()) {
+            ConfigException e = assertThrows(ConfigException.class, () -> jwtRetriever.configure(configs, OAUTHBEARER_MECHANISM, jaasConfigEntries));
+            assertNotNull(e.getMessage());
+            assertInstanceOf(ConfigException.class, e);
+        }
+    }
+
+    @Test
+    public void testConfigureWithInvalidPassphrase() throws Exception {
+        String tokenEndpointUrl = "https://www.example.com";
+        String privateKeyFile = generatePrivateKey().getPath();
+        String clientId = "test-client-id";
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, tokenEndpointUrl);
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG, privateKeyFile);
+
+        Map<String, ?> configs = getSaslConfigs(
+            Map.of(
+                SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, tokenEndpointUrl,
+                SASL_OAUTHBEARER_ASSERTION_ALGORITHM, DEFAULT_SASL_OAUTHBEARER_ASSERTION_ALGORITHM,
+                SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE, privateKeyFile,
+                SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, clientId,
+                SaslConfigs.SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_PASSPHRASE, "this-passphrase-is-invalid"
+            )
+        );
+
+        List<AppConfigurationEntry> jaasConfigEntries = getJaasConfigEntries();
+
+        try (PrivateKeyJwtRetriever jwtRetriever = new PrivateKeyJwtRetriever()) {
+            JwtRetrieverException e = assertThrows(JwtRetrieverException.class, () -> jwtRetriever.configure(configs, OAUTHBEARER_MECHANISM, jaasConfigEntries));
+            assertNotNull(e.getCause());
+            assertInstanceOf(IOException.class, e.getCause());
+        }
+    }
+
+    @Test
+    public void testConfigureWithOptionalClientId() throws Exception {
+        String tokenEndpointUrl = "https://www.example.com";
+        String privateKeyFile = generatePrivateKey().getPath();
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, tokenEndpointUrl);
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_FILES_CONFIG, privateKeyFile);
+
+        Map<String, ?> configs = getSaslConfigs(
+            Map.of(
+                SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, tokenEndpointUrl,
+                SASL_OAUTHBEARER_ASSERTION_ALGORITHM, DEFAULT_SASL_OAUTHBEARER_ASSERTION_ALGORITHM,
+                SASL_OAUTHBEARER_ASSERTION_PRIVATE_KEY_FILE, privateKeyFile
+                // Note: clientId is intentionally omitted to test optional behavior
+            )
+        );
+
+        List<AppConfigurationEntry> jaasConfigEntries = getJaasConfigEntries();
+
+        try (PrivateKeyJwtRetriever jwtRetriever = new PrivateKeyJwtRetriever()) {
+            assertDoesNotThrow(() -> jwtRetriever.configure(configs, OAUTHBEARER_MECHANISM, jaasConfigEntries));
+        }
+    }
+
+    @Test
+    public void testRetrieveWithoutConfigure() throws IOException {
+        try (PrivateKeyJwtRetriever jwtRetriever = new PrivateKeyJwtRetriever()) {
+            IllegalStateException e = assertThrows(IllegalStateException.class, jwtRetriever::retrieve);
+            assertNotNull(e.getMessage());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/PrivateKeyRequestFormatterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/PrivateKeyRequestFormatterTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer.internals.secured;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PrivateKeyRequestFormatterTest extends OAuthBearerTest {
+
+    private static final String TEST_ASSERTION = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test.signature";
+    private static final String TEST_CLIENT_ID = "test-client";
+    private static final String TEST_SCOPE = "test-scope";
+    private static final Supplier<String> ASSERTION_SUPPLIER = () -> TEST_ASSERTION;
+
+    @Test
+    public void testFormatHeaders() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        Map<String, String> headers = formatter.formatHeaders();
+
+        assertEquals("application/json", headers.get("Accept"));
+        assertEquals("no-cache", headers.get("Cache-Control"));
+        assertEquals("application/x-www-form-urlencoded", headers.get("Content-Type"));
+        assertEquals(3, headers.size());
+    }
+
+    @Test
+    public void testFormatBodyWithAllParameters() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        String body = formatter.formatBody();
+
+        assertTrue(body.contains("grant_type=client_credentials"));
+        assertTrue(body.contains("client_assertion=" + TEST_ASSERTION));
+        assertTrue(body.contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"));
+        assertTrue(body.contains("client_id=" + TEST_CLIENT_ID));
+        assertTrue(body.contains("scope=" + TEST_SCOPE));
+    }
+
+    @Test
+    public void testFormatBodyWithoutClientId() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            ASSERTION_SUPPLIER,
+            Optional.empty()
+        );
+
+        String body = formatter.formatBody();
+
+        assertTrue(body.contains("grant_type=client_credentials"));
+        assertTrue(body.contains("client_assertion=" + TEST_ASSERTION));
+        assertTrue(body.contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"));
+        assertTrue(body.contains("scope=" + TEST_SCOPE));
+        assertTrue(!body.contains("client_id="));
+    }
+
+    @Test
+    public void testFormatBodyWithoutScope() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            null,
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        String body = formatter.formatBody();
+
+        assertTrue(body.contains("grant_type=client_credentials"));
+        assertTrue(body.contains("client_assertion=" + TEST_ASSERTION));
+        assertTrue(body.contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"));
+        assertTrue(body.contains("client_id=" + TEST_CLIENT_ID));
+        assertTrue(!body.contains("scope="));
+    }
+
+    @Test
+    public void testFormatBodyWithEmptyScope() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            "",
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        String body = formatter.formatBody();
+
+        assertTrue(body.contains("grant_type=client_credentials"));
+        assertTrue(body.contains("client_assertion=" + TEST_ASSERTION));
+        assertTrue(body.contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"));
+        assertTrue(body.contains("client_id=" + TEST_CLIENT_ID));
+        assertTrue(!body.contains("scope="));
+    }
+
+    @Test
+    public void testFormatBodyWithWhitespaceScope() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            "   ",
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        String body = formatter.formatBody();
+
+        assertTrue(body.contains("grant_type=client_credentials"));
+        assertTrue(body.contains("client_assertion=" + TEST_ASSERTION));
+        assertTrue(body.contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"));
+        assertTrue(body.contains("client_id=" + TEST_CLIENT_ID));
+        assertTrue(!body.contains("scope="));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScopeEncodingSource")
+    public void testScopeEncoding(String scope, String expectedEncodedScope) {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            scope,
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        String body = formatter.formatBody();
+        assertTrue(body.contains("scope=" + expectedEncodedScope));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testClientIdEncodingSource")
+    public void testClientIdEncoding(String clientId, String expectedEncodedClientId) {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            ASSERTION_SUPPLIER,
+            Optional.of(clientId)
+        );
+
+        String body = formatter.formatBody();
+        assertTrue(body.contains("client_id=" + expectedEncodedClientId));
+    }
+
+    @Test
+    public void testGetGrantType() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        assertEquals("client_credentials", formatter.getGrantType());
+    }
+
+    @Test
+    public void testGetClientAssertionType() {
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            ASSERTION_SUPPLIER,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        assertEquals("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", formatter.getClientAssertionType());
+    }
+
+    @Test
+    public void testAssertionSupplierCalled() {
+        final String[] capturedAssertion = new String[1];
+        Supplier<String> trackingSupplier = () -> {
+            capturedAssertion[0] = TEST_ASSERTION;
+            return TEST_ASSERTION;
+        };
+
+        PrivateKeyRequestFormatter formatter = new PrivateKeyRequestFormatter(
+            TEST_SCOPE,
+            trackingSupplier,
+            Optional.of(TEST_CLIENT_ID)
+        );
+
+        formatter.formatBody();
+        assertEquals(TEST_ASSERTION, capturedAssertion[0]);
+    }
+
+    private static Stream<Arguments> testScopeEncodingSource() {
+        return Stream.of(
+            Arguments.of("simple-scope", "simple-scope"),
+            Arguments.of("scope with spaces", "scope+with+spaces"),
+            Arguments.of("scope@special!chars", "scope%40special%21chars"),
+            Arguments.of("read:user write:repo", "read%3Auser+write%3Arepo")
+        );
+    }
+
+    private static Stream<Arguments> testClientIdEncodingSource() {
+        return Stream.of(
+            Arguments.of("simple-client", "simple-client"),
+            Arguments.of("client with spaces", "client+with+spaces"),
+            Arguments.of("client@domain.com", "client%40domain.com"),
+            Arguments.of("client:service", "client%3Aservice")
+        );
+    }
+}


### PR DESCRIPTION
# KAFKA-18608: feat: implement private_key_jwt client authentication for OAuth 2.0

Add support for RFC 7523 "private_key_jwt" client authentication method in OAuth Bearer token retrieval, providing an alternative to client_secret authentication using JWT assertions signed with private keys.

## New Components

**Core Implementation:**
- `PrivateKeyJwtRetriever`: Main JWT retriever implementing private_key_jwt client authentication using client_credentials grant type with JWT assertions
- `PrivateKeyRequestFormatter`: HTTP request formatter for OAuth requests with client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
- `KidAssertionJwtTemplate`: JWT template supporting 'kid' (Key ID) header for key identification in multi-key scenarios

**Key Features:**
- Private key JWT assertion generation and signing
- Support for RS256, RS384, RS512, ES256, ES384, ES512 algorithms
- Optional client_id parameter support
- Optional scope parameter support
- Integration with existing HttpJwtRetriever infrastructure

## Configuration

New SASL configuration options:
- `sasl.oauthbearer.client.credentials.client.id`: Client identifier
- `sasl.oauthbearer.assertion.algorithm`: JWT signing algorithm
- `sasl.oauthbearer.assertion.private.key.file`: Private key file path
- `sasl.oauthbearer.assertion.private.key.passphrase`: Optional passphrase

## OAuth 2.0 Compliance

Implements RFC 7523 specification:
- Uses `grant_type=client_credentials`
- Uses `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
- Generates RFC 7519 compliant JWT assertions with proper claims (iss, sub, aud, exp, iat, jti)

## Differentiation from Existing Implementation

- `JwtBearerJwtRetriever`: Uses `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for service account authorization flows
- `PrivateKeyJwtRetriever`: Uses `grant_type=client_credentials` with JWT assertions for client authentication (replaces client_secret with JWT)

## Testing

**Comprehensive test coverage:**
- `PrivateKeyJwtRetrieverTest`: 6 test cases covering configuration, error handling, and private key authentication flows
- `PrivateKeyRequestFormatterTest`: 17 test cases including parameterized tests for URL encoding, optional parameters, and OAuth request formatting
- All tests pass with proper Apache license headers and checkstyle compliance

**Test scenarios include:**
- Valid configuration with required and optional parameters
- Error handling for malformed private keys and invalid passphrases
- Validation that static assertion files are not supported (ConfigException)
- HTTP request formatting with proper OAuth 2.0 parameters
- URL encoding of special characters in client_id and scope
- Header formatting for OAuth token requests

## Example Configuration

```properties
sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ;
sasl.oauthbearer.jwt.retriever.class=org.apache.kafka.common.security.oauthbearer.PrivateKeyJwtRetriever
sasl.oauthbearer.client.credentials.client.id=my-service
sasl.oauthbearer.assertion.algorithm=RS256
sasl.oauthbearer.assertion.private.key.file=/path/to/private-key.pem
sasl.oauthbearer.token.endpoint.url=https://example.com/oauth2/token
sasl.oauthbearer.scope=kafka-access

Delete this text and replace it with a detailed description of your change. The 
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including 
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.
