### PR TITLE
KAFKA-20061 `slf4j-api` version upgrade: 1 -->> 2; `log4j-slf4j-impl` artifact renamed to `log4j-slf4j2-impl`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -239,7 +239,7 @@ License Version 2.0:
 - jspecify-1.0.0
 - log4j-api-2.25.3
 - log4j-core-2.25.3
-- log4j-slf4j-impl-2.25.3
+- log4j-slf4j2-impl-2.25.3
 - log4j-1.2-api-2.25.3
 - lz4-java-1.10.2
 - maven-artifact-3.9.11
@@ -300,7 +300,7 @@ MIT License
 - argparse4j-0.7.0, see: licenses/argparse-MIT
 - classgraph-4.8.179, see: licenses/classgraph-MIT
 - jopt-simple-5.0.4, see: licenses/jopt-simple-MIT
-- slf4j-api-1.7.36, see: licenses/slf4j-MIT
+- slf4j-api-2.0.17, see: licenses/slf4j-MIT
 - pcollections-4.0.2, see: licenses/pcollections-MIT
 
 ---------------------------------------

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -123,7 +123,7 @@ versions += [
   // https://github.com/scalameta/scalafmt/releases/tag/v3.1.0.
   scalafmt: "3.10.2",
   scoverage: "2.5.1",
-  slf4j: "1.7.36",
+  slf4j: "2.0.17",
   snappy: "1.1.10.7",
   spotbugs: "4.9.8",
   mockOAuth2Server: "2.2.1",
@@ -224,7 +224,7 @@ libs += [
   scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScala:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",
-  slf4jLog4j2: "org.apache.logging.log4j:log4j-slf4j-impl:$versions.log4j2",
+  slf4jLog4j2: "org.apache.logging.log4j:log4j-slf4j2-impl:$versions.log4j2",
   snappy: "org.xerial.snappy:snappy-java:$versions.snappy",
   spotbugs: "com.github.spotbugs:spotbugs-annotations:$versions.spotbugs",
   swaggerAnnotations: "io.swagger.core.v3:swagger-annotations:$swaggerVersion",


### PR DESCRIPTION
For rationale - see these related links:

1. log4j/2.x/manual
[log4j/2.x/manual](https://logging.apache.org/log4j/2.x/manual/installation.html#impl-core-bridge-slf4j)
2. apache/logging discussion
[apache/logging-log4j2#2475](https://github.com/apache/logging-log4j2/discussions/2475)
3. slf4j-log4j12 vs. log4j-slf4j-impl
[difference-between-slf4j-log4j12-and-log4j-slf4j-impl](https://stackoverflow.com/questions/70528201/difference-between-slf4j-log4j12-and-log4j-slf4j-impl/70528383#70528383)
4. apache/logging-log4j2/blob/rel/2.25.3
[apache/logging-log4j2/blob/rel/2.25.3](https://github.com/apache/logging-log4j2/blob/rel/2.25.3/log4j-perf-test/pom.xml#L48)

Action points:

- slf4j-api version upgrade: 1.7.36 -->> 2.0.17
- log4j-slf4j-impl artifact has to be renamed to log4j-slf4j2-impl

SLF4J version 2 release notes:

- https://www.slf4j.org/faq.html#changesInVersion200
- https://www.slf4j.org/faq.html#compatibility

ℹ️ For even more related links visit KAFKA-20061
