### PR TITLE
MINOR: change updateBrokerConfig and updateDefaultConfig error message

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -391,7 +391,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
       dynamicBrokerConfigs ++= props.asScala
       updateCurrentConfig(doLog)
     } catch {
-      case e: Exception => error(s"Per-broker configs of $brokerId could not be applied: ${persistentProps.keys()}", e)
+      case e: Exception => error(s"Per-broker configs of $brokerId could not be applied: ${persistentProps.keySet()}", e)
     }
   }
 
@@ -402,7 +402,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
       dynamicDefaultConfigs ++= props.asScala
       updateCurrentConfig(doLog)
     } catch {
-      case e: Exception => error(s"Cluster default configs could not be applied: ${persistentProps.keys()}", e)
+      case e: Exception => error(s"Cluster default configs could not be applied: ${persistentProps.keySet()}", e)
     }
   }
 


### PR DESCRIPTION
The original error show `java.util.Collections$3@af78c87`, after change
it show the `[config.key.3, config.key.1, config.key.2]`

Example:
```
  @Test
  def testPropertiesContent(): Unit = {
    val props = new Properties()
    props.put("config.key.1", "value1")
    props.put("config.key.2", "value2")
    props.put("config.key.3", "value3")

    System.err.println("\nProperties content:") System.err.println(s"
props = $props")        // output: props = {config.key.3=value3,
config.key.2=value2, config.key.1=value1}

    System.err.println(s"\n  props.keySet() = ${props.keySet()}")  //
output: props.keySet() = [config.key.3, config.key.2, config.key.1]

    System.err.println(s"\n  Set from keys = ${props.keys()}")
// output: Set from keySet = java.util.Collections$3@af78c87
  }
```

Reviewers: Lan Ding <isDing_L@163.com>, Ken Huang <s7133700@gmail.com>,
 PoAn Yang <payang@apache.org>
