### PR TITLE
[KAFKA-19331]: Fix error handling when leader not found in applyLocalFollowersDelta

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2536,13 +2536,16 @@ class ReplicaManager(val config: KafkaConfig,
               initialFetchOffset(log)
             ))
           case None =>
-            stateChangeLogger.trace(s"Unable to start fetching $topicPartition with topic ID ${partition.topicId} " +
+            stateChangeLogger.info(s"Unable to start fetching $topicPartition with topic ID ${partition.topicId} " +
               s"from leader ${partition.leaderReplicaIdOpt} because it is not alive.")
+            replicaFetcherManager.addFailedPartition(topicPartition)
         }
       }
 
       replicaFetcherManager.addFetcherForPartitions(partitionAndOffsets)
-      stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
+      if (partitionAndOffsets.nonEmpty) {
+        stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionAndOffsets.size} partitions")
+      }
 
       partitionsToStartFetching.foreach{ case (topicPartition, partition) =>
         completeDelayedOperationsWhenNotPartitionLeader(topicPartition, partition.topicId)}

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -54,6 +54,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.coordinator.transaction.{AddPartitionsToTxnConfig, TransactionLogConfig}
 import org.apache.kafka.image._
+import org.apache.kafka.image.ClusterImageTest
 import org.apache.kafka.metadata.KRaftMetadataCache
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
 import org.apache.kafka.metadata.{LeaderRecoveryState, MetadataCache, PartitionRegistration}
@@ -4966,6 +4967,39 @@ class ReplicaManagerTest {
         FOO_UUID,
         hostedPartition.asInstanceOf[HostedPartition.Offline].partition.flatMap(p => p.topicId).get
       )
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyLocalFollowersDeltaWhenLeaderNotInMetadata(): Unit = {
+    val localId = 1
+    val leaderId = 2
+    val topicPartition = new TopicPartition("foo", 0)
+    val replicaManager = setupReplicaManagerWithMockedPurgatories(
+      new MockTimer(time), localId, aliveBrokerIds = Seq(localId))
+    
+    try {
+      val followerDelta = topicsCreateDelta(localId, isStartIdLeader = false)
+      val clusterImageWithoutLeader = new ClusterImage(
+        util.Map.of(localId, ClusterImageTest.IMAGE1.broker(localId)),
+        util.Map.of())
+      val metadataImage = new MetadataImage(
+        new MetadataProvenance(100L, 10, 1000L, true),
+        new FeaturesImage(Collections.emptyMap(), MetadataVersion.latestProduction()),
+        clusterImageWithoutLeader,
+        followerDelta.apply(),
+        ConfigurationsImage.EMPTY, ClientQuotasImage.EMPTY, ProducerIdsImage.EMPTY,
+        AclsImage.EMPTY, ScramImage.EMPTY, DelegationTokenImage.EMPTY)
+      
+      replicaManager.applyDelta(followerDelta, metadataImage)
+      
+      assertTrue(replicaManager.replicaFetcherManager.failedPartitions.contains(topicPartition))
+      assertEquals(None, replicaManager.replicaFetcherManager.getFetcher(topicPartition))
+      val HostedPartition.Online(partition) = replicaManager.getPartition(topicPartition)
+      assertFalse(partition.isLeader)
+      assertEquals(leaderId, partition.leaderReplicaIdOpt.get)
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }


### PR DESCRIPTION
## Problem
When a partition becomes a follower but the leader broker is not available in the metadata image, the code only logs at TRACE level, doesn't track the partition as failed, and logs a misleading success message with incorrect count.

issue ticket: https://issues.apache.org/jira/browse/KAFKA-19331

## Solution
- Changed log level from TRACE to INFO for better visibility
- Added `addFailedPartition()` call to track failed partitions for retry
- Fixed log message to use `partitionAndOffsets.size` instead of `partitionsToStartFetching.size`
- Added conditional logging to avoid "Started fetchers for 0 partitions" message

## Testing
Added unit test `testApplyLocalFollowersDeltaWhenLeaderNotInMetadata` to verify the fix.

Reviewers: Abhijit Burman <abhijit.burman@avataar.ai>
