### PR TITLE
KAFKA-20121: Create ValueTimestampHeaders and its serializer/deserializer

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
@@ -31,7 +31,8 @@ public final class ValueTimestampHeaders<V> {
 
     private final V value;
     private final long timestamp;
-    private Headers headers;
+    //visible for test
+    volatile Headers headers;
     private final byte[] rawHeaders;
 
     private ValueTimestampHeaders(final V value, final long timestamp, final Headers headers) {
@@ -130,10 +131,18 @@ public final class ValueTimestampHeaders<V> {
     }
 
     public Headers headers() {
-        if (headers == null && rawHeaders != null) {
-            headers = HeadersDeserializer.deserialize(rawHeaders);
+        if (headers == null) {
+            synchronized (this) {
+                if (headers == null) {
+                    if (rawHeaders != null) {
+                        headers = HeadersDeserializer.deserialize(rawHeaders);
+                    } else {
+                        headers = new RecordHeaders();
+                    }
+                }
+            }
         }
-        return headers != null ? headers : new RecordHeaders();
+        return headers;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.streams.state.internals.HeadersDeserializer;
 
 import java.util.Objects;
 
@@ -31,22 +30,18 @@ public final class ValueTimestampHeaders<V> {
 
     private final V value;
     private final long timestamp;
-    //visible for test
-    volatile Headers headers;
-    private final byte[] rawHeaders;
+    private Headers headers;
 
     private ValueTimestampHeaders(final V value, final long timestamp, final Headers headers) {
         this.value = value;
         this.timestamp = timestamp;
         this.headers = headers == null ? new RecordHeaders() : headers;
-        this.rawHeaders = null;
     }
 
     private ValueTimestampHeaders(final V value, final long timestamp, final byte[] rawHeaders) {
         this.value = value;
         this.timestamp = timestamp;
         this.headers = null;
-        this.rawHeaders = rawHeaders;
     }
 
     /**
@@ -131,17 +126,6 @@ public final class ValueTimestampHeaders<V> {
     }
 
     public Headers headers() {
-        if (headers == null) {
-            synchronized (this) {
-                if (headers == null) {
-                    if (rawHeaders != null) {
-                        headers = HeadersDeserializer.deserialize(rawHeaders);
-                    } else {
-                        headers = new RecordHeaders();
-                    }
-                }
-            }
-        }
         return headers;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
@@ -30,7 +30,7 @@ public final class ValueTimestampHeaders<V> {
 
     private final V value;
     private final long timestamp;
-    private Headers headers;
+    private final Headers headers;
 
     private ValueTimestampHeaders(final V value, final long timestamp, final Headers headers) {
         this.value = value;

--- a/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.state.internals.HeadersDeserializer;
+
+import java.util.Objects;
+
+/**
+ * Combines a value with its timestamp and associated record headers.
+ *
+ * @param <V> the value type
+ */
+public final class ValueTimestampHeaders<V> {
+
+    private final V value;
+    private final long timestamp;
+    private Headers headers;
+    private final byte[] rawHeaders;
+
+    private ValueTimestampHeaders(final V value, final long timestamp, final Headers headers) {
+        this.value = value;
+        this.timestamp = timestamp;
+        this.headers = headers == null ? new RecordHeaders() : headers;
+        this.rawHeaders = null;
+    }
+
+    private ValueTimestampHeaders(final V value, final long timestamp, final byte[] rawHeaders) {
+        this.value = value;
+        this.timestamp = timestamp;
+        this.headers = null;
+        this.rawHeaders = rawHeaders;
+    }
+
+    /**
+     * Create a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null}.
+     *
+     * @param value     the value
+     * @param timestamp the timestamp
+     * @param headers   the headers (may be {@code null}, treated as empty)
+     * @param <V>       the type of the value
+     * @return a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null};
+     * otherwise {@code null} is returned
+     */
+    public static <V> ValueTimestampHeaders<V> make(final V value,
+                                                    final long timestamp,
+                                                    final Headers headers) {
+        if (value == null) {
+            return null;
+        }
+        return new ValueTimestampHeaders<>(value, timestamp, headers);
+    }
+
+    /**
+     * Create a new {@link ValueTimestampHeaders} instance.
+     * The provided {@code value} may be {@code null}.
+     *
+     * @param value     the value (may be {@code null})
+     * @param timestamp the timestamp
+     * @param headers   the headers (may be {@code null}, treated as empty)
+     * @param <V>       the type of the value
+     * @return a new {@link ValueTimestampHeaders} instance
+     */
+    public static <V> ValueTimestampHeaders<V> makeAllowNullable(final V value,
+                                                                 final long timestamp,
+                                                                 final Headers headers) {
+        return new ValueTimestampHeaders<>(value, timestamp, headers);
+    }
+
+    /**
+     * Return the wrapped {@code value} of the given {@code valueTimestampHeaders} parameter
+     * if the parameter is not {@code null}.
+     *
+     * @param valueTimestampHeaders a {@link ValueTimestampHeaders} instance; can be {@code null}
+     * @param <V>                   the type of the value
+     * @return the wrapped {@code value} of {@code valueTimestampHeaders} if not {@code null}; otherwise {@code null}
+     */
+    public static <V> V getValueOrNull(final ValueTimestampHeaders<V> valueTimestampHeaders) {
+        return valueTimestampHeaders == null ? null : valueTimestampHeaders.value;
+    }
+
+    /**
+     * <strong>Internal use only.</strong> This method is used by the deserialization infrastructure
+     * and should not be called directly by application code.
+     * <p>
+     * Create a new {@link ValueTimestampHeaders} instance with raw (serialized) headers for lazy deserialization.
+     * The headers will be deserialized lazily when {@link #headers()} is first called, minimizing overhead
+     * during range scans when headers are not accessed.
+     * <p>
+     * This method is used internally by {@link org.apache.kafka.streams.state.internals.ValueTimestampHeadersDeserializer}.
+     *
+     * @param value       the value
+     * @param timestamp   the timestamp
+     * @param rawHeaders  the serialized headers bytes
+     * @param <V>         the type of the value
+     * @return a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null};
+     * otherwise {@code null} is returned
+     */
+    public static <V> ValueTimestampHeaders<V> makeWithRawHeaders(final V value,
+                                                                  final long timestamp,
+                                                                  final byte[] rawHeaders) {
+        if (value == null) {
+            return null;
+        }
+        return new ValueTimestampHeaders<>(value, timestamp, rawHeaders);
+    }
+
+    public V value() {
+        return value;
+    }
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    public Headers headers() {
+        if (headers == null && rawHeaders != null) {
+            headers = HeadersDeserializer.deserialize(rawHeaders);
+        }
+        return headers != null ? headers : new RecordHeaders();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ValueTimestampHeaders)) {
+            return false;
+        }
+        final ValueTimestampHeaders<?> that = (ValueTimestampHeaders<?>) o;
+        // Ensure headers are deserialized before comparison (lazy deserialization)
+        return timestamp == that.timestamp
+            && Objects.equals(value, that.value)
+            && Objects.equals(this.headers(), that.headers());
+    }
+
+    @Override
+    public int hashCode() {
+        // Ensure headers are deserialized before hashing (lazy deserialization)
+        return Objects.hash(value, timestamp, headers());
+    }
+
+    @Override
+    public String toString() {
+        return "ValueTimestampHeaders{" +
+            "value=" + value +
+            ", timestamp=" + timestamp +
+            ", headers=" + headers() +
+            '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ValueTimestampHeaders.java
@@ -38,12 +38,6 @@ public final class ValueTimestampHeaders<V> {
         this.headers = headers == null ? new RecordHeaders() : headers;
     }
 
-    private ValueTimestampHeaders(final V value, final long timestamp, final byte[] rawHeaders) {
-        this.value = value;
-        this.timestamp = timestamp;
-        this.headers = null;
-    }
-
     /**
      * Create a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null}.
      *
@@ -91,32 +85,6 @@ public final class ValueTimestampHeaders<V> {
         return valueTimestampHeaders == null ? null : valueTimestampHeaders.value;
     }
 
-    /**
-     * <strong>Internal use only.</strong> This method is used by the deserialization infrastructure
-     * and should not be called directly by application code.
-     * <p>
-     * Create a new {@link ValueTimestampHeaders} instance with raw (serialized) headers for lazy deserialization.
-     * The headers will be deserialized lazily when {@link #headers()} is first called, minimizing overhead
-     * during range scans when headers are not accessed.
-     * <p>
-     * This method is used internally by {@link org.apache.kafka.streams.state.internals.ValueTimestampHeadersDeserializer}.
-     *
-     * @param value       the value
-     * @param timestamp   the timestamp
-     * @param rawHeaders  the serialized headers bytes
-     * @param <V>         the type of the value
-     * @return a new {@link ValueTimestampHeaders} instance if the provided {@code value} is not {@code null};
-     * otherwise {@code null} is returned
-     */
-    public static <V> ValueTimestampHeaders<V> makeWithRawHeaders(final V value,
-                                                                  final long timestamp,
-                                                                  final byte[] rawHeaders) {
-        if (value == null) {
-            return null;
-        }
-        return new ValueTimestampHeaders<>(value, timestamp, rawHeaders);
-    }
-
     public V value() {
         return value;
     }
@@ -138,16 +106,14 @@ public final class ValueTimestampHeaders<V> {
             return false;
         }
         final ValueTimestampHeaders<?> that = (ValueTimestampHeaders<?>) o;
-        // Ensure headers are deserialized before comparison (lazy deserialization)
         return timestamp == that.timestamp
             && Objects.equals(value, that.value)
-            && Objects.equals(this.headers(), that.headers());
+            && Objects.equals(this.headers, that.headers);
     }
 
     @Override
     public int hashCode() {
-        // Ensure headers are deserialized before hashing (lazy deserialization)
-        return Objects.hash(value, timestamp, headers());
+        return Objects.hash(value, timestamp, headers);
     }
 
     @Override
@@ -155,7 +121,7 @@ public final class ValueTimestampHeaders<V> {
         return "ValueTimestampHeaders{" +
             "value=" + value +
             ", timestamp=" + timestamp +
-            ", headers=" + headers() +
+            ", headers=" + headers +
             '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersDeserializer.java
@@ -86,4 +86,10 @@ public class HeadersDeserializer implements Deserializer<Headers> {
 
         return headers;
     }
+
+    public static Headers deserialize(final byte[] data) {
+        try (HeadersDeserializer deserializer = new HeadersDeserializer()) {
+            return deserializer.deserialize("", data);
+        }
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
@@ -93,7 +94,7 @@ public class HeadersSerializer implements Serializer<Headers> {
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to serialize headers", e);
+            throw new SerializationException("Failed to serialize headers", e);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
@@ -38,6 +39,8 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  *
  * Where:
  * - headersSize: Size of the headersBytes section in bytes, encoded as varint
+ *   - For null/empty headers: headersSize = 0, headersBytes is omitted (0 bytes)
+ *   - For non-empty headers: headersSize > 0, headersBytes follows
  * - headersBytes: Serialized headers ([count(varint)][header1][header2]...) to be deserialized by HeadersDeserializer
  * - timestamp: 8-byte long timestamp
  * - value: Serialized value to be deserialized with the provided value deserializer
@@ -46,6 +49,7 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  */
 class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializer<ValueTimestampHeaders<V>, Void, V> {
     private static final LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
+    private static final HeadersDeserializer HEADERS_DESERIALIZER = new HeadersDeserializer();
 
     public final Deserializer<V> valueDeserializer;
     private final Deserializer<Long> timestampDeserializer;
@@ -75,13 +79,13 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         final int headersSize = ByteUtils.readVarint(buffer);
 
         final byte[] rawHeaders = readBytes(buffer, headersSize);
+        final Headers headers = headersDeserializer.deserialize("", rawHeaders);
         final byte[] rawTimestamp = readBytes(buffer, Long.BYTES);
         final long timestamp = timestampDeserializer.deserialize(topic, rawTimestamp);
-
         final byte[] rawValue = readBytes(buffer, buffer.remaining());
         final V value = valueDeserializer.deserialize(topic, rawValue);
 
-        return ValueTimestampHeaders.makeWithRawHeaders(value, timestamp, rawHeaders);
+        return ValueTimestampHeaders.make(value, timestamp, headers);
     }
 
     @Override
@@ -104,11 +108,11 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
      * @param buffer the ByteBuffer to read from
      * @param length the number of bytes to read
      * @return the byte array containing the read bytes
-     * @throws IllegalArgumentException if buffer doesn't have enough bytes
+     * @throws SerializationException if buffer doesn't have enough bytes
      */
     private static byte[] readBytes(final ByteBuffer buffer, final int length) {
         if (buffer.remaining() < length) {
-            throw new IllegalArgumentException(
+            throw new SerializationException(
                 "Invalid ValueTimestampHeaders format: expected " + length +
                 " bytes but only " + buffer.remaining() + " bytes remaining"
             );
@@ -119,18 +123,20 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
     }
 
     /**
-     * Extract raw value bytes from serialized ValueTimestampHeaders.
+     * Extract value from serialized ValueTimestampHeaders.
      */
-    static byte[] rawValue(final byte[] rawValueTimestampHeaders) {
+    static <V> V value(final byte[] rawValueTimestampHeaders, final Deserializer<V> deserializer) {
         if (rawValueTimestampHeaders == null) {
             return null;
         }
 
         final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
         final int headersSize = ByteUtils.readVarint(buffer);
+        // skip headers plus timestamp
         buffer.position(buffer.position() + headersSize + Long.BYTES);
+        byte[] bytes = readBytes(buffer, buffer.remaining());
 
-        return readBytes(buffer, buffer.remaining());
+        return deserializer.deserialize("", bytes);
     }
 
     /**
@@ -156,7 +162,6 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
         final int headersSize = ByteUtils.readVarint(buffer);
         final byte[] rawHeaders = readBytes(buffer, headersSize);
-
-        return HeadersDeserializer.deserialize(rawHeaders);
+        return HEADERS_DESERIALIZER.deserialize("", rawHeaders);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -52,7 +52,7 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
     private static final HeadersDeserializer HEADERS_DESERIALIZER = new HeadersDeserializer();
 
     public final Deserializer<V> valueDeserializer;
-    private final Deserializer<Long> timestampDeserializer;
+    private final LongDeserializer timestampDeserializer;
     private final HeadersDeserializer headersDeserializer;
 
     ValueTimestampHeadersDeserializer(final Deserializer<V> valueDeserializer) {
@@ -79,7 +79,7 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         final int headersSize = ByteUtils.readVarint(buffer);
 
         final byte[] rawHeaders = readBytes(buffer, headersSize);
-        final Headers headers = headersDeserializer.deserialize("", rawHeaders);
+        final Headers headers = headersDeserializer.deserialize(topic, rawHeaders);
         final byte[] rawTimestamp = readBytes(buffer, Long.BYTES);
         final long timestamp = timestampDeserializer.deserialize(topic, rawTimestamp);
         final byte[] rawValue = readBytes(buffer, buffer.remaining());
@@ -125,7 +125,7 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
     /**
      * Extract value from serialized ValueTimestampHeaders.
      */
-    static <V> V value(final byte[] rawValueTimestampHeaders, final Deserializer<V> deserializer) {
+    static <T> T value(final byte[] rawValueTimestampHeaders, final Deserializer<T> deserializer) {
         if (rawValueTimestampHeaders == null) {
             return null;
         }
@@ -148,7 +148,7 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         buffer.position(buffer.position() + headersSize);
 
         final byte[] rawTimestamp = readBytes(buffer, Long.BYTES);
-        return LONG_DESERIALIZER.deserialize(null, rawTimestamp);
+        return LONG_DESERIALIZER.deserialize("", rawTimestamp);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.utils.ByteUtils;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableDeserializer;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.initNullableDeserializer;
+
+/**
+ * Deserializer for ValueTimestampHeaders.
+ *
+ * Deserialization format (per KIP-1271):
+ * [headersSize(varint)][headersBytes][timestamp(8)][value]
+ *
+ * Where:
+ * - headersSize: Size of the headersBytes section in bytes, encoded as varint
+ * - headersBytes: Serialized headers ([count(varint)][header1][header2]...) to be deserialized by HeadersDeserializer
+ * - timestamp: 8-byte long timestamp
+ * - value: Serialized value to be deserialized with the provided value deserializer
+ *
+ * This is used by KIP-1271 to deserialize values with timestamps and headers from state stores.
+ */
+class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializer<ValueTimestampHeaders<V>, Void, V> {
+    private static final LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
+
+    public final Deserializer<V> valueDeserializer;
+    private final Deserializer<Long> timestampDeserializer;
+    private final HeadersDeserializer headersDeserializer;
+
+    ValueTimestampHeadersDeserializer(final Deserializer<V> valueDeserializer) {
+        Objects.requireNonNull(valueDeserializer);
+        this.valueDeserializer = valueDeserializer;
+        this.timestampDeserializer = new LongDeserializer();
+        this.headersDeserializer = new HeadersDeserializer();
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+        valueDeserializer.configure(configs, isKey);
+        timestampDeserializer.configure(configs, isKey);
+        headersDeserializer.configure(configs, isKey);
+    }
+
+    @Override
+    public ValueTimestampHeaders<V> deserialize(final String topic, final byte[] valueTimestampHeaders) {
+        if (valueTimestampHeaders == null) {
+            return null;
+        }
+
+        final ByteBuffer buffer = ByteBuffer.wrap(valueTimestampHeaders);
+        final int headerSize = ByteUtils.readVarint(buffer);
+
+        final byte[] rawHeaders = new byte[headerSize];
+        buffer.get(rawHeaders);
+
+        final byte[] rawTimestamp = new byte[Long.BYTES];
+        buffer.get(rawTimestamp);
+
+        final long timestamp = timestampDeserializer.deserialize(topic, rawTimestamp);
+
+        final byte[] rawValue = new byte[buffer.remaining()];
+        buffer.get(rawValue);
+
+        final V value = valueDeserializer.deserialize(topic, rawValue);
+
+        return ValueTimestampHeaders.makeWithRawHeaders(value, timestamp, rawHeaders);
+    }
+
+    @Override
+    public void close() {
+        valueDeserializer.close();
+        timestampDeserializer.close();
+        headersDeserializer.close();
+    }
+
+    @Override
+    public void setIfUnset(final SerdeGetter getter) {
+        // ValueTimestampHeadersDeserializer never wraps a null deserializer (or configure would throw),
+        // but it may wrap a deserializer that itself wraps a null deserializer.
+        initNullableDeserializer(valueDeserializer, getter);
+    }
+
+    /**
+     * Extract raw value bytes from serialized ValueTimestampHeaders.
+     */
+    static byte[] rawValue(final byte[] rawValueTimestampHeaders) {
+        if (rawValueTimestampHeaders == null) {
+            return null;
+        }
+
+        final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
+        final int headerSize = ByteUtils.readVarint(buffer);
+        buffer.position(buffer.position() + headerSize + Long.BYTES);
+
+        final byte[] rawValue = new byte[buffer.remaining()];
+        buffer.get(rawValue);
+
+        return rawValue;
+    }
+
+    /**
+     * Extract timestamp from serialized ValueTimestampHeaders.
+     */
+    static long timestamp(final byte[] rawValueTimestampHeaders) {
+        if (rawValueTimestampHeaders == null) {
+            throw new IllegalArgumentException("Cannot extract timestamp from null data");
+        }
+
+        final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
+        final int headerSize = ByteUtils.readVarint(buffer);
+        buffer.position(buffer.position() + headerSize);
+
+        final byte[] rawTimestamp = new byte[Long.BYTES];
+        buffer.get(rawTimestamp);
+
+        return LONG_DESERIALIZER.deserialize(null, rawTimestamp);
+    }
+
+    /**
+     * Extract headers from serialized ValueTimestampHeaders.
+     */
+    static Headers headers(final byte[] rawValueTimestampHeaders) {
+        if (rawValueTimestampHeaders == null) {
+            throw new IllegalArgumentException("Cannot extract headers from null data");
+        }
+
+        final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
+        final int headerSize = ByteUtils.readVarint(buffer);
+        final byte[] rawHeaders = new byte[headerSize];
+        buffer.get(rawHeaders);
+
+        return HeadersDeserializer.deserialize(rawHeaders);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -72,19 +72,13 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         }
 
         final ByteBuffer buffer = ByteBuffer.wrap(valueTimestampHeaders);
-        final int headerSize = ByteUtils.readVarint(buffer);
+        final int headersSize = ByteUtils.readVarint(buffer);
 
-        final byte[] rawHeaders = new byte[headerSize];
-        buffer.get(rawHeaders);
-
-        final byte[] rawTimestamp = new byte[Long.BYTES];
-        buffer.get(rawTimestamp);
-
+        final byte[] rawHeaders = readBytes(buffer, headersSize);
+        final byte[] rawTimestamp = readBytes(buffer, Long.BYTES);
         final long timestamp = timestampDeserializer.deserialize(topic, rawTimestamp);
 
-        final byte[] rawValue = new byte[buffer.remaining()];
-        buffer.get(rawValue);
-
+        final byte[] rawValue = readBytes(buffer, buffer.remaining());
         final V value = valueDeserializer.deserialize(topic, rawValue);
 
         return ValueTimestampHeaders.makeWithRawHeaders(value, timestamp, rawHeaders);
@@ -105,6 +99,26 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
     }
 
     /**
+     * Reads the specified number of bytes from the buffer with validation.
+     *
+     * @param buffer the ByteBuffer to read from
+     * @param length the number of bytes to read
+     * @return the byte array containing the read bytes
+     * @throws IllegalArgumentException if buffer doesn't have enough bytes
+     */
+    private static byte[] readBytes(final ByteBuffer buffer, final int length) {
+        if (buffer.remaining() < length) {
+            throw new IllegalArgumentException(
+                "Invalid ValueTimestampHeaders format: expected " + length +
+                " bytes but only " + buffer.remaining() + " bytes remaining"
+            );
+        }
+        final byte[] bytes = new byte[length];
+        buffer.get(bytes);
+        return bytes;
+    }
+
+    /**
      * Extract raw value bytes from serialized ValueTimestampHeaders.
      */
     static byte[] rawValue(final byte[] rawValueTimestampHeaders) {
@@ -113,30 +127,21 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         }
 
         final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
-        final int headerSize = ByteUtils.readVarint(buffer);
-        buffer.position(buffer.position() + headerSize + Long.BYTES);
+        final int headersSize = ByteUtils.readVarint(buffer);
+        buffer.position(buffer.position() + headersSize + Long.BYTES);
 
-        final byte[] rawValue = new byte[buffer.remaining()];
-        buffer.get(rawValue);
-
-        return rawValue;
+        return readBytes(buffer, buffer.remaining());
     }
 
     /**
      * Extract timestamp from serialized ValueTimestampHeaders.
      */
     static long timestamp(final byte[] rawValueTimestampHeaders) {
-        if (rawValueTimestampHeaders == null) {
-            throw new IllegalArgumentException("Cannot extract timestamp from null data");
-        }
-
         final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
-        final int headerSize = ByteUtils.readVarint(buffer);
-        buffer.position(buffer.position() + headerSize);
+        final int headersSize = ByteUtils.readVarint(buffer);
+        buffer.position(buffer.position() + headersSize);
 
-        final byte[] rawTimestamp = new byte[Long.BYTES];
-        buffer.get(rawTimestamp);
-
+        final byte[] rawTimestamp = readBytes(buffer, Long.BYTES);
         return LONG_DESERIALIZER.deserialize(null, rawTimestamp);
     }
 
@@ -145,13 +150,12 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
      */
     static Headers headers(final byte[] rawValueTimestampHeaders) {
         if (rawValueTimestampHeaders == null) {
-            throw new IllegalArgumentException("Cannot extract headers from null data");
+            return null;
         }
 
         final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
-        final int headerSize = ByteUtils.readVarint(buffer);
-        final byte[] rawHeaders = new byte[headerSize];
-        buffer.get(rawHeaders);
+        final int headersSize = ByteUtils.readVarint(buffer);
+        final byte[] rawHeaders = readBytes(buffer, headersSize);
 
         return HeadersDeserializer.deserialize(rawHeaders);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -39,9 +39,9 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  *
  * Where:
  * - headersSize: Size of the headersBytes section in bytes, encoded as varint
+ * - headersBytes:
  *   - For null/empty headers: headersSize = 0, headersBytes is omitted (0 bytes)
- *   - For non-empty headers: headersSize > 0, headersBytes follows
- * - headersBytes: Serialized headers ([count(varint)][header1][header2]...) to be deserialized by HeadersDeserializer
+ *   - For non-empty headers: headersSize > 0, serialized headers in the format [count(varint)][header1][header2]... to be processed by HeadersDeserializer.
  * - timestamp: 8-byte long timestamp
  * - value: Serialized value to be deserialized with the provided value deserializer
  *

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerde.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerde;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Serde for ValueTimestampHeaders.
+ *
+ * This serde wraps a value serde and handles serialization/deserialization of
+ * values along with their timestamps and headers.
+ *
+ * This is used by KIP-1271 to support headers in state stores.
+ */
+public class ValueTimestampHeadersSerde<V> extends WrappingNullableSerde<ValueTimestampHeaders<V>, Void, V> {
+    public ValueTimestampHeadersSerde(final Serde<V> valueSerde) {
+        super(
+            new ValueTimestampHeadersSerializer<>(requireNonNull(valueSerde, "valueSerde was null").serializer()),
+            new ValueTimestampHeadersDeserializer<>(requireNonNull(valueSerde, "valueSerde was null").deserializer())
+        );
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -41,6 +41,8 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  *
  * Where:
  * - headersSize: Size of the headersBytes section in bytes, encoded as varint
+ *   - For null/empty headers: headersSize = 0, headersBytes is omitted (0 bytes)
+ *   - For non-empty headers: headersSize > 0, headersBytes follows
  * - headersBytes: Serialized headers ([count(varint)][header1][header2]...) from HeadersSerializer
  * - timestamp: 8-byte long timestamp
  * - value: Serialized value using the provided value serializer
@@ -67,19 +69,19 @@ public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSeria
     }
 
     @Override
-    public byte[] serialize(final String topic, final ValueTimestampHeaders<V> data) {
-        if (data == null) {
+    public byte[] serialize(final String topic, final ValueTimestampHeaders<V> valueTimestampHeaders) {
+        if (valueTimestampHeaders == null) {
             return null;
         }
-        return serialize(topic, data.value(), data.timestamp(), data.headers());
+        return serialize(topic, valueTimestampHeaders.value(), valueTimestampHeaders.timestamp(), valueTimestampHeaders.headers());
     }
 
-    public byte[] serialize(final String topic, final V data, final long timestamp, final Headers headers) {
-        if (data == null) {
+    public byte[] serialize(final String topic, final V plainValue, final long timestamp, final Headers headers) {
+        if (plainValue == null) {
             return null;
         }
 
-        final byte[] rawValue = valueSerializer.serialize(topic, headers, data);
+        final byte[] rawValue = valueSerializer.serialize(topic, headers, plainValue);
 
         // Since we can't control the result of the internal serializer, we make sure that the result
         // is not null as well.
@@ -90,17 +92,19 @@ public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSeria
             return null;
         }
 
-        final byte[] rawHeaders = headersSerializer.serialize(topic, headers);  // [count][header1][header2]...
         final byte[] rawTimestamp = timestampSerializer.serialize(topic, timestamp);
+
+        // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
+        final byte[] rawHeaders = headersSerializer.serialize(topic, headers);
 
         // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
              DataOutputStream out = new DataOutputStream(baos)) {
 
-            ByteUtils.writeVarint(rawHeaders.length, out);  // headersSize
-            out.write(rawHeaders);                           // [count][header1][header2]...
-            out.write(rawTimestamp);                         // [timestamp(8)]
-            out.write(rawValue);                             // [value]
+            ByteUtils.writeVarint(rawHeaders.length, out);  // headersSize (it may be 0 due to null/empty headers)
+            out.write(rawHeaders);                          // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
+            out.write(rawTimestamp);                        // [timestamp(8)]
+            out.write(rawValue);                            // [value]
 
             return baos.toByteArray();
         } catch (IOException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -41,9 +41,9 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  *
  * Where:
  * - headersSize: Size of the headersBytes section in bytes, encoded as varint
+ * - headersBytes:
  *   - For null/empty headers: headersSize = 0, headersBytes is omitted (0 bytes)
- *   - For non-empty headers: headersSize > 0, headersBytes follows
- * - headersBytes: Serialized headers ([count(varint)][header1][header2]...) from HeadersSerializer
+ *   - For non-empty headers: headersSize > 0, serialized headers ([count(varint)][header1][header2]...) from HeadersSerializer
  * - timestamp: 8-byte long timestamp
  * - value: Serialized value using the provided value serializer
  *

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -51,7 +51,7 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  */
 public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<ValueTimestampHeaders<V>, Void, V> {
     public final Serializer<V> valueSerializer;
-    private final Serializer<Long> timestampSerializer;
+    private final LongSerializer timestampSerializer;
     private final HeadersSerializer headersSerializer;
 
     ValueTimestampHeadersSerializer(final Serializer<V> valueSerializer) {
@@ -76,7 +76,7 @@ public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSeria
         return serialize(topic, valueTimestampHeaders.value(), valueTimestampHeaders.timestamp(), valueTimestampHeaders.headers());
     }
 
-    public byte[] serialize(final String topic, final V plainValue, final long timestamp, final Headers headers) {
+    private byte[] serialize(final String topic, final V plainValue, final long timestamp, final Headers headers) {
         if (plainValue == null) {
             return null;
         }
@@ -98,8 +98,8 @@ public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSeria
         final byte[] rawHeaders = headersSerializer.serialize(topic, headers);
 
         // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             DataOutputStream out = new DataOutputStream(baos)) {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             final DataOutputStream out = new DataOutputStream(baos)) {
 
             ByteUtils.writeVarint(rawHeaders.length, out);  // headersSize (it may be 0 due to null/empty headers)
             out.write(rawHeaders);                          // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -103,7 +104,7 @@ public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSeria
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to serialize ValueTimestampHeaders", e);
+            throw new SerializationException("Failed to serialize ValueTimestampHeaders", e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.ByteUtils;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.initNullableSerializer;
+
+/**
+ * Serializer for ValueTimestampHeaders.
+ *
+ * Serialization format (per KIP-1271):
+ * [headersSize(varint)][headersBytes][timestamp(8)][value]
+ *
+ * Where:
+ * - headersSize: Size of the headersBytes section in bytes, encoded as varint
+ * - headersBytes: Serialized headers ([count(varint)][header1][header2]...) from HeadersSerializer
+ * - timestamp: 8-byte long timestamp
+ * - value: Serialized value using the provided value serializer
+ *
+ * This is used by KIP-1271 to serialize values with timestamps and headers for state stores.
+ */
+public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<ValueTimestampHeaders<V>, Void, V> {
+    public final Serializer<V> valueSerializer;
+    private final Serializer<Long> timestampSerializer;
+    private final HeadersSerializer headersSerializer;
+
+    ValueTimestampHeadersSerializer(final Serializer<V> valueSerializer) {
+        Objects.requireNonNull(valueSerializer);
+        this.valueSerializer = valueSerializer;
+        this.timestampSerializer = new LongSerializer();
+        this.headersSerializer = new HeadersSerializer();
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+        valueSerializer.configure(configs, isKey);
+        timestampSerializer.configure(configs, isKey);
+        headersSerializer.configure(configs, isKey);
+    }
+
+    @Override
+    public byte[] serialize(final String topic, final ValueTimestampHeaders<V> data) {
+        if (data == null) {
+            return null;
+        }
+        return serialize(topic, data.value(), data.timestamp(), data.headers());
+    }
+
+    public byte[] serialize(final String topic, final V data, final long timestamp, final Headers headers) {
+        if (data == null) {
+            return null;
+        }
+
+        final byte[] rawValue = valueSerializer.serialize(topic, headers, data);
+
+        // Since we can't control the result of the internal serializer, we make sure that the result
+        // is not null as well.
+        // Serializing non-null values to null can be useful when working with Optional-like values
+        // where the Optional.empty case is serialized to null.
+        // See the discussion here: https://github.com/apache/kafka/pull/7679
+        if (rawValue == null) {
+            return null;
+        }
+
+        final byte[] rawHeaders = headersSerializer.serialize(topic, headers);  // [count][header1][header2]...
+        final byte[] rawTimestamp = timestampSerializer.serialize(topic, timestamp);
+
+        // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+
+            ByteUtils.writeVarint(rawHeaders.length, out);  // headersSize
+            out.write(rawHeaders);                           // [count][header1][header2]...
+            out.write(rawTimestamp);                         // [timestamp(8)]
+            out.write(rawValue);                             // [value]
+
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize ValueTimestampHeaders", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        valueSerializer.close();
+        timestampSerializer.close();
+        headersSerializer.close();
+    }
+
+    @Override
+    public void setIfUnset(final SerdeGetter getter) {
+        // ValueTimestampHeadersSerializer never wraps a null serializer (or configure would throw),
+        // but it may wrap a serializer that itself wraps a null serializer.
+        initNullableSerializer(valueSerializer, getter);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.state.internals.HeadersSerializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ValueTimestampHeadersTest {
+
+    private static final String VALUE = "test-value";
+    private static final long TIMESTAMP = 123456789L;
+
+    @Test
+    public void shouldCreateInstanceWithMake() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+
+        assertNotNull(valueTimestampHeaders);
+        assertEquals(VALUE, valueTimestampHeaders.value());
+        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
+        assertEquals(headers, valueTimestampHeaders.headers());
+    }
+
+    @Test
+    public void shouldReturnNullWhenValueIsNullWithMake() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(null, TIMESTAMP, headers);
+
+        assertNull(valueTimestampHeaders);
+    }
+
+    @Test
+    public void shouldCreateInstanceWithMakeAllowNullable() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.makeAllowNullable(VALUE, TIMESTAMP, headers);
+
+        assertNotNull(valueTimestampHeaders);
+        assertEquals(VALUE, valueTimestampHeaders.value());
+        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
+        assertEquals(headers, valueTimestampHeaders.headers());
+    }
+
+    @Test
+    public void shouldCreateInstanceWithNullValueUsingMakeAllowNullable() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.makeAllowNullable(null, TIMESTAMP, headers);
+
+        assertNotNull(valueTimestampHeaders);
+        assertNull(valueTimestampHeaders.value());
+        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
+        assertEquals(headers, valueTimestampHeaders.headers());
+    }
+
+    @Test
+    public void shouldCreateEmptyHeadersWhenHeadersAreNull() {
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, null);
+
+        assertNotNull(valueTimestampHeaders);
+        assertNotNull(valueTimestampHeaders.headers());
+        assertEquals(0, valueTimestampHeaders.headers().toArray().length);
+    }
+
+    @Test
+    public void shouldGetValueOrNull() {
+        final Headers headers = new RecordHeaders();
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+
+        assertEquals(VALUE, ValueTimestampHeaders.getValueOrNull(valueTimestampHeaders));
+        assertNull(ValueTimestampHeaders.getValueOrNull(null));
+    }
+
+    @Test
+    public void shouldBeEqualWhenSameValues() {
+        final Headers headers1 = new RecordHeaders().add("key1", "value1".getBytes());
+        final Headers headers2 = new RecordHeaders().add("key1", "value1".getBytes());
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders1 = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers1);
+        final ValueTimestampHeaders<String> valueTimestampHeaders2 = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers2);
+
+        assertEquals(valueTimestampHeaders1, valueTimestampHeaders2);
+        assertEquals(valueTimestampHeaders1.hashCode(), valueTimestampHeaders2.hashCode());
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenDifferentValues() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders1 = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+        final ValueTimestampHeaders<String> valueTimestampHeaders2 = ValueTimestampHeaders.make("different", TIMESTAMP, headers);
+
+        assertNotEquals(valueTimestampHeaders1, valueTimestampHeaders2);
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenDifferentTimestamps() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders1 = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+        final ValueTimestampHeaders<String> valueTimestampHeaders2 = ValueTimestampHeaders.make(VALUE, TIMESTAMP + 1, headers);
+
+        assertNotEquals(valueTimestampHeaders1, valueTimestampHeaders2);
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenDifferentHeaders() {
+        final Headers headers1 = new RecordHeaders().add("key1", "value1".getBytes());
+        final Headers headers2 = new RecordHeaders().add("key2", "value2".getBytes());
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders1 = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers1);
+        final ValueTimestampHeaders<String> valueTimestampHeaders2 = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers2);
+
+        assertNotEquals(valueTimestampHeaders1, valueTimestampHeaders2);
+    }
+
+    @Test
+    public void shouldBeEqualToItself() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+
+        assertEquals(valueTimestampHeaders, valueTimestampHeaders);
+    }
+
+    @Test
+    public void shouldHaveCorrectToString() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+
+        final String toString = valueTimestampHeaders.toString();
+        assertNotNull(toString);
+        assertTrue(toString.contains("value=" + VALUE));
+        assertTrue(toString.contains("timestamp=" + TIMESTAMP));
+    }
+
+    @Test
+    public void shouldCreateInstanceWithMakeWithRawHeaders() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+
+        assertNotNull(valueTimestampHeaders);
+        assertEquals(VALUE, valueTimestampHeaders.value());
+        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
+
+        final Headers deserializedHeaders = valueTimestampHeaders.headers();
+        assertNotNull(deserializedHeaders);
+        assertEquals(1, deserializedHeaders.toArray().length);
+        assertEquals("key1", deserializedHeaders.lastHeader("key1").key());
+        assertArrayEquals("value1".getBytes(), deserializedHeaders.lastHeader("key1").value());
+    }
+
+    @Test
+    public void shouldReturnNullWhenValueIsNullWithMakeWithRawHeaders() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.makeWithRawHeaders(null, TIMESTAMP, rawHeaders);
+
+        assertNull(valueTimestampHeaders);
+    }
+
+    @Test
+    public void shouldHandleEmptyRawHeaders() {
+        final Headers headers = new RecordHeaders();
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+
+        assertNotNull(valueTimestampHeaders);
+        final Headers deserializedHeaders = valueTimestampHeaders.headers();
+        assertNotNull(deserializedHeaders);
+        assertEquals(0, deserializedHeaders.toArray().length);
+    }
+
+    @Test
+    public void shouldBeEqualWhenCreatedWithMakeAndMakeWithRawHeaders() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders1 =
+            ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+        final ValueTimestampHeaders<String> valueTimestampHeaders2 =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+
+        assertEquals(valueTimestampHeaders1, valueTimestampHeaders2);
+        assertEquals(valueTimestampHeaders1.hashCode(), valueTimestampHeaders2.hashCode());
+    }
+
+    @Test
+    public void shouldBeEqualWhenBothCreatedWithMakeWithRawHeaders() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders1 =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+        final ValueTimestampHeaders<String> valueTimestampHeaders2 =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+
+        assertEquals(valueTimestampHeaders1, valueTimestampHeaders2);
+        assertEquals(valueTimestampHeaders1.hashCode(), valueTimestampHeaders2.hashCode());
+    }
+
+    @Test
+    public void shouldCallHeadersMultipleTimesWithoutError() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+
+        final Headers headers1 = valueTimestampHeaders.headers();
+        final Headers headers2 = valueTimestampHeaders.headers();
+
+        assertNotNull(headers1);
+        assertNotNull(headers2);
+        assertEquals(headers1, headers2);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
@@ -175,6 +175,24 @@ public class ValueTimestampHeadersTest {
     }
 
     @Test
+    public void shouldDeserializeHeaderLazily() {
+        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
+        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
+
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
+
+        assertNotNull(valueTimestampHeaders);
+        assertEquals(VALUE, valueTimestampHeaders.value());
+        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
+        assertNull(valueTimestampHeaders.headers, "should be null before invocation of headers()");
+        valueTimestampHeaders.headers();
+        assertNotNull(valueTimestampHeaders.headers, "should be deserialize after invocation of headers()");
+        assertEquals(headers, valueTimestampHeaders.headers);
+        assertEquals(headers, valueTimestampHeaders.headers());
+    }
+
+    @Test
     public void shouldReturnNullWhenValueIsNullWithMakeWithRawHeaders() {
         final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
         final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);

--- a/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
@@ -18,11 +18,9 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.streams.state.internals.HeadersSerializer;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -87,8 +85,11 @@ public class ValueTimestampHeadersTest {
     @Test
     public void shouldGetValueOrNull() {
         final Headers headers = new RecordHeaders();
-        final ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+        ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+        assertEquals(VALUE, ValueTimestampHeaders.getValueOrNull(valueTimestampHeaders));
+        assertNull(ValueTimestampHeaders.getValueOrNull(null));
 
+        valueTimestampHeaders = ValueTimestampHeaders.makeAllowNullable(VALUE, TIMESTAMP, null);
         assertEquals(VALUE, ValueTimestampHeaders.getValueOrNull(valueTimestampHeaders));
         assertNull(ValueTimestampHeaders.getValueOrNull(null));
     }
@@ -153,111 +154,5 @@ public class ValueTimestampHeadersTest {
         assertNotNull(toString);
         assertTrue(toString.contains("value=" + VALUE));
         assertTrue(toString.contains("timestamp=" + TIMESTAMP));
-    }
-
-    @Test
-    public void shouldCreateInstanceWithMakeWithRawHeaders() {
-        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-
-        assertNotNull(valueTimestampHeaders);
-        assertEquals(VALUE, valueTimestampHeaders.value());
-        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
-
-        final Headers deserializedHeaders = valueTimestampHeaders.headers();
-        assertNotNull(deserializedHeaders);
-        assertEquals(1, deserializedHeaders.toArray().length);
-        assertEquals("key1", deserializedHeaders.lastHeader("key1").key());
-        assertArrayEquals("value1".getBytes(), deserializedHeaders.lastHeader("key1").value());
-    }
-
-    @Test
-    public void shouldDeserializeHeaderLazily() {
-        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-
-        assertNotNull(valueTimestampHeaders);
-        assertEquals(VALUE, valueTimestampHeaders.value());
-        assertEquals(TIMESTAMP, valueTimestampHeaders.timestamp());
-        assertNull(valueTimestampHeaders.headers, "should be null before invocation of headers()");
-        valueTimestampHeaders.headers();
-        assertNotNull(valueTimestampHeaders.headers, "should be deserialize after invocation of headers()");
-        assertEquals(headers, valueTimestampHeaders.headers);
-        assertEquals(headers, valueTimestampHeaders.headers());
-    }
-
-    @Test
-    public void shouldReturnNullWhenValueIsNullWithMakeWithRawHeaders() {
-        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders =
-            ValueTimestampHeaders.makeWithRawHeaders(null, TIMESTAMP, rawHeaders);
-
-        assertNull(valueTimestampHeaders);
-    }
-
-    @Test
-    public void shouldHandleEmptyRawHeaders() {
-        final Headers headers = new RecordHeaders();
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-
-        assertNotNull(valueTimestampHeaders);
-        final Headers deserializedHeaders = valueTimestampHeaders.headers();
-        assertNotNull(deserializedHeaders);
-        assertEquals(0, deserializedHeaders.toArray().length);
-    }
-
-    @Test
-    public void shouldBeEqualWhenCreatedWithMakeAndMakeWithRawHeaders() {
-        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders1 =
-            ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
-        final ValueTimestampHeaders<String> valueTimestampHeaders2 =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-
-        assertEquals(valueTimestampHeaders1, valueTimestampHeaders2);
-        assertEquals(valueTimestampHeaders1.hashCode(), valueTimestampHeaders2.hashCode());
-    }
-
-    @Test
-    public void shouldBeEqualWhenBothCreatedWithMakeWithRawHeaders() {
-        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders1 =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-        final ValueTimestampHeaders<String> valueTimestampHeaders2 =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-
-        assertEquals(valueTimestampHeaders1, valueTimestampHeaders2);
-        assertEquals(valueTimestampHeaders1.hashCode(), valueTimestampHeaders2.hashCode());
-    }
-
-    @Test
-    public void shouldCallHeadersMultipleTimesWithoutError() {
-        final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
-        final byte[] rawHeaders = new HeadersSerializer().serialize("", headers);
-
-        final ValueTimestampHeaders<String> valueTimestampHeaders =
-            ValueTimestampHeaders.makeWithRawHeaders(VALUE, TIMESTAMP, rawHeaders);
-
-        final Headers headers1 = valueTimestampHeaders.headers();
-        final Headers headers2 = valueTimestampHeaders.headers();
-
-        assertNotNull(headers1);
-        assertNotNull(headers2);
-        assertEquals(headers1, headers2);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/ValueTimestampHeadersTest.java
@@ -87,10 +87,10 @@ public class ValueTimestampHeadersTest {
         final Headers headers = new RecordHeaders();
         ValueTimestampHeaders<String> valueTimestampHeaders = ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
         assertEquals(VALUE, ValueTimestampHeaders.getValueOrNull(valueTimestampHeaders));
-        assertNull(ValueTimestampHeaders.getValueOrNull(null));
 
-        valueTimestampHeaders = ValueTimestampHeaders.makeAllowNullable(VALUE, TIMESTAMP, null);
-        assertEquals(VALUE, ValueTimestampHeaders.getValueOrNull(valueTimestampHeaders));
+        valueTimestampHeaders = ValueTimestampHeaders.makeAllowNullable(null, TIMESTAMP, headers);
+        assertNull(ValueTimestampHeaders.getValueOrNull(valueTimestampHeaders));
+
         assertNull(ValueTimestampHeaders.getValueOrNull(null));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -123,5 +125,37 @@ public class HeadersDeserializerTest {
         assertNotNull(header);
         assertEquals("key1", header.key());
         assertArrayEquals(new byte[0], header.value());
+    }
+
+    @Test
+    public void shouldAllowDuplicateKeys() {
+        final Headers original = new RecordHeaders()
+            .add("key0", "value0".getBytes())
+            .add("key0", "value0".getBytes())
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes())
+            .add("key2", "value3".getBytes());
+        final byte[] serialized = serializer.serialize("", original);
+        final Headers deserialized = deserializer.deserialize("", serialized);
+        assertNotNull(deserialized);
+
+        final Header[] headerArray = deserialized.toArray();
+        assertEquals(5, headerArray.length);
+        final Iterator<Header> iterator = deserialized.iterator();
+        Header next = iterator.next();
+        assertEquals("key0", next.key());
+        assertArrayEquals("value0".getBytes(), next.value());
+        next = iterator.next();
+        assertEquals("key0", next.key());
+        assertArrayEquals("value0".getBytes(), next.value());
+        next = iterator.next();
+        assertEquals("key1", next.key());
+        assertArrayEquals("value1".getBytes(), next.value());
+        next = iterator.next();
+        assertEquals("key2", next.key());
+        assertArrayEquals("value2".getBytes(), next.value());
+        next = iterator.next();
+        assertEquals("key2", next.key());
+        assertArrayEquals("value3".getBytes(), next.value());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
@@ -129,29 +129,4 @@ public class HeadersSerializerTest {
         assertEquals("key1", header.key());
         assertArrayEquals(new byte[0], header.value());
     }
-
-    @Test
-    public void shouldSerializeHeadersWithSpecialCharacters() {
-        final Headers headers = new RecordHeaders()
-            .add("key-with-dash", "value".getBytes())
-            .add("key.with.dots", "value".getBytes())
-            .add("key_with_underscores", "value".getBytes());
-        final byte[] serialized = serializer.serialize("", headers);
-
-        assertNotNull(serialized);
-        assertTrue(serialized.length > 0);
-
-        final Headers deserialized = deserializer.deserialize("", serialized);
-        assertNotNull(deserialized);
-        assertEquals(3, deserialized.toArray().length);
-
-        assertNotNull(deserialized.lastHeader("key-with-dash"));
-        assertArrayEquals("value".getBytes(), deserialized.lastHeader("key-with-dash").value());
-
-        assertNotNull(deserialized.lastHeader("key.with.dots"));
-        assertArrayEquals("value".getBytes(), deserialized.lastHeader("key.with.dots").value());
-
-        assertNotNull(deserialized.lastHeader("key_with_underscores"));
-        assertArrayEquals("value".getBytes(), deserialized.lastHeader("key_with_underscores").value());
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ValueTimestampHeadersDeserializerTest {
+
+    private static final String TOPIC = "test-topic";
+    private ValueTimestampHeadersSerializer<String> serializer;
+    private ValueTimestampHeadersDeserializer<String> deserializer;
+
+    @BeforeEach
+    void setup() {
+        serializer = new ValueTimestampHeadersSerializer<>(Serdes.String().serializer());
+        deserializer = new ValueTimestampHeadersDeserializer<>(Serdes.String().deserializer());
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (serializer != null) {
+            serializer.close();
+        }
+        if (deserializer != null) {
+            deserializer.close();
+        }
+    }
+
+    @Test
+    public void shouldDeserializeNull() {
+        final ValueTimestampHeaders<String> result = deserializer.deserialize(TOPIC, null);
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldDeserializeWithEmptyHeaders() {
+        final Headers headers = new RecordHeaders();
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
+
+        assertNotNull(deserialized);
+        assertEquals("test-value", deserialized.value());
+        assertEquals(123456789L, deserialized.timestamp());
+        assertNotNull(deserialized.headers());
+        assertEquals(0, deserialized.headers().toArray().length);
+    }
+
+    @Test
+    public void shouldDeserializeWithSingleHeader() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
+
+        assertNotNull(deserialized);
+        assertEquals("test-value", deserialized.value());
+        assertEquals(123456789L, deserialized.timestamp());
+
+        final Headers deserializedHeaders = deserialized.headers();
+        assertNotNull(deserializedHeaders);
+        assertEquals(1, deserializedHeaders.toArray().length);
+
+        final Header header = deserializedHeaders.lastHeader("key1");
+        assertNotNull(header);
+        assertEquals("key1", header.key());
+        assertArrayEquals("value1".getBytes(), header.value());
+    }
+
+    @Test
+    public void shouldDeserializeWithMultipleHeaders() {
+        final Headers headers = new RecordHeaders()
+            .add("key0", "value0".getBytes())
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
+
+        assertNotNull(deserialized);
+        assertEquals("test-value", deserialized.value());
+        assertEquals(123456789L, deserialized.timestamp());
+
+        final Headers deserializedHeaders = deserialized.headers();
+        assertNotNull(deserializedHeaders);
+        Header[] headersArray = deserializedHeaders.toArray();
+        assertEquals(3, headersArray.length);
+
+        for (int i = 0; i < headersArray.length; i++) {
+            Header header = headersArray[i];
+            assertEquals("key" + i, header.key());
+            assertArrayEquals(("value" + i).getBytes(), header.value());
+        }
+    }
+
+    @Test
+    public void shouldReturnNullWhenSerializingNullValue() {
+        // When value is null, serializer returns null (by design)
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.makeAllowNullable(null, 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        assertNull(serialized, "Serializer should return null when value is null");
+
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
+        assertNull(deserialized, "Deserializer should return null when input is null");
+    }
+
+    @Test
+    public void shouldDeserializeWithHeaderContainingNullValue() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", null);
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
+
+        assertNotNull(deserialized);
+        assertEquals("test-value", deserialized.value());
+        assertEquals(123456789L, deserialized.timestamp());
+
+        final Header header = deserialized.headers().lastHeader("key1");
+        assertNotNull(header);
+        assertEquals("key1", header.key());
+        assertNull(header.value());
+    }
+
+    @Test
+    public void shouldDeserializeWithLargeValue() {
+        final StringBuilder largeValue = new StringBuilder();
+        largeValue.append("x".repeat(10000));
+
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make(largeValue.toString(), 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
+
+        assertNotNull(deserialized);
+        assertEquals(largeValue.toString(), deserialized.value());
+        assertEquals(123456789L, deserialized.timestamp());
+        assertEquals(1, deserialized.headers().toArray().length);
+    }
+
+    @Test
+    public void shouldExtractRawValue() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(serialized);
+
+        assertNotNull(rawValue);
+
+        try (Serde<String> stringSerde = Serdes.String()) {
+            final String value = stringSerde.deserializer().deserialize(TOPIC, rawValue);
+            assertEquals("test-value", value);
+        }
+    }
+
+    @Test
+    public void shouldReturnNullForRawValueWhenInputIsNull() {
+        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(null);
+        assertNull(rawValue);
+    }
+
+    @Test
+    public void shouldExtractTimestamp() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final long timestamp = ValueTimestampHeadersDeserializer.timestamp(serialized);
+
+        assertEquals(123456789L, timestamp);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenExtractingTimestampFromNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            ValueTimestampHeadersDeserializer.timestamp(null)
+        );
+    }
+
+    @Test
+    public void shouldExtractHeaders() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final Headers extractedHeaders = ValueTimestampHeadersDeserializer.headers(serialized);
+
+        assertNotNull(extractedHeaders);
+        assertEquals(2, extractedHeaders.toArray().length);
+        assertArrayEquals("value1".getBytes(), extractedHeaders.lastHeader("key1").value());
+        assertArrayEquals("value2".getBytes(), extractedHeaders.lastHeader("key2").value());
+    }
+
+    @Test
+    public void shouldExtractEmptyHeaders() {
+        final Headers headers = new RecordHeaders();
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make("test-value", 123456789L, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        final Headers extractedHeaders = ValueTimestampHeadersDeserializer.headers(serialized);
+
+        assertNotNull(extractedHeaders);
+        assertEquals(0, extractedHeaders.toArray().length);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenExtractingHeadersFromNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            ValueTimestampHeadersDeserializer.headers(null)
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -173,25 +173,6 @@ public class ValueTimestampHeadersDeserializerTest {
     }
 
     @Test
-    public void shouldDeserializeWithLargeValue() {
-        final StringBuilder largeValue = new StringBuilder();
-        largeValue.append("x".repeat(10000));
-
-        final Headers headers = new RecordHeaders()
-            .add("key1", "value1".getBytes());
-        final ValueTimestampHeaders<String> original =
-            ValueTimestampHeaders.make(largeValue.toString(), 123456789L, headers);
-
-        final byte[] serialized = serializer.serialize(TOPIC, original);
-        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, serialized);
-
-        assertNotNull(deserialized);
-        assertEquals(largeValue.toString(), deserialized.value());
-        assertEquals(123456789L, deserialized.timestamp());
-        assertEquals(1, deserialized.headers().toArray().length);
-    }
-
-    @Test
     public void shouldExtractValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -27,8 +28,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -105,7 +109,7 @@ public class ValueTimestampHeadersDeserializerTest {
     public void shouldDeserializeWithMultipleHeaders() {
         final Headers headers = new RecordHeaders()
             .add("key0", "value0".getBytes())
-            .add("key1", "value1".getBytes())
+            .add("key0", "value1".getBytes())
             .add("key2", "value2".getBytes());
         final ValueTimestampHeaders<String> original =
             ValueTimestampHeaders.make("test-value", 123456789L, headers);
@@ -119,14 +123,19 @@ public class ValueTimestampHeadersDeserializerTest {
 
         final Headers deserializedHeaders = deserialized.headers();
         assertNotNull(deserializedHeaders);
-        Header[] headersArray = deserializedHeaders.toArray();
+        final Header[] headersArray = deserializedHeaders.toArray();
         assertEquals(3, headersArray.length);
-
-        for (int i = 0; i < headersArray.length; i++) {
-            Header header = headersArray[i];
-            assertEquals("key" + i, header.key());
-            assertArrayEquals(("value" + i).getBytes(), header.value());
-        }
+        final Iterator<Header> iterator = headers.iterator();
+        Header next = iterator.next();
+        assertEquals("key0", next.key());
+        assertArrayEquals(("value0").getBytes(), next.value());
+        next = iterator.next();
+        assertEquals("key0", next.key());
+        assertArrayEquals(("value1").getBytes(), next.value());
+        next = iterator.next();
+        assertEquals("key2", next.key());
+        assertArrayEquals(("value2").getBytes(), next.value());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
@@ -183,27 +192,25 @@ public class ValueTimestampHeadersDeserializerTest {
     }
 
     @Test
-    public void shouldExtractRawValue() {
+    public void shouldExtractValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());
         final ValueTimestampHeaders<String> original =
             ValueTimestampHeaders.make("test-value", 123456789L, headers);
 
         final byte[] serialized = serializer.serialize(TOPIC, original);
-        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(serialized);
-
-        assertNotNull(rawValue);
 
         try (Serde<String> stringSerde = Serdes.String()) {
-            final String value = stringSerde.deserializer().deserialize(TOPIC, rawValue);
+            final String value = ValueTimestampHeadersDeserializer.value(serialized, stringSerde.deserializer());
+            assertNotNull(value);
             assertEquals("test-value", value);
         }
     }
 
     @Test
     public void shouldReturnNullForRawValueWhenInputIsNull() {
-        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(null);
-        assertNull(rawValue);
+        final ValueTimestampHeaders<String> value = ValueTimestampHeadersDeserializer.value(null, deserializer);
+        assertNull(value);
     }
 
     @Test
@@ -268,9 +275,9 @@ public class ValueTimestampHeadersDeserializerTest {
         // Create malformed data: only headersSize varint, no actual headers or timestamp
         final byte[] malformedData = new byte[] {0x02};  // headersSize = 1 but no data follows
 
-        assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(SerializationException.class, () ->
             deserializer.deserialize(TOPIC, malformedData),
-            "Should throw IllegalArgumentException for malformed data"
+            "Should throw SerializationException for malformed data"
         );
     }
 
@@ -282,9 +289,9 @@ public class ValueTimestampHeadersDeserializerTest {
             0x00, 0x00  // Only 2 bytes when 10 + 8 (timestamp) are expected
         };
 
-        assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(SerializationException.class, () ->
             deserializer.deserialize(TOPIC, malformedData),
-            "Should throw IllegalArgumentException when buffer doesn't have enough data"
+            "Should throw SerializationException when buffer doesn't have enough data"
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -60,7 +60,7 @@ public class ValueTimestampHeadersDeserializerTest {
     }
 
     @Test
-    public void shouldDeserializeNull() {
+    public void shouldDeserializeNullToNull() {
         final ValueTimestampHeaders<String> result = deserializer.deserialize(TOPIC, null);
         assertNull(result);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -181,7 +181,7 @@ public class ValueTimestampHeadersDeserializerTest {
 
         final byte[] serialized = serializer.serialize(TOPIC, original);
 
-        try (Serde<String> stringSerde = Serdes.String()) {
+        try (final Serde<String> stringSerde = Serdes.String()) {
             final String value = ValueTimestampHeadersDeserializer.value(serialized, stringSerde.deserializer());
             assertNotNull(value);
             assertEquals("test-value", value);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -222,7 +222,8 @@ public class ValueTimestampHeadersDeserializerTest {
 
     @Test
     public void shouldThrowExceptionWhenExtractingTimestampFromNull() {
-        assertThrows(IllegalArgumentException.class, () ->
+        // ByteBuffer.wrap() throws NullPointerException for null input
+        assertThrows(NullPointerException.class, () ->
             ValueTimestampHeadersDeserializer.timestamp(null)
         );
     }
@@ -258,9 +259,33 @@ public class ValueTimestampHeadersDeserializerTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenExtractingHeadersFromNull() {
+    public void shouldReturnNullWhenExtractingHeadersFromNull() {
+        final Headers headers = ValueTimestampHeadersDeserializer.headers(null);
+        assertNull(headers);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenDataIsTooShort() {
+        // Create malformed data: only headersSize varint, no actual headers or timestamp
+        final byte[] malformedData = new byte[] {0x02};  // headersSize = 1 but no data follows
+
         assertThrows(IllegalArgumentException.class, () ->
-            ValueTimestampHeadersDeserializer.headers(null)
+            deserializer.deserialize(TOPIC, malformedData),
+            "Should throw IllegalArgumentException for malformed data"
+        );
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHeadersSizeIsInconsistent() {
+        // Create data with headersSize = 10 but not enough actual data
+        final byte[] malformedData = new byte[] {
+            0x14,  // headersSize = 10 (ZigZag encoding)
+            0x00, 0x00  // Only 2 bytes when 10 + 8 (timestamp) are expected
+        };
+
+        assertThrows(IllegalArgumentException.class, () ->
+            deserializer.deserialize(TOPIC, malformedData),
+            "Should throw IllegalArgumentException when buffer doesn't have enough data"
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -131,7 +131,6 @@ public class ValueTimestampHeadersDeserializerTest {
 
     @Test
     public void shouldReturnNullWhenSerializingNullValue() {
-        // When value is null, serializer returns null (by design)
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());
         final ValueTimestampHeaders<String> original =

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 
@@ -101,7 +102,7 @@ public class ValueTimestampHeadersSerializerTest {
     public void shouldSerializeValueWithMultipleHeaders() {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes())
-            .add("key2", "value2".getBytes())
+            .add("key1", "value2".getBytes())
             .add("key3", "value3".getBytes());
         final ValueTimestampHeaders<String> valueTimestampHeaders =
             ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
@@ -138,47 +139,10 @@ public class ValueTimestampHeadersSerializerTest {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());
         final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
-
-        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(serialized);
-        assertNotNull(rawValue);
-
-        final String deserializedValue = Serdes.String().deserializer().deserialize(TOPIC, rawValue);
-        assertEquals(VALUE, deserializedValue);
-    }
-
-    @Test
-    public void shouldExtractTimestamp() {
-        final Headers headers = new RecordHeaders()
-            .add("key1", "value1".getBytes());
-        final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
-
-        final long extractedTimestamp = ValueTimestampHeadersDeserializer.timestamp(serialized);
-        assertEquals(TIMESTAMP, extractedTimestamp);
-    }
-
-    @Test
-    public void shouldExtractHeaders() {
-        final Headers headers = new RecordHeaders()
-            .add("key1", "value1".getBytes())
-            .add("key2", "value2".getBytes());
-        final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
-
-        final Headers extractedHeaders = ValueTimestampHeadersDeserializer.headers(serialized);
-        assertNotNull(extractedHeaders);
-        assertEquals(2, extractedHeaders.toArray().length);
-        assertArrayEquals("value1".getBytes(), extractedHeaders.lastHeader("key1").value());
-        assertArrayEquals("value2".getBytes(), extractedHeaders.lastHeader("key2").value());
-    }
-
-    @Test
-    public void shouldDeserializeNull() {
-        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, null);
-        assertNull(deserialized);
-    }
-
-    @Test
-    public void shouldReturnNullForRawValueOfNull() {
-        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(null);
-        assertNull(rawValue);
+        try (Serde<String> stringSerde = Serdes.String()) {
+            final String value = ValueTimestampHeadersDeserializer.value(serialized, stringSerde.deserializer());
+            assertNotNull(value);
+            assertEquals(VALUE, value);
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ValueTimestampHeadersSerializerTest {
+
+    private static final String TOPIC = "test-topic";
+    private static final long TIMESTAMP = 123456789L;
+    private static final String VALUE = "test-value";
+
+    private ValueTimestampHeadersSerializer<String> serializer;
+    private ValueTimestampHeadersDeserializer<String> deserializer;
+
+    @BeforeEach
+    void setup() {
+        serializer = new ValueTimestampHeadersSerializer<>(Serdes.String().serializer());
+        deserializer = new ValueTimestampHeadersDeserializer<>(Serdes.String().deserializer());
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (serializer != null) {
+            serializer.close();
+        }
+        if (deserializer != null) {
+            deserializer.close();
+        }
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeNonNullData() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final ValueTimestampHeaders<String> original =
+            ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, original);
+        assertNotNull(serialized);
+
+        final ValueTimestampHeaders<String> deserialized =
+            deserializer.deserialize(TOPIC, serialized);
+
+        assertNotNull(deserialized);
+        assertEquals(original.value(), deserialized.value());
+        assertEquals(original.timestamp(), deserialized.timestamp());
+        assertArrayEquals(original.headers().toArray(), deserialized.headers().toArray());
+    }
+
+    @Test
+    public void shouldSerializeNullDataAsNull() {
+        final byte[] serialized = serializer.serialize(TOPIC, null);
+        assertNull(serialized);
+    }
+
+    @Test
+    public void shouldSerializeValueWithEmptyHeaders() {
+        final Headers emptyHeaders = new RecordHeaders();
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.make(VALUE, TIMESTAMP, emptyHeaders);
+
+        final byte[] serialized = serializer.serialize(TOPIC, valueTimestampHeaders);
+        assertNotNull(serialized);
+
+        final ValueTimestampHeaders<String> deserialized =
+            deserializer.deserialize(TOPIC, serialized);
+
+        assertEquals(VALUE, deserialized.value());
+        assertEquals(TIMESTAMP, deserialized.timestamp());
+        assertEquals(0, deserialized.headers().toArray().length);
+    }
+
+    @Test
+    public void shouldSerializeValueWithMultipleHeaders() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes())
+            .add("key3", "value3".getBytes());
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.make(VALUE, TIMESTAMP, headers);
+
+        final byte[] serialized = serializer.serialize(TOPIC, valueTimestampHeaders);
+        assertNotNull(serialized);
+
+        final ValueTimestampHeaders<String> deserialized =
+            deserializer.deserialize(TOPIC, serialized);
+
+        assertEquals(VALUE, deserialized.value());
+        assertEquals(TIMESTAMP, deserialized.timestamp());
+        assertEquals(3, deserialized.headers().toArray().length);
+    }
+
+    @Test
+    public void shouldSerializeValueWithNullHeaders() {
+        final ValueTimestampHeaders<String> valueTimestampHeaders =
+            ValueTimestampHeaders.make(VALUE, TIMESTAMP, null);
+
+        final byte[] serialized = serializer.serialize(TOPIC, valueTimestampHeaders);
+        assertNotNull(serialized);
+
+        final ValueTimestampHeaders<String> deserialized =
+            deserializer.deserialize(TOPIC, serialized);
+
+        assertEquals(VALUE, deserialized.value());
+        assertEquals(TIMESTAMP, deserialized.timestamp());
+        assertEquals(0, deserialized.headers().toArray().length);
+    }
+
+    @Test
+    public void shouldExtractRawValue() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
+
+        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(serialized);
+        assertNotNull(rawValue);
+
+        final String deserializedValue = Serdes.String().deserializer().deserialize(TOPIC, rawValue);
+        assertEquals(VALUE, deserializedValue);
+    }
+
+    @Test
+    public void shouldExtractTimestamp() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes());
+        final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
+
+        final long extractedTimestamp = ValueTimestampHeadersDeserializer.timestamp(serialized);
+        assertEquals(TIMESTAMP, extractedTimestamp);
+    }
+
+    @Test
+    public void shouldExtractHeaders() {
+        final Headers headers = new RecordHeaders()
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes());
+        final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
+
+        final Headers extractedHeaders = ValueTimestampHeadersDeserializer.headers(serialized);
+        assertNotNull(extractedHeaders);
+        assertEquals(2, extractedHeaders.toArray().length);
+        assertArrayEquals("value1".getBytes(), extractedHeaders.lastHeader("key1").value());
+        assertArrayEquals("value2".getBytes(), extractedHeaders.lastHeader("key2").value());
+    }
+
+    @Test
+    public void shouldDeserializeNull() {
+        final ValueTimestampHeaders<String> deserialized = deserializer.deserialize(TOPIC, null);
+        assertNull(deserialized);
+    }
+
+    @Test
+    public void shouldReturnNullForRawValueOfNull() {
+        final byte[] rawValue = ValueTimestampHeadersDeserializer.rawValue(null);
+        assertNull(rawValue);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 
@@ -119,30 +118,10 @@ public class ValueTimestampHeadersSerializerTest {
     }
 
     @Test
-    public void shouldSerializeValueWithNullHeaders() {
+    public void shouldReturnNullWhenSerializingNullValue() {
         final ValueTimestampHeaders<String> valueTimestampHeaders =
-            ValueTimestampHeaders.make(VALUE, TIMESTAMP, null);
-
+            ValueTimestampHeaders.makeAllowNullable(null, TIMESTAMP, new RecordHeaders());
         final byte[] serialized = serializer.serialize(TOPIC, valueTimestampHeaders);
-        assertNotNull(serialized);
-
-        final ValueTimestampHeaders<String> deserialized =
-            deserializer.deserialize(TOPIC, serialized);
-
-        assertEquals(VALUE, deserialized.value());
-        assertEquals(TIMESTAMP, deserialized.timestamp());
-        assertEquals(0, deserialized.headers().toArray().length);
-    }
-
-    @Test
-    public void shouldExtractRawValue() {
-        final Headers headers = new RecordHeaders()
-            .add("key1", "value1".getBytes());
-        final byte[] serialized = serializer.serialize(TOPIC, VALUE, TIMESTAMP, headers);
-        try (Serde<String> stringSerde = Serdes.String()) {
-            final String value = ValueTimestampHeadersDeserializer.value(serialized, stringSerde.deserializer());
-            assertNotNull(value);
-            assertEquals(VALUE, value);
-        }
+        assertNull(serialized);
     }
 }


### PR DESCRIPTION
This PR adds the `ValueTimestampHeaders` and its related
serializer/deserializer as infrastructure of KIP-1271.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
