### PR TITLE
KAFKA-20137: Add javadoc to public APIs in org.apache.kafka.clients.producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/BufferExhaustedException.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/BufferExhaustedException.java
@@ -30,6 +30,11 @@ public class BufferExhaustedException extends TimeoutException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new BufferExhaustedException with the specified detail message.
+     *
+     * @param message The error message
+     */
     public BufferExhaustedException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/PreparedTxnState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/PreparedTxnState.java
@@ -77,10 +77,20 @@ public class PreparedTxnState {
         this.epoch = epoch;
     }
 
+    /**
+     * Gets the producer ID associated with this prepared transaction state.
+     *
+     * @return The producer ID
+     */
     public long producerId() {
         return producerId;
     }
 
+    /**
+     * Gets the producer epoch associated with this prepared transaction state.
+     *
+     * @return The producer epoch
+     */
     public short epoch() {
         return epoch;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -83,12 +83,12 @@ public interface Producer<K, V> extends Closeable {
     void completeTransaction(PreparedTxnState preparedTxnState) throws ProducerFencedException;
 
     /**
-     * @see KafkaProducer#registerMetricForSubscription(KafkaMetric) 
+     * See {@link KafkaProducer#registerMetricForSubscription(KafkaMetric)}
      */
     void registerMetricForSubscription(KafkaMetric metric);
 
     /**
-     * @see KafkaProducer#unregisterMetricFromSubscription(KafkaMetric) 
+     * See {@link KafkaProducer#unregisterMetricFromSubscription(KafkaMetric)}
      */
     void unregisterMetricFromSubscription(KafkaMetric metric);
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -674,22 +674,47 @@ public class ProducerConfig extends AbstractConfig {
         return newConfigs;
     }
 
+    /**
+     * Constructs a new ProducerConfig with the given properties.
+     *
+     * @param props The producer configuration properties
+     */
     public ProducerConfig(Properties props) {
         super(CONFIG, props);
     }
 
+    /**
+     * Constructs a new ProducerConfig with the given configuration map.
+     *
+     * @param props The producer configuration map
+     */
     public ProducerConfig(Map<String, Object> props) {
         super(CONFIG, props);
     }
 
+    /**
+     * Gets the set of all producer configuration names.
+     *
+     * @return The set of configuration names
+     */
     public static Set<String> configNames() {
         return CONFIG.names();
     }
 
+    /**
+     * Gets a copy of the producer configuration definition.
+     *
+     * @return A new ConfigDef instance containing the producer configuration definition
+     */
     public static ConfigDef configDef() {
         return new ConfigDef(CONFIG);
     }
 
+    /**
+     * Generates HTML documentation for producer configurations.
+     *
+     * @param args Command line arguments (unused)
+     */
     public static void main(String[] args) {
         System.out.println(CONFIG.toHtml(4, config -> "producerconfigs_" + config));
     }


### PR DESCRIPTION
## Summary

This PR adds missing Javadocs to public APIs within the
`org.apache.kafka.clients.producer` package to improve documentation
coverage and  consistency with project standards.

## Changes

Added missing Javadocs to public classes, methods, and fields in 4 files
- BufferExhaustedException
- PreparedTxnState
- MockProducer
- ProducerConfig

## Test Plan
- No functional changes, documentation only
- Verified that Javadoc formatting follows existing Kafka conventions

Reviewers: Andrew Schofield <aschofield@confluent.io>
