### PR TITLE
MINOR:  Streams group should not be reported as failed solely due to an internal topic deletion error.

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -749,7 +749,13 @@ public class StreamsGroupCommand {
             if (!internalTopicsToBeDeleted.keySet().isEmpty()) {
                 printInternalTopicErrors(internalTopicsDeletionFailures, success.keySet(), internalTopicsToBeDeleted.keySet());
             }
-            // for testing purpose: return all failures, however we don’t want the operation to fail just because deleting internal topics failed.
+            // for testing purpose: return all failures,
+            // however we don’t want the operation to fail just because internal topics were not found to be deleted.
+            internalTopicsDeletionFailures.forEach((group, error) -> {
+                if (error instanceof UnknownTopicOrPartitionException) {
+                    failed.put(group, error);
+                }
+            });
             failed.putAll(success);
             return failed;
         }

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -749,9 +749,8 @@ public class StreamsGroupCommand {
             if (!internalTopicsToBeDeleted.keySet().isEmpty()) {
                 printInternalTopicErrors(internalTopicsDeletionFailures, success.keySet(), internalTopicsToBeDeleted.keySet());
             }
-            // for testing purpose: return all failures, including internal topics deletion failures
+            // for testing purpose: return all failures, however we don’t want the operation to fail just because deleting internal topics failed.
             failed.putAll(success);
-            failed.putAll(internalTopicsDeletionFailures);
             return failed;
         }
 

--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -752,7 +752,7 @@ public class StreamsGroupCommand {
             // for testing purpose: return all failures,
             // however we don’t want the operation to fail just because internal topics were not found to be deleted.
             internalTopicsDeletionFailures.forEach((group, error) -> {
-                if (error instanceof UnknownTopicOrPartitionException) {
+                if (!(error instanceof UnknownTopicOrPartitionException)) {
                     failed.put(group, error);
                 }
             });


### PR DESCRIPTION
When deleting a streams group, if the deletion of internal topics fails
due to `UnknownTopicOrPartitionException`, we currently return an error.
While this isn’t technically incorrect, it would be preferable to return
exit code 0 here, since the group itself was successfully deleted and no
internal topics remain (either because they were never created or
because they were deleted manually).

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
