### PR TITLE
KAFKA-20031: RPCProducerIdManager#sanityCheckResponse fails to detect overlapping producer id

### DIFF
--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -188,7 +188,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
     }
 
     private boolean sanityCheckResponse(AllocateProducerIdsResponseData data) {
-        if (data.producerIdStart() < currentProducerIdBlock.get().lastProducerId()) {
+        if (data.producerIdStart() <= currentProducerIdBlock.get().lastProducerId()) {
             log.error("{} Producer ID block is not monotonic with current block: current={} response={}", logPrefix, currentProducerIdBlock.get(), data);
         } else if (data.producerIdStart() < 0 || data.producerIdLen() < 0 || data.producerIdStart() > Long.MAX_VALUE - data.producerIdLen()) {
             log.error("{} Producer ID block includes invalid ID range: {}", logPrefix, data);

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -58,7 +58,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
 
     // Visible for testing
     final AtomicReference<ProducerIdsBlock> nextProducerIdBlock = new AtomicReference<>(null);
-    private final AtomicReference<ProducerIdsBlock> currentProducerIdBlock = new AtomicReference<>(ProducerIdsBlock.EMPTY);
+    final AtomicReference<ProducerIdsBlock> currentProducerIdBlock = new AtomicReference<>(ProducerIdsBlock.EMPTY);
     private final AtomicBoolean requestInFlight = new AtomicBoolean(false);
     private final AtomicLong backoffDeadlineMs = new AtomicLong(NO_RETRY);
 


### PR DESCRIPTION
We may get a duplicate producer id if the producer ID at the start of
the response is the same as last producer ID in the current block, so we
make sanity check more robust.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
