### PR TITLE
KAFKA-19993: Correct the docs of Consumer#committed about the nonexistent partition

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
@@ -179,6 +179,31 @@ public class PlaintextConsumerCommitTest {
     }
 
     @ClusterTest
+    public void testClassicConsumerNoCommittedOffsets() {
+        testNoCommittedOffsets(GroupProtocol.CLASSIC);
+    }
+
+    @ClusterTest
+    public void testAsyncConsumerNoCommittedOffsets() {
+        testNoCommittedOffsets(GroupProtocol.CONSUMER);
+    }
+
+    private void testNoCommittedOffsets(GroupProtocol groupProtocol) {
+        try (var consumer = createConsumer(groupProtocol, true)) {
+            consumer.assign(List.of(tp));
+            // commit for one partition
+            var metadata = new OffsetAndMetadata(5, Optional.of(15), "foo");
+            consumer.commitSync(Map.of(tp, metadata));
+
+            // fetch offset for two partitions
+            var committed = consumer.committed(Set.of(tp, tp1));
+            assertEquals(2, committed.size());
+            assertEquals(metadata, committed.get(tp));
+            assertNull(committed.get(tp1));
+        }
+    }
+
+    @ClusterTest
     public void testClassicConsumerAsyncCommit() throws InterruptedException {
         testAsyncCommit(GroupProtocol.CLASSIC);
     }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerCommitTest.java
@@ -195,11 +195,16 @@ public class PlaintextConsumerCommitTest {
             var metadata = new OffsetAndMetadata(5, Optional.of(15), "foo");
             consumer.commitSync(Map.of(tp, metadata));
 
-            // fetch offset for two partitions
-            var committed = consumer.committed(Set.of(tp, tp1));
-            assertEquals(2, committed.size());
+            TopicPartition tp2 = new TopicPartition(topic, 2);
+            // fetch offset for three partitions:
+            // 1. tp: exists and has committed offset
+            // 2. tp1: exists but has NO committed offset
+            // 3. tp2: does not exist
+            var committed = consumer.committed(Set.of(tp, tp1, tp2));
+            assertEquals(3, committed.size());
             assertEquals(metadata, committed.get(tp));
             assertNull(committed.get(tp1));
+            assertNull(committed.get(tp2));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1338,7 +1338,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Get the last committed offsets for the given partitions (whether the commit happened by this process or
      * another). The returned offsets will be used as the position for the consumer in the event of a failure.
      * <p>
-     * If any of the partitions requested do not exist, an exception would be thrown.
+     * If any of the partitions requested do not exist, the result map will contain null as the value for that partition.
      * <p>
      * This call will block to do a remote call to get the latest committed offsets from the server.
      *

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1306,7 +1306,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Get the last committed offsets for the given partitions (whether the commit happened by this process or
      * another). The returned offsets will be used as the position for the consumer in the event of a failure.
      * <p>
-     * If any of the partitions requested do not exist, an exception would be thrown.
+     * If any of the partitions requested do not exist, the result map will contain null as the value for that partition.
      * <p>
      * This call will do a remote call to get the latest committed offsets from the server, and will block until the
      * committed offsets are gotten successfully, an unrecoverable error is encountered (in which case it is thrown to


### PR DESCRIPTION
Updated the Javadoc for `Consumer#committed` to specify that null is
returned for   nonexistent partitions instead of throwing an exception.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
