### PR TITLE
Add producer metrics for adaptive partitioning

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
@@ -28,11 +28,12 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * Built-in default partitioner.  Note, that this is just a utility class that is used directly from
  * RecordAccumulator, it does not implement the Partitioner interface.
- *
+ * <p>
  * The class keeps track of various bookkeeping information required for adaptive sticky partitioning
  * (described in detail in KIP-794).  There is one partitioner object per topic.
  */
@@ -40,24 +41,52 @@ public class BuiltInPartitioner {
     private final Logger log;
     private final String topic;
     private final int stickyBatchSize;
+    private final LongAdder adaptivePartitionSwitches;
+    private final LongAdder partitionsExcludedDueToLatency;
 
     private volatile PartitionLoadStats partitionLoadStats = null;
+    private volatile double currentLoadSkew = 0.0;
     private final AtomicReference<StickyPartitionInfo> stickyPartitionInfo = new AtomicReference<>();
 
 
     /**
      * BuiltInPartitioner constructor.
      *
-     * @param topic The topic
+     * @param topic           The topic
      * @param stickyBatchSize How much to produce to partition before switch
      */
     public BuiltInPartitioner(LogContext logContext, String topic, int stickyBatchSize) {
+        this(logContext, topic, stickyBatchSize, new LongAdder());
+    }
+
+    /**
+     * BuiltInPartitioner constructor.
+     *
+     * @param topic                     The topic
+     * @param stickyBatchSize           How much to produce to partition before switch
+     * @param adaptivePartitionSwitches The counter to increment when adaptive partitioning is used
+     */
+    public BuiltInPartitioner(LogContext logContext, String topic, int stickyBatchSize, LongAdder adaptivePartitionSwitches) {
         this.log = logContext.logger(BuiltInPartitioner.class);
         this.topic = topic;
         if (stickyBatchSize < 1) {
             throw new IllegalArgumentException("stickyBatchSize must be >= 1 but got " + stickyBatchSize);
         }
         this.stickyBatchSize = stickyBatchSize;
+        this.adaptivePartitionSwitches = adaptivePartitionSwitches;
+        this.partitionsExcludedDueToLatency = new LongAdder();
+    }
+
+    public long adaptivePartitionSwitches() {
+        return adaptivePartitionSwitches.sum();
+    }
+
+    public void recordPartitionExclusion() {
+        this.partitionsExcludedDueToLatency.increment();
+    }
+
+    public long partitionsExcludedDueToLatency() {
+        return this.partitionsExcludedDueToLatency.sum();
     }
 
     /**
@@ -105,6 +134,7 @@ public class BuiltInPartitioner {
             int partitionIndex = Math.abs(searchResult + 1);
             assert partitionIndex < partitionLoadStats.length;
             partition = partitionLoadStats.partitionIds[partitionIndex];
+            adaptivePartitionSwitches.increment();
         }
 
         log.trace("Switching to partition {} in topic {}", partition, topic);
@@ -128,27 +158,25 @@ public class BuiltInPartitioner {
     /**
      * Peek currently chosen sticky partition.  This method works in conjunction with {@link #isPartitionChanged}
      * and {@link #updatePartitionInfo}.  The workflow is the following:
-     *
+     * <p>
      * 1. peekCurrentPartitionInfo is called to know which partition to lock.
      * 2. Lock partition's batch queue.
      * 3. isPartitionChanged under lock to make sure that nobody raced us.
      * 4. Append data to buffer.
      * 5. updatePartitionInfo to update produced bytes and maybe switch partition.
-     *
-     *  It's important that steps 3-5 are under partition's batch queue lock.
+     * <p>
+     * It's important that steps 3-5 are under partition's batch queue lock.
      *
      * @param cluster The cluster information (needed if there is no current partition)
      * @return sticky partition info object
      */
     StickyPartitionInfo peekCurrentPartitionInfo(Cluster cluster) {
         StickyPartitionInfo partitionInfo = stickyPartitionInfo.get();
-        if (partitionInfo != null)
-            return partitionInfo;
+        if (partitionInfo != null) return partitionInfo;
 
         // We're the first to create it.
         partitionInfo = new StickyPartitionInfo(nextPartition(cluster));
-        if (stickyPartitionInfo.compareAndSet(null, partitionInfo))
-            return partitionInfo;
+        if (stickyPartitionInfo.compareAndSet(null, partitionInfo)) return partitionInfo;
 
         // Someone has raced us.
         return stickyPartitionInfo.get();
@@ -172,7 +200,7 @@ public class BuiltInPartitioner {
      *
      * @param partitionInfo The sticky partition info object returned by peekCurrentPartitionInfo
      * @param appendedBytes The number of bytes appended to this partition
-     * @param cluster The cluster information
+     * @param cluster       The cluster information
      */
     void updatePartitionInfo(StickyPartitionInfo partitionInfo, int appendedBytes, Cluster cluster) {
         updatePartitionInfo(partitionInfo, appendedBytes, cluster, true);
@@ -279,13 +307,14 @@ public class BuiltInPartitioner {
 
         // Calculate max queue size + 1 and check if all sizes are the same.
         int maxSizePlus1 = queueSizes[0];
+        int minSize = queueSizes[0];
         boolean allEqual = true;
         for (int i = 1; i < length; i++) {
-            if (queueSizes[i] != maxSizePlus1)
-                allEqual = false;
-            if (queueSizes[i] > maxSizePlus1)
-                maxSizePlus1 = queueSizes[i];
+            if (queueSizes[i] != maxSizePlus1) allEqual = false;
+            if (queueSizes[i] > maxSizePlus1) maxSizePlus1 = queueSizes[i];
+            if (queueSizes[i] < minSize) minSize = queueSizes[i];
         }
+        this.currentLoadSkew = maxSizePlus1 - minSize;
         ++maxSizePlus1;
 
         if (allEqual && length == queueSizes.length) {
@@ -302,9 +331,12 @@ public class BuiltInPartitioner {
         for (int i = 1; i < length; i++) {
             queueSizes[i] = maxSizePlus1 - queueSizes[i] + queueSizes[i - 1];
         }
-        log.trace("Partition load stats for topic {}: CFT={}, IDs={}, length={}",
-                topic, queueSizes, partitionIds, length);
+        log.trace("Partition load stats for topic {}: CFT={}, IDs={}, length={}", topic, queueSizes, partitionIds, length);
         partitionLoadStats = new PartitionLoadStats(queueSizes, partitionIds, length);
+    }
+
+    public double loadSkew() {
+        return this.currentLoadSkew;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -89,6 +89,7 @@ public class RecordAccumulator {
     private final Map<String, Integer> nodesDrainIndex;
     private final TransactionManager transactionManager;
     private long nextBatchExpiryTimeMs = Long.MAX_VALUE; // the earliest time (absolute) a batch will expire.
+    private final SenderMetricsRegistry metricsRegistry;
 
     /**
      * Create a new record accumulator
@@ -145,6 +146,7 @@ public class RecordAccumulator {
         this.time = time;
         nodesDrainIndex = new HashMap<>();
         this.transactionManager = transactionManager;
+        this.metricsRegistry = new SenderMetricsRegistry(metrics);
         registerMetrics(metrics, metricGrpName);
     }
 
@@ -210,6 +212,36 @@ public class RecordAccumulator {
             metrics.metricName("buffer-available-bytes", metricGrpName,
                 "The total amount of buffer memory that is not being used (either unallocated or in the free list)."),
             (config, now) -> free.availableMemory());
+
+        metrics.addMetric(
+            metricsRegistry.adaptivePartitionSwitchesTotal,
+            (config, now) -> {
+                long sum = 0;
+                for (TopicInfo topicInfo : topicInfoMap.values()) {
+                    sum += topicInfo.builtInPartitioner.adaptivePartitionSwitches();
+                }
+                return (double) sum;
+            });
+
+        metrics.addMetric(
+            metricsRegistry.partitionLoadSkew,
+            (config, now) -> {
+                double maxSkew = 0.0;
+                for (TopicInfo topicInfo : topicInfoMap.values()) {
+                    maxSkew = Math.max(maxSkew, topicInfo.builtInPartitioner.loadSkew());
+                }
+                return maxSkew;
+            });
+
+        metrics.addMetric(
+            metricsRegistry.adaptivePartitionUnavailableTotal,
+            (config, now) -> {
+                long sum = 0;
+                for (TopicInfo topicInfo : topicInfoMap.values()) {
+                    sum += topicInfo.builtInPartitioner.partitionsExcludedDueToLatency();
+                }
+                return (double) sum;
+            });
     }
 
     private void setPartition(AppendCallbacks callbacks, int partition) {
@@ -282,7 +314,17 @@ public class RecordAccumulator {
                                      long maxTimeToBlock,
                                      long nowMs,
                                      Cluster cluster) throws InterruptedException {
-        TopicInfo topicInfo = topicInfoMap.computeIfAbsent(topic, k -> new TopicInfo(createBuiltInPartitioner(logContext, k, batchSize)));
+        TopicInfo topicInfo = topicInfoMap.computeIfAbsent(topic, k -> {
+            BuiltInPartitioner partitioner = createBuiltInPartitioner(logContext, k, batchSize);
+            Map<String, String> topicTags = Collections.singletonMap("topic", k);
+            metricsRegistry.addMetric(metricsRegistry.topicAdaptivePartitionSwitchesTotal(topicTags),
+                (config, now) -> (double) partitioner.adaptivePartitionSwitches());
+            metricsRegistry.addMetric(metricsRegistry.topicPartitionLoadSkew(topicTags),
+                (config, now) -> partitioner.loadSkew());
+            metricsRegistry.addMetric(metricsRegistry.topicAdaptivePartitionUnavailableTotal(topicTags),
+                (config, now) -> (double) partitioner.partitionsExcludedDueToLatency());
+            return new TopicInfo(partitioner);
+        });
 
         // We keep track of the number of appending thread to make sure we do not miss batches in
         // abortIncompleteBatches().
@@ -727,8 +769,10 @@ public class RecordAccumulator {
                         // so we read ready time first to avoid accidentally marking partition
                         // unavailable if we read while the metrics are being updated.
                         long readyTimeMs = nodeLatencyStats.readyTimeMs;
-                        if (readyTimeMs - nodeLatencyStats.drainTimeMs > partitionAvailabilityTimeoutMs)
+                        if (readyTimeMs - nodeLatencyStats.drainTimeMs > partitionAvailabilityTimeoutMs) {
                             --queueSizesIndex;
+                            topicInfo.builtInPartitioner.recordPartitionExclusion();
+                        }
                     }
                 }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -56,6 +56,9 @@ public class SenderMetricsRegistry {
     public final MetricName metadataAge;
     public final MetricName batchSplitRate;
     public final MetricName batchSplitTotal;
+    public final MetricName adaptivePartitionSwitchesTotal;
+    public final MetricName partitionLoadSkew;
+    public final MetricName adaptivePartitionUnavailableTotal;
 
     private final MetricNameTemplate topicRecordSendRate;
     private final MetricNameTemplate topicRecordSendTotal;
@@ -66,6 +69,9 @@ public class SenderMetricsRegistry {
     private final MetricNameTemplate topicRecordRetryTotal;
     private final MetricNameTemplate topicRecordErrorRate;
     private final MetricNameTemplate topicRecordErrorTotal;
+    private final MetricNameTemplate topicAdaptivePartitionSwitchesTotal;
+    private final MetricNameTemplate topicPartitionLoadSkew;
+    private final MetricNameTemplate topicAdaptivePartitionUnavailableTotal;
     
     private final Metrics metrics;
     private final Set<String> tags;
@@ -119,6 +125,12 @@ public class SenderMetricsRegistry {
                 "The average number of batch splits per second");
         this.batchSplitTotal = createMetricName("batch-split-total", 
                 "The total number of batch splits");
+        this.adaptivePartitionSwitchesTotal = createMetricName("adaptive-partition-switches-total",
+                "The total number of times the producer switched partitions due to adaptive partitioning logic.");
+        this.partitionLoadSkew = createMetricName("partition-load-skew",
+                "The difference between the maximum and minimum queue size for a topic, indicating load imbalance.");
+        this.adaptivePartitionUnavailableTotal = createMetricName("adaptive-partition-unavailable-total",
+                "The total number of times a partition was excluded from adaptive partitioning due to high latency.");
 
         this.produceThrottleTimeAvg = createMetricName("produce-throttle-time-avg",
                 "The average time in ms a request was throttled by a broker");
@@ -149,7 +161,25 @@ public class SenderMetricsRegistry {
                 "The average per-second number of record sends that resulted in errors for a topic");
         this.topicRecordErrorTotal = createTopicTemplate("record-error-total",
                 "The total number of record sends that resulted in errors for a topic");
+        this.topicAdaptivePartitionSwitchesTotal = createTopicTemplate("adaptive-partition-switches-total",
+                "The total number of times the producer switched partitions due to adaptive partitioning logic for a topic.");
+        this.topicPartitionLoadSkew = createTopicTemplate("partition-load-skew",
+                "The difference between the maximum and minimum queue size for a topic, indicating load imbalance.");
+        this.topicAdaptivePartitionUnavailableTotal = createTopicTemplate("adaptive-partition-unavailable-total",
+                "The total number of times a partition was excluded from adaptive partitioning due to high latency for a topic.");
 
+    }
+
+    public MetricName topicAdaptivePartitionSwitchesTotal(Map<String, String> tags) {
+        return this.metrics.metricInstance(this.topicAdaptivePartitionSwitchesTotal, tags);
+    }
+
+    public MetricName topicPartitionLoadSkew(Map<String, String> tags) {
+        return this.metrics.metricInstance(this.topicPartitionLoadSkew, tags);
+    }
+
+    public MetricName topicAdaptivePartitionUnavailableTotal(Map<String, String> tags) {
+        return this.metrics.metricInstance(this.topicAdaptivePartitionUnavailableTotal, tags);
     }
 
     private MetricName createMetricName(String name, String description) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/AdaptivePartitioningObservabilityTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/AdaptivePartitioningObservabilityTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.producer.internals;
+
+import org.apache.kafka.clients.MetadataSnapshot;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AdaptivePartitioningObservabilityTest {
+    private static final Node[] NODES = new Node[]{new Node(0, "localhost", 99), new Node(1, "localhost", 100), new Node(2, "localhost", 101)};
+    static final String TOPIC_A = "topicA";
+    static final String TOPIC_B = "topicB";
+    final LogContext logContext = new LogContext();
+
+    @Test
+    public void testAdaptivePartitioningOccurs() {
+        LongAdder switches = new LongAdder();
+        BuiltInPartitioner builtInPartitioner = new SequentialPartitioner(logContext, TOPIC_A, 1, switches);
+
+        int[] queueSizes = {5, 0, 3};
+        int[] partitionIds = {0, 1, 2};
+        List<PartitionInfo> allPartitions = new ArrayList<>();
+        for (int i = 0; i < partitionIds.length; i++) {
+            allPartitions.add(new PartitionInfo(TOPIC_A, i, NODES[i % NODES.length], NODES, NODES));
+        }
+
+        builtInPartitioner.updatePartitionLoadStats(queueSizes, partitionIds, queueSizes.length);
+        Cluster testCluster = new Cluster("clusterId", asList(NODES), allPartitions, Collections.emptySet(), Collections.emptySet());
+
+        int[] frequencies = new int[queueSizes.length];
+        int iterations = 1000;
+        for (int i = 0; i < iterations; i++) {
+            BuiltInPartitioner.StickyPartitionInfo partitionInfo = builtInPartitioner.peekCurrentPartitionInfo(testCluster);
+            frequencies[partitionInfo.partition()]++;
+            builtInPartitioner.updatePartitionInfo(partitionInfo, 1, testCluster);
+        }
+
+        assertTrue(frequencies[1] > frequencies[0]);
+        assertTrue(frequencies[1] > frequencies[2]);
+        assertTrue(switches.sum() >= iterations);
+
+        double skew = builtInPartitioner.loadSkew();
+        assertEquals(5.0, skew, "Partition load skew should be 5.0");
+    }
+
+    @Test
+    public void testExcludedPartitionsMetric() throws Exception {
+        long availabilityTimeoutMs = 100;
+        Metrics metrics = new Metrics();
+        Time time = new MockTime();
+
+        RecordAccumulator.PartitionerConfig config = new RecordAccumulator.PartitionerConfig(true, availabilityTimeoutMs);
+        RecordAccumulator accum = new RecordAccumulator(logContext, 1024, Compression.of(CompressionType.NONE).build(), 0, 0L, 0L, 60000, config, metrics, "producer-metrics", time, null, new BufferPool(1024 * 10, 1024, metrics, time, "producer-internal-metrics"));
+
+        List<PartitionInfo> partitions = asList(new PartitionInfo(TOPIC_B, 0, NODES[0], NODES, NODES));
+        Cluster cluster = new Cluster("clusterId", asList(NODES), partitions, Collections.emptySet(), Collections.emptySet());
+
+
+        accum.append(TOPIC_B, RecordMetadata.UNKNOWN_PARTITION, 0L, null, new byte[10], null, null, 1000L, time.milliseconds(), cluster);
+
+        int nodeId = 0;
+        accum.updateNodeLatencyStats(nodeId, time.milliseconds(), true);
+        time.sleep(availabilityTimeoutMs + 1);
+        accum.updateNodeLatencyStats(nodeId, time.milliseconds(), false);
+
+        TopicPartition tp = new TopicPartition(TOPIC_B, 0);
+        List<Integer> replicaIds = Arrays.asList(0, 1);
+        List<Integer> inSyncReplicaIds = Arrays.asList(0, 1);
+        PartitionMetadata partitionMetadata = new PartitionMetadata(Errors.NONE, tp, Optional.of(NODES[0].id()), Optional.empty(), replicaIds, inSyncReplicaIds, Collections.emptyList());
+
+        Map<Integer, Node> nodeMap = Arrays.stream(NODES).collect(Collectors.toMap(Node::id, n -> n));
+
+        MetadataSnapshot metadataSnapshot = new MetadataSnapshot("clusterId", nodeMap, Collections.singletonList(partitionMetadata), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), null, Collections.emptyMap(), cluster);
+
+        accum.ready(metadataSnapshot, time.milliseconds());
+
+        assertEquals(1.0, (Double) metrics.metric(metrics.metricName("adaptive-partition-unavailable-total", "producer-metrics")).metricValue(), 0.01);
+
+        Map<String, String> tags = Collections.singletonMap("topic", TOPIC_B);
+        assertEquals(1.0, (Double) metrics.metric(metrics.metricName("adaptive-partition-unavailable-total", "producer-topic-metrics", tags)).metricValue(), 0.01);
+
+        accum.close();
+        metrics.close();
+    }
+
+    private static class SequentialPartitioner extends BuiltInPartitioner {
+        AtomicInteger mockRandom = new AtomicInteger();
+
+        public SequentialPartitioner(LogContext logContext, String topic, int stickyBatchSize, LongAdder switches) {
+            super(logContext, topic, stickyBatchSize, switches);
+        }
+
+        @Override
+        int randomPartition() {
+            return mockRandom.getAndAdd(1);
+        }
+    }
+}


### PR DESCRIPTION
Expose producer and per-topic metrics for adaptive sticky partitioning, including adaptive partition switches, partition load skew, and partition exclusions due to latency.
Adds unit tests to validate metric behavior.