### PR TITLE
KAFKA-20046: switched the java version for streams-scala from 17 to 11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ plugins {
 ext {
   minClientJavaVersion = 11
   minNonClientJavaVersion = 17
-  modulesNeedingJava11 = [":clients", ":generator", ":streams", ":streams:test-utils", ":streams:examples", ":streams-scala", ":test-common:test-common-util"]
+  modulesNeedingJava11 = [":clients", ":generator", ":streams", ":streams:test-utils", ":streams:examples", ":streams:streams-scala", ":test-common:test-common-util"]
 
   buildVersionFileName = "kafka-version.properties"
 


### PR DESCRIPTION
Verified that the classes are compiled with version 55 using javap

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>, PoAn Yang <payang@apache.org>
