### PR TITLE
KAFKA-20080: Add test case for duplicate ports with different hostnames in KafkaConfigTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -211,6 +211,10 @@ class KafkaConfigTest {
     props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "PLAINTEXT://localhost:9091,SSL://localhost:9091")
     assertBadConfigContainingMessage(props, "Each listener must have a different port")
 
+    // listeners with duplicate port but different hostnames
+    props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "PLAINTEXT://host1:9092,SSL://host2:9092")
+    assertBadConfigContainingMessage(props, "Each listener must have a different port")
+
     // listeners with duplicate name
     props.setProperty(SocketServerConfigs.LISTENERS_CONFIG, "PLAINTEXT://localhost:9091,PLAINTEXT://localhost:9092")
     assertBadConfigContainingMessage(props, "Each listener must have a different name")


### PR DESCRIPTION
### Description
As described in
[KAFKA-20080](https://issues.apache.org/jira/browse/KAFKA-20080), the
configuration "PLAINTEXT://host1:9092,SSL://host2:9092" should fail
validation due to duplicate ports, but we currently lack a unit test for
this specific case.

This PR adds the missing test case to `KafkaConfigTest`.

### Verification
Ran the specific test using Gradle:
`./gradlew :core:test --tests
"kafka.server.KafkaConfigTest.testDuplicateListeners"`

**Output:**
```
Gradle Test Run :core:test > Gradle Test Executor 3 > KafkaConfigTest >
testDuplicateListeners() PASSED
```

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
