### PR TITLE
KAFKA-19233: Allow fenced members to rejoin streams group with epoch 0

### DIFF
--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -1086,7 +1086,6 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         .setWarmupTasks(List.empty.asJava)
 
       assertEquals(expectedRejoinResponse, rejoinResponse)
-
     } finally {
       admin.close()
     }

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -1028,7 +1028,7 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
 
       val topology = createMockTopology(topicName)
 
-      // Join and wait for assignment.
+      // Join the group.
       var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponseData = null
       TestUtils.waitUntilTrue(() => {
         streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
@@ -1049,19 +1049,15 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         streamsGroupHeartbeatResponse.errorCode == Errors.NONE.code() &&
           streamsGroupHeartbeatResponse.activeTasks() != null &&
           !streamsGroupHeartbeatResponse.activeTasks().isEmpty
-      }, "Did not get assignment within the timeout period.")
+      }, "Could not join the group successfully.")
 
-      // Verify we have an epoch and assignment.
-      assertEquals(memberId, streamsGroupHeartbeatResponse.memberId())
-      assertTrue(streamsGroupHeartbeatResponse.memberEpoch() > 0)
-      assertNotNull(streamsGroupHeartbeatResponse.activeTasks())
+      // Verify initial join success with assignment.
+      assertEquals(2, streamsGroupHeartbeatResponse.memberEpoch())
 
-      val epochBeforeRejoin = streamsGroupHeartbeatResponse.memberEpoch()
-      val expectedActiveTasks = List(
-        new StreamsGroupHeartbeatResponseData.TaskIds()
-          .setSubtopologyId("subtopology-1")
-          .setPartitions(List(0, 1, 2).map(_.asInstanceOf[Integer]).asJava)
-      ).asJava
+      // Expected assignment.
+      val expectedActiveTasks = List(new StreamsGroupHeartbeatResponseData.TaskIds()
+        .setSubtopologyId(streamsGroupHeartbeatResponse.activeTasks().get(0).subtopologyId())
+        .setPartitions(List[Integer](0, 1, 2).asJava)).asJava
 
       // Simulate a fenced member attempting to rejoin with epoch=0.
       val rejoinResponse = streamsGroupHeartbeat(
@@ -1075,11 +1071,13 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         topology = topology
       )
 
-      // Verify the full rejoin response.
+      // Verify the full response.
+      // Since the topology hasn't changed, the member should get their current
+      // state back with the same epoch (2) and assignment.
       val expectedRejoinResponse = new StreamsGroupHeartbeatResponseData()
         .setErrorCode(Errors.NONE.code())
         .setMemberId(memberId)
-        .setMemberEpoch(epochBeforeRejoin)
+        .setMemberEpoch(2)
         .setHeartbeatIntervalMs(rejoinResponse.heartbeatIntervalMs())
         .setActiveTasks(expectedActiveTasks)
         .setStandbyTasks(List.empty.asJava)

--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -1003,6 +1003,95 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
     }
   }
 
+  @ClusterTest
+  def testFencedMemberCanRejoinWithEpochZero(): Unit = {
+    val admin = cluster.admin()
+    val memberId = "test-fenced-rejoin-member"
+    val groupId = "test-fenced-rejoin-group"
+    val topicName = "test-fenced-topic"
+
+    try {
+      TestUtils.createOffsetsTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq
+      )
+
+      // Create topic first.
+      TestUtils.createTopicWithAdmin(
+        admin = admin,
+        brokers = cluster.brokers.values().asScala.toSeq,
+        controllers = cluster.controllers().values().asScala.toSeq,
+        topic = topicName,
+        numPartitions = 3
+      )
+
+      val topology = createMockTopology(topicName)
+
+      // Join and wait for assignment.
+      var streamsGroupHeartbeatResponse: StreamsGroupHeartbeatResponseData = null
+      TestUtils.waitUntilTrue(() => {
+        streamsGroupHeartbeatResponse = streamsGroupHeartbeat(
+          groupId = groupId,
+          memberId = memberId,
+          rebalanceTimeoutMs = 1000,
+          activeTasks = Option(streamsGroupHeartbeatResponse)
+            .map(r => convertTaskIds(r.activeTasks()))
+            .getOrElse(List.empty),
+          standbyTasks = Option(streamsGroupHeartbeatResponse)
+            .map(r => convertTaskIds(r.standbyTasks()))
+            .getOrElse(List.empty),
+          warmupTasks = Option(streamsGroupHeartbeatResponse)
+            .map(r => convertTaskIds(r.warmupTasks()))
+            .getOrElse(List.empty),
+          topology = topology
+        )
+        streamsGroupHeartbeatResponse.errorCode == Errors.NONE.code() &&
+          streamsGroupHeartbeatResponse.activeTasks() != null &&
+          !streamsGroupHeartbeatResponse.activeTasks().isEmpty
+      }, "Did not get assignment within the timeout period.")
+
+      // Verify we have an epoch and assignment.
+      assertEquals(memberId, streamsGroupHeartbeatResponse.memberId())
+      assertTrue(streamsGroupHeartbeatResponse.memberEpoch() > 0)
+      assertNotNull(streamsGroupHeartbeatResponse.activeTasks())
+
+      val epochBeforeRejoin = streamsGroupHeartbeatResponse.memberEpoch()
+      val expectedActiveTasks = List(
+        new StreamsGroupHeartbeatResponseData.TaskIds()
+          .setSubtopologyId("subtopology-1")
+          .setPartitions(List(0, 1, 2).map(_.asInstanceOf[Integer]).asJava)
+      ).asJava
+
+      // Simulate a fenced member attempting to rejoin with epoch=0.
+      val rejoinResponse = streamsGroupHeartbeat(
+        groupId = groupId,
+        memberId = memberId,
+        memberEpoch = 0,
+        rebalanceTimeoutMs = 1000,
+        activeTasks = List.empty,
+        standbyTasks = List.empty,
+        warmupTasks = List.empty,
+        topology = topology
+      )
+
+      // Verify the full rejoin response.
+      val expectedRejoinResponse = new StreamsGroupHeartbeatResponseData()
+        .setErrorCode(Errors.NONE.code())
+        .setMemberId(memberId)
+        .setMemberEpoch(epochBeforeRejoin)
+        .setHeartbeatIntervalMs(rejoinResponse.heartbeatIntervalMs())
+        .setActiveTasks(expectedActiveTasks)
+        .setStandbyTasks(List.empty.asJava)
+        .setWarmupTasks(List.empty.asJava)
+
+      assertEquals(expectedRejoinResponse, rejoinResponse)
+
+    } finally {
+      admin.close()
+    }
+  }
+
   private def convertTaskIds(responseTasks: java.util.List[StreamsGroupHeartbeatResponseData.TaskIds]): List[StreamsGroupHeartbeatRequestData.TaskIds] = {
     if (responseTasks == null) {
       List()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1707,6 +1707,9 @@ public class GroupMetadataManager {
         List<StreamsGroupHeartbeatRequestData.TaskIds> ownedStandbyTasks,
         List<StreamsGroupHeartbeatRequestData.TaskIds> ownedWarmupTasks
     ) {
+        // Epoch 0 is a special value indicating the member wants to (re)join the group.
+        if (receivedMemberEpoch == 0) return;
+
         if (receivedMemberEpoch > member.memberEpoch()) {
             throw new FencedMemberEpochException("The streams group member has a greater member "
                 + "epoch (" + receivedMemberEpoch + ") than the one known by the group coordinator ("


### PR DESCRIPTION
This fix allows members to rejoin a streams group with memberEpoch=0
after being fenced, as specified by KIP-848. Previously, the validation
in throwIfStreamsGroupMemberEpochIsInvalid rejected epoch=0 when the
member had a higher epoch on the server.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Lucas Brutschy
 <lbrutschy@confluent.io>
