### PR TITLE
KAFKA-20017: incorrect warn log when alterConfig suceeds

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -622,7 +622,7 @@ public class MirrorSourceConnector extends SourceConnector {
                                 + sourceAndTarget.target() + "' is not compatible with " +
                                 "IncrementalAlterConfigs " +
                                 "API", e));
-                    } else if (e != null){
+                    } else if (e != null) {
                         log.warn("Could not alter configuration of topic {}.", k.name(), e);
                     } else {
                         log.debug("Successfully altered configuration of topic {}.", k.name());

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -622,8 +622,10 @@ public class MirrorSourceConnector extends SourceConnector {
                                 + sourceAndTarget.target() + "' is not compatible with " +
                                 "IncrementalAlterConfigs " +
                                 "API", e));
-                    } else {
+                    } else if (e != null){
                         log.warn("Could not alter configuration of topic {}.", k.name(), e);
+                    } else {
+                        log.debug("Successfully altered configuration of topic {}.", k.name());
                     }
                 }));
             return null;


### PR DESCRIPTION
Fix incorrect warn log when alterConfig succeeds and add debug logging
for successful updates.

Reviewers: Luke Chen <showuon@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
