### PR TITLE
MINOR: Unwrap exceptions in CoordinatorTimerImpl and CoordinatorExecutorImpl

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.common.runtime;
 
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 
 import org.slf4j.Logger;
@@ -85,6 +86,11 @@ public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
                     return operation.onComplete(result.result(), result.exception());
                 }
             ).exceptionally(exception -> {
+                // Exceptions may be wrapped in CompletionException or ExecutionException
+                // when propagated through CompletableFuture chains, so we unwrap them
+                // before checking types with instanceof.
+                exception = Errors.maybeUnwrapException(exception);
+
                 // Remove the task after a failure.
                 tasks.remove(key, task);
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -86,9 +86,9 @@ public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
                     return operation.onComplete(result.result(), result.exception());
                 }
             ).exceptionally(exception -> {
-                // Exceptions may be wrapped in CompletionException or ExecutionException
-                // when propagated through CompletableFuture chains, so we unwrap them
-                // before checking types with instanceof.
+                // Exceptions may be wrapped in CompletionException when propagated
+                // through CompletableFuture chains, so we unwrap them before
+                // checking types with instanceof.
                 exception = Errors.maybeUnwrapException(exception);
 
                 // Remove the task after a failure.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorTimerImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorTimerImpl.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.common.runtime;
 
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.server.util.timer.Timer;
 import org.apache.kafka.server.util.timer.TimerTask;
@@ -97,6 +98,11 @@ public class CoordinatorTimerImpl<U> implements CoordinatorTimer<U> {
                         return operation.generateRecords();
                     }
                 ).exceptionally(ex -> {
+                    // Exceptions may be wrapped in CompletionException or ExecutionException
+                    // when propagated through CompletableFuture chains, so we unwrap them
+                    // before checking types with instanceof.
+                    ex = Errors.maybeUnwrapException(ex);
+
                     // Remove the task after a failure.
                     tasks.remove(key, this);
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorTimerImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorTimerImpl.java
@@ -98,9 +98,9 @@ public class CoordinatorTimerImpl<U> implements CoordinatorTimer<U> {
                         return operation.generateRecords();
                     }
                 ).exceptionally(ex -> {
-                    // Exceptions may be wrapped in CompletionException or ExecutionException
-                    // when propagated through CompletableFuture chains, so we unwrap them
-                    // before checking types with instanceof.
+                    // Exceptions may be wrapped in CompletionException when propagated
+                    // through CompletableFuture chains, so we unwrap them before
+                    // checking types with instanceof.
                     ex = Errors.maybeUnwrapException(ex);
 
                     // Remove the task after a failure.


### PR DESCRIPTION
The exceptionally handlers in CoordinatorTimerImpl and
CoordinatorExecutorImpl use instanceof checks to determine how to handle
failures. However, exceptions propagated through CompletableFuture
chains may be wrapped in CompletionException,  causing the instanceof
checks to fail and the exceptions to be  misclassified. This could lead
to incorrect behavior such as retrying  when the coordinator is no
longer active or logging at the wrong level.

This patch unwraps exceptions using Errors.maybeUnwrapException at the
top of each exceptionally handler before performing the instanceof
checks. It also adds parameterized test coverage in
CoordinatorTimerImplTest to verify correct behavior with both wrapped
and unwrapped exceptions.

Reviewers: Sean Quah <squah@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
