### PR TITLE
Improve find-unfinished-test.py with bug fixes and new features

### DIFF
--- a/committer-tools/find-unfinished-test.py
+++ b/committer-tools/find-unfinished-test.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 import argparse
+import sys
 from datetime import datetime
+from typing import Optional, Tuple, Dict
 
 
 def pretty_time_duration(seconds: float) -> str:
+    """Format duration in seconds as a human-readable string (e.g., '1h23m45s')."""
     time_min, time_sec = divmod(int(seconds), 60)
     time_hour, time_min = divmod(time_min, 60)
     time_fmt = ""
@@ -29,38 +32,153 @@ def pretty_time_duration(seconds: float) -> str:
     return time_fmt
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Parse Gradle log output to find hanging tests")
-    parser.add_argument("file", type=argparse.FileType("r"), help="Text file containing Gradle stdout")
-    args = parser.parse_args()
-
-    started = dict()
-    last_test_line = None
-    for line in args.file.readlines():
+def parse_test_line(line: str) -> Optional[Tuple[str, str, str]]:
+    """
+    Parse a Gradle test log line.
+    
+    Returns:
+        Tuple of (test_name, status, timestamp) if line is valid, None otherwise.
+    """
+    try:
         if "Gradle Test Run" not in line:
-            continue
-        last_test_line = line
-
-        toks = line.strip().split(" > ")
-        name, status = toks[-1].rsplit(" ", 1)
+            return None
+        
+        # Extract timestamp (first token before space)
+        parts = line.strip().split(" ", 1)
+        if len(parts) < 2:
+            return None
+        timestamp = parts[0]
+        
+        # Parse test name and status
+        toks = parts[1].split(" > ")
+        if len(toks) < 3:
+            return None
+        
+        # Last token should be "name STATUS"
+        name_status = toks[-1].rsplit(" ", 1)
+        if len(name_status) != 2:
+            return None
+        
+        name, status = name_status
         name_toks = toks[2:-1] + [name]
         test = " > ".join(name_toks)
+        
+        return (test, status, timestamp)
+    except (ValueError, IndexError):
+        # Malformed line, skip it
+        return None
+
+
+def parse_timestamp(timestamp_str: str) -> Optional[datetime]:
+    """Parse ISO format timestamp string to datetime object."""
+    try:
+        return datetime.fromisoformat(timestamp_str)
+    except (ValueError, AttributeError):
+        return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Parse Gradle log output to find hanging tests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s gradle.log
+  %(prog)s gradle.log --min-duration 300
+  %(prog)s gradle.log --min-duration 60 --summary
+        """
+    )
+    parser.add_argument("file", type=argparse.FileType("r"), 
+                       help="Text file containing Gradle stdout")
+    parser.add_argument("--min-duration", type=int, default=0,
+                       help="Minimum duration in seconds to report (default: 0, report all)")
+    parser.add_argument("--summary", action="store_true",
+                       help="Show summary statistics")
+    args = parser.parse_args()
+
+    started: Dict[str, Tuple[str, str]] = {}  # test_name -> (line, timestamp)
+    last_test_line: Optional[str] = None
+    total_tests_processed = 0
+    malformed_lines = 0
+
+    for line in args.file.readlines():
+        parsed = parse_test_line(line)
+        if parsed is None:
+            if "Gradle Test Run" in line:
+                malformed_lines += 1
+            continue
+        
+        test, status, timestamp = parsed
+        total_tests_processed += 1
+        last_test_line = line
+
         if status == "STARTED":
-            started[test] = line
+            started[test] = (line, timestamp)
+        elif status in ("PASSED", "FAILED", "SKIPPED"):
+            # Test finished, remove from started dict
+            started.pop(test, None)
+
+    if last_test_line is None:
+        print("No test lines found in the log file.", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse the last timestamp to calculate durations
+    last_parsed = parse_test_line(last_test_line)
+    if last_parsed is None:
+        print("Could not parse last test line timestamp.", file=sys.stderr)
+        sys.exit(1)
+    
+    _, _, last_timestamp = last_parsed
+    last_dt = parse_timestamp(last_timestamp)
+    if last_dt is None:
+        print(f"Could not parse timestamp: {last_timestamp}", file=sys.stderr)
+        sys.exit(1)
+
+    # Filter and sort unfinished tests by duration
+    unfinished_tests = []
+    for test_name, (line, start_timestamp) in started.items():
+        start_dt = parse_timestamp(start_timestamp)
+        if start_dt is None:
+            continue
+        
+        duration_seconds = (last_dt - start_dt).total_seconds()
+        if duration_seconds >= args.min_duration:
+            unfinished_tests.append((test_name, line, start_timestamp, duration_seconds))
+    
+    # Sort by duration (longest first)
+    unfinished_tests.sort(key=lambda x: x[3], reverse=True)
+
+    if len(unfinished_tests) > 0:
+        print(f"Found {len(unfinished_tests)} test(s) that were started, but apparently not finished")
+        if args.min_duration > 0:
+            print(f"(Filtered to tests running for at least {args.min_duration} seconds)")
+        print()
+    else:
+        if args.min_duration > 0:
+            print(f"No unfinished tests found running for at least {args.min_duration} seconds.")
         else:
-            started.pop(test)
+            print("No unfinished tests found.")
+        sys.exit(0)
 
-    last_timestamp, _ = last_test_line.split(" ", 1)
-    last_dt = datetime.fromisoformat(last_timestamp)
+    for test_name, line, start_timestamp, duration_seconds in unfinished_tests:
+        print("-" * 80)
+        print(f"Test: {test_name}")
+        print(f"Duration: {pretty_time_duration(duration_seconds)} ({int(duration_seconds)}s)")
+        print(f"Started at: {start_timestamp}")
+        print(f"Raw line: {line.strip()}")
 
-    if len(started) > 0:
-        print("Found tests that were started, but apparently not finished")
-
-    for started_not_finished, line in started.items():
-        print("-"*80)
-        timestamp, _ = line.split(" ", 1)
-        dt = datetime.fromisoformat(timestamp)
-        dur_s = (last_dt - dt).total_seconds()
-        print(f"Test: {started_not_finished}")
-        print(f"Duration: {pretty_time_duration(dur_s)}")
-        print(f"Raw line: {line}")
+    if args.summary:
+        print()
+        print("=" * 80)
+        print("Summary:")
+        print(f"  Total tests processed: {total_tests_processed}")
+        print(f"  Unfinished tests: {len(unfinished_tests)}")
+        if len(unfinished_tests) > 0:
+            avg_duration = sum(d for _, _, _, d in unfinished_tests) / len(unfinished_tests)
+            max_duration = unfinished_tests[0][3]
+            min_duration = unfinished_tests[-1][3]
+            print(f"  Average duration: {pretty_time_duration(avg_duration)} ({int(avg_duration)}s)")
+            print(f"  Longest duration: {pretty_time_duration(max_duration)} ({int(max_duration)}s)")
+            print(f"  Shortest duration: {pretty_time_duration(min_duration)} ({int(min_duration)}s)")
+        if malformed_lines > 0:
+            print(f"  Malformed lines skipped: {malformed_lines}")


### PR DESCRIPTION
## Summary
This PR improves the `find-unfinished-test.py` script with critical bug fixes and useful new features for analyzing hanging tests in Gradle logs.

## Bug Fixes
- **Fix crash when no test lines found**: Added null check for `last_test_line` to prevent crash when log file contains no test output
- **Fix KeyError on test completion**: Changed `started.pop(test)` to `started.pop(test, None)` to handle tests that finish without being in STARTED state
- **Robust error handling**: Added comprehensive error handling for malformed log lines with graceful degradation

## New Features
- **`--min-duration` option**: Filter unfinished tests by minimum runtime (in seconds) to focus on long-running tests
- **`--summary` flag**: Display statistics including total tests processed, average/min/max durations, and malformed line count
- **Sorted output**: Tests are now sorted by duration (longest first) for easier identification of problematic tests
- **Enhanced output**: Improved formatting with timestamps, duration in both human-readable and seconds format

## Code Improvements
- Extracted `parse_test_line()` and `parse_timestamp()` helper functions for better code organization
- Added type hints throughout the codebase
- Added comprehensive docstrings
- Added usage examples in help text
- Track and report malformed lines count for better diagnostics

## Testing
- Verified script compiles without errors
- Tested with edge cases (empty files, malformed lines)
- All existing functionality preserved

## Impact
- **Lines changed**: 144 insertions, 26 deletions (net +118 lines)
- **Backward compatible**: Yes, all existing functionality preserved
- **Breaking changes**: None