### PR TITLE
KAFKA-20052: Share commitSync for deleted topic

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -49,6 +49,7 @@ import org.apache.kafka.common.errors.InvalidRecordStateException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -2923,6 +2924,37 @@ public class ShareConsumerTest {
             records = waitedPoll(shareConsumer, 2500L, 5);
             assertEquals(5, records.count());
             verifyShareGroupStateTopicRecordsProduced();
+        }
+    }
+
+    @ClusterTest
+    public void testCommitSyncFailsForDeletedTopic() throws InterruptedException {
+        Uuid topicId = createTopic("baz", 1, 1);
+        alterShareAutoOffsetReset("group1", "earliest");
+        try (Producer<byte[], byte[]> producer = createProducer();
+             ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer(
+                 "group1",
+                 Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, EXPLICIT))
+        ) {
+            for (int i = 0; i < 10; i++) {
+                ProducerRecord<byte[], byte[]> record = new ProducerRecord<>("baz", 0, null, "key".getBytes(), ("Message " + i).getBytes());
+                producer.send(record);
+            }
+            producer.flush();
+
+            shareConsumer.subscribe(List.of("baz"));
+            ConsumerRecords<byte[], byte[]> records = waitedPoll(shareConsumer, 2500L, 10);
+            assertEquals(10, records.count());
+
+            records.forEach(shareConsumer::acknowledge);
+
+            // Topic deletion does not necessarily become apparent across the cluster immediately, so sleep a short while
+            deleteTopic("baz");
+            Thread.sleep(5000);
+
+            Map<TopicIdPartition, Optional<KafkaException>> commitResult = shareConsumer.commitSync();
+            assertEquals(1, commitResult.size());
+            assertInstanceOf(UnknownTopicIdException.class, commitResult.get(new TopicIdPartition(topicId, 0, "baz")).get());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareInFlightBatch.java
@@ -148,16 +148,18 @@ public class ShareInFlightBatch<K, V> {
         int recordsRenewed = 0;
         boolean isCompletedExceptionally = acknowledgements.isCompletedExceptionally();
         if (acknowledgements.isCompleted()) {
-            Map<Long, AcknowledgeType> ackTypeMap = acknowledgements.getAcknowledgementsTypeMap();
-            for (Map.Entry<Long, AcknowledgeType> ackTypeEntry : ackTypeMap.entrySet()) {
-                long offset = ackTypeEntry.getKey();
-                AcknowledgeType ackType = ackTypeEntry.getValue();
-                ConsumerRecord<K, V> record = renewingRecords.remove(offset);
-                if (ackType == AcknowledgeType.RENEW) {
-                    if (record != null && !isCompletedExceptionally) {
-                        // The record is moved into renewed state, and will then become in-flight later.
-                        renewedRecords.put(offset, record);
-                        recordsRenewed++;
+            if (renewingRecords != null) {
+                Map<Long, AcknowledgeType> ackTypeMap = acknowledgements.getAcknowledgementsTypeMap();
+                for (Map.Entry<Long, AcknowledgeType> ackTypeEntry : ackTypeMap.entrySet()) {
+                    long offset = ackTypeEntry.getKey();
+                    AcknowledgeType ackType = ackTypeEntry.getValue();
+                    ConsumerRecord<K, V> record = renewingRecords.remove(offset);
+                    if (ackType == AcknowledgeType.RENEW) {
+                        if (record != null && !isCompletedExceptionally) {
+                            // The record is moved into renewed state, and will then become in-flight later.
+                            renewedRecords.put(offset, record);
+                            recordsRenewed++;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When a topic with outstanding acknowledgements is deleted,
SHARE_ACKNOWLEDGE fails with a topic-level UNKNOWN_TOPIC_ID error code.
This error code was not being handled as an immediate failure, which
meant that the request would be retried until it timed out. As a result,
`ShareConsumer.commitSync()` failed with a `TimeoutException` for the
partition, rather than `UnknownTopicIdException`.

In addition, there was a mistake in `ShareInFlightBatch` which meant
that an NPE occurred as the timeout was delivered.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Chirag Wadhwa
 <cwadhwa@confluent.io>
