### PR TITLE
MINOR: Simplify timeout handling in CoordinatorRuntime

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.utils.LogContext;
 
 import org.slf4j.Logger;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -36,21 +35,18 @@ public class CoordinatorExecutorImpl<S extends CoordinatorShard<U>, U> implement
     private final TopicPartition shard;
     private final CoordinatorRuntime<S, U> runtime;
     private final ExecutorService executor;
-    private final Duration writeTimeout;
     private final Map<String, TaskRunnable<?>> tasks = new ConcurrentHashMap<>();
 
     public CoordinatorExecutorImpl(
         LogContext logContext,
         TopicPartition shard,
         CoordinatorRuntime<S, U> runtime,
-        ExecutorService executor,
-        Duration writeTimeout
+        ExecutorService executor
     ) {
         this.log = logContext.logger(CoordinatorExecutorImpl.class);
         this.shard = shard;
         this.runtime = runtime;
         this.executor = executor;
-        this.writeTimeout = writeTimeout;
     }
 
     private <R> TaskResult<R> executeTask(TaskRunnable<R> task) {
@@ -83,7 +79,6 @@ public class CoordinatorExecutorImpl<S extends CoordinatorShard<U>, U> implement
             runtime.scheduleWriteOperation(
                 key,
                 shard,
-                writeTimeout,
                 coordinator -> {
                     // If the task associated with the key is not us, it means
                     // that the task was either replaced or cancelled. We stop.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -2102,7 +2102,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param coordinatorShardBuilderSupplier   The coordinator builder.
      * @param time                              The system time.
      * @param timer                             The system timer.
-     * @param writeTimeout               The write operation timeout.
+     * @param writeTimeout                      The write operation timeout.
      * @param runtimeMetrics                    The runtime metrics.
      * @param coordinatorMetrics                The coordinator metrics.
      * @param serializer                        The serializer.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -113,7 +113,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier;
         private Time time = Time.SYSTEM;
         private Timer timer;
-        private Duration defaultWriteTimeout;
+        private Duration writeTimeout;
         private CoordinatorRuntimeMetrics runtimeMetrics;
         private CoordinatorMetrics coordinatorMetrics;
         private Serializer<U> serializer;
@@ -162,8 +162,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             return this;
         }
 
-        public Builder<S, U> withDefaultWriteTimeOut(Duration defaultWriteTimeout) {
-            this.defaultWriteTimeout = defaultWriteTimeout;
+        public Builder<S, U> withWriteTimeout(Duration writeTimeout) {
+            this.writeTimeout = writeTimeout;
             return this;
         }
 
@@ -246,7 +246,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 coordinatorShardBuilderSupplier,
                 time,
                 timer,
-                defaultWriteTimeout,
+                writeTimeout,
                 runtimeMetrics,
                 coordinatorMetrics,
                 serializer,
@@ -378,7 +378,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 @Override
                 public void run() {
                     String eventName = "Timeout(tp=" + tp + ", key=" + key + ")";
-                    CoordinatorWriteEvent<Void> event = new CoordinatorWriteEvent<>(eventName, tp, defaultWriteTimeout, coordinator -> {
+                    CoordinatorWriteEvent<Void> event = new CoordinatorWriteEvent<>(eventName, tp, writeTimeout, coordinator -> {
                         log.debug("Executing write event {} for timer {}.", eventName, key);
 
                         // If the task is different, it means that the timer has been
@@ -644,8 +644,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 logContext,
                 tp,
                 CoordinatorRuntime.this,
-                executorService,
-                defaultWriteTimeout
+                executorService
             );
             this.bufferSupplier = new BufferSupplier.GrowableBufferSupplier();
             this.cachedBufferSize = new AtomicLong(0);
@@ -2016,7 +2015,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     /**
      * The write operation timeout
      */
-    private final Duration defaultWriteTimeout;
+    private final Duration writeTimeout;
 
     /**
      * The coordinators keyed by topic partition.
@@ -2103,7 +2102,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param coordinatorShardBuilderSupplier   The coordinator builder.
      * @param time                              The system time.
      * @param timer                             The system timer.
-     * @param defaultWriteTimeout               The write operation timeout.
+     * @param writeTimeout               The write operation timeout.
      * @param runtimeMetrics                    The runtime metrics.
      * @param coordinatorMetrics                The coordinator metrics.
      * @param serializer                        The serializer.
@@ -2122,7 +2121,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier,
         Time time,
         Timer timer,
-        Duration defaultWriteTimeout,
+        Duration writeTimeout,
         CoordinatorRuntimeMetrics runtimeMetrics,
         CoordinatorMetrics coordinatorMetrics,
         Serializer<U> serializer,
@@ -2135,7 +2134,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         this.log = logContext.logger(CoordinatorRuntime.class);
         this.time = time;
         this.timer = timer;
-        this.defaultWriteTimeout = defaultWriteTimeout;
+        this.writeTimeout = writeTimeout;
         this.coordinators = new ConcurrentHashMap<>();
         this.processor = processor;
         this.partitionWriter = partitionWriter;
@@ -2250,7 +2249,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      *
      * @param name      The name of the write operation.
      * @param tp        The address of the coordinator (aka its topic-partitions).
-     * @param timeout   The write operation timeout.
      * @param op        The write operation.
      *
      * @return A future that will be completed with the result of the write operation
@@ -2261,12 +2259,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     public <T> CompletableFuture<T> scheduleWriteOperation(
         String name,
         TopicPartition tp,
-        Duration timeout,
         CoordinatorWriteOperation<S, T, U> op
     ) {
         throwIfNotRunning();
         log.debug("Scheduled execution of write operation {}.", name);
-        CoordinatorWriteEvent<T> event = new CoordinatorWriteEvent<>(name, tp, timeout, op);
+        CoordinatorWriteEvent<T> event = new CoordinatorWriteEvent<>(name, tp, writeTimeout, op);
         enqueueLast(event);
         return event.future;
     }
@@ -2275,7 +2272,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * Schedule a write operation for each coordinator.
      *
      * @param name      The name of the write operation.
-     * @param timeout   The write operation timeout.
      * @param op        The write operation.
      *
      * @return A list of futures where each future will be completed with the result of the write operation
@@ -2285,7 +2281,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      */
     public <T> List<CompletableFuture<T>> scheduleWriteAllOperation(
         String name,
-        Duration timeout,
         CoordinatorWriteOperation<S, T, U> op
     ) {
         throwIfNotRunning();
@@ -2293,7 +2288,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         return coordinators
             .keySet()
             .stream()
-            .map(tp -> scheduleWriteOperation(name, tp, timeout, op))
+            .map(tp -> scheduleWriteOperation(name, tp, op))
             .collect(Collectors.toList());
     }
 
@@ -2305,7 +2300,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param transactionalId   The transactional id.
      * @param producerId        The producer id.
      * @param producerEpoch     The producer epoch.
-     * @param timeout           The write operation timeout.
      * @param op                The write operation.
      * @param apiVersion        The Version of the Txn_Offset_Commit request
      *
@@ -2320,7 +2314,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         String transactionalId,
         long producerId,
         short producerEpoch,
-        Duration timeout,
         CoordinatorWriteOperation<S, T, U> op,
         int apiVersion
     ) {
@@ -2340,7 +2333,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 producerId,
                 producerEpoch,
                 verificationGuard,
-                timeout,
+                writeTimeout,
                 op
             );
             enqueueLast(event);
@@ -2369,8 +2362,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         short producerEpoch,
         int coordinatorEpoch,
         TransactionResult result,
-        short transactionVersion,
-        Duration timeout
+        short transactionVersion
     ) {
         throwIfNotRunning();
         log.debug("Scheduled execution of transaction completion for {} with producer id={}, producer epoch={}, " +
@@ -2383,7 +2375,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             coordinatorEpoch,
             result,
             transactionVersion,
-            timeout
+            writeTimeout
         );
         enqueueLast(event);
         return event.future;

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -60,19 +60,17 @@ public class CoordinatorExecutorImplTest {
             LOG_CONTEXT,
             SHARD_PARTITION,
             runtime,
-            executorService,
-            WRITE_TIMEOUT
+            executorService
         );
 
         when(runtime.scheduleWriteOperation(
             eq(TASK_KEY),
             eq(SHARD_PARTITION),
-            eq(WRITE_TIMEOUT),
             any()
         )).thenAnswer(args -> {
             assertTrue(executor.isScheduled(TASK_KEY));
             CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String> op =
-                args.getArgument(3);
+                args.getArgument(2);
             assertEquals(
                 new CoordinatorResult<>(List.of("record"), null),
                 op.generateRecordsAndResult(coordinatorShard)
@@ -120,18 +118,16 @@ public class CoordinatorExecutorImplTest {
             LOG_CONTEXT,
             SHARD_PARTITION,
             runtime,
-            executorService,
-            WRITE_TIMEOUT
+            executorService
         );
 
         when(runtime.scheduleWriteOperation(
             eq(TASK_KEY),
             eq(SHARD_PARTITION),
-            eq(WRITE_TIMEOUT),
             any()
         )).thenAnswer(args -> {
             CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String> op =
-                args.getArgument(3);
+                args.getArgument(2);
             assertEquals(
                 new CoordinatorResult<>(List.of(), null),
                 op.generateRecordsAndResult(coordinatorShard)
@@ -178,8 +174,7 @@ public class CoordinatorExecutorImplTest {
             LOG_CONTEXT,
             SHARD_PARTITION,
             runtime,
-            executorService,
-            WRITE_TIMEOUT
+            executorService
         );
 
         when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
@@ -223,21 +218,19 @@ public class CoordinatorExecutorImplTest {
             LOG_CONTEXT,
             SHARD_PARTITION,
             runtime,
-            executorService,
-            WRITE_TIMEOUT
+            executorService
         );
 
         when(runtime.scheduleWriteOperation(
             eq(TASK_KEY),
             eq(SHARD_PARTITION),
-            eq(WRITE_TIMEOUT),
             any()
         )).thenAnswer(args -> {
             // Cancel the task before running the write operation.
             executor.cancel(TASK_KEY);
 
             CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String> op =
-                args.getArgument(3);
+                args.getArgument(2);
             Throwable ex = assertThrows(RejectedExecutionException.class, () -> op.generateRecordsAndResult(coordinatorShard));
             return FutureUtils.failedFuture(ex);
         });
@@ -278,14 +271,12 @@ public class CoordinatorExecutorImplTest {
             LOG_CONTEXT,
             SHARD_PARTITION,
             runtime,
-            executorService,
-            WRITE_TIMEOUT
+            executorService
         );
 
         when(runtime.scheduleWriteOperation(
             eq(TASK_KEY),
             eq(SHARD_PARTITION),
-            eq(WRITE_TIMEOUT),
             any()
         )).thenReturn(FutureUtils.failedFuture(new Throwable("Oh no!")));
 
@@ -327,8 +318,7 @@ public class CoordinatorExecutorImplTest {
             LOG_CONTEXT,
             SHARD_PARTITION,
             runtime,
-            executorService,
-            WRITE_TIMEOUT
+            executorService
         );
 
         List<CoordinatorRuntime.CoordinatorWriteOperation<CoordinatorShard<String>, Void, String>> writeOperations = new ArrayList<>();
@@ -336,10 +326,9 @@ public class CoordinatorExecutorImplTest {
         when(runtime.scheduleWriteOperation(
             anyString(),
             eq(SHARD_PARTITION),
-            eq(WRITE_TIMEOUT),
             any()
         )).thenAnswer(args -> {
-            writeOperations.add(args.getArgument(3));
+            writeOperations.add(args.getArgument(2));
             CompletableFuture<Void> writeFuture = new CompletableFuture<>();
             writeFutures.add(writeFuture);
             return writeFuture;

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -119,7 +119,7 @@ public class CoordinatorRuntimeTest {
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
                 .withCoordinatorShardBuilderSupplier(supplier)
@@ -192,7 +192,7 @@ public class CoordinatorRuntimeTest {
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
                 .withCoordinatorShardBuilderSupplier(supplier)
@@ -245,7 +245,7 @@ public class CoordinatorRuntimeTest {
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
                 .withCoordinatorShardBuilderSupplier(supplier)
@@ -302,7 +302,7 @@ public class CoordinatorRuntimeTest {
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
                 .withCoordinatorShardBuilderSupplier(supplier)
@@ -375,7 +375,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -432,7 +432,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -489,7 +489,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -534,7 +534,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -585,7 +585,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -641,7 +641,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -669,7 +669,7 @@ public class CoordinatorRuntimeTest {
         CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
 
@@ -682,12 +682,11 @@ public class CoordinatorRuntimeTest {
             (short) 50,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
 
         // Write #2 but without any records.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of(), "response2")
         );
 
@@ -731,7 +730,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -753,7 +752,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(0L), ctx.coordinator.snapshotRegistry().epochsList());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1")
         );
 
@@ -774,7 +773,7 @@ public class CoordinatorRuntimeTest {
         ), writer.entries(TP));
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3"), "response2"));
 
         // Verify that the write is not committed yet.
@@ -795,7 +794,7 @@ public class CoordinatorRuntimeTest {
         ), writer.entries(TP));
 
         // Write #3 but without any records.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(List.of(), "response3"));
 
         // Verify that the write is not committed yet.
@@ -838,7 +837,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(3L), ctx.coordinator.snapshotRegistry().epochsList());
 
         // Write #4 but without records.
-        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP,
             state -> new CoordinatorResult<>(List.of(), "response4"));
 
         // It is completed immediately because the state is fully committed.
@@ -854,7 +853,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -868,7 +867,7 @@ public class CoordinatorRuntimeTest {
 
         // Scheduling a write fails with a NotCoordinatorException because the coordinator
         // does not exist.
-        CompletableFuture<String> write = runtime.scheduleWriteOperation("write", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write", TP,
             state -> new CoordinatorResult<>(List.of(), "response1"));
         assertFutureThrows(NotCoordinatorException.class, write);
     }
@@ -880,7 +879,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -897,7 +896,7 @@ public class CoordinatorRuntimeTest {
 
         // Scheduling a write that fails when the operation is called. The exception
         // is used to complete the future.
-        CompletableFuture<String> write = runtime.scheduleWriteOperation("write", TP, DEFAULT_WRITE_TIMEOUT, state -> {
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write", TP, state -> {
             throw new KafkaException("error");
         });
         assertFutureThrows(KafkaException.class, write);
@@ -910,7 +909,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -952,7 +951,7 @@ public class CoordinatorRuntimeTest {
         );
 
         // Write. It should fail.
-        CompletableFuture<String> write = runtime.scheduleWriteOperation("write", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"));
         assertFutureThrows(IllegalArgumentException.class, write);
 
@@ -972,7 +971,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -994,7 +993,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(0L), ctx.coordinator.snapshotRegistry().epochsList());
 
         // Write #1. It should succeed and be applied to the coordinator.
-        runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"));
 
         // Verify that the state has been updated.
@@ -1005,7 +1004,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #2. It should fail because the writer is configured to only
         // accept 1 write.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3", "record4", "record5"), "response2"));
         assertFutureThrows(KafkaException.class, write2);
 
@@ -1026,7 +1025,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1048,10 +1047,10 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(0L), ctx.coordinator.snapshotRegistry().epochsList());
 
         // Write #1. We should get a TimeoutException because the HWM will not advance.
-        CompletableFuture<String> timedOutWrite = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(3),
+        CompletableFuture<String> timedOutWrite = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"));
 
-        timer.advanceClock(4);
+        timer.advanceClock(DEFAULT_WRITE_TIMEOUT.toMillis() + 1);
 
         assertFutureThrows(org.apache.kafka.common.errors.TimeoutException.class, timedOutWrite);
     }
@@ -1065,7 +1064,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1088,7 +1087,7 @@ public class CoordinatorRuntimeTest {
 
         // Writes.
         AtomicInteger cnt = new AtomicInteger(0);
-        List<CompletableFuture<List<String>>> writes = runtime.scheduleWriteAllOperation("write", DEFAULT_WRITE_TIMEOUT, state -> {
+        List<CompletableFuture<List<String>>> writes = runtime.scheduleWriteAllOperation("write", state -> {
             int counter = cnt.getAndIncrement();
             return new CoordinatorResult<>(
                 List.of("record#" + counter),
@@ -1138,7 +1137,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1176,7 +1175,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             (short) 50,
-            Duration.ofMillis(5000),
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -1235,7 +1233,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1269,7 +1267,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             (short) 50,
-            Duration.ofMillis(5000),
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -1299,7 +1296,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1328,7 +1325,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             transactionalEpoch,
-            DEFAULT_WRITE_TIMEOUT,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -1363,8 +1359,7 @@ public class CoordinatorRuntimeTest {
             markerEpoch,
             10,
             result,
-            transactionVersion,
-            DEFAULT_WRITE_TIMEOUT
+            transactionVersion
         );
 
         // Verify that the completion is not committed yet.
@@ -1428,7 +1423,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1458,8 +1453,7 @@ public class CoordinatorRuntimeTest {
             (short) 5,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            Duration.ofMillis(3)
+            TransactionVersion.TV_1.featureLevel()
         );
 
         // Verify that the state has been updated.
@@ -1468,7 +1462,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(0L, 1L), ctx.coordinator.snapshotRegistry().epochsList());
 
         // Advance clock to timeout Complete #1.
-        timer.advanceClock(4);
+        timer.advanceClock(DEFAULT_WRITE_TIMEOUT.toMillis() + 1);
 
         assertFutureThrows(org.apache.kafka.common.errors.TimeoutException.class, timedOutCompletion);
 
@@ -1491,7 +1485,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1519,7 +1513,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             (short) 5,
-            DEFAULT_WRITE_TIMEOUT,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -1539,8 +1532,7 @@ public class CoordinatorRuntimeTest {
             (short) 5,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
         assertFutureThrows(KafkaException.class, complete1);
 
@@ -1560,7 +1552,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1607,7 +1599,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             (short) 5,
-            DEFAULT_WRITE_TIMEOUT,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -1631,8 +1622,7 @@ public class CoordinatorRuntimeTest {
             (short) 5,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
         assertFutureThrows(IllegalArgumentException.class, complete1);
 
@@ -1662,7 +1652,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1690,7 +1680,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             transactionalEpoch,
-            DEFAULT_WRITE_TIMEOUT,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -1711,8 +1700,7 @@ public class CoordinatorRuntimeTest {
             markerEpoch,
             10,
             TransactionResult.COMMIT,
-            transactionVersion,
-            DEFAULT_WRITE_TIMEOUT
+            transactionVersion
         );
 
         // Verify that InvalidProducerEpochException is thrown.
@@ -1749,7 +1737,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1770,11 +1758,11 @@ public class CoordinatorRuntimeTest {
         assertEquals(0, ctx.coordinator.lastCommittedOffset());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"));
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3", "record4"), "response2"));
 
         // Commit write #1.
@@ -1809,7 +1797,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -1836,7 +1824,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1857,11 +1845,11 @@ public class CoordinatorRuntimeTest {
         assertEquals(0, ctx.coordinator.lastCommittedOffset());
 
         // Write #1.
-        runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"));
 
         // Write #2.
-        runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3", "record4"), "response2"));
 
         // Commit write #1.
@@ -1884,7 +1872,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -1906,11 +1894,11 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(coordinator2, 10);
 
         // Writes
-        runtime.scheduleWriteOperation("write#0", coordinator0, DEFAULT_WRITE_TIMEOUT,
+        runtime.scheduleWriteOperation("write#0", coordinator0,
             state -> new CoordinatorResult<>(List.of("record0"), "response0"));
-        runtime.scheduleWriteOperation("write#1", coordinator1, DEFAULT_WRITE_TIMEOUT,
+        runtime.scheduleWriteOperation("write#1", coordinator1,
             state -> new CoordinatorResult<>(List.of("record1"), "response1"));
-        runtime.scheduleWriteOperation("write#2", coordinator2, DEFAULT_WRITE_TIMEOUT,
+        runtime.scheduleWriteOperation("write#2", coordinator2,
             state -> new CoordinatorResult<>(List.of("record2"), "response2"));
 
         // Commit writes.
@@ -1940,7 +1928,7 @@ public class CoordinatorRuntimeTest {
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
                 .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
@@ -1960,11 +1948,11 @@ public class CoordinatorRuntimeTest {
         assertEquals(0, ctx.coordinator.lastCommittedOffset());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1"));
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3", "record4"), "response2"));
 
         // Writes are inflight.
@@ -2014,7 +2002,7 @@ public class CoordinatorRuntimeTest {
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
                 .withCoordinatorShardBuilderSupplier(supplier)
@@ -2079,7 +2067,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(30))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2137,7 +2125,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2214,7 +2202,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2288,7 +2276,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2350,7 +2338,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2426,7 +2414,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2471,7 +2459,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2524,7 +2512,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
@@ -2583,7 +2571,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -2656,7 +2644,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader(
                     new CoordinatorLoader.LoadSummary(
                         startTimeMs,
@@ -2715,7 +2703,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(Time.SYSTEM)
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader(
                     new CoordinatorLoader.LoadSummary(
                         1000,
@@ -2775,7 +2763,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(Time.SYSTEM)
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader(
                     new CoordinatorLoader.LoadSummary(
                         1000,
@@ -2829,7 +2817,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -2849,13 +2837,13 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
         processor.poll();
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record2"), "response2")
         );
         processor.poll();
@@ -2905,7 +2893,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -2922,7 +2910,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
 
@@ -2935,17 +2923,16 @@ public class CoordinatorRuntimeTest {
             (short) 50,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
 
         // Write #2 but without any records.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of(), "response2")
         );
 
         // Write #3, also without any records. Should complete together with write #2.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(List.of(), "response3")
         );
 
@@ -2985,7 +2972,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -3005,13 +2992,13 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // Write#1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("Write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("Write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
         processor.poll();
 
         // Write#2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("Write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("Write#2", TP,
             state -> new CoordinatorResult<>(List.of("record2"), "response2")
         );
         processor.poll();
@@ -3061,7 +3048,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -3088,8 +3075,7 @@ public class CoordinatorRuntimeTest {
             (short) 50,
             1,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
         processor.poll();
 
@@ -3133,7 +3119,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -3164,7 +3150,7 @@ public class CoordinatorRuntimeTest {
         }
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -3187,7 +3173,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(mockWriter)
@@ -3212,7 +3198,7 @@ public class CoordinatorRuntimeTest {
         List<String> largeRecords = List.of("A".repeat(100 * 1024 * 1024));
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(largeRecords, "response1", null, true, false)
         );
 
@@ -3236,7 +3222,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(mockWriter)
@@ -3261,7 +3247,7 @@ public class CoordinatorRuntimeTest {
         List<String> records = List.of("A".repeat(INITIAL_BUFFER_SIZE + 1024));
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -3289,7 +3275,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withWriteTimeout(DEFAULT_WRITE_TIMEOUT)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(mockWriter)
@@ -3313,7 +3299,7 @@ public class CoordinatorRuntimeTest {
         List<String> records = List.of("A".repeat(INITIAL_BUFFER_SIZE + 1024));
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -3333,7 +3319,7 @@ public class CoordinatorRuntimeTest {
         when(maxBufferSizeSupplierMock.get()).thenReturn(batchSize - 66);
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records, "response2")
         );
         assertFalse(write2.isCompletedExceptionally());
@@ -3343,7 +3329,7 @@ public class CoordinatorRuntimeTest {
         verify(runtimeMetrics, times(1)).recordBufferCacheDiscarded();
 
         // Write #3.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, DEFAULT_WRITE_TIMEOUT,
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records, "response3")
         );
         assertFalse(write3.isCompletedExceptionally());
@@ -3362,7 +3348,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -3398,7 +3384,7 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write #1 with two records.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 2), "response1")
         );
 
@@ -3419,7 +3405,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(), writer.entries(TP));
 
         // Write #2 with one record.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response2")
         );
 
@@ -3439,7 +3425,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #3 with one record. This one cannot go into the existing batch
         // so the existing batch should be flushed and a new one should be created.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response3")
         );
 
@@ -3498,7 +3484,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -3534,7 +3520,7 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write all the records.
-        CompletableFuture<String> write = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -3551,7 +3537,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -3587,15 +3573,15 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 1), "response1"));
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(1, 2), "response2"));
 
         // Write #3.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response3"));
 
         // Verify the state.
@@ -3611,7 +3597,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #4. This write cannot make it in the current batch. So the current batch
         // is flushed. It will fail. So we expect all writes to fail.
-        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response4"));
 
         // Verify the futures.
@@ -3638,7 +3624,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -3700,7 +3686,7 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 1), "response1"));
 
         // Verify the state.
@@ -3713,7 +3699,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(), writer.entries(TP));
 
         // Write #2. It should fail.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(1, 2), "response2"));
 
         // Verify the futures.
@@ -3737,7 +3723,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -3761,7 +3747,7 @@ public class CoordinatorRuntimeTest {
         assertNull(ctx.currentBatch);
 
         // Write #1 with one record.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record#1"), "response1")
         );
 
@@ -3783,7 +3769,6 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             (short) 50,
-            Duration.ofMillis(20),
             state -> new CoordinatorResult<>(List.of("record#2"), "response2"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
@@ -3804,7 +3789,7 @@ public class CoordinatorRuntimeTest {
         ), writer.entries(TP));
 
         // Write #3 with one record.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(List.of("record#3"), "response3")
         );
 
@@ -3831,8 +3816,7 @@ public class CoordinatorRuntimeTest {
             (short) 50,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
 
         // Verify that the completion is not committed yet.
@@ -3873,7 +3857,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -3900,12 +3884,12 @@ public class CoordinatorRuntimeTest {
         assertNull(ctx.currentBatch);
 
         // Write #1.
-        runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1", "record2"), "response1")
         );
 
         // Write #2.
-        runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3"), "response2")
         );
 
@@ -3982,7 +3966,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -4021,22 +4005,22 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write #1.
-        runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 1), "response1")
         );
 
         // Write #2.
-        runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(1, 2), "response2")
         );
 
         // Write #3.
-        runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response3")
         );
 
         // Write #4.
-        runtime.scheduleWriteOperation("write#4", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#4", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response4")
         );
 
@@ -4063,7 +4047,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(), writer.entries(TP));
 
         // Write #5.
-        runtime.scheduleWriteOperation("write#5", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#5", TP,
             state -> new CoordinatorResult<>(records.subList(4, 5), "response5")
         );
 
@@ -4172,7 +4156,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -4199,7 +4183,7 @@ public class CoordinatorRuntimeTest {
         assertNull(ctx.currentBatch);
 
         // Write #1.
-        runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
 
@@ -4210,13 +4194,12 @@ public class CoordinatorRuntimeTest {
             "transactional-id",
             100L,
             (short) 50,
-            Duration.ofMillis(20),
             state -> new CoordinatorResult<>(List.of("record2"), "response2"),
             TXN_OFFSET_COMMIT_LATEST_VERSION
         );
 
         // Write #3.
-        runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record3"), "response3")
         );
 
@@ -4334,7 +4317,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4374,20 +4357,20 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 1), "response1"));
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(1, 2), "response2"));
 
         // Write #3.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response3"));
 
         // Write #4. This write cannot make it in the current batch. So the current batch
         // is flushed. It will fail. So we expect all writes to fail.
-        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response4"));
 
         // Verify the futures.
@@ -4450,7 +4433,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4473,7 +4456,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(List.of(2L), ctx.coordinator.snapshotRegistry().epochsList());
 
         // Schedule a write operation that does not generate any records.
-        CompletableFuture<String> write = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of(), "response1"));
 
         // The write operation should not be done.
@@ -4500,7 +4483,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4537,14 +4520,14 @@ public class CoordinatorRuntimeTest {
 
         // Let's try to write all the records atomically (the default) to ensure
         // that it fails.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "write#1")
         );
 
         assertFutureThrows(RecordTooLargeException.class, write1);
 
         // Let's try to write the same records non-atomically.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records, "write#2", null, true, false)
         );
 
@@ -4610,7 +4593,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4651,7 +4634,7 @@ public class CoordinatorRuntimeTest {
         String record = new String(payload);
 
         // Let's write the first three records.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "write#1", null, true, false)
         );
 
@@ -4670,7 +4653,7 @@ public class CoordinatorRuntimeTest {
         // pending batch, allocate a new batch, and put the record into it.
         // Note that the batch will fail only when the batch is written because the
         // MemoryBatchBuilder always accept one record.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of(record), "write#2", null, true, false)
         );
 
@@ -4707,7 +4690,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4743,15 +4726,15 @@ public class CoordinatorRuntimeTest {
         }).collect(Collectors.toList());
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 1), "response1", null, true, false));
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(1, 2), "response2", null, true, false));
 
         // Write #3.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response3", null, true, false));
 
         // Verify the state.
@@ -4767,7 +4750,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #4. This write cannot make it in the current batch. So the current batch
         // is flushed. It will fail. So we expect all writes to fail.
-        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write4 = runtime.scheduleWriteOperation("write#4", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response4", null, true, false));
 
         // Verify the futures.
@@ -4795,7 +4778,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4817,7 +4800,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #1, which fails.
         serializer.throwOnNextOperation();
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("1"), "response1"));
 
         // Write #1 should fail and leave an empty batch.
@@ -4825,7 +4808,7 @@ public class CoordinatorRuntimeTest {
         assertNotNull(ctx.currentBatch);
 
         // Write #2, with no records.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of(), "response2"));
 
         // Write #2 should not be attached to the empty batch.
@@ -4843,8 +4826,7 @@ public class CoordinatorRuntimeTest {
             (short) 50,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            DEFAULT_WRITE_TIMEOUT
+            TransactionVersion.TV_1.featureLevel()
         );
 
         // Verify that the completion is not committed yet.
@@ -4867,7 +4849,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -4901,7 +4883,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #1 with two records.
         long firstBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 2), "response1")
         );
 
@@ -4909,7 +4891,7 @@ public class CoordinatorRuntimeTest {
         assertNotNull(ctx.currentBatch);
 
         // Write #2 with one record.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response2")
         );
 
@@ -4920,7 +4902,7 @@ public class CoordinatorRuntimeTest {
         // Write #3 with one record. This one cannot go into the existing batch
         // so the existing batch should be flushed and a new one should be created.
         long secondBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response3")
         );
 
@@ -4981,7 +4963,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -5015,7 +4997,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #1 with two records.
         long firstBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records.subList(0, 2), "response1")
         );
 
@@ -5023,7 +5005,7 @@ public class CoordinatorRuntimeTest {
         assertNotNull(ctx.currentBatch);
 
         // Write #2 with one record.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(records.subList(2, 3), "response2")
         );
 
@@ -5034,7 +5016,7 @@ public class CoordinatorRuntimeTest {
         // Write #3 with one record. This one cannot go into the existing batch
         // so the existing batch should be flushed and a new one should be created.
         long secondBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> new CoordinatorResult<>(records.subList(3, 4), "response3")
         );
 
@@ -5092,7 +5074,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -5125,7 +5107,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #1 with the small records, batch will be about half full
         long firstBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -5141,7 +5123,7 @@ public class CoordinatorRuntimeTest {
         // Write #2 with the large record. This record is too large to go into the previous batch
         // uncompressed but fits in a new buffer, so we should flush the previous batch and allocate
         // a new one.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(largeRecord, "response2")
         );
 
@@ -5179,7 +5161,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -5212,7 +5194,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #1 with the small records, batch will be about half full
         long firstBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -5230,7 +5212,7 @@ public class CoordinatorRuntimeTest {
         // previous batch and successfully allocate a new batch for this record. The new batch
         // will also trigger an immediate flush.
         long secondBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(largeRecord, "response2")
         );
 
@@ -5266,7 +5248,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -5299,7 +5281,7 @@ public class CoordinatorRuntimeTest {
 
         // Write #1 with the small records, batch will be about half full
         long firstBatchTimestamp = timer.time().milliseconds();
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(records, "response1")
         );
 
@@ -5320,7 +5302,7 @@ public class CoordinatorRuntimeTest {
         // Write #2 with the large record. This record is too large to go into the previous batch
         // and is not compressible so it should be flushed. It is also too large to fit in a new batch
         // so the write should fail with RecordTooLargeException
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(50),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(largeRecord, "response2")
         );
 
@@ -5359,7 +5341,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(writeTimeout)
+                .withWriteTimeout(writeTimeout)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -5379,15 +5361,15 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // write#1 will be committed and update the high watermark. Record time spent in purgatory.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, writeTimeout,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
         // write#2 will time out sitting in the purgatory. Record time spent in purgatory.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, writeTimeout,
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record2"), "response2")
         );
         // write#3 will error while appending. Does not spend time in purgatory.
-        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP, writeTimeout,
+        CompletableFuture<String> write3 = runtime.scheduleWriteOperation("write#3", TP,
             state -> {
                 throw new KafkaException("write#3 failed.");
             });
@@ -5447,7 +5429,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(writeTimeout)
+                .withWriteTimeout(writeTimeout)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -5467,7 +5449,7 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // write#1 will be committed and update the high watermark. Record time spent in purgatory.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, writeTimeout,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
 
@@ -5516,7 +5498,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(writeTimeout)
+                .withWriteTimeout(writeTimeout)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -5543,8 +5525,7 @@ public class CoordinatorRuntimeTest {
             (short) 50,
             1,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            writeTimeout
+            TransactionVersion.TV_1.featureLevel()
         );
         processor.poll();
 
@@ -5597,7 +5578,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
-                .withDefaultWriteTimeOut(writeTimeout)
+                .withWriteTimeout(writeTimeout)
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(writer)
@@ -5617,7 +5598,7 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // Schedule a write which schedules an async tasks.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, writeTimeout,
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> {
                 state.executor().schedule(
                     "write#1#task",
@@ -5680,7 +5661,7 @@ public class CoordinatorRuntimeTest {
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(clockTimer.time())
                 .withTimer(schedulerTimer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withWriteTimeout(Duration.ofMillis(30))
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
@@ -5702,7 +5683,7 @@ public class CoordinatorRuntimeTest {
         assertNull(ctx.currentBatch);
 
         // Write #1.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP,
             state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
         assertFalse(write1.isDone());
@@ -5720,7 +5701,7 @@ public class CoordinatorRuntimeTest {
         assertEquals(2, schedulerTimer.size());
 
         // Write #2.
-        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP, Duration.ofMillis(20),
+        CompletableFuture<String> write2 = runtime.scheduleWriteOperation("write#2", TP,
             state -> new CoordinatorResult<>(List.of("record2"), "response2")
         );
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -72,7 +72,6 @@ import org.apache.kafka.server.transaction.AddPartitionsToTxnManager
 import org.apache.kafka.storage.internals.log.AppendOrigin
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 
-import java.time.Duration
 import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
@@ -1792,8 +1791,7 @@ class KafkaApis(val requestChannel: RequestChannel,
               marker.producerEpoch,
               marker.coordinatorEpoch,
               marker.transactionResult,
-              markerTransactionVersion,
-              Duration.ofMillis(config.requestTimeoutMs.toLong)
+              markerTransactionVersion
             ).whenComplete { (_, exception) =>
               val error = if (exception == null) {
                 Errors.NONE

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -114,7 +114,6 @@ import java.lang.{Byte => JByte}
 import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import java.time.Duration
 import java.util
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.function.Consumer
@@ -3123,8 +3122,7 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.eq(1.toShort),
       ArgumentMatchers.eq(0),
       ArgumentMatchers.eq(TransactionResult.COMMIT),
-      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel()),
-      any()
+      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel())
     )).thenReturn(CompletableFuture.completedFuture[Void](null))
 
     kafkaApis = createKafkaApis()
@@ -3275,8 +3273,7 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.eq(1.toShort),
       ArgumentMatchers.eq(0),
       ArgumentMatchers.eq(TransactionResult.COMMIT),
-      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel()),
-      ArgumentMatchers.eq(Duration.ofMillis(ServerConfigs.REQUEST_TIMEOUT_MS_DEFAULT))
+      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel())
     )).thenReturn(CompletableFuture.completedFuture[Void](null))
 
     when(groupCoordinator.completeTransaction(
@@ -3285,8 +3282,7 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.eq(1.toShort),
       ArgumentMatchers.eq(0),
       ArgumentMatchers.eq(TransactionResult.ABORT),
-      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel()),
-      ArgumentMatchers.eq(Duration.ofMillis(ServerConfigs.REQUEST_TIMEOUT_MS_DEFAULT))
+      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel())
     )).thenReturn(CompletableFuture.completedFuture[Void](null))
 
     val entriesPerPartition: ArgumentCaptor[Map[TopicIdPartition, MemoryRecords]] =
@@ -3393,8 +3389,7 @@ class KafkaApisTest extends Logging {
       ArgumentMatchers.eq(1.toShort),
       ArgumentMatchers.eq(0),
       ArgumentMatchers.eq(TransactionResult.COMMIT),
-      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel()),
-      ArgumentMatchers.eq(Duration.ofMillis(ServerConfigs.REQUEST_TIMEOUT_MS_DEFAULT))
+      ArgumentMatchers.eq(TransactionVersion.TV_2.featureLevel())
     )).thenReturn(FutureUtils.failedFuture[Void](error.exception()))
     kafkaApis = createKafkaApis()
     kafkaApis.handleWriteTxnMarkersRequest(requestChannelRequest, RequestLocal.noCaching)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -58,7 +58,6 @@ import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -386,7 +385,6 @@ public interface GroupCoordinator {
      * @param coordinatorEpoch  The epoch of the transaction coordinator.
      * @param result            The transaction result.
      * @param transactionVersion The transaction version (1 = TV1, 2 = TV2, etc.).
-     * @param timeout           The operation timeout.
      *
      * @return A future yielding the result.
      */
@@ -396,8 +394,7 @@ public interface GroupCoordinator {
         short producerEpoch,
         int coordinatorEpoch,
         TransactionResult result,
-        short transactionVersion,
-        Duration timeout
+        short transactionVersion
     );
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -269,7 +269,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withPartitionWriter(writer)
                     .withLoader(loader)
                     .withCoordinatorShardBuilderSupplier(supplier)
-                    .withDefaultWriteTimeOut(Duration.ofMillis(config.offsetCommitTimeoutMs()))
+                    .withWriteTimeout(Duration.ofMillis(config.offsetCommitTimeoutMs()))
                     .withCoordinatorRuntimeMetrics(coordinatorRuntimeMetrics)
                     .withCoordinatorMetrics(groupCoordinatorMetrics)
                     .withSerializer(new GroupCoordinatorRecordSerde())
@@ -494,7 +494,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "consumer-group-heartbeat",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.consumerGroupHeartbeat(context, request)
         ).exceptionally(exception -> handleOperationException(
             "consumer-group-heartbeat",
@@ -622,7 +621,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "streams-group-heartbeat",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.streamsGroupHeartbeat(context, request)
         ).exceptionally(exception -> handleOperationException(
             "streams-group-heartbeat",
@@ -688,7 +686,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "share-group-heartbeat",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.shareGroupHeartbeat(context, request)
         ).thenCompose(result -> {
             if (result.getValue().isPresent()) {
@@ -868,7 +865,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "uninitialize-share-group-state",
             topicPartitionFor(groupId),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.uninitializeShareGroupState(groupId, topicPartitionMap)
         ).thenApply(__ -> new ShareGroupHeartbeatResponseData()
             .setErrorCode(error.code())
@@ -890,7 +886,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "initialize-share-group-state",
             topicPartitionFor(groupId),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.initializeShareGroupState(groupId, topicPartitionMap)
         ).handle((__, exp) -> {
             if (exp == null) {
@@ -938,7 +933,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         runtime.scheduleWriteOperation(
             "classic-group-join",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.classicGroupJoin(context, request, responseFuture)
         ).exceptionally(exception -> {
             if (!responseFuture.isDone()) {
@@ -982,7 +976,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         runtime.scheduleWriteOperation(
             "classic-group-sync",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.classicGroupSync(context, request, responseFuture)
         ).exceptionally(exception -> {
             if (!responseFuture.isDone()) {
@@ -1023,7 +1016,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "classic-group-heartbeat",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.classicGroupHeartbeat(context, request)
         ).exceptionally(exception -> handleOperationException(
             "classic-group-heartbeat",
@@ -1066,7 +1058,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "classic-group-leave",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.classicGroupLeave(context, request)
         ).exceptionally(exception -> handleOperationException(
             "classic-group-leave",
@@ -1317,7 +1308,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "share-group-offsets-alter",
             topicPartitionFor(groupId),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.alterShareGroupOffsets(groupId, request)
         ).thenCompose(result ->
             persisterInitialize(result.getValue(), result.getKey())
@@ -1500,7 +1490,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "delete-groups",
             topicPartition,
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.deleteGroups(context, groupIds)
         ).exceptionally(exception -> handleOperationException(
             "delete-groups",
@@ -1519,7 +1508,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "delete-share-groups",
             topicPartition,
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.sharePartitionDeleteRequests(groupList)
         ).thenCompose(
             this::performShareGroupsDeletion
@@ -1650,7 +1638,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return runtime.scheduleWriteOperation(
                 name,
                 topicPartitionFor(request.groupId()),
-                Duration.ofMillis(config.offsetCommitTimeoutMs()),
                 coordinator -> new CoordinatorResult<>(
                     List.of(),
                     coordinator.fetchOffsets(request, Long.MAX_VALUE)
@@ -1953,7 +1940,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "initiate-delete-share-group-offsets",
             topicPartitionFor(groupId),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.initiateDeleteShareGroupOffsets(groupId, requestData)
         ).thenCompose(resultHolder -> deleteShareGroupOffsetsState(groupId, resultHolder)
         ).exceptionally(exception -> handleOperationException(
@@ -2058,7 +2044,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "complete-delete-share-group-offsets",
             topicPartitionFor(groupId),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.completeDeleteShareGroupOffsets(groupId, successTopics, errorTopicResponses)
         ).exceptionally(exception -> handleOperationException(
             "complete-delete-share-group-offsets",
@@ -2096,7 +2081,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "commit-offset",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.commitOffset(context, request)
         ).exceptionally(exception -> handleOperationException(
             "commit-offset",
@@ -2136,7 +2120,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
             request.transactionalId(),
             request.producerId(),
             request.producerEpoch(),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.commitTransactionalOffset(context, request),
             context.requestVersion()
         ).exceptionally(exception -> handleOperationException(
@@ -2172,7 +2155,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
             "delete-offsets",
             topicPartitionFor(request.groupId()),
-            Duration.ofMillis(config.offsetCommitTimeoutMs()),
             coordinator -> coordinator.deleteOffsets(context, request)
         ).exceptionally(exception -> handleOperationException(
             "delete-offsets",
@@ -2184,7 +2166,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
     }
 
     /**
-     * See {@link GroupCoordinator#completeTransaction(TopicPartition, long, short, int, TransactionResult, short, Duration)}.
+     * See {@link GroupCoordinator#completeTransaction(TopicPartition, long, short, int, TransactionResult, short)}.
      */
     @Override
     public CompletableFuture<Void> completeTransaction(
@@ -2193,8 +2175,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         short producerEpoch,
         int coordinatorEpoch,
         TransactionResult result,
-        short transactionVersion,
-        Duration timeout
+        short transactionVersion
     ) {
         if (!isActive.get()) {
             return FutureUtils.failedFuture(Errors.COORDINATOR_NOT_AVAILABLE.exception());
@@ -2213,8 +2194,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             producerEpoch,
             coordinatorEpoch,
             result,
-            transactionVersion,
-            timeout
+            transactionVersion
         );
     }
 
@@ -2297,7 +2277,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 FutureUtils.mapExceptionally(
                     runtime.scheduleWriteAllOperation(
                         "on-topics-deleted",
-                        Duration.ofMillis(config.offsetCommitTimeoutMs()),
                         coordinator -> coordinator.onTopicsDeleted(deletedTopics)
                     ),
                     exception -> {
@@ -2315,7 +2294,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 FutureUtils.mapExceptionally(
                     runtime.scheduleWriteAllOperation(
                         "maybe-cleanup-share-group-state",
-                        Duration.ofMillis(config.offsetCommitTimeoutMs()),
                         coordinator -> coordinator.maybeCleanupShareGroupState(deletedTopicIds)
                     ),
                     exception -> {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -127,7 +127,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
 import java.net.InetAddress;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -245,7 +244,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("consumer-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             new ConsumerGroupHeartbeatResponseData()
@@ -283,7 +281,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("consumer-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
@@ -502,7 +499,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("streams-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             new StreamsGroupHeartbeatResult(
@@ -562,7 +558,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("streams-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
@@ -1052,7 +1047,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-join"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             new JoinGroupResponseData()
@@ -1082,7 +1076,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-join"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(new IllegalStateException()));
 
@@ -1207,7 +1200,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-sync"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             new SyncGroupResponseData()
@@ -1236,7 +1228,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-sync"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(new IllegalStateException()));
 
@@ -1317,7 +1308,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             new HeartbeatResponseData()
@@ -1346,7 +1336,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(
             new CoordinatorLoadInProgressException(null)
@@ -1375,7 +1364,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(
             new RebalanceInProgressException()
@@ -1745,7 +1733,6 @@ public class GroupCoordinatorServiceTest {
             when(runtime.scheduleWriteOperation(
                 ArgumentMatchers.eq(fetchAllOffsets ? "fetch-all-offsets" : "fetch-offsets"),
                 ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-                ArgumentMatchers.eq(Duration.ofMillis(5000)),
                 ArgumentMatchers.any()
             )).thenReturn(CompletableFuture.completedFuture(response));
         } else {
@@ -1849,7 +1836,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq(fetchAllOffsets ? "fetch-all-offsets" : "fetch-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(new CompletionException(error.exception())));
 
@@ -1881,7 +1867,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-leave"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             new LeaveGroupResponseData()
@@ -1918,7 +1903,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("classic-group-leave"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(
             new UnknownMemberIdException()
@@ -2281,7 +2265,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(response));
 
@@ -2321,7 +2304,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(response));
 
@@ -2366,7 +2348,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
@@ -2442,14 +2423,12 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(Map.of()));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 2)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection1));
 
@@ -2457,14 +2436,12 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(resultCollectionFuture);
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 1)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(Errors.COORDINATOR_LOAD_IN_PROGRESS.exception()));
 
@@ -2523,7 +2500,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             Map.of("share-group-id-1", Map.entry(createDeleteShareRequest("share-group-id-1", shareGroupTopicId, List.of(0, 1)), Errors.NONE))
@@ -2546,7 +2522,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 1)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection1));
 
@@ -2554,7 +2529,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection2));
 
@@ -2605,7 +2579,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             Map.of("share-group-id-1", Map.entry(createDeleteShareRequest("share-group-id-1", shareGroupTopicId, List.of(0, 1)), Errors.NONE))
@@ -2641,7 +2614,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 1)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection1));
 
@@ -2649,7 +2621,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 2)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection2));
 
@@ -2691,7 +2662,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.failedFuture(
             Errors.COORDINATOR_NOT_AVAILABLE.exception()
@@ -2701,7 +2671,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 1)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection1));
 
@@ -2743,7 +2712,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             Map.of("share-group-id-1", Map.entry(EMPTY_PARAMS, Errors.forException(new GroupNotEmptyException("bad stuff"))))
@@ -2760,7 +2728,6 @@ public class GroupCoordinatorServiceTest {
         verify(persister, times(0)).deleteState(ArgumentMatchers.any());
         verify(runtime, times(0)).scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
@@ -2796,7 +2763,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             Map.of("share-group-id-1", Map.entry(createDeleteShareRequest("share-group-id-1", shareGroupTopicId, List.of(0, 1)), Errors.NONE))
@@ -2806,7 +2772,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 1)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.failedFuture(Errors.CLUSTER_AUTHORIZATION_FAILED.exception()));
 
@@ -2847,14 +2812,12 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-share-groups"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(Map.of()));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
@@ -3010,7 +2973,6 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.eq("transactional-id"),
             ArgumentMatchers.eq(10L),
             ArgumentMatchers.eq((short) 5),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any(),
             ArgumentMatchers.eq((int) txnOffsetCommitVersion)
         )).thenReturn(CompletableFuture.completedFuture(response));
@@ -3065,7 +3027,6 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.eq("transactional-id"),
             ArgumentMatchers.eq(10L),
             ArgumentMatchers.eq((short) 5),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any(),
             ArgumentMatchers.eq((int) ApiKeys.TXN_OFFSET_COMMIT.latestVersion())
         )).thenReturn(FutureUtils.failedFuture(new CompletionException(error.exception())));
@@ -3094,8 +3055,7 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.eq((short) 5),
             ArgumentMatchers.eq(10),
             ArgumentMatchers.eq(TransactionResult.COMMIT),
-            ArgumentMatchers.eq(TransactionVersion.TV_1.featureLevel()),
-            ArgumentMatchers.eq(Duration.ofMillis(100))
+            ArgumentMatchers.eq(TransactionVersion.TV_1.featureLevel())
         )).thenReturn(CompletableFuture.completedFuture(null));
 
         CompletableFuture<Void> future = service.completeTransaction(
@@ -3104,8 +3064,7 @@ public class GroupCoordinatorServiceTest {
             (short) 5,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            Duration.ofMillis(100)
+            TransactionVersion.TV_1.featureLevel()
         );
 
         assertNull(future.get());
@@ -3125,8 +3084,7 @@ public class GroupCoordinatorServiceTest {
             (short) 5,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            Duration.ofMillis(100)
+            TransactionVersion.TV_1.featureLevel()
         );
 
         assertFutureThrows(CoordinatorNotAvailableException.class, future);
@@ -3146,8 +3104,7 @@ public class GroupCoordinatorServiceTest {
             (short) 5,
             10,
             TransactionResult.COMMIT,
-            TransactionVersion.TV_1.featureLevel(),
-            Duration.ofMillis(100)
+            TransactionVersion.TV_1.featureLevel()
         );
 
         assertFutureThrows(IllegalStateException.class, future);
@@ -3203,13 +3160,11 @@ public class GroupCoordinatorServiceTest {
 
         when(runtime.scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-topics-deleted"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(offsetFutures);
 
         when(runtime.scheduleWriteAllOperation(
             ArgumentMatchers.eq("maybe-cleanup-share-group-state"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(shareFutures);
 
@@ -3219,12 +3174,10 @@ public class GroupCoordinatorServiceTest {
         // Wait for the operations to be scheduled and verify method is blocked.
         verify(runtime, timeout(5000).times(1)).scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-topics-deleted"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
         verify(runtime, timeout(5000).times(1)).scheduleWriteAllOperation(
             ArgumentMatchers.eq("maybe-cleanup-share-group-state"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
         assertFalse(resultFuture.isDone());
@@ -3257,12 +3210,10 @@ public class GroupCoordinatorServiceTest {
         // Verify no operations scheduled.
         verify(runtime, times(0)).scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-topics-deleted"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
         verify(runtime, times(0)).scheduleWriteAllOperation(
             ArgumentMatchers.eq("maybe-cleanup-share-group-state"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
     }
@@ -3289,7 +3240,6 @@ public class GroupCoordinatorServiceTest {
         // Mock operations with 3 futures, some failing.
         when(runtime.scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-topics-deleted"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(Arrays.asList(
             CompletableFuture.completedFuture(null),
@@ -3299,7 +3249,6 @@ public class GroupCoordinatorServiceTest {
 
         when(runtime.scheduleWriteAllOperation(
             ArgumentMatchers.eq("maybe-cleanup-share-group-state"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(Arrays.asList(
             CompletableFuture.completedFuture(null),
@@ -3313,12 +3262,10 @@ public class GroupCoordinatorServiceTest {
         // Verify operations were still scheduled exactly once.
         verify(runtime, times(1)).scheduleWriteAllOperation(
             ArgumentMatchers.eq("on-topics-deleted"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
         verify(runtime, times(1)).scheduleWriteAllOperation(
             ArgumentMatchers.eq("maybe-cleanup-share-group-state"),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         );
     }
@@ -3359,7 +3306,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("share-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(
             Map.entry(
@@ -3398,7 +3344,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("share-group-heartbeat"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(exception));
 
@@ -4537,14 +4482,12 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("complete-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(responseData));
 
@@ -4612,14 +4555,12 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("complete-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(responseData));
 
@@ -4740,7 +4681,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -4778,7 +4718,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -4814,7 +4753,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_SERVER_ERROR.exception()));
 
@@ -4850,7 +4788,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
 
@@ -4892,7 +4829,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -4936,7 +4872,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -4978,7 +4913,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5036,7 +4970,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5094,7 +5027,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5155,7 +5087,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5216,7 +5147,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5307,7 +5237,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5379,7 +5308,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5392,7 +5320,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("complete-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_SERVER_ERROR.exception()));
 
@@ -5505,7 +5432,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initiate-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(deleteShareGroupOffsetsResultHolder));
 
@@ -5518,7 +5444,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("complete-delete-share-group-offsets"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(responseData));
 
@@ -5558,7 +5483,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
 
@@ -5575,7 +5499,6 @@ public class GroupCoordinatorServiceTest {
         assertEquals(defaultResponse, service.persisterInitialize(params, defaultResponse).getNow(null));
         verify(runtime, times(1)).scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
@@ -5601,13 +5524,11 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("uninitialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
@@ -5625,12 +5546,10 @@ public class GroupCoordinatorServiceTest {
         verify(runtime, times(0)).scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
         verify(runtime, times(1)).scheduleWriteOperation(
             ArgumentMatchers.eq("uninitialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
@@ -5663,13 +5582,11 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("uninitialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
@@ -5690,12 +5607,10 @@ public class GroupCoordinatorServiceTest {
         verify(runtime, times(0)).scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
         verify(runtime, times(1)).scheduleWriteOperation(
             ArgumentMatchers.eq("uninitialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
@@ -5733,13 +5648,11 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.failedFuture(exp));
 
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("uninitialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
@@ -5760,12 +5673,10 @@ public class GroupCoordinatorServiceTest {
         verify(runtime, times(1)).scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
         verify(runtime, times(1)).scheduleWriteOperation(
             ArgumentMatchers.eq("uninitialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );
@@ -5861,7 +5772,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("share-group-offsets-alter"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(alterShareGroupOffsetsIntermediate));
 
@@ -5909,7 +5819,6 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("share-group-offsets-alter"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(
             new GroupNotEmptyException("bad stuff")
@@ -5959,14 +5868,12 @@ public class GroupCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
             ArgumentMatchers.eq(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)),
-            ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(null));
 
         assertEquals(defaultResponse, service.persisterInitialize(params, defaultResponse).getNow(null));
         verify(runtime, times(1)).scheduleWriteOperation(
             ArgumentMatchers.eq("initialize-share-group-state"),
-            ArgumentMatchers.any(),
             ArgumentMatchers.any(),
             ArgumentMatchers.any()
         );

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -57,7 +57,6 @@ import org.apache.kafka.server.util.timer.Timer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -201,7 +200,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-share-group-state"),
             eq(new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, 0)),
-            eq(Duration.ofMillis(5000)),
             any()
         ))
             .thenReturn(CompletableFuture.completedFuture(response1))
@@ -316,7 +314,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("read-update-leader-epoch-state"),
             eq(new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, 0)),
-            any(),
             any()
         ))
             .thenReturn(CompletableFuture.completedFuture(new ReadShareGroupStateResponseData()
@@ -398,7 +395,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("read-share-group-state-summary"),
             eq(new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, 0)),
-            any(),
             any())
         ).thenReturn(CompletableFuture.completedFuture(new ReadShareGroupStateSummaryResponseData()
             .setResults(List.of(topicData1)))
@@ -479,7 +475,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("delete-share-group-state"),
             eq(new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, 0)),
-            eq(Duration.ofMillis(5000)),
             any()
         )).thenReturn(CompletableFuture.completedFuture(response1)).thenReturn(CompletableFuture.completedFuture(response2));
 
@@ -564,7 +559,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("initialize-share-group-state"),
             eq(new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, 0)),
-            eq(Duration.ofMillis(5000)),
             any())).thenReturn(CompletableFuture.completedFuture(response1)).thenReturn(CompletableFuture.completedFuture(response2)
         );
 
@@ -1181,7 +1175,7 @@ class ShareCoordinatorServiceTest {
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
 
-        when(runtime.scheduleWriteOperation(any(), any(), any(), any()))
+        when(runtime.scheduleWriteOperation(any(), any(), any()))
             .thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception()));
 
         assertEquals(new WriteShareGroupStateResponseData()
@@ -1233,7 +1227,7 @@ class ShareCoordinatorServiceTest {
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
 
-        when(runtime.scheduleWriteOperation(any(), any(), any(), any()))
+        when(runtime.scheduleWriteOperation(any(), any(), any()))
             .thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_SERVER_ERROR.exception()));
 
         assertEquals(new ReadShareGroupStateResponseData()
@@ -1277,7 +1271,7 @@ class ShareCoordinatorServiceTest {
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
 
-        when(runtime.scheduleWriteOperation(any(), any(), any(), any()))
+        when(runtime.scheduleWriteOperation(any(), any(), any()))
             .thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_SERVER_ERROR.exception()));
 
         assertEquals(new ReadShareGroupStateSummaryResponseData()
@@ -1321,7 +1315,7 @@ class ShareCoordinatorServiceTest {
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
 
-        when(runtime.scheduleWriteOperation(any(), any(), any(), any()))
+        when(runtime.scheduleWriteOperation(any(), any(), any()))
             .thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception()));
 
         assertEquals(new DeleteShareGroupStateResponseData()
@@ -1364,7 +1358,7 @@ class ShareCoordinatorServiceTest {
         Uuid topicId = Uuid.randomUuid();
         int partition = 0;
 
-        when(runtime.scheduleWriteOperation(any(), any(), any(), any())).thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception()));
+        when(runtime.scheduleWriteOperation(any(), any(), any())).thenReturn(FutureUtils.failedFuture(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception()));
 
         assertEquals(
             new InitializeShareGroupStateResponseData().setResults(List.of(new InitializeShareGroupStateResponseData.InitializeStateResult()
@@ -1468,7 +1462,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         )).thenReturn(
             CompletableFuture.completedFuture(Optional.of(10L))
@@ -1495,7 +1488,6 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // Prune should be called.
@@ -1503,14 +1495,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // Prune should be called.
         verify(runtime, times(2))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1552,7 +1542,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             eq(tp1),
-            any(),
             any()
         )).thenReturn(
             CompletableFuture.completedFuture(Optional.of(10L))
@@ -1563,7 +1552,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             eq(tp2),
-            any(),
             any()
         )).thenReturn(
             CompletableFuture.completedFuture(Optional.of(20L))
@@ -1590,7 +1578,6 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // Prune should be called.
@@ -1598,14 +1585,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // Prune should be called as future completes exceptionally.
         verify(runtime, times(4))   // Second prune with 2 topic partitions.
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1629,7 +1614,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         )).thenReturn(CompletableFuture.failedFuture(Errors.UNKNOWN_SERVER_ERROR.exception()));
 
@@ -1652,14 +1636,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
         verify(runtime, times(1))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1681,7 +1663,6 @@ class ShareCoordinatorServiceTest {
 
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
-            any(),
             any(),
             any()
         )).thenReturn(CompletableFuture.completedFuture(Optional.of(20L)));
@@ -1705,14 +1686,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
         verify(runtime, times(1))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1733,7 +1712,6 @@ class ShareCoordinatorServiceTest {
 
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
-            any(),
             any(),
             any()
         )).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
@@ -1757,14 +1735,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
         verify(runtime, times(1))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1794,7 +1770,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         )).thenReturn(
             CompletableFuture.completedFuture(Optional.of(10L))
@@ -1820,7 +1795,6 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
@@ -1828,14 +1802,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
         verify(runtime, times(2))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1869,7 +1841,6 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         )).thenReturn(
             CompletableFuture.completedFuture(Optional.of(10L))
@@ -1896,7 +1867,6 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
@@ -1904,14 +1874,12 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(30005L); // prune should be called
         verify(runtime, times(2))
             .scheduleWriteOperation(
                 eq("write-state-record-prune"),
-                any(),
                 any(),
                 any());
 
@@ -1946,7 +1914,6 @@ class ShareCoordinatorServiceTest {
 
         when(runtime.scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
-            any(),
             any()
         )).thenReturn(List.of(CompletableFuture.completedFuture(null)));
 
@@ -1956,21 +1923,18 @@ class ShareCoordinatorServiceTest {
             .scheduleWriteOperation(
                 eq("snapshot-cold-partitions"),
                 any(),
-                any(),
                 any());
 
         timer.advanceClock(10005L); // Snapshotting should be called.
         verify(runtime, times(1))
             .scheduleWriteAllOperation(
                 eq("snapshot-cold-partitions"),
-                any(),
                 any());
 
         timer.advanceClock(10005L); // Snapshotting should be called.
         verify(runtime, times(2))
             .scheduleWriteAllOperation(
                 eq("snapshot-cold-partitions"),
-                any(),
                 any());
 
         checkMetrics(metrics);
@@ -1987,7 +1951,6 @@ class ShareCoordinatorServiceTest {
 
         when(runtime.scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
-            any(),
             any()
         )).thenReturn(
             List.of(CompletableFuture.completedFuture(null), CompletableFuture.failedFuture(new Exception("bad stuff")))
@@ -2013,21 +1976,18 @@ class ShareCoordinatorServiceTest {
         verify(runtime, times(0))
             .scheduleWriteAllOperation(
                 eq("snapshot-cold-partitions"),
-                any(),
                 any());
 
         timer.advanceClock(10005L); // Snapshotting should be called.
         verify(runtime, times(1))   // For 2 topic partitions.
             .scheduleWriteAllOperation(
                 eq("snapshot-cold-partitions"),
-                any(),
                 any());
 
         timer.advanceClock(10005L); // Snapshotting should be called (despite previous partial failure).
         verify(runtime, times(2))   // For 2 topic partitions.
             .scheduleWriteAllOperation(
                 eq("snapshot-cold-partitions"),
-                any(),
                 any());
 
         checkMetrics(metrics);
@@ -2059,14 +2019,12 @@ class ShareCoordinatorServiceTest {
         when(runtime.scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         )).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         // Snapshot job.
         when(runtime.scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
-            any(),
             any()
         )).thenReturn(List.of());
 
@@ -2084,12 +2042,10 @@ class ShareCoordinatorServiceTest {
         verify(runtime, times(0)).scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         );
         verify(runtime, times(0)).scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
-            any(),
             any()
         );
         assertFalse(service.shouldRunPeriodicJob());
@@ -2104,12 +2060,10 @@ class ShareCoordinatorServiceTest {
         verify(runtime, times(1)).scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         );
         verify(runtime, times(1)).scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
-            any(),
             any()
         );
         assertTrue(service.shouldRunPeriodicJob());
@@ -2124,12 +2078,10 @@ class ShareCoordinatorServiceTest {
         verify(runtime, times(1)).scheduleWriteOperation(
             eq("write-state-record-prune"),
             any(),
-            any(),
             any()
         );
         verify(runtime, times(1)).scheduleWriteAllOperation(
             eq("snapshot-cold-partitions"),
-            any(),
             any()
         );
         assertFalse(service.shouldRunPeriodicJob());
@@ -2196,7 +2148,6 @@ class ShareCoordinatorServiceTest {
 
         when(runtime.scheduleWriteAllOperation(
             eq("on-topics-deleted"),
-            any(),
             any()
         )).thenReturn(
             List.of(
@@ -2209,7 +2160,6 @@ class ShareCoordinatorServiceTest {
         assertDoesNotThrow(() -> service.onTopicsDeleted(Set.of(), BufferSupplier.NO_CACHING));
         verify(runtime, times(0)).scheduleWriteAllOperation(
             eq("on-topics-deleted"),
-            any(),
             any()
         );
     }
@@ -2237,7 +2187,6 @@ class ShareCoordinatorServiceTest {
 
         when(runtime.scheduleWriteAllOperation(
             eq("on-topics-deleted"),
-            any(),
             any()
         )).thenReturn(
             List.of(
@@ -2250,7 +2199,6 @@ class ShareCoordinatorServiceTest {
         assertDoesNotThrow(() -> service.onTopicsDeleted(Set.of(Uuid.randomUuid()), BufferSupplier.NO_CACHING));
         verify(runtime, times(1)).scheduleWriteAllOperation(
             eq("on-topics-deleted"),
-            any(),
             any()
         );
     }


### PR DESCRIPTION
Remove the timeout parameter from all CoordinatorRuntime schedule
methods and use the writeTimeout field (configured via the builder)
instead. This simplifies the API since the timeout is now configured
once at runtime construction time.

- Rename defaultWriteTimeout to writeTimeout
- Rename withDefaultWriteTimeOut to withWriteTimeout
- Remove timeout parameter from scheduleWriteOperation,
scheduleWriteAllOperation, scheduleTransactionalWriteOperation, and
scheduleTransactionCompletion methods
- Update GroupCoordinator.completeTransaction to remove timeout
parameter
- Update all callers and tests accordingly

Reviewers: Sean Quah <squah@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>
