### PR TITLE
MINOR: Additional logging for ISR and replica set changes

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1147,7 +1147,7 @@ public class ReplicationControlManager {
                 if (record.isPresent()) {
                     records.add(record.get());
                     PartitionChangeRecord change = (PartitionChangeRecord) record.get().message();
-                    PartitionRegistration originalPartition = partition
+                    PartitionRegistration originalPartition = partition;
                     partition = originalPartition.merge(change);
                     if (log.isDebugEnabled()) {
                         log.debug("Node {} has altered ISR for {}-{}. {}",
@@ -1356,7 +1356,7 @@ public class ReplicationControlManager {
 
     private static String logPartitionChangeInfo(
         PartitionRegistration partition,
-        List<BrokerState> requestedIsr,
+        List<BrokerState> requestedIsr
     ) {
         return String.format("Proposed ISR was %s and current ISR is %s. " +
                 "Current replica set is %s. Current partitionEpoch is %d. Current leaderEpoch is %d.",

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -519,14 +519,14 @@ public class ReplicationControlManager {
 
         if (record.removingReplicas() != null || record.addingReplicas() != null) {
             log.info("Replayed partition assignment change {} for topic {}. " +
-                    "(partitionEpoch: {}, leaderEpoch: {}, replicaSet: {} -> {}, isr: {} -> {})",
-                record, topicInfo.name, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch,
-                prevPartitionInfo.replicas, newPartitionInfo.replicas, prevPartitionInfo.isr, newPartitionInfo.isr);
+                    "(isr: {} -> {}, replicaSet: {} -> {}, partitionEpoch: {}, leaderEpoch: {})",
+                record, topicInfo.name, prevPartitionInfo.isr, newPartitionInfo.isr, prevPartitionInfo.replicas,
+                newPartitionInfo.replicas, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch);
         } else if (log.isDebugEnabled()) {
             log.debug("Replayed partition change {} for topic {}. " +
-                "(partitionEpoch: {}, leaderEpoch: {}, replicaSet: {} -> {}, isr: {} -> {})",
-                record, topicInfo.name, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch,
-                prevPartitionInfo.replicas, newPartitionInfo.replicas, prevPartitionInfo.isr, newPartitionInfo.isr);
+                    "(isr: {} -> {}, replicaSet: {} -> {}, partitionEpoch: {}, leaderEpoch: {})",
+                record, topicInfo.name, prevPartitionInfo.isr, newPartitionInfo.isr, prevPartitionInfo.replicas,
+                newPartitionInfo.replicas, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch);
         }
     }
 
@@ -1175,7 +1175,7 @@ public class ReplicationControlManager {
                         // metadata record. We usually only do one or the other.
                         Errors error = NEW_LEADER_ELECTED;
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment and triggered a leadership change. {}. Returning {}.",
+                            "the ongoing partition reassignment and triggered a leadership change {}. Returning {}.",
                             request.brokerId(), topic.name, partitionId, partitionChangeInfo, error);
                         responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                             setPartitionIndex(partitionId).
@@ -1260,9 +1260,11 @@ public class ReplicationControlManager {
             return UNKNOWN_TOPIC_OR_PARTITION;
         }
 
-        String isrAndReplicaSetInfo = String.format("Proposed ISR was %s and current ISR is %s. " +
-            "Current replica set is %s.",
-            partitionData.newIsrWithEpochs(), Arrays.toString(partition.isr), Arrays.toString(partition.replicas));
+        String partitionChangeInfo = String.format("Proposed ISR was %s and current ISR is %s. " +
+                "Current replica set is %s. Proposed partitionEpoch was %d and current partitionEpoch is %d. " +
+                "Proposed leaderEpoch was %d and current leaderEpoch is %d.",
+            partitionData.newIsrWithEpochs(), Arrays.toString(partition.isr), Arrays.toString(partition.replicas),
+            partitionData.partitionEpoch(), partition.partitionEpoch, partitionData.leaderEpoch(), partition.leaderEpoch);
 
         // If the partition leader has a higher leader/partition epoch, then it is likely
         // that this node is no longer the active controller. We return NOT_CONTROLLER in
@@ -1271,27 +1273,27 @@ public class ReplicationControlManager {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current leader epoch is {}, which is greater than the local value {}. {}",
                 brokerId, topic.name, partitionId, partition.leaderEpoch, partitionData.leaderEpoch(),
-                isrAndReplicaSetInfo);
+                partitionChangeInfo);
             return NOT_CONTROLLER;
         }
         if (partitionData.partitionEpoch() > partition.partitionEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current partition epoch is {}, which is greater than the local value {}. {}",
                 brokerId, topic.name, partitionId, partition.partitionEpoch, partitionData.partitionEpoch(),
-                isrAndReplicaSetInfo);
+                partitionChangeInfo);
             return NOT_CONTROLLER;
         }
         if (partitionData.leaderEpoch() < partition.leaderEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current leader epoch is {}, not {}. {}", brokerId, topic.name,
-                    partitionId, partition.leaderEpoch, partitionData.leaderEpoch(), isrAndReplicaSetInfo);
+                    partitionId, partition.leaderEpoch, partitionData.leaderEpoch(), partitionChangeInfo);
 
             return FENCED_LEADER_EPOCH;
         }
         if (brokerId != partition.leader) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current leader is {}. {}", brokerId, topic.name,
-                    partitionId, partition.leader, isrAndReplicaSetInfo);
+                    partitionId, partition.leader, partitionChangeInfo);
 
             return INVALID_REQUEST;
         }
@@ -1299,7 +1301,7 @@ public class ReplicationControlManager {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current partition epoch is {}, not {}. {}", brokerId,
                     topic.name, partitionId, partition.partitionEpoch,
-                    partitionData.partitionEpoch(), isrAndReplicaSetInfo);
+                    partitionData.partitionEpoch(), partitionChangeInfo);
 
             return INVALID_UPDATE_VERSION;
         }
@@ -1310,7 +1312,7 @@ public class ReplicationControlManager {
         if (!Replicas.validateIsr(partition.replicas, newIsr)) {
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR. {}", brokerId,
-                    topic.name, partitionId, isrAndReplicaSetInfo);
+                    topic.name, partitionId, partitionChangeInfo);
 
             return INVALID_REQUEST;
         }
@@ -1318,7 +1320,7 @@ public class ReplicationControlManager {
             // The ISR must always include the current leader.
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR that doesn't include itself. {}",
-                    brokerId, topic.name, partitionId, isrAndReplicaSetInfo);
+                    brokerId, topic.name, partitionId, partitionChangeInfo);
 
             return INVALID_REQUEST;
         }
@@ -1327,7 +1329,7 @@ public class ReplicationControlManager {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the ISR had more than one replica while the leader was still " +
                     "recovering from an unclean leader election {}. {}",
-                    brokerId, topic.name, partitionId, leaderRecoveryState, isrAndReplicaSetInfo);
+                    brokerId, topic.name, partitionId, leaderRecoveryState, partitionChangeInfo);
 
             return INVALID_REQUEST;
         }
@@ -1335,7 +1337,7 @@ public class ReplicationControlManager {
                 leaderRecoveryState == LeaderRecoveryState.RECOVERING) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the leader recovery state cannot change from RECOVERED to RECOVERING. {}",
-                    brokerId, topic.name, partitionId, isrAndReplicaSetInfo);
+                    brokerId, topic.name, partitionId, partitionChangeInfo);
 
             return INVALID_REQUEST;
         }
@@ -1344,7 +1346,7 @@ public class ReplicationControlManager {
         if (!ineligibleReplicas.isEmpty()) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified ineligible replicas {} in the new ISR. {}",
-                    brokerId, topic.name, partitionId, ineligibleReplicas, isrAndReplicaSetInfo);
+                    brokerId, topic.name, partitionId, ineligibleReplicas, partitionChangeInfo);
             return INELIGIBLE_REPLICA;
         }
 
@@ -1810,23 +1812,23 @@ public class ReplicationControlManager {
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
 
             PartitionRegistration partition = topic.parts.get(partitionId);
-            String isrAndReplicaSetInfo = String.format("Current ISR is %s. Current replica set is %s.",
-                Arrays.toString(partition.isr), Arrays.toString(partition.replicas));
+            String partitionInfo = String.format("(isr: %s, replicaSet: %s, partitionEpoch: %d, leaderEpoch: %d)",
+                Arrays.toString(partition.isr), Arrays.toString(partition.replicas), partition.partitionEpoch, partition.leaderEpoch);
 
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 ApiError result = electLeader(topic.name, partitionId,
                         ElectionType.UNCLEAN, records);
                 if (result.error().equals(Errors.NONE)) {
                     log.info("Triggering unclean leader election for offline partition {}-{}. {}",
-                            topic.name, partitionId, isrAndReplicaSetInfo);
+                            topic.name, partitionId, partitionInfo);
                 } else {
                     log.warn("Cannot trigger unclean leader election for offline partition {}-{}: {}. {}",
-                            topic.name, partitionId, result.error(), isrAndReplicaSetInfo);
+                            topic.name, partitionId, result.error(), partitionInfo);
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("Cannot trigger unclean leader election for offline partition {}-{} " +
                                 "because unclean leader election is disabled for this topic. {}",
-                        topic.name, partitionId, isrAndReplicaSetInfo);
+                        topic.name, partitionId, partitionInfo);
             }
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1147,12 +1147,18 @@ public class ReplicationControlManager {
                 if (record.isPresent()) {
                     records.add(record.get());
                     PartitionChangeRecord change = (PartitionChangeRecord) record.get().message();
-                    String isrChange = String.format("ISR was {} and is now {}.", partition.isr, change.isr());
-                    String replicSetChange = String.format("Replica set was {} and is now {}.",  partition.replicas, change.replicas());
+                    String priorIsr = Arrays.toString(partition.isr);
+                    String priorReplicaSet = Arrays.toString(partition.replicas);
+                    int priorPartitionEpoch = partition.partitionEpoch;
+                    int priorLeaderEpoch = partition.leaderEpoch;
                     partition = partition.merge(change);
+                    String partitionChangeInfo = String.format("isr: %s -> %s, replicaSet: %s -> %s, " +
+                            "partitionEpoch: %d -> %d, leaderEpoch: %d -> %d",
+                        priorIsr, Arrays.toString(partition.isr()), priorReplicaSet, Arrays.toString(partition.replicas()),
+                        priorPartitionEpoch, partition.partitionEpoch, priorLeaderEpoch, partition.leaderEpoch);
                     if (log.isDebugEnabled()) {
-                        log.debug("Node {} has altered ISR for {}-{}. {} {}"
-                            request.brokerId(), topic.name, partitionId, isrChange, replicaSetChange);
+                        log.debug("Node {} has altered ISR for {}-{}. {}"
+                            request.brokerId(), topic.name, partitionId, partitionChangeInfo);
                     }
                     if (change.leader() != request.brokerId() &&
                             change.leader() != NO_LEADER_CHANGE) {
@@ -1169,16 +1175,16 @@ public class ReplicationControlManager {
                         // metadata record. We usually only do one or the other.
                         Errors error = NEW_LEADER_ELECTED;
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment and triggered a leadership change. {} {} Returning {}."
-                            request.brokerId(), topic.name, partitionId, isrChange, replicaSetChange, error);
+                            "the ongoing partition reassignment and triggered a leadership change. {}. Returning {}."
+                            request.brokerId(), topic.name, partitionId, partitionChangeInfo, error);
                         responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                             setPartitionIndex(partitionId).
                             setErrorCode(error.code()));
                         continue;
                     } else if (isReassignmentInProgress(partition)) {
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment. {} {}" +
-                            request.brokerId(), topic.name, partitionId, isrChange, replicaSetChange);
+                            "the ongoing partition reassignment. {}" +
+                            request.brokerId(), topic.name, partitionId, partitionChangeInfo);
                     }
                 }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -518,9 +518,15 @@ public class ReplicationControlManager {
         }
 
         if (record.removingReplicas() != null || record.addingReplicas() != null) {
-            log.info("Replayed partition assignment change {} for topic {}", record, topicInfo.name);
+            log.info("Replayed partition assignment change {} for topic {}. " +
+                    "(partitionEpoch: {}, leaderEpoch: {}, replicaSet: {} -> {}, isr: {} -> {})",
+                record, topicInfo.name, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch,
+                prevPartitionInfo.replicas, newPartitionInfo.replicas, prevPartitionInfo.isr, newPartitionInfo.isr);
         } else if (log.isDebugEnabled()) {
-            log.debug("Replayed partition change {} for topic {}", record, topicInfo.name);
+            log.debug("Replayed partition change {} for topic {}. " +
+                "(partitionEpoch: {}, leaderEpoch: {}, replicaSet: {} -> {}, isr: {} -> {}),",
+                record, topicInfo.name, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch,
+                prevPartitionInfo.replicas, newPartitionInfo.replicas, prevPartitionInfo.isr, newPartitionInfo.isr);
         }
     }
 
@@ -1141,10 +1147,12 @@ public class ReplicationControlManager {
                 if (record.isPresent()) {
                     records.add(record.get());
                     PartitionChangeRecord change = (PartitionChangeRecord) record.get().message();
+                    String isrChange = String.format("ISR was {} and is now {}.", partition.isr, change.isr());
+                    String replicSetChange = String.format("Replica set was {} and is now {}.",  partition.replicas, change.replicas());
                     partition = partition.merge(change);
                     if (log.isDebugEnabled()) {
-                        log.debug("Node {} has altered ISR for {}-{} to {}.",
-                            request.brokerId(), topic.name, partitionId, change.isr());
+                        log.debug("Node {} has altered ISR for {}-{}. {} {}"
+                            request.brokerId(), topic.name, partitionId, isrChange, replicaSetChange);
                     }
                     if (change.leader() != request.brokerId() &&
                             change.leader() != NO_LEADER_CHANGE) {
@@ -1161,17 +1169,16 @@ public class ReplicationControlManager {
                         // metadata record. We usually only do one or the other.
                         Errors error = NEW_LEADER_ELECTED;
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment and triggered a " +
-                            "leadership change. Returning {}.",
-                            request.brokerId(), topic.name, partitionId, error);
+                            "the ongoing partition reassignment and triggered a leadership change. {} {} Returning {}."
+                            request.brokerId(), topic.name, partitionId, isrChange, replicaSetChange, error);
                         responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                             setPartitionIndex(partitionId).
                             setErrorCode(error.code()));
                         continue;
                     } else if (isReassignmentInProgress(partition)) {
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment.", request.brokerId(),
-                            topic.name, partitionId);
+                            "the ongoing partition reassignment. {} {}" +
+                            request.brokerId(), topic.name, partitionId, isrChange, replicaSetChange);
                     }
                 }
 
@@ -1247,40 +1254,45 @@ public class ReplicationControlManager {
             return UNKNOWN_TOPIC_OR_PARTITION;
         }
 
+        String isrAndReplicaSetInfo = String.format("Proposed ISR was {} and current ISR is {}. " +
+            "Current replica set is {}.", partitionData.newIsrWithEpochs(), partition.isr, partition.replicas);
+
         // If the partition leader has a higher leader/partition epoch, then it is likely
         // that this node is no longer the active controller. We return NOT_CONTROLLER in
         // this case to give the leader an opportunity to find the new controller.
         if (partitionData.leaderEpoch() > partition.leaderEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the current leader epoch is {}, which is greater than the local value {}.",
-                brokerId, topic.name, partitionId, partition.leaderEpoch, partitionData.leaderEpoch());
+                    "the current leader epoch is {}, which is greater than the local value {}. {}",
+                brokerId, topic.name, partitionId, partition.leaderEpoch, partitionData.leaderEpoch(),
+                isrAndReplicaSetInfo);
             return NOT_CONTROLLER;
         }
         if (partitionData.partitionEpoch() > partition.partitionEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the current partition epoch is {}, which is greater than the local value {}.",
-                brokerId, topic.name, partitionId, partition.partitionEpoch, partitionData.partitionEpoch());
+                    "the current partition epoch is {}, which is greater than the local value {}. {}",
+                brokerId, topic.name, partitionId, partition.partitionEpoch, partitionData.partitionEpoch(),
+                isrAndReplicaSetInfo);
             return NOT_CONTROLLER;
         }
         if (partitionData.leaderEpoch() < partition.leaderEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the current leader epoch is {}, not {}.", brokerId, topic.name,
-                    partitionId, partition.leaderEpoch, partitionData.leaderEpoch());
+                    "the current leader epoch is {}, not {}. {}", brokerId, topic.name,
+                    partitionId, partition.leaderEpoch, partitionData.leaderEpoch(), isrAndReplicaSetInfo);
 
             return FENCED_LEADER_EPOCH;
         }
         if (brokerId != partition.leader) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the current leader is {}.", brokerId, topic.name,
-                    partitionId, partition.leader);
+                    "the current leader is {}. {}", brokerId, topic.name,
+                    partitionId, partition.leader, isrAndReplicaSetInfo);
 
             return INVALID_REQUEST;
         }
         if (partitionData.partitionEpoch() < partition.partitionEpoch) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the current partition epoch is {}, not {}.", brokerId,
+                    "the current partition epoch is {}, not {}. {}", brokerId,
                     topic.name, partitionId, partition.partitionEpoch,
-                    partitionData.partitionEpoch());
+                    partitionData.partitionEpoch(), isrAndReplicaSetInfo);
 
             return INVALID_UPDATE_VERSION;
         }
@@ -1290,34 +1302,33 @@ public class ReplicationControlManager {
 
         if (!Replicas.validateIsr(partition.replicas, newIsr)) {
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "it specified an invalid ISR {}.", brokerId,
-                    topic.name, partitionId, partitionData.newIsrWithEpochs());
+                    "it specified an invalid ISR. {}", brokerId,
+                    topic.name, partitionId, partitionData.newIsrWithEpochs(), isrAndReplicaSetInfo);
 
             return INVALID_REQUEST;
         }
         if (!Replicas.contains(newIsr, partition.leader)) {
             // The ISR must always include the current leader.
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "it specified an invalid ISR {} that doesn't include itself.",
-                    brokerId, topic.name, partitionId, partitionData.newIsrWithEpochs());
+                    "it specified an invalid ISR that doesn't include itself. {}",
+                    brokerId, topic.name, partitionId, isrAndReplicaSetInfo);
 
             return INVALID_REQUEST;
         }
         LeaderRecoveryState leaderRecoveryState = LeaderRecoveryState.of(partitionData.leaderRecoveryState());
         if (leaderRecoveryState == LeaderRecoveryState.RECOVERING && newIsr.length > 1) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the ISR {} had more than one replica while the leader was still " +
-                    "recovering from an unclean leader election {}.",
-                    brokerId, topic.name, partitionId, partitionData.newIsrWithEpochs(),
-                    leaderRecoveryState);
+                    "the ISR had more than one replica while the leader was still " +
+                    "recovering from an unclean leader election {}. {}",
+                    brokerId, topic.name, partitionId, leaderRecoveryState, isrAndReplicaSetInfo);
 
             return INVALID_REQUEST;
         }
         if (partition.leaderRecoveryState == LeaderRecoveryState.RECOVERED &&
                 leaderRecoveryState == LeaderRecoveryState.RECOVERING) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "the leader recovery state cannot change from RECOVERED to RECOVERING.",
-                    brokerId, topic.name, partitionId);
+                    "the leader recovery state cannot change from RECOVERED to RECOVERING. {}",
+                    brokerId, topic.name, partitionId, isrAndReplicaSetInfo);
 
             return INVALID_REQUEST;
         }
@@ -1325,8 +1336,8 @@ public class ReplicationControlManager {
         List<IneligibleReplica> ineligibleReplicas = ineligibleReplicasForIsr(partitionData.newIsrWithEpochs());
         if (!ineligibleReplicas.isEmpty()) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
-                    "it specified ineligible replicas {} in the new ISR {}.",
-                    brokerId, topic.name, partitionId, ineligibleReplicas, partitionData.newIsrWithEpochs());
+                    "it specified ineligible replicas {} in the new ISR. {}",
+                    brokerId, topic.name, partitionId, ineligibleReplicas, isrAndReplicaSetInfo);
             return INELIGIBLE_REPLICA;
         }
 
@@ -1788,21 +1799,27 @@ public class ReplicationControlManager {
         Iterator<TopicIdPartition> iterator = brokersToIsrs.partitionsWithNoLeader();
         while (iterator.hasNext() && records.size() < maxElections) {
             TopicIdPartition topicIdPartition = iterator.next();
+            int partitionId = topicIdPartition.partitionId();
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
+
+            PartitionRegistration partition = topic.parts.get(partitionId);
+            String isrAndReplicaSetInfo = String.format("Current ISR is {}. Current replica set is {}.",
+                partition.isr, partition.replicas);
+
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
-                ApiError result = electLeader(topic.name, topicIdPartition.partitionId(),
+                ApiError result = electLeader(topic.name, partitionId,
                         ElectionType.UNCLEAN, records);
                 if (result.error().equals(Errors.NONE)) {
-                    log.info("Triggering unclean leader election for offline partition {}-{}.",
-                            topic.name, topicIdPartition.partitionId());
+                    log.info("Triggering unclean leader election for offline partition {}-{}. {}",
+                            topic.name, partitionId, isrAndReplicaSetInfo);
                 } else {
-                    log.warn("Cannot trigger unclean leader election for offline partition {}-{}: {}",
-                            topic.name, topicIdPartition.partitionId(), result.error());
+                    log.warn("Cannot trigger unclean leader election for offline partition {}-{}: {}. {}",
+                            topic.name, partitionId, result.error(), isrAndReplicaSetInfo);
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("Cannot trigger unclean leader election for offline partition {}-{} " +
-                                "because unclean leader election is disabled for this topic.",
-                        topic.name, topicIdPartition.partitionId());
+                                "because unclean leader election is disabled for this topic. {}",
+                        topic.name, partitionId, isrAndReplicaSetInfo);
             }
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1822,22 +1822,20 @@ public class ReplicationControlManager {
             int partitionId = topicIdPartition.partitionId();
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
 
-            PartitionRegistration partition = topic.parts.get(partitionId);
-
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 ApiError result = electLeader(topic.name, partitionId,
                         ElectionType.UNCLEAN, records);
                 if (result.error().equals(Errors.NONE)) {
                     log.info("Triggering unclean leader election for offline partition {}-{}. {}",
-                            topic.name, partitionId, logPartitionInfo(partition));
+                            topic.name, partitionId, logPartitionInfo(topic.parts.get(partitionId)));
                 } else {
                     log.warn("Cannot trigger unclean leader election for offline partition {}-{}: {}. {}",
-                            topic.name, partitionId, result.error(), logPartitionInfo(partition));
+                            topic.name, partitionId, result.error(), logPartitionInfo(topic.parts.get(partitionId)));
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("Cannot trigger unclean leader election for offline partition {}-{} " +
                                 "because unclean leader election is disabled for this topic. {}",
-                        topic.name, partitionId, logPartitionInfo(partition));
+                        topic.name, partitionId, logPartitionInfo(topic.parts.get(partitionId)));
             }
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1147,18 +1147,10 @@ public class ReplicationControlManager {
                 if (record.isPresent()) {
                     records.add(record.get());
                     PartitionChangeRecord change = (PartitionChangeRecord) record.get().message();
-                    String priorIsr = Arrays.toString(partition.isr);
-                    String priorReplicaSet = Arrays.toString(partition.replicas);
-                    int priorPartitionEpoch = partition.partitionEpoch;
-                    int priorLeaderEpoch = partition.leaderEpoch;
-                    partition = partition.merge(change);
-                    String partitionChangeInfo = String.format("isr: %s -> %s, replicaSet: %s -> %s, " +
-                            "partitionEpoch: %d -> %d, leaderEpoch: %d -> %d",
-                        priorIsr, Arrays.toString(partition.isr), priorReplicaSet, Arrays.toString(partition.replicas),
-                        priorPartitionEpoch, partition.partitionEpoch, priorLeaderEpoch, partition.leaderEpoch);
+                    PartitionRegistration newPartition = partition.merge(change);
                     if (log.isDebugEnabled()) {
                         log.debug("Node {} has altered ISR for {}-{}. {}",
-                            request.brokerId(), topic.name, partitionId, partitionChangeInfo);
+                            request.brokerId(), topic.name, partitionId, logPartitionChangeInfo(partition, newPartition));
                     }
                     if (change.leader() != request.brokerId() &&
                             change.leader() != NO_LEADER_CHANGE) {
@@ -1176,15 +1168,16 @@ public class ReplicationControlManager {
                         Errors error = NEW_LEADER_ELECTED;
                         log.info("AlterPartition request from node {} for {}-{} completed " +
                             "the ongoing partition reassignment and triggered a leadership change {}. Returning {}.",
-                            request.brokerId(), topic.name, partitionId, partitionChangeInfo, error);
+                            request.brokerId(), topic.name, partitionId,
+                            logPartitionChangeInfo(partition, newPartition), error);
                         responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                             setPartitionIndex(partitionId).
                             setErrorCode(error.code()));
                         continue;
-                    } else if (isReassignmentInProgress(partition)) {
+                    } else if (isReassignmentInProgress(newPartition)) {
                         log.info("AlterPartition request from node {} for {}-{} completed " +
                             "the ongoing partition reassignment. {}",
-                            request.brokerId(), topic.name, partitionId, partitionChangeInfo);
+                            request.brokerId(), topic.name, partitionId, logPartitionChangeInfo(partition, newPartition));
                     }
                 }
 
@@ -1196,15 +1189,24 @@ public class ReplicationControlManager {
                 responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                     setPartitionIndex(partitionId).
                     setErrorCode(Errors.NONE.code()).
-                    setLeaderId(partition.leader).
-                    setIsr(Replicas.toList(partition.isr)).
-                    setLeaderRecoveryState(partition.leaderRecoveryState.value()).
-                    setLeaderEpoch(partition.leaderEpoch).
-                    setPartitionEpoch(partition.partitionEpoch));
+                    setLeaderId(newPartition.leader).
+                    setIsr(Replicas.toList(newPartition.isr)).
+                    setLeaderRecoveryState(newPartition.leaderRecoveryState.value()).
+                    setLeaderEpoch(newPartition.leaderEpoch).
+                    setPartitionEpoch(newPartition.partitionEpoch));
             }
         }
 
         return ControllerResult.of(records, response);
+    }
+
+    private static String logPartitionChangeInfo(PartitionRegistration oldRegistration, PartitionRegistration newRegistration) {
+        return String.format("isr: %s -> %s, replicaSet: %s -> %s, " +
+                "partitionEpoch: %d -> %d, leaderEpoch: %d -> %d",
+            Arrays.toString(oldRegistration.isr), Arrays.toString(newRegistration.isr),
+            Arrays.toString(oldRegistration.replicas), Arrays.toString(newRegistration.replicas),
+            oldRegistration.partitionEpoch, newRegistration.partitionEpoch,
+            oldRegistration.leaderEpoch, newRegistration.leaderEpoch);
     }
 
     /**
@@ -1260,12 +1262,6 @@ public class ReplicationControlManager {
             return UNKNOWN_TOPIC_OR_PARTITION;
         }
 
-        String partitionChangeInfo = String.format("Proposed ISR was %s and current ISR is %s. " +
-                "Current replica set is %s. Proposed partitionEpoch was %d and current partitionEpoch is %d. " +
-                "Proposed leaderEpoch was %d and current leaderEpoch is %d.",
-            partitionData.newIsrWithEpochs(), Arrays.toString(partition.isr), Arrays.toString(partition.replicas),
-            partitionData.partitionEpoch(), partition.partitionEpoch, partitionData.leaderEpoch(), partition.leaderEpoch);
-
         // If the partition leader has a higher leader/partition epoch, then it is likely
         // that this node is no longer the active controller. We return NOT_CONTROLLER in
         // this case to give the leader an opportunity to find the new controller.
@@ -1273,27 +1269,28 @@ public class ReplicationControlManager {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current leader epoch is {}, which is greater than the local value {}. {}",
                 brokerId, topic.name, partitionId, partition.leaderEpoch, partitionData.leaderEpoch(),
-                partitionChangeInfo);
+                logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
             return NOT_CONTROLLER;
         }
         if (partitionData.partitionEpoch() > partition.partitionEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current partition epoch is {}, which is greater than the local value {}. {}",
                 brokerId, topic.name, partitionId, partition.partitionEpoch, partitionData.partitionEpoch(),
-                partitionChangeInfo);
+                logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
             return NOT_CONTROLLER;
         }
         if (partitionData.leaderEpoch() < partition.leaderEpoch) {
             log.debug("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current leader epoch is {}, not {}. {}", brokerId, topic.name,
-                    partitionId, partition.leaderEpoch, partitionData.leaderEpoch(), partitionChangeInfo);
+                    partitionId, partition.leaderEpoch, partitionData.leaderEpoch(),
+                    logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return FENCED_LEADER_EPOCH;
         }
         if (brokerId != partition.leader) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current leader is {}. {}", brokerId, topic.name,
-                    partitionId, partition.leader, partitionChangeInfo);
+                    partitionId, partition.leader, logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return INVALID_REQUEST;
         }
@@ -1301,7 +1298,7 @@ public class ReplicationControlManager {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the current partition epoch is {}, not {}. {}", brokerId,
                     topic.name, partitionId, partition.partitionEpoch,
-                    partitionData.partitionEpoch(), partitionChangeInfo);
+                    partitionData.partitionEpoch(), logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return INVALID_UPDATE_VERSION;
         }
@@ -1312,7 +1309,7 @@ public class ReplicationControlManager {
         if (!Replicas.validateIsr(partition.replicas, newIsr)) {
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR. {}", brokerId,
-                    topic.name, partitionId, partitionChangeInfo);
+                    topic.name, partitionId, logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return INVALID_REQUEST;
         }
@@ -1320,7 +1317,8 @@ public class ReplicationControlManager {
             // The ISR must always include the current leader.
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR that doesn't include itself. {}",
-                    brokerId, topic.name, partitionId, partitionChangeInfo);
+                    brokerId, topic.name, partitionId,
+                    logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return INVALID_REQUEST;
         }
@@ -1329,7 +1327,8 @@ public class ReplicationControlManager {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the ISR had more than one replica while the leader was still " +
                     "recovering from an unclean leader election {}. {}",
-                    brokerId, topic.name, partitionId, leaderRecoveryState, partitionChangeInfo);
+                    brokerId, topic.name, partitionId, leaderRecoveryState,
+                    logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return INVALID_REQUEST;
         }
@@ -1337,7 +1336,8 @@ public class ReplicationControlManager {
                 leaderRecoveryState == LeaderRecoveryState.RECOVERING) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the leader recovery state cannot change from RECOVERED to RECOVERING. {}",
-                    brokerId, topic.name, partitionId, partitionChangeInfo);
+                    brokerId, topic.name, partitionId,
+                    logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
 
             return INVALID_REQUEST;
         }
@@ -1346,11 +1346,22 @@ public class ReplicationControlManager {
         if (!ineligibleReplicas.isEmpty()) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified ineligible replicas {} in the new ISR. {}",
-                    brokerId, topic.name, partitionId, ineligibleReplicas, partitionChangeInfo);
+                    brokerId, topic.name, partitionId, ineligibleReplicas,
+                    logPartitionChangeInfo(partition, partitionData.newIsrWithEpochs()));
             return INELIGIBLE_REPLICA;
         }
 
         return Errors.NONE;
+    }
+
+    private static String logPartitionChangeInfo(
+        PartitionRegistration partition,
+        List<BrokerState> requestedIsr,
+    ) {
+        return String.format("Proposed ISR was %s and current ISR is %s. " +
+                "Current replica set is %s. Current partitionEpoch is %d. Current leaderEpoch is %d.",
+            requestedIsr, Arrays.toString(partition.isr), Arrays.toString(partition.replicas),
+            partition.partitionEpoch, partition.leaderEpoch);
     }
 
     private List<IneligibleReplica> ineligibleReplicasForIsr(List<BrokerState> brokerStates) {
@@ -1812,25 +1823,29 @@ public class ReplicationControlManager {
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
 
             PartitionRegistration partition = topic.parts.get(partitionId);
-            String partitionInfo = String.format("(isr: %s, replicaSet: %s, partitionEpoch: %d, leaderEpoch: %d)",
-                Arrays.toString(partition.isr), Arrays.toString(partition.replicas), partition.partitionEpoch, partition.leaderEpoch);
 
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 ApiError result = electLeader(topic.name, partitionId,
                         ElectionType.UNCLEAN, records);
                 if (result.error().equals(Errors.NONE)) {
                     log.info("Triggering unclean leader election for offline partition {}-{}. {}",
-                            topic.name, partitionId, partitionInfo);
+                            topic.name, partitionId, logPartitionInfo(partition));
                 } else {
                     log.warn("Cannot trigger unclean leader election for offline partition {}-{}: {}. {}",
-                            topic.name, partitionId, result.error(), partitionInfo);
+                            topic.name, partitionId, result.error(), logPartitionInfo(partition));
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("Cannot trigger unclean leader election for offline partition {}-{} " +
                                 "because unclean leader election is disabled for this topic. {}",
-                        topic.name, partitionId, partitionInfo);
+                        topic.name, partitionId, logPartitionInfo(partition));
             }
         }
+    }
+
+    private static String logPartitionInfo(PartitionRegistration partition) {
+        return String.format("(isr: %s, replicaSet: %s, partitionEpoch: %d, leaderEpoch: %d)",
+            Arrays.toString(partition.isr), Arrays.toString(partition.replicas), partition.partitionEpoch,
+            partition.leaderEpoch);
     }
 
     ControllerResult<List<CreatePartitionsTopicResult>> createPartitions(

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -524,7 +524,7 @@ public class ReplicationControlManager {
                 prevPartitionInfo.replicas, newPartitionInfo.replicas, prevPartitionInfo.isr, newPartitionInfo.isr);
         } else if (log.isDebugEnabled()) {
             log.debug("Replayed partition change {} for topic {}. " +
-                "(partitionEpoch: {}, leaderEpoch: {}, replicaSet: {} -> {}, isr: {} -> {}),",
+                "(partitionEpoch: {}, leaderEpoch: {}, replicaSet: {} -> {}, isr: {} -> {})",
                 record, topicInfo.name, newPartitionInfo.partitionEpoch, newPartitionInfo.leaderEpoch,
                 prevPartitionInfo.replicas, newPartitionInfo.replicas, prevPartitionInfo.isr, newPartitionInfo.isr);
         }
@@ -1154,10 +1154,10 @@ public class ReplicationControlManager {
                     partition = partition.merge(change);
                     String partitionChangeInfo = String.format("isr: %s -> %s, replicaSet: %s -> %s, " +
                             "partitionEpoch: %d -> %d, leaderEpoch: %d -> %d",
-                        priorIsr, Arrays.toString(partition.isr()), priorReplicaSet, Arrays.toString(partition.replicas()),
+                        priorIsr, Arrays.toString(partition.isr), priorReplicaSet, Arrays.toString(partition.replicas),
                         priorPartitionEpoch, partition.partitionEpoch, priorLeaderEpoch, partition.leaderEpoch);
                     if (log.isDebugEnabled()) {
-                        log.debug("Node {} has altered ISR for {}-{}. {}"
+                        log.debug("Node {} has altered ISR for {}-{}. {}",
                             request.brokerId(), topic.name, partitionId, partitionChangeInfo);
                     }
                     if (change.leader() != request.brokerId() &&
@@ -1175,7 +1175,7 @@ public class ReplicationControlManager {
                         // metadata record. We usually only do one or the other.
                         Errors error = NEW_LEADER_ELECTED;
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment and triggered a leadership change. {}. Returning {}."
+                            "the ongoing partition reassignment and triggered a leadership change. {}. Returning {}.",
                             request.brokerId(), topic.name, partitionId, partitionChangeInfo, error);
                         responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                             setPartitionIndex(partitionId).
@@ -1183,7 +1183,7 @@ public class ReplicationControlManager {
                         continue;
                     } else if (isReassignmentInProgress(partition)) {
                         log.info("AlterPartition request from node {} for {}-{} completed " +
-                            "the ongoing partition reassignment. {}" +
+                            "the ongoing partition reassignment. {}",
                             request.brokerId(), topic.name, partitionId, partitionChangeInfo);
                     }
                 }
@@ -1260,8 +1260,9 @@ public class ReplicationControlManager {
             return UNKNOWN_TOPIC_OR_PARTITION;
         }
 
-        String isrAndReplicaSetInfo = String.format("Proposed ISR was {} and current ISR is {}. " +
-            "Current replica set is {}.", partitionData.newIsrWithEpochs(), partition.isr, partition.replicas);
+        String isrAndReplicaSetInfo = String.format("Proposed ISR was %s and current ISR is %s. " +
+            "Current replica set is %s.",
+            partitionData.newIsrWithEpochs(), Arrays.toString(partition.isr), Arrays.toString(partition.replicas));
 
         // If the partition leader has a higher leader/partition epoch, then it is likely
         // that this node is no longer the active controller. We return NOT_CONTROLLER in
@@ -1309,7 +1310,7 @@ public class ReplicationControlManager {
         if (!Replicas.validateIsr(partition.replicas, newIsr)) {
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR. {}", brokerId,
-                    topic.name, partitionId, partitionData.newIsrWithEpochs(), isrAndReplicaSetInfo);
+                    topic.name, partitionId, isrAndReplicaSetInfo);
 
             return INVALID_REQUEST;
         }
@@ -1809,8 +1810,8 @@ public class ReplicationControlManager {
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
 
             PartitionRegistration partition = topic.parts.get(partitionId);
-            String isrAndReplicaSetInfo = String.format("Current ISR is {}. Current replica set is {}.",
-                partition.isr, partition.replicas);
+            String isrAndReplicaSetInfo = String.format("Current ISR is %s. Current replica set is %s.",
+                Arrays.toString(partition.isr), Arrays.toString(partition.replicas));
 
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 ApiError result = electLeader(topic.name, partitionId,

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1147,10 +1147,11 @@ public class ReplicationControlManager {
                 if (record.isPresent()) {
                     records.add(record.get());
                     PartitionChangeRecord change = (PartitionChangeRecord) record.get().message();
-                    PartitionRegistration newPartition = partition.merge(change);
+                    PartitionRegistration originalPartition = partition
+                    partition = originalPartition.merge(change);
                     if (log.isDebugEnabled()) {
                         log.debug("Node {} has altered ISR for {}-{}. {}",
-                            request.brokerId(), topic.name, partitionId, logPartitionChangeInfo(partition, newPartition));
+                            request.brokerId(), topic.name, partitionId, logPartitionChangeInfo(originalPartition, partition));
                     }
                     if (change.leader() != request.brokerId() &&
                             change.leader() != NO_LEADER_CHANGE) {
@@ -1169,15 +1170,15 @@ public class ReplicationControlManager {
                         log.info("AlterPartition request from node {} for {}-{} completed " +
                             "the ongoing partition reassignment and triggered a leadership change {}. Returning {}.",
                             request.brokerId(), topic.name, partitionId,
-                            logPartitionChangeInfo(partition, newPartition), error);
+                            logPartitionChangeInfo(originalPartition, partition), error);
                         responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                             setPartitionIndex(partitionId).
                             setErrorCode(error.code()));
                         continue;
-                    } else if (isReassignmentInProgress(newPartition)) {
+                    } else if (isReassignmentInProgress(partition)) {
                         log.info("AlterPartition request from node {} for {}-{} completed " +
                             "the ongoing partition reassignment. {}",
-                            request.brokerId(), topic.name, partitionId, logPartitionChangeInfo(partition, newPartition));
+                            request.brokerId(), topic.name, partitionId, logPartitionChangeInfo(originalPartition, partition));
                     }
                 }
 
@@ -1189,11 +1190,11 @@ public class ReplicationControlManager {
                 responseTopicData.partitions().add(new AlterPartitionResponseData.PartitionData().
                     setPartitionIndex(partitionId).
                     setErrorCode(Errors.NONE.code()).
-                    setLeaderId(newPartition.leader).
-                    setIsr(Replicas.toList(newPartition.isr)).
-                    setLeaderRecoveryState(newPartition.leaderRecoveryState.value()).
-                    setLeaderEpoch(newPartition.leaderEpoch).
-                    setPartitionEpoch(newPartition.partitionEpoch));
+                    setLeaderId(partition.leader).
+                    setIsr(Replicas.toList(partition.isr)).
+                    setLeaderRecoveryState(partition.leaderRecoveryState.value()).
+                    setLeaderEpoch(partition.leaderEpoch).
+                    setPartitionEpoch(partition.partitionEpoch));
             }
         }
 
@@ -1201,8 +1202,7 @@ public class ReplicationControlManager {
     }
 
     private static String logPartitionChangeInfo(PartitionRegistration oldRegistration, PartitionRegistration newRegistration) {
-        return String.format("isr: %s -> %s, replicaSet: %s -> %s, " +
-                "partitionEpoch: %d -> %d, leaderEpoch: %d -> %d",
+        return String.format("isr: %s -> %s, replicaSet: %s -> %s, partitionEpoch: %d -> %d, leaderEpoch: %d -> %d",
             Arrays.toString(oldRegistration.isr), Arrays.toString(newRegistration.isr),
             Arrays.toString(oldRegistration.replicas), Arrays.toString(newRegistration.replicas),
             oldRegistration.partitionEpoch, newRegistration.partitionEpoch,


### PR DESCRIPTION
Adds more detailed logging around partition info (e.g. partitionEpoch,
leaderEpoch, priorISR, priorReplicaSet) for ISR and replica set changes.
This should help with debugging issues in the future.

Reviewers: José Armando García Sancio <jsancio@apache.org>
