### PR TITLE
MINOR: Add integration test for offset deletion on topic deletion

### DIFF
--- a/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
@@ -688,7 +688,7 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
         .setGroupId("grp")
         .setTopics(List(
           new OffsetFetchResponseData.OffsetFetchResponseTopics()
-            .setTopicId(topicId)
+            .setName("foo")
             .setPartitions(List(
               new OffsetFetchResponseData.OffsetFetchResponsePartitions()
                 .setPartitionIndex(0)
@@ -708,7 +708,7 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
           .setMemberEpoch(memberEpoch)
           .setTopics(null),
         requireStable = false,
-        version = ApiKeys.OFFSET_FETCH.latestVersion(isUnstableApiEnabled)
+        version = 9
       )
     )
 
@@ -726,7 +726,9 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
             .setMemberEpoch(-1)
             .setTopics(null),
           requireStable = false,
-          version = ApiKeys.OFFSET_FETCH.latestVersion(isUnstableApiEnabled)
+          // Force using version 9 (and topic names) because unknown topic ids
+          // are filtered out.
+          version = 9
         ).topics.isEmpty
       },
       msg = "Offsets should be deleted after topic deletion."

--- a/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetFetchRequestTest.scala
@@ -16,6 +16,7 @@
  */
 package kafka.server
 
+import kafka.utils.TestUtils
 import org.apache.kafka.common.test.api.{ClusterConfigProperty, ClusterTest, ClusterTestDefaults, Type}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.message.{OffsetFetchRequestData, OffsetFetchResponseData}
@@ -646,6 +647,90 @@ class OffsetFetchRequestTest(cluster: ClusterInstance) extends GroupCoordinatorB
         )
       )
     }
+  }
+
+  @ClusterTest
+  def testCommittedOffsetsDeletedWhenTopicDeleted(): Unit = {
+    // This test verifies that committed offsets are deleted when a topic is deleted.
+    // When a topic is deleted, GroupCoordinatorService.onMetadataUpdate is called which
+    // schedules the deletion of all committed offsets for the deleted topic partitions.
+
+    createOffsetsTopic()
+
+    // Create the topic.
+    val topicId = createTopic(
+      topic = "foo",
+      numPartitions = 3
+    )
+
+    // Join the consumer group. Note that we don't heartbeat here so we must use
+    // a session long enough for the duration of the test.
+    val (memberId, memberEpoch) = joinConsumerGroup("grp", useNewProtocol = true)
+
+    // Commit offsets.
+    for (partitionId <- 0 to 2) {
+      commitOffset(
+        groupId = "grp",
+        memberId = memberId,
+        memberEpoch = memberEpoch,
+        topic = "foo",
+        topicId = topicId,
+        partition = partitionId,
+        offset = 100L + partitionId,
+        expectedError = Errors.NONE,
+        version = ApiKeys.OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)
+      )
+    }
+
+    // Verify that the offsets are committed.
+    assertEquals(
+      new OffsetFetchResponseData.OffsetFetchResponseGroup()
+        .setGroupId("grp")
+        .setTopics(List(
+          new OffsetFetchResponseData.OffsetFetchResponseTopics()
+            .setTopicId(topicId)
+            .setPartitions(List(
+              new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                .setPartitionIndex(0)
+                .setCommittedOffset(100L),
+              new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                .setPartitionIndex(1)
+                .setCommittedOffset(101L),
+              new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                .setPartitionIndex(2)
+                .setCommittedOffset(102L)
+            ).asJava)
+        ).asJava),
+      fetchOffsets(
+        group = new OffsetFetchRequestData.OffsetFetchRequestGroup()
+          .setGroupId("grp")
+          .setMemberId(memberId)
+          .setMemberEpoch(memberEpoch)
+          .setTopics(null),
+        requireStable = false,
+        version = ApiKeys.OFFSET_FETCH.latestVersion(isUnstableApiEnabled)
+      )
+    )
+
+    // Delete the topic.
+    deleteTopic("foo")
+
+    // Wait until the offsets are deleted. The offsets should be deleted
+    // when the topic deletion is processed by onMetadataUpdate.
+    TestUtils.waitUntilTrue(
+      () => {
+        fetchOffsets(
+          group = new OffsetFetchRequestData.OffsetFetchRequestGroup()
+            .setGroupId("grp")
+            .setMemberId("")
+            .setMemberEpoch(-1)
+            .setTopics(null),
+          requireStable = false,
+          version = ApiKeys.OFFSET_FETCH.latestVersion(isUnstableApiEnabled)
+        ).topics.isEmpty
+      },
+      msg = "Offsets should be deleted after topic deletion."
+    )
   }
 
   @ClusterTest


### PR DESCRIPTION
This patch adds an integration test to verify that committed offsets are
deleted when a topic is deleted.

Reviewers: Sean Quah <squah@confluent.io>, Dongnuo Lyu
 <dlyu@confluent.io>, Lianet Magrans <lmagrans@confluent.io>
