### PR TITLE
KAFKA-13392 Resolve Timeout Exception triggering reassign partitions with --bootstrap-server option

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.tools.reassign;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -178,6 +181,7 @@ public class ReassignPartitionsCommand {
                 opts.options.has(opts.additionalOpt),
                 Utils.readFileAsString(opts.options.valueOf(opts.reassignmentJsonFileOpt)),
                 opts.options.valueOf(opts.interBrokerThrottleOpt),
+                opts.options.valueOf(opts.brokerListWithoutThrottleOpt),
                 opts.options.valueOf(opts.replicaAlterLogDirsThrottleOpt),
                 opts.options.valueOf(opts.timeoutOpt),
                 Time.SYSTEM,
@@ -752,21 +756,24 @@ public class ReassignPartitionsCommand {
     /**
      * The entry point for the --execute and --execute-additional commands.
      *
-     * @param adminClient                 The AdminClient to use.
-     * @param additional                  Whether --additional was passed.
-     * @param reassignmentJson            The JSON string to use for the topics to reassign.
-     * @param interBrokerThrottle         The inter-broker throttle to use, or a negative
-     *                                    number to skip using a throttle.
-     * @param logDirThrottle              The replica log directory throttle to use, or a
-     *                                    negative number to skip using a throttle.
-     * @param timeoutMs                   The maximum time in ms to wait for log directory
-     *                                    replica assignment to begin.
-     * @param time                        The Time object to use.
+     * @param adminClient                        The AdminClient to use.
+     * @param additional                         Whether --additional was passed.
+     * @param reassignmentJson                   The JSON string to use for the topics to reassign.
+     * @param interBrokerThrottle                The inter-broker throttle to use, or a negative
+     *                                           number to skip using a throttle.
+     * @param brokerListWithoutThrottleString    The brokerIds string to skip broker-level throttle
+     *                                           config updates for during reassignment.
+     * @param logDirThrottle                     The replica log directory throttle to use, or a
+     *                                           negative number to skip using a throttle.
+     * @param timeoutMs                          The maximum time in ms to wait for log directory
+     *                                           replica assignment to begin.
+     * @param time                               The Time object to use.
      */
     public static void executeAssignment(Admin adminClient,
                                          boolean additional,
                                          String reassignmentJson,
                                          long interBrokerThrottle,
+                                         String brokerListWithoutThrottleString,
                                          long logDirThrottle,
                                          long timeoutMs,
                                          Time time,
@@ -795,14 +802,19 @@ public class ReassignPartitionsCommand {
         if (interBrokerThrottle >= 0 || logDirThrottle >= 0) {
             System.out.println(YOU_MUST_RUN_VERIFY_PERIODICALLY_MESSAGE);
 
+            Set<Integer> brokerWithoutThrottleSet = new HashSet<>();
+            if (!brokerListWithoutThrottleString.isEmpty()) {
+                brokerWithoutThrottleSet = parseCommaSeparatedIntSet(brokerListWithoutThrottleString);
+            }
+
             if (interBrokerThrottle >= 0) {
                 Map<String, Map<Integer, PartitionMove>> moveMap = calculateProposedMoveMap(currentReassignments, proposedParts, currentParts);
-                modifyReassignmentThrottle(adminClient, moveMap, interBrokerThrottle);
+                modifyReassignmentThrottle(adminClient, moveMap, interBrokerThrottle, brokerWithoutThrottleSet);
             }
 
             if (logDirThrottle >= 0) {
                 Set<Integer> movingBrokers = calculateMovingBrokers(proposedReplicas.keySet());
-                modifyLogDirThrottle(adminClient, movingBrokers, logDirThrottle);
+                modifyLogDirThrottle(adminClient, movingBrokers, logDirThrottle, brokerWithoutThrottleSet);
             }
         }
 
@@ -825,6 +837,15 @@ public class ReassignPartitionsCommand {
         if (!proposedReplicas.isEmpty()) {
             executeMoves(adminClient, proposedReplicas, timeoutMs, time);
         }
+    }
+
+    private static Set<Integer> parseCommaSeparatedIntSet(String s) {
+        if (s == null || s.trim().isEmpty()) return Collections.emptySet();
+
+        return Arrays.stream(s.trim().split(","))
+                .filter(t -> !t.isEmpty())
+                .map(Integer::parseInt)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -1078,15 +1099,19 @@ public class ReassignPartitionsCommand {
     /**
      * Calculate the leader throttle configurations to use.
      *
-     * @param moveMap   The movements.
-     * @return          A map from topic names to leader throttle configurations.
+     * @param moveMap                     The movements.
+     * @param brokerWithoutThrottleSet    The brokerIds set to skip broker-level throttle
+     *      *                             config updates for during reassignment.
+     * @return                            A map from topic names to leader throttle configurations.
      */
-    static Map<String, String> calculateLeaderThrottles(Map<String, Map<Integer, PartitionMove>> moveMap) {
+    static Map<String, String> calculateLeaderThrottles(Map<String, Map<Integer, PartitionMove>> moveMap,
+                                                        Set<Integer> brokerWithoutThrottleSet) {
         Map<String, String> results = new HashMap<>();
         moveMap.forEach((topicName, partMoveMap) -> {
             Set<String> components = new TreeSet<>();
             partMoveMap.forEach((partId, move) ->
-                move.sources.forEach(source -> components.add(String.format("%d:%d", partId, source))));
+                move.sources.stream().filter(source -> !brokerWithoutThrottleSet.contains(source))
+                        .forEach(source -> components.add(String.format("%d:%d", partId, source))));
             results.put(topicName, String.join(",", components));
         });
         return results;
@@ -1095,16 +1120,19 @@ public class ReassignPartitionsCommand {
     /**
      * Calculate the follower throttle configurations to use.
      *
-     * @param moveMap   The movements.
-     * @return          A map from topic names to follower throttle configurations.
+     * @param moveMap                       The movements.
+     * @param brokerWithoutThrottleSet      The brokerIds set to skip broker-level throttle
+     *                                      config updates for during reassignment.
+     * @return                              A map from topic names to follower throttle configurations.
      */
-    static Map<String, String> calculateFollowerThrottles(Map<String, Map<Integer, PartitionMove>> moveMap) {
+    static Map<String, String> calculateFollowerThrottles(Map<String, Map<Integer, PartitionMove>> moveMap,
+                                                          Set<Integer> brokerWithoutThrottleSet) {
         Map<String, String> results = new HashMap<>();
         moveMap.forEach((topicName, partMoveMap) -> {
             Set<String> components = new TreeSet<>();
             partMoveMap.forEach((partId, move) ->
                 move.destinations.forEach(destination -> {
-                    if (!move.sources.contains(destination)) {
+                    if (!move.sources.contains(destination) && !brokerWithoutThrottleSet.contains(destination)) {
                         components.add(String.format("%d:%d", partId, destination));
                     }
                 })
@@ -1118,15 +1146,19 @@ public class ReassignPartitionsCommand {
     /**
      * Calculate all the brokers which are involved in the given partition reassignments.
      *
-     * @param moveMap       The partition movements.
-     * @return              A set of all the brokers involved.
+     * @param moveMap                     The partition movements.
+     * @param brokerWithoutThrottleSet    The brokerIds set to skip broker-level throttle
+     *                                    config updates for during reassignment.
+     * @return                            A set of all the brokers involved.
      */
-    static Set<Integer> calculateReassigningBrokers(Map<String, Map<Integer, PartitionMove>> moveMap) {
+    static Set<Integer> calculateReassigningBrokers(Map<String, Map<Integer, PartitionMove>> moveMap,
+                                                    Set<Integer> brokerWithoutThrottleSet) {
         Set<Integer> reassigningBrokers = new TreeSet<>();
         moveMap.values().forEach(partMoveMap -> partMoveMap.values().forEach(partMove -> {
             reassigningBrokers.addAll(partMove.sources);
             reassigningBrokers.addAll(partMove.destinations);
         }));
+        reassigningBrokers.removeAll(brokerWithoutThrottleSet);
         return reassigningBrokers;
     }
 
@@ -1171,13 +1203,14 @@ public class ReassignPartitionsCommand {
     private static void modifyReassignmentThrottle(
         Admin admin,
         Map<String, Map<Integer, PartitionMove>> moveMap,
-        long interBrokerThrottle
+        long interBrokerThrottle,
+        Set<Integer> brokerWithoutThrottleSet
     ) throws ExecutionException, InterruptedException {
-        Map<String, String> leaderThrottles = calculateLeaderThrottles(moveMap);
-        Map<String, String> followerThrottles = calculateFollowerThrottles(moveMap);
+        Map<String, String> leaderThrottles = calculateLeaderThrottles(moveMap, brokerWithoutThrottleSet);
+        Map<String, String> followerThrottles = calculateFollowerThrottles(moveMap, brokerWithoutThrottleSet);
         modifyTopicThrottles(admin, leaderThrottles, followerThrottles);
 
-        Set<Integer> reassigningBrokers = calculateReassigningBrokers(moveMap);
+        Set<Integer> reassigningBrokers = calculateReassigningBrokers(moveMap, brokerWithoutThrottleSet);
         modifyInterBrokerThrottle(admin, reassigningBrokers, interBrokerThrottle);
     }
 
@@ -1215,7 +1248,8 @@ public class ReassignPartitionsCommand {
      */
     static void modifyLogDirThrottle(Admin admin,
                                      Set<Integer> movingBrokers,
-                                     long logDirThrottle) throws ExecutionException, InterruptedException {
+                                     long logDirThrottle,
+                                     Set<Integer> brokerWithoutThrottleSet) throws ExecutionException, InterruptedException {
         if (logDirThrottle >= 0) {
             Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
             movingBrokers.forEach(brokerId -> {
@@ -1495,6 +1529,7 @@ public class ReassignPartitionsCommand {
             opts.bootstrapServerOpt,
             opts.commandConfigOpt,
             opts.interBrokerThrottleOpt,
+            opts.brokerListWithoutThrottleOpt,
             opts.replicaAlterLogDirsThrottleOpt,
             opts.timeoutOpt,
             opts.disallowReplicationFactorChangeOpt

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandOptions.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandOptions.java
@@ -35,6 +35,7 @@ public class ReassignPartitionsCommandOptions extends CommandDefaultOptions {
     final OptionSpec<String> reassignmentJsonFileOpt;
     final OptionSpec<String> topicsToMoveJsonFileOpt;
     final OptionSpec<String> brokerListOpt;
+    final OptionSpec<String> brokerListWithoutThrottleOpt;
     final OptionSpec<String> bootstrapControllerOpt;
     final OptionSpec<?> disableRackAware;
     final OptionSpec<Long> interBrokerThrottleOpt;
@@ -84,6 +85,15 @@ public class ReassignPartitionsCommandOptions extends CommandDefaultOptions {
                 " in the form \"0,1,2\". This is required if --topics-to-move-json-file is used to generate reassignment configuration")
             .withRequiredArg()
             .describedAs("brokerlist")
+            .ofType(String.class);
+
+        brokerListWithoutThrottleOpt = parser.accepts("broker-list-without-throttle", "Optional. Comma-separated broker ID list (e.g. 1,2) that " +
+                        "should be excluded from broker-level throttle config updates during partition reassignment execution. " +
+                        "When --execute and --throttle are used, it normally applies throttle configs on all brokers involved in the reassignment. " +
+                        "If any of those brokers are known to be down or unreachable, adding them to --broker-list-without-throttle makes it " +
+                        "skip the throttle-setting step for those brokers, avoiding retries/timeouts, while still throttling the remaining reachable brokers.")
+            .withRequiredArg()
+            .describedAs("broker list without throttle")
             .ofType(String.class);
 
         bootstrapControllerOpt = parser.accepts("bootstrap-controller", "The controller to use for reassignment. " +

--- a/tools/src/test/java/org/apache/kafka/tools/other/ReplicationQuotasTestRig.java
+++ b/tools/src/test/java/org/apache/kafka/tools/other/ReplicationQuotasTestRig.java
@@ -249,7 +249,7 @@ public class ReplicationQuotasTestRig {
 
             ReassignPartitionsCommand.executeAssignment(adminClient, false,
                 ReassignPartitionsCommand.formatAsReassignmentJson(newAssignment, Map.of()),
-                config.throttle, -1L, 10000L, Time.SYSTEM, false);
+                config.throttle, "", -1L, 10000L, Time.SYSTEM, false);
 
             //Await completion
             waitForReassignmentToComplete();

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommandTest.java
@@ -498,7 +498,7 @@ public class ReassignPartitionsCommandTest {
                             "bar-0: The replication factor is changed from 3 to 1\n" +
                             "foo-0: The replication factor is changed from 3 to 2\n" +
                             "foo-1: The replication factor is changed from 3 to 4",
-                    assertThrows(TerseException.class, () -> executeAssignment(admin, false, assignment, -1L, -1L, 10000L, Time.SYSTEM, true)).getMessage());
+                    assertThrows(TerseException.class, () -> executeAssignment(admin, false, assignment, -1L, "", -1L, 10000L, Time.SYSTEM, true)).getMessage());
         }
     }
 
@@ -757,7 +757,7 @@ public class ReassignPartitionsCommandTest {
                                       Long replicaAlterLogDirsThrottle) throws RuntimeException {
         try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
             executeAssignment(admin, additional, reassignmentJson,
-                    interBrokerThrottle, replicaAlterLogDirsThrottle, 10000L, Time.SYSTEM, false);
+                    interBrokerThrottle, "", replicaAlterLogDirsThrottle, 10000L, Time.SYSTEM, false);
         } catch (ExecutionException | InterruptedException | JsonProcessingException | TerseException e) {
             throw new RuntimeException(e);
         }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.tools.reassign;
 
+import java.util.LinkedHashSet;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.admin.PartitionReassignment;
@@ -566,16 +567,51 @@ public class ReassignPartitionsUnitTest {
         expLeaderThrottle.put("foo", "0:1,0:2,0:3,1:4,1:5,1:6,2:1,2:2,3:1,3:2,4:1,4:2,5:1,5:2");
         expLeaderThrottle.put("bar", "0:2,0:3,0:4");
 
-        assertEquals(expLeaderThrottle, calculateLeaderThrottles(moveMap));
+        assertEquals(expLeaderThrottle, calculateLeaderThrottles(moveMap, Collections.emptySet()));
+
+        // Exclude a subset of brokers(1,2)
+        expLeaderThrottle.put("foo", "0:3,1:4,1:5,1:6");
+        expLeaderThrottle.put("bar", "0:3,0:4");
+
+        Set<Integer> brokerWithoutThrottleSet = new LinkedHashSet<>(Arrays.asList(1, 2));
+        assertEquals(expLeaderThrottle, calculateLeaderThrottles(moveMap, brokerWithoutThrottleSet));
+
+        // Exclude a subset of brokers(2,3,4)
+        expLeaderThrottle.put("foo", "0:1,1:5,1:6,2:1,3:1,4:1,5:1");
+        expLeaderThrottle.put("bar", "");
+
+        brokerWithoutThrottleSet = new LinkedHashSet<>(Arrays.asList(2, 3, 4));
+        assertEquals(expLeaderThrottle, calculateLeaderThrottles(moveMap, brokerWithoutThrottleSet));
 
         Map<String, String> expFollowerThrottle = new HashMap<>();
 
         expFollowerThrottle.put("foo", "0:5,1:7,1:8,2:3,2:4,3:5,3:6,4:3,5:3,5:4,5:5,5:6");
         expFollowerThrottle.put("bar", "0:1");
 
-        assertEquals(expFollowerThrottle, calculateFollowerThrottles(moveMap));
+        assertEquals(expFollowerThrottle, calculateFollowerThrottles(moveMap, Collections.emptySet()));
 
-        assertEquals(Set.of(1, 2, 3, 4, 5, 6, 7, 8), calculateReassigningBrokers(moveMap));
+        // Exclude a subset of brokers(3,5)
+        expFollowerThrottle.put("foo", "1:7,1:8,2:4,3:6,5:4,5:6");
+        expFollowerThrottle.put("bar", "0:1");
+
+        brokerWithoutThrottleSet = new LinkedHashSet<>(Arrays.asList(3, 5));
+        assertEquals(expFollowerThrottle, calculateFollowerThrottles(moveMap, brokerWithoutThrottleSet));
+
+        // Exclude a subset of brokers(1)
+        expFollowerThrottle.put("foo", "0:5,1:7,1:8,2:3,2:4,3:5,3:6,4:3,5:3,5:4,5:5,5:6");
+        expFollowerThrottle.put("bar", "");
+
+        brokerWithoutThrottleSet = new LinkedHashSet<>(Collections.singletonList(1));
+        assertEquals(expFollowerThrottle, calculateFollowerThrottles(moveMap, brokerWithoutThrottleSet));
+
+        assertEquals(Set.of(1, 2, 3, 4, 5, 6, 7, 8), calculateReassigningBrokers(moveMap, Collections.emptySet()));
+        // Exclude a subset of brokers
+        assertEquals(Set.of(2, 3, 4, 5, 6, 7), calculateReassigningBrokers(moveMap, Set.of(1, 8)));
+        // Exclude all brokers (result should be empty)
+        assertEquals(Collections.emptySet(), calculateReassigningBrokers(moveMap, Set.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        // Exclude a broker that doesn’t exist in the reassignment (no change)
+        assertEquals(Set.of(1, 2, 3, 4, 5, 6, 7, 8), calculateReassigningBrokers(moveMap, Set.of(999)));
+
         assertEquals(Set.of(0, 2), calculateMovingBrokers(Set.of(
             new TopicPartitionReplica("quux", 0, 0),
             new TopicPartitionReplica("quux", 1, 2))));
@@ -644,7 +680,7 @@ public class ReassignPartitionsUnitTest {
                     "{\"version\":1,\"partitions\":" +
                         "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1],\"log_dirs\":[\"any\",\"any\"]}," +
                         "{\"topic\":\"quux\",\"partition\":0,\"replicas\":[2,3,4],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
-                        "]}", -1L, -1L, 10000L, Time.SYSTEM, false), "Expected reassignment with non-existent topic to fail").getCause().getMessage());
+                        "]}", -1L, "", -1L, 10000L, Time.SYSTEM, false), "Expected reassignment with non-existent topic to fail").getCause().getMessage());
         }
     }
 
@@ -657,7 +693,7 @@ public class ReassignPartitionsUnitTest {
                     "{\"version\":1,\"partitions\":" +
                         "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1],\"log_dirs\":[\"any\",\"any\"]}," +
                         "{\"topic\":\"foo\",\"partition\":1,\"replicas\":[2,3,4],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
-                        "]}", -1L, -1L, 10000L, Time.SYSTEM, false), "Expected reassignment with non-existent broker id to fail").getMessage());
+                        "]}", -1L, "", -1L, 10000L, Time.SYSTEM, false), "Expected reassignment with non-existent broker id to fail").getMessage());
         }
     }
 
@@ -800,7 +836,7 @@ public class ReassignPartitionsUnitTest {
         try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(4).build()) {
             addTopics(adminClient);
             assertStartsWith("Unexpected character",
-                assertThrows(AdminOperationException.class, () -> executeAssignment(adminClient, false, "{invalid_json", -1L, -1L, 10000L, Time.SYSTEM, false)).getMessage());
+                assertThrows(AdminOperationException.class, () -> executeAssignment(adminClient, false, "{invalid_json", -1L, "", -1L, 10000L, Time.SYSTEM, false)).getMessage());
         }
     }
 


### PR DESCRIPTION
This PR resolved the timeout exception triggering reassign partitions with --bootstrap-server option. More can be found https://issues.apache.org/jira/browse/KAFKA-13392.

**Root cause**
When we run a reassignment using a plan file (e.g. xxx.json), the plan may still include replicas on the down broker. During the execution, we try to apply throttling by calling `adminClient.incrementalAlterConfigs(configs)`. The issue is: this API needs to connect to the target broker to set the broker-level throttle configs.
If the broker is down, it’s obviously unreachable, so the client keeps retrying and eventually times out → TimeoutException.

**My proposed solution**
Add a new parameter: `--broker-list-without-throttle`
Description: Optional. Comma-separated broker ID list (e.g. 1,2) that should be excluded from broker-level throttle config updates during partition reassignment execution. When --execute and --throttle are used, it normally applies throttle configs on all brokers involved in the reassignment. If any of those brokers are known to be down or unreachable, adding them to --broker-list-without-throttle makes it skip the throttle-setting step for those brokers, avoiding retries/timeouts, while still throttling the remaining reachable brokers. 
Value: a list of broker IDs, comma-separated
Example: 1001 or 1001,1002
```/opt/kafka/bin/kafka-reassign-partitions.sh \
  --bootstrap-server xxx.xxx.xxx.xxx:9092 \
  --reassignment-json-file reassignment-test.json \
  --throttle 209715200 \
  --execute \
  --broker-list-without-throttle 1001
```
If broker 1001 is known to be down, and the reassignment plan includes it, then we exclude 1001 from throttle config changes.

**Why this is needed**
- If we don’t use '--throttle' at all, then Kafka won’t set throttle on any broker (including the down one). But that’s risky, migrations can easily blow up network bandwidth or disk IO.
- If we only skip throttling for the known down broker, it doesn’t change the reassignment logic itself, and it avoids the timeout. Meanwhile, healthy brokers still get throttled properly.
