### PR TITLE
KAFKA-20127: Add new methods to StateSerdes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/HeadersBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/HeadersBytesStore.java
@@ -39,11 +39,11 @@ public interface HeadersBytesStore {
      * <p>
      * Empty headers are represented as 0 bytes (headersSize=0, no headersBytes),
      *
-     * @param plainValue the legacy timestamped value bytes
+     * @param valueAndTimestamp the legacy timestamped value bytes
      * @return the value in header-embedded format with empty headers
      */
-    static byte[] convertToHeaderFormat(final byte[] plainValue) {
-        if (plainValue == null) {
+    static byte[] convertToHeaderFormat(final byte[] valueAndTimestamp) {
+        if (valueAndTimestamp == null) {
             return null;
         }
 
@@ -53,9 +53,9 @@ public interface HeadersBytesStore {
         //   headersBytes = [] (empty, 0 bytes)
         // Result: [0x00][payload]
         return ByteBuffer
-            .allocate(1 + plainValue.length)
+            .allocate(1 + valueAndTimestamp.length)
             .put((byte) 0x00)
-            .put(plainValue)
+            .put(valueAndTimestamp)
             .array();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -17,11 +17,11 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.state.internals.ValueAndTimestampSerializer;
 
@@ -150,6 +150,7 @@ public final class StateSerdes<K, V> {
      *
      * @param rawKey  the key as raw bytes
      * @return        the key as typed object
+     * @deprecated Since 4.3. Use {@link #keyFrom(byte[], Headers)} instead.
      */
     @Deprecated
     public K keyFrom(final byte[] rawKey) {
@@ -171,6 +172,7 @@ public final class StateSerdes<K, V> {
      *
      * @param rawValue  the value as raw bytes
      * @return          the value as typed object
+     * @deprecated Since 4.3. Use {@link #valueFrom(byte[], Headers)} instead.
      */
     @Deprecated
     public V valueFrom(final byte[] rawValue) {
@@ -183,8 +185,8 @@ public final class StateSerdes<K, V> {
      * @param rawValue  the value as raw bytes
      * @return          the value as typed object
      */
-    public V valueFrom(final byte[] rawValue, Headers headers) {
-        return valueSerde.deserializer().deserialize(topic, headers, Utils.wrapNullable(rawValue));
+    public V valueFrom(final byte[] rawValue, final Headers headers) {
+        return valueSerde.deserializer().deserialize(topic, headers, rawValue);
     }
 
     /**
@@ -192,21 +194,11 @@ public final class StateSerdes<K, V> {
      *
      * @param key  the key to be serialized
      * @return     the serialized key
+     * @deprecated Since 4.3. Use {@link #rawKey(Object, Headers)} instead.
      */
     @Deprecated
     public byte[] rawKey(final K key) {
-        try {
-            return keySerde.serializer().serialize(topic, key);
-        } catch (final ClassCastException e) {
-            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
-            throw new StreamsException(
-                    String.format("A serializer (%s) is not compatible to the actual key type " +
-                                    "(key type: %s). Change the default Serdes in StreamConfig or " +
-                                    "provide correct Serdes via method parameters.",
-                            keySerializer().getClass().getName(),
-                            keyClass),
-                    e);
-        }
+        return rawKey(key, new RecordHeaders());
     }
 
     /**
@@ -235,30 +227,12 @@ public final class StateSerdes<K, V> {
      *
      * @param value  the value to be serialized
      * @return       the serialized value
+     * @deprecated Since 4.3. Use {@link #rawValue(Object, Headers)} instead.
      */
     @Deprecated
     @SuppressWarnings("rawtypes")
     public byte[] rawValue(final V value) {
-        try {
-            return valueSerde.serializer().serialize(topic, value);
-        } catch (final ClassCastException e) {
-            final String valueClass;
-            final Class<? extends Serializer> serializerClass;
-            if (valueSerializer() instanceof ValueAndTimestampSerializer) {
-                serializerClass = ((ValueAndTimestampSerializer<?>) valueSerializer()).valueSerializer.getClass();
-                valueClass = value == null ? "unknown because value is null" : ((ValueAndTimestamp) value).value().getClass().getName();
-            } else {
-                serializerClass = valueSerializer().getClass();
-                valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
-            }
-            throw new StreamsException(
-                    String.format("A serializer (%s) is not compatible to the actual value type " +
-                                    "(value type: %s). Change the default Serdes in StreamConfig or " +
-                                    "provide correct Serdes via method parameters.",
-                            serializerClass.getName(),
-                            valueClass),
-                    e);
-        }
+        return rawValue(value, new RecordHeaders());
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -176,7 +176,7 @@ public final class StateSerdes<K, V> {
      */
     @Deprecated
     public V valueFrom(final byte[] rawValue) {
-        return valueSerde.deserializer().deserialize(topic, rawValue);
+        return valueFrom(rawValue, new RecordHeaders());
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -154,7 +154,7 @@ public final class StateSerdes<K, V> {
      */
     @Deprecated
     public K keyFrom(final byte[] rawKey) {
-        return keySerde.deserializer().deserialize(topic, rawKey);
+        return keyFrom(rawKey, new RecordHeaders());
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -16,10 +16,12 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.state.internals.ValueAndTimestampSerializer;
 
@@ -149,8 +151,19 @@ public final class StateSerdes<K, V> {
      * @param rawKey  the key as raw bytes
      * @return        the key as typed object
      */
+    @Deprecated
     public K keyFrom(final byte[] rawKey) {
         return keySerde.deserializer().deserialize(topic, rawKey);
+    }
+
+    /**
+     * Deserialize the key from raw bytes.
+     *
+     * @param rawKey  the key as raw bytes
+     * @return        the key as typed object
+     */
+    public K keyFrom(final byte[] rawKey, final Headers headers) {
+        return keySerde.deserializer().deserialize(topic, headers, rawKey);
     }
 
     /**
@@ -159,8 +172,19 @@ public final class StateSerdes<K, V> {
      * @param rawValue  the value as raw bytes
      * @return          the value as typed object
      */
+    @Deprecated
     public V valueFrom(final byte[] rawValue) {
         return valueSerde.deserializer().deserialize(topic, rawValue);
+    }
+
+    /**
+     * Deserialize the value from raw bytes.
+     *
+     * @param rawValue  the value as raw bytes
+     * @return          the value as typed object
+     */
+    public V valueFrom(final byte[] rawValue, Headers headers) {
+        return valueSerde.deserializer().deserialize(topic, headers, Utils.wrapNullable(rawValue));
     }
 
     /**
@@ -169,6 +193,7 @@ public final class StateSerdes<K, V> {
      * @param key  the key to be serialized
      * @return     the serialized key
      */
+    @Deprecated
     public byte[] rawKey(final K key) {
         try {
             return keySerde.serializer().serialize(topic, key);
@@ -185,11 +210,33 @@ public final class StateSerdes<K, V> {
     }
 
     /**
+     * Serialize the given key.
+     *
+     * @param key  the key to be serialized
+     * @return     the serialized key
+     */
+    public byte[] rawKey(final K key, final Headers headers) {
+        try {
+            return keySerde.serializer().serialize(topic, headers, key);
+        } catch (final ClassCastException e) {
+            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
+            throw new StreamsException(
+                String.format("A serializer (%s) is not compatible to the actual key type " +
+                        "(key type: %s). Change the default Serdes in StreamConfig or " +
+                        "provide correct Serdes via method parameters.",
+                    keySerializer().getClass().getName(),
+                    keyClass),
+                e);
+        }
+    }
+
+    /**
      * Serialize the given value.
      *
      * @param value  the value to be serialized
      * @return       the serialized value
      */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public byte[] rawValue(final V value) {
         try {
@@ -211,6 +258,36 @@ public final class StateSerdes<K, V> {
                             serializerClass.getName(),
                             valueClass),
                     e);
+        }
+    }
+
+    /**
+     * Serialize the given value.
+     *
+     * @param value  the value to be serialized
+     * @return       the serialized value
+     */
+    @SuppressWarnings("rawtypes")
+    public byte[] rawValue(final V value, final Headers headers) {
+        try {
+            return valueSerde.serializer().serialize(topic, headers, value);
+        } catch (final ClassCastException e) {
+            final String valueClass;
+            final Class<? extends Serializer> serializerClass;
+            if (valueSerializer() instanceof ValueAndTimestampSerializer) {
+                serializerClass = ((ValueAndTimestampSerializer<?>) valueSerializer()).valueSerializer.getClass();
+                valueClass = value == null ? "unknown because value is null" : ((ValueAndTimestamp) value).value().getClass().getName();
+            } else {
+                serializerClass = valueSerializer().getClass();
+                valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            }
+            throw new StreamsException(
+                String.format("A serializer (%s) is not compatible to the actual value type " +
+                        "(value type: %s). Change the default Serdes in StreamConfig or " +
+                        "provide correct Serdes via method parameters.",
+                    serializerClass.getName(),
+                    valueClass),
+                e);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
@@ -93,7 +94,7 @@ public class HeadersSerializer implements Serializer<Headers> {
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to serialize headers", e);
+            throw new SerializationException("Failed to serialize headers", e);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
@@ -64,18 +63,18 @@ public class HeadersSerializer implements Serializer<Headers> {
      */
     @Override
     public byte[] serialize(final String topic, final Headers headers) {
-        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
+        final Header[] headerArray = (headers == null) ? new Header[0] : headers.toArray();
 
-        if (headersArray.length == 0) {
+        if (headerArray.length == 0) {
             return new byte[0];
         }
 
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
              final DataOutputStream out = new DataOutputStream(baos)) {
 
-            ByteUtils.writeVarint(headersArray.length, out);
+            ByteUtils.writeVarint(headerArray.length, out);
 
-            for (final Header header : headersArray) {
+            for (final Header header : headerArray) {
                 final byte[] keyBytes = header.key().getBytes(StandardCharsets.UTF_8);
                 final byte[] valueBytes = header.value();
 
@@ -94,7 +93,7 @@ public class HeadersSerializer implements Serializer<Headers> {
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new SerializationException("Failed to serialize headers", e);
+            throw new RuntimeException("Failed to serialize headers", e);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -63,18 +63,18 @@ public class HeadersSerializer implements Serializer<Headers> {
      */
     @Override
     public byte[] serialize(final String topic, final Headers headers) {
-        final Header[] headerArray = (headers == null) ? new Header[0] : headers.toArray();
+        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
 
-        if (headerArray.length == 0) {
+        if (headersArray.length == 0) {
             return new byte[0];
         }
 
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
              final DataOutputStream out = new DataOutputStream(baos)) {
 
-            ByteUtils.writeVarint(headerArray.length, out);
+            ByteUtils.writeVarint(headersArray.length, out);
 
-            for (final Header header : headerArray) {
+            for (final Header header : headersArray) {
                 final byte[] keyBytes = header.key().getBytes(StandardCharsets.UTF_8);
                 final byte[] valueBytes = header.value();
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -73,6 +73,8 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
  * @param <K>
  * @param <V>
  */
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class MeteredKeyValueStore<K, V>
     extends WrappedStateStore<KeyValueStore<Bytes, byte[]>, K, V>
     implements KeyValueStore<K, V>, MeteredStateStore {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -57,6 +57,8 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class MeteredSessionStore<K, V>
     extends WrappedStateStore<SessionStore<Bytes, byte[]>, Windowed<K>, V>
     implements SessionStore<K, V>, MeteredStateStore {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -53,6 +53,8 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
  * @param <K>
  * @param <V>
  */
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class MeteredTimestampedKeyValueStore<K, V>
     extends MeteredKeyValueStore<K, ValueAndTimestamp<V>> 
     implements TimestampedKeyValueStore<K, V> {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -65,6 +65,8 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
  * @param <K> The key type
  * @param <V> The (raw) value type
  */
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class MeteredVersionedKeyValueStore<K, V>
     extends WrappedStateStore<VersionedBytesStore, K, V>
     implements VersionedKeyValueStore<K, V> {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -60,6 +60,8 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class MeteredWindowStore<K, V>
     extends WrappedStateStore<WindowStore<Bytes, byte[]>, Windowed<K>, V>
     implements WindowStore<K, V>, MeteredStateStore {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedWindowKeySchemas.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PrefixedWindowKeySchemas.java
@@ -30,6 +30,8 @@ import java.util.List;
 import static org.apache.kafka.streams.state.StateSerdes.TIMESTAMP_SIZE;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
 
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class PrefixedWindowKeySchemas {
 
     private static final int PREFIX_SIZE = 1;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowKeySchema.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowKeySchema.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 import static org.apache.kafka.streams.state.StateSerdes.TIMESTAMP_SIZE;
 
+// TODO: replace with new method in follow-up PR of KIP-1271
+@SuppressWarnings("deprecation")
 public class WindowKeySchema implements RocksDBSegmentedBytesStore.KeySchema {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowKeySchema.class);

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.state;
 
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -27,6 +29,8 @@ import java.nio.ByteBuffer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -134,6 +138,144 @@ public class StateSerdesTest {
             equalTo(
                 "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
                     "is not compatible to the actual key type (key type: java.lang.Integer). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeKeyWithHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+        final Headers headers = new RecordHeaders()
+            .add("header-key", "header-value".getBytes());
+
+        final String key = "test-key";
+        final byte[] serialized = stateSerdes.rawKey(key, headers);
+        final String deserialized = stateSerdes.keyFrom(serialized, headers);
+
+        assertEquals(key, deserialized);
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeValueWithHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+        final Headers headers = new RecordHeaders()
+            .add("header-key", "header-value".getBytes());
+
+        final String value = "test-value";
+        final byte[] serialized = stateSerdes.rawValue(value, headers);
+        final String deserialized = stateSerdes.valueFrom(serialized, headers);
+
+        assertEquals(value, deserialized);
+    }
+
+    @Test
+    public void shouldSerializeKeyWithNullHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+
+        final String key = "test-key";
+        final byte[] serializedWithNull = stateSerdes.rawKey(key, null);
+        final byte[] serializedWithoutHeaders = stateSerdes.rawKey(key);
+
+        assertArrayEquals(serializedWithoutHeaders, serializedWithNull);
+    }
+
+    @Test
+    public void shouldSerializeValueWithNullHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+
+        final String value = "test-value";
+        final byte[] serializedWithNull = stateSerdes.rawValue(value, null);
+        final byte[] serializedWithoutHeaders = stateSerdes.rawValue(value);
+
+        assertArrayEquals(serializedWithoutHeaders, serializedWithNull);
+    }
+
+    @Test
+    public void shouldDeserializeKeyWithNullHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+
+        final String key = "test-key";
+        final byte[] serialized = stateSerdes.rawKey(key);
+
+        final String deserializedWithNull = stateSerdes.keyFrom(serialized, null);
+        final String deserializedWithoutHeaders = stateSerdes.keyFrom(serialized);
+
+        assertEquals(deserializedWithoutHeaders, deserializedWithNull);
+    }
+
+    @Test
+    public void shouldDeserializeValueWithNullHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+
+        final String value = "test-value";
+        final byte[] serialized = stateSerdes.rawValue(value);
+
+        final String deserializedWithNull = stateSerdes.valueFrom(serialized, null);
+        final String deserializedWithoutHeaders = stateSerdes.valueFrom(serialized);
+
+        assertEquals(deserializedWithoutHeaders, deserializedWithNull);
+    }
+
+    @Test
+    public void shouldSerializeKeyWithEmptyHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+        final Headers emptyHeaders = new RecordHeaders();
+
+        final String key = "test-key";
+        final byte[] serialized = stateSerdes.rawKey(key, emptyHeaders);
+
+        assertNotNull(serialized);
+    }
+
+    @Test
+    public void shouldSerializeValueWithEmptyHeaders() {
+        final StateSerdes<String, String> stateSerdes =
+            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+        final Headers emptyHeaders = new RecordHeaders();
+
+        final String value = "test-value";
+        final byte[] serialized = stateSerdes.rawValue(value, emptyHeaders);
+
+        assertNotNull(serialized);
+    }
+
+    @Test
+    public void shouldThrowIfIncompatibleSerdeForKeyWithHeaders() throws ClassNotFoundException {
+        final Class myClass = Class.forName("java.lang.String");
+        final StateSerdes<Object, Object> stateSerdes =
+            new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
+        final Integer myInt = 123;
+        final Headers headers = new RecordHeaders().add("key", "value".getBytes());
+
+        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawKey(myInt, headers));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
+                    "is not compatible to the actual key type (key type: java.lang.Integer). " +
+                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
+    }
+
+    @Test
+    public void shouldThrowIfIncompatibleSerdeForValueWithHeaders() throws ClassNotFoundException {
+        final Class myClass = Class.forName("java.lang.String");
+        final StateSerdes<Object, Object> stateSerdes =
+            new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
+        final Integer myInt = 123;
+        final Headers headers = new RecordHeaders().add("key", "value".getBytes());
+
+        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(myInt, headers));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
+                    "is not compatible to the actual value type (value type: java.lang.Integer). " +
                     "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -18,7 +18,10 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.state.internals.ValueAndTimestampSerde;
@@ -29,10 +32,13 @@ import java.nio.ByteBuffer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 public class StateSerdesTest {
@@ -143,140 +149,46 @@ public class StateSerdesTest {
 
     @Test
     public void shouldSerializeAndDeserializeKeyWithHeaders() {
+        final Serde<String> spyKeySerde = spy(Serdes.String());
+        final Serializer<String> spySerializer = spy(spyKeySerde.serializer());
+        final Deserializer<String> spyDeserializer = spy(spyKeySerde.deserializer());
+        when(spyKeySerde.serializer()).thenReturn(spySerializer);
+        when(spyKeySerde.deserializer()).thenReturn(spyDeserializer);
+
         final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-        final Headers headers = new RecordHeaders()
-            .add("header-key", "header-value".getBytes());
+            new StateSerdes<>("test-topic", spyKeySerde, Serdes.String());
 
+        final Headers headers = new RecordHeaders();
         final String key = "test-key";
-        final byte[] serialized = stateSerdes.rawKey(key, headers);
-        final String deserialized = stateSerdes.keyFrom(serialized, headers);
+        final byte[] rawKey = stateSerdes.rawKey(key, headers);
 
-        assertEquals(key, deserialized);
+        verify(spySerializer).serialize(eq("test-topic"), eq(headers), eq("test-key"));
+
+        final String deserializedKey = stateSerdes.keyFrom(rawKey, headers);
+        verify(spyDeserializer).deserialize(eq("test-topic"), eq(headers), eq(rawKey));
+        assertEquals(key, deserializedKey);
     }
 
     @Test
     public void shouldSerializeAndDeserializeValueWithHeaders() {
+        final Serde<String> spyValueSerde = spy(Serdes.String());
+        final Serializer<String> spySerializer = spy(spyValueSerde.serializer());
+        final Deserializer<String> spyDeserializer = spy(spyValueSerde.deserializer());
+        when(spyValueSerde.serializer()).thenReturn(spySerializer);
+        when(spyValueSerde.deserializer()).thenReturn(spyDeserializer);
+
         final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
+            new StateSerdes<>("test-topic", Serdes.String(), spyValueSerde);
+
         final Headers headers = new RecordHeaders()
             .add("header-key", "header-value".getBytes());
-
         final String value = "test-value";
         final byte[] serialized = stateSerdes.rawValue(value, headers);
-        final String deserialized = stateSerdes.valueFrom(serialized, headers);
 
+        verify(spySerializer).serialize(eq("test-topic"), eq(headers), eq("test-value"));
+
+        final String deserialized = stateSerdes.valueFrom(serialized, headers);
+        verify(spyDeserializer).deserialize(eq("test-topic"), eq(headers), eq(serialized));
         assertEquals(value, deserialized);
     }
-
-    @Test
-    public void shouldSerializeKeyWithNullHeaders() {
-        final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-
-        final String key = "test-key";
-        final byte[] serializedWithNull = stateSerdes.rawKey(key, null);
-        final byte[] serializedWithoutHeaders = stateSerdes.rawKey(key);
-
-        assertArrayEquals(serializedWithoutHeaders, serializedWithNull);
-    }
-
-    @Test
-    public void shouldSerializeValueWithNullHeaders() {
-        final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-
-        final String value = "test-value";
-        final byte[] serializedWithNull = stateSerdes.rawValue(value, null);
-        final byte[] serializedWithoutHeaders = stateSerdes.rawValue(value);
-
-        assertArrayEquals(serializedWithoutHeaders, serializedWithNull);
-    }
-
-    @Test
-    public void shouldDeserializeKeyWithNullHeaders() {
-        final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-
-        final String key = "test-key";
-        final byte[] serialized = stateSerdes.rawKey(key);
-
-        final String deserializedWithNull = stateSerdes.keyFrom(serialized, null);
-        final String deserializedWithoutHeaders = stateSerdes.keyFrom(serialized);
-
-        assertEquals(deserializedWithoutHeaders, deserializedWithNull);
-    }
-
-    @Test
-    public void shouldDeserializeValueWithNullHeaders() {
-        final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-
-        final String value = "test-value";
-        final byte[] serialized = stateSerdes.rawValue(value);
-
-        final String deserializedWithNull = stateSerdes.valueFrom(serialized, null);
-        final String deserializedWithoutHeaders = stateSerdes.valueFrom(serialized);
-
-        assertEquals(deserializedWithoutHeaders, deserializedWithNull);
-    }
-
-    @Test
-    public void shouldSerializeKeyWithEmptyHeaders() {
-        final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-        final Headers emptyHeaders = new RecordHeaders();
-
-        final String key = "test-key";
-        final byte[] serialized = stateSerdes.rawKey(key, emptyHeaders);
-
-        assertNotNull(serialized);
-    }
-
-    @Test
-    public void shouldSerializeValueWithEmptyHeaders() {
-        final StateSerdes<String, String> stateSerdes =
-            new StateSerdes<>("test-topic", Serdes.String(), Serdes.String());
-        final Headers emptyHeaders = new RecordHeaders();
-
-        final String value = "test-value";
-        final byte[] serialized = stateSerdes.rawValue(value, emptyHeaders);
-
-        assertNotNull(serialized);
-    }
-
-    @Test
-    public void shouldThrowIfIncompatibleSerdeForKeyWithHeaders() throws ClassNotFoundException {
-        final Class myClass = Class.forName("java.lang.String");
-        final StateSerdes<Object, Object> stateSerdes =
-            new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
-        final Integer myInt = 123;
-        final Headers headers = new RecordHeaders().add("key", "value".getBytes());
-
-        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawKey(myInt, headers));
-        assertThat(
-            e.getMessage(),
-            equalTo(
-                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
-                    "is not compatible to the actual key type (key type: java.lang.Integer). " +
-                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
-    }
-
-    @Test
-    public void shouldThrowIfIncompatibleSerdeForValueWithHeaders() throws ClassNotFoundException {
-        final Class myClass = Class.forName("java.lang.String");
-        final StateSerdes<Object, Object> stateSerdes =
-            new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
-        final Integer myInt = 123;
-        final Headers headers = new RecordHeaders().add("key", "value".getBytes());
-
-        final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(myInt, headers));
-        assertThat(
-            e.getMessage(),
-            equalTo(
-                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
-                    "is not compatible to the actual value type (value type: java.lang.Integer). " +
-                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
-    }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -169,11 +170,11 @@ public class MeteredKeyValueStoreTest {
         final Deserializer<String> valueDeserializer = mock(Deserializer.class);
         final Serializer<String> valueSerializer = mock(Serializer.class);
         when(keySerde.serializer()).thenReturn(keySerializer);
-        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
         when(valueSerde.deserializer()).thenReturn(valueDeserializer);
-        when(valueDeserializer.deserialize(topic, VALUE_BYTES)).thenReturn(VALUE);
+        when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_BYTES)).thenReturn(VALUE);
         when(valueSerde.serializer()).thenReturn(valueSerializer);
-        when(valueSerializer.serialize(topic, VALUE)).thenReturn(VALUE_BYTES);
+        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE)).thenReturn(VALUE_BYTES);
         when(inner.get(KEY_BYTES)).thenReturn(VALUE_BYTES);
         metered = new MeteredKeyValueStore<>(
             inner,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -173,11 +174,11 @@ public class MeteredSessionStoreTest {
         final Deserializer<String> valueDeserializer = mock(Deserializer.class);
         final Serializer<String> valueSerializer = mock(Serializer.class);
         when(keySerde.serializer()).thenReturn(keySerializer);
-        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
         when(valueSerde.deserializer()).thenReturn(valueDeserializer);
-        when(valueDeserializer.deserialize(topic, VALUE_BYTES)).thenReturn(VALUE);
+        when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_BYTES)).thenReturn(VALUE);
         when(valueSerde.serializer()).thenReturn(valueSerializer);
-        when(valueSerializer.serialize(topic, VALUE)).thenReturn(VALUE_BYTES);
+        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE)).thenReturn(VALUE_BYTES);
         when(innerStore.fetchSession(KEY_BYTES, START_TIMESTAMP, END_TIMESTAMP)).thenReturn(VALUE_BYTES);
         store = new MeteredSessionStore<>(
             innerStore,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -181,11 +182,11 @@ public class MeteredTimestampedKeyValueStoreTest {
         final Deserializer<ValueAndTimestamp<String>> valueDeserializer = mock(Deserializer.class);
         final Serializer<ValueAndTimestamp<String>> valueSerializer = mock(Serializer.class);
         when(keySerde.serializer()).thenReturn(keySerializer);
-        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
         when(valueSerde.deserializer()).thenReturn(valueDeserializer);
-        when(valueDeserializer.deserialize(topic, VALUE_AND_TIMESTAMP_BYTES)).thenReturn(VALUE_AND_TIMESTAMP);
+        when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_AND_TIMESTAMP_BYTES)).thenReturn(VALUE_AND_TIMESTAMP);
         when(valueSerde.serializer()).thenReturn(valueSerializer);
-        when(valueSerializer.serialize(topic, VALUE_AND_TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE_AND_TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         when(inner.get(KEY_BYTES)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         metered = new MeteredTimestampedKeyValueStore<>(
             inner,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
@@ -176,11 +177,11 @@ public class MeteredTimestampedWindowStoreTest {
         @SuppressWarnings("unchecked")
         final Serializer<ValueAndTimestamp<String>> valueSerializer = mock(Serializer.class);
         when(keySerde.serializer()).thenReturn(keySerializer);
-        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
         when(valueSerde.deserializer()).thenReturn(valueDeserializer);
-        when(valueDeserializer.deserialize(topic, VALUE_AND_TIMESTAMP_BYTES)).thenReturn(VALUE_AND_TIMESTAMP);
+        when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_AND_TIMESTAMP_BYTES)).thenReturn(VALUE_AND_TIMESTAMP);
         when(valueSerde.serializer()).thenReturn(valueSerializer);
-        when(valueSerializer.serialize(topic, VALUE_AND_TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE_AND_TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         when(innerStoreMock.fetch(KEY_BYTES, TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         store = new MeteredTimestampedWindowStore<>(
             innerStoreMock,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
@@ -75,6 +76,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -179,8 +181,10 @@ public class MeteredVersionedKeyValueStoreTest {
 
         store.put(KEY, VALUE, TIMESTAMP);
 
-        verify(keySerializer).serialize(changelogTopicName, KEY);
-        verify(valueSerializer).serialize(changelogTopicName, VALUE);
+        verify(keySerializer).serialize(changelogTopicName, new RecordHeaders(), KEY);
+        verify(valueSerializer).serialize(changelogTopicName, new RecordHeaders(), VALUE);
+        verify(keySerializer, never()).serialize(changelogTopicName, KEY);
+        verify(valueSerializer, never()).serialize(changelogTopicName, VALUE);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -170,11 +171,11 @@ public class MeteredWindowStoreTest {
         final Deserializer<String> valueDeserializer = mock(Deserializer.class);
         final Serializer<String> valueSerializer = mock(Serializer.class);
         when(keySerde.serializer()).thenReturn(keySerializer);
-        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
         when(valueSerde.deserializer()).thenReturn(valueDeserializer);
-        when(valueDeserializer.deserialize(topic, VALUE_BYTES)).thenReturn(VALUE);
+        when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_BYTES)).thenReturn(VALUE);
         when(valueSerde.serializer()).thenReturn(valueSerializer);
-        when(valueSerializer.serialize(topic, VALUE)).thenReturn(VALUE_BYTES);
+        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE)).thenReturn(VALUE_BYTES);
         when(innerStoreMock.fetch(KEY_BYTES, TIMESTAMP)).thenReturn(VALUE_BYTES);
         store = new MeteredWindowStore<>(
             innerStoreMock,


### PR DESCRIPTION
This PR is part of implementation of KIP-1271, adding new methods to
enable storing headers in state store.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>,  Matthias J. Sax
 <matthias@confluent.io>
