### PR TITLE
KAFKA-XXXXX: Improve consumer rebalance warning log with exception stack trace

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManager.java
@@ -478,13 +478,13 @@ public class ConsumerMembershipManager extends AbstractMembershipManager<Consume
         Optional<KafkaException> error = event.error();
         CompletableFuture<Void> future = event.future();
 
-            if (error.isPresent()) {
-                Exception e = error.get();
-                log.warn(
-                    "Rebalance step failed in method={}, proceeding to next phase",
-                    methodName.fullyQualifiedMethodName(),
-                    e
-                );
+        if (error.isPresent()) {
+            Exception e = error.get();
+            log.warn(
+                "The {} method failed during rebalance; proceeding to the next phase",
+                methodName.fullyQualifiedMethodName(),
+                e
+            );
 
             future.completeExceptionally(e);
         } else {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManager.java
@@ -478,13 +478,13 @@ public class ConsumerMembershipManager extends AbstractMembershipManager<Consume
         Optional<KafkaException> error = event.error();
         CompletableFuture<Void> future = event.future();
 
-        if (error.isPresent()) {
-            Exception e = error.get();
-            log.warn(
-                    "The {} method completed with an error ({}); signaling to continue to the next phase of rebalance",
+            if (error.isPresent()) {
+                Exception e = error.get();
+                log.warn(
+                    "Rebalance step failed in method={}, proceeding to next phase",
                     methodName.fullyQualifiedMethodName(),
-                    e.getMessage()
-            );
+                    e
+                );
 
             future.completeExceptionally(e);
         } else {


### PR DESCRIPTION
### What changed
Improved the consumer rebalance warning log by logging the full exception object instead of only the message.

### Why
This improves observability and makes it easier to diagnose rebalance-related issues in production environments.

### Testing
./gradlew :clients:compileJava
