### PR TITLE
KAFKA-19877: Clarify ByteBuffer position and limit expectations for Deserializer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
@@ -94,6 +94,11 @@ public interface Deserializer<T> extends Closeable {
      *
      * <p>Similarly, if this method is overridden, the implementation cannot make any assumptions about the
      * passed in {@link ByteBuffer} either.
+     * 
+     * <p>The deserializer is expected to read data starting from the buffer's current position.
+     * Implementations may advance the buffer position by the number of bytes consumed during
+     * deserialization, but must not modify the buffer limit. Callers should not make assumptions
+     * about the buffer's position after deserialization and should treat the buffer as consumed.</p>
      *
      * <p>It is recommended to deserialize a {@code null} {@link ByteBuffer} to a {@code null} object.
      *


### PR DESCRIPTION
### Motivation

The Deserializer interface currently does not clearly specify how a `ByteBuffer`'s
`position` and `limit` should be treated during and after deserialization.
This ambiguity can lead to inconsistent implementations and incorrect assumptions
by callers.

### Changes

- Clarified the contract for `Deserializer#deserialize(String, Headers, ByteBuffer)`
  to state that implementations should read from the buffer’s current position,
  may advance the position by the number of bytes consumed, and must not modify
  the buffer limit.
- Documented that callers should not make assumptions about the buffer position
  after deserialization.

### Notes

This change is documentation-only and does not modify runtime behavior.
