### PR TITLE
MINOR: Fix typo in broker-configs.md

### DIFF
--- a/docs/configuration/broker-configs.md
+++ b/docs/configuration/broker-configs.md
@@ -33,7 +33,8 @@ The essential configurations are the following:
   * `process.roles`
   * `controller.quorum.bootstrap.servers`
   * `controller.listener.names` 
-Topic configurations and defaults are discussed in more detail below. {{< include-html file="/static/43/generated/kafka_config.html" >}} 
+
+Broker configurations and defaults are discussed in more detail below. {{< include-html file="/static/43/generated/kafka_config.html" >}} 
 
 More details about broker configuration can be found in the scala class `kafka.server.KafkaConfig`.
 


### PR DESCRIPTION
This patch fixes a typo in `broker-configs.md`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
