### PR TITLE
KAFKA-20042: Upgraded Jose4J to 0.9.6 to remediate CVE-2024-29371

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -239,7 +239,7 @@ jetty-servlet-9.4.57.v20241219
 jetty-servlets-9.4.57.v20241219
 jetty-util-9.4.57.v20241219
 jetty-util-ajax-9.4.57.v20241219
-jose4j-0.9.5
+jose4j-0.9.6
 lz4-java-1.10.1
 maven-artifact-3.9.6
 metrics-core-4.1.12.1

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -239,7 +239,7 @@ jetty-servlet-9.4.57.v20241219
 jetty-servlets-9.4.57.v20241219
 jetty-util-9.4.57.v20241219
 jetty-util-ajax-9.4.57.v20241219
-jose4j-0.9.4
+jose4j-0.9.5
 lz4-java-1.10.1
 maven-artifact-3.9.6
 metrics-core-4.1.12.1

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -111,7 +111,7 @@ versions += [
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.5",
+  jose4j: "0.9.6",
   junit: "5.10.2",
   jqwik: "1.8.3",
   kafka_0100: "0.10.0.1",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -111,7 +111,7 @@ versions += [
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.4",
+  jose4j: "0.9.5",
   junit: "5.10.2",
   jqwik: "1.8.3",
   kafka_0100: "0.10.0.1",


### PR DESCRIPTION
Upgraded Jose4J from 0.9.4 to 0.9.6 to remediate CVE-2024-29371

Reviewers: Shicheng Rao <shichengrao@users.noreply.github.com>, Chia-Ping Tsai <chia7712@gmail.com>
