### PR TITLE
MINOR: Update bootstrap-controller port in kraft.md example

### DIFF
--- a/docs/operations/kraft.md
+++ b/docs/operations/kraft.md
@@ -201,7 +201,7 @@ If the dynamic controller cluster already exists, it can be shrunk using the `bi
 When using controller endpoints use the --bootstrap-controller flag: 
     
     
-    $ bin/kafka-metadata-quorum.sh --bootstrap-controller localhost:9092 remove-controller --controller-id <id> --controller-directory-id <directory-id>
+    $ bin/kafka-metadata-quorum.sh --bootstrap-controller localhost:9093 remove-controller --controller-id <id> --controller-directory-id <directory-id>
 
 ## Debugging
 


### PR DESCRIPTION
The remove controller command was using port 9092 (broker port) instead
of port 9093 (controller port) so fixed it

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
