### PR TITLE
MINOR: Remove debug print within testFileDoesNotExist

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/CachedFileTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/CachedFileTest.java
@@ -110,8 +110,6 @@ public class CachedFileTest extends OAuthBearerTest {
         assertThrows(KafkaException.class, cachedFile::contents);
         assertThrows(KafkaException.class, cachedFile::transformed);
 
-        System.out.println("yo");
-
         // "Restore" the file and make sure it's refreshed.
         Utils.sleep(10);
         Files.writeString(tmpFile.toPath(), "valid data!", StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);


### PR DESCRIPTION
This PR deletes un-necessary debug print within test (i.e.,
`testFileDoesNotExist`)

Reviewers: TengYao Chi <kitingiao@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Chih-Yuan Chien <joshua2519@gmail.com>, Ryan
 Huang <hcr@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
