### PR TITLE
KAFKA-20111: Handle pre-4.1 brokers in kafka-configs.sh for groups

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -386,7 +386,7 @@ object ConfigCommand extends Logging {
         case ClientMetricsType =>
           adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.CLIENT_METRICS), new ListConfigResourcesOptions).all().get().asScala.map(_.name).toSeq
         case GroupType =>
-          adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++ listGroupConfigResources(adminClient).map(resources => resources.asScala.map(_.name).toSet).getOrElse(Set() ++ entityName)
+          adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++ listGroupConfigResources(adminClient).map(resources => resources.asScala.map(_.name).toSet).getOrElse(Set.empty)
         case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
       })
 
@@ -538,12 +538,12 @@ object ConfigCommand extends Logging {
     try {
       Some(adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all.get)
     } catch {
-      // (KIP-1142) 4.1 and later admin client connecting to an older broker will not be able to list group config resources
+      // (KIP-1142) 4.1+ admin client vs older broker: treat UnsupportedVersionException as None
       case e: ExecutionException =>
         e.getCause match {
           case _: UnsupportedVersionException =>
             Option.empty
-          case _ => throw e
+          case cause => throw cause
         }
       case e: Throwable => throw e
     }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -539,7 +539,13 @@ object ConfigCommand extends Logging {
       adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all().get()
     } catch {
       // 4.1 and later admin client connecting to an older broker will not be able to list group config resources (KIP-1142)
-      case _: UnsupportedVersionException => java.util.Set.of()
+      case e: ExecutionException =>
+        e.getCause match {
+          case _: UnsupportedVersionException =>
+            java.util.Set.of()
+          case _ => throw e
+        }
+      case e: Throwable => throw e
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -539,13 +539,8 @@ object ConfigCommand extends Logging {
       Some(adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all.get)
     } catch {
       // (KIP-1142) 4.1+ admin client vs older broker: treat UnsupportedVersionException as None
-      case e: ExecutionException =>
-        e.getCause match {
-          case _: UnsupportedVersionException =>
-            Option.empty
-          case cause => throw cause
-        }
-      case e: Throwable => throw e
+      case e: ExecutionException if e.getCause.isInstanceOf[UnsupportedVersionException] => None
+      case e: ExecutionException => throw e.getCause
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -367,7 +367,7 @@ object ConfigCommand extends Logging {
               return
             }
           case GroupType =>
-            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) && listGroupConfigResources(adminClient).forall(resources => resources.stream.noneMatch(_.name == name))) {
+            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) && listGroupConfigResources(adminClient).exists(resources => resources.stream.noneMatch(_.name == name))) {
               System.out.println(s"The ${entityType.dropRight(1)} '$name' doesn't exist and doesn't have dynamic config.")
               return
             }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -367,9 +367,7 @@ object ConfigCommand extends Logging {
               return
             }
           case GroupType =>
-            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) &&
-              adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all.get
-                .stream.noneMatch(_.name == name)) {
+            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) && listGroupConfigResources(adminClient).stream.noneMatch(_.name == name)) {
               System.out.println(s"The ${entityType.dropRight(1)} '$name' doesn't exist and doesn't have dynamic config.")
               return
             }
@@ -388,8 +386,7 @@ object ConfigCommand extends Logging {
         case ClientMetricsType =>
           adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.CLIENT_METRICS), new ListConfigResourcesOptions).all().get().asScala.map(_.name).toSeq
         case GroupType =>
-          adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++
-            adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all().get().asScala.map(_.name).toSet
+          adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++ listGroupConfigResources(adminClient).asScala.map(_.name).toSet
         case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
       })
 
@@ -535,6 +532,15 @@ object ConfigCommand extends Logging {
     }
 
     adminClient.describeClientQuotas(ClientQuotaFilter.containsOnly(components.asJava)).entities.get(30, TimeUnit.SECONDS).asScala
+  }
+
+  private def listGroupConfigResources(adminClient: Admin): java.util.Collection[ConfigResource] = {
+    try {
+      adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all().get()
+    } catch {
+      // 4.1 and later admin client connecting to an older broker will not be able to list group config resources (KIP-1142)
+      case _: UnsupportedVersionException => java.util.Set.of()
+    }
   }
 
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -367,7 +367,7 @@ object ConfigCommand extends Logging {
               return
             }
           case GroupType =>
-            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) && listGroupConfigResources(adminClient).exists(resources => resources.stream.noneMatch(_.name == name))) {
+            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId == name) && listGroupConfigResources(adminClient).exists(resources => resources.stream.noneMatch(_.name == name))) {
               System.out.println(s"The ${entityType.dropRight(1)} '$name' doesn't exist and doesn't have dynamic config.")
               return
             }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -22,7 +22,7 @@ import kafka.utils.Implicits._
 import kafka.utils.Logging
 import org.apache.kafka.clients.admin.{Admin, AlterClientQuotasOptions, AlterConfigOp, AlterConfigsOptions, ConfigEntry, DescribeClusterOptions, DescribeConfigsOptions, ListConfigResourcesOptions, ListTopicsOptions, ScramCredentialInfo, UserScramCredentialDeletion, UserScramCredentialUpsertion, ScramMechanism => PublicScramMechanism}
 import org.apache.kafka.common.config.ConfigResource
-import org.apache.kafka.common.errors.{InvalidConfigurationException, UnsupportedVersionException}
+import org.apache.kafka.common.errors.{ClusterAuthorizationException, InvalidConfigurationException, UnsupportedVersionException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter, ClientQuotaFilterComponent}
@@ -538,8 +538,9 @@ object ConfigCommand extends Logging {
     try {
       Some(adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all.get)
     } catch {
-      // (KIP-1142) 4.1+ admin client vs older broker: treat UnsupportedVersionException as None
+      // (KIP-1142) 4.1+ admin client vs older broker: treat UnsupportedVersionException and ClusterAuthorizationException as None
       case e: ExecutionException if e.getCause.isInstanceOf[UnsupportedVersionException] => None
+      case e: ExecutionException if e.getCause.isInstanceOf[ClusterAuthorizationException] => None
       case e: ExecutionException => throw e.getCause
     }
   }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -367,7 +367,7 @@ object ConfigCommand extends Logging {
               return
             }
           case GroupType =>
-            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) && listGroupConfigResources(adminClient).stream.noneMatch(_.name == name)) {
+            if (adminClient.listGroups().all.get.stream.noneMatch(_.groupId() == name) && listGroupConfigResources(adminClient).forall(resources => resources.stream.noneMatch(_.name == name))) {
               System.out.println(s"The ${entityType.dropRight(1)} '$name' doesn't exist and doesn't have dynamic config.")
               return
             }
@@ -386,7 +386,7 @@ object ConfigCommand extends Logging {
         case ClientMetricsType =>
           adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.CLIENT_METRICS), new ListConfigResourcesOptions).all().get().asScala.map(_.name).toSeq
         case GroupType =>
-          adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++ listGroupConfigResources(adminClient).asScala.map(_.name).toSet
+          adminClient.listGroups().all.get.asScala.map(_.groupId).toSet ++ listGroupConfigResources(adminClient).map(resources => resources.asScala.map(_.name).toSet).getOrElse(Set() ++ entityName)
         case entityType => throw new IllegalArgumentException(s"Invalid entity type: $entityType")
       })
 
@@ -534,15 +534,15 @@ object ConfigCommand extends Logging {
     adminClient.describeClientQuotas(ClientQuotaFilter.containsOnly(components.asJava)).entities.get(30, TimeUnit.SECONDS).asScala
   }
 
-  private def listGroupConfigResources(adminClient: Admin): java.util.Collection[ConfigResource] = {
+  private def listGroupConfigResources(adminClient: Admin): Option[java.util.Collection[ConfigResource]] = {
     try {
-      adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all().get()
+      Some(adminClient.listConfigResources(java.util.Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions).all.get)
     } catch {
-      // 4.1 and later admin client connecting to an older broker will not be able to list group config resources (KIP-1142)
+      // (KIP-1142) 4.1 and later admin client connecting to an older broker will not be able to list group config resources
       case e: ExecutionException =>
         e.getCause match {
           case _: UnsupportedVersionException =>
-            java.util.Set.of()
+            Option.empty
           case _ => throw e
         }
       case e: Throwable => throw e

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
@@ -38,6 +38,7 @@ import org.apache.kafka.clients.admin.ListConfigResourcesResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
@@ -1440,6 +1441,33 @@ public class ConfigCommandTest {
         };
 
         ConfigCommand.describeConfig(mockAdminClient, describeOpts);
+        assertTrue(listedConfigResources.get());
+    }
+
+    @Test
+    public void testDescribeGroupConfigOldBrokerNotAuthorized() {
+        ConfigCommand.ConfigCommandOptions describeOpts = new ConfigCommand.ConfigCommandOptions(toArray("--bootstrap-server", "localhost:9092",
+            "--entity-type", "groups",
+            "--describe"));
+
+        KafkaFutureImpl<Collection<ConfigResource>> future = new KafkaFutureImpl<>();
+        ListConfigResourcesResult listConfigResourcesResult = mock(ListConfigResourcesResult.class);
+        when(listConfigResourcesResult.all()).thenReturn(future);
+
+        AtomicBoolean listedConfigResources = new AtomicBoolean(false);
+        Node node = new Node(1, "localhost", 9092);
+        MockAdminClient mockAdminClient = new MockAdminClient(List.of(node), node) {
+            @Override
+            public ListConfigResourcesResult listConfigResources(Set<ConfigResource.Type> configResourceTypes, ListConfigResourcesOptions options) {
+                ConfigResource.Type type = configResourceTypes.iterator().next();
+                assertEquals(ConfigResource.Type.GROUP, type);
+                future.completeExceptionally(new ClusterAuthorizationException("Not authorized to the cluster"));
+                listedConfigResources.set(true);
+                return listConfigResourcesResult;
+            }
+        };
+
+        assertThrows(ClusterAuthorizationException.class, () -> ConfigCommand.describeConfig(mockAdminClient, describeOpts));
         assertTrue(listedConfigResources.get());
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
@@ -1426,6 +1426,7 @@ public class ConfigCommandTest {
         ListConfigResourcesResult listConfigResourcesResult = mock(ListConfigResourcesResult.class);
         when(listConfigResourcesResult.all()).thenReturn(future);
 
+        AtomicBoolean listedConfigResources = new AtomicBoolean(false);
         Node node = new Node(1, "localhost", 9092);
         MockAdminClient mockAdminClient = new MockAdminClient(List.of(node), node) {
             @Override
@@ -1433,11 +1434,13 @@ public class ConfigCommandTest {
                 ConfigResource.Type type = configResourceTypes.iterator().next();
                 assertEquals(ConfigResource.Type.GROUP, type);
                 future.completeExceptionally(new UnsupportedVersionException("The v0 ListConfigResources only supports CLIENT_METRICS"));
+                listedConfigResources.set(true);
                 return listConfigResourcesResult;
             }
         };
 
         ConfigCommand.describeConfig(mockAdminClient, describeOpts);
+        assertTrue(listedConfigResources.get());
     }
 
     public static String[] toArray(String... first) {

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
@@ -33,10 +33,13 @@ import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeUserScramCredentialsOptions;
 import org.apache.kafka.clients.admin.DescribeUserScramCredentialsResult;
+import org.apache.kafka.clients.admin.ListConfigResourcesOptions;
+import org.apache.kafka.clients.admin.ListConfigResourcesResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -1413,6 +1416,30 @@ public class ConfigCommandTest {
         assertEquals("An entity name must be specified with --alter of groups", exception.getMessage());
     }
 
+    @Test
+    public void testDescribeGroupConfigOldBroker() {
+        ConfigCommand.ConfigCommandOptions describeOpts = new ConfigCommand.ConfigCommandOptions(toArray("--bootstrap-server", "localhost:9092",
+            "--entity-type", "groups",
+            "--describe"));
+
+        KafkaFutureImpl<Collection<ConfigResource>> future = new KafkaFutureImpl<>();
+        ListConfigResourcesResult listConfigResourcesResult = mock(ListConfigResourcesResult.class);
+        when(listConfigResourcesResult.all()).thenReturn(future);
+
+        Node node = new Node(1, "localhost", 9092);
+        MockAdminClient mockAdminClient = new MockAdminClient(List.of(node), node) {
+            @Override
+            public ListConfigResourcesResult listConfigResources(Set<ConfigResource.Type> configResourceTypes, ListConfigResourcesOptions options) {
+                ConfigResource.Type type = configResourceTypes.iterator().next();
+                assertEquals(ConfigResource.Type.GROUP, type);
+                future.completeExceptionally(new UnsupportedVersionException("The v0 ListConfigResources only supports CLIENT_METRICS"));
+                return listConfigResourcesResult;
+            }
+        };
+
+        ConfigCommand.describeConfig(mockAdminClient, describeOpts);
+    }
+
     public static String[] toArray(String... first) {
         return first;
     }
@@ -1461,6 +1488,11 @@ public class ConfigCommandTest {
         @Override
         public AlterClientQuotasResult alterClientQuotas(Collection<ClientQuotaAlteration> entries, AlterClientQuotasOptions options) {
             return mock(AlterClientQuotasResult.class);
+        }
+
+        @Override
+        public ListConfigResourcesResult listConfigResources(Set<ConfigResource.Type> configResourceTypes, ListConfigResourcesOptions options) {
+            return mock(ListConfigResourcesResult.class);
         }
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
@@ -1467,7 +1467,34 @@ public class ConfigCommandTest {
             }
         };
 
-        assertThrows(ClusterAuthorizationException.class, () -> ConfigCommand.describeConfig(mockAdminClient, describeOpts));
+        ConfigCommand.describeConfig(mockAdminClient, describeOpts);
+        assertTrue(listedConfigResources.get());
+    }
+
+    @Test
+    public void testDescribeGroupConfigOldBrokerUnexpectedException() {
+        ConfigCommand.ConfigCommandOptions describeOpts = new ConfigCommand.ConfigCommandOptions(toArray("--bootstrap-server", "localhost:9092",
+            "--entity-type", "groups",
+            "--describe"));
+
+        KafkaFutureImpl<Collection<ConfigResource>> future = new KafkaFutureImpl<>();
+        ListConfigResourcesResult listConfigResourcesResult = mock(ListConfigResourcesResult.class);
+        when(listConfigResourcesResult.all()).thenReturn(future);
+
+        AtomicBoolean listedConfigResources = new AtomicBoolean(false);
+        Node node = new Node(1, "localhost", 9092);
+        MockAdminClient mockAdminClient = new MockAdminClient(List.of(node), node) {
+            @Override
+            public ListConfigResourcesResult listConfigResources(Set<ConfigResource.Type> configResourceTypes, ListConfigResourcesOptions options) {
+                ConfigResource.Type type = configResourceTypes.iterator().next();
+                assertEquals(ConfigResource.Type.GROUP, type);
+                future.completeExceptionally(new InvalidConfigurationException("That was unexpected"));
+                listedConfigResources.set(true);
+                return listConfigResourcesResult;
+            }
+        };
+
+        assertThrows(InvalidConfigurationException.class, () -> ConfigCommand.describeConfig(mockAdminClient, describeOpts));
         assertTrue(listedConfigResources.get());
     }
 


### PR DESCRIPTION
KIP-1142 introduced `Admin.listConfigResources()` for listing resources
which have configurations, but which may not actually exist as run-time
entities such as consumer groups which have not yet had any members.
Internally, this works by using v1 of the `LIST_CONFIG_RESOURCES` RPC
which is only supported in AK 4.1 and later. As a result, if you try to
describe the config for groups with older brokers, they do not support
v1 of the RPC and fail with `UnsupportedVersionException`. This PR
handles the exception in the config tool since the exception is harmless
and gives the same behaviour as we used to get with earlier versions.

Reviewers: David Jacot <djacot@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
