### PR TITLE
KAFKA-20115: Group coordinator fails to unload metadata when no longer leader or follower

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
@@ -26,7 +26,9 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -35,9 +37,13 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
+import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.coordinator.group.GroupCoordinatorService;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.test.TestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +52,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -333,6 +341,50 @@ public class ConsumerIntegrationTest {
                     consumer2.assignment().equals(Set.of(new TopicPartition(topic, 0), new TopicPartition(topic, 1), new TopicPartition(topic, 2)));
             }, "Consumer with topic partition mapping should be 0 -> 5 | 1 -> 3, 4 | 2 -> 0, 1, 2");
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @ClusterTest(
+        brokers = 2,
+        types = {Type.KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, value = "3000")
+        }
+    )
+    public void testSingleCoordinatorOwnershipAfterPartitionReassignment(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException, TimeoutException {
+        try (var producer = clusterInstance.<byte[], byte[]>producer()) {
+            producer.send(new ProducerRecord<>("topic", "value".getBytes(StandardCharsets.UTF_8)));
+        }
+
+        try (var admin = clusterInstance.admin()) {
+            admin.createTopics(List.of(new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, Map.of(0, List.of(0))))).all().get();
+        }
+
+        try (var consumer = clusterInstance.consumer(Map.of(ConsumerConfig.GROUP_ID_CONFIG, "test-group"));
+             var admin = clusterInstance.admin()) {
+            consumer.subscribe(List.of("topic"));
+            TestUtils.waitForCondition(() -> consumer.poll(Duration.ofMillis(100)).isEmpty(), "polling to join group");
+            // append records to coordinator
+            consumer.commitSync();
+
+            // unload the coordinator by changing leader (0 -> 1)
+            admin.alterPartitionReassignments(Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0),
+                Optional.of(new NewPartitionReassignment(List.of(1))))).all().get();
+        }
+
+        Function<GroupCoordinator, List<TopicPartition>> partitionsInGroupMetrics = service -> assertDoesNotThrow(() -> {
+            var f0 = GroupCoordinatorService.class.getDeclaredField("groupCoordinatorMetrics");
+            f0.setAccessible(true);
+            var f1 = GroupCoordinatorMetrics.class.getDeclaredField("shards");
+            f1.setAccessible(true);
+            return List.copyOf(((Map<TopicPartition, ?>) f1.get(f0.get(service))).keySet());
+        });
+
+        // the offset partition should NOT be hosted by multiple coordinators
+        var tps = clusterInstance.brokers().values().stream()
+            .flatMap(b -> partitionsInGroupMetrics.apply(b.groupCoordinator()).stream()).toList();
+        assertEquals(1, tps.size());
     }
 
     private void sendMsg(ClusterInstance clusterInstance, String topic, int sendMsgNum) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerIntegrationTest.java
@@ -37,10 +37,8 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
-import org.apache.kafka.coordinator.group.GroupCoordinator;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
-import org.apache.kafka.coordinator.group.GroupCoordinatorService;
-import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics;
 import org.apache.kafka.test.TestUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -52,9 +50,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -343,7 +339,6 @@ public class ConsumerIntegrationTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @ClusterTest(
         brokers = 2,
         types = {Type.KRAFT},
@@ -362,29 +357,35 @@ public class ConsumerIntegrationTest {
         }
 
         try (var consumer = clusterInstance.consumer(Map.of(ConsumerConfig.GROUP_ID_CONFIG, "test-group"));
-             var admin = clusterInstance.admin()) {
+            var admin = clusterInstance.admin()) {
             consumer.subscribe(List.of("topic"));
             TestUtils.waitForCondition(() -> consumer.poll(Duration.ofMillis(100)).isEmpty(), "polling to join group");
-            // append records to coordinator
+            // Append records to coordinator.
             consumer.commitSync();
 
-            // unload the coordinator by changing leader (0 -> 1)
-            admin.alterPartitionReassignments(Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0),
-                Optional.of(new NewPartitionReassignment(List.of(1))))).all().get();
+            var broker0Metrics = clusterInstance.brokers().get(0).metrics();
+            var broker1Metrics = clusterInstance.brokers().get(1).metrics();
+            var activeNumPartitions = broker0Metrics.metricName(
+                "num-partitions",
+                GroupCoordinatorRuntimeMetrics.METRICS_GROUP,
+                Map.of("state", "active")
+            );
+
+            assertEquals(1L, broker0Metrics.metric(activeNumPartitions).metricValue());
+            assertEquals(0L, broker1Metrics.metric(activeNumPartitions).metricValue());
+
+            // Unload the coordinator by changing leader (0 -> 1).
+            admin.alterPartitionReassignments(
+                Map.of(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0), Optional.of(new NewPartitionReassignment(List.of(1))))
+            ).all().get();
+
+            // Wait for the coordinator metrics to update after leadership change.
+            TestUtils.waitForCondition(() ->
+                0L == (Long) broker0Metrics.metric(activeNumPartitions).metricValue() &&
+                    1L == (Long) broker1Metrics.metric(activeNumPartitions).metricValue(),
+                "Incorrect num-partitions metric after partition reassignment to the new coordinator"
+            );
         }
-
-        Function<GroupCoordinator, List<TopicPartition>> partitionsInGroupMetrics = service -> assertDoesNotThrow(() -> {
-            var f0 = GroupCoordinatorService.class.getDeclaredField("groupCoordinatorMetrics");
-            f0.setAccessible(true);
-            var f1 = GroupCoordinatorMetrics.class.getDeclaredField("shards");
-            f1.setAccessible(true);
-            return List.copyOf(((Map<TopicPartition, ?>) f1.get(f0.get(service))).keySet());
-        });
-
-        // the offset partition should NOT be hosted by multiple coordinators
-        var tps = clusterInstance.brokers().values().stream()
-            .flatMap(b -> partitionsInGroupMetrics.apply(b.groupCoordinator()).stream()).toList();
-        assertEquals(1, tps.size());
     }
 
     private void sendMsg(ClusterInstance clusterInstance, String topic, int sendMsgNum) {


### PR DESCRIPTION
While the underlying cause of KAFKA-20115 was addressed by the
resolution of KAFKA-19519, this commit introduces a dedicated
integration test to ensure the scenario remains covered. This prevents
future regressions and ensures the expected behavior is explicitly
verified within the test suite.

Reviewers: David Jacot <djacot@confluent.io>
