### PR TITLE
MINOR: Use more appropriate exception when validate builder parameters

### DIFF
--- a/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
@@ -148,13 +148,13 @@ public class LogManagerBuilder {
     }
 
     public LogManager build() {
-        if (logDirs == null) throw new RuntimeException("you must set logDirs");
-        if (configRepository == null) throw new RuntimeException("you must set configRepository");
-        if (initialDefaultConfig == null) throw new RuntimeException("you must set initialDefaultConfig");
-        if (cleanerConfig == null) throw new RuntimeException("you must set cleanerConfig");
-        if (scheduler == null) throw new RuntimeException("you must set scheduler");
-        if (brokerTopicStats == null) throw new RuntimeException("you must set brokerTopicStats");
-        if (logDirFailureChannel == null) throw new RuntimeException("you must set logDirFailureChannel");
+        if (logDirs == null) throw new IllegalStateException("you must set logDirs");
+        if (configRepository == null) throw new IllegalStateException("you must set configRepository");
+        if (initialDefaultConfig == null) throw new IllegalStateException("you must set initialDefaultConfig");
+        if (cleanerConfig == null) throw new IllegalStateException("you must set cleanerConfig");
+        if (scheduler == null) throw new IllegalStateException("you must set scheduler");
+        if (brokerTopicStats == null) throw new IllegalStateException("you must set brokerTopicStats");
+        if (logDirFailureChannel == null) throw new IllegalStateException("you must set logDirFailureChannel");
         return new LogManager(CollectionConverters.asScala(logDirs).toSeq(),
                               CollectionConverters.asScala(initialOfflineDirs).toSeq(),
                               configRepository,

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -100,10 +100,10 @@ public class ReplicaManagerBuilder {
 
     public ReplicaManager build() {
         if (config == null) config = new KafkaConfig(Map.of());
-        if (logManager == null) throw new RuntimeException("You must set logManager");
-        if (metadataCache == null) throw new RuntimeException("You must set metadataCache");
-        if (logDirFailureChannel == null) throw new RuntimeException("You must set logDirFailureChannel");
-        if (alterPartitionManager == null) throw new RuntimeException("You must set alterIsrManager");
+        if (logManager == null) throw new IllegalStateException("You must set logManager");
+        if (metadataCache == null) throw new IllegalStateException("You must set metadataCache");
+        if (logDirFailureChannel == null) throw new IllegalStateException("You must set logDirFailureChannel");
+        if (alterPartitionManager == null) throw new IllegalStateException("You must set alterIsrManager");
         if (brokerTopicStats == null) brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig().isRemoteStorageSystemEnabled());
         // Initialize metrics in the end just before passing it to ReplicaManager to ensure ReplicaManager closes the
         // metrics correctly. There might be a resource leak if it is initialized and an exception occurs between


### PR DESCRIPTION
This PR changes exception types to be more concrete when handling the
parameters of the builder. `IllegalStateException` is more semantically
appropriate here as it indicates the builder is in an invalid state,
i.e., missing pararmeter)

Reviewers: Matthias J. Sax <mjsax@apache.org>, David Arthur
 <mumrah@gmail.com>
