### PR TITLE
KAFKA-20069: remove templateData.js in release.py

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@
 group=org.apache.kafka
 # NOTE: When you change this version number, you should also make sure to update
 # the version numbers in
-#  - docs/js/templateData.js
 #  - tests/kafkatest/__init__.py
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py

--- a/release/release.py
+++ b/release/release.py
@@ -295,8 +295,6 @@ textfiles.replace(f"{repo_dir}/streams/quickstart/java/src/main/resources/archet
 print("Updating ducktape version.py")
 textfiles.replace(f"{repo_dir}/tests/kafkatest/version.py", "^DEV_VERSION =.*",
     f"DEV_VERSION = KafkaVersion(\"{release_version}-SNAPSHOT\")", regex=True)
-print("Updating docs templateData.js")
-textfiles.replace(f"{repo_dir}/docs/js/templateData.js", "-SNAPSHOT", "", regex=True)
 git.commit(f"Bump version to {release_version}")
 git.create_tag(rc_tag)
 git.switch_branch(starting_branch)


### PR DESCRIPTION
The `templateData.js` is removed by
https://github.com/apache/kafka/pull/21195. We should also remove
related paths.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
