### PR TITLE
MINOR: Optimize Struct.validate() field iteration

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -225,7 +225,10 @@ public class Struct {
      * fails, throws a {@link DataException}.
      */
     public void validate() {
-        for (Field field : schema.fields()) {
+        List<Field> fields = schema.fields();
+        int numFields = fields.size();
+        for (int i = 0; i < numFields; i++) {
+            Field field = fields.get(i);
             Schema fieldSchema = field.schema();
             Object value = values[field.index()];
             if (value == null && (fieldSchema.isOptional() || fieldSchema.defaultValue() != null))


### PR DESCRIPTION
i was profiling kafka-connect when i found a small hotspot related to iterating over the fields. i believe the solution was to not use the iterator.

here is the flamechart for cpu where i found this (the blue specifically):

<img width="1620" height="449" alt="image" src="https://github.com/user-attachments/assets/e7a7121e-ca38-43ea-9e64-58890e57b826" />


inset:

<img width="1628" height="555" alt="image" src="https://github.com/user-attachments/assets/54081aab-7505-4433-a31b-d81f8f3d7d13" />


i am independently trying to optimize the schema-registry library as well.