### PR TITLE
KAFKA-20026: Reduce the list metadata calls to RLMM during segment cleanup

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -1286,8 +1286,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         }
 
         private RemoteLogMetadataStats calculateMetadataAndSize(Iterator<RemoteLogSegmentMetadata> segmentMetadataIter) {
-            // Good to have an API from RLMM to get all the remote leader epochs of all the segments of a partition
-            // instead of going through all the segments and building it here.
+            // Good to have an API from RLMM to get the RemoteLogMetadataStats instead of going through all the segments
+            // and building it here.
             Set<Integer> epochsSet = new HashSet<>();
             int metadataCount = 0;
             long sizeInBytes = 0;
@@ -1492,10 +1492,10 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             }
             // compute valid remote-log size in bytes for the current partition if the size of the partition exceeds
             // the configured limit.
+            long startTimeMs = time.milliseconds();
             long remoteLogSizeBytes = 0L;
             if (!isAllSegmentsValid) {
                 boolean isAllValid = true;
-                long startTimeMs = time.milliseconds();
                 Set<RemoteLogSegmentId> visitedSegmentIds = new HashSet<>();
                 for (Integer epoch : epochEntries.navigableKeySet()) {
                     // remoteLogSize(topicIdPartition, epochEntry.epoch) may not be completely accurate as the remote
@@ -1524,11 +1524,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                     }
                 }
                 this.isAllSegmentsValid = isAllValid && fullCopyFinishedSegmentsSizeInBytes == remoteLogSizeBytes;
-                brokerTopicStats.recordRemoteLogSizeComputationTime(topicIdPartition.topic(), topicIdPartition.partition(), time.milliseconds() - startTimeMs);
             } else {
                 // Once all the segments are valid, then the future segments to be uploaded by this leader are also valid.
                 remoteLogSizeBytes = fullCopyFinishedSegmentsSizeInBytes;
             }
+            brokerTopicStats.recordRemoteLogSizeComputationTime(topicIdPartition.topic(), topicIdPartition.partition(),
+                    time.milliseconds() - startTimeMs);
             // This is the total size of segments in local log that have their base-offset > local-log-start-offset
             // and size of the segments in remote storage which have their end-offset < local-log-start-offset.
             long totalSize = onlyLocalLogSegmentsSize + remoteLogSizeBytes;

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -1485,10 +1485,11 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                                                            long logEndOffset,
                                                            NavigableMap<Integer, Long> epochEntries,
                                                            long fullRemoteLogSizeBytesCopyFinishedSegments) throws RemoteStorageException {
-            if (retentionSize < 0) {
+            if (retentionSize < 0 || (onlyLocalLogSegmentsSize + fullRemoteLogSizeBytesCopyFinishedSegments) <= retentionSize) {
                 return Optional.empty();
             }
-
+            // compute valid remote-log size in bytes for the current partition if the size of the partition exceeds
+            // the configured limit.
             long remoteLogSizeBytes = 0L;
             if (!isAllSegmentsValid) {
                 boolean isAllValid = true;

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -1137,6 +1137,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
     class RLMExpirationTask extends RLMTask {
         private final Logger logger;
+        private volatile boolean isAllSegmentsValid = false;
 
         public RLMExpirationTask(TopicIdPartition topicIdPartition) {
             super(topicIdPartition);
@@ -1146,6 +1147,16 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         @Override
         protected void execute(UnifiedLog log) throws InterruptedException, RemoteStorageException, ExecutionException {
             cleanupExpiredRemoteLogSegments();
+        }
+
+        @Override
+        public void cancel() {
+            isAllSegmentsValid = false;
+            super.cancel();
+        }
+
+        boolean isAllSegmentsValid() {
+            return isAllSegmentsValid;
         }
 
         public void handleLogStartOffsetUpdate(TopicPartition topicPartition, long remoteLogStartOffset) {
@@ -1260,7 +1271,45 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             brokerTopicStats.recordRemoteDeleteLagBytes(topic, partition, sizeOfDeletableSegmentsBytes);
         }
 
-        /** Cleanup expired and dangling remote log segments. */
+        private static class RemoteLogMetadataStats {
+            private final Set<Integer> epochsSet;
+            private final int metadataCount;
+            private final long remoteLogSizeBytes;
+            private final long remoteLogSizeBytesCopyFinishedSegments;
+
+            private RemoteLogMetadataStats(Set<Integer> epochsSet, int metadataCount, long remoteLogSizeBytes, long remoteLogSizeBytesCopyFinishedSegments) {
+                this.epochsSet = epochsSet;
+                this.metadataCount = metadataCount;
+                this.remoteLogSizeBytes = remoteLogSizeBytes;
+                this.remoteLogSizeBytesCopyFinishedSegments = remoteLogSizeBytesCopyFinishedSegments;
+            }
+        }
+
+        private RemoteLogMetadataStats calculateMetadataAndSize(Iterator<RemoteLogSegmentMetadata> segmentMetadataIter) {
+            // Good to have an API from RLMM to get all the remote leader epochs of all the segments of a partition
+            // instead of going through all the segments and building it here.
+            Set<Integer> epochsSet = new HashSet<>();
+            int metadataCount = 0;
+            long remoteLogSizeBytes = 0;
+            long remoteLogSizeBytesCopyFinishedSegments = 0;
+            while (segmentMetadataIter.hasNext()) {
+                RemoteLogSegmentMetadata segmentMetadata = segmentMetadataIter.next();
+                epochsSet.addAll(segmentMetadata.segmentLeaderEpochs().keySet());
+                metadataCount++;
+                RemoteLogSegmentState state = segmentMetadata.state();
+                if (state == RemoteLogSegmentState.COPY_SEGMENT_FINISHED) {
+                    remoteLogSizeBytesCopyFinishedSegments += segmentMetadata.segmentSizeInBytes();
+                    remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
+                } else if (state == RemoteLogSegmentState.DELETE_SEGMENT_STARTED) {
+                    remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
+                }
+            }
+            return new RemoteLogMetadataStats(epochsSet, metadataCount, remoteLogSizeBytes, remoteLogSizeBytesCopyFinishedSegments);
+        }
+
+        /**
+         * Cleanup expired and dangling remote log segments.
+         */
         void cleanupExpiredRemoteLogSegments() throws RemoteStorageException, ExecutionException, InterruptedException {
             if (isCancelled()) {
                 logger.info("Returning from remote log segments cleanup as the task state is changed");
@@ -1276,29 +1325,17 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             final UnifiedLog log = logOptional.get();
 
             // Cleanup remote log segments and update the log start offset if applicable.
-            final Iterator<RemoteLogSegmentMetadata> segmentMetadataIter = remoteLogMetadataManagerPlugin.get().listRemoteLogSegments(topicIdPartition);
-            if (!segmentMetadataIter.hasNext()) {
+            Iterator<RemoteLogSegmentMetadata> segmentMetadataIter = remoteLogMetadataManagerPlugin.get().listRemoteLogSegments(topicIdPartition);
+            RemoteLogMetadataStats stats = calculateMetadataAndSize(segmentMetadataIter);
+            if (stats.metadataCount == 0) {
                 updateMetadataCountAndLogSizeWith(0, 0);
                 logger.debug("No remote log segments available on remote storage for partition: {}", topicIdPartition);
                 return;
             }
-
-            final Set<Integer> epochsSet = new HashSet<>();
-            int metadataCount = 0;
-            long remoteLogSizeBytes = 0;
-            // Good to have an API from RLMM to get all the remote leader epochs of all the segments of a partition
-            // instead of going through all the segments and building it here.
-            while (segmentMetadataIter.hasNext()) {
-                RemoteLogSegmentMetadata segmentMetadata = segmentMetadataIter.next();
-                epochsSet.addAll(segmentMetadata.segmentLeaderEpochs().keySet());
-                metadataCount++;
-                remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
-            }
-
-            updateMetadataCountAndLogSizeWith(metadataCount, remoteLogSizeBytes);
+            updateMetadataCountAndLogSizeWith(stats.metadataCount, stats.remoteLogSizeBytes);
 
             // All the leader epochs in sorted order that exists in remote storage
-            final List<Integer> remoteLeaderEpochs = new ArrayList<>(epochsSet);
+            final List<Integer> remoteLeaderEpochs = new ArrayList<>(stats.epochsSet);
             Collections.sort(remoteLeaderEpochs);
 
             LeaderEpochFileCache leaderEpochCache = log.leaderEpochCache();
@@ -1308,7 +1345,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             long logStartOffset = log.logStartOffset();
             long logEndOffset = log.logEndOffset();
             Optional<RetentionSizeData> retentionSizeData = buildRetentionSizeData(log.config().retentionSize,
-                    log.onlyLocalLogSegmentsSize(), logEndOffset, epochWithOffsets);
+                    log.onlyLocalLogSegmentsSize(), logEndOffset, epochWithOffsets, stats.remoteLogSizeBytesCopyFinishedSegments);
             Optional<RetentionTimeData> retentionTimeData = buildRetentionTimeData(log.config().retentionMs);
 
             RemoteLogRetentionHandler remoteLogRetentionHandler = new RemoteLogRetentionHandler(retentionSizeData, retentionTimeData);
@@ -1443,13 +1480,19 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                     : Optional.empty();
         }
 
-        private Optional<RetentionSizeData> buildRetentionSizeData(long retentionSize,
-                                                                   long onlyLocalLogSegmentsSize,
-                                                                   long logEndOffset,
-                                                                   NavigableMap<Integer, Long> epochEntries) throws RemoteStorageException {
-            if (retentionSize > -1) {
+        Optional<RetentionSizeData> buildRetentionSizeData(long retentionSize,
+                                                           long onlyLocalLogSegmentsSize,
+                                                           long logEndOffset,
+                                                           NavigableMap<Integer, Long> epochEntries,
+                                                           long fullRemoteLogSizeBytesCopyFinishedSegments) throws RemoteStorageException {
+            if (retentionSize < 0) {
+                return Optional.empty();
+            }
+
+            long remoteLogSizeBytes = 0L;
+            if (!isAllSegmentsValid) {
+                boolean isAllValid = true;
                 long startTimeMs = time.milliseconds();
-                long remoteLogSizeBytes = 0L;
                 Set<RemoteLogSegmentId> visitedSegmentIds = new HashSet<>();
                 for (Integer epoch : epochEntries.navigableKeySet()) {
                     // remoteLogSize(topicIdPartition, epochEntry.epoch) may not be completely accurate as the remote
@@ -1465,26 +1508,32 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                         // "DELETE_SEGMENT_FINISHED" means deletion completed, so there is nothing to count.
                         if (segmentMetadata.state().equals(RemoteLogSegmentState.COPY_SEGMENT_FINISHED)) {
                             RemoteLogSegmentId segmentId = segmentMetadata.remoteLogSegmentId();
-                            if (!visitedSegmentIds.contains(segmentId) && isRemoteSegmentWithinLeaderEpochs(segmentMetadata, logEndOffset, epochEntries)) {
-                                remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
+                            if (!visitedSegmentIds.contains(segmentId)) {
                                 visitedSegmentIds.add(segmentId);
+                                boolean isValid = isRemoteSegmentWithinLeaderEpochs(segmentMetadata, logEndOffset, epochEntries);
+                                if (isValid) {
+                                    remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
+                                } else {
+                                    isAllValid = false;
+                                }
                             }
                         }
                     }
                 }
-
+                this.isAllSegmentsValid = isAllValid && fullRemoteLogSizeBytesCopyFinishedSegments == remoteLogSizeBytes;
                 brokerTopicStats.recordRemoteLogSizeComputationTime(topicIdPartition.topic(), topicIdPartition.partition(), time.milliseconds() - startTimeMs);
-
-                // This is the total size of segments in local log that have their base-offset > local-log-start-offset
-                // and size of the segments in remote storage which have their end-offset < local-log-start-offset.
-                long totalSize = onlyLocalLogSegmentsSize + remoteLogSizeBytes;
-                if (totalSize > retentionSize) {
-                    long remainingBreachedSize = totalSize - retentionSize;
-                    RetentionSizeData retentionSizeData = new RetentionSizeData(retentionSize, remainingBreachedSize);
-                    return Optional.of(retentionSizeData);
-                }
+            } else {
+                // Once all the segments are valid, then the future segments to be uploaded by this leader are also valid.
+                remoteLogSizeBytes = fullRemoteLogSizeBytesCopyFinishedSegments;
             }
-
+            // This is the total size of segments in local log that have their base-offset > local-log-start-offset
+            // and size of the segments in remote storage which have their end-offset < local-log-start-offset.
+            long totalSize = onlyLocalLogSegmentsSize + remoteLogSizeBytes;
+            if (totalSize > retentionSize) {
+                long remainingBreachedSize = totalSize - retentionSize;
+                RetentionSizeData retentionSizeData = new RetentionSizeData(retentionSize, remainingBreachedSize);
+                return Optional.of(retentionSizeData);
+            }
             return Optional.empty();
         }
     }
@@ -2189,6 +2238,14 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
             this.retentionSize = retentionSize;
             this.remainingBreachedSize = remainingBreachedSize;
+        }
+
+        long retentionSize() {
+            return retentionSize;
+        }
+
+        long remainingBreachedSize() {
+            return remainingBreachedSize;
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -1274,14 +1274,14 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         private static class RemoteLogMetadataStats {
             private final Set<Integer> epochsSet;
             private final int metadataCount;
-            private final long remoteLogSizeBytes;
-            private final long remoteLogSizeBytesCopyFinishedSegments;
+            private final long sizeInBytes;
+            private final long copyFinishedSegmentsSizeInBytes;
 
-            private RemoteLogMetadataStats(Set<Integer> epochsSet, int metadataCount, long remoteLogSizeBytes, long remoteLogSizeBytesCopyFinishedSegments) {
+            private RemoteLogMetadataStats(Set<Integer> epochsSet, int metadataCount, long sizeInBytes, long copyFinishedSegmentsSizeInBytes) {
                 this.epochsSet = epochsSet;
                 this.metadataCount = metadataCount;
-                this.remoteLogSizeBytes = remoteLogSizeBytes;
-                this.remoteLogSizeBytesCopyFinishedSegments = remoteLogSizeBytesCopyFinishedSegments;
+                this.sizeInBytes = sizeInBytes;
+                this.copyFinishedSegmentsSizeInBytes = copyFinishedSegmentsSizeInBytes;
             }
         }
 
@@ -1290,21 +1290,23 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             // instead of going through all the segments and building it here.
             Set<Integer> epochsSet = new HashSet<>();
             int metadataCount = 0;
-            long remoteLogSizeBytes = 0;
-            long remoteLogSizeBytesCopyFinishedSegments = 0;
+            long sizeInBytes = 0;
+            long copyFinishedSegmentsSizeInBytes = 0;
             while (segmentMetadataIter.hasNext()) {
                 RemoteLogSegmentMetadata segmentMetadata = segmentMetadataIter.next();
                 epochsSet.addAll(segmentMetadata.segmentLeaderEpochs().keySet());
                 metadataCount++;
                 RemoteLogSegmentState state = segmentMetadata.state();
+                // COPY_SEGMENT_STARTED state is excluded from the `sizeInBytes` calculation as it can pollute the
+                // metric during the upload retries.
                 if (state == RemoteLogSegmentState.COPY_SEGMENT_FINISHED) {
-                    remoteLogSizeBytesCopyFinishedSegments += segmentMetadata.segmentSizeInBytes();
-                    remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
+                    copyFinishedSegmentsSizeInBytes += segmentMetadata.segmentSizeInBytes();
+                    sizeInBytes += segmentMetadata.segmentSizeInBytes();
                 } else if (state == RemoteLogSegmentState.DELETE_SEGMENT_STARTED) {
-                    remoteLogSizeBytes += segmentMetadata.segmentSizeInBytes();
+                    sizeInBytes += segmentMetadata.segmentSizeInBytes();
                 }
             }
-            return new RemoteLogMetadataStats(epochsSet, metadataCount, remoteLogSizeBytes, remoteLogSizeBytesCopyFinishedSegments);
+            return new RemoteLogMetadataStats(epochsSet, metadataCount, sizeInBytes, copyFinishedSegmentsSizeInBytes);
         }
 
         /**
@@ -1332,7 +1334,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 logger.debug("No remote log segments available on remote storage for partition: {}", topicIdPartition);
                 return;
             }
-            updateMetadataCountAndLogSizeWith(stats.metadataCount, stats.remoteLogSizeBytes);
+            updateMetadataCountAndLogSizeWith(stats.metadataCount, stats.sizeInBytes);
 
             // All the leader epochs in sorted order that exists in remote storage
             final List<Integer> remoteLeaderEpochs = new ArrayList<>(stats.epochsSet);
@@ -1345,7 +1347,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             long logStartOffset = log.logStartOffset();
             long logEndOffset = log.logEndOffset();
             Optional<RetentionSizeData> retentionSizeData = buildRetentionSizeData(log.config().retentionSize,
-                    log.onlyLocalLogSegmentsSize(), logEndOffset, epochWithOffsets, stats.remoteLogSizeBytesCopyFinishedSegments);
+                    log.onlyLocalLogSegmentsSize(), logEndOffset, epochWithOffsets, stats.copyFinishedSegmentsSizeInBytes);
             Optional<RetentionTimeData> retentionTimeData = buildRetentionTimeData(log.config().retentionMs);
 
             RemoteLogRetentionHandler remoteLogRetentionHandler = new RemoteLogRetentionHandler(retentionSizeData, retentionTimeData);
@@ -1484,8 +1486,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                                                            long onlyLocalLogSegmentsSize,
                                                            long logEndOffset,
                                                            NavigableMap<Integer, Long> epochEntries,
-                                                           long fullRemoteLogSizeBytesCopyFinishedSegments) throws RemoteStorageException {
-            if (retentionSize < 0 || (onlyLocalLogSegmentsSize + fullRemoteLogSizeBytesCopyFinishedSegments) <= retentionSize) {
+                                                           long fullCopyFinishedSegmentsSizeInBytes) throws RemoteStorageException {
+            if (retentionSize < 0 || (onlyLocalLogSegmentsSize + fullCopyFinishedSegmentsSizeInBytes) <= retentionSize) {
                 return Optional.empty();
             }
             // compute valid remote-log size in bytes for the current partition if the size of the partition exceeds
@@ -1521,11 +1523,11 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                         }
                     }
                 }
-                this.isAllSegmentsValid = isAllValid && fullRemoteLogSizeBytesCopyFinishedSegments == remoteLogSizeBytes;
+                this.isAllSegmentsValid = isAllValid && fullCopyFinishedSegmentsSizeInBytes == remoteLogSizeBytes;
                 brokerTopicStats.recordRemoteLogSizeComputationTime(topicIdPartition.topic(), topicIdPartition.partition(), time.milliseconds() - startTimeMs);
             } else {
                 // Once all the segments are valid, then the future segments to be uploaded by this leader are also valid.
-                remoteLogSizeBytes = fullRemoteLogSizeBytesCopyFinishedSegments;
+                remoteLogSizeBytes = fullCopyFinishedSegmentsSizeInBytes;
             }
             // This is the total size of segments in local log that have their base-offset > local-log-start-offset
             // and size of the segments in remote storage which have their end-offset < local-log-start-offset.

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2184,17 +2184,17 @@ public class RemoteLogManagerTest {
         long logEndOffset = 100L;
         NavigableMap<Integer, Long> epochEntries = new TreeMap<>();
         epochEntries.put(0, 0L);
-        long fullRemoteLogSizeBytesCopyFinishedSegments = 1600L;
+        long fullCopyFinishedSegmentsSizeInBytes = 1600L;
         RemoteLogManager.RLMExpirationTask expirationTask = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         assertFalse(expirationTask.isAllSegmentsValid());
 
         // 1. retentionSize < 0
         Optional<RemoteLogManager.RetentionSizeData> result = expirationTask
-                .buildRetentionSizeData(-1L, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
+                .buildRetentionSizeData(-1L, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullCopyFinishedSegmentsSizeInBytes);
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
-        // 2. When (onlyLocalLogSegmentsSize + fullRemoteLogSizeBytesCopyFinishedSegments) <= configure-retention-size
+        // 2. When (onlyLocalLogSegmentsSize + fullCopyFinishedSegmentsSizeInBytes) <= configure-retention-size
         result = expirationTask
                 .buildRetentionSizeData(-1L, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 500L);
         assertFalse(result.isPresent());
@@ -2206,7 +2206,7 @@ public class RemoteLogManagerTest {
         // 3. totalSize <= retentionSize
         // totalSize = 500 (local) + 0 (remote, as listRemoteLogSegments returns empty) = 500. retentionSize = 1000.
         result = expirationTask
-                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullCopyFinishedSegmentsSizeInBytes);
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
@@ -2221,14 +2221,14 @@ public class RemoteLogManagerTest {
                 });
 
         result = expirationTask
-                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullCopyFinishedSegmentsSizeInBytes);
         assertTrue(result.isPresent());
         assertEquals(1000L, result.get().retentionSize());
         assertEquals(500L, result.get().remainingBreachedSize()); // (500 + 1000) - 1000 = 500
         assertFalse(expirationTask.isAllSegmentsValid());
         assertEquals(1, invocationCount.get());
 
-        // 5. Provide the valid `fullRemoteLogSizeBytesCopyFinishedSegments` size
+        // 5. Provide the valid `fullCopyFinishedSegmentsSizeInBytes` size
         result = expirationTask
                 .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 1000L);
         assertTrue(result.isPresent());

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -1139,7 +1139,7 @@ public class RemoteLogManagerTest {
         when(mockStateManager.fetchSnapshot(anyLong())).thenReturn(Optional.of(mockProducerSnapshotIndex));
         when(mockLog.lastStableOffset()).thenReturn(250L);
         Map<String, Long> logProps = new HashMap<>();
-        logProps.put("retention.bytes", 1000000L);
+        logProps.put("retention.bytes", 5000L);
         logProps.put("retention.ms", -1L);
         LogConfig logConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(logConfig);
@@ -2194,17 +2194,23 @@ public class RemoteLogManagerTest {
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
+        // 2. When (onlyLocalLogSegmentsSize + fullRemoteLogSizeBytesCopyFinishedSegments) <= configure-retention-size
+        result = expirationTask
+                .buildRetentionSizeData(-1L, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 500L);
+        assertFalse(result.isPresent());
+        assertFalse(expirationTask.isAllSegmentsValid());
+
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
                 .thenReturn(Collections.emptyIterator());
 
-        // 2. totalSize <= retentionSize
+        // 3. totalSize <= retentionSize
         // totalSize = 500 (local) + 0 (remote, as listRemoteLogSegments returns empty) = 500. retentionSize = 1000.
         result = expirationTask
                 .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
-        // 3. totalSize > retentionSize
+        // 4. totalSize > retentionSize
         // totalSize = 500 (local) + 1000 (remote) = 1500. retentionSize = 1000.
         AtomicInteger invocationCount = new AtomicInteger(0);
         RemoteLogSegmentMetadata segmentMetadata = createRemoteLogSegmentMetadata(0, 50, Collections.singletonMap(0, 0L));
@@ -2222,7 +2228,7 @@ public class RemoteLogManagerTest {
         assertFalse(expirationTask.isAllSegmentsValid());
         assertEquals(1, invocationCount.get());
 
-        // Provide the valid `fullRemoteLogSizeBytesCopyFinishedSegments` size
+        // 5. Provide the valid `fullRemoteLogSizeBytesCopyFinishedSegments` size
         result = expirationTask
                 .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 1000L);
         assertTrue(result.isPresent());

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2194,7 +2194,6 @@ public class RemoteLogManagerTest {
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
-        // Mock listRemoteLogSegments to return an empty iterator to avoid NPE or complex mocking for now
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
                 .thenReturn(Collections.emptyIterator());
 
@@ -2206,9 +2205,7 @@ public class RemoteLogManagerTest {
         assertFalse(expirationTask.isAllSegmentsValid());
 
         // 3. totalSize > retentionSize
-        // totalSize = 500 (local) + 1024 (remote) = 1524. retentionSize = 1000.
-        
-        // Mock a segment
+        // totalSize = 500 (local) + 1000 (remote) = 1500. retentionSize = 1000.
         AtomicInteger invocationCount = new AtomicInteger(0);
         RemoteLogSegmentMetadata segmentMetadata = createRemoteLogSegmentMetadata(0, 50, Collections.singletonMap(0, 0L));
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), eq(0)))
@@ -2225,6 +2222,7 @@ public class RemoteLogManagerTest {
         assertFalse(expirationTask.isAllSegmentsValid());
         assertEquals(1, invocationCount.get());
 
+        // Provide the valid `fullRemoteLogSizeBytesCopyFinishedSegments` size
         result = expirationTask
                 .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 1000L);
         assertTrue(result.isPresent());
@@ -2234,7 +2232,7 @@ public class RemoteLogManagerTest {
         assertEquals(2, invocationCount.get());
 
         // Once all the segments are validated and the computed segmentSize for listRemoteLogSegments(tpId) and
-        // listRemoteLogSegments(tpId, epoch) are same, then the subsequent calls to buildRetentionSizeData should not
+        // listRemoteLogSegments(tpId, epoch) are same, then the next calls to `buildRetentionSizeData` should not
         // invoke listRemoteLogSegments(tpId, epoch) again.
         result = expirationTask
                 .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 1000L);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2177,6 +2177,76 @@ public class RemoteLogManagerTest {
         }
     }
 
+    @Test
+    public void testBuildRetentionSizeData() throws RemoteStorageException {
+        long retentionSize = 1000L;
+        long onlyLocalLogSegmentsSize = 500L;
+        long logEndOffset = 100L;
+        NavigableMap<Integer, Long> epochEntries = new TreeMap<>();
+        epochEntries.put(0, 0L);
+        long fullRemoteLogSizeBytesCopyFinishedSegments = 1600L;
+        RemoteLogManager.RLMExpirationTask expirationTask = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
+        assertFalse(expirationTask.isAllSegmentsValid());
+
+        // 1. retentionSize < 0
+        Optional<RemoteLogManager.RetentionSizeData> result = expirationTask
+                .buildRetentionSizeData(-1L, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
+        assertFalse(result.isPresent());
+        assertFalse(expirationTask.isAllSegmentsValid());
+
+        // Mock listRemoteLogSegments to return an empty iterator to avoid NPE or complex mocking for now
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
+                .thenReturn(Collections.emptyIterator());
+
+        // 2. totalSize <= retentionSize
+        // totalSize = 500 (local) + 0 (remote, as listRemoteLogSegments returns empty) = 500. retentionSize = 1000.
+        result = expirationTask
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
+        assertFalse(result.isPresent());
+        assertFalse(expirationTask.isAllSegmentsValid());
+
+        // 3. totalSize > retentionSize
+        // totalSize = 500 (local) + 1024 (remote) = 1524. retentionSize = 1000.
+        
+        // Mock a segment
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        RemoteLogSegmentMetadata segmentMetadata = createRemoteLogSegmentMetadata(0, 50, Collections.singletonMap(0, 0L));
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), eq(0)))
+                .thenAnswer(invocation -> {
+                    invocationCount.incrementAndGet();
+                    return Collections.singletonList(segmentMetadata).iterator();
+                });
+
+        result = expirationTask
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullRemoteLogSizeBytesCopyFinishedSegments);
+        assertTrue(result.isPresent());
+        assertEquals(1000L, result.get().retentionSize());
+        assertEquals(500L, result.get().remainingBreachedSize()); // (500 + 1000) - 1000 = 500
+        assertFalse(expirationTask.isAllSegmentsValid());
+        assertEquals(1, invocationCount.get());
+
+        result = expirationTask
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 1000L);
+        assertTrue(result.isPresent());
+        assertEquals(1000L, result.get().retentionSize());
+        assertEquals(500L, result.get().remainingBreachedSize()); // (500 + 1000) - 1000 = 500
+        assertTrue(expirationTask.isAllSegmentsValid());
+        assertEquals(2, invocationCount.get());
+
+        // Once all the segments are validated and the computed segmentSize for listRemoteLogSegments(tpId) and
+        // listRemoteLogSegments(tpId, epoch) are same, then the subsequent calls to buildRetentionSizeData should not
+        // invoke listRemoteLogSegments(tpId, epoch) again.
+        result = expirationTask
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 1000L);
+        assertTrue(result.isPresent());
+        assertEquals(500L, result.get().remainingBreachedSize());
+        assertEquals(2, invocationCount.get());
+        assertTrue(expirationTask.isAllSegmentsValid());
+
+        expirationTask.cancel();
+        assertFalse(expirationTask.isAllSegmentsValid());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testRemoteSizeTime() {

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2196,21 +2196,21 @@ public class RemoteLogManagerTest {
 
         // 2. When (onlyLocalLogSegmentsSize + fullCopyFinishedSegmentsSizeInBytes) <= configure-retention-size
         result = expirationTask
-                .buildRetentionSizeData(-1L, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 500L);
+                .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, 500L);
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
-        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
-                .thenReturn(Collections.emptyIterator());
-
         // 3. totalSize <= retentionSize
         // totalSize = 500 (local) + 0 (remote, as listRemoteLogSegments returns empty) = 500. retentionSize = 1000.
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
+                .thenReturn(Collections.emptyIterator());
         result = expirationTask
                 .buildRetentionSizeData(retentionSize, onlyLocalLogSegmentsSize, logEndOffset, epochEntries, fullCopyFinishedSegmentsSizeInBytes);
         assertFalse(result.isPresent());
         assertFalse(expirationTask.isAllSegmentsValid());
 
         // 4. totalSize > retentionSize
+        // Each remote log segment size is 1000 bytes.
         // totalSize = 500 (local) + 1000 (remote) = 1500. retentionSize = 1000.
         AtomicInteger invocationCount = new AtomicInteger(0);
         RemoteLogSegmentMetadata segmentMetadata = createRemoteLogSegmentMetadata(0, 50, Collections.singletonMap(0, 0L));


### PR DESCRIPTION
- RemoteLogManager already calculates the segmentSizeInBytes of all the
remote-log segments for a partition including the stale segments.
- Once all the segments are validated, then the computed segmentSize for
listRemoteLogSegments(tpId) and listRemoteLogSegments(tpId, epoch) will
match as the deletion proceeds, then the subsequent calls to
`buildRetentionSizeData` should not validate / invoke the
listRemoteLogSegments(tpId, epoch) again.
- It helps to reduce the unnecessary listRemoteLogSegments(tpId, epoch)
calls to RLMM and saves CPU resources.
- Added UTs

Note that COPY_SEGMENT_STARTED state is excluded from the
`remoteLogSizeInBytes` metric calculation as it pollutes the metric
during the upload retries.

Reviewers: Luke Chen <showuon@gmail.com>
