### PR TITLE
KAFKA-20072 updated random uuid generator to not include hyphen

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -75,7 +75,7 @@ public class Uuid implements Comparable<Uuid> {
      */
     public static Uuid randomUuid() {
         Uuid uuid = unsafeRandomUuid();
-        while (RESERVED.contains(uuid) || uuid.toString().startsWith("-")) {
+        while (RESERVED.contains(uuid) || uuid.toString().contains("-")) {
             uuid = unsafeRandomUuid();
         }
         return uuid;


### PR DESCRIPTION
This fix prevents hyphens in the uuid of the topics which solves the jira issue KAFKA-20072 of difficulty in copying the id.
All client unit test for random uuid generator passed.
