### PR TITLE
KAFKA-20024: wmic os get osarchitecture is unreliable for detecting OS bitness in bat scripts

### DIFF
--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -25,10 +25,14 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
     rem detect OS architecture
-    wmic os get osarchitecture | find /i "32-bit" >nul 2>&1
-    IF NOT ERRORLEVEL 1 (
-        rem 32-bit OS
-        set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
+    IF /I "%PROCESSOR_ARCHITECTURE%" EQU "x86" (
+        IF NOT DEFINED PROCESSOR_ARCHITEW6432 (
+            rem 32-bit OS
+            set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
+        ) ELSE (
+            rem 32-bit process running on 64-bit Windows system
+            set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G
+        )
     ) ELSE (
         rem 64-bit OS
         set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G


### PR DESCRIPTION
Hello，During my usage of Kafka, I identified an issue. In the kafka-server-start.bat script, there is a logic that sets different startup parameters based on the bitness (32-bit/64-bit) of the operating system. The relevant code is as follows:

<img width="1107" height="528" alt="image" src="https://github.com/user-attachments/assets/c7730e58-1e30-47a1-82d5-7b8e327eb5d5" />

It first queries wmic os get osarchitecture, then determines whether the operating system is 32-bit or 64-bit by checking if the result contains the string "32-bit". However, my actual tests show that this method is not reliable—the returned results vary across Windows systems with different languages and regional settings, as shown below:

English Windows:
<img width="810" height="114" alt="image" src="https://github.com/user-attachments/assets/42acc377-fb49-45d2-ba15-ac6049f556d1" />

Chinese Windows:
<img width="853" height="109" alt="image" src="https://github.com/user-attachments/assets/b7b1a606-54a9-40ef-b3bd-ed5172af3681" />


French Windows:
<img width="823" height="112" alt="image" src="https://github.com/user-attachments/assets/2a85348e-a13c-402a-9c7d-dcd658837db5" />


German Windows:
<img width="831" height="123" alt="image" src="https://github.com/user-attachments/assets/22661fba-7375-4f5b-9a65-f57db1f37677" />


Japanese Windows:
<img width="882" height="115" alt="image" src="https://github.com/user-attachments/assets/6fb4f9df-bf5e-4479-b7f0-80aed045765e" />


Older Windows XP systems:
<img width="975" height="172" alt="image" src="https://github.com/user-attachments/assets/fbb381a3-2591-4543-bdbf-88bab26027ad" />


Kafka has users across the globe, and the current approach lacks universality.
