### PR TITLE
KAFKA-20019: Fetch responses can exceed maxBytes when mixing local and tiered storage partitions

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -196,6 +196,26 @@ object ReplicaManager {
     timestamp < 0 &&
       (!timestampMinSupportedVersion.contains(timestamp) || version < timestampMinSupportedVersion(timestamp))
   }
+
+  /**
+   * Creates a placeholder Records instance that reports a specific size without allocating memory.
+   * This is used for tiered storage fetch placeholders to properly account for reserved fetch size
+   * in bytesReadable calculations without the memory overhead of allocating large buffers.
+   */
+  private[server] class PlaceholderRecords(size: Int) extends AbstractRecords {
+    override def sizeInBytes(): Int = size
+
+    override def batches(): java.lang.Iterable[RecordBatch] = java.util.Collections.emptyList()
+
+    override def batchIterator(): org.apache.kafka.common.utils.AbstractIterator[RecordBatch] =
+      new org.apache.kafka.common.utils.AbstractIterator[RecordBatch] {
+        override def makeNext(): RecordBatch = allDone()
+      }
+
+    override def writeTo(channel: org.apache.kafka.common.network.TransferableChannel, position: Int, length: Int): Int = 0
+
+    override def slice(position: Int, size: Int): Records = MemoryRecords.EMPTY
+  }
 }
 
 class ReplicaManager(val config: KafkaConfig,
@@ -1949,7 +1969,12 @@ class ReplicaManager(val config: KafkaConfig,
           } else {
             Optional.empty[RemoteStorageFetchInfo]()
           }
-          new FetchDataInfo(new LogOffsetMetadata(offset), MemoryRecords.EMPTY, false, Optional.empty(), remoteStorageFetchInfoOpt)
+          // Use a placeholder Records with sizeInBytes = adjustedMaxBytes instead of EMPTY (which has size 0).
+          // This ensures bytesReadable accounts for the reserved remote fetch size, preventing fetch responses
+          // from exceeding fetch.max.bytes when combining local and tiered storage fetches.
+          // PlaceholderRecords avoids allocating memory for the fetch size accounting.
+          val placeholderRecords = new ReplicaManager.PlaceholderRecords(adjustedMaxBytes)
+          new FetchDataInfo(new LogOffsetMetadata(offset), placeholderRecords, false, Optional.empty(), remoteStorageFetchInfoOpt)
         }
 
         new LogReadResult(fetchDataInfo,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5783,7 +5783,8 @@ class ReplicaManagerTest {
     assertEquals(1L, fetchInfo.fetchOffsetMetadata.messageOffset)
     assertEquals(UnifiedLog.UNKNOWN_OFFSET, fetchInfo.fetchOffsetMetadata.segmentBaseOffset)
     assertEquals(-1, fetchInfo.fetchOffsetMetadata.relativePositionInSegment)
-    assertEquals(MemoryRecords.EMPTY, fetchInfo.records)
+    // placeholder records should use adjustedMaxBytes for size
+    assertEquals(100, fetchInfo.records.sizeInBytes)
     assertTrue(fetchInfo.delayedRemoteStorageFetch.isPresent)
 
     val allMetrics = metrics.metrics()
@@ -5791,6 +5792,57 @@ class ReplicaManagerTest {
     val maxMetric = allMetrics.get(metrics.metricName("remote-fetch-throttle-time-max", "RemoteLogManager"))
     assertEquals(Double.NaN, avgMetric.metricValue)
     assertEquals(Double.NaN, maxMetric.metricValue)
+  }
+
+  @Test
+  def testRemoteFetchSizeAccountingWithMultiplePartitions(): Unit = {
+    val fetchMaxBytes = 250
+    val partitionMaxBytes = 100
+    val replicaManager = setupReplicaManagerWithMockedPurgatories(new MockTimer(time),
+      aliveBrokerIds = Seq(0, 1), enableRemoteStorage = true, shouldMockLog = true,
+      remoteFetchQuotaExceeded = Some(false))
+
+    try {
+      val tp0 = new TopicPartition(topic, 0)
+      val tp1 = new TopicPartition(topic, 1)
+      val tidp0 = new TopicIdPartition(topicId, tp0)
+      val tidp1 = new TopicIdPartition(topicId, tp1)
+
+      val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints.asJava)
+      replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+      replicaManager.createPartition(tp1).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+
+      val replicas = Seq[Integer](0, 1).asJava
+      val leaderEpoch = 0
+
+      val delta0 = createLeaderDelta(topicId, tp0, replicas.get(0), replicas, replicas)
+      val delta1 = createLeaderDelta(topicId, tp1, replicas.get(0), replicas, replicas)
+      val image0 = imageFromTopics(delta0.apply())
+      val image1 = imageFromTopics(delta1.apply())
+      replicaManager.applyDelta(delta0, image0)
+      replicaManager.applyDelta(delta1, image1)
+
+      val params = new FetchParams(-1, 1, 100, 0, fetchMaxBytes, FetchIsolation.LOG_END, Optional.empty)
+      val results = replicaManager.readFromLog(params, Seq(
+        tidp0 -> new PartitionData(topicId, 1, 0, partitionMaxBytes, Optional.of[Integer](leaderEpoch), Optional.of[Integer](leaderEpoch)),
+        tidp1 -> new PartitionData(topicId, 1, 0, partitionMaxBytes, Optional.of[Integer](leaderEpoch), Optional.of[Integer](leaderEpoch))),
+        UNBOUNDED_QUOTA, false)
+
+      assertEquals(2, results.size)
+      var totalSize = 0
+      results.foreach { case (tidp, result) =>
+        assertTrue(result.info.delayedRemoteStorageFetch.isPresent)
+        val fetchBytes = result.info.delayedRemoteStorageFetch.get().fetchMaxBytes
+        assertEquals(fetchBytes, result.info.records.sizeInBytes)
+        totalSize += result.info.records.sizeInBytes
+      }
+
+      // verify total size doesn't exceed fetchMaxBytes
+      assertTrue(totalSize <= fetchMaxBytes,
+        s"Total placeholder size $totalSize should not exceed fetchMaxBytes $fetchMaxBytes")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
   }
 
   @Test


### PR DESCRIPTION

When a fetch request spans multiple partitions with a mix of local and remote (tiered storage) data, the broker can return more than `fetch.max.bytes` in a single response. For example, with `fetch.max.bytes=1MB`:

- If partition 1 returns 1 MB from local storage
- And partition 2 returns 1 MB from tiered storage
- The total response can be 2 MB, exceeding the configured limit

This can cause consumer-side issues if consumers aren't configured to accept payloads this large.

