### PR TITLE
MINOR: Add test for ConfigDef.convertToString with null type

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -660,6 +660,12 @@ public class ConfigDefTest {
     }
 
     @Test
+    public void testConvertValueToStringNullType() {
+        assertEquals("foobar", ConfigDef.convertToString("foobar", null));
+        assertNull(ConfigDef.convertToString(null, null));
+    }
+
+    @Test
     public void testClassWithAlias() {
         final String alias = "PluginAlias";
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();


### PR DESCRIPTION
Add test for `ConfigDef.convertToString` with null type.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
