### PR TITLE
MINOR: reenabled checkstyle rules for finals for the streams module.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -222,8 +222,11 @@
     <suppress checks="(NPathComplexity|CyclomaticComplexity)"
               files="(KStreamSlidingWindowAggregate|RackAwareTaskAssignor).java"/>
 
-    <!-- suppress FinalLocalVariable outside of the streams package. -->
+    <!-- suppress FinalLocalVariable and FinalParameters outside of the streams package. -->
     <suppress checks="FinalLocalVariable"
+              files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
+
+    <suppress checks="FinalParameters"
               files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
 
     <!-- Generated code -->
@@ -374,8 +377,5 @@
 
      <!-- Add the new suppression rule for JaasTestUtils.java -->
     <suppress checks="ImportControl" files="(JaasTestUtils).java" />
-
-    <suppress checks="FinalLocalVariable" files="."/>
-    <suppress checks="FinalParameters" files="."/>
 
 </suppressions>

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceTaskClosureIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceTaskClosureIntegrationTest.java
@@ -229,7 +229,7 @@ public class RebalanceTaskClosureIntegrationTest {
                 // to avoid that the "pending task" get fully initialized
                 // (otherwise, we don't have a pending task when the shutdown happens)
                 pendingShutdownLatch.await();
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/ExceptionHandlerUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/ExceptionHandlerUtils.java
@@ -86,7 +86,7 @@ public class ExceptionHandlerUtils {
         final ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(deadLetterQueueTopicName, null, context.timestamp(), key, value);
         // Copy original headers from record that causes exception
         if (context.headers() != null) {
-            for (Header header : context.headers()) {
+            for (final Header header : context.headers()) {
                 producerRecord.headers().add(header);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableValueGetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableValueGetter.java
@@ -30,7 +30,7 @@ public interface KTableValueGetter<K, V> {
      * not exceeding the provided timestamp bound. This method may only be called if
      * {@link #isVersioned()} is true.
      */
-    default ValueAndTimestamp<V> get(K key, long asOfTimestamp) {
+    default ValueAndTimestamp<V> get(final K key, final long asOfTimestamp) {
         throw new UnsupportedOperationException("get(key, timestamp) is only supported for versioned stores");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignKeyExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignKeyExtractor.java
@@ -38,11 +38,11 @@ import java.util.function.Function;
 public interface ForeignKeyExtractor<KLeft, VLeft, KRight> {
     KRight extract(KLeft key, VLeft value);
 
-    static <KLeft, VLeft, KRight> ForeignKeyExtractor<? super KLeft, ? super VLeft, ? extends KRight> fromFunction(Function<? super VLeft, ? extends KRight> function) {
+    static <KLeft, VLeft, KRight> ForeignKeyExtractor<? super KLeft, ? super VLeft, ? extends KRight> fromFunction(final Function<? super VLeft, ? extends KRight> function) {
         return (key, value) -> function.apply(value);
     }
 
-    static <KLeft, VLeft, KRight> ForeignKeyExtractor<? super KLeft, ? super VLeft, ? extends KRight> fromBiFunction(BiFunction<? super KLeft, ? super VLeft, ? extends KRight> biFunction) {
+    static <KLeft, VLeft, KRight> ForeignKeyExtractor<? super KLeft, ? super VLeft, ? extends KRight> fromBiFunction(final BiFunction<? super KLeft, ? super VLeft, ? extends KRight> biFunction) {
         return biFunction::apply;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/BatchingStateRestoreCallback.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/BatchingStateRestoreCallback.java
@@ -39,7 +39,7 @@ public interface BatchingStateRestoreCallback extends StateRestoreCallback {
     void restoreAll(Collection<KeyValue<byte[], byte[]>> records);
 
     @Override
-    default void restore(byte[] key, byte[] value) {
+    default void restore(final byte[] key, final byte[] value) {
         throw new UnsupportedOperationException();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignor.java
@@ -78,7 +78,7 @@ public interface TaskAssignor extends Configurable {
      * @param error        the corresponding error type if one was detected while processing the returned assignment,
      *                     or AssignmentError.NONE if the returned assignment was valid
      */
-    default void onAssignmentComputed(GroupAssignment assignment, GroupSubscription subscription, AssignmentError error) {}
+    default void onAssignmentComputed(final GroupAssignment assignment, final GroupSubscription subscription, final AssignmentError error) {}
 
     @Override
     default void configure(final Map<String, ?> configs) {}

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslStoreSuppliers.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslStoreSuppliers.java
@@ -50,7 +50,7 @@ import java.util.Map;
 public interface DslStoreSuppliers extends Configurable {
 
     @Override
-    default void configure(Map<String, ?> configs) {
+    default void configure(final Map<String, ?> configs) {
         // optional to configure this class
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -72,7 +72,7 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * @return The iterator for this range, from key with the smallest bytes to the key with the largest bytes of keys.
      * @throws InvalidStateStoreException if the store is not initialized
      */
-    default KeyValueIterator<K, V> reverseRange(K from, K to) {
+    default KeyValueIterator<K, V> reverseRange(final K from, final K to) {
         throw new UnsupportedOperationException();
     }
 
@@ -119,7 +119,7 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * @return The iterator for keys having the specified prefix.
      * @throws InvalidStateStoreException if the store is not initialized
      */
-    default <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(P prefix, PS prefixKeySerializer) {
+    default <PS extends Serializer<P>, P> KeyValueIterator<K, V> prefixScan(final P prefix, final PS prefixKeySerializer) {
         throw new UnsupportedOperationException();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -118,7 +118,7 @@ public interface ReadOnlyWindowStore<K, V> {
      * @throws NullPointerException       if {@code null} is used for key.
      * @throws IllegalArgumentException   if duration is negative or can't be represented as {@code long milliseconds}
      */
-    default WindowStoreIterator<V> backwardFetch(K key, Instant timeFrom, Instant timeTo) throws IllegalArgumentException  {
+    default WindowStoreIterator<V> backwardFetch(final K key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException  {
         throw new UnsupportedOperationException();
     }
 
@@ -156,7 +156,7 @@ public interface ReadOnlyWindowStore<K, V> {
      * @throws InvalidStateStoreException if the store is not initialized
      * @throws IllegalArgumentException   if duration is negative or can't be represented as {@code long milliseconds}
      */
-    default KeyValueIterator<Windowed<K>, V> backwardFetch(K keyFrom, K keyTo, Instant timeFrom, Instant timeTo)
+    default KeyValueIterator<Windowed<K>, V> backwardFetch(final K keyFrom, final K keyTo, final Instant timeFrom, final Instant timeTo)
         throws IllegalArgumentException  {
         throw new UnsupportedOperationException();
     }
@@ -204,7 +204,7 @@ public interface ReadOnlyWindowStore<K, V> {
      * @throws NullPointerException       if {@code null} is used for any key
      * @throws IllegalArgumentException   if duration is negative or can't be represented as {@code long milliseconds}
      */
-    default KeyValueIterator<Windowed<K>, V> backwardFetchAll(Instant timeFrom, Instant timeTo) throws IllegalArgumentException  {
+    default KeyValueIterator<Windowed<K>, V> backwardFetchAll(final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException  {
         throw new UnsupportedOperationException();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -93,7 +93,7 @@ public class HeadersSerializer implements Serializer<Headers> {
             }
 
             return baos.toByteArray();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new SerializationException("Failed to serialize headers", e);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
@@ -167,7 +167,7 @@ public interface SegmentedBytesStore extends StateStore {
          * @param timestamp
          * @return  The key that represents the prefixed Segmented key in bytes.
          */
-        default Bytes toStoreBinaryKeyPrefix(final Bytes key, long timestamp) {
+        default Bytes toStoreBinaryKeyPrefix(final Bytes key, final long timestamp) {
             throw new UnsupportedOperationException();
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -134,7 +134,7 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         final int headersSize = ByteUtils.readVarint(buffer);
         // skip headers plus timestamp
         buffer.position(buffer.position() + headersSize + Long.BYTES);
-        byte[] bytes = readBytes(buffer, buffer.remaining());
+        final byte[] bytes = readBytes(buffer, buffer.remaining());
 
         return deserializer.deserialize("", bytes);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -107,7 +107,7 @@ public class ValueTimestampHeadersSerializer<V> implements WrappingNullableSeria
             out.write(rawValue);                            // [value]
 
             return baos.toByteArray();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new SerializationException("Failed to serialize ValueTimestampHeaders", e);
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/HeadersBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/HeadersBytesStoreTest.java
@@ -46,7 +46,7 @@ public class HeadersBytesStoreTest {
         assertNotNull(converted);
         assertEquals(legacyValue.length + 1, converted.length, "converted bytes should have empty header bytes");
         assertEquals(0x00, converted[0], "First byte for empty header should be the 0x00");
-        byte[] actualPayload = Arrays.copyOfRange(converted, 1, converted.length);
+        final byte[] actualPayload = Arrays.copyOfRange(converted, 1, converted.length);
         assertArrayEquals(legacyValue, actualPayload);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessorTest.java
@@ -120,7 +120,7 @@ public class DualColumnFamilyAccessorTest {
     public void shouldThrowProcessorStateExceptionWhenPutFailsOnDeleteColumnFamily() throws RocksDBException {
         doThrow(new RocksDBException("Delete failed")).when(dbAccessor).delete(oldCF, KEY);
 
-        ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.put(dbAccessor, KEY, NEW_VALUE));
+        final ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.put(dbAccessor, KEY, NEW_VALUE));
 
         assertEquals("Error while removing key from store " + STORE_NAME, exception.getMessage());
     }
@@ -129,7 +129,7 @@ public class DualColumnFamilyAccessorTest {
     public void shouldThrowProcessorStateExceptionWhenPutFailsOnNewColumnFamily() throws RocksDBException {
         doThrow(new RocksDBException("Put failed")).when(dbAccessor).put(newCF, KEY, NEW_VALUE);
 
-        ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.put(dbAccessor, KEY, NEW_VALUE));
+        final ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.put(dbAccessor, KEY, NEW_VALUE));
 
         assertEquals("Error while putting key/value into store " + STORE_NAME, exception.getMessage());
     }
@@ -138,7 +138,7 @@ public class DualColumnFamilyAccessorTest {
     public void shouldThrowProcessorStateExceptionWhenDeleteFailsOnOldColumnFamilyWithNullValue() throws RocksDBException {
         doThrow(new RocksDBException("Delete failed")).when(dbAccessor).delete(eq(oldCF), any(byte[].class));
 
-        ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.put(dbAccessor, KEY, null));
+        final ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.put(dbAccessor, KEY, null));
 
         assertEquals("Error while removing key from store " + STORE_NAME, exception.getMessage());
     }
@@ -196,7 +196,7 @@ public class DualColumnFamilyAccessorTest {
 
     @Test
     public void shouldGetValueWithReadOptions() throws RocksDBException {
-        ReadOptions readOptions = mock(ReadOptions.class);
+        final ReadOptions readOptions = mock(ReadOptions.class);
         when(dbAccessor.get(newCF, readOptions, KEY)).thenReturn(NEW_VALUE);
 
         final byte[] result = accessor.get(dbAccessor, KEY, readOptions);
@@ -208,7 +208,7 @@ public class DualColumnFamilyAccessorTest {
 
     @Test
     public void shouldGetFromOldColumnFamilyWithReadOptionsAndConvert() throws RocksDBException {
-        ReadOptions readOptions = mock(ReadOptions.class);
+        final ReadOptions readOptions = mock(ReadOptions.class);
         when(dbAccessor.get(newCF, readOptions, KEY)).thenReturn(null);
         when(dbAccessor.get(oldCF, readOptions, KEY)).thenReturn(OLD_VALUE);
 
@@ -317,7 +317,7 @@ public class DualColumnFamilyAccessorTest {
 
         doThrow(new RocksDBException("Delete range failed")).when(dbAccessor).deleteRange(eq(oldCF), any(byte[].class), any(byte[].class));
 
-        ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.deleteRange(dbAccessor, from, to));
+        final ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.deleteRange(dbAccessor, from, to));
 
         assertEquals("Error while removing key from store " + STORE_NAME, exception.getMessage());
     }
@@ -330,7 +330,7 @@ public class DualColumnFamilyAccessorTest {
         lenient().doNothing().when(dbAccessor).deleteRange(eq(oldCF), any(byte[].class), any(byte[].class));
         doThrow(new RocksDBException("Delete range failed")).when(dbAccessor).deleteRange(eq(newCF), any(byte[].class), any(byte[].class));
 
-        ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.deleteRange(dbAccessor, from, to));
+        final ProcessorStateException exception = assertThrows(ProcessorStateException.class, () -> accessor.deleteRange(dbAccessor, from, to));
 
         assertEquals("Error while removing key from store " + STORE_NAME, exception.getMessage());
         verify(dbAccessor).deleteRange(oldCF, from, to);
@@ -380,7 +380,7 @@ public class DualColumnFamilyAccessorTest {
         when(dbAccessor.newIterator(newCF)).thenReturn(newIterFormat);
         when(dbAccessor.newIterator(oldCF)).thenReturn(oldIterFormat);
 
-        ManagedKeyValueIterator<Bytes, byte[]> iterator = accessor.all(dbAccessor, true);
+        final ManagedKeyValueIterator<Bytes, byte[]> iterator = accessor.all(dbAccessor, true);
 
         assertNotNull(iterator);
         verify(oldIterFormat).seekToFirst();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
@@ -89,7 +89,7 @@ public class HeadersDeserializerTest {
         final Header[] headerArray = deserialized.toArray();
         assertEquals(3, headerArray.length);
         for (int i = 0; i < headerArray.length; i++) {
-            Header next = headerArray[i];
+            final Header next = headerArray[i];
             assertEquals("key" + i, next.key());
             assertArrayEquals(("value" + i).getBytes(), next.value());
         }


### PR DESCRIPTION
Fixed the checkstyle violations.

Reviewers: Matthias J. Sax <matthias@confluent.io>
