### PR TITLE
MINOR: Fix boolean formatting consistency in protocol definitions

### DIFF
--- a/clients/src/main/resources/common/message/DescribeShareGroupOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/DescribeShareGroupOffsetsResponse.json
@@ -51,7 +51,7 @@
             "about": "The share-partition start offset." },
           { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
             "about": "The leader epoch of the partition." },
-          { "name": "Lag", "type": "int64", "versions": "1+", "ignorable": "true", "default": -1,
+          { "name": "Lag", "type": "int64", "versions": "1+", "ignorable": true, "default": -1,
             "about": "The share-partition lag." },
           { "name": "ErrorCode", "type": "int16", "versions": "0+",
             "about": "The partition-level error code, or 0 if there was no error." },

--- a/clients/src/main/resources/common/message/ReadShareGroupStateSummaryResponse.json
+++ b/clients/src/main/resources/common/message/ReadShareGroupStateSummaryResponse.json
@@ -48,7 +48,7 @@
           "about": "The leader epoch of the share-partition." },
         { "name": "StartOffset", "type": "int64", "versions": "0+",
           "about": "The share-partition start offset." },
-        { "name": "DeliveryCompleteCount", "type": "int32", "versions": "1+", "ignorable": "true", "default": "-1",
+        { "name": "DeliveryCompleteCount", "type": "int32", "versions": "1+", "ignorable": true, "default": "-1",
           "about": "The number of offsets greater than or equal to share-partition start offset for which delivery has been completed." }
       ]}
     ]}

--- a/clients/src/main/resources/common/message/WriteShareGroupStateRequest.json
+++ b/clients/src/main/resources/common/message/WriteShareGroupStateRequest.json
@@ -40,7 +40,7 @@
           "about": "The leader epoch of the share-partition." },
         { "name": "StartOffset", "type": "int64", "versions": "0+",
           "about": "The share-partition start offset, or -1 if the start offset is not being written." },
-        { "name": "DeliveryCompleteCount", "type": "int32", "versions": "1+", "ignorable": "true", "default": "-1",
+        { "name": "DeliveryCompleteCount", "type": "int32", "versions": "1+", "ignorable": true, "default": "-1",
           "about": "The number of offsets greater than or equal to share-partition start offset for which delivery has been completed." },
         { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+",
           "about": "The state batches for the share-partition.", "fields": [


### PR DESCRIPTION
Updated the following files to use raw `true`:
- `ReadShareGroupStateSummaryResponse.json`
- `DescribeShareGroupOffsetsResponse.json`
- `WriteShareGroupStateRequest.json`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
