### PR TITLE
KAFKA-20064: Made PartitionLeaderCache thread safe.

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
@@ -28,11 +28,10 @@ import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.Utils;
-
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -79,9 +78,7 @@ public class ConcurrentListOffsetsRequestTest {
         adminClient = KafkaAdminClient.createInternal(new AdminClientConfig(clusterInstance.setClientSaslConfig(props), true),
                 null, new TestHostResolver());
 
-        Field clientField = KafkaAdminClient.class.getDeclaredField("client");
-        clientField.setAccessible(true);
-        networkClient = (NetworkClient) clientField.get(adminClient);
+        networkClient = TestUtils.fieldValue(adminClient, KafkaAdminClient.class, "client");
     }
 
     @AfterEach
@@ -121,12 +118,10 @@ public class ConcurrentListOffsetsRequestTest {
     }
 
     private TestPartitionLeaderCache replacePartitionLeaderCache(CountDownLatch invalidationLatch) throws Exception {
-        Field partitionLeaderCacheField = KafkaAdminClient.class.getDeclaredField("partitionLeaderCache");
-        partitionLeaderCacheField.setAccessible(true);
-        PartitionLeaderCache oldPartitionLeaderCache = (PartitionLeaderCache) partitionLeaderCacheField.get(adminClient);
+        PartitionLeaderCache oldPartitionLeaderCache = TestUtils.fieldValue(adminClient, KafkaAdminClient.class, "partitionLeaderCache");
 
         TestPartitionLeaderCache partitionLeaderCache = new TestPartitionLeaderCache(oldPartitionLeaderCache.get(getTopicPartitions()), invalidationLatch);
-        partitionLeaderCacheField.set(adminClient, partitionLeaderCache);
+        TestUtils.setFieldValue(adminClient, "partitionLeaderCache", partitionLeaderCache);
         return partitionLeaderCache;
     }
 
@@ -194,7 +189,6 @@ public class ConcurrentListOffsetsRequestTest {
 
         @Override
         public InetAddress[] resolve(String host) throws UnknownHostException {
-            System.out.println("RESOLVE: " + host);
             if (injectHostResolverError.get()) {
                 throw new UnknownHostException();
             }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
@@ -96,10 +96,10 @@ public class ConcurrentListOffsetsRequestTest {
 
         final CountDownLatch invalidationLatch = new CountDownLatch(1);
         // Replacing the partition leader cache in order to be able to synchronize the calls so that they happen in the right order to reproduce the issue
-        replacePartitionLeaderCache(invalidationLatch);
+        TestPartitionLeaderCache testPartitionLeaderCache = replacePartitionLeaderCache(invalidationLatch);
 
         // closing the connection to the first node. not using clusterInstance.shutdownBroker to reduce flakiness
-        networkClient.close(clusterInstance.aliveBrokers().keySet().iterator().next().toString());
+        networkClient.close(testPartitionLeaderCache.get(getTopicPartitions()).values().iterator().next().toString());
         // as next call with try to resolve the host for the closed node, it's time to let it fail, which will lead to cache invalidation
         injectHostResolverError.set(true);
 
@@ -120,13 +120,14 @@ public class ConcurrentListOffsetsRequestTest {
         assertInstanceOf(TimeoutException.class, executionException.getCause());
     }
 
-    private void replacePartitionLeaderCache(CountDownLatch latch0) throws Exception {
+    private TestPartitionLeaderCache replacePartitionLeaderCache(CountDownLatch invalidationLatch) throws Exception {
         Field partitionLeaderCacheField = KafkaAdminClient.class.getDeclaredField("partitionLeaderCache");
         partitionLeaderCacheField.setAccessible(true);
         PartitionLeaderCache oldPartitionLeaderCache = (PartitionLeaderCache) partitionLeaderCacheField.get(adminClient);
 
-        TestPartitionLeaderCache partitionLeaderCache = new TestPartitionLeaderCache(oldPartitionLeaderCache.get(getTopicPartitions()), latch0);
+        TestPartitionLeaderCache partitionLeaderCache = new TestPartitionLeaderCache(oldPartitionLeaderCache.get(getTopicPartitions()), invalidationLatch);
         partitionLeaderCacheField.set(adminClient, partitionLeaderCache);
+        return partitionLeaderCache;
     }
 
     private ListOffsetsResult listAllOffsets() {
@@ -159,8 +160,8 @@ public class ConcurrentListOffsetsRequestTest {
         @Override
         public Map<TopicPartition, Integer> get(Collection<TopicPartition> keys) {
             Map<TopicPartition, Integer> result = super.get(keys);
-            // waiting for the second call: first one was from the request that invalidates teh cache
-            if (getCounter.incrementAndGet() == 2) {
+            // waiting for the third call: first one was to close the network connection, second one was from the request that invalidates the cache
+            if (getCounter.incrementAndGet() == 3) {
                 newRequestCheckLatch.countDown();
                 try {
                     // letting the remove method proceed and actually remove the data
@@ -193,6 +194,7 @@ public class ConcurrentListOffsetsRequestTest {
 
         @Override
         public InetAddress[] resolve(String host) throws UnknownHostException {
+            System.out.println("RESOLVE: " + host);
             if (injectHostResolverError.get()) {
                 throw new UnknownHostException();
             }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.DefaultHostResolver;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.admin.internals.PartitionLeaderCache;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.test.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.Type;
+import org.apache.kafka.common.utils.Utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ClusterTestDefaults(
+        types = {Type.KRAFT},
+        brokers = 3
+)
+public class ConcurrentListOffsetsRequestTest {
+    private static final String TOPIC = "topic";
+    private static final short REPLICAS = 1;
+    private static final int PARTITION = 2;
+    private static final int TIMEOUT = 1000;
+    private final ClusterInstance clusterInstance;
+    private Admin adminClient;
+    private NetworkClient networkClient;
+    private final AtomicBoolean injectHostResolverError = new AtomicBoolean(false);
+
+    ConcurrentListOffsetsRequestTest(ClusterInstance clusterInstance) {
+        this.clusterInstance = clusterInstance;
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        clusterInstance.waitForReadyBrokers();
+        clusterInstance.createTopic(TOPIC, PARTITION, REPLICAS);
+        Map<String, Object> props = Map.of(
+                "default.api.timeout.ms", TIMEOUT,
+                "request.timeout.ms", TIMEOUT,
+                CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+        adminClient = KafkaAdminClient.createInternal(new AdminClientConfig(clusterInstance.setClientSaslConfig(props), true),
+                null, new TestHostResolver());
+
+        Field clientField = KafkaAdminClient.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        networkClient = (NetworkClient) clientField.get(adminClient);
+    }
+
+    @AfterEach
+    public void teardown() {
+        Utils.closeQuietly(adminClient, "ListOffsetsAdminClient");
+    }
+
+    @ClusterTest
+    public void correctlyHandleConcurrentModificationOfPartitionLeaderCache() throws Exception {
+        // making one request to prepopulate the partition leader cache so we have something to delete later
+        listAllOffsets().all().get(TIMEOUT * 2, TimeUnit.SECONDS);
+
+        final CountDownLatch invalidationLatch = new CountDownLatch(1);
+        // Replacing the partition leader cache in order to be able to synchronize the calls so that they happen in the right order to reproduce the issue
+        replacePartitionLeaderCache(invalidationLatch);
+
+        // closing the connection to the first node. not using clusterInstance.shutdownBroker to reduce flakiness
+        networkClient.close(clusterInstance.aliveBrokers().keySet().iterator().next().toString());
+        // as next call with try to resolve the host for the closed node, it's time to let it fail, which will lead to cache invalidation
+        injectHostResolverError.set(true);
+
+        // making another request(this request will face the host resolver error and remove the node from the cache)
+        ListOffsetsResult failInducingResult = listAllOffsets();
+        // waiting until we get to the invalidation
+        invalidationLatch.await();
+        // making another request. at this point the fail inducing request is waiting for this one before it deletes the keys associated with the node
+        // the TestPartitionLeaderCache class synchronizes the calls to mimic the race condition
+        ListOffsetsResult failingResult = listAllOffsets();
+
+        // verifying that we correctly declined the call
+        ExecutionException executionException = assertThrows(ExecutionException.class, () -> failInducingResult.all().get(TIMEOUT * 2, TimeUnit.MILLISECONDS));
+        assertInstanceOf(TimeoutException.class, executionException.getCause());
+
+        // verifying that we correctly declined the call
+        executionException = assertThrows(ExecutionException.class, () -> failingResult.all().get(TIMEOUT * 2, TimeUnit.MILLISECONDS));
+        assertInstanceOf(TimeoutException.class, executionException.getCause());
+    }
+
+    private void replacePartitionLeaderCache(CountDownLatch latch0) throws Exception {
+        Field partitionLeaderCacheField = KafkaAdminClient.class.getDeclaredField("partitionLeaderCache");
+        partitionLeaderCacheField.setAccessible(true);
+        PartitionLeaderCache oldPartitionLeaderCache = (PartitionLeaderCache) partitionLeaderCacheField.get(adminClient);
+
+        TestPartitionLeaderCache partitionLeaderCache = new TestPartitionLeaderCache(oldPartitionLeaderCache.get(getTopicPartitions()), latch0);
+        partitionLeaderCacheField.set(adminClient, partitionLeaderCache);
+    }
+
+    private ListOffsetsResult listAllOffsets() {
+        List<TopicPartition> partitions = getTopicPartitions();
+
+        Map<TopicPartition, OffsetSpec> offsetSpecMap = partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
+        return adminClient.listOffsets(offsetSpecMap, new ListOffsetsOptions(IsolationLevel.READ_UNCOMMITTED));
+    }
+
+    private List<TopicPartition> getTopicPartitions() {
+        List<TopicPartition> partitions = new ArrayList<>();
+        for (int i = 0; i < PARTITION; i++) {
+            partitions.add(new TopicPartition(TOPIC, i));
+        }
+        return partitions;
+    }
+
+    private static class TestPartitionLeaderCache extends PartitionLeaderCache {
+
+        private final AtomicInteger getCounter = new AtomicInteger(0);
+        private final CountDownLatch invalidationLatch;
+        private final CountDownLatch newRequestCheckLatch = new CountDownLatch(1);
+        private final CountDownLatch removeCompleteLatch = new CountDownLatch(1);
+
+        public TestPartitionLeaderCache(Map<TopicPartition, Integer> oldPartitionLeaderCache, final CountDownLatch invalidationLatch) {
+            put(oldPartitionLeaderCache);
+            this.invalidationLatch = invalidationLatch;
+        }
+
+        @Override
+        public Map<TopicPartition, Integer> get(Collection<TopicPartition> keys) {
+            Map<TopicPartition, Integer> result = super.get(keys);
+            // waiting for the second call: first one was from the request that invalidates teh cache
+            if (getCounter.incrementAndGet() == 2) {
+                newRequestCheckLatch.countDown();
+                try {
+                    // letting the remove method proceed and actually remove the data
+                    removeCompleteLatch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return result;
+        }
+
+        @Override
+        public void remove(Collection<TopicPartition> keys) {
+            try {
+                // letting the caller know that we've reached the invalidation step, and it's time to send the second request
+                invalidationLatch.countDown();
+                // waiting for the second request to reach get
+                newRequestCheckLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            super.remove(keys);
+            // once the value removed, we are letting the get method proceed and return the value
+            removeCompleteLatch.countDown();
+        }
+    }
+
+    private class TestHostResolver extends DefaultHostResolver {
+
+        @Override
+        public InetAddress[] resolve(String host) throws UnknownHostException {
+            if (injectHostResolverError.get()) {
+                throw new UnknownHostException();
+            }
+            return super.resolve(host);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -63,6 +63,7 @@ import org.apache.kafka.clients.admin.internals.ListConsumerGroupOffsetsHandler;
 import org.apache.kafka.clients.admin.internals.ListOffsetsHandler;
 import org.apache.kafka.clients.admin.internals.ListShareGroupOffsetsHandler;
 import org.apache.kafka.clients.admin.internals.ListTransactionsHandler;
+import org.apache.kafka.clients.admin.internals.PartitionLeaderCache;
 import org.apache.kafka.clients.admin.internals.PartitionLeaderStrategy;
 import org.apache.kafka.clients.admin.internals.RemoveMembersFromConsumerGroupHandler;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -407,7 +408,7 @@ public class KafkaAdminClient extends AdminClient {
     private final long retryBackoffMaxMs;
     private final ExponentialBackoff retryBackoff;
     private final MetadataRecoveryStrategy metadataRecoveryStrategy;
-    private final Map<TopicPartition, Integer> partitionLeaderCache;
+    private final PartitionLeaderCache partitionLeaderCache;
     private final AdminFetchMetricsManager adminFetchMetricsManager;
     private final Optional<ClientTelemetryReporter> clientTelemetryReporter;
 
@@ -631,7 +632,7 @@ public class KafkaAdminClient extends AdminClient {
             CommonClientConfigs.RETRY_BACKOFF_JITTER);
         this.clientTelemetryReporter = clientTelemetryReporter;
         this.metadataRecoveryStrategy = MetadataRecoveryStrategy.forName(config.getString(AdminClientConfig.METADATA_RECOVERY_STRATEGY_CONFIG));
-        this.partitionLeaderCache = new HashMap<>();
+        this.partitionLeaderCache = new PartitionLeaderCache();
         this.adminFetchMetricsManager = new AdminFetchMetricsManager(metrics);
         config.logUnused();
         AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
@@ -34,7 +34,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
@@ -56,7 +55,7 @@ public class AbortTransactionHandler extends AdminApiHandler.Batched<TopicPartit
 
     public static PartitionLeaderStrategy.PartitionLeaderFuture<Void> newFuture(
         Set<TopicPartition> topicPartitions,
-        Map<TopicPartition, Integer> partitionLeaderCache
+        PartitionLeaderCache partitionLeaderCache
     ) {
         return new PartitionLeaderStrategy.PartitionLeaderFuture<>(topicPartitions, partitionLeaderCache);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiDriver.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiDriver.java
@@ -115,8 +115,13 @@ public class AdminApiDriver<K, V> {
         // metadata. For all cached keys, they can proceed straight to the fulfillment map.
         // Note that the cache is only used on the initial calls, and any errors that result
         // in additional lookups use the full set of lookup keys.
-        retryLookup(future.uncachedLookupKeys());
-        future.cachedKeyBrokerIdMapping().forEach((key, brokerId) -> fulfillmentMap.put(new FulfillmentScope(brokerId), key));
+        future.cachedKeyBrokerIdMapping().forEach((key, brokerId) -> {
+            if (AdminApiFuture.UNKNOWN_BROKER_ID.equals(brokerId)) {
+                unmap(key);
+            } else {
+                fulfillmentMap.put(new FulfillmentScope(brokerId), key);
+            }
+        });
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
@@ -19,13 +19,15 @@ package org.apache.kafka.clients.admin.internals;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public interface AdminApiFuture<K, V> {
+
+    Integer UNKNOWN_BROKER_ID = -1;
 
     /**
      * The initial set of lookup keys. Although this will usually match the fulfillment
@@ -39,22 +41,17 @@ public interface AdminApiFuture<K, V> {
     Set<K> lookupKeys();
 
     /**
-     * The set of request keys that do not have cached key-broker id mappings. If there
-     * is no cached key mapping, this will be the same as the lookup keys.
-     * Can be empty, but only if the cached key mapping is not empty.
-     */
-    default Set<K> uncachedLookupKeys() {
-        return lookupKeys();
-    }
-
-    /**
-     * The cached key-broker id mapping. For lookup strategies that do not make use of a
-     * cache of metadata, this will be empty.
+     * The cached key-broker id mapping. For non-cached values(or lookup strategies that do not make use of a
+     * cache of metadata) the broker id will be {@link #UNKNOWN_BROKER_ID}
      *
      * @return mapping of keys to broker ids
      */
     default Map<K, Integer> cachedKeyBrokerIdMapping() {
-        return Collections.emptyMap();
+        Map<K, Integer> result = new HashMap<>();
+        for (K key : lookupKeys()) {
+            result.put(key, UNKNOWN_BROKER_ID);
+        }
+        return result;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DeleteRecordsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DeleteRecordsHandler.java
@@ -73,7 +73,7 @@ public final class DeleteRecordsHandler extends Batched<TopicPartition, DeletedR
 
     public static PartitionLeaderStrategy.PartitionLeaderFuture<DeletedRecords> newFuture(
             Collection<TopicPartition> topicPartitions,
-            Map<TopicPartition, Integer> partitionLeaderCache
+            PartitionLeaderCache partitionLeaderCache
     ) {
         return new PartitionLeaderStrategy.PartitionLeaderFuture<>(new HashSet<>(topicPartitions), partitionLeaderCache);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
@@ -68,7 +68,7 @@ public class DescribeProducersHandler extends AdminApiHandler.Batched<TopicParti
 
     public static PartitionLeaderStrategy.PartitionLeaderFuture<PartitionProducerState> newFuture(
         Collection<TopicPartition> topicPartitions,
-        Map<TopicPartition, Integer> partitionLeaderCache
+        PartitionLeaderCache partitionLeaderCache
     ) {
         return new PartitionLeaderStrategy.PartitionLeaderFuture<>(new HashSet<>(topicPartitions), partitionLeaderCache);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListOffsetsHandler.java
@@ -223,7 +223,7 @@ public final class ListOffsetsHandler extends Batched<TopicPartition, ListOffset
 
     public static PartitionLeaderStrategy.PartitionLeaderFuture<ListOffsetsResultInfo> newFuture(
         Collection<TopicPartition> topicPartitions,
-        Map<TopicPartition, Integer> partitionLeaderCache
+        PartitionLeaderCache partitionLeaderCache
     ) {
         return new PartitionLeaderStrategy.PartitionLeaderFuture<>(new HashSet<>(topicPartitions), partitionLeaderCache);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/PartitionLeaderCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/PartitionLeaderCache.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PartitionLeaderCache {
+
+    private final Map<TopicPartition, Integer> cache = new HashMap<>();
+
+    public Map<TopicPartition, Integer> get(Collection<TopicPartition> keys) {
+        Map<TopicPartition, Integer> result = new HashMap<>();
+        synchronized (cache) {
+            for (TopicPartition key : keys) {
+                if (cache.containsKey(key)) {
+                    result.put(key, cache.get(key));
+                }
+            }
+        }
+        return result;
+    }
+
+    public void put(Map<TopicPartition, Integer> values) {
+        synchronized (cache) {
+            cache.putAll(values);
+        }
+    }
+
+    public void remove(Collection<TopicPartition> keys) {
+        synchronized (cache) {
+            for (TopicPartition key : keys) {
+                cache.remove(key);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Introduced a new class - PartitionLeaderCache
* Changed the usage of the cache to make calls atomic(e.g. getting
cached and non-cached values as one call instead of two, deleting cached
values as one call, not one by one)
* Added an integration test that tests the concurrent access of the
cache

Reviewers: Andrew Schofield <aschofield@confluent.io>
