### PR TITLE
KAFKA-17999: Fix flaky DynamicConnectionQuotaTest testDynamicConnectionQuota

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1385,6 +1385,11 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
     connectionRatePerIp.getOrDefault(ip, defaultConnectionRatePerIp)
   }
 
+  // Visible for testing
+  private[network] def maxConnectionsPerIpOverrideForIp(ip: InetAddress): Option[Int] = {
+    maxConnectionsPerIpOverrides.get(ip)
+  }
+
   private[network] def addListener(config: KafkaConfig, listenerName: ListenerName): Unit = {
     counts.synchronized {
       if (!maxConnectionsPerListener.contains(listenerName)) {

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1386,6 +1386,11 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   }
 
   // Visible for testing
+  private[network] def maxConnectionsPerIpForIp(ip: InetAddress): Int = {
+    maxConnectionsPerIpOverrides.getOrElse(ip, defaultMaxConnectionsPerIp)
+  }
+  
+  // Visible for testing
   private[network] def maxConnectionsPerIpOverrideForIp(ip: InetAddress): Option[Int] = {
     maxConnectionsPerIpOverrides.get(ip)
   }

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -103,7 +103,14 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     val maxConnectionsPerIPOverride = 7
     props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride")
     reconfigureServers(props, perBrokerConfig = false, (SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride"))
-    waitForMaxConnectionsOverrideApplied("localhost", maxConnectionsPerIPOverride)
+    
+    val localhostAddr = InetAddress.getByName("localhost")
+    val quotas = brokers.head.socketServer.connectionQuotas
+    TestUtils.waitUntilTrue(
+      () => quotas.maxConnectionsPerIpOverrideForIp(localhostAddr).contains(maxConnectionsPerIPOverride),
+      s"maxConnectionsPerIpOverrides not applied yet for ip=localhost (expected=$maxConnectionsPerIPOverride, " +
+        s"current=${quotas.maxConnectionsPerIpOverrideForIp(localhostAddr)})"
+    )
 
     verifyMaxConnections(maxConnectionsPerIPOverride, connectAndVerify)
   }
@@ -414,16 +421,5 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
       new ClientQuotaAlteration(entity, ops)
     }.asJavaCollection
     adminClient.alterClientQuotas(entries)
-  }
-
-  private def waitForMaxConnectionsOverrideApplied(ip: String, expected: Int): Unit = {
-    val addr = InetAddress.getByName(ip)
-    val quotas = brokers.head.socketServer.connectionQuotas
-
-    TestUtils.waitUntilTrue(
-      () => quotas.maxConnectionsPerIpOverrideForIp(addr).contains(expected),
-      s"maxConnectionsPerIpOverrides not applied yet for ip=$ip (expected=$expected, current=${quotas.maxConnectionsPerIpOverrideForIp(addr)})",
-      50000
-    )
   }
 }

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -83,6 +83,8 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
   @Test
   def testDynamicConnectionQuota(): Unit = {
     val maxConnectionsPerIP = 5
+    val localhostAddr = InetAddress.getByName("localhost")
+    val quotas = brokers.head.socketServer.connectionQuotas
 
     def connectAndVerify(): Unit = {
       val socket = connect()
@@ -97,6 +99,11 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_CONFIG, maxConnectionsPerIP.toString)
     reconfigureServers(props, perBrokerConfig = false, (SocketServerConfigs.MAX_CONNECTIONS_PER_IP_CONFIG, maxConnectionsPerIP.toString))
 
+    TestUtils.waitUntilTrue(
+      () => quotas.maxConnectionsPerIpForIp(localhostAddr) == maxConnectionsPerIP,
+      s"maxConnectionsPerIp not applied yet for ip=localhost (expected=$maxConnectionsPerIP, current=${quotas.maxConnectionsPerIpForIp(localhostAddr)})"
+    )
+    
     verifyMaxConnections(maxConnectionsPerIP, connectAndVerify)
 
     // Increase MaxConnectionsPerIpOverrides for localhost to 7
@@ -104,8 +111,6 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride")
     reconfigureServers(props, perBrokerConfig = false, (SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride"))
     
-    val localhostAddr = InetAddress.getByName("localhost")
-    val quotas = brokers.head.socketServer.connectionQuotas
     TestUtils.waitUntilTrue(
       () => quotas.maxConnectionsPerIpOverrideForIp(localhostAddr).contains(maxConnectionsPerIPOverride),
       s"maxConnectionsPerIpOverrides not applied yet for ip=localhost (expected=$maxConnectionsPerIPOverride, " +

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -29,7 +29,6 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.record.internal.{MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.{ProduceRequest, ProduceResponse}
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.test.api.Flaky
 import org.apache.kafka.common.{KafkaException, Uuid, requests}
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.server.config.QuotaConfig
@@ -81,7 +80,6 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     }
   }
 
-  @Flaky("KAFKA-17999")
   @Test
   def testDynamicConnectionQuota(): Unit = {
     val maxConnectionsPerIP = 5
@@ -105,7 +103,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     val maxConnectionsPerIPOverride = 7
     props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride")
     reconfigureServers(props, perBrokerConfig = false, (SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride"))
-    waitForMaxConnectionsOverrideApplied("127.0.0.1", maxConnectionsPerIPOverride)
+    waitForMaxConnectionsOverrideApplied("localhost", maxConnectionsPerIPOverride)
 
     verifyMaxConnections(maxConnectionsPerIPOverride, connectAndVerify)
   }

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -105,6 +105,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     val maxConnectionsPerIPOverride = 7
     props.put(SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride")
     reconfigureServers(props, perBrokerConfig = false, (SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG, s"localhost:$maxConnectionsPerIPOverride"))
+    waitForMaxConnectionsOverrideApplied("127.0.0.1", maxConnectionsPerIPOverride)
 
     verifyMaxConnections(maxConnectionsPerIPOverride, connectAndVerify)
   }
@@ -415,5 +416,16 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
       new ClientQuotaAlteration(entity, ops)
     }.asJavaCollection
     adminClient.alterClientQuotas(entries)
+  }
+
+  private def waitForMaxConnectionsOverrideApplied(ip: String, expected: Int): Unit = {
+    val addr = InetAddress.getByName(ip)
+    val quotas = brokers.head.socketServer.connectionQuotas
+
+    TestUtils.waitUntilTrue(
+      () => quotas.maxConnectionsPerIpOverrideForIp(addr).contains(expected),
+      s"maxConnectionsPerIpOverrides not applied yet for ip=$ip (expected=$expected, current=${quotas.maxConnectionsPerIpOverrideForIp(addr)})",
+      50000
+    )
   }
 }


### PR DESCRIPTION
### Summary
- Fix flakiness in
`DynamicConnectionQuotaTest#testDynamicConnectionQuota` by waiting until
the broker’s `max.connections.per.ip.overrides` is actually applied in
`ConnectionQuotas` before running the second verification.
- Fixes https://issues.apache.org/jira/browse/KAFKA-17999

### Background

`testDynamicConnectionQuota` dynamically updates
`max.connections.per.ip.overrides` from 5 to 7 and immediately starts
`verifyMaxConnections(7, ...)`.

In practice, the config update is propagated asynchronously: the broker
`SocketServer` reconfigure is triggered, but there is a short window
where the data-plane acceptor still evaluates new connections using the
old override state(i.e, 5). This can cause one of the “prefill” sockets
in the second verification to be rejected under `max=5`, breaking the
test’s assumptions and leading to intermittent failures.

### Changes
- Add a test-only accessor in `ConnectionQuotas` to check whether an
override for a given IP is present.
- In `DynamicConnectionQuotaTest`, after altering
`max.connections.per.ip.overrides`, wait until the broker’s
`ConnectionQuotas` observes 127.0.0.1 -> 7 before executing the second
`verifyMaxConnections(...)`.

### Reproduction / Verification
- Before: intermittent failures observed in `testDynamicConnectionQuota`
when the override was not yet applied during the second verification.
- After: repeated runs show the second verification consistently sees
max=7 and the test becomes deterministic.

### Test Fail Ratio in my local.
- Before : 7/50 ~= 13%
- After : 0/500 ~= 0%

### Flaky / Success diagram
<img width="1568" height="730" alt="fail-1"
src="https://github.com/user-attachments/assets/e41d9a56-7140-49ee-89c9-c4b076b9fbf2"
/>

Reviewers: Mickael Maison <mimaison@users.noreply.github.com>, Mickael
 Maison <mimaison@apache.org>
