### PR TITLE
MINOR: Remove unintentional console output in MetadataCacheTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -814,7 +814,6 @@ class MetadataCacheTest {
     checkTopicMetadata(topic0, Set(1, 2), resultTopic.partitions().asScala)
 
     // With start index and quota reached
-    System.out.println("here")
     response = metadataCache.describeTopicResponse(util.List.of(topic0, topic1).iterator, listenerName, t => if (t.equals(topic0)) 2 else 0, 1, false)
     result = response.topics().asScala.toList
     assertEquals(1, result.size)


### PR DESCRIPTION
The commit
(https://github.com/apache/kafka/commit/7d13e8b70d1c7a9fc5092bb8c2653fec7f7beb29)
seems to have added an un-necessary debug line.

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>, TengYao Chi <frankvicky@apache.org>, Lan Ding
 <isDing_L@163.com>, Ken Huang <s7133700@gmail.com>
