### PR TITLE
KAFKA-20129: Fix server error when appending or subtracting a non-existent config key

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -417,10 +417,12 @@ object ConfigAdminManager {
     configKeys: Map[String, ConfigKey]
   ): Unit = {
     def listType(configName: String, configKeys: Map[String, ConfigKey]): Boolean = {
-      val configKey = configKeys(configName)
-      if (configKey == null)
-        throw new InvalidConfigurationException(s"Unknown config name: $configName")
-      configKey.`type` == ConfigDef.Type.LIST
+      configKeys.get(configName) match {
+        case Some(configKey) =>
+          configKey.`type` == ConfigDef.Type.LIST
+        case None =>
+          throw new InvalidConfigurationException(s"Unknown config name: $configName")
+      }
     }
 
     alterConfigOps.foreach { alterConfigOp =>


### PR DESCRIPTION
Replace `configKeys(configName)` with `configKeys.get(configName)`
pattern matching  to throw `InvalidConfigurationException` instead of
`NoSuchElementException` for  non-existent config keys in
APPEND/SUBTRACT operations.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
