### PR TITLE
(WIP-PoC) KIP-1271: Allow to Store Record Headers in State Stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
@@ -25,8 +25,10 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.VersionedKeyValueStore;
 import org.apache.kafka.streams.state.VersionedRecord;
 import org.apache.kafka.streams.state.WindowStore;
@@ -54,7 +56,9 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
     }
 
     static StateStore wrapWithReadWriteStore(final StateStore store) {
-        if (store instanceof TimestampedKeyValueStore) {
+        if (store instanceof TimestampedKeyValueStoreWithHeaders) {
+            return new TimestampedKeyValueStoreReadWriteDecoratorWithHeaders<>((TimestampedKeyValueStoreWithHeaders<?, ?>) store);
+        } else if (store instanceof TimestampedKeyValueStore) {
             return new TimestampedKeyValueStoreReadWriteDecorator<>((TimestampedKeyValueStore<?, ?>) store);
         } else if (store instanceof VersionedKeyValueStore) {
             return new VersionedKeyValueStoreReadWriteDecorator<>((VersionedKeyValueStore<?, ?>) store);
@@ -145,6 +149,15 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
         implements TimestampedKeyValueStore<K, V> {
 
         TimestampedKeyValueStoreReadWriteDecorator(final TimestampedKeyValueStore<K, V> inner) {
+            super(inner);
+        }
+    }
+
+    static class TimestampedKeyValueStoreReadWriteDecoratorWithHeaders<K, V>
+        extends KeyValueStoreReadWriteDecorator<K, ValueTimestampHeaders<V>>
+        implements TimestampedKeyValueStoreWithHeaders<K, V> {
+
+        TimestampedKeyValueStoreReadWriteDecoratorWithHeaders(final TimestampedKeyValueStoreWithHeaders<K, V> inner) {
             super(inner);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/HeadersBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/HeadersBytesStore.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Marker interface to indicate that a bytes store understands the value-with-headers format
+ * and can convert legacy "plain value" entries to the new format.
+ * <p>
+ * Per the KIP, the value format is: [header_length(varint)][headers_bytes][payload_bytes]
+ * where payload_bytes is the existing serialized value (e.g., [timestamp(8)][value] for timestamped stores).
+ */
+public interface HeadersBytesStore {
+
+  /**
+   * Converts a legacy value (without headers) to the header-embedded format.
+   * <p>
+   * For timestamped stores, the legacy format is: [timestamp(8)][value]
+   * The new format is: [header_length(2)][headers][timestamp(8)][value]
+   * <p>
+   * This method adds empty headers to the existing value format.
+   *
+   * @param key   the key bytes (may be used for context-dependent conversion; typically unused)
+   * @param value the legacy value bytes (for timestamped stores: [timestamp(8)][value])
+   * @return the value in header-embedded format with empty headers
+   */
+  static byte[] convertToHeaderFormat(final byte[] key, final byte[] value) {
+    return null;
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/HeadersBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/HeadersBytesStore.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.apache.kafka.common.utils.ByteUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
@@ -39,7 +44,25 @@ public interface HeadersBytesStore {
    * @param value the legacy value bytes (for timestamped stores: [timestamp(8)][value])
    * @return the value in header-embedded format with empty headers
    */
-  static byte[] convertToHeaderFormat(final byte[] key, final byte[] value) {
-    return null;
-  }
+    static byte[] convertToHeaderFormat(final byte[] key, final byte[] value) {
+        if (value == null) {
+            return null;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+
+            // Empty headers serialize to an empty byte array (per HeadersSerializer.serialize())
+            final byte[] emptyHeadersBytes = new byte[0];
+
+            // Write format: [headers_size(varint)][headers_bytes][payload]
+            ByteUtils.writeVarint(emptyHeadersBytes.length, out);  // headers_size = 0
+            // No headers_bytes to write (empty array)
+            out.write(value);                                       // payload: [timestamp(8)][value]
+
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to convert to header format", e);
+        }
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.ByteUtils;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.state.internals.ValueAndTimestampSerializer;
 
@@ -183,7 +185,7 @@ public final class StateSerdes<K, V> {
      * @return          the value as typed object
      */
     public V valueFrom(final byte[] rawValue, Headers headers) {
-        return valueSerde.deserializer().deserialize(topic, headers, rawValue);
+        return valueSerde.deserializer().deserialize(topic, headers, Utils.wrapNullable(rawValue));
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -149,8 +150,19 @@ public final class StateSerdes<K, V> {
      * @param rawKey  the key as raw bytes
      * @return        the key as typed object
      */
+    // @Deprecated
     public K keyFrom(final byte[] rawKey) {
         return keySerde.deserializer().deserialize(topic, rawKey);
+    }
+
+    /**
+     * Deserialize the key from raw bytes.
+     *
+     * @param rawKey  the key as raw bytes
+     * @return        the key as typed object
+     */
+    public K keyFrom(final byte[] rawKey, final Headers headers) {
+        return keySerde.deserializer().deserialize(topic, headers, rawKey);
     }
 
     /**
@@ -159,8 +171,19 @@ public final class StateSerdes<K, V> {
      * @param rawValue  the value as raw bytes
      * @return          the value as typed object
      */
+    // @Deprecated
     public V valueFrom(final byte[] rawValue) {
         return valueSerde.deserializer().deserialize(topic, rawValue);
+    }
+
+    /**
+     * Deserialize the value from raw bytes.
+     *
+     * @param rawValue  the value as raw bytes
+     * @return          the value as typed object
+     */
+    public V valueFrom(final byte[] rawValue, Headers headers) {
+        return valueSerde.deserializer().deserialize(topic, headers, rawValue);
     }
 
     /**
@@ -169,6 +192,7 @@ public final class StateSerdes<K, V> {
      * @param key  the key to be serialized
      * @return     the serialized key
      */
+    // @Deprecated
     public byte[] rawKey(final K key) {
         try {
             return keySerde.serializer().serialize(topic, key);
@@ -185,11 +209,33 @@ public final class StateSerdes<K, V> {
     }
 
     /**
+     * Serialize the given key.
+     *
+     * @param key  the key to be serialized
+     * @return     the serialized key
+     */
+    public byte[] rawKey(final K key, final Headers headers) {
+        try {
+            return keySerde.serializer().serialize(topic, headers, key);
+        } catch (final ClassCastException e) {
+            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
+            throw new StreamsException(
+                String.format("A serializer (%s) is not compatible to the actual key type " +
+                        "(key type: %s). Change the default Serdes in StreamConfig or " +
+                        "provide correct Serdes via method parameters.",
+                    keySerializer().getClass().getName(),
+                    keyClass),
+                e);
+        }
+    }
+
+    /**
      * Serialize the given value.
      *
      * @param value  the value to be serialized
      * @return       the serialized value
      */
+    // @Deprecated
     @SuppressWarnings("rawtypes")
     public byte[] rawValue(final V value) {
         try {
@@ -211,6 +257,36 @@ public final class StateSerdes<K, V> {
                             serializerClass.getName(),
                             valueClass),
                     e);
+        }
+    }
+
+    /**
+     * Serialize the given value.
+     *
+     * @param value  the value to be serialized
+     * @return       the serialized value
+     */
+    @SuppressWarnings("rawtypes")
+    public byte[] rawValue(final V value, final Headers headers) {
+        try {
+            return valueSerde.serializer().serialize(topic, headers, value);
+        } catch (final ClassCastException e) {
+            final String valueClass;
+            final Class<? extends Serializer> serializerClass;
+            if (valueSerializer() instanceof ValueAndTimestampSerializer) {
+                serializerClass = ((ValueAndTimestampSerializer<?>) valueSerializer()).valueSerializer.getClass();
+                valueClass = value == null ? "unknown because value is null" : ((ValueAndTimestamp) value).value().getClass().getName();
+            } else {
+                serializerClass = valueSerializer().getClass();
+                valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            }
+            throw new StreamsException(
+                String.format("A serializer (%s) is not compatible to the actual value type " +
+                        "(value type: %s). Change the default Serdes in StreamConfig or " +
+                        "provide correct Serdes via method parameters.",
+                    serializerClass.getName(),
+                    valueClass),
+                e);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.state.internals.RocksDbVersionedKeyValueBytesSto
 import org.apache.kafka.streams.state.internals.RocksDbWindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilderWithHeaders;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
 import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
@@ -114,6 +115,11 @@ public final class Stores {
     public static KeyValueBytesStoreSupplier persistentTimestampedKeyValueStore(final String name) {
         Objects.requireNonNull(name, "name cannot be null");
         return new RocksDBKeyValueBytesStoreSupplier(name, true);
+    }
+
+    public static KeyValueBytesStoreSupplier persistentTimestampedKeyValueStoreWithHeaders(final String name) {
+        Objects.requireNonNull(name, "name cannot be null");
+        return new RocksDBKeyValueBytesStoreSupplier(name, true, true);
     }
 
     /**
@@ -483,6 +489,13 @@ public final class Stores {
                                                                                                       final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
         return new TimestampedKeyValueStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+    }
+
+    public static <K, V> StoreBuilder<TimestampedKeyValueStoreWithHeaders<K, V>> timestampedKeyValueStoreBuilderWithHeaders(final KeyValueBytesStoreSupplier supplier,
+                                                                                                      final Serde<K> keySerde,
+                                                                                                      final Serde<V> valueSerde) {
+        Objects.requireNonNull(supplier, "supplier cannot be null");
+        return new TimestampedKeyValueStoreBuilderWithHeaders<>(supplier, keySerde, valueSerde, Time.SYSTEM);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/TimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/TimestampedKeyValueStoreWithHeaders.java
@@ -1,0 +1,11 @@
+package org.apache.kafka.streams.state;
+
+/**
+ * A key-(value/timestamp/headers) store that supports put/get/delete.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+public interface TimestampedKeyValueStoreWithHeaders<K, V>
+    extends KeyValueStore<K, ValueTimestampHeaders<V>> {
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
+import java.util.Objects;
+
+/**
+ * Combines a value with its timestamp and associated record headers.
+ *
+ * @param <V> the value type
+ */
+public final class ValueTimestampHeaders<V> {
+
+  private final V value;
+  private final long timestamp;
+  private final Headers headers;
+
+  private ValueTimestampHeaders(final V value, final long timestamp, final Headers headers) {
+    this.value = value;
+    this.timestamp = timestamp;
+    this.headers = headers == null ? new RecordHeaders() : headers;
+  }
+
+  /**
+   * Create a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null}.
+   *
+   * @param value     the value
+   * @param timestamp the timestamp
+   * @param headers   the headers (may be {@code null}, treated as empty)
+   * @param <V>       the type of the value
+   * @return a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null};
+   * otherwise {@code null} is returned
+   */
+  public static <V> ValueTimestampHeaders<V> make(final V value,
+                                                  final long timestamp,
+                                                  final Headers headers) {
+    if (value == null) {
+      return null;
+    }
+    return new ValueTimestampHeaders<>(value, timestamp, headers);
+  }
+
+  /**
+   * Create a new {@link ValueTimestampHeaders} instance.
+   * The provided {@code value} may be {@code null}.
+   *
+   * @param value     the value (may be {@code null})
+   * @param timestamp the timestamp
+   * @param headers   the headers (may be {@code null}, treated as empty)
+   * @param <V>       the type of the value
+   * @return a new {@link ValueTimestampHeaders} instance
+   */
+  public static <V> ValueTimestampHeaders<V> makeAllowNullable(final V value,
+                                                               final long timestamp,
+                                                               final Headers headers) {
+    return new ValueTimestampHeaders<>(value, timestamp, headers);
+  }
+
+  /**
+   * Return the wrapped {@code value} of the given {@code valueTimestampHeaders} parameter
+   * if the parameter is not {@code null}.
+   *
+   * @param valueTimestampHeaders a {@link ValueTimestampHeaders} instance; can be {@code null}
+   * @param <V>                   the type of the value
+   * @return the wrapped {@code value} of {@code valueTimestampHeaders} if not {@code null}; otherwise {@code null}
+   */
+  public static <V> V getValueOrNull(final ValueTimestampHeaders<V> valueTimestampHeaders) {
+    return valueTimestampHeaders == null ? null : valueTimestampHeaders.value;
+  }
+
+  public V value() {
+    return value;
+  }
+
+  public long timestamp() {
+    return timestamp;
+  }
+
+  public Headers headers() {
+    return headers;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ValueTimestampHeaders)) {
+      return false;
+    }
+    final ValueTimestampHeaders<?> that = (ValueTimestampHeaders<?>) o;
+    // Headers does not implement deep equals; compare serialized forms or iterate.
+    return timestamp == that.timestamp
+        && Objects.equals(value, that.value)
+        && headersEqual(headers, that.headers);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(value, timestamp);
+    result = 31 * result + headersHash(headers);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ValueTimestampHeaders{" +
+        "value=" + value +
+        ", timestamp=" + timestamp +
+        ", headers=" + headers +
+        '}';
+  }
+
+  private static boolean headersEqual(final Headers a, final Headers b) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    return a.toArray().length == b.toArray().length
+        && java.util.Arrays.equals(a.toArray(), b.toArray());
+  }
+
+  private static int headersHash(final Headers headers) {
+    if (headers == null) {
+      return 0;
+    }
+    return java.util.Arrays.hashCode(headers.toArray());
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+import java.util.List;
+
+import static org.apache.kafka.streams.state.internals.ValueTimestampHeadersDeserializer.rawValue;
+import static org.apache.kafka.streams.state.internals.ValueTimestampHeadersDeserializer.timestamp;
+
+/**
+ * Change-logging wrapper for a timestamped key-value bytes store whose values also carry headers.
+ * <p>
+ * the header-aware serialized value format produced by {@link ValueTimestampHeadersSerializer}.
+ * <p>
+ * Semantics:
+ *  - The inner store value format is:
+ *        [ varint header_length ][ header_bytes ][ 8-byte timestamp ][ value_bytes ]
+ *  - The changelog record value logged via {@code log(...)} remains just {@code value_bytes}
+ *    (no timestamp, no headers), and the timestamp is logged separately.
+ */
+public class ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders
+    extends ChangeLoggingKeyValueBytesStore {
+
+  ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders(final KeyValueStore<Bytes, byte[]> inner) {
+    super(inner);
+  }
+
+  @Override
+  public void put(final Bytes key,
+                  final byte[] valueTimestampHeaders) {
+    wrapped().put(key, valueTimestampHeaders);
+    log(
+        key,
+        rawValue(valueTimestampHeaders),
+        valueTimestampHeaders == null
+            ? internalContext.recordContext().timestamp()
+            : timestamp(valueTimestampHeaders)
+    );
+  }
+
+  @Override
+  public byte[] putIfAbsent(final Bytes key,
+                            final byte[] valueTimestampHeaders) {
+    final byte[] previous = wrapped().putIfAbsent(key, valueTimestampHeaders);
+    if (previous == null) {
+      // then it was absent
+      log(
+          key,
+          rawValue(valueTimestampHeaders),
+          valueTimestampHeaders == null
+              ? internalContext.recordContext().timestamp()
+              : timestamp(valueTimestampHeaders)
+      );
+    }
+    return previous;
+  }
+
+  @Override
+  public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+    wrapped().putAll(entries);
+    for (final KeyValue<Bytes, byte[]> entry : entries) {
+      final byte[] valueTimestampHeaders = entry.value;
+      log(
+          entry.key,
+          rawValue(valueTimestampHeaders),
+          valueTimestampHeaders == null
+              ? internalContext.recordContext().timestamp()
+              : timestamp(valueTimestampHeaders)
+      );
+    }
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersDeserializer.java
@@ -83,6 +83,11 @@ public final class HeadersDeserializer implements Deserializer<Headers> {
     return headers;
   }
 
+  public static Headers deserialize(final byte[] data) {
+    HeadersDeserializer deserializer = new HeadersDeserializer();
+    return deserializer.deserialize("", data);
+  }
+
   @Override
   public void close() {
     // no-op

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersDeserializer.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/*
+ * Deserializer for org.apache.kafka.common.header.Headers using the KIP‑1271 format:
+ *
+ * headers_bytes :=
+ *   varint header_count
+ *   repeated header_count times:
+ *     varint key_length
+ *     key_length bytes of UTF-8 key
+ *     varint value_length   // -1 means null
+ *     value_length bytes of value (if value_length >= 0)
+ */
+
+public final class HeadersDeserializer implements Deserializer<Headers> {
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+  }
+
+  @Override
+  public Headers deserialize(final String topic, final byte[] data) {
+    if (data == null || data.length == 0) {
+      return new RecordHeaders();
+    }
+
+    final Index idx = new Index();
+    final int headerCount = readVarint(data, idx);
+
+    if (headerCount < 0) {
+      throw new IllegalArgumentException("Negative headerCount: " + headerCount);
+    }
+
+    final RecordHeaders headers = new RecordHeaders();
+
+    for (int i = 0; i < headerCount; i++) {
+      // key length
+      final int keyLen = readVarint(data, idx);
+      if (keyLen < 0) {
+        throw new IllegalArgumentException("Negative key length: " + keyLen);
+      }
+
+      final String key = new String(data, idx.pos, keyLen, StandardCharsets.UTF_8);
+      idx.pos += keyLen;
+
+      // value length (-1 == null)
+      final int valueLen = readVarint(data, idx);
+      final byte[] value;
+      if (valueLen < 0) {
+        value = null;
+      } else {
+        value = new byte[valueLen];
+        System.arraycopy(data, idx.pos, value, 0, valueLen);
+        idx.pos += valueLen;
+      }
+
+      headers.add(key, value);
+    }
+
+    return headers;
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+
+  private static final class Index {
+    int pos = 0;
+  }
+
+  /**
+   * Read a signed int encoded as zigzag+LEB128 varint.
+   */
+  private static int readVarint(final byte[] data, final Index idx) {
+    int raw = 0;
+    int shift = 0;
+
+    while (true) {
+      if (idx.pos >= data.length) {
+        throw new IllegalArgumentException("Truncated varint at position " + idx.pos);
+      }
+      final int b = data[idx.pos++] & 0xFF;
+      raw |= (b & 0x7F) << shift;
+      if ((b & 0x80) == 0) {
+        break;
+      }
+      shift += 7;
+      if (shift > 28) {
+        throw new IllegalArgumentException("Varint too long at position " + (idx.pos - 1));
+      }
+    }
+
+    // inverse zigzag: signed int
+    return (raw >>> 1) ^ -(raw & 1);
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/*
+ * Serializer for org.apache.kafka.common.header.Headers using the KIP‑1271 format:
+ *
+ * headers_bytes :=
+ *   varint header_count
+ *   repeated header_count times:
+ *     varint key_length
+ *     key_length bytes of UTF‑8 key
+ *     varint value_length   // -1 means null
+ *     value_length bytes of value (if value_length >= 0)
+ *
+ * Note: "varint" here is a signed int encoded with zigzag + LEB128.
+ */
+public final class HeadersSerializer implements Serializer<Headers> {
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    // no-op
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final Headers headers) {
+    if (headers == null || !headers.iterator().hasNext()) {
+      return new byte[0];
+    }
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    // 1) header_count
+    final int headerCount = count(headers);
+    writeVarint(headerCount, out);
+
+    // 2) each header in iteration order (order is preserved)
+    for (final Header header : headers) {
+      final byte[] keyBytes = header.key().getBytes(StandardCharsets.UTF_8);
+      final byte[] valueBytes = header.value();
+
+      // key length + key bytes
+      writeVarint(keyBytes.length, out);
+      out.writeBytes(keyBytes);
+
+      // value length (-1 for null) + value bytes
+      if (valueBytes == null) {
+        writeVarint(-1, out);
+      } else {
+        writeVarint(valueBytes.length, out);
+        out.writeBytes(valueBytes);
+      }
+    }
+
+    byte[] headersBytes = out.toByteArray();
+    byte[] headersLength = getLengthAsVarint(headersBytes);
+    return ByteBuffer.allocate(headersLength.length + headersBytes.length )
+        .put(headersLength)
+        .put(headersBytes)
+        .array();
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+
+  // ----------------------------------------------------------------------
+  // Varint encoding (signed int via zigzag + LEB128)
+  // ----------------------------------------------------------------------
+
+  private static void writeVarint(final int value, final ByteArrayOutputStream out) {
+    // Zigzag transform: map signed int -> unsigned so that small negative
+    // and small positive values both get small encodings.
+    int v = (value << 1) ^ (value >> 31);
+
+    while ((v & ~0x7F) != 0) {
+      out.write((v & 0x7F) | 0x80);
+      v >>>= 7;
+    }
+    out.write(v & 0x7F);
+  }
+
+  private static int count(final Headers headers) {
+    int c = 0;
+    for (final Header ignored : headers) {
+      c++;
+    }
+    return c;
+  }
+
+  private byte[] getLengthAsVarint(byte[] data) {
+    if (data == null) {
+      return encodeVarint(-1); // Handle null as -1
+    }
+    return encodeVarint(data.length);
+  }
+
+  /**
+   * Encodes an integer into an unsigned varint (LEB128).
+   */
+  private byte[] encodeVarint(int value) {
+    // We assume value is non-negative and treated as unsigned in the 32-bit range.
+    byte[] buffer = new byte[5]; // max 5 bytes for 32-bit varint
+    int pos = 0;
+
+    while ((value & ~0x7F) != 0) {
+      // Write 7 bits and set continuation bit
+      buffer[pos++] = (byte) ((value & 0x7F) | 0x80);
+      value >>>= 7;
+    }
+
+    // Last byte (no continuation bit)
+    buffer[pos++] = (byte) (value & 0x7F);
+
+    // Trim to actual length
+    byte[] result = new byte[pos];
+    System.arraycopy(buffer, 0, result, 0, pos);
+    return result;
+  }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -47,11 +47,13 @@ public final class HeadersSerializer implements Serializer<Headers> {
 
   @Override
   public byte[] serialize(final String topic, final Headers headers) {
-    if (headers == null || !headers.iterator().hasNext()) {
-      return new byte[0];
-    }
-
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    if (headers == null || !headers.iterator().hasNext()) {
+      // Empty headers: return [varint(0)] instead of []
+      byte[] headersLength = getLengthAsVarint(new byte[0]);
+      return headersLength;
+    }
 
     // 1) header_count
     final int headerCount = count(headers);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
@@ -44,6 +45,7 @@ import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.internals.StoreQueryUtils.QueryHandler;
 import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
@@ -315,12 +317,18 @@ public class MeteredKeyValueStore<K, V>
         }
     }
 
+    //@Deprecated
     @Override
     public void put(final K key,
                     final V value) {
         Objects.requireNonNull(key, "key cannot be null");
         try {
-            maybeMeasureLatency(() -> wrapped().put(keyBytes(key), serdes.rawValue(value)), time, putSensor);
+            if (value instanceof ValueTimestampHeaders) {
+                Headers headers = ((ValueTimestampHeaders<?>) value).headers();
+                maybeMeasureLatency(() -> wrapped().put(keyBytes(key, headers), serdes.rawValue(value, headers)), time, putSensor);
+            } else {
+                maybeMeasureLatency(() -> wrapped().put(keyBytes(key), serdes.rawValue(value)), time, putSensor);
+            }
             maybeRecordE2ELatency();
         } catch (final ProcessorStateException e) {
             final String message = String.format(e.getMessage(), key, value);
@@ -420,8 +428,13 @@ public class MeteredKeyValueStore<K, V>
         return value != null ? serdes.valueFrom(value) : null;
     }
 
+    // @Deprecated
     protected Bytes keyBytes(final K key) {
         return Bytes.wrap(serdes.rawKey(key));
+    }
+
+    protected Bytes keyBytes(final K key, final Headers headers) {
+        return Bytes.wrap(serdes.rawKey(key, headers));
     }
 
     private List<KeyValue<Bytes, byte[]>> innerEntries(final List<KeyValue<K, V>> from) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
+
+/**
+ * A Metered {@link TimestampedKeyValueStoreWithHeaders} wrapper that is used for recording operation metrics, and hence
+ * its inner KeyValueStore implementation does not need to provide its own metrics collecting functionality.
+ *
+ * The inner {@link KeyValueStore} of this class is of type &lt;Bytes, byte[]&gt;,
+ * hence we use {@link Serde}s to convert from &lt;K, ValueTimestampHeaders&lt;V&gt;&gt; to &lt;Bytes, byte[]&gt;.
+ *
+ * @param <K> key type
+ * @param <V> value type (wrapped in {@link ValueTimestampHeaders})
+ */
+public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
+    extends MeteredKeyValueStore<K, ValueTimestampHeaders<V>>
+    implements TimestampedKeyValueStoreWithHeaders<K, V> {
+
+  MeteredTimestampedKeyValueStoreWithHeaders(final KeyValueStore<Bytes, byte[]> inner,
+                                             final String metricScope,
+                                             final Time time,
+                                             final Serde<K> keySerde,
+                                             final Serde<ValueTimestampHeaders<V>> valueSerde) {
+    super(inner, metricScope, time, keySerde, valueSerde);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected Serde<ValueTimestampHeaders<V>> prepareValueSerdeForStore(final Serde<ValueTimestampHeaders<V>> valueSerde,
+                                                                      final SerdeGetter getter) {
+    if (valueSerde == null) {
+      return new ValueTimestampHeadersSerde<>((Serde<V>) getter.valueSerde());
+    } else {
+      return super.prepareValueSerdeForStore(valueSerde, getter);
+    }
+  }
+
+  /**
+   * Returns both the raw serialized bytes and the deserialized {@link ValueTimestampHeaders}.
+   */
+  public RawAndDeserializedValue<V> getWithBinary(final K key, final Headers headers) {
+    try {
+      return maybeMeasureLatency(() -> {
+        final byte[] serializedValue = wrapped().get(keyBytes(key, headers));
+        return new RawAndDeserializedValue<>(serializedValue, outerValue(serializedValue));
+      }, time, getSensor);
+    } catch (final ProcessorStateException e) {
+      final String message = String.format(e.getMessage(), key);
+      throw new ProcessorStateException(message, e);
+    }
+  }
+
+  /**
+   * Only writes if the new serialized value differs (and timestamp increases) from the old serialized value.
+   */
+  public boolean putIfDifferentValues(final K key,
+                                      final Headers headers,
+                                      final ValueTimestampHeaders<V> newValue,
+                                      final byte[] oldSerializedValue) {
+    try {
+      return maybeMeasureLatency(
+          () -> {
+            final byte[] newSerializedValue = serdes.rawValue(newValue, headers);
+            if (ValueTimestampHeadersSerializer.valuesAndHeadersAreSameAndTimeIsIncreasing(
+                oldSerializedValue,
+                newSerializedValue
+            )) {
+              return false;
+            } else {
+              wrapped().put(keyBytes(key, headers), newSerializedValue);
+              return true;
+            }
+          },
+          time,
+          putSensor
+      );
+    } catch (final ProcessorStateException e) {
+      final String message = String.format(e.getMessage(), key, newValue);
+      throw new ProcessorStateException(message, e);
+    }
+  }
+
+  static class RawAndDeserializedValue<ValueType> {
+    final byte[] serializedValue;
+    final ValueTimestampHeaders<ValueType> value;
+
+    RawAndDeserializedValue(final byte[] serializedValue,
+                            final ValueTimestampHeaders<ValueType> value) {
+      this.serializedValue = serializedValue;
+      this.value = value;
+    }
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -27,6 +27,8 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 
 
+import java.util.Objects;
+
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 /**
@@ -60,6 +62,23 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
     } else {
       return super.prepareValueSerdeForStore(valueSerde, getter);
     }
+  }
+
+  @Override
+  public ValueTimestampHeaders<V> get(final K key) {
+    Objects.requireNonNull(key, "key cannot be null");
+    try {
+      return maybeMeasureLatency(() -> outerValue(wrapped().get(keyBytes(key))), time, getSensor);
+    } catch (final ProcessorStateException e) {
+      final String message = String.format(e.getMessage(), key);
+      throw new ProcessorStateException(message, e);
+    }
+  }
+
+  protected ValueTimestampHeaders<V> outerValue(final byte[] value) {
+    Headers headers =
+        HeadersDeserializer.deserialize(ValueTimestampHeadersDeserializer.rawHeaders(value));
+    return value != null ? serdes.valueFrom(value, headers) : null;
   }
 
   /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueBytesStoreSupplier.java
@@ -24,11 +24,20 @@ public class RocksDBKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupp
 
     private final String name;
     private final boolean returnTimestampedStore;
+    private final boolean hasHeaders;
 
     public RocksDBKeyValueBytesStoreSupplier(final String name,
                                              final boolean returnTimestampedStore) {
         this.name = name;
         this.returnTimestampedStore = returnTimestampedStore;
+        this.hasHeaders = false;
+    }
+    public RocksDBKeyValueBytesStoreSupplier(final String name,
+                                             final boolean returnTimestampedStore,
+                                             final boolean hasHeaders) {
+        this.name = name;
+        this.returnTimestampedStore = returnTimestampedStore;
+        this.hasHeaders = hasHeaders;
     }
 
     @Override
@@ -38,9 +47,11 @@ public class RocksDBKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupp
 
     @Override
     public KeyValueStore<Bytes, byte[]> get() {
-        return returnTimestampedStore ?
-            new RocksDBTimestampedStore(name, metricsScope()) :
-            new RocksDBStore(name, metricsScope());
+        return returnTimestampedStore
+            ? hasHeaders
+            ? new RocksDBTimestampedStoreWithHeaders(name, metricsScope())
+            : new RocksDBTimestampedStore(name, metricsScope())
+            : new RocksDBStore(name, metricsScope());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -1,0 +1,522 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.AbstractIterator;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.state.HeadersBytesStore;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.WriteBatchInterface;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+
+/**
+ * A persistent key-(value-timestamp-headers) store based on RocksDB.
+ *
+ * This is analogous to {@link RocksDBTimestampedStore}, but the "new" column family stores
+ * a header-aware format. Legacy values (without headers) are converted on the fly using
+ * {@link HeadersBytesStore#convertToHeaderFormat(byte[], byte[])}.
+ */
+public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements HeadersBytesStore {
+
+  private static final Logger log = LoggerFactory.getLogger(RocksDBTimestampedStoreWithHeaders.class);
+
+  // New column family for header-aware timestamped values.
+  // You can rename this if you prefer a different CF name.
+  private static final byte[] TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME =
+      "keyValueWithTimestampAndHeaders".getBytes(StandardCharsets.UTF_8);
+
+  public RocksDBTimestampedStoreWithHeaders(final String name,
+                                            final String metricsScope) {
+    super(name, metricsScope);
+  }
+
+  RocksDBTimestampedStoreWithHeaders(final String name,
+                                     final String parentDir,
+                                     final RocksDBMetricsRecorder metricsRecorder) {
+    super(name, parentDir, metricsRecorder);
+  }
+
+  @Override
+  void openRocksDB(final DBOptions dbOptions,
+                   final ColumnFamilyOptions columnFamilyOptions) {
+    // We open two CFs:
+    //  - DEFAULT_COLUMN_FAMILY: legacy (non-header) timestamped values
+    //  - TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME: new header-aware format
+    //
+    // On first open with no legacy data, we just use the new CF.
+    final List<ColumnFamilyHandle> columnFamilies = openRocksDB(
+        dbOptions,
+        new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions),
+        new ColumnFamilyDescriptor(TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME, columnFamilyOptions)
+    );
+
+    final ColumnFamilyHandle legacyCf = columnFamilies.get(0);
+    final ColumnFamilyHandle headersCf = columnFamilies.get(1);
+
+    final RocksIterator legacyIter = db.newIterator(legacyCf);
+    legacyIter.seekToFirst();
+    if (legacyIter.isValid()) {
+      log.info("Opening store {} in upgrade mode (legacy timestamped -> header-aware timestamped)", name);
+      cfAccessor = new DualColumnFamilyAccessor(legacyCf, headersCf);
+    } else {
+      log.info("Opening store {} in regular header-aware mode", name);
+      cfAccessor = new SingleColumnFamilyAccessor(headersCf);
+      legacyCf.close();
+    }
+    legacyIter.close();
+  }
+
+  /**
+   * Accessor that supports dual-column-family upgrade: legacy CF (no headers)
+   * and new CF (header-aware format).
+   */
+  private class DualColumnFamilyAccessor implements ColumnFamilyAccessor {
+
+    private final ColumnFamilyHandle oldColumnFamily;
+    private final ColumnFamilyHandle newColumnFamily;
+
+    private DualColumnFamilyAccessor(final ColumnFamilyHandle oldColumnFamily,
+                                     final ColumnFamilyHandle newColumnFamily) {
+      this.oldColumnFamily = oldColumnFamily;
+      this.newColumnFamily = newColumnFamily;
+    }
+
+    @Override
+    public void put(final DBAccessor accessor,
+                    final byte[] key,
+                    final byte[] valueWithHeaders) {
+      synchronized (position) {
+        if (valueWithHeaders == null) {
+          try {
+            accessor.delete(oldColumnFamily, key);
+          } catch (final RocksDBException e) {
+            throw new ProcessorStateException("Error while removing key from store " + name, e);
+          }
+          try {
+            accessor.delete(newColumnFamily, key);
+          } catch (final RocksDBException e) {
+            throw new ProcessorStateException("Error while removing key from store " + name, e);
+          }
+        } else {
+          try {
+            accessor.delete(oldColumnFamily, key);
+          } catch (final RocksDBException e) {
+            throw new ProcessorStateException("Error while removing key from store " + name, e);
+          }
+          try {
+            accessor.put(newColumnFamily, key, valueWithHeaders);
+            StoreQueryUtils.updatePosition(position, context);
+          } catch (final RocksDBException e) {
+            throw new ProcessorStateException("Error while putting key/value into store " + name, e);
+          }
+        }
+      }
+    }
+
+    @Override
+    public void prepareBatch(final List<KeyValue<Bytes, byte[]>> entries,
+                             final WriteBatchInterface batch) throws RocksDBException {
+      for (final KeyValue<Bytes, byte[]> entry : entries) {
+        Objects.requireNonNull(entry.key, "key cannot be null");
+        addToBatch(entry.key.get(), entry.value, batch);
+      }
+    }
+
+    @Override
+    public byte[] get(final DBAccessor accessor, final byte[] key) throws RocksDBException {
+      return get(accessor, key, Optional.empty());
+    }
+
+    @Override
+    public byte[] get(final DBAccessor accessor,
+                      final byte[] key,
+                      final ReadOptions readOptions) throws RocksDBException {
+      return get(accessor, key, Optional.of(readOptions));
+    }
+
+    private byte[] get(final DBAccessor accessor,
+                       final byte[] key,
+                       final Optional<ReadOptions> readOptions) throws RocksDBException {
+      final byte[] valueWithHeaders =
+          readOptions.isPresent()
+              ? accessor.get(newColumnFamily, readOptions.get(), key)
+              : accessor.get(newColumnFamily, key);
+
+      if (valueWithHeaders != null) {
+        return valueWithHeaders;
+      }
+
+      final byte[] legacyValue =
+          readOptions.isPresent()
+              ? accessor.get(oldColumnFamily, readOptions.get(), key)
+              : accessor.get(oldColumnFamily, key);
+
+      if (legacyValue != null) {
+        // Convert legacy timestamped value into new header-aware format.
+        final byte[] converted = convertToHeaderFormat(key, legacyValue);
+        // We can eagerly write back the converted value to new CF.
+        put(accessor, key, converted);
+        return converted;
+      }
+
+      return null;
+    }
+
+    @Override
+    public byte[] getOnly(final DBAccessor accessor,
+                          final byte[] key) throws RocksDBException {
+      final byte[] valueWithHeaders = accessor.get(newColumnFamily, key);
+      if (valueWithHeaders != null) {
+        return valueWithHeaders;
+      }
+
+      final byte[] legacyValue = accessor.get(oldColumnFamily, key);
+      if (legacyValue != null) {
+        // For "getOnly", we must NOT mutate state; just convert on the fly.
+        return convertToHeaderFormat(key, legacyValue);
+      }
+      return null;
+    }
+
+    @Override
+    public ManagedKeyValueIterator<Bytes, byte[]> range(final DBAccessor accessor,
+                                                        final Bytes from,
+                                                        final Bytes to,
+                                                        final boolean forward) {
+      return new RocksDBDualCFRangeIterator(
+          name,
+          accessor.newIterator(newColumnFamily),
+          accessor.newIterator(oldColumnFamily),
+          from,
+          to,
+          forward,
+          /* toInclusive = */ true
+      );
+    }
+
+    @Override
+    public void deleteRange(final DBAccessor accessor,
+                            final byte[] from,
+                            final byte[] to) {
+      try {
+        accessor.deleteRange(oldColumnFamily, from, to);
+      } catch (final RocksDBException e) {
+        throw new ProcessorStateException("Error while removing key from store " + name, e);
+      }
+      try {
+        accessor.deleteRange(newColumnFamily, from, to);
+      } catch (final RocksDBException e) {
+        throw new ProcessorStateException("Error while removing key from store " + name, e);
+      }
+    }
+
+    @Override
+    public ManagedKeyValueIterator<Bytes, byte[]> all(final DBAccessor accessor,
+                                                      final boolean forward) {
+      final RocksIterator iterWithHeaders = accessor.newIterator(newColumnFamily);
+      final RocksIterator iterLegacy = accessor.newIterator(oldColumnFamily);
+      if (forward) {
+        iterWithHeaders.seekToFirst();
+        iterLegacy.seekToFirst();
+      } else {
+        iterWithHeaders.seekToLast();
+        iterLegacy.seekToLast();
+      }
+      return new RocksDBDualCFIterator(name, iterWithHeaders, iterLegacy, forward);
+    }
+
+    @Override
+    public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final DBAccessor accessor,
+                                                             final Bytes prefix) {
+      final Bytes to = incrementWithoutOverflow(prefix);
+      return new RocksDBDualCFRangeIterator(
+          name,
+          accessor.newIterator(newColumnFamily),
+          accessor.newIterator(oldColumnFamily),
+          prefix,
+          to,
+          true,
+          /* toInclusive = */ false
+      );
+    }
+
+    @Override
+    public long approximateNumEntries(final DBAccessor accessor) throws RocksDBException {
+      return accessor.approximateNumEntries(oldColumnFamily)
+          + accessor.approximateNumEntries(newColumnFamily);
+    }
+
+    @Override
+    public void flush(final DBAccessor accessor) throws RocksDBException {
+      accessor.flush(oldColumnFamily, newColumnFamily);
+    }
+
+    @Override
+    public void addToBatch(final byte[] key,
+                           final byte[] value,
+                           final WriteBatchInterface batch) throws RocksDBException {
+      if (value == null) {
+        batch.delete(oldColumnFamily, key);
+        batch.delete(newColumnFamily, key);
+      } else {
+        batch.delete(oldColumnFamily, key);
+        batch.put(newColumnFamily, key, value);
+      }
+    }
+
+    @Override
+    public void close() {
+      oldColumnFamily.close();
+      newColumnFamily.close();
+    }
+  }
+
+  /**
+   * Iterator that merges the new (header-aware) CF and legacy CF, converting legacy values
+   * to the new format on the fly.
+   */
+  private static class RocksDBDualCFIterator
+      extends AbstractIterator<KeyValue<Bytes, byte[]>>
+      implements ManagedKeyValueIterator<Bytes, byte[]> {
+
+    // RocksDB's JNI interface does not expose getters/setters that allow the
+    // comparator to be pluggable, and the default is lexicographic, so it's
+    // safe to just force lexicographic comparator here for now.
+    private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
+
+    private final String storeName;
+    private final RocksIterator iterWithHeaders;
+    private final RocksIterator iterLegacy;
+    private final boolean forward;
+
+    private volatile boolean open = true;
+
+    private byte[] nextWithHeaders;
+    private byte[] nextLegacy;
+    private KeyValue<Bytes, byte[]> next;
+    private Runnable closeCallback = null;
+
+    RocksDBDualCFIterator(final String storeName,
+                          final RocksIterator iterWithHeaders,
+                          final RocksIterator iterLegacy,
+                          final boolean forward) {
+      this.iterWithHeaders = iterWithHeaders;
+      this.iterLegacy = iterLegacy;
+      this.storeName = storeName;
+      this.forward = forward;
+    }
+
+    @Override
+    public synchronized boolean hasNext() {
+      if (!open) {
+        throw new InvalidStateStoreException(
+            String.format("RocksDB iterator for store %s has closed", storeName)
+        );
+      }
+      return super.hasNext();
+    }
+
+    @Override
+    public synchronized KeyValue<Bytes, byte[]> next() {
+      return super.next();
+    }
+
+    @Override
+    protected KeyValue<Bytes, byte[]> makeNext() {
+      if (nextLegacy == null && iterLegacy.isValid()) {
+        nextLegacy = iterLegacy.key();
+      }
+      if (nextWithHeaders == null && iterWithHeaders.isValid()) {
+        nextWithHeaders = iterWithHeaders.key();
+      }
+
+      if (nextLegacy == null && !iterLegacy.isValid()) {
+        if (nextWithHeaders == null && !iterWithHeaders.isValid()) {
+          return allDone();
+        } else {
+          next = KeyValue.pair(new Bytes(nextWithHeaders), iterWithHeaders.value());
+          nextWithHeaders = null;
+          if (forward) {
+            iterWithHeaders.next();
+          } else {
+            iterWithHeaders.prev();
+          }
+        }
+      } else {
+        if (nextWithHeaders == null) {
+          next = KeyValue.pair(
+              new Bytes(nextLegacy),
+              convertToHeaderFormat(iterLegacy.key(), iterLegacy.value())
+          );
+          nextLegacy = null;
+          if (forward) {
+            iterLegacy.next();
+          } else {
+            iterLegacy.prev();
+          }
+        } else {
+          if (forward) {
+            if (comparator.compare(nextLegacy, nextWithHeaders) <= 0) {
+              next = KeyValue.pair(
+                  new Bytes(nextLegacy),
+                  convertToHeaderFormat(iterLegacy.key(), iterLegacy.value())
+              );
+              nextLegacy = null;
+              iterLegacy.next();
+            } else {
+              next = KeyValue.pair(new Bytes(nextWithHeaders), iterWithHeaders.value());
+              nextWithHeaders = null;
+              iterWithHeaders.next();
+            }
+          } else {
+            if (comparator.compare(nextLegacy, nextWithHeaders) >= 0) {
+              next = KeyValue.pair(
+                  new Bytes(nextLegacy),
+                  convertToHeaderFormat(iterLegacy.key(), iterLegacy.value())
+              );
+              nextLegacy = null;
+              iterLegacy.prev();
+            } else {
+              next = KeyValue.pair(new Bytes(nextWithHeaders), iterWithHeaders.value());
+              nextWithHeaders = null;
+              iterWithHeaders.prev();
+            }
+          }
+        }
+      }
+      return next;
+    }
+
+    @Override
+    public synchronized void close() {
+      if (closeCallback == null) {
+        throw new IllegalStateException(
+            "RocksDBDualCFIterator expects close callback to be set immediately upon creation"
+        );
+      }
+      closeCallback.run();
+      iterLegacy.close();
+      iterWithHeaders.close();
+      open = false;
+    }
+
+    @Override
+    public Bytes peekNextKey() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      return next.key;
+    }
+
+    @Override
+    public void onClose(final Runnable closeCallback) {
+      this.closeCallback = closeCallback;
+    }
+  }
+
+  private static class RocksDBDualCFRangeIterator extends RocksDBDualCFIterator {
+
+    // same comparator semantics as parent
+    private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
+
+    private final byte[] rawLastKey;
+    private final boolean forward;
+    private final boolean toInclusive;
+
+    RocksDBDualCFRangeIterator(final String storeName,
+                               final RocksIterator iterWithHeaders,
+                               final RocksIterator iterLegacy,
+                               final Bytes from,
+                               final Bytes to,
+                               final boolean forward,
+                               final boolean toInclusive) {
+      super(storeName, iterWithHeaders, iterLegacy, forward);
+      this.forward = forward;
+      this.toInclusive = toInclusive;
+
+      if (forward) {
+        if (from == null) {
+          iterWithHeaders.seekToFirst();
+          iterLegacy.seekToFirst();
+        } else {
+          iterWithHeaders.seek(from.get());
+          iterLegacy.seek(from.get());
+        }
+        rawLastKey = to == null ? null : to.get();
+      } else {
+        if (to == null) {
+          iterWithHeaders.seekToLast();
+          iterLegacy.seekToLast();
+        } else {
+          iterWithHeaders.seekForPrev(to.get());
+          iterLegacy.seekForPrev(to.get());
+        }
+        rawLastKey = from == null ? null : from.get();
+      }
+    }
+
+    @Override
+    protected KeyValue<Bytes, byte[]> makeNext() {
+      final KeyValue<Bytes, byte[]> next = super.makeNext();
+      if (next == null) {
+        return allDone();
+      } else if (rawLastKey == null) {
+        // null means range endpoint is open
+        return next;
+      } else {
+        if (forward) {
+          if (comparator.compare(next.key.get(), rawLastKey) < 0) {
+            return next;
+          } else if (comparator.compare(next.key.get(), rawLastKey) == 0) {
+            return toInclusive ? next : allDone();
+          } else {
+            return allDone();
+          }
+        } else {
+          if (comparator.compare(next.key.get(), rawLastKey) >= 0) {
+            return next;
+          } else {
+            return allDone();
+          }
+        }
+      }
+    }
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -57,8 +57,11 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
 
   private static final Logger log = LoggerFactory.getLogger(RocksDBTimestampedStoreWithHeaders.class);
 
+  // Legacy column family name - must match RocksDBTimestampedStore.TIMESTAMPED_VALUES_COLUMN_FAMILY_NAME
+  private static final byte[] LEGACY_TIMESTAMPED_CF_NAME =
+      "keyValueWithTimestamp".getBytes(StandardCharsets.UTF_8);
+
   // New column family for header-aware timestamped values.
-  // You can rename this if you prefer a different CF name.
   private static final byte[] TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME =
       "keyValueWithTimestampAndHeaders".getBytes(StandardCharsets.UTF_8);
 
@@ -76,19 +79,25 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
   @Override
   void openRocksDB(final DBOptions dbOptions,
                    final ColumnFamilyOptions columnFamilyOptions) {
-    // We open two CFs:
-    //  - DEFAULT_COLUMN_FAMILY: legacy (non-header) timestamped values
+    // We open three CFs:
+    //  - DEFAULT_COLUMN_FAMILY: required by RocksDB (not used)
+    //  - LEGACY_TIMESTAMPED_CF_NAME: legacy timestamped values (without headers)
     //  - TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME: new header-aware format
     //
     // On first open with no legacy data, we just use the new CF.
     final List<ColumnFamilyHandle> columnFamilies = openRocksDB(
         dbOptions,
         new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions),
+        new ColumnFamilyDescriptor(LEGACY_TIMESTAMPED_CF_NAME, columnFamilyOptions),
         new ColumnFamilyDescriptor(TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME, columnFamilyOptions)
     );
 
-    final ColumnFamilyHandle legacyCf = columnFamilies.get(0);
-    final ColumnFamilyHandle headersCf = columnFamilies.get(1);
+    final ColumnFamilyHandle defaultCf = columnFamilies.get(0);
+    final ColumnFamilyHandle legacyCf = columnFamilies.get(1);
+    final ColumnFamilyHandle headersCf = columnFamilies.get(2);
+
+    // Close the default CF as we don't use it
+    defaultCf.close();
 
     final RocksIterator legacyIter = db.newIterator(legacyCf);
     legacyIter.seekToFirst();
@@ -104,8 +113,8 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
   }
 
   /**
-   * Accessor that supports dual-column-family upgrade: legacy CF (no headers)
-   * and new CF (header-aware format).
+   * Accessor that supports dual-column-family upgrade: legacy CF (timestamped without headers)
+   * and new CF (timestamped with headers).
    */
   private class DualColumnFamilyAccessor implements ColumnFamilyAccessor {
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderWithHeaders.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import java.util.Objects;
+
+/**
+ * Builder for {@link TimestampedKeyValueStoreWithHeaders} instances.
+ *
+ * This is analogous to {@link TimestampedKeyValueStoreBuilder}, but uses
+ * {@link ValueTimestampHeaders} as the value wrapper and wires up the
+ * header-aware store stack (change-logging, caching, metering).
+ */
+public class TimestampedKeyValueStoreBuilderWithHeaders<K, V>
+    extends AbstractStoreBuilder<K, ValueTimestampHeaders<V>, TimestampedKeyValueStoreWithHeaders<K, V>> {
+
+  private final KeyValueBytesStoreSupplier storeSupplier;
+
+  public TimestampedKeyValueStoreBuilderWithHeaders(final KeyValueBytesStoreSupplier storeSupplier,
+                                                    final Serde<K> keySerde,
+                                                    final Serde<V> valueSerde,
+                                                    final Time time) {
+    super(
+        storeSupplier.name(),
+        keySerde,
+        valueSerde == null ? null : new ValueTimestampHeadersSerde<>(valueSerde),
+        time
+    );
+    Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
+    Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
+    this.storeSupplier = storeSupplier;
+  }
+
+  @Override
+  public TimestampedKeyValueStoreWithHeaders<K, V> build() {
+    KeyValueStore<Bytes, byte[]> store = storeSupplier.get();
+
+    return new MeteredTimestampedKeyValueStoreWithHeaders<>(
+        maybeWrapCaching(maybeWrapLogging(store)),
+        storeSupplier.metricsScope(),
+        time,
+        keySerde,
+        valueSerde
+    );
+  }
+
+  private KeyValueStore<Bytes, byte[]> maybeWrapCaching(final KeyValueStore<Bytes, byte[]> inner) {
+    if (!enableCaching) {
+      return inner;
+    }
+    return new CachingKeyValueStore(inner, true);
+  }
+
+  private KeyValueStore<Bytes, byte[]> maybeWrapLogging(final KeyValueStore<Bytes, byte[]> inner) {
+    if (!enableLogging) {
+      return inner;
+    }
+    return new ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders(inner);
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.utils.ByteUtils;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableDeserializer;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.initNullableDeserializer;
+
+class ValueTimestampHeadersDeserializer<V>
+    implements WrappingNullableDeserializer<ValueTimestampHeaders<V>, Void, V> {
+
+  private static final LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
+
+  public final Deserializer<V> valueDeserializer;
+  private final Deserializer<Long> timestampDeserializer;
+  private final HeadersDeserializer headersDeserializer;
+
+  ValueTimestampHeadersDeserializer(final Deserializer<V> valueDeserializer) {
+    Objects.requireNonNull(valueDeserializer);
+    this.valueDeserializer = valueDeserializer;
+    this.timestampDeserializer = new LongDeserializer();
+    this.headersDeserializer = new HeadersDeserializer();
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs,
+                        final boolean isKey) {
+    valueDeserializer.configure(configs, isKey);
+    timestampDeserializer.configure(configs, isKey);
+    // HeadersDeserializer has no internal config
+  }
+
+  @Override
+  public ValueTimestampHeaders<V> deserialize(final String topic,
+                                              final byte[] valueTimestampHeadersBytes) {
+    if (valueTimestampHeadersBytes == null) {
+      return null;
+    }
+    final Headers headers =
+        headersDeserializer.deserialize(topic, rawHeaders(valueTimestampHeadersBytes));
+    final long timestamp =
+        timestampDeserializer.deserialize(topic, rawTimestamp(valueTimestampHeadersBytes));
+
+    final V value =
+        valueDeserializer.deserialize(topic, rawValue(valueTimestampHeadersBytes));
+
+    return ValueTimestampHeaders.makeAllowNullable(value, timestamp, headers);
+  }
+
+  @Override
+  public void close() {
+    valueDeserializer.close();
+    timestampDeserializer.close();
+    // HeadersDeserializer has nothing to close
+  }
+
+  static byte[] rawValue(final byte[] recordBytes) {
+    if (recordBytes == null) {
+      return null;
+    }
+
+    final ByteBuffer buffer = ByteBuffer.wrap(recordBytes);
+
+    try {
+      // 1. Read the header length using the UNSIGNED/PLAIN varint reader
+      // This moves the buffer position to the start of [header_bytes]
+      final int headerLength = ByteUtils.readUnsignedVarint(buffer);
+
+      // 2. Calculate the skip distance: header_bytes + 8-byte timestamp
+      int offsetToValue = buffer.position() + headerLength + Long.BYTES;
+
+      // 3. Check if the record is long enough to actually contain a value
+      if (offsetToValue > recordBytes.length) {
+        throw new IllegalArgumentException(
+            "Corrupt record: Calculated value offset " + offsetToValue +
+                " exceeds total record length " + recordBytes.length
+        );
+      }
+
+      // 4. Move the pointer to the start of [value_bytes]
+      buffer.position(offsetToValue);
+
+      // 5. The remaining bytes in the buffer are the [value_bytes]
+      final byte[] value = new byte[buffer.remaining()];
+      buffer.get(value);
+
+      return value;
+
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to extract raw value from record", e);
+    }
+  }
+
+  /**
+   * Extract the 8-byte timestamp from the layout:
+   * [ varint header_length ][ header_bytes ][ 8-byte timestamp ][ value_bytes ]
+   */
+  private static byte[] rawTimestamp(final byte[] rawBytes) {
+    if (rawBytes == null) {
+      return null;
+    }
+
+    final ByteBuffer buffer = ByteBuffer.wrap(rawBytes);
+
+    try {
+      // 1. Read the length of the headers (Plain/Unsigned Varint)
+      // This advances the position past the varint itself
+      final int headerLength = ByteUtils.readUnsignedVarint(buffer);
+
+      // 2. Skip the header bytes to reach the timestamp
+      // New position = [Position after Varint] + [headerLength]
+      int timestampOffset = buffer.position() + headerLength;
+
+      // 3. Validate that we have enough bytes remaining for an 8-byte long
+      if (timestampOffset + Long.BYTES > rawBytes.length) {
+        throw new IllegalArgumentException(
+            "Corrupt record: header length " + headerLength +
+                " pushes timestamp past end of array."
+        );
+      }
+
+      // 4. Extract the 8 bytes
+      byte[] timestampBytes = new byte[Long.BYTES];
+      System.arraycopy(rawBytes, timestampOffset, timestampBytes, 0, Long.BYTES);
+
+      return timestampBytes;
+
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Could not parse record structure", e);
+    }
+  }
+
+  /**
+   * Extract the timestamp value directly from the serialized record.
+   */
+  static long timestamp(final byte[] rawBytes) {
+    if (rawBytes == null) {
+      throw new IllegalArgumentException("Cannot read timestamp from null bytes");
+    }
+    return LONG_DESERIALIZER.deserialize(null, rawTimestamp(rawBytes));
+  }
+
+  /**
+   * Extract the raw headers_bytes segment (between timestamp and value).
+   */
+  private static byte[] rawHeaders(final byte[] rawBytes) {
+
+    if (rawBytes == null) {
+      return null;
+    }
+
+    // Safety check: Minimal possible size (1 byte varint + 8 bytes TS)
+    if (rawBytes.length < 9) {
+      throw new IllegalArgumentException("Record too short to contain headers and timestamp");
+    }
+
+    final ByteBuffer buffer = ByteBuffer.wrap(rawBytes);
+
+    // 1. Read Varint (Starts at Index 0)
+    // This moves the buffer position to the start of the Header Bytes
+    final int headerLength;
+    try {
+      headerLength = readPlainVarint(buffer);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Could not parse Header Length Varint", e);
+    }
+
+    // 2. Validation
+    // We need at least (headerLength + 8 bytes for Timestamp) remaining
+    if (headerLength < 0 || buffer.remaining() < headerLength + Long.BYTES) {
+      throw new IllegalArgumentException("Invalid header length: " + headerLength
+          + ". Buffer remaining: " + buffer.remaining());
+    }
+
+    if (headerLength == 0) {
+      return new byte[0];
+    }
+
+    // 3. Extract the bytes
+    // buffer.get() copies headerLength bytes from the current position into the array
+    byte[] headers = new byte[headerLength];
+    buffer.get(headers);
+
+    return headers;
+  }
+
+  public static int readPlainVarint(ByteBuffer buffer) {
+    int value = 0;
+    int i = 0;
+    byte b;
+    while (((b = buffer.get()) & 0x80) != 0) {
+      value |= (b & 0x7F) << i;
+      i += 7;
+      if (i > 28) throw new IllegalArgumentException("Varint too long");
+    }
+    value |= b << i;
+    return value;
+  }
+
+  @Override
+  public void setIfUnset(final SerdeGetter getter) {
+    // ValueTimestampHeadersDeserializer never wraps a null deserializer (or configure would throw),
+    // but it may wrap a deserializer that itself wraps a null deserializer.
+    initNullableDeserializer(valueDeserializer, getter);
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -67,7 +67,7 @@ class ValueTimestampHeadersDeserializer<V>
         timestampDeserializer.deserialize(topic, rawTimestamp(valueTimestampHeadersBytes));
 
     final V value =
-        valueDeserializer.deserialize(topic, rawValue(valueTimestampHeadersBytes));
+        valueDeserializer.deserialize(topic, headers, rawValue(valueTimestampHeadersBytes));
 
     return ValueTimestampHeaders.makeAllowNullable(value, timestamp, headers);
   }
@@ -168,7 +168,7 @@ class ValueTimestampHeadersDeserializer<V>
   /**
    * Extract the raw headers_bytes segment (between timestamp and value).
    */
-  private static byte[] rawHeaders(final byte[] rawBytes) {
+  public static byte[] rawHeaders(final byte[] rawBytes) {
 
     if (rawBytes == null) {
       return null;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerde.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerde;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import static java.util.Objects.requireNonNull;
+
+public class ValueTimestampHeadersSerde<V> extends WrappingNullableSerde<ValueTimestampHeaders<V>, Void, V> {
+  public ValueTimestampHeadersSerde(final Serde<V> valueSerde) {
+    super(
+        new ValueTimestampHeadersSerializer<>(requireNonNull(valueSerde, "valueSerde was null").serializer()),
+        new ValueTimestampHeadersDeserializer<>(requireNonNull(valueSerde, "valueSerde was null").deserializer())
+    );
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.initNullableSerializer;
+
+/**
+ * Serializer for {@link ValueTimestampHeaders}, analogous to {@link ValueAndTimestampSerializer}.
+ */
+public class ValueTimestampHeadersSerializer<V>
+    implements WrappingNullableSerializer<ValueTimestampHeaders<V>, Void, V> {
+
+  public final Serializer<V> valueSerializer;
+  private final Serializer<Long> timestampSerializer;
+  public final HeadersSerializer headersSerializer;
+
+  ValueTimestampHeadersSerializer(final Serializer<V> valueSerializer) {
+    Objects.requireNonNull(valueSerializer);
+    this.valueSerializer = valueSerializer;
+    this.timestampSerializer = new LongSerializer();
+    this.headersSerializer = new HeadersSerializer();
+  }
+
+  /**
+   * Compare two serialized records (produced by this serializer) and return true iff:
+   *  - the underlying value bytes are identical, and
+   *  - the new timestamp is strictly greater than the old timestamp.
+   * <p>
+   */
+  public static boolean valuesAndHeadersAreSameAndTimeIsIncreasing(final byte[] oldRecord,
+                                                         final byte[] newRecord) {
+    if (oldRecord == newRecord) {
+      // same reference, so they are trivially the same (might both be null)
+      return true;
+    } else if (oldRecord == null || newRecord == null) {
+      // only one is null, so they cannot be the same
+      return false;
+    } else if (newRecord.length != oldRecord.length) {
+      // they are different length, so they cannot be the same
+      return false;
+    } else if (timeIsDecreasing(oldRecord, newRecord)) {
+      // the record time represents the beginning of the validity interval,
+      // so if the time moves backwards, we need to do the update regardless
+      // of whether the value has changed
+      return false;
+    } else {
+      // all other checks have fallen through, so we actually compare
+      // the binary data of the two values
+      return valuesAndHeadersAreSame(oldRecord, newRecord);
+    }
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs,
+                        final boolean isKey) {
+    valueSerializer.configure(configs, isKey);
+    timestampSerializer.configure(configs, isKey);
+    headersSerializer.configure(configs, isKey);
+  }
+
+  @Override
+  public byte[] serialize(final String topic,
+                          final ValueTimestampHeaders<V> data) {
+    if (data == null) {
+      return null;
+    }
+    return serialize(topic, data.value(), data.timestamp(), data.headers());
+  }
+
+  public byte[] serialize(final String topic,
+                          final V data,
+                          final long timestamp,
+                          final Headers headers
+                          ) {
+    if (data == null) {
+      return null;
+    }
+
+    final byte[] rawValue = valueSerializer.serialize(topic, headers, data);
+    // Since we can't control the result of the internal serializer, we make sure that the result
+    // is not null as well.
+    //
+    // Serializing non-null values to null can be useful when working with Optional-like values
+    // where the Optional.empty case is serialized to null.
+    // See the discussion here: https://github.com/apache/kafka/pull/7679
+    if (rawValue == null) {
+      return null;
+    }
+
+    final byte[] rawTimestamp = timestampSerializer.serialize(topic, timestamp);
+    final byte[] rawHeaders = headersSerializer.serialize(topic, headers);
+    return ByteBuffer
+        .allocate(rawHeaders.length + rawTimestamp.length + rawValue.length)
+        .put(rawHeaders)
+        .put(rawTimestamp)
+        .put(rawValue)
+        .array();
+  }
+
+  @Override
+  public void close() {
+    valueSerializer.close();
+    timestampSerializer.close();
+    headersSerializer.close();
+  }
+
+  private static boolean timeIsDecreasing(final byte[] oldRecord,
+                                          final byte[] newRecord) {
+    return extractTimestamp(newRecord) <= extractTimestamp(oldRecord);
+  }
+
+  private static long extractTimestamp(final byte[] bytes) {
+
+    final byte[] timestampBytes = new byte[Long.BYTES];
+    System.arraycopy(bytes, headersFiledLength (bytes), timestampBytes, 0, Long.BYTES);
+    return ByteBuffer.wrap(timestampBytes).getLong();
+  }
+
+
+  private static boolean valuesAndHeadersAreSame(final byte[] left,
+                                       final byte[] right) {
+    int headersFiledLength = headersFiledLength (left);
+    // check if headers are same
+    for (int i = 0; i < headersFiledLength; i++) {
+      if (left[i] != right[i]) {
+        return false;
+      }
+    }
+    // check if values are same
+    for (int i = headersFiledLength (left) + Long.BYTES; i < left.length; i++) {
+      if (left[i] != right[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void setIfUnset(final SerdeGetter getter) {
+    // ValueTimestampHeadersSerializer never wraps a null serializer (or configure would throw),
+    // but it may wrap a serializer that itself wraps a null serializer.
+    initNullableSerializer(valueSerializer, getter);
+  }
+
+  private static int readVarint(byte[] data, Integer offset) {
+    ByteArrayInputStream bais = new ByteArrayInputStream(data);
+    return readVarint(bais, offset);
+  }
+
+  /**
+   * Reads an unsigned varint from an Input Stream.
+   * This is useful because it advances the "pointer" to the
+   * actual data following the varint.
+   */
+  private static int readVarint(ByteArrayInputStream in, Integer offset) {
+    int value = 0;
+    int shift = 0;
+    int b;
+
+    // Loop until we find a byte with the MSB set to 0
+    while (true) {
+      b = in.read();
+      if (b == -1) throw new RuntimeException("Unexpected end of stream while reading varint");
+
+      // Extract the 7 least significant bits and shift them into place
+      value |= (b & 0x7F) << shift;
+
+      // If the MSB (0x80) is not set, this is the last byte of the varint
+      if ((b & 0x80) == 0) {
+        break;
+      }
+
+      shift += 7;
+      offset += 1;
+
+      // Safety check for 32-bit integers
+      if (shift >= 35) {
+        throw new RuntimeException("Varint is too long (overflow)");
+      }
+    }
+
+    return value;
+  }
+
+  private static int headersFiledLength(byte[] bytes) {
+    Integer offset = 0;
+    int headersLength =  readVarint(bytes, offset);
+    return headersLength + offset;
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -210,8 +210,10 @@ public class ValueTimestampHeadersSerializer<V>
   }
 
   private static int headersFiledLength(byte[] bytes) {
-    Integer offset = 0;
-    int headersLength =  readVarint(bytes, offset);
-    return headersLength + offset;
+    ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+    int headersLength = readVarint(bais, 0);
+    // bais.available() tells us how many bytes are left, so we can calculate how many were consumed
+    int varintSize = bytes.length - bais.available();
+    return varintSize + headersLength;
   }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/TimestampedKeyValueStoreUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/TimestampedKeyValueStoreUpgradeTest.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.tests;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test for upgrading from TimestampedKeyValueStore to TimestampedKeyValueStoreWithHeaders.
+ * This test validates the upgrade path described in KIP-1271.
+ *
+ * The upgrade should allow:
+ * 1. Reading legacy data (written without headers) with empty headers
+ * 2. Writing new data with headers
+ * 3. Both legacy and new data coexisting in the same store
+ */
+public class TimestampedKeyValueStoreUpgradeTest {
+
+    @TempDir
+    File stateDir;
+
+    @Test
+    public void shouldUpgradeFromTimestampedStoreToTimestampedStoreWithHeaders() throws Exception {
+        final String storeName = "upgrade-test-store";
+        final long timestamp1 = 1000L;
+        final long timestamp2 = 2000L;
+        final long timestamp3 = 3000L;
+        final File tempStateDir = new File(stateDir, "backup");
+
+        // Step 1: Create a legacy TimestampedKeyValueStore and write data
+        TopologyTestDriver legacyDriver = null;
+        try {
+            final StoreBuilder<TimestampedKeyValueStore<String, String>> legacyStoreBuilder =
+                    Stores.timestampedKeyValueStoreBuilder(
+                            Stores.persistentTimestampedKeyValueStore(storeName),
+                            Serdes.String(),
+                            Serdes.String()
+                    );
+
+            final Topology topology = new Topology();
+            topology.addSource("source", "input-topic")
+                    .addProcessor("processor", () -> new Processor<Object, Object, Object, Object>() {
+                        @Override
+                        public void process(Record<Object, Object> record) {
+                        }
+                    }, "source")
+                    .addStateStore(legacyStoreBuilder, "processor");
+
+            final Properties props = createStreamsConfig();
+
+            legacyDriver = new TopologyTestDriver(topology, props);
+            final KeyValueStore<String, ValueAndTimestamp<String>> legacyStore =
+                    legacyDriver.getTimestampedKeyValueStore(storeName);
+
+            assertNotNull(legacyStore, "Legacy store should not be null");
+
+            // Write legacy data without headers
+            legacyStore.put("key1", ValueAndTimestamp.make("value1", timestamp1));
+            legacyStore.put("key2", ValueAndTimestamp.make("value2", timestamp2));
+
+            // Verify legacy data can be read
+            final ValueAndTimestamp<String> result1 = legacyStore.get("key1");
+            assertNotNull(result1);
+            assertEquals("value1", result1.value());
+            assertEquals(timestamp1, result1.timestamp());
+
+            // Flush the store to ensure data is written to disk
+            legacyStore.flush();
+
+            // Copy the state directory BEFORE closing the driver
+            copyDirectory(new File(stateDir, "upgrade-test-app"), tempStateDir);
+        } finally {
+            if (legacyDriver != null) {
+                legacyDriver.close();
+            }
+        }
+
+        // Step 2: Reopen the same store as TimestampedKeyValueStoreWithHeaders
+        {
+            // Restore the state directory from backup
+            copyDirectory(tempStateDir, new File(stateDir, "upgrade-test-app"));
+
+            final StoreBuilder<TimestampedKeyValueStoreWithHeaders<String, String>> headerStoreBuilder =
+                    Stores.timestampedKeyValueStoreBuilderWithHeaders(
+                            Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName),
+                            Serdes.String(),
+                            Serdes.String()
+                    );
+
+            final Topology topology = new Topology();
+            topology.addSource("source", "input-topic")
+                    .addProcessor("processor", () -> new Processor<Object, Object, Object, Object>() {
+                        @Override
+                        public void process(Record<Object, Object> record) {
+                        }
+                    }, "source")
+                    .addStateStore(headerStoreBuilder, "processor");
+
+            final Properties props = createStreamsConfig();
+
+            try (TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
+                final KeyValueStore<String, ValueTimestampHeaders<String>> headerStore =
+                        driver.getTimestampedKeyValueStoreWithHeaders(storeName);
+
+                assertNotNull(headerStore, "Header store should not be null");
+
+                // Step 3: Verify legacy data can be read with empty headers
+                final ValueTimestampHeaders<String> legacyResult1 = headerStore.get("key1");
+                assertNotNull(legacyResult1, "Legacy key1 should be readable");
+                assertEquals("value1", legacyResult1.value());
+                assertEquals(timestamp1, legacyResult1.timestamp());
+                assertNotNull(legacyResult1.headers(), "Headers should not be null");
+                assertEquals(0, legacyResult1.headers().toArray().length, "Legacy data should have empty headers");
+
+                final ValueTimestampHeaders<String> legacyResult2 = headerStore.get("key2");
+                assertNotNull(legacyResult2, "Legacy key2 should be readable");
+                assertEquals("value2", legacyResult2.value());
+                assertEquals(timestamp2, legacyResult2.timestamp());
+                assertEquals(0, legacyResult2.headers().toArray().length, "Legacy data should have empty headers");
+
+                // Step 4: Write new data with headers
+                final RecordHeaders headers3 = new RecordHeaders();
+                headers3.add("source", "upgrade-test".getBytes());
+                headers3.add("version", "2.0".getBytes());
+
+                headerStore.put(
+                        "key3",
+                        ValueTimestampHeaders.make("value3", timestamp3, headers3)
+                );
+
+                // Step 5: Verify new data can be read with headers
+                final ValueTimestampHeaders<String> newResult = headerStore.get("key3");
+                assertNotNull(newResult, "New key3 should be readable");
+                assertEquals("value3", newResult.value());
+                assertEquals(timestamp3, newResult.timestamp());
+                assertNotNull(newResult.headers());
+                assertEquals(2, newResult.headers().toArray().length, "New data should have 2 headers");
+                assertEquals("upgrade-test", new String(newResult.headers().lastHeader("source").value()));
+                assertEquals("2.0", new String(newResult.headers().lastHeader("version").value()));
+
+                // Step 6: Verify we can update legacy data with headers
+                final RecordHeaders headers1Updated = new RecordHeaders();
+                headers1Updated.add("updated", "true".getBytes());
+
+                headerStore.put(
+                        "key1",
+                        ValueTimestampHeaders.make("value1-updated", timestamp1 + 100, headers1Updated)
+                );
+
+                final ValueTimestampHeaders<String> updatedResult = headerStore.get("key1");
+                assertNotNull(updatedResult);
+                assertEquals("value1-updated", updatedResult.value());
+                assertEquals(timestamp1 + 100, updatedResult.timestamp());
+                assertEquals(1, updatedResult.headers().toArray().length);
+                assertEquals("true", new String(updatedResult.headers().lastHeader("updated").value()));
+
+                // Step 7: Verify all keys are present (legacy and new)
+                assertNotNull(headerStore.get("key1"), "key1 should still exist");
+                assertNotNull(headerStore.get("key2"), "key2 should still exist");
+                assertNotNull(headerStore.get("key3"), "key3 should exist");
+            }
+        }
+    }
+
+    private Properties createStreamsConfig() {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "upgrade-test-app");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+        props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        return props;
+    }
+
+    private void copyDirectory(final File source, final File target) throws IOException {
+        if (!source.exists()) {
+            return;
+        }
+        if (!target.exists()) {
+            target.mkdirs();
+        }
+        try (Stream<Path> paths = Files.walk(source.toPath())) {
+            paths.forEach(sourcePath -> {
+                try {
+                    final Path targetPath = target.toPath().resolve(source.toPath().relativize(sourcePath));
+                    if (Files.isDirectory(sourcePath)) {
+                        if (!Files.exists(targetPath)) {
+                            Files.createDirectories(targetPath);
+                        }
+                    } else {
+                        Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/tests/TimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/TimestampedKeyValueStoreWithHeadersTest.java
@@ -1,0 +1,82 @@
+package org.apache.kafka.streams.tests;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TimestampedKeyValueStoreWithHeadersTest {
+
+  @Test
+  public void shouldPutAndGetUsingRecordContext() {
+    // 1. Define the Store Builder
+    StoreBuilder<TimestampedKeyValueStoreWithHeaders<String, String>> storeBuilder =
+        Stores.timestampedKeyValueStoreBuilderWithHeaders(
+            Stores.persistentTimestampedKeyValueStoreWithHeaders("test-store"),
+            Serdes.String(),
+            Serdes.String()
+        );
+
+    // 2. Setup the topology with a dummy connection
+    Topology topology = new Topology();
+    topology.addSource("source", "input-topic")
+        .addProcessor("processor", () -> new Processor<Object, Object, Object, Object>() {
+          @Override
+          public void process(Record<Object, Object> record) {}
+        }, "source")
+        .addStateStore(storeBuilder, "processor");
+
+    // 3. Setup Driver Properties (Including the missing Serdes)
+    Properties props = new Properties();
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-app");
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+    props.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kafka-streams");
+    // These two lines fix the ConfigException:
+    props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+
+    try (TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
+
+      // 4. Retrieve the store
+      KeyValueStore<String, ValueTimestampHeaders<String>> store =
+          driver.getTimestampedKeyValueStoreWithHeaders("test-store");
+
+      assertNotNull(store, "Store 'test-store' should not be null");
+
+      // 5. Create the incoming Record
+      long now = System.currentTimeMillis();
+      final Record<String, String> record = new Record<>(
+          "user-123",
+          "active-status",
+          now
+      );
+      record.headers().add("source", "unit-test".getBytes());
+
+      // 6. Store and Verify
+      store.put(
+          record.key(),
+          ValueTimestampHeaders.make(record.value(), record.timestamp(), record.headers())
+      );
+
+      final ValueTimestampHeaders<String> result = store.get(record.key());
+
+      assertNotNull(result);
+      assertEquals(record.value(), result.value());
+      assertEquals(record.timestamp(), result.timestamp());
+      assertEquals(record.headers(), result.headers());
+    }
+  }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/tests/TimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/TimestampedKeyValueStoreWithHeadersTest.java
@@ -58,25 +58,44 @@ public class TimestampedKeyValueStoreWithHeadersTest {
 
       // 5. Create the incoming Record
       long now = System.currentTimeMillis();
-      final Record<String, String> record = new Record<>(
+      final Record<String, String> record1 = new Record<>(
           "user-123",
           "active-status",
           now
       );
-      record.headers().add("source", "unit-test".getBytes());
+      record1.headers().add("source", "unit-test".getBytes());
+
+      // store record with empty headers
+      final Record<String, String> record2 = new Record<>(
+          "user-321",
+          "passive-status",
+          now + 1000
+      );
 
       // 6. Store and Verify
       store.put(
-          record.key(),
-          ValueTimestampHeaders.make(record.value(), record.timestamp(), record.headers())
+          record1.key(),
+          ValueTimestampHeaders.make(record1.value(), record1.timestamp(), record1.headers())
+      );
+      store.put(
+          record2.key(),
+          ValueTimestampHeaders.make(record2.value(), record2.timestamp(), record2.headers())
       );
 
-      final ValueTimestampHeaders<String> result = store.get(record.key());
+      final ValueTimestampHeaders<String> result1 = store.get(record1.key());
 
-      assertNotNull(result);
-      assertEquals(record.value(), result.value());
-      assertEquals(record.timestamp(), result.timestamp());
-      assertEquals(record.headers(), result.headers());
+      assertNotNull(result1);
+      assertEquals(record1.value(), result1.value());
+      assertEquals(record1.timestamp(), result1.timestamp());
+      assertEquals(record1.headers(), result1.headers());
+
+      final ValueTimestampHeaders<String> result2 = store.get(record2.key());
+
+      assertNotNull(result1);
+      assertEquals(record2.value(), result2.value());
+      assertEquals(record2.timestamp(), result2.timestamp());
+      assertNotNull(result2.headers());
+      assertEquals(0, result2.headers().toArray().length);
     }
   }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -81,8 +81,10 @@ import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.VersionedKeyValueStore;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -1019,6 +1021,12 @@ public class TopologyTestDriver implements Closeable {
     public <K, V> KeyValueStore<K, ValueAndTimestamp<V>> getTimestampedKeyValueStore(final String name) {
         final StateStore store = getStateStore(name, false);
         return store instanceof TimestampedKeyValueStore ? (TimestampedKeyValueStore<K, V>) store : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <K, V> KeyValueStore<K, ValueTimestampHeaders<V>> getTimestampedKeyValueStoreWithHeaders(final String name) {
+        final StateStore store = getStateStore(name, false);
+        return store instanceof TimestampedKeyValueStoreWithHeaders ? (TimestampedKeyValueStoreWithHeaders<K, V>) store : null;
     }
 
     /**


### PR DESCRIPTION
This is a PoC PR of
[KIP-1271](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1271%3A+Allow+to+Store+Record+Headers+in+State+Stores).
For (`TimestampedKeyValueStoreWithHeaders`)