### PR TITLE
MINOR: Document that REMAIN_IN_GROUP is ignored with streams protocol

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/CloseOptions.java
+++ b/streams/src/main/java/org/apache/kafka/streams/CloseOptions.java
@@ -26,7 +26,9 @@ public class CloseOptions {
      *
      * <ul>
      *   <li><b>{@code LEAVE_GROUP}</b>: means the consumer leave the group.</li>
-     *   <li><b>{@code REMAIN_IN_GROUP}</b>: means the consumer will remain in the group.</li>
+     *   <li><b>{@code REMAIN_IN_GROUP}</b>: means the consumer will not leave the group explicitly.
+     *       Note that this option is ignored when using the streams group protocol
+     *       ({@code group.protocol=streams}); in that case, the consumer will always leave the group.</li>
      * </ul>
      */
     public enum GroupMembershipOperation {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1439,6 +1439,9 @@ public class KafkaStreams implements AutoCloseable {
     /**
      * Shutdown this {@code KafkaStreams} instance by signaling all the threads to stop, and then wait for them to join.
      * This will block until all threads have stopped.
+     * <p>
+     * When using the classic protocol, the consumer will not leave the group explicitly. However, when using
+     * the streams group protocol ({@code group.protocol=streams}), the consumer will always leave the group.
      */
     public void close() {
         close(Optional.empty(), org.apache.kafka.streams.CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP);
@@ -1584,6 +1587,9 @@ public class KafkaStreams implements AutoCloseable {
      * threads to join.
      * A {@code timeout} of {@link Duration#ZERO} (or any other zero duration) makes the close operation asynchronous.
      * Negative-duration timeouts are rejected.
+     * <p>
+     * When using the classic protocol, the consumer will not leave the group explicitly. However, when using
+     * the streams group protocol ({@code group.protocol=streams}), the consumer will always leave the group.
      *
      * @param timeout how long to wait for the threads to shut down
      * @return {@code true} if all threads were successfully stopped&mdash;{@code false} if the timeout was reached

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1879,6 +1879,9 @@ public class StreamThread extends Thread implements ProcessingThread {
         try {
             final GroupMembershipOperation membershipOperation =
                 leaveGroupRequested.get() == org.apache.kafka.streams.CloseOptions.GroupMembershipOperation.LEAVE_GROUP ? LEAVE_GROUP : REMAIN_IN_GROUP;
+            if (membershipOperation == REMAIN_IN_GROUP && streamsRebalanceData.isPresent()) {
+                log.info("The consumer will leave the group since the streams group protocol is used");
+            }
             mainConsumer.close(CloseOptions.groupMembershipOperation(membershipOperation));
         } catch (final Throwable e) {
             log.error("Failed to close consumer due to the following error:", e);


### PR DESCRIPTION
## Summary

When using the streams group protocol (`group.protocol=streams`), the
consumer always leaves the group on close, regardless of whether
`REMAIN_IN_GROUP` was specified. This differs from the classic protocol
behavior where the consumer does not leave the group explicitly by
default.

This PR documents this behavior in the javadocs for
`CloseOptions.GroupMembershipOperation`, `KafkaStreams.close()`, and
`KafkaStreams.close(Duration)`, and adds an INFO log message when a
close occurs with the streams protocol to inform users about this
behavior.

## Test plan

- Verified checkstyle and spotlessCheck pass
- Documentation-only changes with minor log addition

Reviewers: Matthias J. Sax <matthias@confluent.io>
