### PR TITLE
[backport 3.9]  KAFKA-17862: [buffer pool] corruption during buffer reuse from the pool

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -164,7 +164,8 @@ public class ProducerConfig extends AbstractConfig {
             + "either an unrecoverable error is encountered, the retries have been exhausted, "
             + "or the record is added to a batch which reached an earlier delivery expiration deadline. "
             + "The value of this config should be greater than or equal to the sum of <code>" + REQUEST_TIMEOUT_MS_CONFIG + "</code> "
-            + "and <code>" + LINGER_MS_CONFIG + "</code>.";
+            + "and <code>" + LINGER_MS_CONFIG + "</code>.  <code>" + DELIVERY_TIMEOUT_MS_CONFIG + "</code> applies only before a record batch is sent. "
+            + "After a request is in-flight, completion depends on broker responses or network failures, not on the delivery timeout.";
 
     /** <code>client.id</code> */
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -164,7 +164,7 @@ public class ProducerConfig extends AbstractConfig {
             + "either an unrecoverable error is encountered, the retries have been exhausted, "
             + "or the record is added to a batch which reached an earlier delivery expiration deadline. "
             + "The value of this config should be greater than or equal to the sum of <code>" + REQUEST_TIMEOUT_MS_CONFIG + "</code> "
-            + "and <code>" + LINGER_MS_CONFIG + "</code>.  <code>" + DELIVERY_TIMEOUT_MS_CONFIG + "</code> applies only before a record batch is sent. "
+            + "and <code>" + LINGER_MS_CONFIG + "</code>. <code>" + DELIVERY_TIMEOUT_MS_CONFIG + "</code> applies only before a record batch is sent. "
             + "After a request is in-flight, completion depends on broker responses or network failures, not on the delivery timeout.";
 
     /** <code>client.id</code> */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -180,42 +180,6 @@ public class Sender implements Runnable {
         this.accumulator.deallocate(batch);
     }
 
-    /**
-     *  Get the in-flight batches that has reached delivery timeout.
-     */
-    private List<ProducerBatch> getExpiredInflightBatches(long now) {
-        List<ProducerBatch> expiredBatches = new ArrayList<>();
-
-        for (Iterator<Map.Entry<TopicPartition, List<ProducerBatch>>> batchIt = inFlightBatches.entrySet().iterator(); batchIt.hasNext();) {
-            Map.Entry<TopicPartition, List<ProducerBatch>> entry = batchIt.next();
-            List<ProducerBatch> partitionInFlightBatches = entry.getValue();
-            if (partitionInFlightBatches != null) {
-                Iterator<ProducerBatch> iter = partitionInFlightBatches.iterator();
-                while (iter.hasNext()) {
-                    ProducerBatch batch = iter.next();
-                    if (batch.hasReachedDeliveryTimeout(accumulator.getDeliveryTimeoutMs(), now)) {
-                        iter.remove();
-                        // expireBatches is called in Sender.sendProducerData, before client.poll.
-                        // The !batch.isDone() invariant should always hold. An IllegalStateException
-                        // exception will be thrown if the invariant is violated.
-                        if (!batch.isDone()) {
-                            expiredBatches.add(batch);
-                        } else {
-                            throw new IllegalStateException(batch.topicPartition + " batch created at " +
-                                batch.createdMs + " gets unexpected final state " + batch.finalState());
-                        }
-                    } else {
-                        accumulator.maybeUpdateNextBatchExpiryTime(batch);
-                        break;
-                    }
-                }
-                if (partitionInFlightBatches.isEmpty()) {
-                    batchIt.remove();
-                }
-            }
-        }
-        return expiredBatches;
-    }
 
     private void addToInflightBatches(List<ProducerBatch> batches) {
         for (ProducerBatch batch : batches) {
@@ -412,9 +376,9 @@ public class Sender implements Runnable {
         }
 
         accumulator.resetNextBatchExpiryTime();
-        List<ProducerBatch> expiredInflightBatches = getExpiredInflightBatches(now);
+        // Do not expire in-flight batches here.
+        // Releasing their buffers prematurely could return active data to the buffer pool, leading to buffer corruption 
         List<ProducerBatch> expiredBatches = this.accumulator.expiredBatches(now);
-        expiredBatches.addAll(expiredInflightBatches);
 
         // Reset the producer id if an expired batch has previously been sent to the broker. Also update the metrics
         // for expired batches. see the documentation of @TransactionState.resetIdempotentProducerId to understand why

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -117,6 +117,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.clients.producer.internals.ProducerTestUtils.runUntil;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -2566,7 +2567,7 @@ public class SenderTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testInflightBatchesExpireOnDeliveryTimeout() throws InterruptedException {
+    public void testInflightBatchesNotExpiredBeforeResponseAfterDeliveryTimeout() throws InterruptedException {
         long deliveryTimeoutMs = 1500L;
         setupWithTransactionState(null, true, null);
 
@@ -2576,17 +2577,17 @@ public class SenderTest {
         assertEquals(1, client.inFlightRequestCount());
         assertEquals(1, sender.inFlightBatches(tp0).size(), "Expect one in-flight batch in accumulator");
 
-        Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new HashMap<>();
-        responseMap.put(tp0, new ProduceResponse.PartitionResponse(Errors.NONE, 0L, 0L, 0L));
-        client.respond(new ProduceResponse(responseMap));
-
+        // let delivery timeout expire without responding
         time.sleep(deliveryTimeoutMs);
-        sender.runOnce();  // receive first response
-        assertEquals(0, sender.inFlightBatches(tp0).size(), "Expect zero in-flight batch in accumulator");
-        assertInstanceOf(
-            TimeoutException.class,
-            assertThrows(ExecutionException.class, request::get).getCause(),
-            "The expired batch should throw a TimeoutException");
+        sender.runOnce();
+        // inflight batch should still be there
+        assertEquals(1, sender.inFlightBatches(tp0).size());
+        assertFalse(request.isDone());
+
+        client.respond(produceResponse(tp0, 0L, Errors.NONE, 0, 0L, null));
+        sender.runOnce();
+        assertEquals(0, sender.inFlightBatches(tp0).size());
+        assertDoesNotThrow(() -> request.get());
     }
 
     @Test
@@ -2690,8 +2691,7 @@ public class SenderTest {
     }
 
     @Test
-    public void testExpiredBatchDoesNotSplitOnMessageTooLargeError() throws Exception {
-        long deliverTimeoutMs = 1500L;
+    public void testExpiredBatchStillSplitOnMessageTooLargeError() throws Exception {
         // create a producer batch with more than one record so it is eligible for splitting
         Future<RecordMetadata> request1 = appendToAccumulator(tp0);
         Future<RecordMetadata> request2 = appendToAccumulator(tp0);
@@ -2702,18 +2702,30 @@ public class SenderTest {
         // return a MESSAGE_TOO_LARGE error
         client.respond(produceResponse(tp0, -1, Errors.MESSAGE_TOO_LARGE, -1));
 
-        time.sleep(deliverTimeoutMs);
-        // expire the batch and process the response
+        //  process MESSAGE_TOO_LARGE response and split the batch
         sender.runOnce();
+        verify(accumulator, atLeastOnce()).splitAndReenqueue(any());
+
+        assertEquals(0, client.inFlightRequestCount());
+        //  send the split batches
+        sender.runOnce();
+
+        int inflightAfterFailure = client.inFlightRequestCount();
+        int batchesAfterFailure = sender.inFlightBatches(tp0).size();
+
+        //  in-flight requests and batches should remain unchanged
+        sender.runOnce();
+        assertEquals(inflightAfterFailure, client.inFlightRequestCount());
+        assertEquals(batchesAfterFailure, sender.inFlightBatches(tp0).size());
+
+        client.respond(produceResponse(tp0, 0, Errors.NONE, 0));
+        //  handle the response
+        sender.runOnce();
+
+        assertEquals(0, client.inFlightRequestCount());
+        assertEquals(0, sender.inFlightBatches(tp0).size());
         assertTrue(request1.isDone());
         assertTrue(request2.isDone());
-        assertEquals(0, client.inFlightRequestCount());
-        assertEquals(0, sender.inFlightBatches(tp0).size());
-
-        // run again and must not split big batch and resend anything.
-        sender.runOnce();
-        assertEquals(0, client.inFlightRequestCount());
-        assertEquals(0, sender.inFlightBatches(tp0).size());
     }
 
     @Test
@@ -2725,6 +2737,7 @@ public class SenderTest {
         appendToAccumulator(tp0, 0L, "key", "value");
 
         sender.runOnce();
+        long nowBeforeSecondRun = time.milliseconds();
         sender.runOnce();
         time.setCurrentTimeMs(time.milliseconds() + accumulator.getDeliveryTimeoutMs() + 1);
         sender.runOnce();
@@ -2734,14 +2747,14 @@ public class SenderTest {
         inOrder.verify(client, atLeastOnce()).newClientRequest(anyString(), any(), anyLong(), anyBoolean(), anyInt(), any());
         inOrder.verify(client, atLeastOnce()).send(any(), anyLong());
         inOrder.verify(client).poll(eq(0L), anyLong());
-        inOrder.verify(client).poll(eq(accumulator.getDeliveryTimeoutMs()), anyLong());
+        inOrder.verify(client).poll(eq(Long.MAX_VALUE - nowBeforeSecondRun), anyLong());
         inOrder.verify(client).poll(geq(1L), anyLong());
 
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testExpiredBatchesInMultiplePartitions() throws Exception {
+    public void testInflightBatchesAcrossPartitionsRemainAfterDeliveryTimeoutUntilResponse() throws Exception {
         long deliveryTimeoutMs = 1500L;
         setupWithTransactionState(null, true, null);
 
@@ -2752,22 +2765,27 @@ public class SenderTest {
         // Send request.
         sender.runOnce();
         assertEquals(1, client.inFlightRequestCount());
-        assertEquals(1, sender.inFlightBatches(tp0).size(), "Expect one in-flight batch in accumulator");
+        assertEquals(1, sender.inFlightBatches(tp0).size());
+        assertEquals(1, sender.inFlightBatches(tp1).size());
 
-        Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new HashMap<>();
-        responseMap.put(tp0, new ProduceResponse.PartitionResponse(Errors.NONE, 0L, 0L, 0L));
-        client.respond(new ProduceResponse(responseMap));
-
-        // Successfully expire both batches.
+        // let delivery timeout expire without responding
         time.sleep(deliveryTimeoutMs);
         sender.runOnce();
+
+        // inflight batches should still exist
+        assertEquals(1, sender.inFlightBatches(tp0).size());
+        assertEquals(1, sender.inFlightBatches(tp1).size());
+        assertFalse(request1.isDone());
+        assertFalse(request2.isDone());
+        Map<TopicPartition, OffsetAndError> responses = new LinkedHashMap<>();
+        responses.put(tp1, new OffsetAndError(-1, Errors.NONE));
+        responses.put(tp0, new OffsetAndError(-1, Errors.NONE));
+        client.respond(produceResponse(responses));
+        sender.runOnce();
+
         assertEquals(0, sender.inFlightBatches(tp0).size(), "Expect zero in-flight batch in accumulator");
-
-        ExecutionException e = assertThrows(ExecutionException.class, request1::get);
-        assertInstanceOf(TimeoutException.class, e.getCause());
-
-        e = assertThrows(ExecutionException.class, request2::get);
-        assertInstanceOf(TimeoutException.class, e.getCause());
+        assertDoesNotThrow(() -> request1.get());
+        assertDoesNotThrow(() -> request2.get());
     }
 
     @Test
@@ -3128,8 +3146,9 @@ public class SenderTest {
         client.disconnect(node.idString(), true);
         client.backoff(node, 10);
 
-        sender.runOnce(); // now expire the batch.
-        assertFutureFailure(request1, TimeoutException.class);
+        sender.runOnce();
+        assertFutureFailure(request1, NetworkException.class);
+        assertEquals(0, sender.inFlightBatches(tp0).size());
 
         time.sleep(20);
 
@@ -3741,8 +3760,8 @@ public class SenderTest {
         this.metrics = new Metrics(metricConfig, time);
         BufferPool pool = (customPool == null) ? new BufferPool(totalSize, batchSize, metrics, time, metricGrpName) : customPool;
 
-        this.accumulator = new RecordAccumulator(logContext, batchSize, Compression.NONE, lingerMs, 0L, 0L,
-            DELIVERY_TIMEOUT_MS, metrics, metricGrpName, time, apiVersions, transactionManager, pool);
+        this.accumulator = spy(new RecordAccumulator(logContext, batchSize, Compression.NONE, lingerMs, 0L, 0L,
+            DELIVERY_TIMEOUT_MS, metrics, metricGrpName, time, apiVersions, transactionManager, pool));
         this.senderMetricsRegistry = new SenderMetricsRegistry(this.metrics);
         this.sender = new Sender(logContext, this.client, this.metadata, this.accumulator, guaranteeOrder, MAX_REQUEST_SIZE, ACKS_ALL,
             retries, this.senderMetricsRegistry, this.time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InvalidTxnStateException;
+import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -123,6 +124,8 @@ public class TransactionManagerTest {
     private static final int MAX_BLOCK_TIMEOUT = 1000;
     private static final int REQUEST_TIMEOUT = 1000;
     private static final long DEFAULT_RETRY_BACKOFF_MS = 100L;
+
+    private static final String NETWORK_DISCONNECTED_MSG = "Disconnected from node";
 
     private final String transactionalId = "foobar";
     private final int transactionTimeoutMs = 1121;
@@ -717,16 +720,13 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.hasInflightBatches(tp0));
         assertEquals(1, transactionManager.sequenceNumber(tp0));
 
-        time.sleep(5000); // delivery time out
-        sender.runOnce();
-
-        // The retried request will remain inflight until the request timeout
-        // is reached even though the delivery timeout has expired and the
-        // future has completed exceptionally.
-        assertTrue(responseFuture1.isDone());
-        TestUtils.assertFutureThrows(responseFuture1, TimeoutException.class);
+        ProducerTestUtils.runUntil(sender, () -> {
+            time.sleep(5000); // advance the "now" so NetworkClient sees the request as expired
+            return responseFuture1.isDone();
+        });
+        assertInstanceOf(NetworkException.class, assertThrows(ExecutionException.class, responseFuture1::get).getCause());
         assertFalse(transactionManager.hasInFlightRequest());
-        assertEquals(1, client.inFlightRequestCount());
+        assertEquals(0, client.inFlightRequestCount());
 
         sender.runOnce(); // bump the epoch
         assertEquals(epoch + 1, transactionManager.producerIdAndEpoch().epoch);
@@ -740,10 +740,12 @@ public class TransactionManagerTest {
         assertEquals(0, transactionManager.firstInFlightSequence(tp0));
         assertEquals(1, transactionManager.sequenceNumber(tp0));
 
-        time.sleep(5000); // request time out again
-        sender.runOnce();
-        assertTrue(transactionManager.hasInflightBatches(tp0)); // the latter batch failed and retried
-        assertFalse(responseFuture2.isDone());
+        ProducerTestUtils.runUntil(sender, () -> {
+            time.sleep(5000); // advance the "now" so NetworkClient sees the request as expired
+            return responseFuture2.isDone();
+        });
+        assertFalse(transactionManager.hasInflightBatches(tp0)); // the latter batch failed and retried
+        assertTrue(responseFuture2.isDone());
     }
 
     private ProducerBatch writeIdempotentBatchWithValue(TransactionManager manager,
@@ -2697,8 +2699,10 @@ public class TransactionManagerTest {
 
         TransactionalRequestResult commitResult = transactionManager.beginCommit();
 
-        // Sleep 10 seconds to make sure that the batches in the queue would be expired if they can't be drained.
-        time.sleep(10000);
+        ProducerTestUtils.runUntil(sender, () -> {
+            time.sleep(10000); // advance "now" so NetworkClient sees request as expired
+            return responseFuture.isDone();
+        });
         // Disconnect the target node for the pending produce request. This will ensure that sender will try to
         // expire the batch.
         Node clusterNode = metadata.fetch().nodes().get(0);
@@ -2707,13 +2711,16 @@ public class TransactionManagerTest {
         runUntil(responseFuture::isDone);  // We should try to flush the produce, but expire it instead without sending anything.
 
         // make sure the produce was expired.
-        assertInstanceOf(
-            TimeoutException.class,
+        NetworkException timeoutEx1 = assertInstanceOf(
+            NetworkException.class,
             assertThrows(ExecutionException.class, responseFuture::get).getCause(),
-            "Expected to get a TimeoutException since the queued ProducerBatch should have been expired");
+            "Expected the produce request to fail due to network disconnect");
+        assertTrue(timeoutEx1.getMessage().contains(NETWORK_DISCONNECTED_MSG));
+
         runUntil(commitResult::isCompleted);  // the commit shouldn't be completed without being sent since the produce request failed.
-        assertFalse(commitResult.isSuccessful());  // the commit shouldn't succeed since the produce request failed.
-        assertThrows(TimeoutException.class, commitResult::await);
+        assertFalse(commitResult.isSuccessful());  // the commit shouldn't succeed since the produce request failed due to network disconnect.
+        NetworkException timeoutEx2 = assertThrows(NetworkException.class, () -> commitResult.await(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
+        assertTrue(timeoutEx2.getMessage().contains(NETWORK_DISCONNECTED_MSG));
 
         assertTrue(transactionManager.hasAbortableError());
         assertTrue(transactionManager.hasOngoingTransaction());

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -782,9 +782,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     // return if we have no valid messages or if this is a duplicate of the last appended entry
     if (appendInfo.validBytes <= 0) appendInfo
     else {
-
+      val isLeader = origin != AppendOrigin.REPLICATION
       // trim any invalid bytes or partial messages before appending it to the on-disk log
-      var validRecords = trimInvalidBytes(records, appendInfo)
+      var validRecords = trimInvalidBytes(records, appendInfo, isLeader)
 
       // they are valid, insert them in the log
       lock synchronized {
@@ -1256,9 +1256,10 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    *
    * @param records The records to trim
    * @param info The general information of the message set
+   * @param isLeader whether the record set is from the leader
    * @return A trimmed message set. This may be the same as what was passed in or it may not.
    */
-  private def trimInvalidBytes(records: MemoryRecords, info: LogAppendInfo): MemoryRecords = {
+  private def trimInvalidBytes(records: MemoryRecords, info: LogAppendInfo, isLeader: Boolean): MemoryRecords = {
     val validBytes = info.validBytes
     if (validBytes < 0)
       throw new CorruptRecordException(s"Cannot append record batch with illegal length $validBytes to " +
@@ -1269,6 +1270,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       // trim invalid bytes
       val validByteBuffer = records.buffer.duplicate()
       validByteBuffer.limit(validBytes)
+      if (isLeader) {
+        warn(s"Trimming invalid bytes from message set. Original size: ${records.sizeInBytes()} bytes, valid bytes: $validBytes, trimmed bytes: ${records.sizeInBytes() - validBytes}.")
+      }
       MemoryRecords.readableRecords(validByteBuffer)
     }
   }


### PR DESCRIPTION
see https://github.com/apache/kafka/pull/19489
We also need to add a backport for 3.9.