### PR TITLE
KAFKA-20034: set deliveryCompleteCount to 0 when share partition is initialized with non negative start offset.

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -3468,7 +3468,7 @@ public class ShareConsumerTest {
                 producer.send(record);
             }
             producer.flush();
-            // Create a new share consumer. Since the share.auto.offset.reset is not altered, it should be latest by default.
+            // Create a new share consumer.
             ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));
             shareConsumer.subscribe(List.of(tp.topic()));
             // Polling share consumer to make sure it joins the group and consumes the produced records.
@@ -3483,6 +3483,8 @@ public class ShareConsumerTest {
             shareConsumer.close();
             // Delete the share group offsets.
             deleteShareGroupOffsets(adminClient, groupId, tp.topic());
+            // Verify that the share partition offsets are deleted.
+            verifySharePartitionOffsetsDeleted(adminClient, groupId, tp);
             // Create a new share consumer.
             ShareConsumer<byte[], byte[]> shareConsumer2 = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));
             shareConsumer2.subscribe(List.of(tp.topic()));
@@ -4201,6 +4203,14 @@ public class ShareConsumerTest {
                 sharePartitionOffsetInfo.lag().isPresent() &&
                 sharePartitionOffsetInfo.lag().get() == expectedLag;
         }, DEFAULT_MAX_WAIT_MS, DEFAULT_POLL_INTERVAL_MS, () -> "Failed to retrieve share partition lag");
+    }
+
+    private void verifySharePartitionOffsetsDeleted(Admin adminClient, String groupId, TopicPartition tp) throws InterruptedException {
+        TestUtils.waitForCondition(
+            () -> sharePartitionOffsetInfo(adminClient, groupId, tp) == null, 
+            DEFAULT_MAX_WAIT_MS, 
+            DEFAULT_POLL_INTERVAL_MS, 
+            () -> "Failed to retrieve share partition lag");
     }
 
     private void alterShareGroupOffsets(Admin adminClient, String groupId, TopicPartition topicPartition, Long newOffset) throws InterruptedException, ExecutionException {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -3445,12 +3445,12 @@ public class ShareConsumerTest {
             verifySharePartitionLag(adminClient, groupId, tp, 0L);
             // Closing the share consumer so that the offsets can be altered.
             shareConsumer.close();
-            // Alter the start offset of the share partition to 0.
-            alterShareGroupOffsets(adminClient, groupId, tp, 0L);
-            // After altering, the share partition start offset should be 0.
-            verifySharePartitionStartOffset(adminClient, groupId, tp, 0L);
-            // Verify that the lag is now 105 since the start offset is altered to 0 and there are total 105 records in the partition.
-            verifySharePartitionLag(adminClient, groupId, tp, 105L);
+            // Alter the start offset of the share partition to 40.
+            alterShareGroupOffsets(adminClient, groupId, tp, 40L);
+            // After altering, the share partition start offset should be 40.
+            verifySharePartitionStartOffset(adminClient, groupId, tp, 40L);
+            // Verify that the lag is now 65 since the start offset is altered to 40 and there are total 105 records in the partition.
+            verifySharePartitionLag(adminClient, groupId, tp, 65L);
         } catch (InterruptedException | ExecutionException e) {
             fail("Test failed with exception: " + e.getMessage());
         }
@@ -3481,7 +3481,7 @@ public class ShareConsumerTest {
             verifySharePartitionLag(adminClient, groupId, tp, 0L);
             // Closing the share consumer so that the offsets can be deleted.
             shareConsumer.close();
-            // Delete the start offset of the share partition to 0.
+            // Delete the share group offsets.
             deleteShareGroupOffsets(adminClient, groupId, tp.topic());
             // Create a new share consumer.
             ShareConsumer<byte[], byte[]> shareConsumer2 = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.AlterConfigsOptions;
 import org.apache.kafka.clients.admin.AlterShareGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteShareGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.DescribeShareGroupsOptions;
 import org.apache.kafka.clients.admin.ListShareGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.ListShareGroupOffsetsResult;
@@ -3448,20 +3449,53 @@ public class ShareConsumerTest {
             alterShareGroupOffsets(adminClient, groupId, tp, 0L);
             // After altering, the share partition start offset should be 0.
             verifySharePartitionStartOffset(adminClient, groupId, tp, 0L);
-            // Create another share consumer.
+            // Verify that the lag is now 105 since the start offset is altered to 0 and there are total 105 records in the partition.
+            verifySharePartitionLag(adminClient, groupId, tp, 105L);
+        } catch (InterruptedException | ExecutionException e) {
+            fail("Test failed with exception: " + e.getMessage());
+        }
+    }
+
+    @ClusterTest
+    public void testSharePartitionLagAfterDeleteShareGroupOffsets() {
+        String groupId = "group1";
+        alterShareAutoOffsetReset(groupId, "earliest");
+        try (Producer<byte[], byte[]> producer = createProducer();
+             Admin adminClient = createAdminClient()) {
+            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp.topic(), tp.partition(), null, "key".getBytes(), "Message".getBytes());
+            // Producing 5 records to the topic partition.
+            for (int i = 0; i < 5; i++) {
+                producer.send(record);
+            }
+            producer.flush();
+            // Create a new share consumer. Since the share.auto.offset.reset is not altered, it should be latest by default.
+            ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));
+            shareConsumer.subscribe(List.of(tp.topic()));
+            // Polling share consumer to make sure it joins the group and consumes the produced records.
+            ConsumerRecords<byte[], byte[]> records = waitedPoll(shareConsumer, 2500L, 5);
+            assertEquals(5, records.count());
+            // Accept the records first to move the offset forward and register the state with persister.
+            records.forEach(r -> shareConsumer.acknowledge(r, AcknowledgeType.ACCEPT));
+            shareConsumer.commitSync();
+            // After accepting, the lag should be 0 because the record is consumed successfully.
+            verifySharePartitionLag(adminClient, groupId, tp, 0L);
+            // Closing the share consumer so that the offsets can be deleted.
+            shareConsumer.close();
+            // Delete the start offset of the share partition to 0.
+            deleteShareGroupOffsets(adminClient, groupId, tp.topic());
+            // Create a new share consumer.
             ShareConsumer<byte[], byte[]> shareConsumer2 = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));
             shareConsumer2.subscribe(List.of(tp.topic()));
-            // Since the start offset was altered, the new share consumer should start consuming from offset 0 onwards.
-            // Polling share consumer to make sure all 150 records (0 - 104) are consumed.
-            records = waitedPoll(shareConsumer2, 2500L, 105);
-            assertEquals(105, records.count());
-            // Since the consumed records haven't been acknowledged yet, the share partition lag should be 105.
-            verifySharePartitionLag(adminClient, groupId, tp, 105L);
-            // Acknowledge and commit the consumed records to update the share partition state.
+            // Since the offsets are deleted, the share consumer should consume from the beginning (share.auto.offset.reset is earliest).
+            // Thus, the consumer should consume all 5 records again.
+            records = waitedPoll(shareConsumer2, 2500L, 5);
+            assertEquals(5, records.count());
+            // Accept the records first to move the offset forward and register the state with persister.
             records.forEach(r -> shareConsumer2.acknowledge(r, AcknowledgeType.ACCEPT));
             shareConsumer2.commitSync();
-            // After acknowledging the lag should be 0, because the records hav been accepted.
+            // After accepting, the lag should be 0 because the records are consumed successfully.
             verifySharePartitionLag(adminClient, groupId, tp, 0L);
+            // Closing the share consumer so that the offsets can be deleted.
             shareConsumer2.close();
         } catch (InterruptedException | ExecutionException e) {
             fail("Test failed with exception: " + e.getMessage());
@@ -4174,6 +4208,13 @@ public class ShareConsumerTest {
             groupId,
             Map.of(topicPartition, newOffset),
             new AlterShareGroupOffsetsOptions().timeoutMs(30000)).partitionResult(topicPartition).get();
+    }
+
+    private void deleteShareGroupOffsets(Admin adminClient, String groupId, String topic) throws InterruptedException, ExecutionException {
+        adminClient.deleteShareGroupOffsets(
+            groupId,
+            Set.of(topic),
+            new DeleteShareGroupOffsetsOptions().timeoutMs(30000)).topicResult(topic).get();
     }
 
     private void alterShareRecordLockDurationMs(String groupId, int newValue) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -21,6 +21,7 @@ import kafka.server.KafkaBroker;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsOptions;
+import org.apache.kafka.clients.admin.AlterShareGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeShareGroupsOptions;
@@ -3412,6 +3413,62 @@ public class ShareConsumerTest {
     }
 
     @ClusterTest
+    public void testSharePartitionLagAfterAlterShareGroupOffsets() {
+        String groupId = "group1";
+        try (Producer<byte[], byte[]> producer = createProducer();
+             Admin adminClient = createAdminClient()) {
+            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(tp.topic(), tp.partition(), null, "key".getBytes(), "Message".getBytes());
+            // Producing 100 records to the topic partition.
+            for (int i = 0; i < 100; i++) {
+                producer.send(record);
+            }
+            producer.flush();
+
+            // Create a new share consumer. Since the share.auto.offset.reset is not altered, it should be latest by default.
+            ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));
+            shareConsumer.subscribe(List.of(tp.topic()));
+            // Polling share consumer to make sure it joins the group and subscribes to the topic.
+            waitedPoll(shareConsumer, 2500L, 0, true, groupId, List.of(new TopicPartition(tp.topic(), 0)));
+            // Producing 5 additional records to the topic partition.
+            for (int i = 0; i < 5; i++) {
+                producer.send(record);
+            }
+            producer.flush();
+            // Polling share consumer to make sure the records are consumed.
+            ConsumerRecords<byte[], byte[]> records = waitedPoll(shareConsumer, 2500L, 5);
+            assertEquals(5, records.count());
+            // Accept the record first to move the offset forward and register the state with persister.
+            records.forEach(r -> shareConsumer.acknowledge(r, AcknowledgeType.ACCEPT));
+            shareConsumer.commitSync();
+            // After accepting, the lag should be 0 because the record is consumed successfully.
+            verifySharePartitionLag(adminClient, groupId, tp, 0L);
+            // Closing the share consumer so that the offsets can be altered.
+            shareConsumer.close();
+            // Alter the start offset of the share partition to 0.
+            alterShareGroupOffsets(adminClient, groupId, tp, 0L);
+            // After altering, the share partition start offset should be 0.
+            verifySharePartitionStartOffset(adminClient, groupId, tp, 0L);
+            // Create another share consumer.
+            ShareConsumer<byte[], byte[]> shareConsumer2 = createShareConsumer(groupId, Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT));
+            shareConsumer2.subscribe(List.of(tp.topic()));
+            // Since the start offset was altered, the new share consumer should start consuming from offset 0 onwards.
+            // Polling share consumer to make sure all 150 records (0 - 104) are consumed.
+            records = waitedPoll(shareConsumer2, 2500L, 105);
+            assertEquals(105, records.count());
+            // Since the consumed records haven't been acknowledged yet, the share partition lag should be 105.
+            verifySharePartitionLag(adminClient, groupId, tp, 105L);
+            // Acknowledge and commit the consumed records to update the share partition state.
+            records.forEach(r -> shareConsumer2.acknowledge(r, AcknowledgeType.ACCEPT));
+            shareConsumer2.commitSync();
+            // After acknowledging the lag should be 0, because the records hav been accepted.
+            verifySharePartitionLag(adminClient, groupId, tp, 0L);
+            shareConsumer2.close();
+        } catch (InterruptedException | ExecutionException e) {
+            fail("Test failed with exception: " + e.getMessage());
+        }
+    }
+
+    @ClusterTest
     public void testFetchWithThrottledDelivery() {
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -4095,6 +4152,14 @@ public class ShareConsumerTest {
         return partitionResult;
     }
 
+    private void verifySharePartitionStartOffset(Admin adminClient, String groupId, TopicPartition tp, long expectedStartOffset) throws InterruptedException {
+        TestUtils.waitForCondition(() -> {
+            SharePartitionOffsetInfo sharePartitionOffsetInfo = sharePartitionOffsetInfo(adminClient, groupId, tp);
+            return sharePartitionOffsetInfo != null &&
+                sharePartitionOffsetInfo.startOffset() == expectedStartOffset;
+        }, DEFAULT_MAX_WAIT_MS, DEFAULT_POLL_INTERVAL_MS, () -> "Failed to retrieve share partition lag");
+    }
+
     private void verifySharePartitionLag(Admin adminClient, String groupId, TopicPartition tp, long expectedLag) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             SharePartitionOffsetInfo sharePartitionOffsetInfo = sharePartitionOffsetInfo(adminClient, groupId, tp);
@@ -4102,6 +4167,13 @@ public class ShareConsumerTest {
                 sharePartitionOffsetInfo.lag().isPresent() &&
                 sharePartitionOffsetInfo.lag().get() == expectedLag;
         }, DEFAULT_MAX_WAIT_MS, DEFAULT_POLL_INTERVAL_MS, () -> "Failed to retrieve share partition lag");
+    }
+
+    private void alterShareGroupOffsets(Admin adminClient, String groupId, TopicPartition topicPartition, Long newOffset) throws InterruptedException, ExecutionException {
+        adminClient.alterShareGroupOffsets(
+            groupId,
+            Map.of(topicPartition, newOffset),
+            new AlterShareGroupOffsetsOptions().timeoutMs(30000)).partitionResult(topicPartition).get();
     }
 
     private void alterShareRecordLockDurationMs(String groupId, int newValue) {

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PartitionFactory.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PartitionFactory.java
@@ -42,7 +42,12 @@ public class PartitionFactory {
     }
 
     public static PartitionStateData newPartitionStateData(int partition, int stateEpoch, long startOffset) {
-        return new PartitionData(partition, stateEpoch, startOffset, UNINITIALIZED_DELIVERY_COMPLETE_COUNT, DEFAULT_ERROR_CODE, DEFAULT_ERR_MESSAGE, DEFAULT_LEADER_EPOCH, null);
+        // If the start offset is uninitialized (when the share partition is being initialized for the first time), the 
+        // consumption hasn't started yet, and lag cannot be calculated. Thus, deliveryCompleteCount is also set as -1. 
+        // But, if start offset is a non-negative value (when the start offset is altered), the lag can be calculated 
+        // from that point onward. Hence, we set deliveryCompleteCount to 0 in that case.
+        int deliveryCompleteCount = startOffset == UNINITIALIZED_START_OFFSET ? UNINITIALIZED_DELIVERY_COMPLETE_COUNT : 0;
+        return new PartitionData(partition, stateEpoch, startOffset, deliveryCompleteCount, DEFAULT_ERROR_CODE, DEFAULT_ERR_MESSAGE, DEFAULT_LEADER_EPOCH, null);
     }
 
     public static PartitionErrorData newPartitionErrorData(int partition, short errorCode, String errorMessage) {


### PR DESCRIPTION
Currently, when the start offset for a share partition is altered, the
deliveryCompleteCount is set as -1. This results in a hyphenated lag,
until the consumption begins, leading to some write states sent to the
persister. But, when the start offset is altered to some non zero value,
the system should be able to calculate the lag, irrespective of whether
the consumption has begun or not from the new place. This PR resolves
this by setting the deliveryCompleteCount to 0, whenever the start
offset is changed to a non negative value.

Test Results ->  <img width="1726" height="928" alt="image"
src="https://github.com/user-attachments/assets/35dc8b43-4590-4d80-868e-1764d7ceb2f8"
/>

Reviewers: Sushant Mahajan <smahajan@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
