### PR TITLE
MINOR: Log time spent cleaning share group state

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -1038,7 +1038,13 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
     public CoordinatorResult<Void, CoordinatorRecord> maybeCleanupShareGroupState(
         Set<Uuid> deletedTopicIds
     ) {
-        return groupMetadataManager.maybeCleanupShareGroupState(deletedTopicIds);
+        final long startTimeMs = time.milliseconds();
+        final var result = groupMetadataManager.maybeCleanupShareGroupState(deletedTopicIds);
+
+        log.info("Generated {} records in {} milliseconds while cleaning share group state for topics {}.",
+            result.records().size(), time.milliseconds() - startTimeMs, deletedTopicIds);
+
+        return result;
     }
 
     /**


### PR DESCRIPTION
This patch logs the time spent while cleaning the share group state on
topic deletions.

Reviewers: Andrew Schofield <aschofield@confluent.io>
