### PR TITLE
KAFKA-20103 properties value assignment syntax changed to 'propName = value' (to comply with Gradle 10 requirements)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1276,7 +1276,7 @@ project(':core') {
       exclude('kafka-clients*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   task genProtocolErrorDocs(type: JavaExec) {
@@ -1380,7 +1380,7 @@ project(':core') {
     from "$rootDir/LICENSE"
     from "$rootDir/NOTICE"
     into 'site-docs'
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   tasks.create(name: "releaseTarGz", dependsOn: configurations.archives.artifacts, type: Tar) {
@@ -1425,7 +1425,7 @@ project(':core') {
     from(project(':streams:test-utils').configurations.runtimeClasspath) { into("libs/") }
     from(project(':streams:examples').jar) { into("libs/") }
     from(project(':streams:examples').configurations.runtimeClasspath) { into("libs/") }
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -1453,7 +1453,7 @@ project(':core') {
     //By default gradle does not handle test dependencies between the sub-projects
     //This line is to include clients project test jar to dependant-testlibs
     from (project(':clients').testJar ) { "${layout.buildDirectory.get().asFile.path}/dependant-testlibs" }
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   systemTestLibs.dependsOn('jar', 'testJar', 'copyDependantTestLibs')
@@ -2110,7 +2110,7 @@ project(':clients') {
   }
 
   jar {
-    enabled false
+    enabled = false
     dependsOn 'shadowJar'
   }
 
@@ -2728,7 +2728,7 @@ project(':tools') {
     }
     from (configurations.releaseOnly)
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -2785,7 +2785,7 @@ project(':trogdor') {
       exclude('kafka-clients*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -2829,7 +2829,7 @@ project(':shell') {
       include('jline-*jar')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -2923,7 +2923,7 @@ project(':streams') {
       exclude('kafka-clients*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   task createStreamsVersionFile() {
@@ -3035,7 +3035,7 @@ project(':streams:streams-scala') {
       exclude('kafka-streams*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3107,7 +3107,7 @@ project(':streams:test-utils') {
       exclude('kafka-streams*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3145,7 +3145,7 @@ project(':streams:examples') {
       exclude('kafka-streams*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs-${versions.scala}"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3671,7 +3671,7 @@ project(':connect:api') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3706,7 +3706,7 @@ project(':connect:transforms') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3744,7 +3744,7 @@ project(':connect:json') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3852,7 +3852,7 @@ project(':connect:runtime') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -3961,7 +3961,7 @@ project(':connect:file') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -4000,7 +4000,7 @@ project(':connect:basic-auth-extension') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {
@@ -4066,7 +4066,7 @@ project(':connect:mirror') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   task genMirrorConnectorConfigDocs(type: JavaExec) {
@@ -4128,7 +4128,7 @@ project(':connect:mirror-client') {
       exclude('connect-*')
     }
     into "${layout.buildDirectory.get().asFile.path}/dependant-libs"
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy = 'exclude'
   }
 
   jar {


### PR DESCRIPTION
:information_source: Note for reviewers: skip to this comment:
https://github.com/apache/kafka/pull/21373#issuecomment-5109008686  ___
Related link:
https://docs.gradle.org/9.6.1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

JIRA ticket: KAFKA-20103

Reviewers: Shivamrut <gshivamrut@gmail.com>, Mickael Maison
 <mickael.maison@gmail.com>
