### PR TITLE
MINOR: Refactor onPartitionsDeleted to onTopicsDeleted

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -2278,10 +2278,10 @@ public class GroupCoordinatorService implements GroupCoordinator {
      * @param topicsDelta The topics delta containing deleted topic IDs.
      */
     private void handlePartitionsDeletion(TopicsDelta topicsDelta) {
-        var topicIds = topicsDelta.deletedTopicIds();
+        var deletedTopicIds = topicsDelta.deletedTopicIds();
         var deletedTopicNames = new HashSet<String>();
 
-        topicIds.forEach(topicId -> {
+        deletedTopicIds.forEach(topicId -> {
             var topicImage = topicsDelta.image().getTopic(topicId);
             if (topicImage != null) {
                 deletedTopicNames.add(topicImage.name());
@@ -2308,17 +2308,17 @@ public class GroupCoordinatorService implements GroupCoordinator {
             );
         }
 
-        if (!topicIds.isEmpty()) {
+        if (!deletedTopicIds.isEmpty()) {
             // Schedule share group state cleanup.
             futures.addAll(
                 FutureUtils.mapExceptionally(
                     runtime.scheduleWriteAllOperation(
                         "maybe-cleanup-share-group-state",
                         Duration.ofMillis(config.offsetCommitTimeoutMs()),
-                        coordinator -> coordinator.maybeCleanupShareGroupState(topicIds)
+                        coordinator -> coordinator.maybeCleanupShareGroupState(deletedTopicIds)
                     ),
                     exception -> {
-                        log.error("Unable to cleanup state for the deleted topics {}", topicIds, exception);
+                        log.error("Unable to cleanup state for the deleted topics {}", deletedTopicIds, exception);
                         return null;
                     }
                 )

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -2266,9 +2266,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
         metadataImage = wrappedImage;
         runtime.onMetadataUpdate(wrappedDelta, wrappedImage);
 
-        // Handle partition deletions from the delta.
+        // Handle topic deletions from the delta.
         if (delta.topicsDelta() != null && !delta.topicsDelta().deletedTopicIds().isEmpty()) {
-            handlePartitionsDeletion(delta.topicsDelta());
+            handleTopicsDeletion(delta.topicsDelta());
         }
     }
 
@@ -2278,7 +2278,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
      *
      * @param topicsDelta The topics delta containing deleted topic IDs.
      */
-    private void handlePartitionsDeletion(TopicsDelta topicsDelta) {
+    private void handleTopicsDeletion(TopicsDelta topicsDelta) {
         var deletedTopicIds = topicsDelta.deletedTopicIds();
         var deletedTopics = new ArrayList<DeletedTopic>();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -2272,38 +2272,36 @@ public class GroupCoordinatorService implements GroupCoordinator {
     }
 
     /**
-     * Handles the deletion of topic partitions by scheduling write operations
+     * Handles the deletion of topics by scheduling write operations
      * to delete committed offsets and clean up share group state.
      *
      * @param topicsDelta The topics delta containing deleted topic IDs.
      */
     private void handlePartitionsDeletion(TopicsDelta topicsDelta) {
-        var topicPartitions = new ArrayList<TopicPartition>();
         var topicIds = topicsDelta.deletedTopicIds();
+        var deletedTopicNames = new HashSet<String>();
 
         topicIds.forEach(topicId -> {
             var topicImage = topicsDelta.image().getTopic(topicId);
             if (topicImage != null) {
-                topicImage.partitions().keySet().forEach(partitionId ->
-                    topicPartitions.add(new TopicPartition(topicImage.name(), partitionId))
-                );
+                deletedTopicNames.add(topicImage.name());
             }
         });
 
         var futures = new ArrayList<CompletableFuture<Void>>();
 
-        if (!topicPartitions.isEmpty()) {
+        if (!deletedTopicNames.isEmpty()) {
             // Schedule offset deletion.
             futures.addAll(
                 FutureUtils.mapExceptionally(
                     runtime.scheduleWriteAllOperation(
-                        "on-partition-deleted",
+                        "on-topics-deleted",
                         Duration.ofMillis(config.offsetCommitTimeoutMs()),
-                        coordinator -> coordinator.onPartitionsDeleted(topicPartitions)
+                        coordinator -> coordinator.onTopicsDeleted(deletedTopicNames)
                     ),
                     exception -> {
-                        log.error("Could not delete offsets for deleted partitions {} due to: {}.",
-                            topicPartitions, exception.getMessage(), exception);
+                        log.error("Could not delete offsets for deleted topics {} due to: {}.",
+                            deletedTopicNames, exception.getMessage(), exception);
                         return null;
                     }
                 )

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -95,6 +95,7 @@ import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataDelta
 import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MultiThreadedEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
+import org.apache.kafka.coordinator.group.GroupCoordinatorShard.DeletedTopic;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
@@ -2279,29 +2280,29 @@ public class GroupCoordinatorService implements GroupCoordinator {
      */
     private void handlePartitionsDeletion(TopicsDelta topicsDelta) {
         var deletedTopicIds = topicsDelta.deletedTopicIds();
-        var deletedTopicNames = new HashSet<String>();
+        var deletedTopics = new ArrayList<DeletedTopic>();
 
         deletedTopicIds.forEach(topicId -> {
             var topicImage = topicsDelta.image().getTopic(topicId);
             if (topicImage != null) {
-                deletedTopicNames.add(topicImage.name());
+                deletedTopics.add(new DeletedTopic(topicId, topicImage.name()));
             }
         });
 
         var futures = new ArrayList<CompletableFuture<Void>>();
 
-        if (!deletedTopicNames.isEmpty()) {
+        if (!deletedTopics.isEmpty()) {
             // Schedule offset deletion.
             futures.addAll(
                 FutureUtils.mapExceptionally(
                     runtime.scheduleWriteAllOperation(
                         "on-topics-deleted",
                         Duration.ofMillis(config.offsetCommitTimeoutMs()),
-                        coordinator -> coordinator.onTopicsDeleted(deletedTopicNames)
+                        coordinator -> coordinator.onTopicsDeleted(deletedTopics)
                     ),
                     exception -> {
                         log.error("Could not delete offsets for deleted topics {} due to: {}.",
-                            deletedTopicNames, exception.getMessage(), exception);
+                            deletedTopics, exception.getMessage(), exception);
                         return null;
                     }
                 )

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -1008,19 +1008,19 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     }
 
     /**
-     * Remove offsets of the partitions that have been deleted.
+     * Remove offsets of the topics that have been deleted.
      *
-     * @param topicPartitions   The partitions that have been deleted.
+     * @param deletedTopicNames   The names of the topics that have been deleted.
      * @return The list of tombstones (offset commit) to append.
      */
-    public CoordinatorResult<Void, CoordinatorRecord> onPartitionsDeleted(
-        List<TopicPartition> topicPartitions
+    public CoordinatorResult<Void, CoordinatorRecord> onTopicsDeleted(
+        Set<String> deletedTopicNames
     ) {
         final long startTimeMs = time.milliseconds();
-        final List<CoordinatorRecord> records = offsetMetadataManager.onPartitionsDeleted(topicPartitions);
+        final List<CoordinatorRecord> records = offsetMetadataManager.onTopicsDeleted(deletedTopicNames);
 
-        log.info("Generated {} tombstone records in {} milliseconds while deleting offsets for partitions {}.",
-            records.size(), time.milliseconds() - startTimeMs, topicPartitions);
+        log.info("Generated {} tombstone records in {} milliseconds while deleting offsets for topics {}.",
+            records.size(), time.milliseconds() - startTimeMs, deletedTopicNames);
 
         return new CoordinatorResult<>(records, false);
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -359,6 +359,16 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     }
 
     /**
+     * Represents a deleted topic with its ID and name.
+     * Used during offset cleanup to ensure only offsets for the correct
+     * topic incarnation are deleted (preventing race conditions with topic recreation).
+     *
+     * @param id    The topic ID.
+     * @param name  The topic name.
+     */
+    public record DeletedTopic(Uuid id, String name) { }
+
+    /**
      * The group/offsets expiration key to schedule a timer task.
      *
      * Visible for testing.
@@ -1010,17 +1020,17 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     /**
      * Remove offsets of the topics that have been deleted.
      *
-     * @param deletedTopicNames   The names of the topics that have been deleted.
+     * @param deletedTopics   The topics that have been deleted.
      * @return The list of tombstones (offset commit) to append.
      */
     public CoordinatorResult<Void, CoordinatorRecord> onTopicsDeleted(
-        Set<String> deletedTopicNames
+        List<DeletedTopic> deletedTopics
     ) {
         final long startTimeMs = time.milliseconds();
-        final List<CoordinatorRecord> records = offsetMetadataManager.onTopicsDeleted(deletedTopicNames);
+        final List<CoordinatorRecord> records = offsetMetadataManager.onTopicsDeleted(deletedTopics);
 
         log.info("Generated {} tombstone records in {} milliseconds while deleting offsets for topics {}.",
-            records.size(), time.milliseconds() - startTimeMs, deletedTopicNames);
+            records.size(), time.milliseconds() - startTimeMs, deletedTopics);
 
         return new CoordinatorResult<>(records, false);
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
@@ -56,11 +55,10 @@ import org.apache.kafka.timeline.TimelineHashSet;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -1079,39 +1077,32 @@ public class OffsetMetadataManager {
     }
 
     /**
-     * Remove offsets of the partitions that have been deleted.
+     * Remove offsets of the topics that have been deleted.
      *
-     * @param topicPartitions   The partitions that have been deleted.
+     * @param deletedTopicNames   The names of the topics that have been deleted.
      * @return The list of tombstones (offset commit) to append.
      */
-    public List<CoordinatorRecord> onPartitionsDeleted(
-        List<TopicPartition> topicPartitions
+    public List<CoordinatorRecord> onTopicsDeleted(
+        Set<String> deletedTopicNames
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
 
-        Map<String, List<Integer>> partitionsByTopic = new HashMap<>();
-        topicPartitions.forEach(tp -> partitionsByTopic
-            .computeIfAbsent(tp.topic(), __ -> new ArrayList<>())
-            .add(tp.partition())
-        );
-
         Consumer<Offsets> delete = offsetsToClean -> {
             offsetsToClean.offsetsByGroup.forEach((groupId, topicOffsets) -> {
-                topicOffsets.forEach((topic, partitionOffsets) -> {
-                    if (partitionsByTopic.containsKey(topic)) {
-                        partitionsByTopic.get(topic).forEach(partition -> {
-                            if (partitionOffsets.containsKey(partition)) {
-                                appendOffsetCommitTombstone(groupId, topic, partition, records);
-                            }
+                deletedTopicNames.forEach(topic -> {
+                    var partitionOffsets = topicOffsets.get(topic);
+                    if (partitionOffsets != null) {
+                        partitionOffsets.keySet().forEach(partition -> {
+                            appendOffsetCommitTombstone(groupId, topic, partition, records);
                         });
                     }
                 });
             });
         };
 
-        // Delete the partitions from the main storage.
+        // Delete the offsets from the main storage.
         delete.accept(offsets);
-        // Delete the partitions from the pending transactional offsets.
+        // Delete the offsets from the pending transactional offsets.
         pendingTransactionalOffsets.forEach((__, offsets) -> delete.accept(offsets));
 
         return records;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorResult;
+import org.apache.kafka.coordinator.group.GroupCoordinatorShard.DeletedTopic;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
@@ -58,7 +59,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -1079,24 +1079,27 @@ public class OffsetMetadataManager {
     /**
      * Remove offsets of the topics that have been deleted.
      *
-     * @param deletedTopicNames   The names of the topics that have been deleted.
+     * @param deletedTopics   The topics that have been deleted.
      * @return The list of tombstones (offset commit) to append.
      */
     public List<CoordinatorRecord> onTopicsDeleted(
-        Set<String> deletedTopicNames
+        List<DeletedTopic> deletedTopics
     ) {
         List<CoordinatorRecord> records = new ArrayList<>();
 
         Consumer<Offsets> delete = offsetsToClean -> {
             offsetsToClean.offsetsByGroup.forEach((groupId, topicOffsets) -> {
-                deletedTopicNames.forEach(topic -> {
-                    var partitionOffsets = topicOffsets.get(topic);
+                for (DeletedTopic deletedTopic : deletedTopics) {
+                    var partitionOffsets = topicOffsets.get(deletedTopic.name());
                     if (partitionOffsets != null) {
-                        partitionOffsets.keySet().forEach(partition -> {
-                            appendOffsetCommitTombstone(groupId, topic, partition, records);
+                        partitionOffsets.forEach((partition, offsetAndMetadata) -> {
+                            // Delete if the topic ID matches or if the stored topic ID is ZERO_UUID (legacy records).
+                            if (offsetAndMetadata.topicId.equals(Uuid.ZERO_UUID) || offsetAndMetadata.topicId.equals(deletedTopic.id())) {
+                                appendOffsetCommitTombstone(groupId, deletedTopic.name(), partition, records);
+                            }
                         });
                     }
-                });
+                }
             });
         };
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -3202,7 +3202,7 @@ public class GroupCoordinatorServiceTest {
         );
 
         when(runtime.scheduleWriteAllOperation(
-            ArgumentMatchers.eq("on-partition-deleted"),
+            ArgumentMatchers.eq("on-topics-deleted"),
             ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(offsetFutures);
@@ -3218,7 +3218,7 @@ public class GroupCoordinatorServiceTest {
 
         // Wait for the operations to be scheduled and verify method is blocked.
         verify(runtime, timeout(5000).times(1)).scheduleWriteAllOperation(
-            ArgumentMatchers.eq("on-partition-deleted"),
+            ArgumentMatchers.eq("on-topics-deleted"),
             ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
@@ -3256,7 +3256,7 @@ public class GroupCoordinatorServiceTest {
 
         // Verify no operations scheduled.
         verify(runtime, times(0)).scheduleWriteAllOperation(
-            ArgumentMatchers.eq("on-partition-deleted"),
+            ArgumentMatchers.eq("on-topics-deleted"),
             ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
@@ -3288,7 +3288,7 @@ public class GroupCoordinatorServiceTest {
 
         // Mock operations with 3 futures, some failing.
         when(runtime.scheduleWriteAllOperation(
-            ArgumentMatchers.eq("on-partition-deleted"),
+            ArgumentMatchers.eq("on-topics-deleted"),
             ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(Arrays.asList(
@@ -3312,7 +3312,7 @@ public class GroupCoordinatorServiceTest {
 
         // Verify operations were still scheduled exactly once.
         verify(runtime, times(1)).scheduleWriteAllOperation(
-            ArgumentMatchers.eq("on-partition-deleted"),
+            ArgumentMatchers.eq("on-topics-deleted"),
             ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -49,6 +49,7 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorMetricsShard;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorResult;
 import org.apache.kafka.coordinator.common.runtime.MockCoordinatorTimer;
+import org.apache.kafka.coordinator.group.GroupCoordinatorShard.DeletedTopic;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
@@ -1545,19 +1546,18 @@ public class GroupCoordinatorShardTest {
             metricsShard
         );
 
+        Uuid fooTopicId = Uuid.randomUuid();
+        List<DeletedTopic> deletedTopics = List.of(new DeletedTopic(fooTopicId, "foo"));
+
         List<CoordinatorRecord> records = List.of(GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord(
             "group",
             "foo",
             0
         ));
 
-        when(offsetMetadataManager.onTopicsDeleted(
-            Set.of("foo")
-        )).thenReturn(records);
+        when(offsetMetadataManager.onTopicsDeleted(deletedTopics)).thenReturn(records);
 
-        CoordinatorResult<Void, CoordinatorRecord> result = coordinator.onTopicsDeleted(
-            Set.of("foo")
-        );
+        CoordinatorResult<Void, CoordinatorRecord> result = coordinator.onTopicsDeleted(deletedTopics);
 
         assertEquals(records, result.records());
         assertNull(result.response());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
@@ -1530,7 +1529,7 @@ public class GroupCoordinatorShardTest {
     }
 
     @Test
-    public void testOnPartitionsDeleted() {
+    public void testOnTopicsDeleted() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         CoordinatorMetrics coordinatorMetrics = mock(CoordinatorMetrics.class);
@@ -1552,12 +1551,12 @@ public class GroupCoordinatorShardTest {
             0
         ));
 
-        when(offsetMetadataManager.onPartitionsDeleted(
-            List.of(new TopicPartition("foo", 0))
+        when(offsetMetadataManager.onTopicsDeleted(
+            Set.of("foo")
         )).thenReturn(records);
 
-        CoordinatorResult<Void, CoordinatorRecord> result = coordinator.onPartitionsDeleted(
-            List.of(new TopicPartition("foo", 0))
+        CoordinatorResult<Void, CoordinatorRecord> result = coordinator.onTopicsDeleted(
+            Set.of("foo")
         );
 
         assertEquals(records, result.records());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
@@ -285,10 +284,10 @@ public class OffsetMetadataManagerTest {
             return result;
         }
 
-        public List<CoordinatorRecord> deletePartitions(
-            List<TopicPartition> topicPartitions
+        public List<CoordinatorRecord> deleteTopics(
+            Set<String> deletedTopicNames
         ) {
-            List<CoordinatorRecord> records = offsetMetadataManager.onPartitionsDeleted(topicPartitions);
+            List<CoordinatorRecord> records = offsetMetadataManager.onTopicsDeleted(deletedTopicNames);
             records.forEach(this::replay);
             return records;
         }
@@ -3550,7 +3549,7 @@ public class OffsetMetadataManagerTest {
     }
 
     @Test
-    public void testOnPartitionsDeleted() {
+    public void testOnTopicsDeleted() {
         OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
 
         // Commit offsets.
@@ -3566,20 +3565,14 @@ public class OffsetMetadataManagerTest {
         context.commitOffset(100L, "grp-2", "foo", 2, 200, 1, context.time.milliseconds());
         context.commitOffset(100L, "grp-2", "foo", 3, 300, 1, context.time.milliseconds());
 
-        // Delete partitions.
-        List<CoordinatorRecord> records = context.deletePartitions(Arrays.asList(
-            new TopicPartition("foo", 1),
-            new TopicPartition("foo", 2),
-            new TopicPartition("foo", 3),
-            new TopicPartition("bar", 1)
-        ));
+        // Delete topics.
+        List<CoordinatorRecord> records = context.deleteTopics(Set.of("foo"));
 
-        // Verify.
+        // Verify. All partitions for topic "foo" should be deleted.
         List<CoordinatorRecord> expectedRecords = Arrays.asList(
             GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 1),
             GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 2),
             GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 3),
-            GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-1", "bar", 1),
             GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-2", "foo", 1),
             GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-2", "foo", 2),
             GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-2", "foo", 3)
@@ -3590,7 +3583,9 @@ public class OffsetMetadataManagerTest {
         assertFalse(context.hasOffset("grp-0", "foo", 1));
         assertFalse(context.hasOffset("grp-0", "foo", 2));
         assertFalse(context.hasOffset("grp-0", "foo", 3));
-        assertFalse(context.hasOffset("grp-1", "bar", 1));
+        assertTrue(context.hasOffset("grp-1", "bar", 1));
+        assertTrue(context.hasOffset("grp-1", "bar", 2));
+        assertTrue(context.hasOffset("grp-1", "bar", 3));
         assertFalse(context.hasOffset("grp-2", "foo", 1));
         assertFalse(context.hasOffset("grp-2", "foo", 2));
         assertFalse(context.hasOffset("grp-2", "foo", 3));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -51,6 +51,7 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorResult;
 import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MockCoordinatorExecutor;
 import org.apache.kafka.coordinator.common.runtime.MockCoordinatorTimer;
+import org.apache.kafka.coordinator.group.GroupCoordinatorShard.DeletedTopic;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupMember;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
@@ -285,9 +286,9 @@ public class OffsetMetadataManagerTest {
         }
 
         public List<CoordinatorRecord> deleteTopics(
-            Set<String> deletedTopicNames
+            List<DeletedTopic> deletedTopics
         ) {
-            List<CoordinatorRecord> records = offsetMetadataManager.onTopicsDeleted(deletedTopicNames);
+            List<CoordinatorRecord> records = offsetMetadataManager.onTopicsDeleted(deletedTopics);
             records.forEach(this::replay);
             return records;
         }
@@ -3549,10 +3550,12 @@ public class OffsetMetadataManagerTest {
     }
 
     @Test
-    public void testOnTopicsDeleted() {
+    public void testOnTopicsDeletedWithZeroTopicId() {
         OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
 
-        // Commit offsets.
+        Uuid fooTopicId = Uuid.randomUuid();
+
+        // Commit offsets with ZERO_UUID (legacy behavior).
         context.commitOffset("grp-0", "foo", 1, 100, 1, context.time.milliseconds());
         context.commitOffset("grp-0", "foo", 2, 200, 1, context.time.milliseconds());
         context.commitOffset("grp-0", "foo", 3, 300, 1, context.time.milliseconds());
@@ -3565,8 +3568,8 @@ public class OffsetMetadataManagerTest {
         context.commitOffset(100L, "grp-2", "foo", 2, 200, 1, context.time.milliseconds());
         context.commitOffset(100L, "grp-2", "foo", 3, 300, 1, context.time.milliseconds());
 
-        // Delete topics.
-        List<CoordinatorRecord> records = context.deleteTopics(Set.of("foo"));
+        // Delete topics. Offsets with ZERO_UUID should be deleted for backwards compatibility.
+        List<CoordinatorRecord> records = context.deleteTopics(List.of(new DeletedTopic(fooTopicId, "foo")));
 
         // Verify. All partitions for topic "foo" should be deleted.
         List<CoordinatorRecord> expectedRecords = Arrays.asList(
@@ -3589,6 +3592,77 @@ public class OffsetMetadataManagerTest {
         assertFalse(context.hasOffset("grp-2", "foo", 1));
         assertFalse(context.hasOffset("grp-2", "foo", 2));
         assertFalse(context.hasOffset("grp-2", "foo", 3));
+    }
+
+    @Test
+    public void testOnTopicsDeletedWithMatchingTopicId() {
+        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+
+        // Commit offsets with the topic ID.
+        context.commitOffset(RecordBatch.NO_PRODUCER_ID, "grp-0", fooTopicId, "foo", 1, 100, 1, context.time.milliseconds());
+        context.commitOffset(RecordBatch.NO_PRODUCER_ID, "grp-0", fooTopicId, "foo", 2, 200, 1, context.time.milliseconds());
+
+        // Delete topics with matching topic ID.
+        List<CoordinatorRecord> records = context.deleteTopics(List.of(new DeletedTopic(fooTopicId, "foo")));
+
+        // Verify offsets are deleted.
+        List<CoordinatorRecord> expectedRecords = Arrays.asList(
+            GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 1),
+            GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 2)
+        );
+
+        assertEquals(new HashSet<>(expectedRecords), new HashSet<>(records));
+
+        assertFalse(context.hasOffset("grp-0", "foo", 1));
+        assertFalse(context.hasOffset("grp-0", "foo", 2));
+    }
+
+    @Test
+    public void testOnTopicsDeletedWithMismatchedTopicId() {
+        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
+
+        Uuid oldTopicId = Uuid.randomUuid();
+        Uuid newTopicId = Uuid.randomUuid();
+
+        // Commit offsets with the NEW topic ID (simulating offset for recreated topic).
+        context.commitOffset(RecordBatch.NO_PRODUCER_ID, "grp-0", newTopicId, "foo", 1, 100, 1, context.time.milliseconds());
+        context.commitOffset(RecordBatch.NO_PRODUCER_ID, "grp-0", newTopicId, "foo", 2, 200, 1, context.time.milliseconds());
+
+        // Delete topics with OLD topic ID (simulating deletion of old topic).
+        List<CoordinatorRecord> records = context.deleteTopics(List.of(new DeletedTopic(oldTopicId, "foo")));
+
+        // Verify offsets are NOT deleted because topic IDs don't match.
+        assertEquals(0, records.size());
+
+        assertTrue(context.hasOffset("grp-0", "foo", 1));
+        assertTrue(context.hasOffset("grp-0", "foo", 2));
+    }
+
+    @Test
+    public void testOnTopicsDeletedWithMixedTopicIds() {
+        OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+
+        // Commit offsets: some with matching topic ID, some with ZERO_UUID (legacy).
+        context.commitOffset(RecordBatch.NO_PRODUCER_ID, "grp-0", fooTopicId, "foo", 1, 100, 1, context.time.milliseconds());
+        context.commitOffset(RecordBatch.NO_PRODUCER_ID, "grp-0", Uuid.ZERO_UUID, "foo", 2, 200, 1, context.time.milliseconds());
+
+        // Delete topics.
+        List<CoordinatorRecord> records = context.deleteTopics(List.of(new DeletedTopic(fooTopicId, "foo")));
+
+        // Verify both offsets are deleted (matching ID and legacy ZERO_UUID).
+        List<CoordinatorRecord> expectedRecords = Arrays.asList(
+            GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 1),
+            GroupCoordinatorRecordHelpers.newOffsetCommitTombstoneRecord("grp-0", "foo", 2)
+        );
+
+        assertEquals(new HashSet<>(expectedRecords), new HashSet<>(records));
+
+        assertFalse(context.hasOffset("grp-0", "foo", 1));
+        assertFalse(context.hasOffset("grp-0", "foo", 2));
     }
 
     private void verifyReplay(


### PR DESCRIPTION
Refactor the internal partition deletion handling to work with topic
names instead of individual TopicPartition objects. Since topic deletion
always deletes all partitions, tracking individual partitions is
unnecessary overhead.

Key changes:
- Rename onPartitionsDeleted to onTopicsDeleted
- Change parameter from List<TopicPartition> to Set<String>
- Optimize iteration to look up deleted topics directly instead of
iterating all stored topics and checking membership

Reviewers: Dongnuo Lyu <dlyu@confluent.io>, Sean Quah
 <squah@confluent.io>, Lianet Magrans <lmagrans@confluent.io>
