### PR TITLE
MINOR: Add javadoc for ConfigDef.convertToString()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -790,6 +790,17 @@ public class ConfigDef {
         }
     }
 
+    /**
+     * Convert the provided object into a string based on its type.
+     * <p>
+     * This method uses Java's {@link #toString()} for {@link Type#BOOLEAN}, {@link Type#SHORT}, {@link Type#INT},
+     * {@link Type#LONG}, {@link Type#DOUBLE}, {@link Type#STRING} and {@link Type#PASSWORD} objects.
+     * For {@link Type#LIST} objects, Java's {@link #toString()} is used for each entry and entries are concatenated
+     * separated by commas. For {@link Type#CLASS} objects, {@link Class#getName()} is used.
+     * @param parsedValue The object to convert into a string
+     * @param type The type of the object
+     * @return The string representation of the provided object and type
+     */
     public static String convertToString(Object parsedValue, Type type) {
         if (parsedValue == null) {
             return null;

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -616,7 +616,10 @@ public class ConfigDefTest {
 
     @Test
     public void testConvertValueToStringDouble() {
-        assertEquals("3.125", ConfigDef.convertToString(3.125, Type.DOUBLE));
+        assertEquals("3.125", ConfigDef.convertToString(3.125d, Type.DOUBLE));
+        assertEquals("1.7976931348623157E308", ConfigDef.convertToString(Double.MAX_VALUE, Type.DOUBLE));
+        assertEquals("1.024E8",  ConfigDef.convertToString(102400000d, Type.DOUBLE));
+        assertEquals("-1.024E8",  ConfigDef.convertToString(-102400000d, Type.DOUBLE));
         assertNull(ConfigDef.convertToString(null, Type.DOUBLE));
     }
 


### PR DESCRIPTION
Also added test case for `convertToString()` with Double values to
highlight Java uses scientific notation for large (and small) values.

For example if you set `log.cleaner.io.max.bytes.per.second` to
`102400000` via the Admin API, when describing it, you get `1.024E8`
back, not `102400000`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
