### PR TITLE
KAFKA-20177, Handle malformed partition.metadata without NPE

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataReadBuffer.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataReadBuffer.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 
 public class PartitionMetadataReadBuffer {
     private static final Pattern WHITE_SPACES_PATTERN = Pattern.compile(":\\s+");
+    private static final String VERSION_KEY = "version";
+    private static final String TOPIC_ID_KEY = "topic_id";
 
     private final String location;
     private final BufferedReader reader;
@@ -38,39 +40,50 @@ public class PartitionMetadataReadBuffer {
     }
 
     PartitionMetadata read() throws IOException {
-        String line = null;
-        Uuid metadataTopicId;
+        String line = reader.readLine();
+        String[] versionArr = parseLine(line, VERSION_KEY);
+        int version = parseVersion(line, versionArr[1]);
 
+        // To ensure downgrade compatibility, check if version is at least 0
+        if (version < PartitionMetadataFile.CURRENT_VERSION) {
+            throw new IOException("Unrecognized version of partition metadata file (" + location + "): " + version);
+        }
+
+        line = reader.readLine();
+        String[] topicIdArr = parseLine(line, TOPIC_ID_KEY);
+        Uuid metadataTopicId = parseTopicId(line, topicIdArr[1]);
+
+        if (metadataTopicId.equals(Uuid.ZERO_UUID)) {
+            throw new IOException("Invalid topic ID in partition metadata file (" + location + ")");
+        }
+
+        return new PartitionMetadata(version, metadataTopicId);
+    }
+
+    private String[] parseLine(String line, String expectedKey) throws IOException {
+        if (line == null) {
+            throw malformedLineException(null);
+        }
+
+        String[] parts = WHITE_SPACES_PATTERN.split(line, 2);
+        if (parts.length != 2 || !expectedKey.equals(parts[0])) {
+            throw malformedLineException(line);
+        }
+        return parts;
+    }
+
+    private int parseVersion(String line, String value) throws IOException {
         try {
-            line = reader.readLine();
-            String[] versionArr = WHITE_SPACES_PATTERN.split(line);
-
-            if (versionArr.length == 2) {
-                int version = Integer.parseInt(versionArr[1]);
-                // To ensure downgrade compatibility, check if version is at least 0
-                if (version >= PartitionMetadataFile.CURRENT_VERSION) {
-                    line = reader.readLine();
-                    String[] topicIdArr = WHITE_SPACES_PATTERN.split(line);
-
-                    if (topicIdArr.length == 2) {
-                        metadataTopicId = Uuid.fromString(topicIdArr[1]);
-
-                        if (metadataTopicId.equals(Uuid.ZERO_UUID)) {
-                            throw new IOException("Invalid topic ID in partition metadata file (" + location + ")");
-                        }
-
-                        return new PartitionMetadata(version, metadataTopicId);
-                    } else {
-                        throw malformedLineException(line);
-                    }
-                } else {
-                    throw new IOException("Unrecognized version of partition metadata file (" + location + "): " + version);
-                }
-            } else {
-                throw malformedLineException(line);
-            }
-
+            return Integer.parseInt(value);
         } catch (NumberFormatException e) {
+            throw malformedLineException(line, e);
+        }
+    }
+
+    private Uuid parseTopicId(String line, String value) throws IOException {
+        try {
+            return Uuid.fromString(value);
+        } catch (IllegalArgumentException e) {
             throw malformedLineException(line, e);
         }
     }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.storage.internals.checkpoint;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InconsistentTopicIdException;
+import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel;
 import org.apache.kafka.test.TestUtils;
 
@@ -28,6 +29,7 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -94,5 +96,20 @@ class PartitionMetadataFileTest  {
         PartitionMetadata metadata = partitionMetadataFile.read();
         assertEquals(0, metadata.version());
         assertEquals(topicId, metadata.topicId());
+    }
+
+    @Test
+    public void testReadMalformedFileThrowsKafkaStorageExceptionAndMarksLogDirOffline() throws IOException {
+        LogDirFailureChannel channel = Mockito.mock(LogDirFailureChannel.class);
+        PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(file, channel);
+
+        Files.writeString(file.toPath(), "version: 0\n", StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+        assertThrows(KafkaStorageException.class, partitionMetadataFile::read);
+        Mockito.verify(channel).maybeAddOfflineLogDir(
+            Mockito.anyString(),
+            Mockito.contains("Error while reading partition metadata file"),
+            Mockito.any(IOException.class)
+        );
     }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataReadBufferTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataReadBufferTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.storage.internals.checkpoint;
+
+import org.apache.kafka.common.Uuid;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PartitionMetadataReadBufferTest {
+
+    @Test
+    void testReadValidPartitionMetadata() throws IOException {
+        Uuid topicId = Uuid.randomUuid();
+        PartitionMetadataReadBuffer readBuffer = new PartitionMetadataReadBuffer(
+            "/tmp/partition.metadata",
+            reader("version: 0\ntopic_id: " + topicId + "\n")
+        );
+
+        PartitionMetadata metadata = readBuffer.read();
+        assertEquals(0, metadata.version());
+        assertEquals(topicId, metadata.topicId());
+    }
+
+    @Test
+    void testReadFailsForEmptyFile() {
+        PartitionMetadataReadBuffer readBuffer = new PartitionMetadataReadBuffer(
+            "/tmp/partition.metadata",
+            reader("")
+        );
+
+        IOException exception = assertThrows(IOException.class, readBuffer::read);
+        assertTrue(exception.getMessage().contains("Malformed line in partition metadata file"));
+    }
+
+    @Test
+    void testReadFailsWhenTopicIdLineIsMissing() {
+        PartitionMetadataReadBuffer readBuffer = new PartitionMetadataReadBuffer(
+            "/tmp/partition.metadata",
+            reader("version: 0\n")
+        );
+
+        IOException exception = assertThrows(IOException.class, readBuffer::read);
+        assertTrue(exception.getMessage().contains("Malformed line in partition metadata file"));
+    }
+
+    @Test
+    void testReadFailsWhenTopicIdIsMalformed() {
+        PartitionMetadataReadBuffer readBuffer = new PartitionMetadataReadBuffer(
+            "/tmp/partition.metadata",
+            reader("version: 0\ntopic_id: not-a-uuid\n")
+        );
+
+        IOException exception = assertThrows(IOException.class, readBuffer::read);
+        assertTrue(exception.getMessage().contains("Malformed line in partition metadata file"));
+    }
+
+    @Test
+    void testReadFailsWhenTopicIdIsZeroUuid() {
+        PartitionMetadataReadBuffer readBuffer = new PartitionMetadataReadBuffer(
+            "/tmp/partition.metadata",
+            reader("version: 0\ntopic_id: " + Uuid.ZERO_UUID + "\n")
+        );
+
+        IOException exception = assertThrows(IOException.class, readBuffer::read);
+        assertTrue(exception.getMessage().contains("Invalid topic ID in partition metadata file"));
+    }
+
+    private BufferedReader reader(String content) {
+        return new BufferedReader(new StringReader(content));
+    }
+}


### PR DESCRIPTION
Make PartitionMetadataReadBuffer robust to empty/truncated metadata files by avoiding null-based parsing and validating expected keys explicitly. Malformed topic IDs are now surfaced as malformed-line IOExceptions instead of runtime exceptions.

