### PR TITLE
KAFKA-20002: Reset-by-duration should not hand back task to state-updater

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1849,7 +1849,6 @@ public class TaskManager {
         for (final TopicPartition partition : partitions) {
             final Task task = getActiveTask(partition);
             task.maybeInitTaskTimeoutOrThrow(nowMs, timeoutException);
-            stateUpdater.add(task);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1847,8 +1847,7 @@ public class TaskManager {
         final long nowMs
     ) {
         for (final TopicPartition partition : partitions) {
-            final Task task = getActiveTask(partition);
-            task.maybeInitTaskTimeoutOrThrow(nowMs, timeoutException);
+            getActiveTask(partition).maybeInitTaskTimeoutOrThrow(nowMs, timeoutException);
         }
     }
 


### PR DESCRIPTION
This bug was introduced via KAFKA-18015.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Vincent Potuček
 (@Pankraz76)
