### PR TITLE
MINOR: rename TaskRegistry methods to better reflect their purpose.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -68,7 +68,7 @@ public class TaskExecutor {
         int totalProcessed = 0;
         Task lastProcessed = null;
 
-        for (final Task task : tasks.activeTasks()) {
+        for (final Task task : tasks.activeInitializedTasks()) {
             final long now = time.milliseconds();
             try {
                 if (executionMetadata.canProcessTask(task, now)) {
@@ -233,7 +233,7 @@ public class TaskExecutor {
 
     private void updateTaskCommitMetadata(final Map<TopicPartition, OffsetAndMetadata> allOffsets) {
         if (!allOffsets.isEmpty()) {
-            for (final Task task : tasks.activeTasks()) {
+            for (final Task task : tasks.activeInitializedTasks()) {
                 if (task instanceof StreamTask) {
                     for (final TopicPartition topicPartition : task.inputPartitions()) {
                         if (allOffsets.containsKey(topicPartition)) {
@@ -261,7 +261,7 @@ public class TaskExecutor {
     int punctuate() {
         int punctuated = 0;
 
-        for (final Task task : tasks.activeTasks()) {
+        for (final Task task : tasks.activeInitializedTasks()) {
             try {
                 if (executionMetadata.canPunctuateTask(task)) {
                     if (task.maybePunctuateStreamTime()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -280,6 +280,7 @@ class Tasks implements TasksRegistry {
     @Override
     public synchronized void clear() {
         pendingTasksToInit.clear();
+        pendingTasksToClose.clear();
         pendingActiveTasksToCreate.clear();
         pendingStandbyTasksToCreate.clear();
         activeTasksPerId.clear();
@@ -290,7 +291,7 @@ class Tasks implements TasksRegistry {
 
     // TODO: change return type to `StreamTask`
     @Override
-    public Task activeTasksForInputPartition(final TopicPartition partition) {
+    public Task activeInitializedTasksForInputPartition(final TopicPartition partition) {
         return activeTasksPerPartition.get(partition);
     }
 
@@ -305,7 +306,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public Task task(final TaskId taskId) {
+    public Task initializedTask(final TaskId taskId) {
         final Task task = getTask(taskId);
 
         if (task != null)
@@ -315,26 +316,26 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public Collection<Task> tasks(final Collection<TaskId> taskIds) {
+    public Collection<Task> initializedTasks(final Collection<TaskId> taskIds) {
         final Set<Task> tasks = new HashSet<>();
         for (final TaskId taskId : taskIds) {
-            tasks.add(task(taskId));
+            tasks.add(initializedTask(taskId));
         }
         return tasks;
     }
 
     @Override
-    public synchronized Collection<TaskId> activeTaskIds() {
+    public synchronized Collection<TaskId> activeInitializedTaskIds() {
         return Collections.unmodifiableCollection(activeTasksPerId.keySet());
     }
 
     @Override
-    public synchronized Collection<Task> activeTasks() {
+    public synchronized Collection<Task> activeInitializedTasks() {
         return Collections.unmodifiableCollection(activeTasksPerId.values());
     }
 
     @Override
-    public synchronized Collection<Task> standbyTasks() {
+    public synchronized Collection<Task> standbyInitializedTasks() {
         return Collections.unmodifiableCollection(standbyTasksPerId.values());
     }
 
@@ -343,12 +344,12 @@ class Tasks implements TasksRegistry {
      * and the returned task could be modified by other threads concurrently
      */
     @Override
-    public synchronized Set<Task> allTasks() {
+    public synchronized Set<Task> allInitializedTasks() {
         return union(HashSet::new, new HashSet<>(activeTasksPerId.values()), new HashSet<>(standbyTasksPerId.values()));
     }
 
     @Override
-    public synchronized Set<Task> allNonFailedTasks() {
+    public synchronized Set<Task> allNonFailedInitializedTasks() {
         final Set<Task> nonFailedActiveTasks = activeTasksPerId.values().stream()
             .filter(task -> !failedTaskIds.contains(task.id()))
             .collect(Collectors.toSet());
@@ -359,12 +360,12 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public synchronized Set<TaskId> allTaskIds() {
+    public synchronized Set<TaskId> allInitializedTaskIds() {
         return union(HashSet::new, activeTasksPerId.keySet(), standbyTasksPerId.keySet());
     }
 
     @Override
-    public synchronized Map<TaskId, Task> allTasksPerId() {
+    public synchronized Map<TaskId, Task> allInitializedTasksPerId() {
         final Map<TaskId, Task> ret = new HashMap<>();
         ret.putAll(activeTasksPerId);
         ret.putAll(standbyTasksPerId);
@@ -372,7 +373,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public boolean contains(final TaskId taskId) {
+    public boolean containsInitialized(final TaskId taskId) {
         return getTask(taskId) != null;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
@@ -69,25 +69,25 @@ public interface TasksRegistry {
 
     void clear();
 
-    Task activeTasksForInputPartition(final TopicPartition partition);
+    Task activeInitializedTasksForInputPartition(final TopicPartition partition);
 
-    Task task(final TaskId taskId);
+    Task initializedTask(final TaskId taskId);
 
-    Collection<Task> tasks(final Collection<TaskId> taskIds);
+    Collection<Task> initializedTasks(final Collection<TaskId> taskIds);
 
-    Collection<TaskId> activeTaskIds();
+    Collection<TaskId> activeInitializedTaskIds();
 
-    Collection<Task> activeTasks();
+    Collection<Task> activeInitializedTasks();
 
-    Collection<Task> standbyTasks();
+    Collection<Task> standbyInitializedTasks();
 
-    Set<Task> allTasks();
+    Set<Task> allInitializedTasks();
 
-    Set<Task> allNonFailedTasks();
+    Set<Task> allNonFailedInitializedTasks();
 
-    Map<TaskId, Task> allTasksPerId();
+    Map<TaskId, Task> allInitializedTasksPerId();
 
-    Set<TaskId> allTaskIds();
+    Set<TaskId> allInitializedTaskIds();
 
-    boolean contains(final TaskId taskId);
+    boolean containsInitialized(final TaskId taskId);
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -38,7 +38,7 @@ public class TaskExecutorTest {
         final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
 
         taskExecutor.punctuate();
-        verify(tasks).activeTasks();
+        verify(tasks).activeInitializedTasks();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -239,8 +239,8 @@ public class TaskManagerTest {
             .withInputPartitions(taskId00Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00, taskId01));
-        when(tasks.task(taskId00)).thenReturn(activeTask1);
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.initializedTask(taskId00)).thenReturn(activeTask1);
         final KafkaFuture<Void> mockFuture = KafkaFuture.completedFuture(null);
         when(schedulingTaskManager.lockTasks(any())).thenReturn(mockFuture);
 
@@ -274,7 +274,7 @@ public class TaskManagerTest {
     public void shouldLockActiveOnHandleAssignmentWithProcessingThreads() {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.allTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.allInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
         final KafkaFuture<Void> mockFuture = KafkaFuture.completedFuture(null);
         when(schedulingTaskManager.lockTasks(any())).thenReturn(mockFuture);
 
@@ -297,7 +297,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.allTasks()).thenReturn(Set.of(activeTask1, activeTask2));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(activeTask1, activeTask2));
         final KafkaFuture<Void> mockFuture = KafkaFuture.completedFuture(null);
         when(schedulingTaskManager.lockTasks(any())).thenReturn(mockFuture);
 
@@ -333,7 +333,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.activeTasks()).thenReturn(Set.of(activeTask1, activeTask2));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(activeTask1, activeTask2));
 
         taskManager.resumePollingForPartitionsWithAvailableSpace();
 
@@ -351,7 +351,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.activeTasks()).thenReturn(Set.of(activeTask1, activeTask2));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(activeTask1, activeTask2));
 
         taskManager.updateLags();
 
@@ -630,7 +630,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(reassignedActiveTask));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(reassignedActiveTask));
 
         taskManager.handleAssignment(
             mkMap(mkEntry(reassignedActiveTask.id(), reassignedActiveTask.inputPartitions())),
@@ -669,7 +669,7 @@ public class TaskManagerTest {
         assertEquals(taskException, exception.getCause());
         verify(tasks).addFailedTask(failedActiveTaskToRecycle);
         verify(tasks, never()).addTask(failedActiveTaskToRecycle);
-        verify(tasks).allNonFailedTasks();
+        verify(tasks).allNonFailedInitializedTasks();
         verify(standbyTaskCreator, never()).createStandbyTaskFromActive(failedActiveTaskToRecycle, taskId03Partitions);
     }
 
@@ -699,7 +699,7 @@ public class TaskManagerTest {
         assertEquals(taskException, exception.getCause());
         verify(tasks).addFailedTask(failedStandbyTaskToRecycle);
         verify(tasks, never()).addTask(failedStandbyTaskToRecycle);
-        verify(tasks).allNonFailedTasks();
+        verify(tasks).allNonFailedInitializedTasks();
         verify(activeTaskCreator, never()).createActiveTaskFromStandby(failedStandbyTaskToRecycle, taskId03Partitions, consumer);
     }
 
@@ -729,7 +729,7 @@ public class TaskManagerTest {
         assertEquals(taskException, exception.getCause());
         verify(tasks).addFailedTask(failedActiveTaskToReassign);
         verify(tasks, never()).addTask(failedActiveTaskToReassign);
-        verify(tasks).allNonFailedTasks();
+        verify(tasks).allNonFailedInitializedTasks();
         verify(tasks, never()).updateActiveTaskInputPartitions(failedActiveTaskToReassign, taskId00Partitions);
     }
 
@@ -743,7 +743,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(reassignedActiveTask1));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(reassignedActiveTask1));
         when(stateUpdater.tasks()).thenReturn(Set.of(reassignedActiveTask2));
         when(stateUpdater.remove(reassignedActiveTask2.id()))
             .thenReturn(CompletableFuture.completedFuture(new StateUpdater.RemovedTaskResult(reassignedActiveTask2)));
@@ -848,7 +848,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         when(stateUpdater.tasks()).thenReturn(Set.of(standbyTaskInStateUpdater));
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId03, runningActiveTask)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId03, runningActiveTask)));
         when(tasks.pendingTasksToInit()).thenReturn(Set.of(activeTaskToInit));
         assertEquals(
             taskManager.allTasks(),
@@ -871,7 +871,7 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId03, activeTask)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId03, activeTask)));
         assertEquals(taskManager.allRunningTasks(), mkMap(mkEntry(taskId03, activeTask)));
     }
 
@@ -923,7 +923,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions)
             .inState(State.CREATED).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToRecycle));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(activeTaskToRecycle));
         when(standbyTaskCreator.createStandbyTaskFromActive(activeTaskToRecycle, taskId01Partitions))
             .thenReturn(standbyTask);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
@@ -943,7 +943,7 @@ public class TaskManagerTest {
             .inState(State.RUNNING)
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(standbyTaskToRecycle));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(standbyTaskToRecycle));
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         final IllegalStateException illegalStateException = assertThrows(
@@ -966,7 +966,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToClose));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(activeTaskToClose));
 
         taskManager.handleAssignment(Collections.emptyMap(), Collections.emptyMap());
 
@@ -984,7 +984,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(standbyTaskToClose));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(standbyTaskToClose));
 
         final IllegalStateException illegalStateException = assertThrows(
             IllegalStateException.class,
@@ -1004,7 +1004,7 @@ public class TaskManagerTest {
         final Set<TopicPartition> newInputPartitions = taskId02Partitions;
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToUpdateInputPartitions));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(activeTaskToUpdateInputPartitions));
         when(tasks.updateActiveTaskInputPartitions(activeTaskToUpdateInputPartitions, newInputPartitions)).thenReturn(true);
 
         taskManager.handleAssignment(
@@ -1024,7 +1024,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToResume));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(activeTaskToResume));
 
         taskManager.handleAssignment(
             mkMap(mkEntry(activeTaskToResume.id(), activeTaskToResume.inputPartitions())),
@@ -1042,7 +1042,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId03Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToResume));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(activeTaskToResume));
 
         taskManager.handleAssignment(
             mkMap(mkEntry(activeTaskToResume.id(), activeTaskToResume.inputPartitions())),
@@ -1064,7 +1064,7 @@ public class TaskManagerTest {
         final Set<TopicPartition> newInputPartitions = taskId03Partitions;
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(standbyTaskToUpdateInputPartitions));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(standbyTaskToUpdateInputPartitions));
 
         final IllegalStateException illegalStateException = assertThrows(
             IllegalStateException.class,
@@ -1089,7 +1089,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(activeTaskToClose));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(activeTaskToClose));
 
         taskManager.handleAssignment(
             mkMap(mkEntry(activeTaskToCreate.id(), activeTaskToCreate.inputPartitions())),
@@ -1770,7 +1770,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId00Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(statefulTask0));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(statefulTask0));
         final Set<TopicPartition> assigned = Set.of(t1p0, t1p1);
         when(consumer.assignment()).thenReturn(assigned);
 
@@ -1792,9 +1792,9 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
         when(stateUpdater.tasks()).thenReturn(Set.of(standbyTask, restoringStatefulTask));
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(runningStatefulTask));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(runningStatefulTask));
         expectLockObtainedFor(taskId00, taskId01, taskId02, taskId03);
         expectDirectoryNotEmpty(taskId00, taskId01, taskId02, taskId03);
         makeTaskFolders(
@@ -1826,7 +1826,7 @@ public class TaskManagerTest {
         when(runningStatefulTask.changelogOffsets()).thenReturn(changelogOffsets);
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
 
         assertThat(
             taskManager.taskOffsetSums(),
@@ -1912,7 +1912,7 @@ public class TaskManagerTest {
             .thenReturn(mkMap(mkEntry(t1p2changelog, changelogOffsetOfRestoringStandbyTask)));
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringStandbyTask, restoringStatefulTask));
 
         assertThat(
@@ -1937,7 +1937,7 @@ public class TaskManagerTest {
             ));
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, false);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId01, restoringStatefulTask)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId01, restoringStatefulTask)));
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringStatefulTask));
 
         assertThat(
@@ -2009,7 +2009,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, task)));
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, task)));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -2069,7 +2069,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(task00));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -2090,7 +2090,7 @@ public class TaskManagerTest {
         doThrow(new RuntimeException("KABOOM!")).when(task00).closeClean();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(task00));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -2121,8 +2121,8 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01));
-        when(tasks.allTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01));
+        when(tasks.allInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
 
         final ArrayList<TaskDirectory> taskFolders = new ArrayList<>(2);
         taskFolders.add(new TaskDirectory(testFolder.resolve(taskId00.toString()).toFile(), null));
@@ -2183,8 +2183,8 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.task(taskId03)).thenReturn(corruptedActiveTask);
-        when(tasks.task(taskId02)).thenReturn(corruptedStandbyTask);
+        when(tasks.initializedTask(taskId03)).thenReturn(corruptedActiveTask);
+        when(tasks.initializedTask(taskId02)).thenReturn(corruptedStandbyTask);
 
         taskManager.handleCorruption(Set.of(corruptedActiveTask.id(), corruptedStandbyTask.id()));
 
@@ -2209,9 +2209,9 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(task00);
-        when(tasks.allTasksPerId()).thenReturn(singletonMap(taskId00, task00));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00));
+        when(tasks.initializedTask(taskId00)).thenReturn(task00);
+        when(tasks.allInitializedTasksPerId()).thenReturn(singletonMap(taskId00, task00));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00));
 
         when(task00.prepareCommit(false)).thenReturn(emptyMap());
         doNothing().when(task00).postCommit(anyBoolean());
@@ -2241,9 +2241,9 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(task00);
-        when(tasks.allTasksPerId()).thenReturn(singletonMap(taskId00, task00));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00));
+        when(tasks.initializedTask(taskId00)).thenReturn(task00);
+        when(tasks.allInitializedTasksPerId()).thenReturn(singletonMap(taskId00, task00));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00));
 
         when(task00.prepareCommit(false)).thenReturn(emptyMap());
         when(task00.changelogPartitions()).thenReturn(taskId00ChangelogPartitions);
@@ -2276,12 +2276,12 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(corruptedTask);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(
+        when(tasks.initializedTask(taskId00)).thenReturn(corruptedTask);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(
             mkEntry(taskId00, corruptedTask),
             mkEntry(taskId01, nonCorruptedTask)
         ));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
 
         when(nonCorruptedTask.commitNeeded()).thenReturn(true);
         when(nonCorruptedTask.prepareCommit(true)).thenReturn(emptyMap());
@@ -2315,8 +2315,8 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions)
             .inState(State.RUNNING).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(mkEntry(taskId02, corruptedTask)));
-        when(tasks.task(taskId02)).thenReturn(corruptedTask);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId02, corruptedTask)));
+        when(tasks.initializedTask(taskId02)).thenReturn(corruptedTask);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
         when(consumer.assignment()).thenReturn(intersection(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions));
 
@@ -2340,12 +2340,12 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions).build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(corruptedStandby);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(
+        when(tasks.initializedTask(taskId00)).thenReturn(corruptedStandby);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(
             mkEntry(taskId00, corruptedStandby),
             mkEntry(taskId01, runningNonCorruptedActive)
         ));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId01));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId01));
 
         when(runningNonCorruptedActive.commitNeeded()).thenReturn(true);
         when(runningNonCorruptedActive.prepareCommit(true))
@@ -2386,12 +2386,12 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(corruptedActive);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(
+        when(tasks.initializedTask(taskId00)).thenReturn(corruptedActive);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(
             mkEntry(taskId00, corruptedActive),
             mkEntry(taskId01, uncorruptedActive)
         ));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
 
         when(uncorruptedActive.commitNeeded()).thenReturn(true);
         when(uncorruptedActive.prepareCommit(true)).thenReturn(emptyMap());
@@ -2430,12 +2430,12 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(corruptedActive);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(
+        when(tasks.initializedTask(taskId00)).thenReturn(corruptedActive);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(
             mkEntry(taskId00, corruptedActive),
             mkEntry(taskId01, uncorruptedActive)
         ));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
 
         final StreamsProducer producer = mock(StreamsProducer.class);
         when(activeTaskCreator.streamsProducer()).thenReturn(producer);
@@ -2446,7 +2446,7 @@ public class TaskManagerTest {
 
         // mock uncorrupted task to indicate that it needs commit and will return offsets
         final Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(t1p1, new OffsetAndMetadata(0L, null));
-        when(tasks.tasks(singleton(taskId01))).thenReturn(Set.of(uncorruptedActive));
+        when(tasks.initializedTasks(singleton(taskId01))).thenReturn(Set.of(uncorruptedActive));
         when(uncorruptedActive.commitNeeded()).thenReturn(true);
         when(uncorruptedActive.prepareCommit(true)).thenReturn(offsets);
         when(uncorruptedActive.prepareCommit(false)).thenReturn(emptyMap());
@@ -2511,13 +2511,13 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.task(taskId00)).thenReturn(corruptedActive);
-        when(tasks.allTasksPerId()).thenReturn(mkMap(
+        when(tasks.initializedTask(taskId00)).thenReturn(corruptedActive);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(
             mkEntry(taskId00, corruptedActive),
             mkEntry(taskId01, uncorruptedActive)
         ));
-        when(tasks.activeTaskIds()).thenReturn(Set.of(taskId00, taskId01));
-        when(tasks.activeTasks()).thenReturn(Set.of(corruptedActive, uncorruptedActive));
+        when(tasks.activeInitializedTaskIds()).thenReturn(Set.of(taskId00, taskId01));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(corruptedActive, uncorruptedActive));
 
         // we need to mock uncorrupted task to indicate that it needs commit and will return offsets
         final Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(t1p1, new OffsetAndMetadata(0L, null));
@@ -2591,7 +2591,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(revokedActiveTask, unrevokedActiveTaskWithCommit, unrevokedActiveTaskWithoutCommit));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(revokedActiveTask, unrevokedActiveTaskWithCommit, unrevokedActiveTaskWithoutCommit));
 
         when(consumer.assignment()).thenReturn(union(HashSet::new, taskId00Partitions, taskId01Partitions, taskId02Partitions));
 
@@ -2677,8 +2677,8 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(revokedActiveTask, unrevokedActiveTaskWithCommit, unrevokedActiveTaskWithoutCommit));
-        when(tasks.tasks(Set.of(taskId00, taskId01))).thenReturn(Set.of(revokedActiveTask, unrevokedActiveTaskWithCommit));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(revokedActiveTask, unrevokedActiveTaskWithCommit, unrevokedActiveTaskWithoutCommit));
+        when(tasks.initializedTasks(Set.of(taskId00, taskId01))).thenReturn(Set.of(revokedActiveTask, unrevokedActiveTaskWithCommit));
 
         final StreamsProducer producer = mock(StreamsProducer.class);
         when(activeTaskCreator.streamsProducer()).thenReturn(producer);
@@ -2791,7 +2791,7 @@ public class TaskManagerTest {
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
 
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(task00));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(task00));
 
         when(tasks.drainPendingTasksToInit()).thenReturn(emptySet());
         when(tasks.hasPendingTasksToInit()).thenReturn(false);
@@ -2827,7 +2827,7 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final Set<TopicPartition> newPartitionsSet = Set.of(t1p1);
 
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(task00));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(task00));
         when(tasks.drainPendingTasksToInit()).thenReturn(emptySet());
         when(tasks.hasPendingTasksToInit()).thenReturn(false);
         when(tasks.updateActiveTaskInputPartitions(task00, newPartitionsSet)).thenReturn(true);
@@ -2963,7 +2963,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(t1p0, new OffsetAndMetadata(0L, null));
 
@@ -3007,7 +3007,7 @@ public class TaskManagerTest {
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
 
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01, task02, task10));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01, task02, task10));
 
         final StreamsProducer producer = mock(StreamsProducer.class);
         when(activeTaskCreator.streamsProducer()).thenReturn(producer);
@@ -3099,7 +3099,7 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(offsets01);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01, task02, task03));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01, task02, task03));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3150,7 +3150,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01, task02));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01, task02));
 
         when(task00.commitNeeded()).thenReturn(false);
         when(task01.commitNeeded()).thenReturn(true); // only task01 needs commit
@@ -3181,7 +3181,7 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(task00));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(task00));
         when(stateUpdater.tasks()).thenReturn(Set.of(task01));
 
         final Map<TaskId, Set<TopicPartition>> assignmentActive = singletonMap(taskId00, taskId00Partitions);
@@ -3215,7 +3215,7 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        when(tasks.allNonFailedTasks()).thenReturn(Set.of(task00));
+        when(tasks.allNonFailedInitializedTasks()).thenReturn(Set.of(task00));
         when(stateUpdater.tasks()).thenReturn(Set.of(task01));
 
         // mock to remove standby task from state updater
@@ -3283,7 +3283,7 @@ public class TaskManagerTest {
         doThrow(new RuntimeException("KABOOM!")).when(task00).suspend();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3323,7 +3323,7 @@ public class TaskManagerTest {
         doThrow(new RuntimeException("oops"))
             .when(task02).suspend();
 
-        when(tasks.activeTasks()).thenReturn(Set.of(task00, task01, task02));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00, task01, task02));
 
         final RuntimeException exception = assertThrows(
             RuntimeException.class,
@@ -3360,7 +3360,7 @@ public class TaskManagerTest {
 
         doThrow(new RuntimeException("whatever")).when(activeTaskCreator).close();
 
-        when(tasks.activeTasks()).thenReturn(Set.of(task00));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00));
 
         final RuntimeException exception = assertThrows(
             RuntimeException.class,
@@ -3460,7 +3460,7 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01, task02));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01, task02));
 
         final RuntimeException thrown = assertThrows(RuntimeException.class,
             () -> taskManager.handleRevocation(union(HashSet::new, taskId01Partitions, taskId02Partitions)));
@@ -3497,7 +3497,7 @@ public class TaskManagerTest {
             .when(task02).suspend();
         doThrow(new RuntimeException("whatever")).when(activeTaskCreator).close();
 
-        when(tasks.activeTasks()).thenReturn(Set.of(task00, task01, task02));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00, task01, task02));
 
         taskManager.shutdown(false);
 
@@ -3530,7 +3530,7 @@ public class TaskManagerTest {
 
         when(stateUpdater.tasks()).thenReturn(Set.of(standbyTask00)).thenReturn(Set.of());
         when(stateUpdater.standbyTasks()).thenReturn(Set.of(standbyTask00));
-        when(tasks.standbyTasks()).thenReturn(Set.of(standbyTask00));
+        when(tasks.standbyInitializedTasks()).thenReturn(Set.of(standbyTask00));
 
         final CompletableFuture<StateUpdater.RemovedTaskResult> futureForStandbyTask = new CompletableFuture<>();
         when(stateUpdater.remove(taskId00)).thenReturn(futureForStandbyTask);
@@ -3750,7 +3750,7 @@ public class TaskManagerTest {
         when(task01.prepareCommit(true)).thenReturn(emptyMap());
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3846,7 +3846,7 @@ public class TaskManagerTest {
         when(task00.prepareCommit(true)).thenReturn(emptyMap());
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3874,7 +3874,7 @@ public class TaskManagerTest {
         when(task01.commitNeeded()).thenReturn(true);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3903,7 +3903,7 @@ public class TaskManagerTest {
         when(task01.prepareCommit(true)).thenReturn(offsets);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3928,7 +3928,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task01, task02));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task01, task02));
 
         final StreamsProducer producer = mock(StreamsProducer.class);
         when(activeTaskCreator.streamsProducer()).thenReturn(producer);
@@ -3975,7 +3975,7 @@ public class TaskManagerTest {
         when(task00.prepareCommit(true)).thenThrow(new RuntimeException("opsh."));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -3998,7 +3998,7 @@ public class TaskManagerTest {
         when(task01.prepareCommit(true)).thenThrow(new RuntimeException("opsh."));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4030,7 +4030,7 @@ public class TaskManagerTest {
             .thenReturn(singletonMap(t1p1, 17L));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4060,7 +4060,7 @@ public class TaskManagerTest {
             .thenReturn(singletonMap(t1p1, 17L));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4088,7 +4088,7 @@ public class TaskManagerTest {
         when(task00.purgeableOffsets()).thenReturn(singletonMap(t1p1, 5L));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4145,7 +4145,7 @@ public class TaskManagerTest {
         expectedCommittedOffsets.putAll(offsets1);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01, task02, task03));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01, task02, task03));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4205,7 +4205,7 @@ public class TaskManagerTest {
             .thenReturn(false); // no more records
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00, task01));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00, task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4250,7 +4250,7 @@ public class TaskManagerTest {
             .thenReturn(false);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00, task01, task02));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00, task01, task02));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4277,7 +4277,7 @@ public class TaskManagerTest {
             .thenThrow(new TaskMigratedException("migrated", new RuntimeException("cause")));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4294,7 +4294,7 @@ public class TaskManagerTest {
         when(task00.process(anyLong())).thenThrow(new RuntimeException("oops"));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4315,7 +4315,7 @@ public class TaskManagerTest {
             .thenThrow(new TaskMigratedException("migrated", new RuntimeException("cause")));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4332,7 +4332,7 @@ public class TaskManagerTest {
         when(task00.maybePunctuateStreamTime()).thenThrow(new KafkaException("oops"));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4350,7 +4350,7 @@ public class TaskManagerTest {
         when(task00.maybePunctuateSystemTime()).thenReturn(true);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.activeTasks()).thenReturn(Set.of(task00));
+        when(tasks.activeInitializedTasks()).thenReturn(Set.of(task00));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4386,7 +4386,7 @@ public class TaskManagerTest {
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
-        when(tasks.allTasks()).thenReturn(Set.of(task00));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00));
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(TaskManager.class)) {
             appender.setClassLogger(TaskManager.class, Level.DEBUG);
@@ -4591,7 +4591,7 @@ public class TaskManagerTest {
         when(task01.prepareCommit(true)).thenReturn(offsets);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4706,7 +4706,7 @@ public class TaskManagerTest {
         when(task01.prepareCommit(true)).thenReturn(offsets);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4737,7 +4737,7 @@ public class TaskManagerTest {
         when(task01.prepareCommit(true)).thenReturn(offsets);
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4769,7 +4769,7 @@ public class TaskManagerTest {
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
 
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
@@ -4863,7 +4863,7 @@ public class TaskManagerTest {
             .build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.allTasks()).thenReturn(Set.of(task00, task01));
+        when(tasks.allInitializedTasks()).thenReturn(Set.of(task00, task01));
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -75,25 +75,25 @@ public class TasksTest {
         tasks.addActiveTasks(Set.of(statefulTask, statelessTask));
         tasks.addStandbyTasks(Collections.singletonList(standbyTask));
 
-        assertEquals(statefulTask, tasks.task(statefulTask.id()));
-        assertEquals(statelessTask, tasks.task(statelessTask.id()));
-        assertEquals(standbyTask, tasks.task(standbyTask.id()));
+        assertEquals(statefulTask, tasks.initializedTask(statefulTask.id()));
+        assertEquals(statelessTask, tasks.initializedTask(statelessTask.id()));
+        assertEquals(standbyTask, tasks.initializedTask(standbyTask.id()));
 
-        assertEquals(Set.of(statefulTask, statelessTask), new HashSet<>(tasks.activeTasks()));
-        assertEquals(Set.of(standbyTask), new HashSet<>(tasks.standbyTasks()));
-        assertEquals(Set.of(statefulTask, statelessTask, standbyTask), tasks.allTasks());
-        assertEquals(Set.of(statefulTask, standbyTask), tasks.tasks(Set.of(statefulTask.id(), standbyTask.id())));
-        assertEquals(Set.of(statefulTask.id(), statelessTask.id(), standbyTask.id()), tasks.allTaskIds());
+        assertEquals(Set.of(statefulTask, statelessTask), new HashSet<>(tasks.activeInitializedTasks()));
+        assertEquals(Set.of(standbyTask), new HashSet<>(tasks.standbyInitializedTasks()));
+        assertEquals(Set.of(statefulTask, statelessTask, standbyTask), tasks.allInitializedTasks());
+        assertEquals(Set.of(statefulTask, standbyTask), tasks.initializedTasks(Set.of(statefulTask.id(), standbyTask.id())));
+        assertEquals(Set.of(statefulTask.id(), statelessTask.id(), standbyTask.id()), tasks.allInitializedTaskIds());
         assertEquals(
             mkMap(
                 mkEntry(statefulTask.id(), statefulTask),
                 mkEntry(statelessTask.id(), statelessTask),
                 mkEntry(standbyTask.id(), standbyTask)
             ),
-            tasks.allTasksPerId());
-        assertTrue(tasks.contains(statefulTask.id()));
-        assertTrue(tasks.contains(statelessTask.id()));
-        assertTrue(tasks.contains(statefulTask.id()));
+            tasks.allInitializedTasksPerId());
+        assertTrue(tasks.containsInitialized(statefulTask.id()));
+        assertTrue(tasks.containsInitialized(statelessTask.id()));
+        assertTrue(tasks.containsInitialized(statefulTask.id()));
     }
 
     @Test
@@ -192,12 +192,12 @@ public class TasksTest {
 
         tasks.addFailedTask(activeTask1);
 
-        assertEquals(activeTask1, tasks.task(TASK_0_0));
-        assertEquals(activeTask2, tasks.task(TASK_0_1));
-        assertTrue(tasks.allTasks().contains(activeTask1));
-        assertTrue(tasks.allTasks().contains(activeTask2));
-        assertFalse(tasks.allNonFailedTasks().contains(activeTask1));
-        assertTrue(tasks.allNonFailedTasks().contains(activeTask2));
+        assertEquals(activeTask1, tasks.initializedTask(TASK_0_0));
+        assertEquals(activeTask2, tasks.initializedTask(TASK_0_1));
+        assertTrue(tasks.allInitializedTasks().contains(activeTask1));
+        assertTrue(tasks.allInitializedTasks().contains(activeTask2));
+        assertFalse(tasks.allNonFailedInitializedTasks().contains(activeTask1));
+        assertTrue(tasks.allNonFailedInitializedTasks().contains(activeTask2));
     }
 
     @Test
@@ -207,11 +207,11 @@ public class TasksTest {
         tasks.addFailedTask(activeTask1);
 
         tasks.removeTask(activeTask1);
-        assertFalse(tasks.allNonFailedTasks().contains(activeTask1));
-        assertFalse(tasks.allTasks().contains(activeTask1));
+        assertFalse(tasks.allNonFailedInitializedTasks().contains(activeTask1));
+        assertFalse(tasks.allInitializedTasks().contains(activeTask1));
 
         tasks.addTask(activeTask1);
-        assertTrue(tasks.allNonFailedTasks().contains(activeTask1));
+        assertTrue(tasks.allNonFailedInitializedTasks().contains(activeTask1));
     }
 
     @Test
@@ -221,11 +221,11 @@ public class TasksTest {
         tasks.addFailedTask(activeTask1);
 
         tasks.clear();
-        assertFalse(tasks.allNonFailedTasks().contains(activeTask1));
-        assertFalse(tasks.allTasks().contains(activeTask1));
+        assertFalse(tasks.allNonFailedInitializedTasks().contains(activeTask1));
+        assertFalse(tasks.allInitializedTasks().contains(activeTask1));
 
         tasks.addTask(activeTask1);
-        assertTrue(tasks.allNonFailedTasks().contains(activeTask1));
+        assertTrue(tasks.allNonFailedInitializedTasks().contains(activeTask1));
     }
 
     @Test
@@ -260,6 +260,6 @@ public class TasksTest {
 
         tasks.removeTask(activeTask1);
         assertFalse(tasks.pendingTasksToInit().contains(activeTask1));
-        assertFalse(tasks.allTasks().contains(activeTask1));
+        assertFalse(tasks.allInitializedTasks().contains(activeTask1));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
@@ -69,8 +69,8 @@ public class DefaultTaskManagerTest {
     @BeforeEach
     public void setUp() {
         when(task.isProcessable(anyLong())).thenReturn(true);
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
-        when(tasks.task(taskId)).thenReturn(task);
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.initializedTask(taskId)).thenReturn(task);
     }
 
     @Test
@@ -94,14 +94,14 @@ public class DefaultTaskManagerTest {
         taskManager.add(Collections.singleton(task));
 
         verify(tasks).addTask(task);
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         assertEquals(1, taskManager.getTasks().size());
     }
 
     @Test
     public void shouldAssignTaskThatCanBeProcessed() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
 
         assertEquals(task, taskManager.assignNextTask(taskExecutor));
@@ -145,7 +145,7 @@ public class DefaultTaskManagerTest {
         final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
         final Thread awaitingThread = new Thread(awaitingRunnable);
         awaitingThread.start();
-        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeTasks();
+        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
         awaitingThread.interrupt();
 
@@ -160,7 +160,7 @@ public class DefaultTaskManagerTest {
         final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
         final Thread awaitingThread = new Thread(awaitingRunnable);
         awaitingThread.start();
-        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeTasks();
+        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
         taskManager.signalTaskExecutors();
 
@@ -180,7 +180,7 @@ public class DefaultTaskManagerTest {
         final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
         final Thread awaitingThread = new Thread(awaitingRunnable);
         awaitingThread.start();
-        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeTasks();
+        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
         taskManager.unassignTask(task, taskExecutor);
 
@@ -195,7 +195,7 @@ public class DefaultTaskManagerTest {
         final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
         final Thread awaitingThread = new Thread(awaitingRunnable);
         awaitingThread.start();
-        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeTasks();
+        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
         taskManager.add(Collections.singleton(task));
 
@@ -212,7 +212,7 @@ public class DefaultTaskManagerTest {
         final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
         final Thread awaitingThread = new Thread(awaitingRunnable);
         awaitingThread.start();
-        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeTasks();
+        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
         taskManager.unlockAllTasks();
 
@@ -225,7 +225,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldAssignTasksThatCanBeSystemTimePunctuated() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         when(task.canPunctuateSystemTime()).thenReturn(true);
 
@@ -236,7 +236,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldAssignTasksThatCanBeStreamTimePunctuated() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canPunctuateTask(eq(task))).thenReturn(true);
         when(task.canPunctuateStreamTime()).thenReturn(true);
 
@@ -247,7 +247,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotAssignTasksIfUncaughtExceptionPresent() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         ensureTaskMakesProgress();
         taskManager.assignNextTask(taskExecutor);
         taskManager.setUncaughtException(new StreamsException("Exception"), taskId);
@@ -259,7 +259,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotAssignTasksForPunctuationIfPunctuationDisabled() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canPunctuateTask(eq(task))).thenReturn(false);
         when(task.canPunctuateStreamTime()).thenReturn(true);
         when(task.canPunctuateSystemTime()).thenReturn(true);
@@ -270,7 +270,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotAssignTasksForProcessingIfProcessingDisabled() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(false);
         when(task.isProcessable(anyLong())).thenReturn(true);
 
@@ -280,7 +280,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldUnassignTask() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
 
         assertEquals(task, taskManager.assignNextTask(taskExecutor));
@@ -292,7 +292,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotUnassignNotOwnedTask() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
 
         assertEquals(task, taskManager.assignNextTask(taskExecutor));
@@ -319,16 +319,16 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldRemoveTask() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
-        when(tasks.task(task.id())).thenReturn(task);
-        when(tasks.contains(task.id())).thenReturn(true);
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.initializedTask(task.id())).thenReturn(task);
+        when(tasks.containsInitialized(task.id())).thenReturn(true);
 
         taskManager.lockTasks(Collections.singleton(task.id()));
         taskManager.remove(task.id());
 
         verify(tasks).removeTask(task);
         reset(tasks);
-        when(tasks.activeTasks()).thenReturn(Collections.emptySet());
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.emptySet());
 
         assertEquals(0, taskManager.getTasks().size());
     }
@@ -336,10 +336,10 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotAssignLockedTask() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
-        when(tasks.task(task.id())).thenReturn(task);
-        when(tasks.contains(task.id())).thenReturn(true);
+        when(tasks.initializedTask(task.id())).thenReturn(task);
+        when(tasks.containsInitialized(task.id())).thenReturn(true);
 
         assertTrue(taskManager.lockTasks(Collections.singleton(task.id())).isDone());
 
@@ -349,10 +349,10 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldLockAnEmptySetOfTasks() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
-        when(tasks.task(task.id())).thenReturn(task);
-        when(tasks.contains(task.id())).thenReturn(true);
+        when(tasks.initializedTask(task.id())).thenReturn(task);
+        when(tasks.containsInitialized(task.id())).thenReturn(true);
 
         assertTrue(taskManager.lockTasks(Collections.emptySet()).isDone());
 
@@ -365,10 +365,10 @@ public class DefaultTaskManagerTest {
         final KafkaFutureImpl<StreamTask> future = new KafkaFutureImpl<>();
 
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
-        when(tasks.task(task.id())).thenReturn(task);
-        when(tasks.contains(task.id())).thenReturn(true);
+        when(tasks.initializedTask(task.id())).thenReturn(task);
+        when(tasks.containsInitialized(task.id())).thenReturn(true);
         when(taskExecutor.unassign()).thenReturn(future);
 
         assertEquals(task, taskManager.assignNextTask(taskExecutor));
@@ -386,10 +386,10 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotAssignAnyLockedTask() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
-        when(tasks.task(task.id())).thenReturn(task);
-        when(tasks.contains(task.id())).thenReturn(true);
+        when(tasks.initializedTask(task.id())).thenReturn(task);
+        when(tasks.containsInitialized(task.id())).thenReturn(true);
 
         assertTrue(taskManager.lockAllTasks().isDone());
 
@@ -407,7 +407,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldNotSetUncaughtExceptionsTwice() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         taskManager.assignNextTask(taskExecutor);
         taskManager.setUncaughtException(exception, task.id());
@@ -419,7 +419,7 @@ public class DefaultTaskManagerTest {
     @Test
     public void shouldReturnAndClearExceptionsOnDrainExceptions() {
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         taskManager.assignNextTask(taskExecutor);
         taskManager.setUncaughtException(exception, task.id());
@@ -433,9 +433,9 @@ public class DefaultTaskManagerTest {
         final KafkaFutureImpl<StreamTask> future = new KafkaFutureImpl<>();
 
         taskManager.add(Collections.singleton(task));
-        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
-        when(tasks.task(task.id())).thenReturn(task);
-        when(tasks.contains(task.id())).thenReturn(true);
+        when(tasks.activeInitializedTasks()).thenReturn(Collections.singleton(task));
+        when(tasks.initializedTask(task.id())).thenReturn(task);
+        when(tasks.containsInitialized(task.id())).thenReturn(true);
         when(taskExecutor.unassign()).thenReturn(future);
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
 


### PR DESCRIPTION
Changed the name of method that work only with initialized tasks(not
pending) to better reflect their purpose.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Lucas Brutschy
 <lbrutschy@confluent.io>
