### PR TITLE
MINOR: Update the lz4 version from 1.10.1 to 1.10.2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -241,7 +241,7 @@ License Version 2.0:
 - log4j-core-2.25.3
 - log4j-slf4j-impl-2.25.3
 - log4j-1.2-api-2.25.3
-- lz4-java-1.10.1
+- lz4-java-1.10.2
 - maven-artifact-3.9.11
 - metrics-core-2.2.0
 - opentelemetry-proto-1.3.2-alpha

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -109,7 +109,7 @@ versions += [
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24
-  lz4: "1.10.1",
+  lz4: "1.10.2",
   mavenArtifact: "3.9.11",
   metrics: "2.2.0",
   mockito: "5.20.0",


### PR DESCRIPTION
LZ4 1.10.2 release note:
https://github.com/yawkat/lz4-java/releases/tag/v1.10.2

Changes:
- Updated dependencies.gradle to reflect the new version.
- Updated LICENSE-binary to match the version upgrade.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
