### PR TITLE
MINOR: bump NOTICE-binary copyright to 2026

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Kafka
-Copyright 2021 The Apache Software Foundation.
+Copyright 2026 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
Bump NOTICE-binary copyright to 2026.

Reviewers: Maros Orsak <maros.orsak159@gmail.com>, TengYao Chi
 <frankvicky@apache.org>
