### PR TITLE
KAFKA-12641: RemoteLogMetadataCache: bound leader-epoch state and cache highest copied offset

### DIFF
--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java
@@ -128,9 +128,9 @@ public interface RemoteLogMetadataManager extends Configurable, Closeable {
             throws RemoteStorageException;
 
     /**
-     * Returns the highest log offset of topic partition for the given leader epoch in remote storage. This is used by
-     * remote log management subsystem to know up to which offset the segments have been copied to remote storage for
-     * a given leader epoch.
+     * Returns the highest log offset that has been successfully copied to remote storage for the given leader epoch.
+     * This is a monotonic progress marker used by the management subsystem and is retained even after delete
+     * transitions to avoid recopying segments; it may be higher than offsets currently present in remote storage.
      *
      * @param topicIdPartition topic partition
      * @param leaderEpoch      leader epoch

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogLeaderEpochState.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogLeaderEpochState.java
@@ -147,6 +147,10 @@ class RemoteLogLeaderEpochState {
         return highestLogOffset;
     }
 
+    boolean isEmpty() {
+        return offsetToId.isEmpty() && unreferencedSegmentIds.isEmpty();
+    }
+
     /**
      * Returns the RemoteLogSegmentId of a segment for the given offset, if there exists a mapping associated with
      * the greatest offset less than or equal to the given offset, or null if there is no such mapping.

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
@@ -102,10 +102,11 @@ public class RemoteLogMetadataCache {
             = new ConcurrentHashMap<>();
 
     // It contains leader epoch to the respective entry containing the state.
-    // TODO We are not clearing the entry for epoch when RemoteLogLeaderEpochState becomes empty. This will be addressed
-    // later. We will look into it when we integrate these APIs along with RemoteLogManager changes.
-    // https://issues.apache.org/jira/browse/KAFKA-12641
+    // Entries are removed once all segments for the epoch are deleted to avoid unbounded growth (KAFKA-12641).
     protected final ConcurrentMap<Integer, RemoteLogLeaderEpochState> leaderEpochEntries = new ConcurrentHashMap<>();
+    // Tracks the highest offset per leader epoch that has been successfully copied. This is monotonic and retained
+    // after deletions to avoid recopying; it grows only with the number of leader epochs.
+    private final ConcurrentMap<Integer, Long> leaderEpochToHighestOffset = new ConcurrentHashMap<>();
 
     private final CountDownLatch initializedLatch = new CountDownLatch(1);
 
@@ -120,6 +121,7 @@ public class RemoteLogMetadataCache {
     boolean awaitInitialized(long timeout, TimeUnit unit) throws InterruptedException {
         return initializedLatch.await(timeout, unit);
     }
+
 
     /**
      * Returns {@link RemoteLogSegmentMetadata} if it exists for the given leader-epoch containing the offset and with
@@ -217,9 +219,10 @@ public class RemoteLogMetadataCache {
     protected final void handleSegmentWithCopySegmentFinishedState(RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
         doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
             (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) -> {
-                long leaderEpochEndOffset = highestOffsetForEpoch(leaderEpoch, remoteLogSegmentMetadata);
+                long epochEndOffset = highestOffsetForEpoch(leaderEpoch, remoteLogSegmentMetadata);
                 remoteLogLeaderEpochState
-                        .handleSegmentWithCopySegmentFinishedState(startOffset, segmentId, leaderEpochEndOffset);
+                        .handleSegmentWithCopySegmentFinishedState(startOffset, segmentId, epochEndOffset);
+                leaderEpochToHighestOffset.merge(leaderEpoch, epochEndOffset, Math::max);
             });
 
         // Put the entry with the updated metadata.
@@ -240,13 +243,17 @@ public class RemoteLogMetadataCache {
     private void handleSegmentWithDeleteSegmentFinishedState(RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
         log.debug("Removing the entry as it reached the terminal state: [{}]", remoteLogSegmentMetadata);
 
-        doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
-            (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) ->
-                    remoteLogLeaderEpochState.handleSegmentWithDeleteSegmentFinishedState(segmentId));
+        RemoteLogSegmentId remoteLogSegmentId = remoteLogSegmentMetadata.remoteLogSegmentId();
+        for (Integer leaderEpoch : remoteLogSegmentMetadata.segmentLeaderEpochs().keySet()) {
+            leaderEpochEntries.computeIfPresent(leaderEpoch, (epoch, remoteLogLeaderEpochState) -> {
+                remoteLogLeaderEpochState.handleSegmentWithDeleteSegmentFinishedState(remoteLogSegmentId);
+                return remoteLogLeaderEpochState.isEmpty() ? null : remoteLogLeaderEpochState;
+            });
+        }
 
         // Remove the segment's id to metadata mapping because this segment is considered as deleted and it cleared all
         // the state of this segment in the cache.
-        idToSegmentMetadata.remove(remoteLogSegmentMetadata.remoteLogSegmentId());
+        idToSegmentMetadata.remove(remoteLogSegmentId);
     }
 
     private void doHandleSegmentStateTransitionForLeaderEpochs(RemoteLogSegmentMetadata remoteLogSegmentMetadata,
@@ -299,14 +306,16 @@ public class RemoteLogMetadataCache {
     }
 
     /**
-     * Returns the highest offset of a segment for the given leader epoch if exists, else it returns empty. The segments
-     * that have reached the {@link RemoteLogSegmentState#COPY_SEGMENT_FINISHED} or later states are considered here.
+     * Returns the highest offset that has reached {@link RemoteLogSegmentState#COPY_SEGMENT_FINISHED} for the given
+     * leader epoch. This is a monotonic progress marker and is retained even after delete transitions so it does not
+     * regress or disappear. It may be higher than the end offset of segments currently present in remote storage
+     * when older segments have been deleted due to retention.
      *
      * @param leaderEpoch leader epoch
      */
     Optional<Long> highestOffsetForEpoch(int leaderEpoch) {
-        RemoteLogLeaderEpochState entry = leaderEpochEntries.get(leaderEpoch);
-        return entry != null ? Optional.ofNullable(entry.highestLogOffset()) : Optional.empty();
+        // TODO: If a future snapshot/rehydration path bypasses COPY_SEGMENT_FINISHED updates, it must rebuild this map.
+        return Optional.ofNullable(leaderEpochToHighestOffset.get(leaderEpoch));
     }
 
     /**

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java
@@ -167,6 +167,88 @@ public class RemoteLogMetadataCacheTest {
         assertTrue(cache.isInitialized());
     }
 
+    @Test
+    public void testLeaderEpochEntryCleanupOnDeleteFinished() throws RemoteResourceNotFoundException {
+        cache.markInitialized();
+        int leaderEpoch = 2;
+        long startOffset = 0L;
+        long endOffset = 100L;
+        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+        RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, startOffset, endOffset,
+                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, startOffset));
+        cache.addCopyInProgressSegment(segmentMetadata);
+
+        RemoteLogSegmentMetadataUpdate copyFinished = new RemoteLogSegmentMetadataUpdate(
+                segmentId, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1);
+        cache.updateRemoteLogSegmentMetadata(copyFinished);
+
+        assertTrue(cache.leaderEpochEntries.containsKey(leaderEpoch));
+        assertEquals(Optional.of(endOffset), cache.highestOffsetForEpoch(leaderEpoch));
+
+        RemoteLogSegmentMetadataUpdate deleteStarted = new RemoteLogSegmentMetadataUpdate(
+                segmentId, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId1);
+        cache.updateRemoteLogSegmentMetadata(deleteStarted);
+        RemoteLogSegmentMetadataUpdate deleteFinished = new RemoteLogSegmentMetadataUpdate(
+                segmentId, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+        cache.updateRemoteLogSegmentMetadata(deleteFinished);
+
+        assertFalse(cache.leaderEpochEntries.containsKey(leaderEpoch));
+        assertEquals(Optional.of(endOffset), cache.highestOffsetForEpoch(leaderEpoch));
+    }
+
+    @Test
+    public void testHighestOffsetForEpochIsMonotonic() throws RemoteResourceNotFoundException {
+        cache.markInitialized();
+        int leaderEpoch = 1;
+
+        RemoteLogSegmentId highSegmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+        RemoteLogSegmentMetadata highSegment = new RemoteLogSegmentMetadata(highSegmentId, 51L, 100L,
+                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, 51L));
+        cache.addCopyInProgressSegment(highSegment);
+        cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                highSegmentId, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1));
+
+        RemoteLogSegmentId lowSegmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+        RemoteLogSegmentMetadata lowSegment = new RemoteLogSegmentMetadata(lowSegmentId, 0L, 50L,
+                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, 0L));
+        cache.addCopyInProgressSegment(lowSegment);
+        cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                lowSegmentId, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1));
+
+        assertEquals(Optional.of(100L), cache.highestOffsetForEpoch(leaderEpoch));
+    }
+
+    @Test
+    public void testLeaderEpochEntryRetainedWhenSegmentsRemain() throws RemoteResourceNotFoundException {
+        cache.markInitialized();
+        int leaderEpoch = 3;
+
+        RemoteLogSegmentId segmentId1 = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+        RemoteLogSegmentMetadata segment1 = new RemoteLogSegmentMetadata(segmentId1, 0L, 100L,
+                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, 0L));
+        cache.addCopyInProgressSegment(segment1);
+        cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId1, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1));
+
+        RemoteLogSegmentId segmentId2 = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+        RemoteLogSegmentMetadata segment2 = new RemoteLogSegmentMetadata(segmentId2, 101L, 200L,
+                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, 101L));
+        cache.addCopyInProgressSegment(segment2);
+        cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId2, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1));
+
+        assertTrue(cache.leaderEpochEntries.containsKey(leaderEpoch));
+        assertEquals(Optional.of(200L), cache.highestOffsetForEpoch(leaderEpoch));
+
+        cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId1, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId1));
+        cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId1, time.milliseconds(), Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1));
+
+        assertTrue(cache.leaderEpochEntries.containsKey(leaderEpoch));
+        assertEquals(Optional.of(200L), cache.highestOffsetForEpoch(leaderEpoch));
+    }
+
     private void updateAndVerifyCacheContents(RemoteLogSegmentMetadataUpdate updatedMetadata,
                                               RemoteLogSegmentState expectedSegmentState,
                                               int leaderEpoch) throws RemoteResourceNotFoundException {


### PR DESCRIPTION
JIRA: KAFKA-12641

## Summary
This PR bounds per-leader-epoch cache growth in `RemoteLogMetadataCache` and defines `highestOffsetForEpoch` as a monotonic “highest successfully copied offset” watermark that is retained across retention-driven deletes.

## Problem / Motivation
1) **Unbounded leader-epoch state growth**  
`RemoteLogMetadataCache` keeps a per-leader-epoch `RemoteLogLeaderEpochState`. When all remote segments for an epoch are deleted, the epoch entry can become empty but historically was not removed, causing the cache to grow without bound over time (KAFKA-12641).

2) **Progress signal semantics**  
The management subsystem consumes `highestOffsetForEpoch` as a progress signal. This value should be a monotonic watermark of what has been successfully copied, and it should not regress or disappear due to retention-driven deletes.

## Changes
### 1) Bound leader-epoch entry growth (KAFKA-12641)
Remove a leader-epoch entry once all segments for that epoch have been deleted (i.e. the per-epoch state becomes empty) to avoid unbounded growth.

### 2) Make `highestOffsetForEpoch` a pure lookup of a monotonic watermark
Maintain a per-epoch `leaderEpochToHighestOffset` watermark:
- Updated on `COPY_SEGMENT_FINISHED` and merged via `max` (monotonic).
- `highestOffsetForEpoch(int leaderEpoch)` becomes a pure lookup into this map (no fallback / hidden side-effects).

Rationale: we now delete empty `leaderEpochEntries`, so `highestOffsetForEpoch` must not depend on per-epoch state that can be removed due to retention; otherwise the progress watermark could disappear and trigger recopy loops.

NOTE: The watermark may be **higher than offsets currently present in remote storage** after retention-driven deletes.

### 3) Documentation clarifications
Update Javadocs (both cache and public API) to explicitly state:
- This value is a monotonic progress marker used by the management subsystem.
- It is retained after delete transitions and may exceed offsets currently present in remote storage.

## Testing
Executed locally:
- `./gradlew :storage:test --tests org.apache.kafka.server.log.remote.metadata.storage.RemoteLogMetadataCacheTest`
- `./gradlew :storage:test`

## Files touched
- `storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java`
- `storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java`
- `storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java`
- `storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java`
