### PR TITLE
KAFKA-10863: Convert ControRecordType schema to use auto-generated protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/internal/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/ControlRecordType.java
@@ -17,10 +17,9 @@
 package org.apache.kafka.common.record.internal;
 
 import org.apache.kafka.common.InvalidRecordException;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
-import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.message.ControlRecordTypeSchema;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,46 +58,45 @@ public enum ControlRecordType {
 
     private static final Logger log = LoggerFactory.getLogger(ControlRecordType.class);
 
-    static final short CURRENT_CONTROL_RECORD_KEY_VERSION = 0;
-    static final int CURRENT_CONTROL_RECORD_KEY_SIZE = 4;
-    private static final Schema CONTROL_RECORD_KEY_SCHEMA_VERSION_V0 = new Schema(
-            new Field("version", Type.INT16),
-            new Field("type", Type.INT16));
-
     private final short type;
+    private final ByteBuffer buffer;
 
     ControlRecordType(short type) {
         this.type = type;
+        ControlRecordTypeSchema schema = new ControlRecordTypeSchema().setType(type);
+        buffer = MessageUtil.toVersionPrefixedByteBuffer(ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION, schema);
     }
 
     public short type() {
         return type;
     }
 
-    public Struct recordKey() {
+    public ByteBuffer recordKey() {
         if (this == UNKNOWN)
             throw new IllegalArgumentException("Cannot serialize UNKNOWN control record type");
-
-        Struct struct = new Struct(CONTROL_RECORD_KEY_SCHEMA_VERSION_V0);
-        struct.set("version", CURRENT_CONTROL_RECORD_KEY_VERSION);
-        struct.set("type", type);
-        return struct;
+        return buffer.duplicate();
     }
 
-    public static short parseTypeId(ByteBuffer key) {
-        if (key.remaining() < CURRENT_CONTROL_RECORD_KEY_SIZE)
-            throw new InvalidRecordException("Invalid value size found for end control record key. Must have " +
-                    "at least " + CURRENT_CONTROL_RECORD_KEY_SIZE + " bytes, but found only " + key.remaining());
+    public int controlRecordKeySize() {
+        return buffer.remaining();
+    }
 
-        short version = key.getShort(0);
-        if (version < 0)
+    private static short parseTypeId(ByteBuffer key) {
+        // We should duplicate the original buffer since it will be read again in some cases, for example,
+        // read by KafkaRaftClient and RaftClient.Listener
+        ByteBuffer buffer = key.duplicate();
+        short version = buffer.getShort();
+        if (version < ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION)
             throw new InvalidRecordException("Invalid version found for control record: " + version +
                     ". May indicate data corruption");
 
-        if (version != CURRENT_CONTROL_RECORD_KEY_VERSION)
+        if (version > ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION) {
             log.debug("Received unknown control record key version {}. Parsing as version {}", version,
-                    CURRENT_CONTROL_RECORD_KEY_VERSION);
-        return key.getShort(2);
+                    ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION);
+            version = ControlRecordTypeSchema.HIGHEST_SUPPORTED_VERSION;
+        }
+        ControlRecordTypeSchema schema = new ControlRecordTypeSchema(new ByteBufferAccessor(buffer), version);
+        return schema.type();
     }
 
     public static ControlRecordType fromTypeId(short typeId) {

--- a/clients/src/main/java/org/apache/kafka/common/record/internal/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/ControlRecordType.java
@@ -57,6 +57,7 @@ public enum ControlRecordType {
     UNKNOWN((short) -1);
 
     private static final Logger log = LoggerFactory.getLogger(ControlRecordType.class);
+    private static final int CONTROL_RECORD_KEY_SIZE = 4;
 
     private final short type;
     private final ByteBuffer buffer;
@@ -85,6 +86,10 @@ public enum ControlRecordType {
         // We should duplicate the original buffer since it will be read again in some cases, for example,
         // read by KafkaRaftClient and RaftClient.Listener
         ByteBuffer buffer = key.duplicate();
+        if (buffer.remaining() < CONTROL_RECORD_KEY_SIZE)
+            throw new InvalidRecordException("Invalid value size found for control record key. " +
+                    "Must have at least " + CONTROL_RECORD_KEY_SIZE + " bytes, but found only " + buffer.remaining());
+
         short version = buffer.getShort();
         if (version < ControlRecordTypeSchema.LOWEST_SUPPORTED_VERSION)
             throw new InvalidRecordException("Invalid version found for control record: " + version +

--- a/clients/src/main/java/org/apache/kafka/common/record/internal/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/ControlRecordType.java
@@ -81,7 +81,7 @@ public enum ControlRecordType {
         return buffer.remaining();
     }
 
-    private static short parseTypeId(ByteBuffer key) {
+    public static short parseTypeId(ByteBuffer key) {
         // We should duplicate the original buffer since it will be read again in some cases, for example,
         // read by KafkaRaftClient and RaftClient.Listener
         ByteBuffer buffer = key.duplicate();

--- a/clients/src/main/java/org/apache/kafka/common/record/internal/EndTransactionMarker.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/EndTransactionMarker.java
@@ -104,7 +104,7 @@ public class EndTransactionMarker {
 
     public int endTxnMarkerValueSize() {
         return DefaultRecord.sizeInBytes(0, 0L,
-                ControlRecordType.CURRENT_CONTROL_RECORD_KEY_SIZE,
+                type.controlRecordKeySize(),
                 buffer.remaining(),
                 Record.EMPTY_HEADERS);
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/internal/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/MemoryRecordsBuilder.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.message.SnapshotHeaderRecord;
 import org.apache.kafka.common.message.VotersRecord;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.Utils;
@@ -545,10 +544,9 @@ public class MemoryRecordsBuilder implements AutoCloseable {
      * @param record The record to append
      */
     public void appendControlRecordWithOffset(long offset, SimpleRecord record) {
-        short typeId = ControlRecordType.parseTypeId(record.key());
-        ControlRecordType type = ControlRecordType.fromTypeId(typeId);
+        ControlRecordType type = ControlRecordType.parse(record.key());
         if (type == ControlRecordType.UNKNOWN)
-            throw new IllegalArgumentException("Cannot append record with unknown control record type " + typeId);
+            throw new IllegalArgumentException("Cannot append record with unknown control record type");
 
         appendWithOffset(offset, true, record.timestamp(),
             record.key(), record.value(), record.headers());
@@ -612,10 +610,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
      * @param value The control record value
      */
     public void appendControlRecord(long timestamp, ControlRecordType type, ByteBuffer value) {
-        Struct keyStruct = type.recordKey();
-        ByteBuffer key = ByteBuffer.allocate(keyStruct.sizeOf());
-        keyStruct.writeTo(key);
-        key.flip();
+        ByteBuffer key = type.recordKey();
         appendWithOffset(nextSequentialOffset(), true, timestamp, key, value, Record.EMPTY_HEADERS);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/internal/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/MemoryRecordsBuilder.java
@@ -544,9 +544,10 @@ public class MemoryRecordsBuilder implements AutoCloseable {
      * @param record The record to append
      */
     public void appendControlRecordWithOffset(long offset, SimpleRecord record) {
-        ControlRecordType type = ControlRecordType.parse(record.key());
+        short typeId = ControlRecordType.parseTypeId(record.key());
+        ControlRecordType type = ControlRecordType.fromTypeId(typeId);
         if (type == ControlRecordType.UNKNOWN)
-            throw new IllegalArgumentException("Cannot append record with unknown control record type");
+            throw new IllegalArgumentException("Cannot append record with unknown control record type " + typeId);
 
         appendWithOffset(offset, true, record.timestamp(),
             record.key(), record.value(), record.headers());

--- a/clients/src/main/resources/common/message/ControlRecordTypeSchema.json
+++ b/clients/src/main/resources/common/message/ControlRecordTypeSchema.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "ControlRecordTypeSchema",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "Type", "type": "int16", "versions": "0+",
+      "about": "The type of the control record, such as commit or abort"
+    }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/common/record/internal/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/internal/EndTransactionMarkerTest.java
@@ -103,7 +103,7 @@ public class EndTransactionMarkerTest {
             EndTransactionMarker marker = new EndTransactionMarker(type, 1);
             int offsetSize = ByteUtils.sizeOfVarint(0);
             int timestampSize = ByteUtils.sizeOfVarlong(0);
-            int keySize = ControlRecordType.CURRENT_CONTROL_RECORD_KEY_SIZE;
+            int keySize = type.controlRecordKeySize();
             int valueSize = marker.serializeValue().remaining();
             int headerSize = ByteUtils.sizeOfVarint(Record.EMPTY_HEADERS.length);
             int totalSize = 1 + offsetSize + timestampSize + ByteUtils.sizeOfVarint(keySize) + keySize + ByteUtils.sizeOfVarint(valueSize) + valueSize + headerSize;

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -334,7 +334,8 @@ object DumpLogSegments {
   }
 
   private def printControlRecord(record: Record): Unit = {
-    ControlRecordType.parse(record.key) match {
+    val controlTypeId = ControlRecordType.parseTypeId(record.key)
+    ControlRecordType.fromTypeId(controlTypeId) match {
       case ControlRecordType.ABORT | ControlRecordType.COMMIT =>
         val endTxnMarker = EndTransactionMarker.deserialize(record)
         print(s" endTxnMarker: ${endTxnMarker.controlType} coordinatorEpoch: ${endTxnMarker.coordinatorEpoch}")
@@ -354,7 +355,7 @@ object DumpLogSegments {
         val voters = ControlRecordUtils.deserializeVotersRecord(record)
         print(s" KRaftVoters ${VotersRecordJsonConverter.write(voters, voters.version())}")
       case controlType =>
-        print(s" controlType: $controlType")
+        print(s" controlType: $controlType($controlTypeId)")
     }
   }
 

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -334,8 +334,7 @@ object DumpLogSegments {
   }
 
   private def printControlRecord(record: Record): Unit = {
-    val controlTypeId = ControlRecordType.parseTypeId(record.key)
-    ControlRecordType.fromTypeId(controlTypeId) match {
+    ControlRecordType.parse(record.key) match {
       case ControlRecordType.ABORT | ControlRecordType.COMMIT =>
         val endTxnMarker = EndTransactionMarker.deserialize(record)
         print(s" endTxnMarker: ${endTxnMarker.controlType} coordinatorEpoch: ${endTxnMarker.coordinatorEpoch}")
@@ -355,7 +354,7 @@ object DumpLogSegments {
         val voters = ControlRecordUtils.deserializeVotersRecord(record)
         print(s" KRaftVoters ${VotersRecordJsonConverter.write(voters, voters.version())}")
       case controlType =>
-        print(s" controlType: $controlType($controlTypeId)")
+        print(s" controlType: $controlType")
     }
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1147,11 +1147,7 @@ class LogCleanerTest extends Logging {
 
     // Now we append one transaction with a key which conflicts with the COMMIT marker appended above
     def commitRecordKey(): ByteBuffer = {
-      val keySize = ControlRecordType.COMMIT.recordKey().sizeOf()
-      val key = ByteBuffer.allocate(keySize)
-      ControlRecordType.COMMIT.recordKey().writeTo(key)
-      key.flip()
-      key
+      ControlRecordType.COMMIT.recordKey()
     }
 
     val producerId2 = 2L

--- a/metadata/src/main/java/org/apache/kafka/metadata/util/BatchFileReader.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/util/BatchFileReader.java
@@ -101,8 +101,7 @@ public final class BatchFileReader implements Iterator<BatchFileReader.BatchAndT
         List<ApiMessageAndVersion> messages = new ArrayList<>();
         for (Record record : input) {
             try {
-                short typeId = ControlRecordType.parseTypeId(record.key());
-                ControlRecordType type = ControlRecordType.fromTypeId(typeId);
+                ControlRecordType type = ControlRecordType.parse(record.key());
                 switch (type) {
                     case LEADER_CHANGE: {
                         LeaderChangeMessage message = new LeaderChangeMessage();

--- a/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
@@ -130,8 +130,7 @@ public final class SnapshotFileReader implements AutoCloseable {
     private void handleControlBatch(FileChannelRecordBatch batch) {
         for (Record record : batch) {
             try {
-                short typeId = ControlRecordType.parseTypeId(record.key());
-                ControlRecordType type = ControlRecordType.fromTypeId(typeId);
+                ControlRecordType type = ControlRecordType.parse(record.key());
                 switch (type) {
                     case LEADER_CHANGE:
                         LeaderChangeMessage message = new LeaderChangeMessage();


### PR DESCRIPTION
Modified From #19110

1. Convert ControlRecordType schema to use auto-generated protocol
`ControlRecordTypeSchema`.
2. Substitute `CURRENT_CONTROL_RECORD_KEY_SIZE` with
`controlRecordKeySize()` method since the size is accumulated from
`ControlRecordTypeSchema`.
3. Add buffer to `ControlRecordType` to avoid twice compute from
`recordKey()` and `controlRecordKeySize()`.
4. flexibleVersions is set to none.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
