### PR TITLE
MINOR: Fix thread safety issue in CoordinatorTimerImpl by using ConcurrentHashMap

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorTimerImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorTimerImpl.java
@@ -24,9 +24,9 @@ import org.apache.kafka.server.util.timer.TimerTask;
 
 import org.slf4j.Logger;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +42,7 @@ public class CoordinatorTimerImpl<U> implements CoordinatorTimer<U> {
     private final Logger log;
     private final Timer timer;
     private final CoordinatorShardScheduler<U> scheduler;
-    private final Map<String, TimerTask> tasks = new HashMap<>();
+    private final Map<String, TimerTask> tasks = new ConcurrentHashMap<>();
 
     public CoordinatorTimerImpl(
         LogContext logContext,


### PR DESCRIPTION
Fix thread safety issue in `CoordinatorTimerImpl` by using
`ConcurrentHashMap`.

Reviewers: Ken Huang <s7133700@gmail.com>, Sean Quah
 <squah@confluent.io>, Lianet Magrans
 <98415067+lianetm@users.noreply.github.com>
