### PR TITLE
KAFKA-20007: override exit procedure in AclCommandTest#testAclCliWithMisusingBootstrapControllerToServer

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/AclCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/AclCommandTest.java
@@ -220,7 +220,17 @@ public class AclCommandTest {
 
     @ClusterTest
     public void testAclCliWithMisusingBootstrapControllerToServer(ClusterInstance cluster) {
-        assertThrows(RuntimeException.class, () -> testAclCli(cluster, adminArgs(cluster.bootstrapControllers(), Optional.empty())));
+        Exit.setExitProcedure((status, message) -> {
+            if (status == 1)
+                throw new RuntimeException("Exiting command");
+            else
+                throw new AssertionError("Unexpected exit with status " + status);
+        });
+        try {
+            assertThrows(RuntimeException.class, () -> testAclCli(cluster, adminArgs(cluster.bootstrapControllers(), Optional.empty())));
+        } finally {
+            Exit.resetExitProcedure();
+        }
     }
 
     @ClusterTest

--- a/tools/src/test/java/org/apache/kafka/tools/AclCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/AclCommandTest.java
@@ -220,17 +220,7 @@ public class AclCommandTest {
 
     @ClusterTest
     public void testAclCliWithMisusingBootstrapControllerToServer(ClusterInstance cluster) {
-        Exit.setExitProcedure((status, message) -> {
-            if (status == 1)
-                throw new RuntimeException("Exiting command");
-            else
-                throw new AssertionError("Unexpected exit with status " + status);
-        });
-        try {
-            assertThrows(RuntimeException.class, () -> testAclCli(cluster, adminArgs(cluster.bootstrapControllers(), Optional.empty())));
-        } finally {
-            Exit.resetExitProcedure();
-        }
+        assertThrows(RuntimeException.class, () -> testAclCli(cluster, adminArgs(cluster.bootstrapControllers(), Optional.empty())));
     }
 
     @ClusterTest
@@ -455,7 +445,17 @@ public class AclCommandTest {
     }
 
     private Map.Entry<String, String> callMain(List<String> args) {
-        return ToolsTestUtils.grabConsoleOutputAndError(() -> AclCommand.main(args.toArray(new String[0])));
+        Exit.setExitProcedure((status, message) -> {
+            if (status == 1)
+                throw new RuntimeException("Exiting command");
+            else
+                throw new AssertionError("Unexpected exit with status " + status);
+        });
+        try {
+            return ToolsTestUtils.grabConsoleOutputAndError(() -> AclCommand.main(args.toArray(new String[0])));
+        } finally {
+            Exit.resetExitProcedure();
+        }
     }
 
     private void testAclCli(ClusterInstance cluster, List<String> cmdArgs) throws InterruptedException {
@@ -517,29 +517,19 @@ public class AclCommandTest {
     }
 
     private void testPatternTypes(List<String> cmdArgs) {
-        Exit.setExitProcedure((status, message) -> {
-            if (status == 1)
-                throw new RuntimeException("Exiting command");
-            else
-                throw new AssertionError("Unexpected exit with status " + status);
-        });
-        try {
-            for (PatternType patternType : PatternType.values()) {
-                List<String> addCmd = new ArrayList<>(cmdArgs);
-                addCmd.addAll(List.of("--allow-principal", PRINCIPAL.toString(), PRODUCER, TOPIC, "Test",
-                        ADD, RESOURCE_PATTERN_TYPE, patternType.toString()));
-                verifyPatternType(addCmd, patternType.isSpecific());
+        for (PatternType patternType : PatternType.values()) {
+            List<String> addCmd = new ArrayList<>(cmdArgs);
+            addCmd.addAll(List.of("--allow-principal", PRINCIPAL.toString(), PRODUCER, TOPIC, "Test",
+                    ADD, RESOURCE_PATTERN_TYPE, patternType.toString()));
+            verifyPatternType(addCmd, patternType.isSpecific());
 
-                List<String> listCmd = new ArrayList<>(cmdArgs);
-                listCmd.addAll(List.of(TOPIC, "Test", LIST, RESOURCE_PATTERN_TYPE, patternType.toString()));
-                verifyPatternType(listCmd, patternType != PatternType.UNKNOWN);
+            List<String> listCmd = new ArrayList<>(cmdArgs);
+            listCmd.addAll(List.of(TOPIC, "Test", LIST, RESOURCE_PATTERN_TYPE, patternType.toString()));
+            verifyPatternType(listCmd, patternType != PatternType.UNKNOWN);
 
-                List<String> removeCmd = new ArrayList<>(cmdArgs);
-                removeCmd.addAll(List.of(TOPIC, "Test", "--force", REMOVE, RESOURCE_PATTERN_TYPE, patternType.toString()));
-                verifyPatternType(removeCmd, patternType != PatternType.UNKNOWN);
-            }
-        } finally {
-            Exit.resetExitProcedure();
+            List<String> removeCmd = new ArrayList<>(cmdArgs);
+            removeCmd.addAll(List.of(TOPIC, "Test", "--force", REMOVE, RESOURCE_PATTERN_TYPE, patternType.toString()));
+            verifyPatternType(removeCmd, patternType != PatternType.UNKNOWN);
         }
     }
 


### PR DESCRIPTION
`AclCommandTest#testAclCliWithMisusingBootstrapControllerToServer`
crashes the Gradle executor as the command exits with a status code 1.

This fix updates the exit procedure prior to invoking the command.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
