### PR TITLE
KAFKA-19925: Fix transaction timeout handling during broker upgrades

### DIFF
--- a/tests/kafkatest/tests/core/transactions_upgrade_test.py
+++ b/tests/kafkatest/tests/core/transactions_upgrade_test.py
@@ -179,7 +179,7 @@ class TransactionsUpgradeTest(Test):
 
         self.perform_upgrade(from_kafka_version)
 
-        copier_timeout_sec = 180
+        copier_timeout_sec = 360 
         for copier in copiers:
             wait_until(lambda: copier.is_done,
                        timeout_sec=copier_timeout_sec,

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -308,8 +308,10 @@ public class TransactionalMessageCopier {
 
         String consumerGroup = parsedArgs.getString("consumerGroup");
 
-        final KafkaProducer<String, String> producer = createProducer(parsedArgs);
+        KafkaProducer<String, String> producer = createProducer(parsedArgs);
         final KafkaConsumer<String, String> consumer = createConsumer(parsedArgs);
+
+        int producerNumber = 0;
 
         final AtomicLong remainingMessages = new AtomicLong(
             parsedArgs.getInt("maxMessages") == -1 ? Long.MAX_VALUE : parsedArgs.getInt("maxMessages"));
@@ -387,7 +389,17 @@ public class TransactionalMessageCopier {
                         long messagesSentWithinCurrentTxn = records.count();
 
                         ConsumerGroupMetadata groupMetadata = useGroupMetadata ? consumer.groupMetadata() : new ConsumerGroupMetadata(consumerGroup);
-                        producer.sendOffsetsToTransaction(consumerPositions(consumer), groupMetadata);
+                        try {
+                            producer.sendOffsetsToTransaction(consumerPositions(consumer), groupMetadata);
+                        } catch (KafkaException e) {
+                            // in case the producer gets stuck here, create a new one and continue the loop
+                            try { producer.close(Duration.ofSeconds(0)); } catch (Exception ignore) {}
+                            parsedArgs.getAttrs().put("transactionalId", parsedArgs.getString("transactionalId") + producerNumber++);
+                            producer = createProducer(parsedArgs);
+                            producer.initTransactions();
+                            resetToLastCommittedPositions(consumer);
+                            continue;  
+                        }
 
                         if (enableRandomAborts && random.nextInt() % 3 == 0) {
                             abortTransactionAndResetPosition(producer, consumer);
@@ -402,7 +414,7 @@ public class TransactionalMessageCopier {
                     } catch (KafkaException e) {
                         log.debug("Aborting transaction after catching exception", e);
                         abortTransactionAndResetPosition(producer, consumer);
-                    }
+                    } 
                 }
             }
         } catch (WakeupException e) {

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -414,7 +414,7 @@ public class TransactionalMessageCopier {
                     } catch (KafkaException e) {
                         log.debug("Aborting transaction after catching exception", e);
                         abortTransactionAndResetPosition(producer, consumer);
-                    } 
+                    }
                 }
             }
         } catch (WakeupException e) {


### PR DESCRIPTION
# Problem 
During broker upgrades, the `sendOffsetsToTransaction` call would sometimes hang. Logs showed that it continuously returned `errorCode=51` which is `CONCURRENT_TRANSACTION`. The test would eventually hit its timeout and fail. This happened for every single version upgrade and occurred in around 30% of the runs.

# Resolution 
The problem above left the producer in a broken state and even after 5-10 minutes of waiting, it didn't resolve itself (even if we waited a few minutes past the transaction.max.ms time). I tried multiple solutions including waiting extended periods of time and re-trying the `sendOffsetsToTransaction` multiple times whenever timeout occurred.

Unfortunately, the producer was just permanently stuck and always receiving the `errorCode=51`. In this case, the recommended resolution in the Kafka docs is to close the previous producer and create a new producer. https://kafka.apache.org/documentation/#usingtransactions 
<img width="652" height="59" alt="image" src="https://github.com/user-attachments/assets/e95500d6-f1b6-44fa-b6a2-5c1800448d32" />

Using the old transaction.id would continue to lead to a stuck state, so this fix creates a brand new producer with a new ID and then rewinds the consumer offset to ensure EOD.

# Testing and Validation
Previously, I was able to run the test for a single version upgrade and have it fail within the first 5-10 runs. After the fix, I was able to run it 40 times continuously with 0 failures. I also ran the full test (all versions) ~5 times with 9/9 cases passing. 