### PR TITLE
Strategy based implementation of acquire mode in SharePartition

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -52,6 +52,11 @@ import org.apache.kafka.server.share.fetch.InFlightBatch;
 import org.apache.kafka.server.share.fetch.InFlightState;
 import org.apache.kafka.server.share.fetch.RecordState;
 import org.apache.kafka.server.share.fetch.ShareAcquiredRecords;
+import org.apache.kafka.server.share.fetch.acquire.AcquireStrategy;
+import org.apache.kafka.server.share.fetch.acquire.BatchCreationContext;
+import org.apache.kafka.server.share.fetch.acquire.BatchCreationResult;
+import org.apache.kafka.server.share.fetch.acquire.BatchOptimizedStrategy;
+import org.apache.kafka.server.share.fetch.acquire.RecordLimitStrategy;
 import org.apache.kafka.server.share.metrics.SharePartitionMetrics;
 import org.apache.kafka.server.share.persister.GroupTopicPartitionData;
 import org.apache.kafka.server.share.persister.PartitionAllData;
@@ -724,7 +729,7 @@ public class SharePartition {
         FetchIsolation isolationLevel
     ) {
         log.trace("Received acquire request for share partition: {}-{} memberId: {}", groupId, topicIdPartition, memberId);
-        boolean isRecordLimitMode = isRecordLimitMode(shareAcquireMode);
+        AcquireStrategy strategy = selectStrategy(shareAcquireMode);
         if (stateNotActive() || maxFetchRecords <= 0) {
             // Nothing to acquire.
             return ShareAcquiredRecords.empty();
@@ -817,7 +822,7 @@ public class SharePartition {
                 // in ARCHIVED state. The fetch returns 0-10 as first batch, then the baseOffset
                 // is adjusted to 5, to the startOffset. As there is no cached batch from 0-10, the
                 // submap will be empty and the first offset for batch for acquire should be 5 not 0.
-                ShareAcquiredRecords shareAcquiredRecords = acquireNewBatchRecords(memberId, fetchPartitionData.records.batches(), isRecordLimitMode,
+                ShareAcquiredRecords shareAcquiredRecords = acquireNewBatchRecords(memberId, fetchPartitionData.records.batches(), strategy,
                     baseOffset, lastOffsetToAcquire, batchSize, maxRecordsToAcquire);
                 return maybeFilterAbortedTransactionalAcquiredRecords(fetchPartitionData, isolationLevel, shareAcquiredRecords);
             }
@@ -857,7 +862,7 @@ public class SharePartition {
                         // fetch returns batches from 0-25, then the sub map will have 2 entries and
                         // gap will be computed correctly.
                         int numRecordsRemaining = maxRecordsToAcquire - acquiredCount;
-                        ShareAcquiredRecords shareAcquiredRecords = acquireNewBatchRecords(memberId, fetchPartitionData.records.batches(), isRecordLimitMode,
+                        ShareAcquiredRecords shareAcquiredRecords = acquireNewBatchRecords(memberId, fetchPartitionData.records.batches(), strategy,
                             maybeGapStartOffset, entry.getKey() - 1, batchSize, numRecordsRemaining);
                         result.addAll(shareAcquiredRecords.acquiredRecords());
                         acquiredCount += shareAcquiredRecords.count();
@@ -874,7 +879,7 @@ public class SharePartition {
                 // Compute if the batch is a full match.
                 boolean fullMatch = checkForFullMatch(inFlightBatch, firstBatch.baseOffset(), lastOffsetToAcquire);
                 int numRecordsRemaining = maxRecordsToAcquire - acquiredCount;
-                boolean recordLimitSubsetMatch = isRecordLimitMode && checkForRecordLimitSubsetMatch(inFlightBatch, maxRecordsToAcquire, acquiredCount);
+                boolean recordLimitSubsetMatch = strategy.requiresSubsetMatch(inFlightBatch, maxRecordsToAcquire, acquiredCount);
                 boolean throttleRecordsDelivery = shouldThrottleRecordsDelivery(inFlightBatch, firstBatch.baseOffset(), lastOffsetToAcquire);
                 // Stop acquiring more records if records delivery has to be throttled. The throttling prevents
                 // complete batch to be archived in case of a single record being corrupt.
@@ -908,7 +913,7 @@ public class SharePartition {
                     // In record_limit mode, we need to ensure that we do not acquire more than
                     // maxRecordsToAcquire. Hence, pass the remaining number of records that can
                     // be acquired.
-                    int acquiredSubsetCount = acquireSubsetBatchRecords(memberId, isRecordLimitMode, numRecordsRemaining, firstBatch.baseOffset(), lastOffsetToAcquire, inFlightBatch, result);
+                    int acquiredSubsetCount = acquireSubsetBatchRecords(memberId, strategy, numRecordsRemaining, firstBatch.baseOffset(), lastOffsetToAcquire, inFlightBatch, result);
 
                     acquiredCount += acquiredSubsetCount;
                     // If records are throttled, return immediately and set `maxRecordsToAcquire = 0`
@@ -950,7 +955,7 @@ public class SharePartition {
             if (acquiredCount < maxRecordsToAcquire && subMap.lastEntry().getValue().lastOffset() < lastOffsetToAcquire) {
                 log.trace("There exists another batch which needs to be acquired as well");
                 int numRecordsRemaining = maxRecordsToAcquire - acquiredCount;
-                ShareAcquiredRecords shareAcquiredRecords = acquireNewBatchRecords(memberId, fetchPartitionData.records.batches(), isRecordLimitMode,
+                ShareAcquiredRecords shareAcquiredRecords = acquireNewBatchRecords(memberId, fetchPartitionData.records.batches(), strategy,
                     subMap.lastEntry().getValue().lastOffset() + 1,
                     lastOffsetToAcquire, batchSize, numRecordsRemaining);
                 result.addAll(shareAcquiredRecords.acquiredRecords());
@@ -1723,7 +1728,7 @@ public class SharePartition {
     private ShareAcquiredRecords acquireNewBatchRecords(
         String memberId,
         Iterable<? extends RecordBatch> batches,
-        boolean isRecordLimitMode,
+        AcquireStrategy strategy,
         long firstOffset,
         long lastOffset,
         int batchSize,
@@ -1766,7 +1771,7 @@ public class SharePartition {
             }
 
             // Create batches of acquired records.
-            List<AcquiredRecords> acquiredRecords = createBatches(memberId, batches, isRecordLimitMode, maxFetchRecords, firstAcquiredOffset, lastAcquiredOffset, batchSize);
+            List<AcquiredRecords> acquiredRecords = createBatches(memberId, batches, strategy, maxFetchRecords, firstAcquiredOffset, lastAcquiredOffset, batchSize);
             // if the cachedState was empty before acquiring the new batches then startOffset needs to be updated
             if (cachedState.firstKey() == firstAcquiredOffset)  {
                 startOffset = firstAcquiredOffset;
@@ -1781,9 +1786,8 @@ public class SharePartition {
             }
             // Update lastAcquireOffset to the last offset of acquired records in record_limit mode
             // Since this is required to calculate the actual number of offsets acquired.
-            if (isRecordLimitMode) {
-                lastAcquiredOffset = acquiredRecords.get(0).lastOffset();
-            }
+            lastAcquiredOffset = strategy.effectiveLastOffset(acquiredRecords, lastAcquiredOffset);
+
             maybeUpdatePersisterGapWindowStartOffset(lastAcquiredOffset + 1);
             return new ShareAcquiredRecords(acquiredRecords, (int) (lastAcquiredOffset - firstAcquiredOffset + 1));
         } finally {
@@ -1794,7 +1798,7 @@ public class SharePartition {
     private List<AcquiredRecords> createBatches(
         String memberId,
         Iterable<? extends RecordBatch> batches,
-        boolean isRecordLimitMode,
+        AcquireStrategy strategy,
         int maxFetchRecords,
         long firstAcquiredOffset,
         long lastAcquiredOffset,
@@ -1802,119 +1806,77 @@ public class SharePartition {
     ) {
         lock.writeLock().lock();
         try {
-            List<AcquiredRecords> result = new ArrayList<>();
-            long currentFirstOffset = firstAcquiredOffset;
-            // Batch splitting only occurs in batch_optimized mode when the number of records to acquire exceeds the batch size.
-            // If acquireMode is record_limit, or the batch size is greater than the number of records to acquire, no splitting is performed.
-            long recordCount = lastAcquiredOffset - firstAcquiredOffset + 1;
-            if (!isRecordLimitMode && recordCount > batchSize) {
-                // The batch is split into multiple batches considering batch size.
-                // Note: Try reading only the baseOffset of the batch and avoid reading the lastOffset
-                // as lastOffset call of RecordBatch is expensive (loads headers).
-                for (RecordBatch batch : batches) {
-                    long batchBaseOffset = batch.baseOffset();
-                    // Check if the batch is already past the last acquired offset then break.
-                    if (batchBaseOffset > lastAcquiredOffset) {
-                        // Break the loop and the last batch will be processed outside the loop.
-                        break;
-                    }
+            BatchCreationContext context = new BatchCreationContext(
+                memberId,
+                batches,
+                firstAcquiredOffset,
+                lastAcquiredOffset,
+                batchSize,
+                maxFetchRecords,
+                createBatchCacheOperations()
+            );
 
-                    // Create new batch once the batch size is reached.
-                    if (batchBaseOffset - currentFirstOffset >= batchSize) {
-                        result.add(new AcquiredRecords()
-                            .setFirstOffset(currentFirstOffset)
-                            .setLastOffset(batchBaseOffset - 1)
-                            .setDeliveryCount((short) 1));
-                        currentFirstOffset = batchBaseOffset;
-                    }
-                }
+            BatchCreationResult result = strategy.createBatches(context);
+
+            if (result.findNextFetchOffsetUpdated()) {
+                updateFindNextFetchOffset(true);
             }
-            // Add the last batch or the only batch if the batch size is greater than the records which
-            // can be acquired.
-            result.add(new AcquiredRecords()
-                .setFirstOffset(currentFirstOffset)
-                .setLastOffset(lastAcquiredOffset)
-                .setDeliveryCount((short) 1));
 
-            if (isRecordLimitMode) {
-                // In record_limit mode, there will always be only one single batch in the result.
-                AcquiredRecords acquiredRecords = result.get(0);
-                // When the count of acquired records exceeds the max fetch limit, only initialize and schedule acquisition lock for
-                // acquired records up to the max fetch boundary and remaining offsets should still in available state.
-                // i.e. acquired records are 10-19 (10 records) and max fetch records is 5, then only 10-14 should be acquired
-                // and offset 15-19 should still in available state.
-                if (acquiredRecords.lastOffset() - acquiredRecords.firstOffset() + 1 > maxFetchRecords) {
-                    InFlightBatch inFlightBatch = new InFlightBatch(
-                        timer,
-                        time,
-                        memberId,
-                        acquiredRecords.firstOffset(),
-                        acquiredRecords.lastOffset(),
-                        RecordState.ACQUIRED,
-                        1,
-                        null,
-                        timeoutHandler,
-                        sharePartitionMetrics);
-                    int delayMs = recordLockDurationMsOrDefault(groupConfigManager, groupId, defaultRecordLockDurationMs);
-                    long lastOffset = acquiredRecords.firstOffset() + maxFetchRecords - 1;
-                    inFlightBatch.maybeInitializeOffsetStateUpdate(lastOffset, delayMs);
-                    updateFindNextFetchOffset(true);
-
-                    cachedState.put(acquiredRecords.firstOffset(), inFlightBatch);
-                    sharePartitionMetrics.recordInFlightBatchMessageCount(
-                        acquiredRecords.lastOffset() - acquiredRecords.firstOffset() + 1);
-                    acquiredRecords.setLastOffset(lastOffset);
-                    return List.of(acquiredRecords);
-                }
-            }
-            addBatches(memberId, result);
-            return result;
+            return result.acquiredRecords();
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-    /**
-     * Add the acquired record batches to the cache and schedule acquisition lock timeouts.
-     *
-     * @param memberId The member id for which the records are acquired.
-     * @param acquiredRecordsList The list of acquired records to add to cache state.
-     */
-    private void addBatches(String memberId, List<AcquiredRecords> acquiredRecordsList) {
-        lock.writeLock().lock();
-        try {
-            acquiredRecordsList.forEach(acquiredRecords -> {
-                AcquisitionLockTimerTask timerTask = scheduleAcquisitionLockTimeout(
-                    memberId, acquiredRecords.firstOffset(), acquiredRecords.lastOffset());
+    // Helper method to create the callback interface implementation
+    private BatchCreationContext.BatchCacheOperations createBatchCacheOperations() {
+        return new BatchCreationContext.BatchCacheOperations() {
+            @Override
+            public void addBatchToCache(String memberId, long firstOffset, long lastOffset,
+                                        AcquisitionLockTimerTask timerTask) {
+                cachedState.put(firstOffset, new InFlightBatch(
+                    timer, time, memberId, firstOffset, lastOffset,
+                    RecordState.ACQUIRED, 1, timerTask, timeoutHandler, sharePartitionMetrics
+                ));
+            }
 
-                cachedState.put(acquiredRecords.firstOffset(), new InFlightBatch(
-                    timer,
-                    time,
-                    memberId,
-                    acquiredRecords.firstOffset(),
-                    acquiredRecords.lastOffset(),
-                    RecordState.ACQUIRED,
-                    1,
-                    timerTask,
-                    timeoutHandler,
-                    sharePartitionMetrics));
-                // Update the in-flight batch message count metrics for the share partition.
-                sharePartitionMetrics.recordInFlightBatchMessageCount(acquiredRecords.lastOffset() - acquiredRecords.firstOffset() + 1);
-            });
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
+            @Override
+            public void addBatchWithOffsetState(String memberId, long firstOffset, long lastOffset,
+                                                long acquiredLastOffset, int delayMs) {
+                InFlightBatch inFlightBatch = new InFlightBatch(
+                    timer, time, memberId, firstOffset, lastOffset,
+                    RecordState.ACQUIRED, 1, null, timeoutHandler, sharePartitionMetrics
+                );
+                inFlightBatch.maybeInitializeOffsetStateUpdate(acquiredLastOffset, delayMs);
+                cachedState.put(firstOffset, inFlightBatch);
+            }
 
-    private boolean checkForRecordLimitSubsetMatch(InFlightBatch inFlightBatch, int maxRecordsToAcquire, int acquiredCount) {
-        long numRecordsInBatch = inFlightBatch.lastOffset() - inFlightBatch.firstOffset() + 1;
-        int numRecordsRemaining = maxRecordsToAcquire - acquiredCount;
-        return numRecordsInBatch > numRecordsRemaining;
+            @Override
+            public AcquisitionLockTimerTask scheduleAcquisitionLockTimeout(String memberId,
+                                                                           long firstOffset, long lastOffset) {
+                return SharePartition.this.scheduleAcquisitionLockTimeout(memberId, firstOffset, lastOffset);
+            }
+
+            @Override
+            public int recordLockDurationMs() {
+                return recordLockDurationMsOrDefault(groupConfigManager, groupId, defaultRecordLockDurationMs);
+            }
+
+            @Override
+            public void updateFindNextFetchOffset(boolean value) {
+                SharePartition.this.updateFindNextFetchOffset(value);
+            }
+
+            @Override
+            public void recordInFlightBatchMessageCount(long count) {
+                sharePartitionMetrics.recordInFlightBatchMessageCount(count);
+            }
+        };
     }
 
     private int acquireSubsetBatchRecords(
         String memberId,
-        boolean isRecordLimitMode,
+        AcquireStrategy strategy,
         long maxFetchRecords,
         long requestFirstOffset,
         long requestLastOffset,
@@ -2001,7 +1963,7 @@ public class SharePartition {
                         offsetState.getKey(), groupId, topicIdPartition);
                     break;
                 }
-                if (isRecordLimitMode && acquiredCount == maxFetchRecords) {
+                if (strategy.shouldStopSubsetAcquisition(acquiredCount, maxFetchRecords)) {
                     // In record_limit mode, acquire only the requested number of records.
                     break;
                 }
@@ -3218,6 +3180,12 @@ public class SharePartition {
         return orderedAbortedTransactions;
     }
 
+    private AcquireStrategy selectStrategy(ShareAcquireMode shareAcquireMode) {
+        return ShareAcquireMode.RECORD_LIMIT.equals(shareAcquireMode)
+            ? RecordLimitStrategy.INSTANCE
+            : BatchOptimizedStrategy.INSTANCE;
+    }
+
     private boolean isBatchAborted(RecordBatch batch, Set<Long> abortedProducerIds) {
         return batch.isTransactional() && abortedProducerIds.contains(batch.producerId());
     }
@@ -3248,10 +3216,6 @@ public class SharePartition {
         } finally {
             lock.readLock().unlock();
         }
-    }
-
-    private boolean isRecordLimitMode(ShareAcquireMode shareAcquireMode) {
-        return ShareAcquireMode.RECORD_LIMIT.equals(shareAcquireMode);
     }
 
     // Visible for testing.

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/AcquireStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/AcquireStrategy.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch.acquire;
+
+import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
+import org.apache.kafka.server.share.fetch.InFlightBatch;
+
+import java.util.List;
+
+/**
+ * Strategy interface for acquiring records in different modes.
+ * <p>
+ * Two modes are supported:
+ * <ul>
+ *   <li>{@code BATCH_OPTIMIZED} - Acquires records in batches optimized for throughput,
+ *       potentially splitting large fetches into multiple batches based on batch size.</li>
+ *   <li>{@code RECORD_LIMIT} - Acquires up to the requested number of records,
+ *       creating a single batch only.</li>
+ * </ul>
+ */
+public interface AcquireStrategy {
+
+    /**
+     * Determines if the in-flight batch requires subset matching based on the acquisition mode
+     * and remaining records to acquire.
+     * <p>
+     * In {@code RECORD_LIMIT} mode, this returns true if the batch contains more records
+     * than can be acquired. In {@code BATCH_OPTIMIZED} mode, this always returns false
+     * as the mode doesn't force subset matching based on record count alone.
+     *
+     * @param inFlightBatch      The in-flight batch to evaluate.
+     * @param maxRecordsToAcquire The maximum total records that can be acquired in this request.
+     * @param acquiredCount      The number of records already acquired.
+     * @return True if subset matching is required, false otherwise.
+     */
+    boolean requiresSubsetMatch(InFlightBatch inFlightBatch, int maxRecordsToAcquire, int acquiredCount);
+
+    /**
+     * Creates acquired record batches from the given offset range.
+     *
+     * @param context The batch creation context.
+     * @return The result containing the list of acquired records and any side effects.
+     */
+    BatchCreationResult createBatches(BatchCreationContext context);
+
+    /**
+     * Calculates the effective last offset to return to the caller after batch creation.
+     *
+     * @param acquiredRecords      The list of acquired records created.
+     * @param originalLastOffset   The original last offset before batch creation.
+     * @return The effective last offset to use for count calculations.
+     */
+    long effectiveLastOffset(List<AcquiredRecords> acquiredRecords, long originalLastOffset);
+
+    /**
+     * Checks if acquisition should stop after acquiring records from a subset batch.
+     *
+     * @param acquiredCount   The number of records acquired from the current batch.
+     * @param maxFetchRecords The maximum number of records to acquire.
+     * @return True if acquisition should stop, false otherwise.
+     */
+    boolean shouldStopSubsetAcquisition(int acquiredCount, long maxFetchRecords);
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/BatchCreationContext.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/BatchCreationContext.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch.acquire;
+
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.server.share.fetch.AcquisitionLockTimerTask;
+
+/**
+ * Context object containing all parameters needed for batch creation.
+ */
+public record BatchCreationContext(
+    String memberId,
+    Iterable<? extends RecordBatch> batches,
+    long firstAcquiredOffset,
+    long lastAcquiredOffset,
+    int batchSize,
+    int maxFetchRecords,
+    BatchCacheOperations cacheOperations // Callback interface for operations that require SharePartition state
+) {
+    /**
+     * Interface for operations that interact with SharePartition's cached state.
+     * This allows the strategy to perform necessary state updates without
+     * direct access to SharePartition internals.
+     */
+    public interface BatchCacheOperations {
+        /**
+         * Adds a new in-flight batch to the cache with acquisition lock scheduled.
+         */
+        void addBatchToCache(
+            String memberId,
+            long firstOffset,
+            long lastOffset,
+            AcquisitionLockTimerTask timerTask
+        );
+
+        /**
+         * Adds a new in-flight batch with offset state initialized for partial acquisition.
+         * Used in record_limit mode when batch exceeds max fetch records.
+         */
+        void addBatchWithOffsetState(
+            String memberId,
+            long firstOffset,
+            long lastOffset,
+            long acquiredLastOffset,
+            int delayMs
+        );
+
+        /**
+         * Schedules an acquisition lock timeout for the given offset range.
+         */
+        AcquisitionLockTimerTask scheduleAcquisitionLockTimeout(
+            String memberId,
+            long firstOffset,
+            long lastOffset
+        );
+
+        /**
+         * Gets the record lock duration in milliseconds.
+         */
+        int recordLockDurationMs();
+
+        /**
+         * Updates the findNextFetchOffset flag.
+         */
+        void updateFindNextFetchOffset(boolean value);
+
+        /**
+         * Records metrics for in-flight batch message count.
+         */
+        void recordInFlightBatchMessageCount(long count);
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/BatchCreationResult.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/BatchCreationResult.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch.acquire;
+
+import org.apache.kafka.common.message.ShareFetchResponseData;
+
+import java.util.List;
+
+public record BatchCreationResult(List<ShareFetchResponseData.AcquiredRecords> acquiredRecords, boolean findNextFetchOffsetUpdated) {
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/BatchOptimizedStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/BatchOptimizedStrategy.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch.acquire;
+
+import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.server.share.fetch.AcquisitionLockTimerTask;
+import org.apache.kafka.server.share.fetch.InFlightBatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Strategy for batch-optimized acquisition mode.
+ * <p>
+ * This mode optimizes for throughput by:
+ * <ul>
+ *   <li>Splitting large fetches into multiple batches based on configured batch size</li>
+ *   <li>Acquiring complete batches without per-record limits</li>
+ *   <li>All records in the range are acquired and scheduled with acquisition locks</li>
+ * </ul>
+ */
+public class BatchOptimizedStrategy implements AcquireStrategy {
+
+    public static final BatchOptimizedStrategy INSTANCE = new BatchOptimizedStrategy();
+
+    private BatchOptimizedStrategy() {
+        // Singleton class.
+    }
+
+    @Override
+    public boolean requiresSubsetMatch(InFlightBatch inFlightBatch, int maxRecordsToAcquire, int acquiredCount) {
+        // batch_optimized mode doesn't force subset matching based on record count alone.
+        // Subset matching is determined by other factors (fullMatch, offsetState, throttling).
+        return false;
+    }
+
+    @Override
+    public BatchCreationResult createBatches(BatchCreationContext context) {
+        List<AcquiredRecords> result = new ArrayList<>();
+        long currentFirstOffset = context.firstAcquiredOffset();
+        long recordCount = context.lastAcquiredOffset() - context.firstAcquiredOffset() + 1;
+
+        // Split into multiple batches if record count exceeds batch size
+        if (recordCount > context.batchSize()) {
+            for (RecordBatch batch : context.batches()) {
+                long batchBaseOffset = batch.baseOffset();
+
+                // Check if the batch is already past the last acquired offset then break.
+                if (batchBaseOffset > context.lastAcquiredOffset()) {
+                    // Break the loop and the last batch will be processed outside the loop.
+                    break;
+                }
+
+                // Create new batch once the batch size is reached
+                if (batchBaseOffset - currentFirstOffset >= context.batchSize()) {
+                    result.add(new AcquiredRecords()
+                        .setFirstOffset(currentFirstOffset)
+                        .setLastOffset(batchBaseOffset - 1)
+                        .setDeliveryCount((short) 1));
+                    currentFirstOffset = batchBaseOffset;
+                }
+            }
+        }
+
+        // Add the last batch or the only batch if the batch size is greater than the records which
+        // can be acquired.
+        result.add(new AcquiredRecords()
+            .setFirstOffset(currentFirstOffset)
+            .setLastOffset(context.lastAcquiredOffset())
+            .setDeliveryCount((short) 1));
+
+        // Add all batches to cache with acquisition locks
+        addBatchesToCache(context, result);
+
+        return new BatchCreationResult(result, false);
+    }
+
+    private void addBatchesToCache(BatchCreationContext context, List<AcquiredRecords> acquiredRecordsList) {
+        for (AcquiredRecords acquiredRecords : acquiredRecordsList) {
+            AcquisitionLockTimerTask timerTask = context.cacheOperations()
+                .scheduleAcquisitionLockTimeout(
+                    context.memberId(),
+                    acquiredRecords.firstOffset(),
+                    acquiredRecords.lastOffset()
+                );
+
+            context.cacheOperations().addBatchToCache(
+                context.memberId(),
+                acquiredRecords.firstOffset(),
+                acquiredRecords.lastOffset(),
+                timerTask
+            );
+
+            context.cacheOperations().recordInFlightBatchMessageCount(
+                acquiredRecords.lastOffset() - acquiredRecords.firstOffset() + 1
+            );
+        }
+    }
+
+    /**
+     * In {@code BATCH_OPTIMIZED} mode, this function returns the original last acquired offset.
+     */
+    @Override
+    public long effectiveLastOffset(List<AcquiredRecords> acquiredRecords, long originalLastOffset) {
+        // In batch_optimized mode, return the original last offset
+        return originalLastOffset;
+    }
+
+    @Override
+    public boolean shouldStopSubsetAcquisition(int acquiredCount, long maxFetchRecords) {
+        // batch_optimized mode doesn't have per-record limits within subset acquisition
+        return false;
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/RecordLimitStrategy.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/acquire/RecordLimitStrategy.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.share.fetch.acquire;
+
+import org.apache.kafka.common.message.ShareFetchResponseData.AcquiredRecords;
+import org.apache.kafka.server.share.fetch.AcquisitionLockTimerTask;
+import org.apache.kafka.server.share.fetch.InFlightBatch;
+
+import java.util.List;
+
+/**
+ * Strategy for record-limit acquisition mode.
+ * <p>
+ * This mode provides precise control over the number of records acquired by:
+ * <ul>
+ *   <li>Creating a single batch containing all records</li>
+ *   <li>Acquiring only up to maxFetchRecords, leaving remaining offsets AVAILABLE</li>
+ *   <li>Initializing offset state when batch exceeds the limit</li>
+ * </ul>
+ */
+public class RecordLimitStrategy implements AcquireStrategy {
+
+    public static final RecordLimitStrategy INSTANCE = new RecordLimitStrategy();
+
+    private RecordLimitStrategy() {
+        // Singleton class.
+    }
+
+    @Override
+    public boolean requiresSubsetMatch(InFlightBatch inFlightBatch, int maxRecordsToAcquire, int acquiredCount) {
+        // In record_limit mode, check if batch has more records than can be acquired
+        long numRecordsInBatch = inFlightBatch.lastOffset() - inFlightBatch.firstOffset() + 1;
+        int numRecordsRemaining = maxRecordsToAcquire - acquiredCount;
+        return numRecordsInBatch > numRecordsRemaining;
+    }
+
+    @Override
+    public BatchCreationResult createBatches(BatchCreationContext context) {
+        // In record_limit mode, always create a single batch
+        AcquiredRecords acquiredRecords = new AcquiredRecords()
+            .setFirstOffset(context.firstAcquiredOffset())
+            .setLastOffset(context.lastAcquiredOffset())
+            .setDeliveryCount((short) 1);
+
+        long recordsInBatch = acquiredRecords.lastOffset() - acquiredRecords.firstOffset() + 1;
+
+        // When batch exceeds max fetch limit, only acquire up to the limit
+        // and leave remaining offsets in AVAILABLE state i.e. acquired records are 10-19 (10 records) and max fetch
+        // records is 5, then only 10-14 should be acquired and offset 15-19 should still in available state.
+        if (recordsInBatch > context.maxFetchRecords()) {
+            return createPartiallyAcquiredBatch(context, acquiredRecords);
+        }
+
+        // Batch fits within limit - add normally
+        AcquisitionLockTimerTask timerTask = context.cacheOperations()
+            .scheduleAcquisitionLockTimeout(
+                context.memberId(),
+                acquiredRecords.firstOffset(),
+                acquiredRecords.lastOffset()
+            );
+
+        context.cacheOperations().addBatchToCache(
+            context.memberId(),
+            acquiredRecords.firstOffset(),
+            acquiredRecords.lastOffset(),
+            timerTask
+        );
+
+        context.cacheOperations().recordInFlightBatchMessageCount(recordsInBatch);
+
+        return new BatchCreationResult(List.of(acquiredRecords), false);
+    }
+
+    /**
+     * Creates a batch where only the first maxFetchRecords are acquired,
+     * and the remaining offsets are left in AVAILABLE state.
+     */
+    private BatchCreationResult createPartiallyAcquiredBatch(
+        BatchCreationContext context,
+        AcquiredRecords acquiredRecords
+    ) {
+        int delayMs = context.cacheOperations().recordLockDurationMs();
+        long acquiredLastOffset = acquiredRecords.firstOffset() + context.maxFetchRecords() - 1;
+
+        // Add batch with offset state initialized - only first maxFetchRecords are ACQUIRED,
+        // remaining are AVAILABLE
+        context.cacheOperations().addBatchWithOffsetState(
+            context.memberId(),
+            acquiredRecords.firstOffset(),
+            acquiredRecords.lastOffset(),
+            acquiredLastOffset,
+            delayMs
+        );
+
+        context.cacheOperations().recordInFlightBatchMessageCount(
+            acquiredRecords.lastOffset() - acquiredRecords.firstOffset() + 1
+        );
+
+        // Update the acquired records to reflect only what was actually acquired
+        acquiredRecords.setLastOffset(acquiredLastOffset);
+
+        // Signal that findNextFetchOffset should be updated since we have AVAILABLE records
+        return new BatchCreationResult(List.of(acquiredRecords), true);
+    }
+
+    /**
+     * This function returns the actual last offset from the acquired
+     * records (which may be less than the original last offset).
+     */
+    @Override
+    public long effectiveLastOffset(List<AcquiredRecords> acquiredRecords, long originalLastOffset) {
+        // In record_limit mode, return the actual last offset from acquired records.
+        // This is needed to calculate the correct acquired count.
+        return acquiredRecords.get(0).lastOffset();
+    }
+
+    @Override
+    public boolean shouldStopSubsetAcquisition(int acquiredCount, long maxFetchRecords) {
+        // In record_limit mode, stop when exactly maxFetchRecords have been acquired
+        return acquiredCount >= maxFetchRecords;
+    }
+}


### PR DESCRIPTION
### About
This PR performs a refactor of `SharePartition.java` `acquire` functionality. The functionality had become quite huge and adding new code in this method looks daunting. Hence, I have refactored the code to use `Strategy` design pattern to distinguish code for acquire mode thereby creating a clean separation between acquisition modes


### Testing
The originally present unit and integrayion tests should cover this change.