### PR TITLE
KAFKA-20163: Missing MM2 default exclude configs

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
@@ -35,12 +35,14 @@ public class DefaultConfigPropertyFilter implements ConfigPropertyFilter {
 
     private static final String CONFIG_PROPERTIES_EXCLUDE_DOC = "List of topic configuration properties and/or regexes "
                                                                 + "that should not be replicated.";
-    public static final String CONFIG_PROPERTIES_EXCLUDE_DEFAULT = "follower\\.replication\\.throttled\\.replicas, "
-                                                                   + "leader\\.replication\\.throttled\\.replicas, "
-                                                                   + "message\\.timestamp\\.difference\\.max\\.ms, "
-                                                                   + "message\\.timestamp\\.type, "
-                                                                   + "unclean\\.leader\\.election\\.enable, "
-                                                                   + "min\\.insync\\.replicas";
+    public static final String CONFIG_PROPERTIES_EXCLUDE_DEFAULT = "follower.replication.throttled.replicas, "
+                                                                   + "leader.replication.throttled.replicas, "
+                                                                   + "message.timestamp.difference.max.ms, "
+                                                                   + "log.message.timestamp.before.max.ms, "
+                                                                   + "log.message.timestamp.after.max.ms, "
+                                                                   + "message.timestamp.type, "
+                                                                   + "unclean.leader.election.enable, "
+                                                                   + "min.insync.replicas";
     private Pattern excludePattern = MirrorUtils.compilePatternList(CONFIG_PROPERTIES_EXCLUDE_DEFAULT);
     private String useDefaultsFrom = USE_DEFAULTS_FROM_DEFAULT;
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -337,12 +337,14 @@ public class MirrorSourceConnectorTest {
     @Test
     public void testNewTopicConfigs() throws Exception {
         Map<String, Object> filterConfig = new HashMap<>();
-        filterConfig.put(DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG, "follower\\.replication\\.throttled\\.replicas, "
-                + "leader\\.replication\\.throttled\\.replicas, "
-                + "message\\.timestamp\\.difference\\.max\\.ms, "
-                + "message\\.timestamp\\.type, "
-                + "unclean\\.leader\\.election\\.enable, "
-                + "min\\.insync\\.replicas,"
+        filterConfig.put(DefaultConfigPropertyFilter.CONFIG_PROPERTIES_EXCLUDE_CONFIG, "follower.replication.throttled.replicas, "
+                + "leader.replication.throttled.replicas, "
+                + "message.timestamp.difference.max.ms, "
+                + "log.message.timestamp.before.max.ms, "
+                + "log.message.timestamp.after.max.ms, "
+                + "message.timestamp.type, "
+                + "unclean.leader.election.enable, "
+                + "min.insync.replicas,"
                 + "exclude_param.*");
         DefaultConfigPropertyFilter filter = new DefaultConfigPropertyFilter();
         filter.configure(filterConfig);
@@ -376,7 +378,6 @@ public class MirrorSourceConnectorTest {
         connector.createNewTopics(Set.of(topic), Map.of(topic, 1L));
         verify(connector).createNewTopics(any(), any());
     }
-
 
     @Test
     public void testMirrorSourceConnectorTaskConfig() {


### PR DESCRIPTION
This patch adds the following missing configuration in MM2 exclude
defaults that were introduced in KIP-937:

- log.message.timestamp.before.max.ms
- log.message.timestamp.after.max.ms

Reviewers: Luke Chen <showuon@gmail.com>
