### PR TITLE
KAFKA-17397: Ensure ClassicKafkaConsumer sends leave request on close even if interrupted

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -522,6 +522,19 @@ public class NetworkClient implements KafkaClient {
     }
 
     /**
+     * Returns true if we can send a {@link ApiKeys#LEAVE_GROUP} request to the given node at {@code now},
+     * ignoring the metadata-update priority gating in isReady().
+     * This method is internal helper for consumers: allow sending {@link ApiKeys#LEAVE_GROUP} even when metadata update is due.
+     *
+     * @param node The node
+     * @param now The current time in ms
+     * @return true if the node is ready
+     */
+    public boolean isReadyForLeaveGroup(Node node, long now) {
+        return canSendRequest(node.idString(), now);
+    }
+
+    /**
      * Are we connected and ready and able to send more requests to the given connection?
      *
      * @param node The node

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.common.Node;
@@ -28,6 +29,7 @@ import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -512,7 +514,24 @@ public class ConsumerNetworkClient implements Closeable {
 
             while (iterator.hasNext()) {
                 ClientRequest request = iterator.next();
-                if (client.ready(node, now)) {
+
+                AbstractRequest.Builder<?> builder = request.requestBuilder();
+                boolean ready = client.ready(node, now);
+
+                if (!ready 
+                    && builder.apiKey() == ApiKeys.LEAVE_GROUP 
+                    && client instanceof NetworkClient) {
+                    // KAFKA-17397 && KAFKA-18031
+                    // When a consumer is leaving a group, it does not need to 
+                    // wait for a metadata update. Otherwise, the LeaveGroup request can remain in unsent 
+                    // and an InterruptException may be thrown on the final poll(), 
+                    // preventing the LeaveGroup request from being sent to the group coordinator. 
+                    // Even though this is a normal shutdown path, it can delay termination until 'session.timeout.ms' elapses.
+                    NetworkClient networkClient = (NetworkClient) client;
+                    ready = networkClient.isReadyForLeaveGroup(node, now);
+                }
+                    
+                if (ready) {
                     client.send(request, now);
                     iterator.remove();
                 } else {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -16,7 +16,6 @@ import java.util
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.errors.InterruptException
-import org.apache.kafka.common.test.api.Flaky
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -27,7 +26,6 @@ import java.util.concurrent.ExecutionException
 @Timeout(60)
 class PlaintextConsumerTest extends AbstractConsumerTest {
 
-  @Flaky("KAFKA-18031")
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testCloseLeavesGroupOnInterrupt(groupProtocol: String): Unit = {


### PR DESCRIPTION
### Description
This PR addresses KAFKA-17397 by ensuring deterministic behavior in
`ClassicKafkaConsumer.close()` under interruption for the classic group
protocol.

In CI, `PlaintextConsumerTest.testCloseLeavesGroupOnInterrupt()` can
fail for `ClassicKafkaConsumer` because `LeaveGroupRequest` is sometimes
blocked by `NetworkClient.isReady()` when a metadata update is due.
Since isReady prioritizes metadata requests, the pending
`LeaveGroupRequest` can remain unsent. When the calling thread is
already interrupted, `ConsumerNetworkClient` may throw an
`InterruptException` before the pending request gets a chance to be
sent. This causes the member to leave only via `session.timeout.ms`,
resulting in test flakiness.

### Changes
Allow `LeaveGroupRequest` to bypass the `metadata-update` gating in
`NetworkClient.isReady()` (while still respecting `canSendRequest`),
ensuring the request is sent during `close()` even when a metadata
update is due.

### Sequence Diagram
<img width="7840" height="5910" alt="seq-1"
src="https://github.com/user-attachments/assets/1849b465-fc9e-4b9b-a76a-66aeab17188e"
/>

- Steps 9, 10, and 11 describe non-deterministic behavior that prevents
the `ClassicKafkaConsumer` from successfully sending a `LEAVE_GROUP`
request when it is interrupted.
- This PR makes the sending of the `LEAVE_GROUP` request deterministic
by bypassing the metadata update step specifically for `LEAVE_GROUP`.
(See, Step 9, 15, 16, 17, 18)

### Fixes
- https://issues.apache.org/jira/browse/KAFKA-17397
- https://issues.apache.org/jira/browse/KAFKA-18031
  - Flaky Test -
https://develocity.apache.org/scans/tests?search.rootProjectNames=kafka&search.timeZoneId=Asia%2FTaipei&tests.container=kafka.api.PlaintextConsumerTest&tests.sortField=FLAKY&tests.test=testCloseLeavesGroupOnInterrupt(String)%5B1%5D

### In local re-produce
- With current trunk branch, the test failed 1~2 times out of 20 runs.
- With this PR, all 500 test runs succeeded (although there were a few
build failures due to busy CPU and full memory.)
```shell
$ grep -r "PASSED" | wc -l
498

$ grep -r "FAILED" | wc -l
2

$ grep -r "FAILED"
run-34.log:> Task :clients:compileJava FAILED
run-34.log:BUILD FAILED in 5s
```

### Note on the implementation
I considered adding `isReadyForLeaveGroup` directly to the `KafkaClient`
interface to keep the design consistent. However, I opted for the
current approach to avoid modifying the interface, as I wasn't sure if
changing the `KafkaClient` interface would require a KIP.

If you believe adding it to the interface is preferable (and acceptable
without or with a KIP ), please let me know. I'm happy to refactor it
and wrote KIP.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
