### PR TITLE
KAFKA-20125: Improve the docs of dynamic-only configurations

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -486,6 +486,13 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
         warn(s"$configName is defined in ${processRoles.mkString(", ")}. It should be defined in the $expectedRole role. $extraMessage")
       }
     }
+    def warnIfDynamicOnlyBrokerQuotaConfigInServerProperties(): Unit = {
+      QuotaConfig.DYNAMIC_ONLY_BROKER_QUOTA_CONFIGS.asScala.foreach { configName =>
+        if (originals.containsKey(configName)) {
+          warn(s"$configName is set in server.properties but is ignored at runtime; configure this property dynamically to take effect.")
+        }
+      }
+    }
     if (processRoles == Set(ProcessRole.BrokerRole)) {
       // KRaft broker-only
       validateQuorumVotersAndQuorumBootstrapServerForKRaft()
@@ -592,6 +599,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     require(principalBuilderClass != null, s"${BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG} must be non-null")
     require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass),
       s"${BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG} must implement KafkaPrincipalSerde")
+
+    warnIfDynamicOnlyBrokerQuotaConfigInServerProperties()
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -486,10 +486,10 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
         warn(s"$configName is defined in ${processRoles.mkString(", ")}. It should be defined in the $expectedRole role. $extraMessage")
       }
     }
-    def warnIfDynamicQuotasInServerProps(): Unit = {
+    def warnIfDynamicQuotasInStaticConfig(): Unit = {
       QuotaConfig.DYNAMIC_ONLY_BROKER_QUOTA_CONFIGS.asScala.foreach { configName =>
         if (originals.containsKey(configName)) {
-          warn(s"$configName is set in server.properties but is ignored at runtime; configure this property dynamically to take effect.")
+          warn(s"$configName is set in the static configuration file but is ignored at runtime; configure this property dynamically to take effect.")
         }
       }
     }
@@ -600,7 +600,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass),
       s"${BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG} must implement KafkaPrincipalSerde")
 
-    warnIfDynamicQuotasInServerProps()
+    warnIfDynamicQuotasInStaticConfig()
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -486,7 +486,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
         warn(s"$configName is defined in ${processRoles.mkString(", ")}. It should be defined in the $expectedRole role. $extraMessage")
       }
     }
-    def warnIfDynamicOnlyBrokerQuotaConfigInServerProperties(): Unit = {
+    def warnIfDynamicQuotasInServerProps(): Unit = {
       QuotaConfig.DYNAMIC_ONLY_BROKER_QUOTA_CONFIGS.asScala.foreach { configName =>
         if (originals.containsKey(configName)) {
           warn(s"$configName is set in server.properties but is ignored at runtime; configure this property dynamically to take effect.")
@@ -600,7 +600,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass),
       s"${BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG} must implement KafkaPrincipalSerde")
 
-    warnIfDynamicOnlyBrokerQuotaConfigInServerProperties()
+    warnIfDynamicQuotasInServerProps()
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -2016,15 +2016,30 @@ class KafkaConfigTest {
   }
 
   @Test
-  def testWarnWhenDynamicOnlyBrokerQuotaConfigsInServerProperties(): Unit = {
-    val props = createDefaultConfig()
-    props.setProperty(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "1000000")
-    Using.resource(LogCaptureAppender.createAndRegister) { appender =>
-      appender.setClassLogger(KafkaConfig.getClass, Level.WARN)
-      KafkaConfig.fromProps(props)
-      assertTrue(appender.getMessages.asScala.exists(_.contains(
-        s"${QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG} is set in server.properties but is ignored at runtime")))
-    }
+  def testWarnIfDynamicQuotasInStaticConfig(): Unit = {
+    val quotaConfigs = Seq(
+      QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG,
+      QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG,
+      QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG
+    )
+
+    quotaConfigs.foreach { config =>
+      Using.resource(LogCaptureAppender.createAndRegister) { appender =>
+        appender.setClassLogger(KafkaConfig.getClass, Level.WARN)
+
+        val props = createDefaultConfig()
+        props.setProperty(config, "1000000")
+
+        KafkaConfig.fromProps(props)
+        
+        val expectedMessage = s"$config is set in the static configuration file but is ignored at runtime; configure this property dynamically to take effect."
+        
+        assertTrue(
+          appender.getMessages.asScala.exists(_.contains(expectedMessage)),
+          s"Expected warning message not found for config: $config"
+        )
+      }
+    }    
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -2016,6 +2016,18 @@ class KafkaConfigTest {
   }
 
   @Test
+  def testWarnWhenDynamicOnlyBrokerQuotaConfigsInServerProperties(): Unit = {
+    val props = createDefaultConfig()
+    props.setProperty(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "1000000")
+    Using.resource(LogCaptureAppender.createAndRegister) { appender =>
+      appender.setClassLogger(KafkaConfig.getClass, Level.WARN)
+      KafkaConfig.fromProps(props)
+      assertTrue(appender.getMessages.asScala.exists(_.contains(
+        s"${QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG} is set in server.properties but is ignored at runtime")))
+    }
+  }
+
+  @Test
   def testLogBrokerHeartbeatIntervalMsShouldBeLowerThanHalfOfBrokerSessionTimeoutMs(): Unit = {
     val props = createDefaultConfig()
     Using.resource(LogCaptureAppender.createAndRegister) { appender =>

--- a/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
@@ -74,16 +74,16 @@ public class QuotaConfig {
 
     public static final String LEADER_REPLICATION_THROTTLED_RATE_CONFIG = "leader.replication.throttled.rate";
     public static final String LEADER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for leaders enumerated in the " +
-            String.format("property %s (for each topic). This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the ", LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
+            String.format("property %s (for each topic). This property can be only set dynamically, and defining it in the static configuration file has no effect. It is suggested that the ", LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
             "limit be kept above 1MB/s for accurate behaviour.";
 
     public static final String FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG = "follower.replication.throttled.rate";
     public static final String FOLLOWER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for followers enumerated in the " +
-            String.format("property %s (for each topic). This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the ", FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
+            String.format("property %s (for each topic). This property can be only set dynamically, and defining it in the static configuration file has no effect. It is suggested that the ", FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
             "limit be kept above 1MB/s for accurate behaviour.";
     public static final String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG = "replica.alter.log.dirs.io.max.bytes.per.second";
     public static final String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC = "A long representing the upper bound (bytes/sec) on disk IO used for moving replica between log directories on the same broker. " +
-            "This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
+            "This property can be only set dynamically, and defining it in the static configuration file has no effect. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
     public static final long QUOTA_BYTES_PER_SECOND_DEFAULT = Long.MAX_VALUE;
 
     public static final Set<String> DYNAMIC_ONLY_BROKER_QUOTA_CONFIGS = Set.of(

--- a/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
@@ -86,6 +86,11 @@ public class QuotaConfig {
             "This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
     public static final long QUOTA_BYTES_PER_SECOND_DEFAULT = Long.MAX_VALUE;
 
+    public static final Set<String> DYNAMIC_ONLY_BROKER_QUOTA_CONFIGS = Set.of(
+            LEADER_REPLICATION_THROTTLED_RATE_CONFIG,
+            FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG,
+            REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG);
+
     public static final String PRODUCER_BYTE_RATE_OVERRIDE_CONFIG = "producer_byte_rate";
     public static final String CONSUMER_BYTE_RATE_OVERRIDE_CONFIG = "consumer_byte_rate";
     public static final String REQUEST_PERCENTAGE_OVERRIDE_CONFIG = "request_percentage";

--- a/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/QuotaConfig.java
@@ -74,16 +74,16 @@ public class QuotaConfig {
 
     public static final String LEADER_REPLICATION_THROTTLED_RATE_CONFIG = "leader.replication.throttled.rate";
     public static final String LEADER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for leaders enumerated in the " +
-            String.format("property %s (for each topic). This property can be only set dynamically. It is suggested that the ", LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
+            String.format("property %s (for each topic). This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the ", LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
             "limit be kept above 1MB/s for accurate behaviour.";
 
     public static final String FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG = "follower.replication.throttled.rate";
     public static final String FOLLOWER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for followers enumerated in the " +
-            String.format("property %s (for each topic). This property can be only set dynamically. It is suggested that the ", FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
+            String.format("property %s (for each topic). This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the ", FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG) +
             "limit be kept above 1MB/s for accurate behaviour.";
     public static final String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG = "replica.alter.log.dirs.io.max.bytes.per.second";
     public static final String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC = "A long representing the upper bound (bytes/sec) on disk IO used for moving replica between log directories on the same broker. " +
-            "This property can be only set dynamically. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
+            "This property can be only set dynamically and static configurations in server.properties are ignored. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
     public static final long QUOTA_BYTES_PER_SECOND_DEFAULT = Long.MAX_VALUE;
 
     public static final String PRODUCER_BYTE_RATE_OVERRIDE_CONFIG = "producer_byte_rate";


### PR DESCRIPTION
This PR updates the documentation for the following configs:

- leader.replication.throttled.rate
- follower.replication.throttled.rate
- replica.alter.log.dirs.io.max.bytes.per.second

to clarify that static configuration in server.properties is accepted
but ignored at runtime, and that these properties are effective only
when set dynamically.

- Added a WARN log at startup when any of these properties are present
in `server.properties`, so misconfiguration is visible in broker logs.


