### PR TITLE
KAFKA-20063 Fix Docker build hang by reordering tar extraction before…

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -34,16 +34,18 @@ RUN set -eux ; \
     apk update ; \
     apk upgrade ; \
     apk add --no-cache bash; \
+    mkdir opt/kafka; \
     if [ -n "$KAFKA_URL" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent procps; \
         wget -nv -O kafka.tgz "$KAFKA_URL"; \
         wget -nv -O kafka.tgz.asc "$KAFKA_URL.asc"; \
         wget -nv -O KEYS https://downloads.apache.org/kafka/KEYS; \
+        tar xfz kafka.tgz -C opt/kafka --strip-components 1; \
         gpg --import KEYS; \
         gpg --batch --verify kafka.tgz.asc kafka.tgz; \
-    fi; \
-    mkdir opt/kafka; \
-    tar xfz kafka.tgz -C opt/kafka --strip-components 1;
+    else \
+        tar xfz kafka.tgz -C opt/kafka --strip-components 1; \
+    fi;
 
 # Generate jsa files using dynamic CDS for kafka server start command and kafka storage format command
 RUN /etc/kafka/docker/jsa_launch


### PR DESCRIPTION
The Docker build for Alpine images intermittently hangs during the tar
extraction phase. This is caused by gcompat being loaded into the
process space during the preceding gpg verification step, which
interferes with Alpine's tar implementation and causes a deadlock.

see
https://blog.tsunanet.net/2022/09/tar-hanging-when-extracting-archive.html

Reviewers: Christo Lolov <lolovc@amazon.com>, TengYao Chi
 <frankvicky@apache.org>, Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>
