### PR TITLE
KAFKA-20087: Automate Docker Images creation workflow

### DIFF
--- a/.github/workflows/docker_rc_automation.yml
+++ b/.github/workflows/docker_rc_automation.yml
@@ -1,0 +1,228 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Automate Docker RC Creation
+
+on:
+  workflow_dispatch:
+    inputs:
+      kafka_url:
+        description: 'Kafka URL to be used to build the docker images (Example: https://archive.apache.org/dist/kafka/3.8.0/kafka_2.13-3.8.0.tgz)'
+        required: true
+      rc_version:
+        description: 'RC version tag (Example: 3.8.0-rc0)'
+        required: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  test-jvm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Trigger Docker Build Test for JVM
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Triggering Docker Build Test workflow for JVM..."
+          gh workflow run docker_build_and_test.yml \
+            --repo ${{ github.repository }} \
+            --ref ${{ github.ref_name }} \
+            --field image_type=jvm \
+            --field kafka_url="${{ inputs.kafka_url }}"
+
+          if [ $? -ne 0 ]; then
+            echo "Failed to trigger workflow"
+            exit 1
+          fi
+
+          echo "Waiting for workflow to start..."
+          sleep 20
+
+          # Get the run ID of the triggered workflow
+          run_id=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow=docker_build_and_test.yml \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          echo "Watching workflow run: $run_id"
+          gh run watch $run_id --repo ${{ github.repository }} --exit-status
+
+  test-native:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Trigger Docker Build Test for Native
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Triggering Docker Build Test workflow for Native..."
+          gh workflow run docker_build_and_test.yml \
+            --repo ${{ github.repository }} \
+            --ref ${{ github.ref_name }} \
+            --field image_type=native \
+            --field kafka_url="${{ inputs.kafka_url }}"
+
+          if [ $? -ne 0 ]; then
+            echo "Failed to trigger workflow"
+            exit 1
+          fi
+
+          echo "Waiting for workflow to start..."
+          sleep 20
+
+          # Get the run ID of the triggered workflow
+          run_id=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow=docker_build_and_test.yml \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          echo "Watching workflow run: $run_id"
+          gh run watch $run_id --repo ${{ github.repository }} --exit-status
+
+  release-jvm:
+    needs: test-jvm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Trigger RC Release for JVM
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Triggering Build and Push Release Candidate Docker Image workflow for JVM..."
+          gh workflow run docker_rc_release.yml \
+            --repo ${{ github.repository }} \
+            --ref ${{ github.ref_name }} \
+            --field image_type=jvm \
+            --field kafka_url="${{ inputs.kafka_url }}" \
+            --field rc_docker_image="apache/kafka:${{ inputs.rc_version }}"
+
+          if [ $? -ne 0 ]; then
+            echo "Failed to trigger workflow"
+            exit 1
+          fi
+
+          echo "Waiting for workflow to start..."
+          sleep 20
+
+          # Get the run ID of the triggered workflow
+          run_id=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow=docker_rc_release.yml \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          echo "Watching workflow run: $run_id"
+          gh run watch $run_id --repo ${{ github.repository }} --exit-status
+
+  release-native:
+    needs: test-native
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Trigger RC Release for Native
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Triggering Build and Push Release Candidate Docker Image workflow for Native..."
+          gh workflow run docker_rc_release.yml \
+            --repo ${{ github.repository }} \
+            --ref ${{ github.ref_name }} \
+            --field image_type=native \
+            --field kafka_url="${{ inputs.kafka_url }}" \
+            --field rc_docker_image="apache/kafka-native:${{ inputs.rc_version }}"
+
+          if [ $? -ne 0 ]; then
+            echo "Failed to trigger workflow"
+            exit 1
+          fi
+
+          echo "Waiting for workflow to start..."
+          sleep 20
+
+          # Get the run ID of the triggered workflow
+          run_id=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow=docker_rc_release.yml \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          echo "Watching workflow run: $run_id"
+          gh run watch $run_id --repo ${{ github.repository }} --exit-status
+
+  verify-dockerhub:
+    needs: [release-jvm, release-native]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify JVM image on DockerHub
+        run: |
+          echo "Verifying apache/kafka:${{ inputs.rc_version }} on DockerHub..."
+
+          # Wait a bit for DockerHub to update
+          sleep 30
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/apache/kafka/tags/${{ inputs.rc_version }}")
+
+          if [ "$response" = "200" ]; then
+            echo "✓ apache/kafka:${{ inputs.rc_version }} found on DockerHub"
+          else
+            echo "✗ apache/kafka:${{ inputs.rc_version }} not found on DockerHub (HTTP $response)"
+            exit 1
+          fi
+
+      - name: Verify Native image on DockerHub
+        run: |
+          echo "Verifying apache/kafka-native:${{ inputs.rc_version }} on DockerHub..."
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/apache/kafka-native/tags/${{ inputs.rc_version }}")
+
+          if [ "$response" = "200" ]; then
+            echo "✓ apache/kafka-native:${{ inputs.rc_version }} found on DockerHub"
+          else
+            echo "✗ apache/kafka-native:${{ inputs.rc_version }} not found on DockerHub (HTTP $response)"
+            exit 1
+          fi
+
+      - name: Summary
+        run: |
+          echo "================================"
+          echo "Docker RC Automation Complete! ✓"
+          echo "================================"
+          echo ""
+          echo "Images published:"
+          echo "  - apache/kafka:${{ inputs.rc_version }}"
+          echo "  - apache/kafka-native:${{ inputs.rc_version }}"
+          echo ""
+          echo "View on DockerHub:"
+          echo "  - https://hub.docker.com/r/apache/kafka/tags?name=${{ inputs.rc_version }}"
+          echo "  - https://hub.docker.com/r/apache/kafka-native/tags?name=${{ inputs.rc_version }}"

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,10 +21,28 @@ Repository Setup
 
 Make sure the `DOCKERHUB_USER` and `DOCKERHUB_TOKEN` secrets are added and made available to Github Actions in Github Repository settings. This is required for pushing the docker image.
 
+Automating Docker RC Creation (Recommended)
+--------------------------------------------
+
+- This is the **recommended and automated way** to create Docker Release Candidate images.
+- Go to `Automate Docker RC Creation` Github Actions Workflow.
+- Provide the `kafka_url` and `rc_version`. The workflow will automatically:
+  1. Build and test both JVM and Native images in parallel
+  2. If tests pass, build and push RC images to DockerHub for both image types
+  3. Verify that the images are available on DockerHub
+- Example:-
+```
+kafka_url: https://archive.apache.org/dist/kafka/3.8.0/kafka_2.13-3.8.0.tgz
+rc_version: 3.8.0-rc0
+```
+- This will create and verify:
+  - `apache/kafka:3.8.0-rc0`
+  - `apache/kafka-native:3.8.0-rc0`
+
 Building image and running tests using github actions
 ----------------------------------------------------
 
-- This is the recommended way to build, test and get a CVE report for the docker image.
+- This is the manual way to build, test and get a CVE report for individual docker images.
 - Just choose the image type and provide kafka url to `Docker Build Test` workflow. It will generate a test report and CVE report that can be shared with the community.
 
 - kafka-url - This is the url to download kafka tarball from. For example kafka tarball url from [Kafka archive](https://archive.apache.org/dist/kafka). For building RC image this will be an RC tarball url.


### PR DESCRIPTION
### Summary
Automates the Docker Release Candidate (RC) creation process.

Currently, release managers have to manually trigger four separate workflows. 
This PR chains them into a single pipeline that:

1. Builds/Tests JVM and Native images in parallel.
2. Pushes RC images to DockerHub upon success.
3. Verifies tags on DockerHub.

### Changes
- Added `.github/workflows/docker_rc_automation.yml`: New workflow to orchestrate the pipeline.
- Updated `docker/README.md`

### Implementation Details
Uses GitHub CLI (`gh`) to orchestrate existing workflows:
- Triggers `docker_build_and_test.yml` for both JVM and native.
- Once passed, triggers `docker_rc_release.yml` for pushing images.
- Finally, verifies the tags via DockerHub API.
- Uses `gh run watch --exit-status` to propagate failures correctly.

### Testing
- Validated the orchestration logic (triggering & watching) in my forked repository.
- Note: Full E2E testing wasn't possible as I don't have access to `DOCKERHUB_TOKEN` secrets.

### Related Issue
Resolves KAFKA-20087(https://issues.apache.org/jira/browse/KAFKA-20087)

Thanks!!