### PR TITLE
KAFKA-20115: Group coordinator fails to unload metadata when no longer leader or follower

### DIFF
--- a/checkstyle/import-control-clients-integration-tests.xml
+++ b/checkstyle/import-control-clients-integration-tests.xml
@@ -20,6 +20,7 @@
 
 <import-control pkg="org.apache.kafka">
     <allow pkg="java"/>
+    <allow pkg="javax.management"/>
     <allow pkg="org.junit"/>
 
     <!-- These are tests, allow whatever -->

--- a/checkstyle/import-control-clients-integration-tests.xml
+++ b/checkstyle/import-control-clients-integration-tests.xml
@@ -20,7 +20,6 @@
 
 <import-control pkg="org.apache.kafka">
     <allow pkg="java"/>
-    <allow pkg="javax.management"/>
     <allow pkg="org.junit"/>
 
     <!-- These are tests, allow whatever -->

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
@@ -38,11 +38,9 @@ import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics;
 import org.apache.kafka.test.TestUtils;
 
-import org.junit.jupiter.api.Assertions;
-
-import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
@@ -52,14 +50,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -357,8 +347,7 @@ public class ConsumerIntegrationTest {
             @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, value = "3000")
         }
     )
-    public void testSingleCoordinatorOwnershipAfterPartitionReassignment(ClusterInstance clusterInstance)
-        throws InterruptedException, ExecutionException, TimeoutException, MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException {
+    public void testSingleCoordinatorOwnershipAfterPartitionReassignment(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException, TimeoutException {
         try (var producer = clusterInstance.<byte[], byte[]>producer()) {
             producer.send(new ProducerRecord<>("topic", "value".getBytes(StandardCharsets.UTF_8)));
         }
@@ -374,40 +363,25 @@ public class ConsumerIntegrationTest {
             // append records to coordinator
             consumer.commitSync();
 
-            var numActivePartitions = (Long) ManagementFactory.getPlatformMBeanServer().getAttribute(
-                new ObjectName("kafka.server:type=group-coordinator-metrics,state=active"), "num-partitions");
-            // The num-partitions metric uses the same name for all brokers and is
-            // registered in the same JVM. Therefore, we infer the owning broker
-            // based on the number of active partitions.
-            // - activePartitions == 1 means metric belongs to broker 0 (partition 0 assigned)
-            // - activePartitions == 0 means metric belongs to broker 1
-            AtomicBoolean isMetricBelongsToFirstBroker = new AtomicBoolean();
-            if (numActivePartitions == 1L) {
-                isMetricBelongsToFirstBroker.set(true);
-            } else if (numActivePartitions == 0L) {
-                isMetricBelongsToFirstBroker.set(false);
-            } else {
-                Assertions.fail("Unexpected number of active partitions: " + numActivePartitions);
-            }
+            var broker0Metrics = clusterInstance.brokers().get(0).metrics();
+            var activeNumPartitions = broker0Metrics.metricName(
+                "num-partitions",
+                GroupCoordinatorRuntimeMetrics.METRICS_GROUP,
+                Map.of("state", "active")
+            );
+
+            assertEquals(1L, broker0Metrics.metric(activeNumPartitions).metricValue());
 
             // unload the coordinator by changing leader (0 -> 1)
-            admin.alterPartitionReassignments(Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0),
-                Optional.of(new NewPartitionReassignment(List.of(1))))
+            admin.alterPartitionReassignments(
+                Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0), Optional.of(new NewPartitionReassignment(List.of(1))))
             ).all().get();
 
             // Wait for the coordinator metrics to update after leadership change
-            TestUtils.waitForCondition(() -> {
-                // Since the partition leader has moved to broker 1:
-                // - If the metric belongs to broker 0, the active num-partitions value should be 0.
-                // - If the metric belongs to broker 1, the active num-partitions value should be 1.
-                var numPartitions = (Long) ManagementFactory.getPlatformMBeanServer().getAttribute(
-                    new ObjectName("kafka.server:type=group-coordinator-metrics,state=active"), "num-partitions");
-                if (isMetricBelongsToFirstBroker.get()) {
-                    return 0L == numPartitions;
-                } else {
-                    return 1L == numPartitions;
-                }
-            }, "incorrect num-partitions value after partition leader change");
+            TestUtils.waitForCondition(() ->
+                0L == (Long) broker0Metrics.metric(activeNumPartitions).metricValue(),
+                "Num-partitions metric should be 1 after partition reassignment to the new coordinator"
+            );
         }
     }
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
@@ -26,7 +26,9 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -35,9 +37,13 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
+import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.coordinator.group.GroupCoordinatorService;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.test.TestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +52,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -333,6 +341,50 @@ public class ConsumerIntegrationTest {
                     consumer2.assignment().equals(Set.of(new TopicPartition(topic, 0), new TopicPartition(topic, 1), new TopicPartition(topic, 2)));
             }, "Consumer with topic partition mapping should be 0 -> 5 | 1 -> 3, 4 | 2 -> 0, 1, 2");
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @ClusterTest(
+        brokers = 2,
+        types = {Type.KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, value = "3000")
+        }
+    )
+    public void testSingleCoordinatorOwnershipAfterPartitionReassignment(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException, TimeoutException {
+        try (var producer = clusterInstance.<byte[], byte[]>producer()) {
+            producer.send(new ProducerRecord<>("topic", "value".getBytes(StandardCharsets.UTF_8)));
+        }
+
+        try (var admin = clusterInstance.admin()) {
+            admin.createTopics(List.of(new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, Map.of(0, List.of(0))))).all().get();
+        }
+
+        try (var consumer = clusterInstance.consumer(Map.of(ConsumerConfig.GROUP_ID_CONFIG, "test-group"));
+             var admin = clusterInstance.admin()) {
+            consumer.subscribe(List.of("topic"));
+            TestUtils.waitForCondition(() -> consumer.poll(Duration.ofMillis(100)).isEmpty(), "polling to join group");
+            // append records to coordinator
+            consumer.commitSync();
+
+            // unload the coordinator by changing leader (0 -> 1)
+            admin.alterPartitionReassignments(Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0),
+                Optional.of(new NewPartitionReassignment(List.of(1))))).all().get();
+        }
+
+        Function<GroupCoordinator, List<TopicPartition>> partitionsInGroupMetrics = service -> assertDoesNotThrow(() -> {
+            var f0 = GroupCoordinatorService.class.getDeclaredField("groupCoordinatorMetrics");
+            f0.setAccessible(true);
+            var f1 = GroupCoordinatorMetrics.class.getDeclaredField("shards");
+            f1.setAccessible(true);
+            return List.copyOf(((Map<TopicPartition, ?>) f1.get(f0.get(service))).keySet());
+        });
+
+        // the offset partition should NOT be hosted by multiple coordinators
+        var tps = clusterInstance.brokers().values().stream()
+            .flatMap(b -> partitionsInGroupMetrics.apply(b.groupCoordinator()).stream()).toList();
+        assertEquals(1, tps.size());
     }
 
     private void sendMsg(ClusterInstance clusterInstance, String topic, int sendMsgNum) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
@@ -360,10 +360,11 @@ public class ConsumerIntegrationTest {
              var admin = clusterInstance.admin()) {
             consumer.subscribe(List.of("topic"));
             TestUtils.waitForCondition(() -> consumer.poll(Duration.ofMillis(100)).isEmpty(), "polling to join group");
-            // append records to coordinator
+            // Append records to coordinator.
             consumer.commitSync();
 
             var broker0Metrics = clusterInstance.brokers().get(0).metrics();
+            var broker1Metrics = clusterInstance.brokers().get(1).metrics();
             var activeNumPartitions = broker0Metrics.metricName(
                 "num-partitions",
                 GroupCoordinatorRuntimeMetrics.METRICS_GROUP,
@@ -371,16 +372,18 @@ public class ConsumerIntegrationTest {
             );
 
             assertEquals(1L, broker0Metrics.metric(activeNumPartitions).metricValue());
+            assertEquals(0L, broker1Metrics.metric(activeNumPartitions).metricValue());
 
-            // unload the coordinator by changing leader (0 -> 1)
+            // Unload the coordinator by changing leader (0 -> 1).
             admin.alterPartitionReassignments(
                 Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0), Optional.of(new NewPartitionReassignment(List.of(1))))
             ).all().get();
 
-            // Wait for the coordinator metrics to update after leadership change
+            // Wait for the coordinator metrics to update after leadership change.
             TestUtils.waitForCondition(() ->
-                0L == (Long) broker0Metrics.metric(activeNumPartitions).metricValue(),
-                "Num-partitions metric should be 1 after partition reassignment to the new coordinator"
+                0L == (Long) broker0Metrics.metric(activeNumPartitions).metricValue() &&
+                    1L == (Long) broker1Metrics.metric(activeNumPartitions).metricValue(),
+                "Incorrect num-partitions metric after partition reassignment to the new coordinator"
             );
         }
     }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
@@ -37,12 +37,12 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
-import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
-import org.apache.kafka.coordinator.group.GroupCoordinatorService;
-import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Assertions;
+
+import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
@@ -52,9 +52,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -343,7 +349,6 @@ public class ConsumerIntegrationTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @ClusterTest(
         brokers = 2,
         types = {Type.KRAFT},
@@ -352,7 +357,8 @@ public class ConsumerIntegrationTest {
             @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, value = "3000")
         }
     )
-    public void testSingleCoordinatorOwnershipAfterPartitionReassignment(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException, TimeoutException {
+    public void testSingleCoordinatorOwnershipAfterPartitionReassignment(ClusterInstance clusterInstance)
+        throws InterruptedException, ExecutionException, TimeoutException, MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException {
         try (var producer = clusterInstance.<byte[], byte[]>producer()) {
             producer.send(new ProducerRecord<>("topic", "value".getBytes(StandardCharsets.UTF_8)));
         }
@@ -368,23 +374,41 @@ public class ConsumerIntegrationTest {
             // append records to coordinator
             consumer.commitSync();
 
+            var numActivePartitions = (Long) ManagementFactory.getPlatformMBeanServer().getAttribute(
+                new ObjectName("kafka.server:type=group-coordinator-metrics,state=active"), "num-partitions");
+            // The num-partitions metric uses the same name for all brokers and is
+            // registered in the same JVM. Therefore, we infer the owning broker
+            // based on the number of active partitions.
+            // - activePartitions == 1 means metric belongs to broker 0 (partition 0 assigned)
+            // - activePartitions == 0 means metric belongs to broker 1
+            AtomicBoolean isMetricBelongsToFirstBroker = new AtomicBoolean();
+            if (numActivePartitions == 1L) {
+                isMetricBelongsToFirstBroker.set(true);
+            } else if (numActivePartitions == 0L) {
+                isMetricBelongsToFirstBroker.set(false);
+            } else {
+                Assertions.fail("Unexpected number of active partitions: " + numActivePartitions);
+            }
+
             // unload the coordinator by changing leader (0 -> 1)
             admin.alterPartitionReassignments(Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0),
-                Optional.of(new NewPartitionReassignment(List.of(1))))).all().get();
+                Optional.of(new NewPartitionReassignment(List.of(1))))
+            ).all().get();
+
+            // Wait for the coordinator metrics to update after leadership change
+            TestUtils.waitForCondition(() -> {
+                // Since the partition leader has moved to broker 1:
+                // - If the metric belongs to broker 0, the active num-partitions value should be 0.
+                // - If the metric belongs to broker 1, the active num-partitions value should be 1.
+                var numPartitions = (Long) ManagementFactory.getPlatformMBeanServer().getAttribute(
+                    new ObjectName("kafka.server:type=group-coordinator-metrics,state=active"), "num-partitions");
+                if (isMetricBelongsToFirstBroker.get()) {
+                    return 0L == numPartitions;
+                } else {
+                    return 1L == numPartitions;
+                }
+            }, "incorrect num-partitions value after partition leader change");
         }
-
-        Function<GroupCoordinator, List<TopicPartition>> partitionsInGroupMetrics = service -> assertDoesNotThrow(() -> {
-            var f0 = GroupCoordinatorService.class.getDeclaredField("groupCoordinatorMetrics");
-            f0.setAccessible(true);
-            var f1 = GroupCoordinatorMetrics.class.getDeclaredField("shards");
-            f1.setAccessible(true);
-            return List.copyOf(((Map<TopicPartition, ?>) f1.get(f0.get(service))).keySet());
-        });
-
-        // the offset partition should NOT be hosted by multiple coordinators
-        var tps = clusterInstance.brokers().values().stream()
-            .flatMap(b -> partitionsInGroupMetrics.apply(b.groupCoordinator()).stream()).toList();
-        assertEquals(1, tps.size());
     }
 
     private void sendMsg(ClusterInstance clusterInstance, String topic, int sendMsgNum) {

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -754,8 +754,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             timer.cancelAll();
             executor.cancelAll();
             deferredEventQueue.failAll(Errors.NOT_COORDINATOR.exception());
-            // There is no need to free the current batch, as we will be closing all related resources anyway.
-            failCurrentBatchWithoutRelease(Errors.NOT_COORDINATOR.exception());
+            failCurrentBatch(Errors.NOT_COORDINATOR.exception());
             if (coordinator != null) {
                 try {
                     coordinator.onUnloaded();
@@ -774,7 +773,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             currentBatch.lingerTimeoutTask.ifPresent(TimerTask::cancel);
 
             // Release the buffer only if it is not larger than the maxBatchSize.
-            int maxBatchSize = partitionWriter.config(tp).maxMessageSize();
+            int maxBatchSize = currentBatch.maxBatchSize;
 
             if (currentBatch.builder.buffer().capacity() <= maxBatchSize) {
                 bufferSupplier.release(currentBatch.builder.buffer());
@@ -880,23 +879,15 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             }
         }
 
-        private void failCurrentBatch(Throwable t) {
-            failCurrentBatch(t, true);
-        }
-
-        private void failCurrentBatchWithoutRelease(Throwable t) {
-            failCurrentBatch(t, false);
-        }
-
         /**
          * Fails the current batch, reverts to the snapshot to the base/start offset of the
          * batch, fails all the associated events.
          */
-        private void failCurrentBatch(Throwable t, boolean freeCurrentBatch) {
+        private void failCurrentBatch(Throwable t) {
             if (currentBatch != null) {
                 coordinator.revertLastWrittenOffset(currentBatch.baseOffset);
                 currentBatch.deferredEvents.complete(t);
-                if (freeCurrentBatch) freeCurrentBatch();
+                freeCurrentBatch();
             }
         }
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -754,7 +754,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             timer.cancelAll();
             executor.cancelAll();
             deferredEventQueue.failAll(Errors.NOT_COORDINATOR.exception());
-            failCurrentBatch(Errors.NOT_COORDINATOR.exception());
+            // There is no need to free the current batch, as we will be closing all related resources anyway.
+            failCurrentBatch(Errors.NOT_COORDINATOR.exception(), false);
             if (coordinator != null) {
                 try {
                     coordinator.onUnloaded();
@@ -880,14 +881,22 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         /**
+         * Convenience method to fail the current batch.
+         * See {@link #failCurrentBatch(Throwable, boolean)} for details.
+         */
+        private void failCurrentBatch(Throwable t) {
+            failCurrentBatch(t, true);
+        }
+
+        /**
          * Fails the current batch, reverts to the snapshot to the base/start offset of the
          * batch, fails all the associated events.
          */
-        private void failCurrentBatch(Throwable t) {
+        private void failCurrentBatch(Throwable t, boolean freeCurrentBatch) {
             if (currentBatch != null) {
                 coordinator.revertLastWrittenOffset(currentBatch.baseOffset);
                 currentBatch.deferredEvents.complete(t);
-                freeCurrentBatch();
+                if (freeCurrentBatch) freeCurrentBatch();
             }
         }
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -773,6 +773,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             currentBatch.lingerTimeoutTask.ifPresent(TimerTask::cancel);
 
             // Release the buffer only if it is not larger than the maxBatchSize.
+            // We avoid querying the log's configuration for the max message size here,
+            // because after a partition leadership change, this throws a NOT_LEADER_OR_FOLLOWER
+            // exception. Such exceptions can propagate unexpectedly and disrupt subsequent operations.
             int maxBatchSize = currentBatch.maxBatchSize;
 
             if (currentBatch.builder.buffer().capacity() <= maxBatchSize) {

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -755,7 +755,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             executor.cancelAll();
             deferredEventQueue.failAll(Errors.NOT_COORDINATOR.exception());
             // There is no need to free the current batch, as we will be closing all related resources anyway.
-            failCurrentBatch(Errors.NOT_COORDINATOR.exception(), false);
+            failCurrentBatchWithoutRelease(Errors.NOT_COORDINATOR.exception());
             if (coordinator != null) {
                 try {
                     coordinator.onUnloaded();
@@ -880,12 +880,12 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             }
         }
 
-        /**
-         * Convenience method to fail the current batch.
-         * See {@link #failCurrentBatch(Throwable, boolean)} for details.
-         */
         private void failCurrentBatch(Throwable t) {
             failCurrentBatch(t, true);
+        }
+
+        private void failCurrentBatchWithoutRelease(Throwable t) {
+            failCurrentBatch(t, false);
         }
 
         /**

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -719,20 +719,20 @@ public class CoordinatorRuntimeTest {
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
-                new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
-                        .withTime(timer.time())
-                        .withTimer(timer)
-                        .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
-                        .withLoader(new MockCoordinatorLoader())
-                        .withEventProcessor(new DirectEventProcessor())
-                        .withPartitionWriter(writer)
-                        .withCoordinatorShardBuilderSupplier(supplier)
-                        .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
-                        .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
-                        .withSerializer(new StringSerializer())
-                        .withAppendLingerMs(OptionalInt.of(10))
-                        .withExecutorService(mock(ExecutorService.class))
-                        .build();
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(supplier)
+                .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withSerializer(new StringSerializer())
+                .withAppendLingerMs(OptionalInt.of(10))
+                .withExecutorService(mock(ExecutorService.class))
+                .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
         when(builder.withLogContext(any())).thenReturn(builder);
@@ -746,8 +746,8 @@ public class CoordinatorRuntimeTest {
 
         // Configure the partition writer with a normal config initially.
         LogConfig initialLogConfig = new LogConfig(
-                Map.of(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, String.valueOf(1024 * 1024) // 1MB
-                ));
+            Map.of(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, String.valueOf(1024 * 1024)) // 1MB
+        );
         when(writer.config(TP)).thenReturn(initialLogConfig);
         when(writer.append(eq(TP), any(), any(), anyShort())).thenReturn(1L);
 
@@ -757,7 +757,7 @@ public class CoordinatorRuntimeTest {
 
         // Schedule a write operation to create a pending batch.
         CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
-                state -> new CoordinatorResult<>(List.of("record1"), "response1")
+            state -> new CoordinatorResult<>(List.of("record1"), "response1")
         );
 
         // Verify that the write is not committed yet and a batch exists.
@@ -782,8 +782,8 @@ public class CoordinatorRuntimeTest {
 
         // Verify that the listener is deregistered.
         verify(writer, times(1)).deregisterListener(
-                eq(TP),
-                any(PartitionWriter.Listener.class)
+            eq(TP),
+            any(PartitionWriter.Listener.class)
         );
 
         // Getting the coordinator context fails because it no longer exists.

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -790,7 +790,6 @@ public class CoordinatorRuntimeTest {
         assertThrows(NotCoordinatorException.class, () -> runtime.contextOrThrow(TP));
     }
 
-
     @Test
     public void testScheduleWriteOp() throws ExecutionException, InterruptedException, TimeoutException {
         MockTimer timer = new MockTimer();

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -711,6 +711,87 @@ public class CoordinatorRuntimeTest {
     }
 
     @Test
+    public void testScheduleUnloadingWithPendingBatchWhenPartitionWriterConfigThrows() {
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = mock(MockPartitionWriter.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+                new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                        .withTime(timer.time())
+                        .withTimer(timer)
+                        .withDefaultWriteTimeOut(DEFAULT_WRITE_TIMEOUT)
+                        .withLoader(new MockCoordinatorLoader())
+                        .withEventProcessor(new DirectEventProcessor())
+                        .withPartitionWriter(writer)
+                        .withCoordinatorShardBuilderSupplier(supplier)
+                        .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
+                        .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                        .withSerializer(new StringSerializer())
+                        .withAppendLingerMs(OptionalInt.of(10))
+                        .withExecutorService(mock(ExecutorService.class))
+                        .build();
+
+        when(builder.withSnapshotRegistry(any())).thenReturn(builder);
+        when(builder.withLogContext(any())).thenReturn(builder);
+        when(builder.withTime(any())).thenReturn(builder);
+        when(builder.withTimer(any())).thenReturn(builder);
+        when(builder.withCoordinatorMetrics(any())).thenReturn(builder);
+        when(builder.withTopicPartition(any())).thenReturn(builder);
+        when(builder.withExecutor(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(coordinator);
+        when(supplier.get()).thenReturn(builder);
+
+        // Configure the partition writer with a normal config initially.
+        LogConfig initialLogConfig = new LogConfig(
+                Map.of(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, String.valueOf(1024 * 1024) // 1MB
+                ));
+        when(writer.config(TP)).thenReturn(initialLogConfig);
+        when(writer.append(eq(TP), any(), any(), anyShort())).thenReturn(1L);
+
+        // Load the coordinator.
+        runtime.scheduleLoadOperation(TP, 10);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+
+        // Schedule a write operation to create a pending batch.
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+                state -> new CoordinatorResult<>(List.of("record1"), "response1")
+        );
+
+        // Verify that the write is not committed yet and a batch exists.
+        assertFalse(write1.isDone());
+        assertNotNull(ctx.currentBatch);
+
+        // Simulate the broker losing leadership: partitionWriter.config() now throws NOT_LEADER_OR_FOLLOWER.
+        // This is the scenario described in KAFKA-20115.
+        when(writer.config(TP)).thenThrow(Errors.NOT_LEADER_OR_FOLLOWER.exception());
+
+        // Schedule the unloading. This should trigger the bug where freeCurrentBatch()
+        // tries to call partitionWriter.config(tp).maxMessageSize() and throws an exception.
+        // Without the fix, this would prevent the coordinator from unloading properly.
+        runtime.scheduleUnloadOperation(TP, OptionalInt.of(ctx.epoch + 1));
+
+        // The unload should complete despite the NOT_LEADER_OR_FOLLOWER exception
+        // when trying to access partition writer config during buffer cleanup.
+        assertEquals(CLOSED, ctx.state);
+
+        // Verify that onUnloaded is called.
+        verify(coordinator, times(1)).onUnloaded();
+
+        // Verify that the listener is deregistered.
+        verify(writer, times(1)).deregisterListener(
+                eq(TP),
+                any(PartitionWriter.Listener.class)
+        );
+
+        // Getting the coordinator context fails because it no longer exists.
+        assertThrows(NotCoordinatorException.class, () -> runtime.contextOrThrow(TP));
+    }
+
+
+    @Test
     public void testScheduleWriteOp() throws ExecutionException, InterruptedException, TimeoutException {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();
@@ -5693,86 +5774,6 @@ public class CoordinatorRuntimeTest {
         assertTrue(write2.isDone());
         // Now that all scheduled tasks have been cancelled, the scheduler queue should be empty.
         assertEquals(0, schedulerTimer.size());
-    }
-
-    @Test
-    public void testScheduleUnloadingWithPendingBatchWhenPartitionWriterConfigThrows() {
-        MockTimer timer = new MockTimer();
-        MockPartitionWriter writer = mock(MockPartitionWriter.class);
-        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
-        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
-        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
-
-        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
-                .withTime(timer.time())
-                .withTimer(timer)
-                .withDefaultWriteTimeOut(Duration.ofMillis(20))
-                .withLoader(new MockCoordinatorLoader())
-                .withEventProcessor(new DirectEventProcessor())
-                .withPartitionWriter(writer)
-                .withCoordinatorShardBuilderSupplier(supplier)
-                .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
-                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
-                .withSerializer(new StringSerializer())
-                .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
-                .build();
-
-        when(builder.withSnapshotRegistry(any())).thenReturn(builder);
-        when(builder.withLogContext(any())).thenReturn(builder);
-        when(builder.withTime(any())).thenReturn(builder);
-        when(builder.withTimer(any())).thenReturn(builder);
-        when(builder.withCoordinatorMetrics(any())).thenReturn(builder);
-        when(builder.withTopicPartition(any())).thenReturn(builder);
-        when(builder.withExecutor(any())).thenReturn(builder);
-        when(builder.build()).thenReturn(coordinator);
-        when(supplier.get()).thenReturn(builder);
-
-        // Configure the partition writer with a normal config initially.
-        LogConfig initialLogConfig = new LogConfig(
-            Map.of(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, String.valueOf(1024 * 1024) // 1MB
-        ));
-        when(writer.config(TP)).thenReturn(initialLogConfig);
-        when(writer.append(eq(TP), any(), any(), anyShort())).thenReturn(1L);
-
-        // Load the coordinator.
-        runtime.scheduleLoadOperation(TP, 10);
-        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
-
-        // Schedule a write operation to create a pending batch.
-        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
-            state -> new CoordinatorResult<>(List.of("record1"), "response1")
-        );
-
-        // Verify that the write is not committed yet and a batch exists.
-        assertFalse(write1.isDone());
-        assertNotNull(ctx.currentBatch);
-
-        // Simulate the broker losing leadership: partitionWriter.config() now throws NOT_LEADER_OR_FOLLOWER.
-        // This is the scenario described in KAFKA-20115.
-        when(writer.config(TP)).thenThrow(Errors.NOT_LEADER_OR_FOLLOWER.exception());
-
-        // Schedule the unloading. This should trigger the bug where freeCurrentBatch()
-        // tries to call partitionWriter.config(tp).maxMessageSize() and throws an exception.
-        // Without the fix, this would prevent the coordinator from unloading properly.
-        runtime.scheduleUnloadOperation(TP, OptionalInt.of(ctx.epoch + 1));
-
-        // The unload should complete despite the NOT_LEADER_OR_FOLLOWER exception
-        // when trying to access partition writer config during buffer cleanup.
-        assertEquals(CLOSED, ctx.state);
-
-        // Verify that onUnloaded is called.
-        verify(coordinator, times(1)).onUnloaded();
-
-        // Verify that the listener is deregistered.
-        verify(writer, times(1)).deregisterListener(
-            eq(TP),
-            any(PartitionWriter.Listener.class)
-        );
-
-        // Getting the coordinator context fails because it no longer exists.
-        assertThrows(NotCoordinatorException.class, () -> runtime.contextOrThrow(TP));
     }
 
     private static <S extends CoordinatorShard<U>, U> ArgumentMatcher<CoordinatorPlayback<U>> coordinatorMatcher(

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -5695,6 +5695,86 @@ public class CoordinatorRuntimeTest {
         assertEquals(0, schedulerTimer.size());
     }
 
+    @Test
+    public void testScheduleUnloadingWithPendingBatchWhenPartitionWriterConfigThrows() {
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = mock(MockPartitionWriter.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(Duration.ofMillis(20))
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(supplier)
+                .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withSerializer(new StringSerializer())
+                .withAppendLingerMs(OptionalInt.of(10))
+                .withExecutorService(mock(ExecutorService.class))
+                .build();
+
+        when(builder.withSnapshotRegistry(any())).thenReturn(builder);
+        when(builder.withLogContext(any())).thenReturn(builder);
+        when(builder.withTime(any())).thenReturn(builder);
+        when(builder.withTimer(any())).thenReturn(builder);
+        when(builder.withCoordinatorMetrics(any())).thenReturn(builder);
+        when(builder.withTopicPartition(any())).thenReturn(builder);
+        when(builder.withExecutor(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(coordinator);
+        when(supplier.get()).thenReturn(builder);
+
+        // Configure the partition writer with a normal config initially.
+        LogConfig initialLogConfig = new LogConfig(
+            Map.of(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, String.valueOf(1024 * 1024) // 1MB
+        ));
+        when(writer.config(TP)).thenReturn(initialLogConfig);
+        when(writer.append(eq(TP), any(), any(), anyShort())).thenReturn(1L);
+
+        // Load the coordinator.
+        runtime.scheduleLoadOperation(TP, 10);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+
+        // Schedule a write operation to create a pending batch.
+        CompletableFuture<String> write1 = runtime.scheduleWriteOperation("write#1", TP, DEFAULT_WRITE_TIMEOUT,
+            state -> new CoordinatorResult<>(List.of("record1"), "response1")
+        );
+
+        // Verify that the write is not committed yet and a batch exists.
+        assertFalse(write1.isDone());
+        assertNotNull(ctx.currentBatch);
+
+        // Simulate the broker losing leadership: partitionWriter.config() now throws NOT_LEADER_OR_FOLLOWER.
+        // This is the scenario described in KAFKA-20115.
+        when(writer.config(TP)).thenThrow(Errors.NOT_LEADER_OR_FOLLOWER.exception());
+
+        // Schedule the unloading. This should trigger the bug where freeCurrentBatch()
+        // tries to call partitionWriter.config(tp).maxMessageSize() and throws an exception.
+        // Without the fix, this would prevent the coordinator from unloading properly.
+        runtime.scheduleUnloadOperation(TP, OptionalInt.of(ctx.epoch + 1));
+
+        // The unload should complete despite the NOT_LEADER_OR_FOLLOWER exception
+        // when trying to access partition writer config during buffer cleanup.
+        assertEquals(CLOSED, ctx.state);
+
+        // Verify that onUnloaded is called.
+        verify(coordinator, times(1)).onUnloaded();
+
+        // Verify that the listener is deregistered.
+        verify(writer, times(1)).deregisterListener(
+            eq(TP),
+            any(PartitionWriter.Listener.class)
+        );
+
+        // Getting the coordinator context fails because it no longer exists.
+        assertThrows(NotCoordinatorException.class, () -> runtime.contextOrThrow(TP));
+    }
+
     private static <S extends CoordinatorShard<U>, U> ArgumentMatcher<CoordinatorPlayback<U>> coordinatorMatcher(
         CoordinatorRuntime<S, U> runtime,
         TopicPartition tp


### PR DESCRIPTION
When a broker loses leadership of a __consumer_offsets partition while a
write batch is pending, the coordinator unload process fails because
freeCurrentBatch() attempts to access partition writer configuration
which throws NOT_LEADER_OR_FOLLOWER exception.

This commit fixes the issue by using cached maxBatchSize instead of
querying log config max message size in `freeCurrentBatch`.

Reviewers: Sean Quah <squah@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>, David Jacot <david.jacot@gmail.com>
