### PR TITLE
MINOR: Remove 4.2 from Streams E2E tests

### DIFF
--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -174,7 +174,7 @@ class StreamsUpgradeTest(Test):
         self.stop_and_await()
 
     @cluster(num_nodes=6)
-    @matrix(from_version=[str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9), str(LATEST_4_0), str(LATEST_4_1), str(LATEST_4_2)],
+    @matrix(from_version=[str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9), str(LATEST_4_0), str(LATEST_4_1)],
             upgrade=[True, False],
             metadata_quorum=[quorum.combined_kraft])
     def test_upgrade_downgrade_state_updater(self, from_version, upgrade, metadata_quorum):


### PR DESCRIPTION
Since Kafka 4.2.0 has not been released yet, using str(LATEST_4_2)
causes the e2e tests to fail, so we should remove it.

Reviewers: TengYao Chi <frankvicky@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>
