### PR TITLE
KAFKA-19998: KRaft client should expose the latest committed kraft version for some readers

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -206,7 +206,7 @@ class BrokerServer(
 
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
 
-      metadataCache = new KRaftMetadataCache(config.nodeId, () => raftManager.client.kraftVersion())
+      metadataCache = new KRaftMetadataCache(config.nodeId, () => raftManager.client.latestCommittedKRaftVersion())
 
       // Create log manager, but don't start it because we need to delay any potential unclean shutdown log recovery
       // until we catch up on the metadata log and have up-to-date topic and broker configs.

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -145,7 +145,7 @@ class ControllerServer(
 
       authorizerPlugin = config.createNewAuthorizer(metrics, ProcessRole.ControllerRole.toString)
 
-      metadataCache = new KRaftMetadataCache(config.nodeId, () => raftManager.client.kraftVersion())
+      metadataCache = new KRaftMetadataCache(config.nodeId, () => raftManager.client.latestCommittedKRaftVersion())
 
       metadataCachePublisher = new KRaftMetadataCachePublisher(metadataCache)
 
@@ -160,7 +160,7 @@ class ControllerServer(
         config.unstableApiVersionsEnabled,
         () => featuresPublisher.features().setFinalizedLevel(
           KRaftVersion.FEATURE_NAME,
-          raftManager.client.kraftVersion().featureLevel())
+          raftManager.client.latestCommittedKRaftVersion().featureLevel())
       )
 
       //  metrics will be set to null when closing a controller, so we should recreate it for testing

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1985,7 +1985,7 @@ public final class QuorumController implements Controller {
                 // Read and write data in the controller event handling thread to avoid stale information.
                 Map<String, Short> controllerFeatures = new HashMap<>(featureControl.finalizedFeatures(Long.MAX_VALUE).featureMap());
                 // Populate finalized features map with latest known kraft version for validation.
-                controllerFeatures.put(KRaftVersion.FEATURE_NAME, raftClient.kraftVersion().featureLevel());
+                controllerFeatures.put(KRaftVersion.FEATURE_NAME, raftClient.latestKRaftVersion().featureLevel());
                 return clusterControl.
                     registerBroker(request, offsetControl.nextWriteOffset(),
                         new FinalizedControllerFeatures(controllerFeatures, Long.MAX_VALUE),

--- a/metadata/src/main/java/org/apache/kafka/controller/RaftClientKRaftVersionAccessor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/RaftClientKRaftVersionAccessor.java
@@ -28,7 +28,7 @@ public final class RaftClientKRaftVersionAccessor implements KRaftVersionAccesso
     }
 
     public KRaftVersion kraftVersion() {
-        return raftClient.kraftVersion();
+        return raftClient.latestKRaftVersion();
     }
 
     public void upgradeKRaftVersion(int epoch, KRaftVersion version, boolean validateOnly) {

--- a/metadata/src/test/java/org/apache/kafka/controller/MockRaftClient.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockRaftClient.java
@@ -797,7 +797,12 @@ public final class MockRaftClient implements RaftClient<ApiMessageAndVersion>, A
     }
 
     @Override
-    public KRaftVersion kraftVersion() {
+    public KRaftVersion latestKRaftVersion() {
+        return lastKRaftVersion;
+    }
+
+    @Override
+    public KRaftVersion latestCommittedKRaftVersion() {
         return lastKRaftVersion;
     }
 

--- a/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
@@ -129,7 +129,12 @@ public class SnapshotEmitterTest {
         }
 
         @Override
-        public KRaftVersion kraftVersion() {
+        public KRaftVersion latestKRaftVersion() {
+            return KRaftVersion.KRAFT_VERSION_0;
+        }
+
+        @Override
+        public KRaftVersion latestCommittedKRaftVersion() {
             return KRaftVersion.KRAFT_VERSION_0;
         }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3829,7 +3829,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     @Override
-    public KRaftVersion kraftVersion() {
+    public KRaftVersion latestKRaftVersion() {
         if (!isInitialized()) {
             throw new IllegalStateException("Cannot read the kraft version before the replica has been initialized");
         }
@@ -3839,6 +3839,18 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             .flatMap(LeaderState::requestedKRaftVersion)
             .map(KRaftVersionUpgrade.Version::kraftVersion)
             .orElseGet(partitionState::lastKraftVersion);
+    }
+
+    @Override
+    public KRaftVersion latestCommittedKRaftVersion() {
+        if (!isInitialized()) {
+            throw new IllegalStateException("Cannot read the committed kraft version before the replica has been initialized");
+        }
+        if (quorum.highWatermark().isPresent()) {
+            return partitionState.kraftVersionAtOffset(quorum.highWatermark().get().offset() - 1);
+        } else {
+            return KRaftVersion.KRAFT_VERSION_0;
+        }
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -250,7 +250,14 @@ public interface RaftClient<T> extends AutoCloseable {
      *
      * @return the current kraft.version.
      */
-    KRaftVersion kraftVersion();
+    KRaftVersion latestKRaftVersion();
+
+    /**
+     * Returns the latest committed kraft.version.
+     *
+     * @return the current kraft.version.
+     */
+    KRaftVersion latestCommittedKRaftVersion();
 
     /**
      * Request that the leader to upgrade the kraft version.

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2443,7 +2443,7 @@ public class KafkaRaftClientReconfigTest {
         }
 
         context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false);
-        assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.kraftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.latestKRaftVersion());
 
         var localLogEndOffset = context.log.endOffset().offset();
         context.client.poll();
@@ -2510,7 +2510,7 @@ public class KafkaRaftClientReconfigTest {
         }
 
         context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false);
-        assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.kraftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.latestKRaftVersion());
 
         // Push the control records to the log
         context.client.poll();
@@ -2587,7 +2587,7 @@ public class KafkaRaftClientReconfigTest {
         var epoch = context.currentEpoch();
 
         // Upgrade not allowed since none of the remote voters support the new version
-        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.kraftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestKRaftVersion());
         assertThrows(
             InvalidUpdateVersionException.class,
             () -> context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false)
@@ -2618,7 +2618,7 @@ public class KafkaRaftClientReconfigTest {
         );
 
         // Upgrade not allowed since one of the voters doesn't support the new version
-        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.kraftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestKRaftVersion());
         assertThrows(
             InvalidUpdateVersionException.class,
             () -> context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false)

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2444,6 +2444,7 @@ public class KafkaRaftClientReconfigTest {
 
         context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false);
         assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.latestKRaftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestCommittedKRaftVersion());
 
         var localLogEndOffset = context.log.endOffset().offset();
         context.client.poll();
@@ -2511,6 +2512,7 @@ public class KafkaRaftClientReconfigTest {
 
         context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false);
         assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.latestKRaftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestCommittedKRaftVersion());
 
         // Push the control records to the log
         context.client.poll();
@@ -2522,6 +2524,10 @@ public class KafkaRaftClientReconfigTest {
             context.pollUntilResponse();
             context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(local.id()));
         }
+
+        // the leader's latestCommittedKRaftVersion should be updated
+        assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.latestKRaftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.latestCommittedKRaftVersion());
 
         // Check that it can still handle update voter request after upgrade
         Endpoints newVoter1Listeners = Endpoints.fromInetSocketAddresses(
@@ -2588,6 +2594,7 @@ public class KafkaRaftClientReconfigTest {
 
         // Upgrade not allowed since none of the remote voters support the new version
         assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestKRaftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestCommittedKRaftVersion());
         assertThrows(
             InvalidUpdateVersionException.class,
             () -> context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false)
@@ -2619,6 +2626,7 @@ public class KafkaRaftClientReconfigTest {
 
         // Upgrade not allowed since one of the voters doesn't support the new version
         assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestKRaftVersion());
+        assertEquals(KRaftVersion.KRAFT_VERSION_0, context.client.latestCommittedKRaftVersion());
         assertThrows(
             InvalidUpdateVersionException.class,
             () -> context.client.upgradeKRaftVersion(epoch, KRaftVersion.KRAFT_VERSION_1, false)


### PR DESCRIPTION
Readers like the `SimpleApiVersionsManager` and the `MetadataCache` should only know about the latest committed kraft version. Others, like the broker registration manager, need to know the potentially uncommitted kraft version.
