### PR TITLE
KAFKA-20093 Do not set KAFKA_URL as ENV in Docker

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -23,8 +23,6 @@ USER root
 # Get kafka from https://archive.apache.org/dist/kafka and pass the url through build arguments
 ARG kafka_url
 
-ENV KAFKA_URL=$kafka_url
-
 COPY jsa_launch /etc/kafka/docker/jsa_launch
 COPY server.properties /etc/kafka/docker/server.properties
 
@@ -35,10 +33,10 @@ RUN set -eux ; \
     apk upgrade ; \
     apk add --no-cache bash; \
     mkdir opt/kafka; \
-    if [ -n "$KAFKA_URL" ]; then \
+    if [ -n "$kafka_url" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent procps; \
-        wget -nv -O kafka.tgz "$KAFKA_URL"; \
-        wget -nv -O kafka.tgz.asc "$KAFKA_URL.asc"; \
+        wget -nv -O kafka.tgz "$kafka_url"; \
+        wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
         wget -nv -O KEYS https://downloads.apache.org/kafka/KEYS; \
         tar xfz kafka.tgz -C opt/kafka --strip-components 1; \
         gpg --import KEYS; \
@@ -62,8 +60,6 @@ USER root
 ARG kafka_url
 ARG build_date
 
-ENV KAFKA_URL=$kafka_url
-
 COPY *kafka.tgz kafka.tgz
 
 LABEL org.label-schema.name="kafka" \
@@ -77,10 +73,10 @@ RUN mkdir opt/kafka; \
     apk update ; \
     apk upgrade ; \
     apk add --no-cache bash; \
-    if [ -n "$KAFKA_URL" ]; then \
+    if [ -n "$kafka_url" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent procps; \
-        wget -nv -O kafka.tgz "$KAFKA_URL"; \
-        wget -nv -O kafka.tgz.asc "$KAFKA_URL.asc"; \
+        wget -nv -O kafka.tgz "$kafka_url"; \
+        wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
         tar xfz kafka.tgz -C /opt/kafka --strip-components 1; \
         wget -nv -O KEYS https://downloads.apache.org/kafka/KEYS; \
         gpg --import KEYS; \

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -19,7 +19,6 @@ ARG kafka_url
 
 WORKDIR /app
 
-ENV KAFKA_URL=$kafka_url
 ENV NATIVE_IMAGE_PATH="native-image"
 ENV KAFKA_DIR="/app/kafka"
 ENV NATIVE_CONFIGS_DIR="/app/native-image-configs"
@@ -31,10 +30,10 @@ COPY native_command.sh native_command.sh
 
 COPY *kafka.tgz /app
 
-RUN if [ -n "$KAFKA_URL" ]; then \
+RUN if [ -n "$kafka_url" ]; then \
         microdnf install wget; \
-        wget -nv -O kafka.tgz "$KAFKA_URL"; \
-        wget -nv -O kafka.tgz.asc "$KAFKA_URL.asc"; \
+        wget -nv -O kafka.tgz "$kafka_url"; \
+        wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
         wget -nv -O KEYS https://downloads.apache.org/kafka/KEYS; \
         gpg --import KEYS; \
         gpg --batch --verify kafka.tgz.asc kafka.tgz; \


### PR DESCRIPTION
When creating a JVM Docker image for Kafka, due to recent(ish) changes
in the Dockerfile, we set KAFKA_URL as an environment variable. This
bakes the environment variable within the Docker image itself. In turn,
this causes a faulty server.properties to be generated, which only
contains a url=<URL> entry.

This PR reverts to using an ARG.

Building the Docker image locally and starting a container from it using
https://hub.docker.com/r/apache/kafka#quick-start no longer exhibits the
ENV.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
