### PR TITLE
KAFKA-20059: Fix flaky ConfigCommandIntegrationTest testUpdateInvalidBrokerConfigs

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
@@ -482,11 +482,6 @@ public class ConfigCommandIntegrationTest {
                 String describeResult = captureStandardOut(run(describeCommand));
                 last.set(describeResult);
 
-                // We will treat unknown config as sensitive
-                // For 'describeResult.contains("sensitive=true")' 
-                
-                // Sensitive config will not return
-                // For 'describeResult.contains("invalid=null")'
                 return describeResult.contains("sensitive=true") && describeResult.contains("invalid=null");
             }, 5000, "Dynamic broker config was not visible within 5s. Last describe output:\n" + last.get());
         }

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
@@ -473,22 +473,22 @@ public class ConfigCommandIntegrationTest {
             AtomicReference<String> last = new AtomicReference<>("");
 
             TestUtils.waitForCondition(() -> {
-                        Stream<String> describeCommand = Stream.concat(
-                                Stream.concat(
-                                        Stream.of("--bootstrap-server", cluster.bootstrapServers()),
-                                        Stream.of(entityOp(brokerIdOrDefault).toArray(new String[0]))),
-                                Stream.of("--entity-type", "brokers", "--describe")
-                        );
-                        String describeResult = captureStandardOut(run(describeCommand));
-                        last.set(describeResult);
+                Stream<String> describeCommand = Stream.concat(
+                        Stream.concat(
+                                Stream.of("--bootstrap-server", cluster.bootstrapServers()),
+                                Stream.of(entityOp(brokerIdOrDefault).toArray(new String[0]))),
+                        Stream.of("--entity-type", "brokers", "--describe")
+                );
+                String describeResult = captureStandardOut(run(describeCommand));
+                last.set(describeResult);
 
-                        // We will treat unknown config as sensitive
-                        // For describeResult.contains("sensitive=true") 
-                        // Sensitive config will not return
-                        // For describeResult.contains("invalid=null")
-                        return describeResult.contains("sensitive=true") && describeResult.contains("invalid=null");
-                    }, 5000,
-                    "Dynamic broker config was not visible within 5s. Last describe output:\n" + last.get());
+                // We will treat unknown config as sensitive
+                // For 'describeResult.contains("sensitive=true")' 
+                
+                // Sensitive config will not return
+                // For 'describeResult.contains("invalid=null")'
+                return describeResult.contains("sensitive=true") && describeResult.contains("invalid=null");
+            }, 5000, "Dynamic broker config was not visible within 5s. Last describe output:\n" + last.get());
         }
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
@@ -482,7 +482,15 @@ public class ConfigCommandIntegrationTest {
                 String describeResult = captureStandardOut(run(describeCommand));
                 last.set(describeResult);
 
-                return describeResult.contains("sensitive=true") && describeResult.contains("invalid=null");
+                boolean hasInvalidNull = describeResult.contains("invalid=null");
+                boolean hasSensitiveTrue = describeResult.contains("sensitive=true");
+
+                if (hasInvalidNull && !hasSensitiveTrue) {
+                    throw new AssertionError("Expected sensitive=true when invalid=null is visible, but it was not present.\n" +
+                            "Describe output:\n" + describeResult);
+                }
+
+                return hasSensitiveTrue && hasInvalidNull;
             }, 5000, "Dynamic broker config was not visible within 5s. Last describe output:\n" + last.get());
         }
     }

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
@@ -482,16 +482,11 @@ public class ConfigCommandIntegrationTest {
                 String describeResult = captureStandardOut(run(describeCommand));
                 last.set(describeResult);
 
-                boolean hasInvalidNull = describeResult.contains("invalid=null");
-                boolean hasSensitiveTrue = describeResult.contains("sensitive=true");
+                return describeResult.contains("invalid=null");
+            }, 5000, () -> "Dynamic broker config was not visible within 5s (missing 'invalid=null').\n" + 
+                    "Last describe output:\n" + last.get());
 
-                if (hasInvalidNull && !hasSensitiveTrue) {
-                    throw new AssertionError("Expected sensitive=true when invalid=null is visible, but it was not present.\n" +
-                            "Describe output:\n" + describeResult);
-                }
-
-                return hasSensitiveTrue && hasInvalidNull;
-            }, 5000, "Dynamic broker config was not visible within 5s. Last describe output:\n" + last.get());
+            assertTrue(last.get().contains("sensitive=true"));
         }
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandIntegrationTest.java
@@ -461,27 +461,34 @@ public class ConfigCommandIntegrationTest {
     }
 
     @ClusterTest
-    public void testUpdateInvalidBrokerConfigs() {
+    public void testUpdateInvalidBrokerConfigs() throws InterruptedException {
         updateAndCheckInvalidBrokerConfig(Optional.empty());
         updateAndCheckInvalidBrokerConfig(Optional.of(String.valueOf((cluster.brokers().entrySet().iterator().next().getKey()))));
     }
 
-    private void updateAndCheckInvalidBrokerConfig(Optional<String> brokerIdOrDefault) {
+    private void updateAndCheckInvalidBrokerConfig(Optional<String> brokerIdOrDefault) throws InterruptedException {
         List<String> alterOpts = generateDefaultAlterOpts(cluster.bootstrapServers());
         try (Admin client = cluster.admin()) {
             alterConfigWithAdmin(client, brokerIdOrDefault, Map.of("invalid", "2"), alterOpts);
+            AtomicReference<String> last = new AtomicReference<>("");
 
-            Stream<String> describeCommand = Stream.concat(
-                    Stream.concat(
-                            Stream.of("--bootstrap-server", cluster.bootstrapServers()),
-                            Stream.of(entityOp(brokerIdOrDefault).toArray(new String[0]))),
-                    Stream.of("--entity-type", "brokers", "--describe"));
-            String describeResult = captureStandardOut(run(describeCommand));
+            TestUtils.waitForCondition(() -> {
+                        Stream<String> describeCommand = Stream.concat(
+                                Stream.concat(
+                                        Stream.of("--bootstrap-server", cluster.bootstrapServers()),
+                                        Stream.of(entityOp(brokerIdOrDefault).toArray(new String[0]))),
+                                Stream.of("--entity-type", "brokers", "--describe")
+                        );
+                        String describeResult = captureStandardOut(run(describeCommand));
+                        last.set(describeResult);
 
-            // We will treat unknown config as sensitive
-            assertTrue(describeResult.contains("sensitive=true"), describeResult);
-            // Sensitive config will not return
-            assertTrue(describeResult.contains("invalid=null"), describeResult);
+                        // We will treat unknown config as sensitive
+                        // For describeResult.contains("sensitive=true") 
+                        // Sensitive config will not return
+                        // For describeResult.contains("invalid=null")
+                        return describeResult.contains("sensitive=true") && describeResult.contains("invalid=null");
+                    }, 5000,
+                    "Dynamic broker config was not visible within 5s. Last describe output:\n" + last.get());
         }
     }
 


### PR DESCRIPTION
### Description
This PR fixes a flaky failure in
`ConfigCommandIntegrationTest.testUpdateInvalidBrokerConfigs`.

The test updates an unknown broker dynamic config `(invalid=2)` and
immediately runs `kafka-configs --describe` to assert that the unknown
config is treated as sensitive `(sensitive=true)` and returned as
`invalid=null`.   In KRaft, the alter request can return before the
change is fully visible to `--describe` because `dynamic config` updates
are applied asynchronously and published via `DynamicConfigPublisher` as
metadata updates are processed.

As a result, the first describe may read stale state and miss the
expected fields, causing intermittent failures.

To make the test robust, we now poll `--describe` for a short period and
proceed once the expected output becomes visible (or fail with the last
observed output on timeout).

### Flaky Test
https://develocity.apache.org/s/2q7zc77kptd66/tests/task/:tools:test/details/org.apache.kafka.tools.ConfigCommandIntegrationTest/testUpdateInvalidBrokerConfigs()%5B2%5D?expanded-stacktrace=WyIwIl0&top-execution=1

Reviewers: Lianet Magrans <lmagrans@confluent.io>
