### PR TITLE
MINOR: Fix typo: 'Unintialized' -> 'Uninitialized'

### DIFF
--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -1036,7 +1036,7 @@ class ShareCoordinatorShardTest {
     }
 
     @Test
-    public void testDeleteStateUnintializedRecord() {
+    public void testDeleteStateUninitializedRecord() {
         DeleteShareGroupStateRequestData request = new DeleteShareGroupStateRequestData()
             .setGroupId(GROUP_ID)
             .setTopics(List.of(new DeleteShareGroupStateRequestData.DeleteStateData()


### PR DESCRIPTION
Fix spelling error in test method name: `Unintialized` ->
`Uninitialized`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
