### PR TITLE
KAFKA-19361: Document that `mapKey` does not break the serialization compatibility

### DIFF
--- a/clients/src/main/resources/common/message/README.md
+++ b/clients/src/main/resources/common/message/README.md
@@ -249,6 +249,11 @@ in this set will be accessible in O(1) time with an automatically generated
 however.  New entries that are added to the set always show up as last in the
 ordering.
 
+Note that "mapKey" does not affect how the data is sent over the network.  It
+only affects the in-memory data structure used by the generated code.  Adding or
+removing "mapKey" on an existing field is not an incompatible change and does
+not require a new version in "validVersions".
+
 Incompatible Changes
 --------------------
 It's very important to avoid making incompatible changes to the message


### PR DESCRIPTION
`mapKey` only affects the in-memory data structure, not serialization:

  - In `MessageDataGenerator#generateVariableLengthReader`,
`isStructArrayWithKeys` only controls which collection class is
instantiated (`ImplicitLinkedHashMultiCollection` vs `ArrayList`), not
how bytes are read from the network.    - In
`MessageDataGenerator#generateClassWriter`, the serialization logic has
no branch for `mapKey` or `hasKeys` — all fields are written the same
way regardless of `mapKey`.

  Therefore, adding or removing `mapKey` on an existing field is a
compatible    change, as demonstrated in #19815 where `mapKey` was added
to    already-released RPCs without bumping `validVersions`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
