### PR TITLE
MINOR: Fix requests version conflict with ducktape in tests/setup.py

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -49,7 +49,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.12.0", "requests==2.32.4", "psutil==5.7.2", "pytest==8.3.3", "mock==5.1.0"],
+      install_requires=["ducktape==0.12.0", "requests>=2.31.0", "psutil==5.7.2", "pytest==8.3.3", "mock==5.1.0"],
       cmdclass={'test': PyTest},
       zip_safe=False
       )


### PR DESCRIPTION
### Summary

Fix Python dependency conflict between `requests` and `ducktape` that
prevents `kafkatest` from being installed.

### Problem

The `tests/setup.py` pins `requests==2.32.4`, but `ducktape==0.12.0`
internally requires `requests==2.31.0`. This causes pip to fail with :
```
ERROR: Cannot install kafkatest and kafkatest==4.3.0.dev0 because these
package versions have conflicting dependencies.
The conflict is caused by:
    kafkatest 4.3.0.dev0 depends on requests==2.32.4
    ducktape 0.12.0 depends on requests==2.31.0
```

This was introduced by dependabot PR #19940 which bumped `requests` from
2.31.0 to 2.32.4 without checking ducktape's transitive dependencies.

### Solution

Change `requests==2.32.4` to `requests>=2.31.0`. This allows pip to
install `requests==2.31.0` (what ducktape needs) while still satisfying
the version constraint.

### Changes

- `tests/setup.py`: Change strict pin `requests==2.32.4` to flexible
`requests>=2.31.0`

### Testing

✅ **System-test-Kafka-Branch-Builder** - [Workflow]  [21/21 tests
passed]
https://confluent-open-source-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/fix-cloud-tagging/2026-02-06--001.7f5b8f9a-4837-486a-864c-b5ad3b17391f--1770366328--confluentinc--fix-cloud-tagging--4b6335ab0f/report.html
- Test:
`tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py`

### Notes

This is a minimal fix. An alternative would be upgrading to
`ducktape==0.13.0` which requires `requests==2.32.2`, but that
introduces more changes and potential risk.

Reviewers: Manikumar Reddy <manikumar.reddy@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
