### PR TITLE
MINOR: Fix Javadoc in coordinator-common

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorEventProcessor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorEventProcessor.java
@@ -19,12 +19,12 @@ package org.apache.kafka.coordinator.common.runtime;
 import java.util.concurrent.RejectedExecutionException;
 
 /**
- * A {{@link CoordinatorEvent}} processor.
+ * A {@link CoordinatorEvent} processor.
  */
 public interface CoordinatorEventProcessor extends AutoCloseable {
 
     /**
-     * Enqueues a new {{@link CoordinatorEvent}} at the end of the processor.
+     * Enqueues a new {@link CoordinatorEvent} at the end of the processor.
      *
      * @param event The event.
      * @throws RejectedExecutionException If the event processor is closed.
@@ -32,7 +32,7 @@ public interface CoordinatorEventProcessor extends AutoCloseable {
     void enqueueLast(CoordinatorEvent event) throws RejectedExecutionException;
 
     /**
-     * Enqueues a new {{@link CoordinatorEvent}} at the front of the processor.
+     * Enqueues a new {@link CoordinatorEvent} at the front of the processor.
      *
      * @param event The event.
      * @throws RejectedExecutionException If the event processor is closed.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorOperationExceptionHelper.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorOperationExceptionHelper.java
@@ -35,6 +35,7 @@ public class CoordinatorOperationExceptionHelper {
      * @param handler           A function which takes an Errors and a String and builds the expected
      *                          output. The String can be null. Note that the function could further
      *                          transform the error depending on the context.
+     * @param log               The logger.
      * @return The output built by the handler.
      * @param <IN> The type of the operation input. It must be a toString'able object.
      * @param <OUT> The type of the value returned by handler.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRecord.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRecord.java
@@ -22,8 +22,8 @@ import org.apache.kafka.server.common.ApiMessageAndVersion;
 import java.util.Objects;
 
 /**
- * A Record which contains an {{@link ApiMessage}} as key and
- * an {{@link ApiMessageAndVersion}} as value. The value could be null to
+ * A Record which contains an {@link ApiMessage} as key and
+ * an {@link ApiMessageAndVersion} as value. The value could be null to
  * represent a tombstone.
  *
  * This class is immutable.
@@ -58,7 +58,7 @@ public class CoordinatorRecord {
      * Constructs a CoordinatorRecord.
      *
      * @param key   A non-null key.
-     * @param value A key or null.
+     * @param value A value or null.
      */
     private CoordinatorRecord(
         ApiMessage key,

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
@@ -270,7 +270,9 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     /**
      * Retrieve the kafka metric name.
      *
-     * @param name The name of the metric.
+     * @param name        The name of the metric.
+     * @param description The description of the metric.
+     * @param keyValue    The additional metric tags as key/value pairs.
      *
      * @return The kafka metric name.
      */

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessor.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * A multithreaded {{@link CoordinatorEvent}} processor which uses a {{@link EventAccumulator}}
+ * A multithreaded {@link CoordinatorEvent} processor which uses a {@link EventAccumulator}
  * which guarantees that events sharing a partition key are not processed concurrently.
  */
 public final class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
@@ -86,8 +86,8 @@ public final class MultiThreadedEventProcessor implements CoordinatorEventProces
      * @param logContext        The log context.
      * @param threadPrefix      The thread prefix.
      * @param numThreads        The number of threads.
-     * @param metrics           The coordinator runtime metrics.
      * @param time              The time.
+     * @param metrics           The coordinator runtime metrics.
      * @param eventAccumulator  The event accumulator.
      */
     public MultiThreadedEventProcessor(
@@ -196,7 +196,7 @@ public final class MultiThreadedEventProcessor implements CoordinatorEventProces
     }
 
     /**
-     * Enqueues a new {{@link CoordinatorEvent}} at the end of the processor.
+     * Enqueues a new {@link CoordinatorEvent} at the end of the processor.
      *
      * @param event The event.
      * @throws RejectedExecutionException If the event processor is closed.
@@ -207,7 +207,7 @@ public final class MultiThreadedEventProcessor implements CoordinatorEventProces
     }
 
     /**
-     * Enqueues a new {{@link CoordinatorEvent}} at the front of the processor.
+     * Enqueues a new {@link CoordinatorEvent} at the front of the processor.
      *
      * @param event The event.
      * @throws RejectedExecutionException If the event processor is closed.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/PartitionWriter.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/PartitionWriter.java
@@ -32,7 +32,7 @@ public interface PartitionWriter {
 
     /**
      * Listener allowing to listen to high watermark changes. This is meant
-     * to be used in conjunction with {{@link PartitionWriter#append(TopicPartition, VerificationGuard, MemoryRecords)}}.
+     * to be used in conjunction with {@link PartitionWriter#append(TopicPartition, VerificationGuard, MemoryRecords, short)}.
      */
     interface Listener {
         void onHighWatermarkUpdated(
@@ -42,7 +42,7 @@ public interface PartitionWriter {
     }
 
     /**
-     * Register a {{@link Listener}}.
+     * Register a {@link Listener}.
      *
      * @param tp        The partition to register the listener to.
      * @param listener  The listener.
@@ -53,7 +53,7 @@ public interface PartitionWriter {
     );
 
     /**
-     * Deregister a {{@link Listener}}.
+     * Deregister a {@link Listener}.
      *
      * @param tp        The partition to deregister the listener from.
      * @param listener  The listener.


### PR DESCRIPTION
This PR fixes Javadoc in coordinator-common, including correcting an
incorrect `{@link} `reference, fixing `{@link} `formatting issues, and
improving parameter descriptions.

Reviewers: Ken Huang <s7133700@gmail.com>, Sean Quah
 <squah@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
