### PR TITLE
KAFKA-20074: Fix flaky PlaintextAdminIntegrationTest#testDescribeStreamsGroupsNotReady

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -254,7 +254,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
 
     val boxed: Optional[java.lang.Short] =
       replicationFactor.map[java.lang.Short](s => java.lang.Short.valueOf(s))
-      
     val streamsRebalanceData = new StreamsRebalanceData(
       UUID.randomUUID(),
       Optional.empty(),

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -241,7 +241,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                                configsToRemove: List[String] = List(),
                                inputTopics: Set[String],
                                changelogTopics: Set[String] = Set(),
-                               streamsGroupId: String): AsyncKafkaConsumer[K, V] = {
+                               streamsGroupId: String,
+                               replicationFactor: Optional[Short] = Optional.empty()): AsyncKafkaConsumer[K, V] = {
     val props = new Properties()
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props.put(ConsumerConfig.GROUP_ID_CONFIG, streamsGroupId)
@@ -251,6 +252,9 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     props ++= configOverrides
     configsToRemove.foreach(props.remove(_))
 
+    val boxed: Optional[java.lang.Short] =
+      replicationFactor.map[java.lang.Short](s => java.lang.Short.valueOf(s))
+      
     val streamsRebalanceData = new StreamsRebalanceData(
       UUID.randomUUID(),
       Optional.empty(),
@@ -259,7 +263,7 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
           inputTopics.asJava,
           util.Set.of(),
           util.Map.of(),
-          changelogTopics.map(c => (c, new StreamsRebalanceData.TopicInfo(Optional.empty(), Optional.empty(), util.Map.of()))).toMap.asJava,
+          changelogTopics.map(c => (c, new StreamsRebalanceData.TopicInfo(Optional.empty(), boxed, util.Map.of()))).toMap.asJava,
           util.Set.of()
         )),
       Map.empty[String, String].asJava

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -4465,10 +4465,12 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val config = createConfig
     client = Admin.create(config)
 
+    val unavailableReplicationFactorInThisCluster = 9999.toShort
     val streams = createStreamsGroup(
       inputTopics = Set(testTopicName),
       changelogTopics = Set(testTopicName + "-changelog"),
-      streamsGroupId = streamsGroupId
+      streamsGroupId = streamsGroupId,
+      replicationFactor = Optional.of(unavailableReplicationFactorInThisCluster),
     )
     streams.poll(JDuration.ofMillis(500L))
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -4470,7 +4470,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       inputTopics = Set(testTopicName),
       changelogTopics = Set(testTopicName + "-changelog"),
       streamsGroupId = streamsGroupId,
-      replicationFactor = Optional.of(unavailableReplicationFactorInThisCluster),
+      replicationFactor = Optional.of(unavailableReplicationFactorInThisCluster)
     )
     streams.poll(JDuration.ofMillis(500L))
 


### PR DESCRIPTION
### Description
This test was flaky because it assumes the Streams group will reach
`GroupState.NOT_READY`, but depending on timing and environment the
Streams changelog topic could be created successfully. When that
happened, the group progressed to `ASSIGNING/RECONCILING/STABLE`, the
test failed to observe `NOT_READY` within the timeout, and it sometimes
produced Reconciliation failed logs during consumer shutdown due to an
unfinished onTasksAssigned-related event.

This change makes the behavior deterministic by allowing
`createStreamsGroup()` to inject a `replication factor` into
`StreamsRebalanceData.TopicInfo`. In
`testDescribeStreamsGroupsNotReady`, we pass an intentionally impossible
replication factor for the current cluster (e.g., 9999), ensuring the
changelog topic creation attempt always fails. As a result, the internal
topic remains missing and the Streams group reliably stays in
`NOT_READY`, eliminating the timing-dependent state transition that
caused the flakiness.

### Detail Flaky Case and Non Flaky Case
<img width="909" height="925" alt="image"
src="https://github.com/user-attachments/assets/003445aa-5410-4dec-850b-efd714e4ff0b"
/>

### Result
- Fixes
https://develocity.apache.org/scans/tests?search.rootProjectNames=kafka&search.timeZoneId=Asia%2FTaipei&tests.container=kafka.api.PlaintextAdminIntegrationTest&tests.sortField=FLAKY&tests.test=testDescribeStreamsGroupsNotReady()

### Related PR
- https://github.com/apache/kafka/pull/21267

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>
