### PR TITLE
MINOR: update KIP-1071 docs for KafkaClientSupplier

### DIFF
--- a/docs/streams/developer-guide/streams-rebalance-protocol.md
+++ b/docs/streams/developer-guide/streams-rebalance-protocol.md
@@ -63,6 +63,8 @@ The following features are not yet available and should be avoided when using th
 
 * **Online Migration**: Group migration while the application is running is not available between the classic and new streams protocol.
 
+* **Custom Client Supplier**: Using a custom `KafkaClientSupplier` will only allow so provide restore/global consumer, producer, and admin client. It's not possible to provide the "main" consumer when "streams" groups are enabled. 
+
 # Why Use the Streams Rebalance Protocol?
 
 The Streams Rebalance Protocol offers several key advantages over the classic client-driven protocol:

--- a/docs/streams/developer-guide/streams-rebalance-protocol.md
+++ b/docs/streams/developer-guide/streams-rebalance-protocol.md
@@ -57,7 +57,7 @@ The following features are not yet available and should be avoided when using th
 
 * **Topology Updates**: If a topology is changed significantly (e.g., by adding new source topics or changing the number of subtopologies), a new streams group must be created.
 
-* **High Availability Assignor**: Only the sticky assignor is supported. This implies that "warmup tasks" are not supported yet.
+* **High Availability Assignor**: Only the sticky assignor is supported. This implies that "warmup tasks" and rack aware assignment are not supported yet.
 
 * **Regular Expressions**: Pattern-based topic subscription is not supported.
 


### PR DESCRIPTION
KafkaClientSupplier is not fully supported with "streams" group. This PR
adds a note to "not supported" features to the docs about it.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
