### PR TITLE
MINOR: Fix log4j.yaml 'level: OFF' in test resources

### DIFF
--- a/clients/clients-integration-tests/src/test/resources/log4j2.yaml
+++ b/clients/clients-integration-tests/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/clients/src/test/resources/log4j2.yaml
+++ b/clients/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/core/src/test/resources/log4j2.yaml
+++ b/core/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/raft/src/test/resources/log4j2.yaml
+++ b/raft/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/storage/api/src/test/resources/log4j2.yaml
+++ b/storage/api/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/storage/src/test/resources/log4j2.yaml
+++ b/storage/src/test/resources/log4j2.yaml
@@ -37,7 +37,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/test-common/test-common-runtime/src/test/resources/log4j2.yaml
+++ b/test-common/test-common-runtime/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/test-common/test-common-util/src/test/resources/log4j2.yaml
+++ b/test-common/test-common-util/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:

--- a/tools/tools-api/src/test/resources/log4j2.yaml
+++ b/tools/tools-api/src/test/resources/log4j2.yaml
@@ -27,7 +27,7 @@ Configuration:
 
   Loggers:
     Root:
-      level: OFF
+      level: "OFF"
       AppenderRef:
         - ref: STDOUT
     Logger:


### PR DESCRIPTION
Some YAML parsers seems to parse `OFF` as `false`, which leads to
failure in log4j configuration loading:

```
2026-01-15T20:10:38.166033500Z main WARN Error while converting string
[false] to type [class org.apache.logging.log4j.Level]. Using default
value [null].
java.lang.IllegalArgumentException: Unknown level constant [FALSE].
        at org.apache.logging.log4j.Level.valueOf(Level.java:348)
        at
org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$LevelConverter.convert(TypeConverters.java:301)
    ...
```

Simply using quotes around `OFF` prevents this issue.

The following YAML

```yaml
  Loggers:
    Root:
      level: OFF # <-- Without ""
      AppenderRef:
        - ref: STDOUT
```

Is parsed to

```json
{
  "Loggers" : {
      "Root" : {
        "level" : false, // <-- Instead of "OFF"
        "AppenderRef" : [ {
          "ref" : "STDOUT"
        } ]
      }
}
```

Mentioned in old YAML specs (https://yaml.org/type/bool.html).  An
element matching this regex is treated as a boolean:
`y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF`
I did not found any mention anywhere that it is not the case anymore,
and I have the error in my applications.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
