### PR TITLE
MINOR : Corrected the stdout parsing in ShareConsumerPerformanceService

### DIFF
--- a/tests/kafkatest/services/performance/share_consumer_performance.py
+++ b/tests/kafkatest/services/performance/share_consumer_performance.py
@@ -131,10 +131,13 @@ class ShareConsumerPerformanceService(PerformanceService):
             last = line
 
         # Parse and save the last line's information
+        # The script kafka-share-consumer-perf-test.sh first prints the header line in the following format:
+        #   start.time, end.time, data.consumed.in.MB, MB.sec, nMsg.sec, data.consumed.in.nMsg, fetch.time.ms
+        # The corresponding results are then printed in the same order, so we can parse the last line for the results.
         if last is not None:
             parts = last.split(',')
             self.results[idx-1] = {
                 'total_mb': float(parts[2]),
                 'mbps': float(parts[3]),
-                'records_per_sec': float(parts[5]),
+                'records_per_sec': float(parts[4]),
             }


### PR DESCRIPTION
The ShareConsumerPerformanceService runs the
`kafka-share-consumer-perf-test.sh` script and parses its stdout to
further report the performance numbers. The script's output format is as
follows ->

`start.time, end.time, data.consumed.in.MB, MB.sec, nMsg.sec,
data.consumed.in.nMsg, fetch.time.ms`

One of the fields it tried to read is `records_per_sec`. As per the
current code, it parses the wrong value (instead of reading the 5th
value (nMsg.sec), it reads the 6th one (data.consumed.in.nMsg)). This PR
corrects that.

Reviewers: Andrew Schofield <aschofield@confluent.io>
