### PR TITLE
MINOR: Fix the  Client/Broker Forward Compatibility table in compatibility page 

### DIFF
--- a/docs/getting-started/compatibility.md
+++ b/docs/getting-started/compatibility.md
@@ -288,33 +288,46 @@ before 3.2.x
     <td rowspan="3">0.x, 1.x, 2.0</td>
     <td>Client</td>
     <td>❌ Not Compatible</td>
-    <td>Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
+    <td>
+
+Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).
+</td>
   </tr>
   <tr>
     <td>Streams</td>
     <td>❌ Not Compatible</td>
-    <td>Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
+    <td>
+
+Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
   </tr>
   <tr>
     <td>Connect</td>
     <td>❌ Not Compatible</td>
-    <td>Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
+    <td>
+
+Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
   </tr>
   <tr>
     <td rowspan="3">2.1 ~ 2.8</td>
     <td>Client</td>
     <td>⚠️ Partially Compatible</td>
-    <td>More details in the [Consumer](/40/documentation.html#upgrade_400_notable_consumer), [Producer](/40/documentation.html#upgrade_400_notable_producer), and [Admin Client](/40/documentation.html#upgrade_400_notable_admin_client) section.</td>
+    <td>
+
+More details in the [Consumer](/40/documentation.html#upgrade_400_notable_consumer), [Producer](/40/documentation.html#upgrade_400_notable_producer), and [Admin Client](/40/documentation.html#upgrade_400_notable_admin_client) section.</td>
   </tr>
   <tr>
     <td>Streams</td>
     <td>⚠️ Limited Compatibility</td>
-    <td>More details in the [Kafka Streams](/40/documentation.html#upgrade_400_notable_kafka_streams) section.</td>
+    <td>
+
+More details in the [Kafka Streams](/40/documentation.html#upgrade_400_notable_kafka_streams) section.</td>
   </tr>
   <tr>
     <td>Connect</td>
     <td>⚠️ Limited Compatibility</td>
-    <td>More details in the [Connect](/40/documentation.html#upgrade_400_notable_connect) section.</td>
+    <td>
+
+More details in the [Connect](/40/documentation.html#upgrade_400_notable_connect) section.</td>
   </tr>
   <tr>
     <td rowspan="3">3.x</td>

--- a/docs/getting-started/compatibility.md
+++ b/docs/getting-started/compatibility.md
@@ -273,156 +273,65 @@ before 3.2.x
 ✅
 </td> </tr> </table>
 
-**Note: Can’t upgrade server from static voter to dynamic voter, see[KAFKA-16538](https://issues.apache.org/jira/browse/KAFKA-16538).**
+**Note: Can’t upgrade server from static voter to dynamic voter, see [KAFKA-16538](https://issues.apache.org/jira/browse/KAFKA-16538).**
 
 ## Client/Broker Forward Compatibility  
-  
-<table>  
-<tr>  
-<th>
 
-Kafka Version
-</th>  
-<th>
-
-Module
-</th>  
-<th>
-
-Compatibility with Kafka 4.0
-</th>  
-<th>
-
-Key Differences/Limitations
-</th> </tr>  
-<tr>  
-<td>
-
-0.x, 1.x, 2.0
-</td>  
-<td>
-
-Client
-</td>  
-<td>
-
-❌ Not Compatible
-</td>  
-<td>
-
-Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)). 
-</td> </tr>  
-<tr>  
-<td>
-
-Streams
-</td>  
-<td>
-
-❌ Not Compatible
-</td>  
-<td>
-
-Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)). 
-</td> </tr>  
-<tr>  
-<td>
-
-Connect
-</td>  
-<td>
-
-❌ Not Compatible
-</td>  
-<td>
-
-Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)). 
-</td> </tr>  
-<tr>  
-<td>
-
-2.1 ~ 2.8
-</td>  
-<td>
-
-Client
-</td>  
-<td>
-
-⚠️ Partially Compatible
-</td>  
-<td>
-
-More details in the [Consumer](/40/documentation.html#upgrade_400_notable_consumer), [Producer](/40/documentation.html#upgrade_400_notable_producer), and [Admin Client](/40/documentation.html#upgrade_400_notable_admin_client) section. 
-</td> </tr>  
-<tr>  
-<td>
-
-Streams
-</td>  
-<td>
-
-⚠️ Limited Compatibility
-</td>  
-<td>
-
-More details in the [Kafka Streams](/40/documentation.html#upgrade_400_notable_kafka_streams) section. 
-</td> </tr>  
-<tr>  
-<td>
-
-Connect
-</td>  
-<td>
-
-⚠️ Limited Compatibility
-</td>  
-<td>
-
-More details in the [Connect](/40/documentation.html#upgrade_400_notable_connect) section. 
-</td> </tr>  
-<tr>  
-<td>
-
-3.x
-</td>  
-<td>
-
-Client
-</td>  
-<td>
-
-✅ Fully Compatible
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-Streams
-</td>  
-<td>
-
-✅ Fully Compatible
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-Connect
-</td>  
-<td>
-
-✅ Fully Compatible
-</td>  
-<td>
-
-
-</td> </tr> </table>
+<table>
+  <tr>
+    <th>Kafka Version</th>
+    <th>Module</th>
+    <th>Compatibility with Kafka 4.0</th>
+    <th>Key Differences/Limitations</th>
+  </tr>
+  <tr>
+    <td rowspan="3">0.x, 1.x, 2.0</td>
+    <td>Client</td>
+    <td>❌ Not Compatible</td>
+    <td>Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
+  </tr>
+  <tr>
+    <td>Streams</td>
+    <td>❌ Not Compatible</td>
+    <td>Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
+  </tr>
+  <tr>
+    <td>Connect</td>
+    <td>❌ Not Compatible</td>
+    <td>Pre-0.10.x protocols are fully removed in Kafka 4.0 ([KIP-896](https://cwiki.apache.org/confluence/x/K5sODg)).</td>
+  </tr>
+  <tr>
+    <td rowspan="3">2.1 ~ 2.8</td>
+    <td>Client</td>
+    <td>⚠️ Partially Compatible</td>
+    <td>More details in the [Consumer](/40/documentation.html#upgrade_400_notable_consumer), [Producer](/40/documentation.html#upgrade_400_notable_producer), and [Admin Client](/40/documentation.html#upgrade_400_notable_admin_client) section.</td>
+  </tr>
+  <tr>
+    <td>Streams</td>
+    <td>⚠️ Limited Compatibility</td>
+    <td>More details in the [Kafka Streams](/40/documentation.html#upgrade_400_notable_kafka_streams) section.</td>
+  </tr>
+  <tr>
+    <td>Connect</td>
+    <td>⚠️ Limited Compatibility</td>
+    <td>More details in the [Connect](/40/documentation.html#upgrade_400_notable_connect) section.</td>
+  </tr>
+  <tr>
+    <td rowspan="3">3.x</td>
+    <td>Client</td>
+    <td>✅ Fully Compatible</td>
+    <td>—</td>
+  </tr>
+  <tr>
+    <td>Streams</td>
+    <td>✅ Fully Compatible</td>
+    <td>—</td>
+  </tr>
+  <tr>
+    <td>Connect</td>
+    <td>✅ Fully Compatible</td>
+    <td>—</td>
+  </tr>
+</table>
 
 Note: Starting with Kafka 4.0, the `--zookeeper` option in AdminClient commands has been removed. Users must use the `--bootstrap-server` option to interact with the Kafka cluster. This change aligns with the transition to KRaft mode. 


### PR DESCRIPTION
The formatting of this table is currently incorrect.   <img width="885"
height="808" alt="image"
src="https://github.com/user-attachments/assets/6ee71dde-0d3d-44d3-8e82-49b5ab922f64"
/>

The following snapshot is for this patch.  <img width="991" height="656"
alt="image"
src="https://github.com/user-attachments/assets/b9958eb0-0a73-47b4-99dd-359efaa60d08"
/>

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
