### PR TITLE
MINOR: Optimize ClientQuotasImage lookup (KAFKA-13022)

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
@@ -42,17 +42,31 @@ import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH
 import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_EXACT;
 import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_SPECIFIED;
 
-
 /**
  * Represents the client quotas in the metadata image.
  * <p>
  * This class is thread-safe.
  */
-public record ClientQuotasImage(Map<ClientQuotaEntity, ClientQuotaImage> entities) {
+public class ClientQuotasImage {
     public static final ClientQuotasImage EMPTY = new ClientQuotasImage(Map.of());
+
+    private final Map<ClientQuotaEntity, ClientQuotaImage> entities;
+    private final Map<String, Map<String, Set<ClientQuotaEntity>>> index;
 
     public ClientQuotasImage(Map<ClientQuotaEntity, ClientQuotaImage> entities) {
         this.entities = Collections.unmodifiableMap(entities);
+        this.index = new HashMap<>();
+        for (ClientQuotaEntity entity : this.entities.keySet()) {
+            for (Entry<String, String> entry : entity.entries().entrySet()) {
+                index.computeIfAbsent(entry.getKey(), k -> new HashMap<>())
+                        .computeIfAbsent(entry.getValue(), k -> new HashSet<>())
+                        .add(entity);
+            }
+        }
+    }
+
+    public Map<ClientQuotaEntity, ClientQuotaImage> entities() {
+        return entities;
     }
 
     public boolean isEmpty() {
@@ -112,18 +126,74 @@ public record ClientQuotasImage(Map<ClientQuotaEntity, ClientQuotaImage> entitie
         }
         if (exactMatch.containsKey(IP) || typeMatch.contains(IP)) {
             if ((exactMatch.containsKey(USER) || typeMatch.contains(USER)) ||
-                (exactMatch.containsKey(CLIENT_ID) || typeMatch.contains(CLIENT_ID))) {
+                    (exactMatch.containsKey(CLIENT_ID) || typeMatch.contains(CLIENT_ID))) {
                 throw new InvalidRequestException("Invalid entity filter component " +
                     "combination. IP filter component should not be used with " +
                     "user or clientId filter component.");
             }
         }
-        // TODO: this is O(N). We should add indexing here to speed it up. See KAFKA-13022.
-        for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : entities.entrySet()) {
-            ClientQuotaEntity entity = entry.getKey();
-            ClientQuotaImage quotaImage = entry.getValue();
-            if (matches(entity, exactMatch, typeMatch, request.strict())) {
-                response.entries().add(toDescribeEntry(entity, quotaImage));
+        Set<ClientQuotaEntity> candidates = null;
+
+        // 1. Filter by exact matches
+        for (Entry<String, String> entry : exactMatch.entrySet()) {
+            Map<String, Set<ClientQuotaEntity>> nameMap = index.get(entry.getKey());
+            Set<ClientQuotaEntity> matches = (nameMap == null) ? Collections.emptySet()
+                    : nameMap.getOrDefault(entry.getValue(), Collections.emptySet());
+
+            if (matches.isEmpty()) {
+                return response;
+            }
+
+            if (candidates == null) {
+                candidates = new HashSet<>(matches);
+            } else {
+                candidates.retainAll(matches);
+            }
+
+            if (candidates.isEmpty()) {
+                return response;
+            }
+        }
+
+        // 2. Filter by type matches
+        for (String type : typeMatch) {
+            Map<String, Set<ClientQuotaEntity>> nameMap = index.get(type);
+            Set<ClientQuotaEntity> matches = new HashSet<>();
+            if (nameMap != null) {
+                for (Set<ClientQuotaEntity> s : nameMap.values()) {
+                    matches.addAll(s);
+                }
+            }
+
+            if (matches.isEmpty()) {
+                return response;
+            }
+
+            if (candidates == null) {
+                candidates = new HashSet<>(matches);
+            } else {
+                candidates.retainAll(matches);
+            }
+
+            if (candidates.isEmpty()) {
+                return response;
+            }
+        }
+
+        if (candidates == null) {
+            for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : entities.entrySet()) {
+                ClientQuotaEntity entity = entry.getKey();
+                ClientQuotaImage quotaImage = entry.getValue();
+                if (matches(entity, exactMatch, typeMatch, request.strict())) {
+                    response.entries().add(toDescribeEntry(entity, quotaImage));
+                }
+            }
+        } else {
+            for (ClientQuotaEntity entity : candidates) {
+                ClientQuotaImage quotaImage = entities.get(entity);
+                if (matches(entity, exactMatch, typeMatch, request.strict())) {
+                    response.entries().add(toDescribeEntry(entity, quotaImage));
+                }
             }
         }
         return response;
@@ -164,6 +234,21 @@ public record ClientQuotasImage(Map<ClientQuotaEntity, ClientQuotaImage> entitie
         }
         data.setValues(quotaImage.toDescribeValues());
         return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ClientQuotasImage that = (ClientQuotasImage) o;
+        return Objects.equals(entities, that.entities);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entities);
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/image/ClientQuotasImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClientQuotasImageTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.ClientQuotaRecord;
 import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData;
+import org.apache.kafka.common.message.DescribeClientQuotasRequestData;
+import org.apache.kafka.common.message.DescribeClientQuotasResponseData;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.RecordTestUtils;
@@ -35,8 +37,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.common.metadata.MetadataRecordType.CLIENT_QUOTA_RECORD;
+import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_EXACT;
+import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_SPECIFIED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 
 @Timeout(value = 40)
 public class ClientQuotasImageTest {
@@ -62,24 +65,21 @@ public class ClientQuotasImageTest {
 
         DELTA1_RECORDS = new ArrayList<>();
         // remove quota
-        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().
-                setEntity(List.of(
-                    new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("bar"),
-                    new EntityData().setEntityType(ClientQuotaEntity.IP).setEntityName("127.0.0.1"))).
-                setKey(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG).
-                setRemove(true), CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().setEntity(List.of(
+                new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("bar"),
+                new EntityData().setEntityType(ClientQuotaEntity.IP).setEntityName("127.0.0.1")))
+                .setKey(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG).setRemove(true),
+                CLIENT_QUOTA_RECORD.highestSupportedVersion()));
         // alter quota
-        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().
-            setEntity(List.of(
-                new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("foo"))).
-            setKey(QuotaConfig.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG).
-            setValue(234.0), CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().setEntity(List.of(
+                new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("foo")))
+                .setKey(QuotaConfig.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG).setValue(234.0),
+                CLIENT_QUOTA_RECORD.highestSupportedVersion()));
         // add quota to entity with existing quota
-        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().
-            setEntity(List.of(
-                new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("foo"))).
-            setKey(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG).
-            setValue(999.0), CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().setEntity(List.of(
+                new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("foo")))
+                .setKey(QuotaConfig.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG).setValue(999.0),
+                CLIENT_QUOTA_RECORD.highestSupportedVersion()));
 
         DELTA1 = new ClientQuotasDelta(IMAGE1);
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
@@ -136,5 +136,41 @@ public class ClientQuotasImageTest {
         RecordListWriter writer = new RecordListWriter();
         image.write(writer);
         return writer.records();
+    }
+    @Test
+    public void testDescribeMatches() {
+        Map<ClientQuotaEntity, ClientQuotaImage> entities = new HashMap<>();
+        Map<String, String> user1 = Map.of(ClientQuotaEntity.USER, "user1");
+        entities.put(new ClientQuotaEntity(user1), new ClientQuotaImage(Map.of("k1", 1.0)));
+
+        Map<String, String> user2 = Map.of(ClientQuotaEntity.USER, "user2");
+        entities.put(new ClientQuotaEntity(user2), new ClientQuotaImage(Map.of("k1", 2.0)));
+
+        Map<String, String> client1 = Map.of(ClientQuotaEntity.CLIENT_ID, "client1");
+        entities.put(new ClientQuotaEntity(client1), new ClientQuotaImage(Map.of("k2", 3.0)));
+
+        ClientQuotasImage image = new ClientQuotasImage(entities);
+
+        // Test exact match
+        DescribeClientQuotasRequestData request1 = new DescribeClientQuotasRequestData();
+        request1.components().add(new DescribeClientQuotasRequestData.ComponentData().
+            setEntityType(ClientQuotaEntity.USER).setMatchType(MATCH_TYPE_EXACT).setMatch("user1"));
+        DescribeClientQuotasResponseData response1 = image.describe(request1);
+        assertEquals(1, response1.entries().size());
+        assertEquals("user1", response1.entries().get(0).entity().get(0).entityName());
+
+        // Test type match
+        DescribeClientQuotasRequestData request2 = new DescribeClientQuotasRequestData();
+        request2.components().add(new DescribeClientQuotasRequestData.ComponentData().
+            setEntityType(ClientQuotaEntity.USER).setMatchType(MATCH_TYPE_SPECIFIED).setMatch(null));
+        DescribeClientQuotasResponseData response2 = image.describe(request2);
+        assertEquals(2, response2.entries().size());
+
+        // Test no match
+        DescribeClientQuotasRequestData request3 = new DescribeClientQuotasRequestData();
+        request3.components().add(new DescribeClientQuotasRequestData.ComponentData().
+            setEntityType(ClientQuotaEntity.USER).setMatchType(MATCH_TYPE_EXACT).setMatch("unknown"));
+        DescribeClientQuotasResponseData response3 = image.describe(request3);
+        assertEquals(0, response3.entries().size());
     }
 }


### PR DESCRIPTION
In ClientQuotasImage.describe, we currently iterate over all ClientQuotaEntity objects (O(N)). This patch introduces an index to improve lookup performance to O(1)/O(M) for typical use cases. Refactored ClientQuotasImage from record to class to support the internal index.
