### PR TITLE
KAFKA-20076: Fix wrong (uppercase) PluginType JSON serialization

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginType.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginType.java
@@ -26,6 +26,8 @@ import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.Locale;
 
 public enum PluginType {
@@ -54,6 +56,7 @@ public enum PluginType {
     }
 
     @Override
+    @JsonValue
     public String toString() {
         return super.toString().toLowerCase(Locale.ROOT);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -401,6 +401,22 @@ public class ConnectorPluginsResourceTest {
     }
 
     @Test
+    public void testConnectorPluginsEndpointReturnsLowercaseTypeInJson() throws Exception {
+        // Call the actual endpoint method
+        List<PluginInfo> plugins = connectorPluginsResource.listConnectorPlugins(true);
+
+        // Serialize the response to JSON (simulating what the REST API does)
+        final ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(plugins);
+
+        // Verify the JSON contains lowercase type fields
+        assertTrue(json.contains("\"type\":\"sink\""),
+            "Expected JSON to contain '\"type\":\"sink\"' but got: " + json);
+        assertTrue(json.contains("\"type\":\"source\""),
+            "Expected JSON to contain '\"type\":\"source\"' but got: " + json);
+    }
+
+    @Test
     public void testListAllPlugins() {
         List<PluginInfo> expectedConnectorPlugins = Stream.of(
                         SINK_CONNECTOR_PLUGINS,


### PR DESCRIPTION
As described in the corresponding JIRA
[KAFKA-20076](https://issues.apache.org/jira/browse/KAFKA-20076), by
changing the `PluginInfo` from being a class to be a record, the
corresponding JSON serialization of the `type` field from `PluginType`
enum is now wrong: uppercase and not lowercase anymore.  This PR fixes
the issue by annotating the `PluginType.toString` with `@JsonValue` so
it's used for serializer/deserialize the `type` field as before.

Reviewers: Christo Lolov <lolovc@amazon.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
