### PR TITLE
Invoke OffsetCommitCallback immediately on commit failure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1113,7 +1113,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             @Override
             public void onFailure(RuntimeException e) {
                 inFlightAsyncCommits.decrementAndGet();
-
+                if (callback != null) {
+                    callback.onComplete(offsets, e);
+                }
                 Exception commitException = e;
 
                 if (e instanceof RetriableException) {


### PR DESCRIPTION
What’s the problem:
- When commitOffsetsAsync fails, the client callback sometimes doesn’t get called.
  This can leave clients hanging, not knowing their commit actually failed.

What’s the fix:
- In doCommitOffsetsAsync.onFailure, call the provided OffsetCommitCallback immediately if it’s not null.
- This ensures clients are always notified about commit failures, fixing KAFKA-10489.

Things to note:
- Rare edge case: if a rebalance happens while a commit is in flight, the callback might be triggered twice.
- Overall, this is safer than the current behavior where clients might never hear about the failure.
