### PR TITLE
KAFKA-16799: Reduce log level for 'Node is not ready' message to TRACE                                                                                                                                                                                                     

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -37,7 +37,6 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetrySender;
-import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
@@ -49,17 +48,12 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-
-import static org.apache.kafka.clients.CommonClientConfigs.RETRY_BACKOFF_EXP_BASE;
-import static org.apache.kafka.clients.CommonClientConfigs.RETRY_BACKOFF_JITTER;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
@@ -77,9 +71,6 @@ public class NetworkClientDelegate implements AutoCloseable {
     private final int requestTimeoutMs;
     private final Queue<UnsentRequest> unsentRequests;
     private final long retryBackoffMs;
-    private final long retryBackoffMaxMs;
-    private final ExponentialBackoff exponentialBackoff;
-    private final Map<Node, BackoffState> nodeBackoffStates;
     private Optional<Exception> metadataError;
     private final boolean notifyMetadataErrorsViaErrorQueue;
     private final AsyncConsumerMetrics asyncConsumerMetrics;
@@ -101,14 +92,6 @@ public class NetworkClientDelegate implements AutoCloseable {
         this.unsentRequests = new ArrayDeque<>();
         this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-        this.retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
-        this.exponentialBackoff = new ExponentialBackoff(
-            retryBackoffMs,
-            RETRY_BACKOFF_EXP_BASE,
-            retryBackoffMaxMs,
-            RETRY_BACKOFF_JITTER
-        );
-        this.nodeBackoffStates = new ConcurrentHashMap<>();
         this.metadataError = Optional.empty();
         this.notifyMetadataErrorsViaErrorQueue = notifyMetadataErrorsViaErrorQueue;
         this.asyncConsumerMetrics = asyncConsumerMetrics;
@@ -239,23 +222,12 @@ public class NetworkClientDelegate implements AutoCloseable {
             return false;
         }
 
-        // Check if we're still in backoff period for this node
-        long backoffDelay = getBackoffDelay(node, currentTimeMs);
-        if (backoffDelay > 0) {
-            // Still in backoff period, skip retry
-            return false;
-        }
-
         ClientRequest request = makeClientRequest(r, node, currentTimeMs);
         if (!client.ready(node, currentTimeMs)) {
-            // Node is not ready - record failure and apply exponential backoff
-            recordNodeNotReady(node, currentTimeMs);
-            log.debug("Node is not ready, handle the request in the next event loop: node={}, request={}", node, r);
+            log.trace("Node is not ready, handle the request in the next event loop: node={}, request={}", node, r);
             return false;
         }
 
-        // Successfully sent - reset backoff for this node
-        resetBackoff(node);
         client.send(request, currentTimeMs);
         return true;
     }
@@ -314,54 +286,6 @@ public class NetworkClientDelegate implements AutoCloseable {
      */
     public boolean nodeUnavailable(final Node node) {
         return client.connectionFailed(node) && client.connectionDelay(node, time.milliseconds()) > 0;
-    }
-
-    /**
-     * Get the remaining backoff delay for a node. Returns 0 if the node is not in backoff or
-     * the backoff period has elapsed.
-     *
-     * @param node The node to check
-     * @param currentTimeMs Current time in milliseconds
-     * @return Remaining backoff delay in milliseconds, or 0 if no backoff is needed
-     */
-    private long getBackoffDelay(Node node, long currentTimeMs) {
-        BackoffState backoffState = nodeBackoffStates.get(node);
-        if (backoffState == null) {
-            return 0;
-        }
-        long remainingDelay = backoffState.nextRetryTimeMs - currentTimeMs;
-        return Math.max(0, remainingDelay);
-    }
-
-    /**
-     * Record that a node is not ready and calculate the next retry time using exponential backoff.
-     *
-     * @param node The node that is not ready
-     * @param currentTimeMs Current time in milliseconds
-     */
-    private void recordNodeNotReady(Node node, long currentTimeMs) {
-        BackoffState backoffState = nodeBackoffStates.computeIfAbsent(node, k -> new BackoffState());
-        // Use current attemptCount (starts at 0) before incrementing, so first backoff is initialInterval
-        long backoffMs = exponentialBackoff.backoff(backoffState.attemptCount);
-        backoffState.attemptCount++;
-        backoffState.nextRetryTimeMs = currentTimeMs + backoffMs;
-    }
-
-    /**
-     * Reset the backoff state for a node after a successful send.
-     *
-     * @param node The node that successfully sent a request
-     */
-    private void resetBackoff(Node node) {
-        nodeBackoffStates.remove(node);
-    }
-
-    /**
-     * Inner class to track backoff state for each node.
-     */
-    private static class BackoffState {
-        long attemptCount = 0;
-        long nextRetryTimeMs = 0;
     }
 
     public void close() throws IOException {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -221,13 +221,13 @@ public class NetworkClientDelegate implements AutoCloseable {
             log.debug("No broker available to send the request: {}. Retrying.", r);
             return false;
         }
-
         ClientRequest request = makeClientRequest(r, node, currentTimeMs);
         if (!client.ready(node, currentTimeMs)) {
+            // enqueue the request again if the node isn't ready yet. The request will be handled in the next iteration
+            // of the event loop
             log.trace("Node is not ready, handle the request in the next event loop: node={}, request={}", node, r);
             return false;
         }
-
         client.send(request, currentTimeMs);
         return true;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetrySender;
+import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
@@ -48,12 +49,17 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+
+import static org.apache.kafka.clients.CommonClientConfigs.RETRY_BACKOFF_EXP_BASE;
+import static org.apache.kafka.clients.CommonClientConfigs.RETRY_BACKOFF_JITTER;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
@@ -71,6 +77,9 @@ public class NetworkClientDelegate implements AutoCloseable {
     private final int requestTimeoutMs;
     private final Queue<UnsentRequest> unsentRequests;
     private final long retryBackoffMs;
+    private final long retryBackoffMaxMs;
+    private final ExponentialBackoff exponentialBackoff;
+    private final Map<Node, BackoffState> nodeBackoffStates;
     private Optional<Exception> metadataError;
     private final boolean notifyMetadataErrorsViaErrorQueue;
     private final AsyncConsumerMetrics asyncConsumerMetrics;
@@ -92,6 +101,14 @@ public class NetworkClientDelegate implements AutoCloseable {
         this.unsentRequests = new ArrayDeque<>();
         this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        this.retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
+        this.exponentialBackoff = new ExponentialBackoff(
+            retryBackoffMs,
+            RETRY_BACKOFF_EXP_BASE,
+            retryBackoffMaxMs,
+            RETRY_BACKOFF_JITTER
+        );
+        this.nodeBackoffStates = new ConcurrentHashMap<>();
         this.metadataError = Optional.empty();
         this.notifyMetadataErrorsViaErrorQueue = notifyMetadataErrorsViaErrorQueue;
         this.asyncConsumerMetrics = asyncConsumerMetrics;
@@ -221,13 +238,24 @@ public class NetworkClientDelegate implements AutoCloseable {
             log.debug("No broker available to send the request: {}. Retrying.", r);
             return false;
         }
+
+        // Check if we're still in backoff period for this node
+        long backoffDelay = getBackoffDelay(node, currentTimeMs);
+        if (backoffDelay > 0) {
+            // Still in backoff period, skip retry
+            return false;
+        }
+
         ClientRequest request = makeClientRequest(r, node, currentTimeMs);
         if (!client.ready(node, currentTimeMs)) {
-            // enqueue the request again if the node isn't ready yet. The request will be handled in the next iteration
-            // of the event loop
+            // Node is not ready - record failure and apply exponential backoff
+            recordNodeNotReady(node, currentTimeMs);
             log.debug("Node is not ready, handle the request in the next event loop: node={}, request={}", node, r);
             return false;
         }
+
+        // Successfully sent - reset backoff for this node
+        resetBackoff(node);
         client.send(request, currentTimeMs);
         return true;
     }
@@ -286,6 +314,54 @@ public class NetworkClientDelegate implements AutoCloseable {
      */
     public boolean nodeUnavailable(final Node node) {
         return client.connectionFailed(node) && client.connectionDelay(node, time.milliseconds()) > 0;
+    }
+
+    /**
+     * Get the remaining backoff delay for a node. Returns 0 if the node is not in backoff or
+     * the backoff period has elapsed.
+     *
+     * @param node The node to check
+     * @param currentTimeMs Current time in milliseconds
+     * @return Remaining backoff delay in milliseconds, or 0 if no backoff is needed
+     */
+    private long getBackoffDelay(Node node, long currentTimeMs) {
+        BackoffState backoffState = nodeBackoffStates.get(node);
+        if (backoffState == null) {
+            return 0;
+        }
+        long remainingDelay = backoffState.nextRetryTimeMs - currentTimeMs;
+        return Math.max(0, remainingDelay);
+    }
+
+    /**
+     * Record that a node is not ready and calculate the next retry time using exponential backoff.
+     *
+     * @param node The node that is not ready
+     * @param currentTimeMs Current time in milliseconds
+     */
+    private void recordNodeNotReady(Node node, long currentTimeMs) {
+        BackoffState backoffState = nodeBackoffStates.computeIfAbsent(node, k -> new BackoffState());
+        // Use current attemptCount (starts at 0) before incrementing, so first backoff is initialInterval
+        long backoffMs = exponentialBackoff.backoff(backoffState.attemptCount);
+        backoffState.attemptCount++;
+        backoffState.nextRetryTimeMs = currentTimeMs + backoffMs;
+    }
+
+    /**
+     * Reset the backoff state for a node after a successful send.
+     *
+     * @param node The node that successfully sent a request
+     */
+    private void resetBackoff(Node node) {
+        nodeBackoffStates.remove(node);
+    }
+
+    /**
+     * Inner class to track backoff state for each node.
+     */
+    private static class BackoffState {
+        long attemptCount = 0;
+        long nextRetryTimeMs = 0;
     }
 
     public void close() throws IOException {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -29,9 +29,13 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest;
+import org.apache.kafka.common.requests.ConsumerGroupHeartbeatResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -46,6 +50,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -56,6 +61,8 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -340,6 +347,8 @@ public class NetworkClientDelegateTest {
         properties.put(GROUP_ID_CONFIG, GROUP_ID);
         properties.put(REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
         properties.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(RETRY_BACKOFF_MS_CONFIG, 100L);
+        properties.put(RETRY_BACKOFF_MAX_MS_CONFIG, 1000L);
         return new NetworkClientDelegate(time,
                 new ConsumerConfig(properties),
                 logContext,
@@ -370,5 +379,113 @@ public class NetworkClientDelegateTest {
 
     private Node mockNode() {
         return new Node(0, "localhost", 99);
+    }
+
+    @Test
+    public void testExponentialBackoffReducesRetryAttemptsWhenNodeNotReady() throws Exception {
+        long retryBackoffMs = 100L;
+        long retryBackoffMaxMs = 1000L;
+        
+        try (NetworkClientDelegate ncd = newNetworkClientDelegate(false)) {
+            Node coordinatorNode = mockNode();
+            
+            ConsumerGroupHeartbeatRequestData heartbeatData = new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(GROUP_ID)
+                .setMemberId("")
+                .setMemberEpoch(0);
+            
+            NetworkClientDelegate.UnsentRequest heartbeatRequest = new NetworkClientDelegate.UnsentRequest(
+                new ConsumerGroupHeartbeatRequest.Builder(heartbeatData),
+                Optional.of(coordinatorNode)
+            );
+            
+            ncd.add(heartbeatRequest);
+            
+            client.delayReady(coordinatorNode, 5000L);
+            
+            List<Long> retryTimestamps = new ArrayList<>();
+            client.setReadyCallback(node -> {
+                if (node.equals(coordinatorNode)) {
+                    retryTimestamps.add(time.milliseconds());
+                }
+            });
+            
+            long startTime = time.milliseconds();
+            int pollCount = 0;
+            
+            while (time.milliseconds() - startTime < 500L) {
+                long currentTime = time.milliseconds();
+                ncd.poll(10, currentTime);
+                pollCount++;
+                time.sleep(1);
+            }
+            
+            assertTrue(retryTimestamps.size() < pollCount, 
+                String.format("Backoff should reduce retry attempts. Retries: %d, Polls: %d", 
+                    retryTimestamps.size(), pollCount));
+            
+            assertFalse(ncd.unsentRequests().isEmpty(), 
+                "Request should still be queued since node never became ready");
+            
+            if (retryTimestamps.size() >= 2) {
+                List<Long> intervals = new ArrayList<>();
+                for (int i = 1; i < retryTimestamps.size(); i++) {
+                    intervals.add(retryTimestamps.get(i) - retryTimestamps.get(i - 1));
+                }
+                
+                for (int i = 0; i < intervals.size(); i++) {
+                    long expectedBackoff = (long) Math.min(
+                        retryBackoffMs * Math.pow(2, i),
+                        retryBackoffMaxMs
+                    );
+                    long tolerance = Math.max(10, expectedBackoff / 10);
+                    long actualInterval = intervals.get(i);
+                    
+                    assertTrue(actualInterval >= expectedBackoff - tolerance,
+                        String.format("Interval %d should be >= %dms (got %dms)", 
+                            i, expectedBackoff - tolerance, actualInterval));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBackoffResetsAfterSuccessfulSend() throws Exception {
+        try (NetworkClientDelegate ncd = newNetworkClientDelegate(false)) {
+            Node coordinatorNode = mockNode();
+            
+            ConsumerGroupHeartbeatRequestData heartbeatData = new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(GROUP_ID)
+                .setMemberId("")
+                .setMemberEpoch(0);
+            
+            NetworkClientDelegate.UnsentRequest request1 = new NetworkClientDelegate.UnsentRequest(
+                new ConsumerGroupHeartbeatRequest.Builder(heartbeatData),
+                Optional.of(coordinatorNode)
+            );
+            
+            ncd.add(request1);
+            
+            client.delayReady(coordinatorNode, 200L);
+            
+            long firstFailureTime = time.milliseconds();
+            ncd.poll(100, firstFailureTime);
+            time.sleep(50);
+            
+            assertFalse(ncd.unsentRequests().isEmpty());
+            
+            time.sleep(200); // Wait for delayReady to expire
+            ConsumerGroupHeartbeatResponseData responseData = new ConsumerGroupHeartbeatResponseData()
+                .setMemberId("member-1")
+                .setMemberEpoch(1);
+            client.prepareResponseFrom(new ConsumerGroupHeartbeatResponse(responseData), coordinatorNode);
+            
+            long successTime = time.milliseconds();
+            ncd.poll(100, successTime);
+            
+            assertTrue(ncd.unsentRequests().isEmpty() || 
+                       ncd.inflightRequestCount() > 0,
+                "Request should be sent when node becomes ready");
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -29,13 +29,9 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
-import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest;
-import org.apache.kafka.common.requests.ConsumerGroupHeartbeatResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -50,7 +46,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -61,8 +56,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -347,8 +340,6 @@ public class NetworkClientDelegateTest {
         properties.put(GROUP_ID_CONFIG, GROUP_ID);
         properties.put(REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
         properties.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        properties.put(RETRY_BACKOFF_MS_CONFIG, 100L);
-        properties.put(RETRY_BACKOFF_MAX_MS_CONFIG, 1000L);
         return new NetworkClientDelegate(time,
                 new ConsumerConfig(properties),
                 logContext,
@@ -379,113 +370,5 @@ public class NetworkClientDelegateTest {
 
     private Node mockNode() {
         return new Node(0, "localhost", 99);
-    }
-
-    @Test
-    public void testExponentialBackoffReducesRetryAttemptsWhenNodeNotReady() throws Exception {
-        long retryBackoffMs = 100L;
-        long retryBackoffMaxMs = 1000L;
-        
-        try (NetworkClientDelegate ncd = newNetworkClientDelegate(false)) {
-            Node coordinatorNode = mockNode();
-            
-            ConsumerGroupHeartbeatRequestData heartbeatData = new ConsumerGroupHeartbeatRequestData()
-                .setGroupId(GROUP_ID)
-                .setMemberId("")
-                .setMemberEpoch(0);
-            
-            NetworkClientDelegate.UnsentRequest heartbeatRequest = new NetworkClientDelegate.UnsentRequest(
-                new ConsumerGroupHeartbeatRequest.Builder(heartbeatData),
-                Optional.of(coordinatorNode)
-            );
-            
-            ncd.add(heartbeatRequest);
-            
-            client.delayReady(coordinatorNode, 5000L);
-            
-            List<Long> retryTimestamps = new ArrayList<>();
-            client.setReadyCallback(node -> {
-                if (node.equals(coordinatorNode)) {
-                    retryTimestamps.add(time.milliseconds());
-                }
-            });
-            
-            long startTime = time.milliseconds();
-            int pollCount = 0;
-            
-            while (time.milliseconds() - startTime < 500L) {
-                long currentTime = time.milliseconds();
-                ncd.poll(10, currentTime);
-                pollCount++;
-                time.sleep(1);
-            }
-            
-            assertTrue(retryTimestamps.size() < pollCount, 
-                String.format("Backoff should reduce retry attempts. Retries: %d, Polls: %d", 
-                    retryTimestamps.size(), pollCount));
-            
-            assertFalse(ncd.unsentRequests().isEmpty(), 
-                "Request should still be queued since node never became ready");
-            
-            if (retryTimestamps.size() >= 2) {
-                List<Long> intervals = new ArrayList<>();
-                for (int i = 1; i < retryTimestamps.size(); i++) {
-                    intervals.add(retryTimestamps.get(i) - retryTimestamps.get(i - 1));
-                }
-                
-                for (int i = 0; i < intervals.size(); i++) {
-                    long expectedBackoff = (long) Math.min(
-                        retryBackoffMs * Math.pow(2, i),
-                        retryBackoffMaxMs
-                    );
-                    long tolerance = Math.max(10, expectedBackoff / 10);
-                    long actualInterval = intervals.get(i);
-                    
-                    assertTrue(actualInterval >= expectedBackoff - tolerance,
-                        String.format("Interval %d should be >= %dms (got %dms)", 
-                            i, expectedBackoff - tolerance, actualInterval));
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testBackoffResetsAfterSuccessfulSend() throws Exception {
-        try (NetworkClientDelegate ncd = newNetworkClientDelegate(false)) {
-            Node coordinatorNode = mockNode();
-            
-            ConsumerGroupHeartbeatRequestData heartbeatData = new ConsumerGroupHeartbeatRequestData()
-                .setGroupId(GROUP_ID)
-                .setMemberId("")
-                .setMemberEpoch(0);
-            
-            NetworkClientDelegate.UnsentRequest request1 = new NetworkClientDelegate.UnsentRequest(
-                new ConsumerGroupHeartbeatRequest.Builder(heartbeatData),
-                Optional.of(coordinatorNode)
-            );
-            
-            ncd.add(request1);
-            
-            client.delayReady(coordinatorNode, 200L);
-            
-            long firstFailureTime = time.milliseconds();
-            ncd.poll(100, firstFailureTime);
-            time.sleep(50);
-            
-            assertFalse(ncd.unsentRequests().isEmpty());
-            
-            time.sleep(200); // Wait for delayReady to expire
-            ConsumerGroupHeartbeatResponseData responseData = new ConsumerGroupHeartbeatResponseData()
-                .setMemberId("member-1")
-                .setMemberEpoch(1);
-            client.prepareResponseFrom(new ConsumerGroupHeartbeatResponse(responseData), coordinatorNode);
-            
-            long successTime = time.milliseconds();
-            ncd.poll(100, successTime);
-            
-            assertTrue(ncd.unsentRequests().isEmpty() || 
-                       ncd.inflightRequestCount() > 0,
-                "Request should be sent when node becomes ready");
-        }
     }
 }


### PR DESCRIPTION
### Problem
During stress testing, AsyncKafkaConsumer's NetworkClientDelegate
produced excessive "Node is not ready" debug log messages, leading to
log spam.

### Solution
Changed the "Node is not ready" log message from DEBUG to TRACE level.

### Rationale
The original PR attempted to add exponential backoff to reduce retry
attempts when a node is not ready. However, reviewers correctly pointed
out that:

1. **Node readiness can change on any poll**: Backoff delays would
prevent timely request sending when nodes become ready (e.g., when
in-flight requests complete or metadata updates finish).

2. **`ready()` returns false for multiple reasons**: The method returns
false for various conditions (metadata update in progress, too many
in-flight requests, connecting state), and these shouldn't all be
treated uniformly with backoff. Some are transient and shouldn't have
any delay.

3. **The real issue is log spam, not retry frequency**: The continuous
checking of node readiness is actually the desired behavior - we want to
send requests as soon as the node becomes ready. By reducing the log
level from DEBUG to TRACE, we eliminate the log spam (not visible with
default DEBUG logging.
