### PR TITLE
KAFKA-20021: Document when Admin#createPartitions throws InvalidPartitionsException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -665,6 +665,8 @@ public interface Admin extends AutoCloseable {
      * replicas with the topics replication factor.</li>
      * <li>Subclasses of {@link org.apache.kafka.common.KafkaException}
      * if the request is invalid in some way.</li>
+     * <li>{@link org.apache.kafka.common.errors.InvalidPartitionsException}
+     * if the requested partition count is less than or equal to the current partition count.</li>
      * </ul>
      *
      * @param newPartitions The topics which should have new partitions created, and corresponding parameters


### PR DESCRIPTION
Refer to https://issues.apache.org/jira/browse/KAFKA-20021.

The `Admin#createPartitions` method anticipates an
`InvalidPartitionsException` when the requested partition count is less
than or equal to the current partition count (i.e., decreasing
partitions or keeping the same count is not allowed).

However, this exception was missing from the Javadoc description of the
returned `CreatePartitionsResult`, see
https://kafka.apache.org/41/javadoc/org/apache/kafka/clients/admin/Admin.html#createPartitions.

This PR adds `InvalidPartitionsException` to the Javadoc to clarify this
behavior for users.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
