### PR TITLE
MINOR: Fix typo in Sender class comment

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -80,7 +80,7 @@ public class Sender implements Runnable {
 
     private final Logger log;
 
-    /* the client for sending requests to the Kafka cluster*/
+    /* the client for sending requests to the Kafka cluster */
     private final KafkaClient client;
 
     /* the record accumulator that batches records */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -80,7 +80,7 @@ public class Sender implements Runnable {
 
     private final Logger log;
 
-    /* the state of each node's connection */
+    /* the client for sending requests to the Kafka cluster*/
     private final KafkaClient client;
 
     /* the record accumulator that batches records */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -80,7 +80,7 @@ public class Sender implements Runnable {
 
     private final Logger log;
 
-    /* the state of each nodes connection */
+    /* the state of each node's connection */
     private final KafkaClient client;
 
     /* the record accumulator that batches records */


### PR DESCRIPTION
- Fix grammar error in Sender.java comment
- Changed "each nodes connection"  ->  "each node's connection"

Reviewers: Andrew Schofield <aschofield@confluent.io>
