### PR TITLE
MINOR: Fix broken KRaftMetadataRequestBenchmark test due to uninitialised ShareCoordinator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3425,6 +3425,7 @@ project(':jmh-benchmarks') {
     implementation project(':group-coordinator')
     implementation project(':group-coordinator:group-coordinator-api')
     implementation project(':metadata')
+    implementation project(':share-coordinator')
     implementation project(':storage')
     implementation project(':streams')
     implementation project(':transaction-coordinator')

--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -46,7 +46,7 @@
     <allow pkg="org.apache.kafka.clients"/>
     <allow pkg="org.apache.kafka.coordinator.common.runtime"/>
     <allow pkg="org.apache.kafka.coordinator.group"/>
-    <allow pkg="org.apache.kafka.coordinator.share" />
+    <allow pkg="org.apache.kafka.coordinator.share"/>
     <allow pkg="org.apache.kafka.image"/>
     <allow pkg="org.apache.kafka.metadata"/>
     <allow pkg="org.apache.kafka.timeline" />

--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -46,6 +46,7 @@
     <allow pkg="org.apache.kafka.clients"/>
     <allow pkg="org.apache.kafka.coordinator.common.runtime"/>
     <allow pkg="org.apache.kafka.coordinator.group"/>
+    <allow pkg="org.apache.kafka.coordinator.share" />
     <allow pkg="org.apache.kafka.image"/>
     <allow pkg="org.apache.kafka.metadata"/>
     <allow pkg="org.apache.kafka.timeline" />

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.GroupConfigManager;
 import org.apache.kafka.coordinator.group.GroupCoordinator;
+import org.apache.kafka.coordinator.share.ShareCoordinator;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
@@ -116,6 +117,7 @@ public class KRaftMetadataRequestBenchmark {
             clientQuotaManager, clientRequestQuotaManager, controllerMutationQuotaManager, replicaQuotaManager,
             replicaQuotaManager, replicaQuotaManager, Optional.empty());
     private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
+    private final ShareCoordinator shareCoordinator = Mockito.mock(ShareCoordinator.class);
     private final SharePartitionManager sharePartitionManager = Mockito.mock(SharePartitionManager.class);
     private final ClientMetricsManager clientMetricsManager = Mockito.mock(ClientMetricsManager.class);
     private final GroupConfigManager groupConfigManager = Mockito.mock(GroupConfigManager.class);
@@ -186,6 +188,7 @@ public class KRaftMetadataRequestBenchmark {
                 setForwardingManager(forwardingManager).
                 setReplicaManager(replicaManager).
                 setGroupCoordinator(groupCoordinator).
+                setShareCoordinator(shareCoordinator).
                 setTxnCoordinator(transactionCoordinator).
                 setAutoTopicCreationManager(autoTopicCreationManager).
                 setBrokerId(brokerId).


### PR DESCRIPTION
Currently the `KRaftMetadataRequestBenchmark` is failing with the
following error:
```
java.lang.RuntimeException: You must set shareCoordinator
        at
kafka.server.builders.KafkaApisBuilder.build(KafkaApisBuilder.java:197)
        at
org.apache.kafka.jmh.metadata.KRaftMetadataRequestBenchmark.createKafkaApis(KRaftMetadataRequestBenchmark.java:210)
        at
org.apache.kafka.jmh.metadata.KRaftMetadataRequestBenchmark.setup(KRaftMetadataRequestBenchmark.java:134)
        at
org.apache.kafka.jmh.metadata.jmh_generated.KRaftMetadataRequestBenchmark_testRequestToJson_jmhTest._jmh_tryInit_f_kraftmetadatarequestbenchmark0_G(KRaftMetadataRequestBenchmark_testRequestToJson_jmhTest.java:451)
        at
org.apache.kafka.jmh.metadata.jmh_generated.KRaftMetadataRequestBenchmark_testRequestToJson_jmhTest.testRequestToJson_AverageTime(KRaftMetadataRequestBenchmark_testRequestToJson_jmhTest.java:164)
        at
java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native
Method)
        at
java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at
java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at
org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:527)
        at
org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:504)
        at
java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at
java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at
java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

After the fix, here are the results:

```
./jmh-benchmarks/jmh.sh -f 1 -i 2 -wi 2
org.apache.kafka.jmh.metadata.KRaftMetadataRequestBenchmark

Benchmark
(partitionCount)  (topicCount)  Mode  Cnt         Score   Error  Units
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
10           500  avgt    2    802296.940          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
10          1000  avgt    2   1554324.508          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
10          5000  avgt    2  20675689.357          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
20           500  avgt    2   1202763.607          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
20          1000  avgt    2   2759721.061          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
20          5000  avgt    2  26355078.691          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
50           500  avgt    2   3186329.977          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
50          1000  avgt    2   6383024.540          ns/op
KRaftMetadataRequestBenchmark.testMetadataRequestForAllTopics
50          5000  avgt    2  49264850.641          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
10           500  avgt    2       375.849          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
10          1000  avgt    2       402.769          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
10          5000  avgt    2       380.075          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
20           500  avgt    2       377.686          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
20          1000  avgt    2       380.253          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
20          5000  avgt    2       389.466          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
50           500  avgt    2       385.464          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
50          1000  avgt    2       390.164          ns/op
KRaftMetadataRequestBenchmark.testRequestToJson
50          5000  avgt    2       408.207          ns/op
```

Reviewers: Andrew Schofield <aschofield@confluent.io>
