### PR TITLE
KAFKA-20058: Fix race condition on backoffDeadlineMs on RPCProducerIdManager causing premature retries

### DIFF
--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -115,7 +115,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
                     requestInFlight.compareAndSet(false, true)) {
                 sendRequest();
                 // Reset backoff after a successful send.
-                backoffDeadlineMs.set(NO_RETRY);
+                backoffDeadlineMs.compareAndSet(retryTimestamp, NO_RETRY);
             }
         }
     }

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -60,6 +60,9 @@ public class RPCProducerIdManager implements ProducerIdManager {
     final AtomicReference<ProducerIdsBlock> nextProducerIdBlock = new AtomicReference<>(null);
     private final AtomicReference<ProducerIdsBlock> currentProducerIdBlock = new AtomicReference<>(ProducerIdsBlock.EMPTY);
     private final AtomicBoolean requestInFlight = new AtomicBoolean(false);
+    
+    // Setting the value of backoffDeadlineMs should be handled only in the response handler thread.
+    // Otherwise, consider using compareAndSet() instead of set().
     private final AtomicLong backoffDeadlineMs = new AtomicLong(NO_RETRY);
 
     public RPCProducerIdManager(int brokerId,
@@ -114,8 +117,6 @@ public class RPCProducerIdManager implements ProducerIdManager {
             if (nextProducerIdBlock.get() == null &&
                     requestInFlight.compareAndSet(false, true)) {
                 sendRequest();
-                // Reset backoff after a successful send.
-                backoffDeadlineMs.compareAndSet(retryTimestamp, NO_RETRY);
             }
         }
     }
@@ -136,6 +137,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
             @Override
             public void onTimeout() {
                 log.warn("{} Timed out when requesting AllocateProducerIds from the controller.", logPrefix);
+                backoffDeadlineMs.set(NO_RETRY);
                 requestInFlight.set(false);
             }
         });
@@ -184,6 +186,8 @@ public class RPCProducerIdManager implements ProducerIdManager {
         }
         if (!successfulResponse) {
             handleUnsuccessfulResponse();
+        } else {
+            backoffDeadlineMs.set(NO_RETRY);
         }
     }
 


### PR DESCRIPTION
### Description
This PR fixes a race condition in
`RPCProducerIdManager.maybeRequestNextBlock()` that can clobber a
newly-set retry backoff and cause premature retries.

The Problem `maybeRequestNextBlock()` sends the controller request
asynchronously and then unconditionally resets `backoffDeadlineMs` to
`NO_RETRY`. On the response path, `handleUnsuccessfulResponse()` sets
`backoffDeadlineMs = now + RETRY_BACKOFF_MS`.

Because the send is asynchronous, the unconditional reset in the request
path can execute after the failure handler has already set the backoff.
This overwrites the valid backoff with `NO_RETRY`. Consequently, a
subsequent `generateProducerId()` call can re-send immediately, leading
to unnecessary controller traffic and flaky test behavior.

### Fix
To avoid this race entirely, `backoffDeadlineMs` is now only updated in
the response handler path:
- Remove the request-path reset of `backoffDeadlineMs` from
`maybeRequestNextBlock()`.
- On a successful response, reset `backoffDeadlineMs` to `NO_RETRY`.
- On timeout, keep the existing semantics by setting `backoffDeadlineMs`
to `NO_RETRY` (no retry backoff is applied on timeout in this code
path).

This keeps backoff state changes localized to the response-handling
thread and prevents request-path updates from clobbering a concurrent
backoff update.

### Flaky Tests fixed by this changes.
-
https://develocity.apache.org/scans/tests?search.rootProjectNames=kafka&search.timeZoneId=Asia%2FTaipei&tests.container=org.apache.kafka.coordinator.transaction.ProducerIdManagerTest&tests.sortField=FLAKY
- `ProducerIdManagerTest#testRetryBackoffOnNoResponse`
- `ProducerIdManagerTest#testRetryBackoffOnAuthException`
- `ProducerIdManagerTest#testRetryBackoffOnVersionMismatch`

### Sequence Diagram in Flaky test cases that trigger race condition.
<img width="1067" height="929" alt="image"
src="https://github.com/user-attachments/assets/fa4337f5-a3a0-4d9d-bbc5-8ef5689c0483"
/>

Reviewers: Justine Olshan <jolshan@confluent.io>, Sean Quah
 <squah@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
