### PR TITLE
KAFKA-20146: Add CI check to detect Python dependency conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,9 @@ jobs:
           ref: ${{ github.sha }}  # this is the default, just being explicit.
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Check Python dependency conflicts
+        shell: bash
+        run: pip install --dry-run ./tests
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:


### PR DESCRIPTION
Add a `pip install --dry-run ./tests` step in the `validate` job to
catch dependency conflicts in `tests/setup.py` early, before Gradle
compilation.

This addresses the issue from #21415 where dependabot bumped `requests`
to 2.32.4, conflicting with `ducktape==0.12.0`'s pin on
`requests==2.31.0`, which went undetected until it broke kafkatest
installation.

Verified locally that `--dry-run` correctly fails with exit code 1 when
a conflict is present.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
