### PR TITLE
KAFKA-20092 buildscript and project dependencies version updates

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,23 +205,23 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-- caffeine-3.2.0
+- caffeine-3.2.3
 - commons-beanutils-1.11.0
 - commons-collections-3.2.2
 - commons-digester-2.1
 - commons-logging-1.3.5
 - commons-validator-1.10.1
-- hash4j-0.22.0
+- hash4j-0.29.0
 - jackson-annotations-2.20
-- jackson-core-2.20.1
-- jackson-databind-2.20.1
-- jackson-dataformat-csv-2.20.1
-- jackson-dataformat-yaml-2.20.1
-- jackson-datatype-jdk8-2.20.1
-- jackson-jakarta-rs-base-2.20.1
-- jackson-jakarta-rs-json-provider-2.20.1
-- jackson-module-blackbird-2.20.1
-- jackson-module-jakarta-xmlbind-annotations-2.20.1
+- jackson-core-2.20.2
+- jackson-databind-2.20.2
+- jackson-dataformat-csv-2.20.2
+- jackson-dataformat-yaml-2.20.2
+- jackson-datatype-jdk8-2.20.2
+- jackson-jakarta-rs-base-2.20.2
+- jackson-jakarta-rs-json-provider-2.20.2
+- jackson-module-blackbird-2.20.2
+- jackson-module-jakarta-xmlbind-annotations-2.20.2
 - jakarta.inject-api-2.0.1
 - jakarta.validation-api-3.0.2
 - javassist-3.30.2-GA
@@ -241,8 +241,8 @@ License Version 2.0:
 - log4j-core-2.25.3
 - log4j-slf4j-impl-2.25.3
 - log4j-1.2-api-2.25.3
-- lz4-java-1.10.2
-- maven-artifact-3.9.11
+- lz4-java-1.10.3
+- maven-artifact-3.9.12
 - metrics-core-2.2.0
 - opentelemetry-proto-1.3.2-alpha
 - plexus-utils-3.6.0
@@ -250,9 +250,9 @@ License Version 2.0:
 - scala-library-2.13.18
 - scala-logging_2.13-3.9.6
 - scala-reflect-2.13.18
-- snappy-java-1.1.10.7
+- snappy-java-1.1.10.8
 - snakeyaml-2.4
-- swagger-annotations-2.2.39
+- swagger-annotations-2.2.43
 
 ===============================================================================
 This product bundles various third-party components under other open source
@@ -277,12 +277,12 @@ see: licenses/eclipse-public-license-2.0
 - hk2-utils-3.0.6
 - osgi-resource-locator-1.0.3
 - aopalliance-repackaged-3.0.6
-- jersey-client-3.1.10
-- jersey-common-3.1.10
-- jersey-container-servlet-3.1.10
-- jersey-container-servlet-core-3.1.10
-- jersey-hk2-3.1.10
-- jersey-server-3.1.10
+- jersey-client-3.1.11
+- jersey-common-3.1.11
+- jersey-container-servlet-3.1.11
+- jersey-container-servlet-core-3.1.11
+- jersey-hk2-3.1.11
+- jersey-server-3.1.11
 
 ---------------------------------------
 CDDL 1.1 + GPLv2 with classpath exception
@@ -298,10 +298,10 @@ see: licenses/CDDL+GPL-1.1
 MIT License
 
 - argparse4j-0.7.0, see: licenses/argparse-MIT
-- classgraph-4.8.179, see: licenses/classgraph-MIT
+- classgraph-4.8.184, see: licenses/classgraph-MIT
 - jopt-simple-5.0.4, see: licenses/jopt-simple-MIT
 - slf4j-api-1.7.36, see: licenses/slf4j-MIT
-- pcollections-4.0.2, see: licenses/pcollections-MIT
+- pcollections-5.0.0, see: licenses/pcollections-MIT
 
 ---------------------------------------
 BSD 2-Clause
@@ -312,8 +312,8 @@ BSD 2-Clause
 ---------------------------------------
 BSD 3-Clause
 
-- jline-3.30.4, see: licenses/jline-BSD-3-clause
-- protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
+- jline-3.30.6, see: licenses/jline-BSD-3-clause
+- protobuf-java-3.25.8, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 
 ---------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -33,14 +33,14 @@ plugins {
   id 'idea'
   id 'jacoco'
   id 'java-library'
-  id 'org.owasp.dependencycheck' version '12.1.8'
+  id 'org.owasp.dependencycheck' version '12.2.0'
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
-  id "com.github.spotbugs" version '6.4.4' apply false
+  id "com.github.spotbugs" version '6.4.8' apply false
   id 'org.scoverage' version '8.1' apply false
   id 'com.gradleup.shadow' version '8.3.9' apply false
-  id 'com.diffplug.spotless' version "8.0.0"
+  id 'com.diffplug.spotless' version "8.2.1"
 }
 
 ext {

--- a/checkstyle/.scalafmt.conf
+++ b/checkstyle/.scalafmt.conf
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-version = 3.10.2
+version = 3.10.3
 runner.dialect = scala213
 docstrings.style = Asterisk
 docstrings.wrap = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ group=org.apache.kafka
 version=4.3.0-SNAPSHOT
 scalaVersion=2.13.18
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
-swaggerVersion=2.2.39
+swaggerVersion=2.2.43
 task=build
 org.gradle.jvmargs=-Xmx4g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,22 +53,22 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.80",
-  caffeine: "3.2.0",
-  bndlib: "7.1.0",
-  checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.2.0",
+  bcpkix: "1.83",
+  caffeine: "3.2.3",
+  bndlib: "7.2.1",
+  checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.3.1",
   commonsValidator: "1.10.1",
-  classgraph: "4.8.179",
+  classgraph: "4.8.184",
   gradle: "9.2.1",
   grgit: "5.3.3",
   httpclient: "4.5.14",
-  jackson: "2.20.1",
+  jackson: "2.20.2",
   jacksonAnnotations: "2.20",
   jacoco: "0.8.14",
   javassist: "3.30.2-GA",
   jetty: "12.0.32",
-  jersey: "3.1.10",
-  jline: "3.30.4",
+  jersey: "3.1.11",
+  jline: "3.30.6",
   jmh: "1.37",
   hamcrest: "3.0",
   scalaLogging: "3.9.6",
@@ -79,8 +79,8 @@ versions += [
   jfreechart: "1.5.6",
   jopt: "5.0.4",
   jose4j: "0.9.6",
-  junit: "5.13.1",
-  jqwik: "1.9.2",
+  junit: "5.14.3",
+  jqwik: "1.9.3",
   kafka_0110: "0.11.0.3",
   kafka_10: "1.0.2",
   kafka_11: "1.1.1",
@@ -109,31 +109,31 @@ versions += [
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.internal.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/internal/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24
-  lz4: "1.10.2",
-  mavenArtifact: "3.9.11",
+  lz4: "1.10.3",
+  mavenArtifact: "3.9.12",
   metrics: "2.2.0",
-  mockito: "5.20.0",
+  mockito: "5.21.0",
   opentelemetryProto: "1.3.2-alpha",
-  protobuf: "3.25.5", // a dependency of opentelemetryProto
-  pcollections: "4.0.2",
+  protobuf: "3.25.8", // a dependency of opentelemetryProto
+  pcollections: "5.0.0",
   re2j: "1.8",
   rocksDB: "10.1.3",
   // When updating the scalafmt version please also update the version field in checkstyle/.scalafmt.conf. scalafmt now
   // has the version field as mandatory in its configuration, see
   // https://github.com/scalameta/scalafmt/releases/tag/v3.1.0.
-  scalafmt: "3.10.2",
-  scoverage: "2.5.1",
+  scalafmt: "3.10.3",
+  scoverage: "2.5.2",
   slf4j: "1.7.36",
-  snappy: "1.1.10.7",
+  snappy: "1.1.10.8",
   spotbugs: "4.9.8",
-  mockOAuth2Server: "2.2.1",
-  zinc: "1.11.0",
+  mockOAuth2Server: "2.3.0",
+  zinc: "1.12.0",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-10",
-  junitPlatform: "1.13.1",
+  junitPlatform: "1.14.3",
   hdrHistogram: "2.2.2",
-  hash4j: "0.22.0"
+  hash4j: "0.29.0"
 ]
 
 libs += [


### PR DESCRIPTION
**Rationale/note:** all updates should be safe (i.e. they are mostly at the patch level).

**JIRA ticket:** KAFKA-20092

**Details:**
- bcpkix: 1.80 -->> 1.83
- caffeine: 3.2.0 -->> 3.2.3
- bndlib: 7.1.0 -->> 7.2.1
- checkstyle: 12.2.0 -->> 12.3.1
- classgraph: 4.8.179 -->> 4.8.184
- jackson: 2.20.1 -->> 2.20.2
- jline: 3.30.4 -->> 3.30.6
- junit: 5.13.1 -->> 5.14.3
- junitPlatform: 1.13.1 -->> 1.14.3
- jqwik: 1.9.2 -->> 1.9.3
- lz4: 1.10.2 -->> 1.10.3
- mavenArtifact: 3.9.11 -->> 3.9.12
- mockito: 5.20.0 -->> 5.21.0
- protobuf: 3.25.5 -->> 3.25.8
- pcollections: 4.0.2 -->> 5.0.0
- scalafmt: 3.10.2 -->> 3.10.3
- scoverage: 2.5.1 -->> 2.5.2
- snappy: 1.1.10.7 -->> 1.1.10.8
- mockOAuth2Server: 2.2.1 -->> 2.3.0
- swagger: 2.2.39 -->> 2.2.43
- zinc: 1.11.0 -->> 1.12.0
- hash4j: 0.22.0 -->> 0.29.0
- gradle plugins:
  - dependencycheck: 12.1.8 -->> 12.2.0
  - spotbugs: 6.4.4 -->> 6.4.8
  - spotless: 8.0.0 -->> 8.2.1

**Some notable release notes:** 
 - JUnit:
   - https://docs.junit.org/5.14.3/release-notes.html
   - https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-5.14
 - pcollections:
   - https://github.com/hrldcpr/pcollections/blob/master/CHANGELOG.md#500---2025-07-23
   - https://github.com/hrldcpr/pcollections/compare/v4.0.2...v5.0.0
 - mockOAuth2Server:
   - https://github.com/navikt/mock-oauth2-server/releases/tag/2.3.0
   - https://github.com/navikt/mock-oauth2-server/compare/2.2.1...2.3.0
 - Mockito: https://github.com/mockito/mockito/releases/tag/v5.21.0
 - Zinc: https://github.com/sbt/zinc/releases/tag/v1.12.0
 - hash4j:
   -  https://github.com/dynatrace-oss/hash4j/tree/v0.29.0/doc/apidiffs
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.29.0
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.28.0
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.27.0
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.26.0
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.25.0
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.24.0
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.23.1
   - https://github.com/dynatrace-oss/hash4j/releases/tag/v0.23.0