### PR TITLE
MINOR: Fixed typos in comments across multiple Java classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1479,7 +1479,7 @@ public class NetworkClient implements KafkaClient {
     // visible for testing
     int nextCorrelationId() {
         if (SaslClientAuthenticator.isReserved(correlation)) {
-            // the numeric overflow is fine as negative values is acceptable
+            // the numeric overflow is fine as negative values are acceptable
             correlation = SaslClientAuthenticator.MAX_RESERVED_CORRELATION_ID + 1;
         }
         return correlation++;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
@@ -53,7 +53,7 @@ public class DescribeClusterResult {
     /**
      * Returns a future which yields the current controller node.
      * <p>
-     * When using {@link AdminClientConfig#BOOTSTRAP_SERVERS_CONFIG}, the controller refer to a random broker.
+     * When using {@link AdminClientConfig#BOOTSTRAP_SERVERS_CONFIG}, the controller refers to a random broker.
      * When using {@link AdminClientConfig#BOOTSTRAP_CONTROLLERS_CONFIG}, it refers to the current voter leader.
      */
     public KafkaFuture<Node> controller() {

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -150,7 +150,7 @@ public class AbstractConfig {
     }
 
     /**
-     * Called directly after user configs got parsed (and thus default values is not set).
+     * Called directly after user configs got parsed (and thus default values are not set).
      * This allows to check user's config.
      *
      * @param parsedValues unmodifiable map of current configuration

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -519,7 +519,7 @@ public class ConfigDef {
         List<String> undefinedConfigKeys = undefinedDependentConfigs();
         if (!undefinedConfigKeys.isEmpty()) {
             String joined = undefinedConfigKeys.stream().map(String::toString).collect(Collectors.joining(","));
-            throw new ConfigException("Some configurations in are referred in the dependents, but not defined: " + joined);
+            throw new ConfigException("Some configurations are referred in the dependents but not defined: " + joined);
         }
         // parse all known keys
         Map<String, Object> values = new HashMap<>();

--- a/clients/src/main/java/org/apache/kafka/common/metrics/PluginMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/PluginMetrics.java
@@ -22,7 +22,7 @@ import java.util.LinkedHashMap;
 
 /**
  * This allows plugins to register metrics and sensors.
- * Any metrics registered by the plugin are automatically removed when the plugin  closed.
+ * Any metrics registered by the plugin are automatically removed when the plugin is closed.
  */
 public interface PluginMetrics {
 


### PR DESCRIPTION
Fixed typos in comments across multiple Java classes to stay consistent and high quality