### PR TITLE
MINOR: remove an unused method and adjust method visibility in Utils.java

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -901,22 +901,10 @@ public final class Utils {
         });
     }
 
-    /**
-     * Returns an empty list if the provided list is null, otherwise returns the list itself.
-     * <p>
-     * This method is useful for avoiding {@code NullPointerException} when working with potentially null lists.
-     *
-     * @param other the list to check for null
-     * @return an empty list if the provided list is null, otherwise the original list
-     */
-    public static <T> List<T> safe(List<T> other) {
-        return other == null ? Collections.emptyList() : other;
-    }
-
    /**
     * Get the ClassLoader which loaded Kafka.
     */
-    public static ClassLoader getKafkaClassLoader() {
+    private static ClassLoader getKafkaClassLoader() {
         return Utils.class.getClassLoader();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -901,13 +901,6 @@ public final class Utils {
         });
     }
 
-   /**
-    * Get the ClassLoader which loaded Kafka.
-    */
-    private static ClassLoader getKafkaClassLoader() {
-        return Utils.class.getClassLoader();
-    }
-
     /**
      * Get the Context ClassLoader on this thread or, if not present, the ClassLoader that
      * loaded Kafka.
@@ -917,7 +910,7 @@ public final class Utils {
     public static ClassLoader getContextOrKafkaClassLoader() {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null)
-            return getKafkaClassLoader();
+            return Utils.class.getClassLoader();
         else
             return cl;
     }


### PR DESCRIPTION
Removed safe(List<T> other): This method is not used.

Removed getKafkaClassLoader(): This method was a simple one-line
wrapper. It has been removed, and its logic
(Utils.class.getClassLoader()) has been inlined into
getContextOrKafkaClassLoader() to simplify the code.

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
