### PR TITLE
Fix high-watermark metric returning -1 for leader

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -119,6 +119,7 @@ public class LeaderState<T> implements EpochState {
         Set<Integer> grantingVoters,
         BatchAccumulator<T> accumulator,
         int fetchTimeoutMs,
+        Optional<LogOffsetMetadata> leaderHighWatermark,
         LogContext logContext,
         KafkaRaftMetrics kafkaRaftMetrics
     ) {
@@ -139,6 +140,7 @@ public class LeaderState<T> implements EpochState {
         this.localVoterNode = localVoterNode;
         this.epoch = epoch;
         this.epochStartOffset = epochStartOffset;
+        this.highWatermark = leaderHighWatermark;
 
         for (VoterSet.VoterNode voterNode: voterSetAtEpochStart.voterNodes()) {
             boolean hasAcknowledgedLeader = voterNode.isVoter(localVoterNode.voterKey());

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -718,6 +718,7 @@ public class QuorumState {
             candidateState.epochElection().grantingVoters(),
             accumulator,
             fetchTimeoutMs,
+            this.state.highWatermark(),
             logContext,
             kafkaRaftMetrics
         );

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -86,6 +86,7 @@ public class LeaderStateTest {
             voters.voterIds(),
             accumulator,
             fetchTimeoutMs,
+            Optional.empty(),
             logContext,
             new KafkaRaftMetrics(new Metrics(), "raft")
         );
@@ -137,6 +138,7 @@ public class LeaderStateTest {
                 Set.of(),
                 null,
                 fetchTimeoutMs,
+                Optional.empty(),
                 logContext,
                 new KafkaRaftMetrics(new Metrics(), "raft")
             )

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -227,7 +227,7 @@ public class QuorumStateTest {
         assertTrue(candidateState.epochElection().isVoteGranted());
 
         state.transitionToLeader(10L, accumulator);
-        assertEquals(Optional.empty(), state.highWatermark());
+        assertEquals(highWatermark, state.highWatermark());
     }
 
     @ParameterizedTest

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -220,7 +220,7 @@ public class KafkaRaftMetricsTest {
             getMetric(metrics, "current-vote-directory-id").metricValue()
         );
         assertEquals((double) 1, getMetric(metrics, "current-epoch").metricValue());
-        assertEquals((double) -1L, getMetric(metrics, "high-watermark").metricValue()); // todo, bug fix
+        assertEquals((double) 5L, getMetric(metrics, "high-watermark").metricValue());
 
         // leader with updated HW
         state.leaderStateOrThrow().updateLocalState(new LogOffsetMetadata(10L), voters);


### PR DESCRIPTION
### Summary
Fixes a bug where the `high-watermark` metric in [KafkaRaftMetrics](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/internals/KafkaRaftMetrics.java:37:0-288:1) temporarily reports `-1` when a Raft node transitions to the [Leader](cci:1://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/QuorumState.java:853:4-855:5) state.

### Detail
Previously, `QuorumState.transitionToLeader` initialized the new [LeaderState](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/LeaderState.java:62:0-1152:1) with an empty high watermark. This caused the metric to drop to `-1` until the first follower fetch updated it. This change updates [QuorumState](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/QuorumState.java:83:0-933:1) to pass the existing high watermark (from the previous [Follower](cci:1://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/QuorumState.java:837:4-839:5) or [Candidate](cci:1://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/QuorumState.java:865:4-867:5) state) to the [LeaderState](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/main/java/org/apache/kafka/raft/LeaderState.java:62:0-1152:1), preserving monotonicity.

### Tests
*   **Updated**: [KafkaRaftMetricsTest](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java:48:0-530:1) to assert the correct high watermark value (e.g., `5`) instead of `-1`.
*   **Updated**: [QuorumStateTest](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java:51:0-2678:1) ([testHighWatermarkRetained](cci:1://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java:193:4-230:5)) to verify the high watermark is preserved on transition.
*   **Updated**: [LeaderStateTest](cci:2://file:///Users/samratrohit/Downloads/Projects/kafka/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java:49:0-875:1) to match the updated constructor signature.
*   Verified that all tests pass with `./gradlew raft:test`.

### Committer Checklist (Excluded from Commit Message)
- [x] Verify that tests pass.
- [x] Verify that checkstyle passes.

---
**NOTE TO MAINTAINERS:**
I am currently unable to create a JIRA ticket due to the public signup restrictions on the ASF JIRA portal. Could a maintainer please help create a ticket for this issue?