### PR TITLE
MINOR: Upgrade jersey libraries to address CVE-2025-12383

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -297,12 +297,12 @@ hk2-utils-2.6.1
 osgi-resource-locator-1.0.3
 aopalliance-repackaged-2.6.1
 jakarta.inject-2.6.1
-jersey-client-2.39.1
-jersey-common-2.39.1
-jersey-container-servlet-2.39.1
-jersey-container-servlet-core-2.39.1
-jersey-hk2-2.39.1
-jersey-server-2.39.1
+jersey-client-2.47
+jersey-common-2.47
+jersey-container-servlet-2.47
+jersey-container-servlet-core-2.47
+jersey-hk2-2.47
+jersey-server-2.47
 
 ---------------------------------------
 CDDL 1.1 + GPLv2 with classpath exception

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,7 +101,7 @@ versions += [
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
   jetty: "9.4.57.v20241219",
-  jersey: "2.39.1",
+  jersey: "2.47",
   jline: "3.25.1",
   jmh: "1.37",
   hamcrest: "2.2",


### PR DESCRIPTION
This PR upgrades `jersey` libraries family from 2.39.1  to 2.46 to address [CVE-2025-12383](https://github.com/advisories/GHSA-7p63-w6x9-6gr7)

Note: while 2.39.1 is not listed as vulnerable - security scanners still may alert it as vulnerable

Reviewers: PoAn Yang <payang@apache.org>, Gaurav Narula <gaurav_narula2@apple.com>, Chia-Ping Tsai <chia7712@gmail.com>
