### PR TITLE
MINOR: use correct deserialize method in ValueTimestampHeaders

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -83,7 +83,7 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         final byte[] rawTimestamp = readBytes(buffer, Long.BYTES);
         final long timestamp = timestampDeserializer.deserialize(topic, rawTimestamp);
         final byte[] rawValue = readBytes(buffer, buffer.remaining());
-        final V value = valueDeserializer.deserialize(topic, rawValue);
+        final V value = valueDeserializer.deserialize(topic, headers, rawValue);
 
         return ValueTimestampHeaders.make(value, timestamp, headers);
     }


### PR DESCRIPTION
When (de)serializing `ValueTimestampHeader` object, we need to use
`deserialize(String, Headers, byte[])` instead of `deserialize(String,
byte[])`.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
