### PR TITLE
KAFKA-20038 Upgrade Log4j to 2.25.3 to fix CVE-2025-68161 

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -236,10 +236,10 @@ License Version 2.0:
 - jetty-session-12.0.15
 - jetty-util-12.0.15
 - jose4j-0.9.4
-- log4j-api-2.24.3
-- log4j-core-2.24.3
-- log4j-slf4j-impl-2.24.3
-- log4j-1.2-api-2.24.3
+- log4j-api-2.25.3
+- log4j-core-2.25.3
+- log4j-slf4j-impl-2.25.3
+- log4j-1.2-api-2.25.3
 - lz4-java-1.10.1
 - maven-artifact-3.9.6
 - metrics-core-2.2.0

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Loggers.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Loggers.java
@@ -202,7 +202,7 @@ public class Loggers {
         LoggerContext context = (LoggerContext) LogManager.getContext(false);
         var results = new HashMap<String, org.apache.logging.log4j.Logger>();
         context.getConfiguration().getLoggers().forEach((name, logger) -> results.put(name, LogManager.getLogger(name)));
-        context.getLoggerRegistry().getLoggers().forEach(logger -> results.put(logger.getName(), logger));
+        context.getLoggers().forEach(logger -> results.put(logger.getName(), logger));
         return results;
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -106,7 +106,7 @@ versions += [
   kafka_37: "3.7.2",
   kafka_38: "3.8.1",
   kafka_39: "3.9.0",
-  log4j2: "2.24.3",
+  log4j2: "2.25.3",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24


### PR DESCRIPTION
Updated lo4j2 version to 2.25.3 to prevent CVE. FYI:
https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core

CVE LINK : https://nvd.nist.gov/vuln/detail/CVE-2025-68161

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, TengYao Chi <frankvicky@apache.org>
