### PR TITLE
KAFKA-20134: Implement TimestampedWindowStoreWithHeaders (2/N)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStoreWithHeaders.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+/**
+ * A RocksDB-backed segmented bytes store with timestamp and headers support.
+ * <p>
+ * This store uses {@link TimestampedSegmentsWithHeaders} to manage segments,
+ * where each segment is a {@link TimestampedSegmentWithHeaders} that extends
+ * {@link RocksDBTimestampedStoreWithHeaders}. This provides automatic dual-CF
+ * migration support from timestamp-only format to timestamp+headers format.
+ */
+public class RocksDBTimestampedSegmentedBytesStoreWithHeaders extends AbstractRocksDBSegmentedBytesStore<TimestampedSegmentWithHeaders> {
+
+    RocksDBTimestampedSegmentedBytesStoreWithHeaders(final String name,
+                                                     final String metricsScope,
+                                                     final long retention,
+                                                     final long segmentInterval,
+                                                     final KeySchema keySchema) {
+        super(name, retention, keySchema, new TimestampedSegmentsWithHeaders(name, metricsScope, retention, segmentInterval));
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.state.HeadersBytesStore;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * A persistent key-(value-timestamp-headers) store based on RocksDB.
+ */
+public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements HeadersBytesStore {
+
+    private static final Logger log = LoggerFactory.getLogger(RocksDBTimestampedStoreWithHeaders.class);
+
+    // Legacy column family name - must match RocksDBTimestampedStore.TIMESTAMPED_VALUES_COLUMN_FAMILY_NAME
+    private static final byte[] LEGACY_TIMESTAMPED_CF_NAME =
+        "keyValueWithTimestamp".getBytes(StandardCharsets.UTF_8);
+
+    // New column family for header-aware timestamped values.
+    private static final byte[] TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME =
+        "keyValueWithTimestampAndHeaders".getBytes(StandardCharsets.UTF_8);
+
+    public RocksDBTimestampedStoreWithHeaders(final String name,
+                                              final String metricsScope) {
+        super(name, metricsScope);
+    }
+
+    RocksDBTimestampedStoreWithHeaders(final String name,
+                                       final String parentDir,
+                                       final RocksDBMetricsRecorder metricsRecorder) {
+        super(name, parentDir, metricsRecorder);
+    }
+
+    @Override
+    void openRocksDB(final DBOptions dbOptions,
+                     final ColumnFamilyOptions columnFamilyOptions) {
+        // Check if we're upgrading from RocksDBTimestampedStore (which uses keyValueWithTimestamp CF)
+        final List<byte[]> existingCFs;
+        try {
+            final org.rocksdb.Options options = new org.rocksdb.Options(dbOptions, new ColumnFamilyOptions());
+            existingCFs = RocksDB.listColumnFamilies(options, dbDir.getAbsolutePath());
+            options.close();
+        } catch (final org.rocksdb.RocksDBException e) {
+            throw new org.apache.kafka.streams.errors.ProcessorStateException("Error listing column families for store " + name, e);
+        }
+
+        final boolean upgradingFromTimestampedStore = existingCFs.stream()
+            .anyMatch(cf -> java.util.Arrays.equals(cf, LEGACY_TIMESTAMPED_CF_NAME));
+
+        if (upgradingFromTimestampedStore) {
+            openWithLegacyTimestampedCF(dbOptions, columnFamilyOptions);
+        } else {
+            openWith2CFs(dbOptions, columnFamilyOptions);
+        }
+    }
+
+    /**
+     * Opens store when upgrading from RocksDBTimestampedStore (3 CFs).
+     * CFs: DEFAULT (closed), keyValueWithTimestamp (legacy), headers (new)
+     */
+    private void openWithLegacyTimestampedCF(final DBOptions dbOptions,
+                                              final ColumnFamilyOptions columnFamilyOptions) {
+        final List<ColumnFamilyHandle> columnFamilies = openRocksDB(
+            dbOptions,
+            // we have to open the default CF to be able to open the legacy CF, but we won't use it
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions),
+            new ColumnFamilyDescriptor(LEGACY_TIMESTAMPED_CF_NAME, columnFamilyOptions),
+            new ColumnFamilyDescriptor(TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME, columnFamilyOptions)
+        );
+        // Close unused default CF
+        columnFamilies.get(0).close();
+
+        final ColumnFamilyHandle legacyCf = columnFamilies.get(1);
+        final ColumnFamilyHandle headersCf = columnFamilies.get(2);
+
+        // Check if legacy CF has data
+        final RocksIterator legacyIter = db.newIterator(legacyCf);
+        legacyIter.seekToFirst();
+        try {
+            if (legacyIter.isValid()) {
+                log.info("Opening store {} in upgrade mode", name);
+                cfAccessor = new DualColumnFamilyAccessor(legacyCf, headersCf,
+                    HeadersBytesStore::convertToHeaderFormat, this);
+            } else {
+                log.info("Opening store {} in regular headers-aware mode", name);
+                cfAccessor = new SingleColumnFamilyAccessor(headersCf);
+                legacyCf.close();
+            }
+        } finally {
+            legacyIter.close();
+        }
+    }
+
+    /**
+     * Opens store with 2-CF design.
+     * CFs: DEFAULT (legacy timestamped without headers), headers (new)
+     */
+    private void openWith2CFs(final DBOptions dbOptions,
+                              final ColumnFamilyOptions columnFamilyOptions) {
+        final List<ColumnFamilyHandle> columnFamilies = openRocksDB(
+            dbOptions,
+            // we have to open the default CF to be able to open the legacy CF, but we won't use it
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions),
+            new ColumnFamilyDescriptor(TIMESTAMPED_VALUES_WITH_HEADERS_CF_NAME, columnFamilyOptions)
+        );
+
+        // Close unused default CF
+        columnFamilies.get(0).close();
+        final ColumnFamilyHandle headersCf = columnFamilies.get(1);
+        log.info("Opening store {} in regular headers-aware mode", name);
+        cfAccessor = new SingleColumnFamilyAccessor(headersCf);
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.state.HeadersBytesStore;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 
@@ -24,12 +25,15 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -64,15 +68,15 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
         // Check if we're upgrading from RocksDBTimestampedStore (which uses keyValueWithTimestamp CF)
         final List<byte[]> existingCFs;
         try {
-            final org.rocksdb.Options options = new org.rocksdb.Options(dbOptions, new ColumnFamilyOptions());
+            final Options options = new Options(dbOptions, new ColumnFamilyOptions());
             existingCFs = RocksDB.listColumnFamilies(options, dbDir.getAbsolutePath());
             options.close();
-        } catch (final org.rocksdb.RocksDBException e) {
-            throw new org.apache.kafka.streams.errors.ProcessorStateException("Error listing column families for store " + name, e);
+        } catch (final RocksDBException e) {
+            throw new ProcessorStateException("Error listing column families for store " + name, e);
         }
 
         final boolean upgradingFromTimestampedStore = existingCFs.stream()
-            .anyMatch(cf -> java.util.Arrays.equals(cf, LEGACY_TIMESTAMPED_CF_NAME));
+            .anyMatch(cf -> Arrays.equals(cf, LEGACY_TIMESTAMPED_CF_NAME));
 
         if (upgradingFromTimestampedStore) {
             openWithLegacyTimestampedCF(dbOptions, columnFamilyOptions);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A segment that stores timestamped key-value pairs with headers.
+ * <p>
+ * This segment extends {@link RocksDBTimestampedStoreWithHeaders} to provide
+ * header-aware storage with dual-column-family migration support from
+ * timestamp-only format to timestamp+headers format.
+ */
+class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders
+    implements Comparable<TimestampedSegmentWithHeaders>, Segment {
+
+    public final long id;
+
+    TimestampedSegmentWithHeaders(final String segmentName,
+                                  final String windowName,
+                                  final long id,
+                                  final Position position,
+                                  final RocksDBMetricsRecorder metricsRecorder) {
+        super(segmentName, windowName, metricsRecorder);
+        this.id = id;
+        this.position = position;
+    }
+
+    @Override
+    public void destroy() throws IOException {
+        Utils.delete(dbDir);
+    }
+
+    @Override
+    public void deleteRange(final Bytes keyFrom, final Bytes keyTo) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareTo(final TimestampedSegmentWithHeaders segment) {
+        return Long.compare(id, segment.id);
+    }
+
+    @Override
+    public void openDB(final Map<String, Object> configs, final File stateDir) {
+        super.openDB(configs, stateDir);
+        // skip the registering step
+    }
+
+    @Override
+    public String toString() {
+        return "TimestampedSegmentWithHeaders(id=" + id + ", name=" + name() + ")";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final TimestampedSegmentWithHeaders segment = (TimestampedSegmentWithHeaders) obj;
+        return id == segment.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeaders.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+
+/**
+ * Manages the {@link TimestampedSegmentWithHeaders}s that are used by the * {@link RocksDBTimestampedSegmentedBytesStoreWithHeaders}.
+ */
+class TimestampedSegmentsWithHeaders extends AbstractSegments<TimestampedSegmentWithHeaders> {
+
+    private final RocksDBMetricsRecorder metricsRecorder;
+
+    TimestampedSegmentsWithHeaders(final String name,
+                                   final String metricsScope,
+                                   final long retentionPeriod,
+                                   final long segmentInterval) {
+        super(name, retentionPeriod, segmentInterval);
+        metricsRecorder = new RocksDBMetricsRecorder(metricsScope, name);
+    }
+
+    @Override
+    public TimestampedSegmentWithHeaders getOrCreateSegment(final long segmentId,
+                                                            final StateStoreContext context) {
+        if (segments.containsKey(segmentId)) {
+            return segments.get(segmentId);
+        } else {
+            final TimestampedSegmentWithHeaders newSegment =
+                new TimestampedSegmentWithHeaders(segmentName(segmentId), name, segmentId, position, metricsRecorder);
+
+            if (segments.put(segmentId, newSegment) != null) {
+                throw new IllegalStateException("TimestampedSegmentWithHeaders already exists. Possible concurrent access.");
+            }
+
+            newSegment.openDB(context.appConfigs(), context.stateDir());
+            return newSegment;
+        }
+    }
+
+    @Override
+    public TimestampedSegmentWithHeaders getOrCreateSegmentIfLive(final long segmentId,
+                                                                   final StateStoreContext context,
+                                                                   final long streamTime) {
+        final TimestampedSegmentWithHeaders segment = super.getOrCreateSegmentIfLive(segmentId, context, streamTime);
+        cleanupExpiredSegments(streamTime);
+        return segment;
+    }
+
+    @Override
+    public void openExisting(final StateStoreContext context, final long streamTime) {
+        metricsRecorder.init(ProcessorContextUtils.metricsImpl(context), context.taskId());
+        super.openExisting(context, streamTime);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedSegmentedBytesStoreWithHeadersTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+public class RocksDBTimestampedSegmentedBytesStoreWithHeadersTest
+    extends AbstractRocksDBSegmentedBytesStoreTest<TimestampedSegmentWithHeaders> {
+
+    private static final String METRICS_SCOPE = "metrics-scope";
+
+    RocksDBTimestampedSegmentedBytesStoreWithHeaders getBytesStore() {
+        return new RocksDBTimestampedSegmentedBytesStoreWithHeaders(
+            storeName,
+            METRICS_SCOPE,
+            retention,
+            segmentInterval,
+            schema
+        );
+    }
+
+    @Override
+    TimestampedSegmentsWithHeaders newSegments() {
+        return new TimestampedSegmentsWithHeaders(storeName, METRICS_SCOPE, retention, segmentInterval);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -37,11 +36,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
 
@@ -56,11 +55,11 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular headers-aware mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in regular headers-aware mode"));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
-            assertThat(iterator.hasNext(), is(false));
+            assertFalse(iterator.hasNext());
         }
     }
 
@@ -75,7 +74,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular headers-aware mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in regular headers-aware mode"));
         } finally {
             rocksDBStore.close();
         }
@@ -101,10 +100,10 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             defaultColumnFamily = columnFamilies.get(0);
             headersColumnFamily = columnFamilies.get(1);
 
-            assertThat(db.get(defaultColumnFamily, "key".getBytes()), new IsNull<>());
-            assertThat(db.getLongProperty(defaultColumnFamily, "rocksdb.estimate-num-keys"), is(0L));
-            assertThat(db.get(headersColumnFamily, "key".getBytes()).length, is(22));
-            assertThat(db.getLongProperty(headersColumnFamily, "rocksdb.estimate-num-keys"), is(1L));
+            assertNull(db.get(defaultColumnFamily, "key".getBytes()));
+            assertEquals(0L, db.getLongProperty(defaultColumnFamily, "rocksdb.estimate-num-keys"));
+            assertEquals(22, db.get(headersColumnFamily, "key".getBytes()).length);
+            assertEquals(1L, db.getLongProperty(headersColumnFamily, "rocksdb.estimate-num-keys"));
         } finally {
             // Order of closing must follow: ColumnFamilyHandle > RocksDB > DBOptions > ColumnFamilyOptions
             if (defaultColumnFamily != null) {
@@ -130,25 +129,25 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in upgrade mode"));
         }
 
         // approx: 7 entries on legacy timestamped CF, 0 in new headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // get() - tests lazy migration on read
 
         // should be no-op on both CFs
-        assertThat(rocksDBStore.get(new Bytes("unknown".getBytes())), new IsNull<>());
+        assertNull(rocksDBStore.get(new Bytes("unknown".getBytes())));
         // approx: 7 entries on legacy CF, 0 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // should migrate key1 from legacy timestamped CF to headers-aware CF
         // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(1) = 10 bytes
-        assertThat(rocksDBStore.get(new Bytes("key1".getBytes())).length, is(1 + 0 + 8 + 1));
+        assertEquals(1 + 0 + 8 + 1, rocksDBStore.get(new Bytes("key1".getBytes())).length);
         // one delete on legacy CF, one put on headers-aware CF
         // approx: 6 entries on legacy CF, 1 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // put() - tests migration on write
 
@@ -156,60 +155,60 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         rocksDBStore.put(new Bytes("key2".getBytes()), "timestamp+22".getBytes());
         // one delete on legacy CF, one put on headers-aware CF
         // approx: 5 entries on legacy CF, 2 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // should delete key3 from both legacy and headers-aware CF
         rocksDBStore.put(new Bytes("key3".getBytes()), null);
         // count is off by one, due to two delete operations (even if one does not delete anything)
         // approx: 4 entries on legacy CF, 1 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         // should add new key8 to headers-aware CF only
         rocksDBStore.put(new Bytes("key8".getBytes()), "headers+timestamp+88888888".getBytes());
         // one delete on legacy CF (no-op), one put on headers-aware CF
         // approx: 3 entries on legacy CF, 2 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         // putIfAbsent() - tests migration on conditional write
 
         // should migrate key4 from legacy CF to headers-aware CF with old value (not new value)
         // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(4) = 13 bytes
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "headers+timestamp+4444".getBytes()).length, is(1 + 0 + 8 + 4));
+        assertEquals(1 + 0 + 8 + 4, rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "headers+timestamp+4444".getBytes()).length);
         // one delete on legacy CF, one put on headers-aware CF
         // approx: 2 entries on legacy CF, 3 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         // should add new key11 to headers-aware CF only (returns null because key doesn't exist)
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key11".getBytes()), "headers+timestamp+11111111111".getBytes()), new IsNull<>());
+        assertNull(rocksDBStore.putIfAbsent(new Bytes("key11".getBytes()), "headers+timestamp+11111111111".getBytes()));
         // one delete on legacy CF (no-op), one put on headers-aware CF
         // approx: 1 entries on legacy CF, 4 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         // should not delete key5 but migrate to headers-aware CF (putIfAbsent with null doesn't delete)
         // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(5) = 14 bytes
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length, is(1 + 0 + 8 + 5));
+        assertEquals(1 + 0 + 8 + 5, rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length);
         // one delete on legacy CF, one put on headers-aware CF
         // approx: 0 entries on legacy CF, 5 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         // should be no-op on both CFs (key doesn't exist)
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key12".getBytes()), null), new IsNull<>());
+        assertNull(rocksDBStore.putIfAbsent(new Bytes("key12".getBytes()), null));
         // two delete operations, however, only one is counted because legacy CF count was zero before already
         // approx: 0 entries on legacy CF, 4 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(4L));
+        assertEquals(4L, rocksDBStore.approximateNumEntries());
 
         // delete() - tests migration on delete
 
         // should delete key6 from both legacy and headers-aware CF
         // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(6) = 15 bytes
-        assertThat(rocksDBStore.delete(new Bytes("key6".getBytes())).length, is(1 + 0 + 8 + 6));
+        assertEquals(1 + 0 + 8 + 6, rocksDBStore.delete(new Bytes("key6".getBytes())).length);
         // two delete operations, however, only one is counted because legacy CF count was zero before already
         // approx: 0 entries on legacy CF, 3 in headers-aware CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         // iterators should not trigger migration (read-only)
         iteratorsShouldNotMigrateData();
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         rocksDBStore.close();
 
@@ -226,7 +225,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key1".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
                 // Total: 1 + 0 + 8 + 1 = 10 bytes
-                assertThat(keyValue.value.length, is(10));
+                assertEquals(10, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
@@ -243,21 +242,21 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
                 // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertThat(keyValue.value.length, is(13));
+                assertEquals(13, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
                 // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertThat(keyValue.value.length, is(14));
+                assertEquals(14, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key7".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('7777777')
                 // Total: 1 + 0 + 8 + 7 = 16 bytes
-                assertThat(keyValue.value.length, is(16));
+                assertEquals(16, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
@@ -279,14 +278,14 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
                 // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertThat(keyValue.value.length, is(13));
+                assertEquals(13, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
                 // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertThat(keyValue.value.length, is(14));
+                assertEquals(14, keyValue.value.length);
             }
             assertFalse(it.hasNext());
         }
@@ -302,21 +301,21 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key7".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('7777777')
                 // Total: 1 + 0 + 8 + 7 = 16 bytes
-                assertThat(keyValue.value.length, is(16));
+                assertEquals(16, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
                 // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertThat(keyValue.value.length, is(14));
+                assertEquals(14, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
                 // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertThat(keyValue.value.length, is(13));
+                assertEquals(13, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
@@ -333,7 +332,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key1".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
                 // Total: 1 + 0 + 8 + 1 = 10 bytes
-                assertThat(keyValue.value.length, is(10));
+                assertEquals(10, keyValue.value.length);
             }
             assertFalse(itAll.hasNext());
         }
@@ -345,14 +344,14 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
                 // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertThat(keyValue.value.length, is(14));
+                assertEquals(14, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
                 // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertThat(keyValue.value.length, is(13));
+                assertEquals(13, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
@@ -368,7 +367,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
                 assertArrayEquals("key1".getBytes(), keyValue.key.get());
                 // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
                 // Total: 1 + 0 + 8 + 1 = 10 bytes
-                assertThat(keyValue.value.length, is(10));
+                assertEquals(10, keyValue.value.length);
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
@@ -430,36 +429,36 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
 
     private void verifyDefaultColumnFamily(final RocksDB db, final ColumnFamilyHandle defaultColumnFamily) throws Exception {
         // DEFAULT CF should be empty (closed on open)
-        assertThat(db.get(defaultColumnFamily, "unknown".getBytes()), new IsNull<>());
-        assertThat(db.get(defaultColumnFamily, "key1".getBytes()), new IsNull<>());
+        assertNull(db.get(defaultColumnFamily, "unknown".getBytes()));
+        assertNull(db.get(defaultColumnFamily, "key1".getBytes()));
     }
 
     private void verifyLegacyTimestampedColumnFamily(final RocksDB db, final ColumnFamilyHandle legacyTimestampedColumnFamily) throws Exception {
         // Legacy timestamped CF should have migrated keys as null, un-migrated as timestamped values
-        assertThat(db.get(legacyTimestampedColumnFamily, "unknown".getBytes()), new IsNull<>());
-        assertThat(db.get(legacyTimestampedColumnFamily, "key1".getBytes()), new IsNull<>()); // migrated
-        assertThat(db.get(legacyTimestampedColumnFamily, "key2".getBytes()), new IsNull<>()); // migrated
-        assertThat(db.get(legacyTimestampedColumnFamily, "key3".getBytes()), new IsNull<>()); // deleted
-        assertThat(db.get(legacyTimestampedColumnFamily, "key4".getBytes()), new IsNull<>()); // migrated
-        assertThat(db.get(legacyTimestampedColumnFamily, "key5".getBytes()), new IsNull<>()); // migrated
-        assertThat(db.get(legacyTimestampedColumnFamily, "key6".getBytes()), new IsNull<>()); // migrated
-        assertThat(db.get(legacyTimestampedColumnFamily, "key7".getBytes()).length, is(8 + 7)); // not migrated
-        assertThat(db.get(legacyTimestampedColumnFamily, "key8".getBytes()), new IsNull<>());
+        assertNull(db.get(legacyTimestampedColumnFamily, "unknown".getBytes()));
+        assertNull(db.get(legacyTimestampedColumnFamily, "key1".getBytes())); // migrated
+        assertNull(db.get(legacyTimestampedColumnFamily, "key2".getBytes())); // migrated
+        assertNull(db.get(legacyTimestampedColumnFamily, "key3".getBytes())); // deleted
+        assertNull(db.get(legacyTimestampedColumnFamily, "key4".getBytes())); // migrated
+        assertNull(db.get(legacyTimestampedColumnFamily, "key5".getBytes())); // migrated
+        assertNull(db.get(legacyTimestampedColumnFamily, "key6".getBytes())); // migrated
+        assertEquals(8 + 7, db.get(legacyTimestampedColumnFamily, "key7".getBytes()).length); // not migrated
+        assertNull(db.get(legacyTimestampedColumnFamily, "key8".getBytes()));
     }
 
     private void verifyHeadersColumnFamily(final RocksDB db, final ColumnFamilyHandle headersColumnFamily) throws Exception {
         // Headers CF should have all migrated/new keys with header-aware format
-        assertThat(db.get(headersColumnFamily, "unknown".getBytes()), new IsNull<>());
-        assertThat(db.get(headersColumnFamily, "key1".getBytes()).length, is(1 + 0 + 8 + 1)); // varint + headers + ts + value
-        assertThat(db.get(headersColumnFamily, "key2".getBytes()).length, is(12));
-        assertThat(db.get(headersColumnFamily, "key3".getBytes()), new IsNull<>());
-        assertThat(db.get(headersColumnFamily, "key4".getBytes()).length, is(1 + 0 + 8 + 4));
-        assertThat(db.get(headersColumnFamily, "key5".getBytes()).length, is(1 + 0 + 8 + 5));
-        assertThat(db.get(headersColumnFamily, "key6".getBytes()), new IsNull<>());
-        assertThat(db.get(headersColumnFamily, "key7".getBytes()), new IsNull<>());
-        assertThat(db.get(headersColumnFamily, "key8".getBytes()).length, is(26));
-        assertThat(db.get(headersColumnFamily, "key11".getBytes()).length, is(29));
-        assertThat(db.get(headersColumnFamily, "key12".getBytes()), new IsNull<>());
+        assertNull(db.get(headersColumnFamily, "unknown".getBytes()));
+        assertEquals(1 + 0 + 8 + 1, db.get(headersColumnFamily, "key1".getBytes()).length); // varint + headers + ts + value
+        assertEquals(12, db.get(headersColumnFamily, "key2".getBytes()).length);
+        assertNull(db.get(headersColumnFamily, "key3".getBytes()));
+        assertEquals(1 + 0 + 8 + 4, db.get(headersColumnFamily, "key4".getBytes()).length);
+        assertEquals(1 + 0 + 8 + 5, db.get(headersColumnFamily, "key5".getBytes()).length);
+        assertNull(db.get(headersColumnFamily, "key6".getBytes()));
+        assertNull(db.get(headersColumnFamily, "key7".getBytes()));
+        assertEquals(26, db.get(headersColumnFamily, "key8".getBytes()).length);
+        assertEquals(29, db.get(headersColumnFamily, "key11".getBytes()).length);
+        assertNull(db.get(headersColumnFamily, "key12".getBytes()));
     }
 
     private void closeColumnFamilies(
@@ -494,7 +493,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in upgrade mode"));
         } finally {
             rocksDBStore.close();
         }
@@ -545,7 +544,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular headers-aware mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in regular headers-aware mode"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
@@ -1,0 +1,590 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogCaptureAppender;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+import org.hamcrest.core.IsNull;
+import org.junit.jupiter.api.Test;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
+
+    private final Serializer<String> stringSerializer = new StringSerializer();
+
+    RocksDBStore getRocksDBStore() {
+        return new RocksDBTimestampedStoreWithHeaders(DB_NAME, METRICS_SCOPE);
+    }
+
+    @Test
+    public void shouldOpenNewStoreInRegularMode() {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular headers-aware mode"));
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
+            assertThat(iterator.hasNext(), is(false));
+        }
+    }
+
+    @Test
+    public void shouldOpenExistingStoreInRegularMode() throws Exception {
+        // prepare store
+        rocksDBStore.init(context, rocksDBStore);
+        rocksDBStore.put(new Bytes("key".getBytes()), "timestampedWithHeaders".getBytes());
+        rocksDBStore.close();
+
+        // re-open store
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular headers-aware mode"));
+        } finally {
+            rocksDBStore.close();
+        }
+
+        // verify store
+        final DBOptions dbOptions = new DBOptions();
+        final ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
+
+        final List<ColumnFamilyDescriptor> columnFamilyDescriptors = asList(
+                new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions),
+                new ColumnFamilyDescriptor("keyValueWithTimestampAndHeaders".getBytes(StandardCharsets.UTF_8), columnFamilyOptions));
+        final List<ColumnFamilyHandle> columnFamilies = new ArrayList<>(columnFamilyDescriptors.size());
+
+        RocksDB db = null;
+        ColumnFamilyHandle defaultColumnFamily = null, headersColumnFamily = null;
+        try {
+            db = RocksDB.open(
+                    dbOptions,
+                    new File(new File(context.stateDir(), "rocksdb"), DB_NAME).getAbsolutePath(),
+                    columnFamilyDescriptors,
+                    columnFamilies);
+
+            defaultColumnFamily = columnFamilies.get(0);
+            headersColumnFamily = columnFamilies.get(1);
+
+            assertThat(db.get(defaultColumnFamily, "key".getBytes()), new IsNull<>());
+            assertThat(db.getLongProperty(defaultColumnFamily, "rocksdb.estimate-num-keys"), is(0L));
+            assertThat(db.get(headersColumnFamily, "key".getBytes()).length, is(22));
+            assertThat(db.getLongProperty(headersColumnFamily, "rocksdb.estimate-num-keys"), is(1L));
+        } finally {
+            // Order of closing must follow: ColumnFamilyHandle > RocksDB > DBOptions > ColumnFamilyOptions
+            if (defaultColumnFamily != null) {
+                defaultColumnFamily.close();
+            }
+            if (headersColumnFamily != null) {
+                headersColumnFamily.close();
+            }
+            if (db != null) {
+                db.close();
+            }
+            dbOptions.close();
+            columnFamilyOptions.close();
+        }
+    }
+
+    @Test
+    public void shouldMigrateFromTimestampedToHeadersAwareColumnFamily() throws Exception {
+        // Prepare legacy RocksDBTimestampedStore with timestamped values
+        prepareOldStore();
+
+        // Open with RocksDBTimestampedStoreWithHeaders - should detect legacy CF and enter upgrade mode
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+        }
+
+        // approx: 7 entries on legacy timestamped CF, 0 in new headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+
+        // get() - tests lazy migration on read
+
+        // should be no-op on both CFs
+        assertThat(rocksDBStore.get(new Bytes("unknown".getBytes())), new IsNull<>());
+        // approx: 7 entries on legacy CF, 0 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+
+        // should migrate key1 from legacy timestamped CF to headers-aware CF
+        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(1) = 10 bytes
+        assertThat(rocksDBStore.get(new Bytes("key1".getBytes())).length, is(1 + 0 + 8 + 1));
+        // one delete on legacy CF, one put on headers-aware CF
+        // approx: 6 entries on legacy CF, 1 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+
+        // put() - tests migration on write
+
+        // should migrate key2 from legacy CF to headers-aware CF with new value
+        rocksDBStore.put(new Bytes("key2".getBytes()), "timestamp+22".getBytes());
+        // one delete on legacy CF, one put on headers-aware CF
+        // approx: 5 entries on legacy CF, 2 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+
+        // should delete key3 from both legacy and headers-aware CF
+        rocksDBStore.put(new Bytes("key3".getBytes()), null);
+        // count is off by one, due to two delete operations (even if one does not delete anything)
+        // approx: 4 entries on legacy CF, 1 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+
+        // should add new key8 to headers-aware CF only
+        rocksDBStore.put(new Bytes("key8".getBytes()), "headers+timestamp+88888888".getBytes());
+        // one delete on legacy CF (no-op), one put on headers-aware CF
+        // approx: 3 entries on legacy CF, 2 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+
+        // putIfAbsent() - tests migration on conditional write
+
+        // should migrate key4 from legacy CF to headers-aware CF with old value (not new value)
+        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(4) = 13 bytes
+        assertThat(rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "headers+timestamp+4444".getBytes()).length, is(1 + 0 + 8 + 4));
+        // one delete on legacy CF, one put on headers-aware CF
+        // approx: 2 entries on legacy CF, 3 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+
+        // should add new key11 to headers-aware CF only (returns null because key doesn't exist)
+        assertThat(rocksDBStore.putIfAbsent(new Bytes("key11".getBytes()), "headers+timestamp+11111111111".getBytes()), new IsNull<>());
+        // one delete on legacy CF (no-op), one put on headers-aware CF
+        // approx: 1 entries on legacy CF, 4 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+
+        // should not delete key5 but migrate to headers-aware CF (putIfAbsent with null doesn't delete)
+        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(5) = 14 bytes
+        assertThat(rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length, is(1 + 0 + 8 + 5));
+        // one delete on legacy CF, one put on headers-aware CF
+        // approx: 0 entries on legacy CF, 5 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+
+        // should be no-op on both CFs (key doesn't exist)
+        assertThat(rocksDBStore.putIfAbsent(new Bytes("key12".getBytes()), null), new IsNull<>());
+        // two delete operations, however, only one is counted because legacy CF count was zero before already
+        // approx: 0 entries on legacy CF, 4 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(4L));
+
+        // delete() - tests migration on delete
+
+        // should delete key6 from both legacy and headers-aware CF
+        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(6) = 15 bytes
+        assertThat(rocksDBStore.delete(new Bytes("key6".getBytes())).length, is(1 + 0 + 8 + 6));
+        // two delete operations, however, only one is counted because legacy CF count was zero before already
+        // approx: 0 entries on legacy CF, 3 in headers-aware CF
+        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+
+        // iterators should not trigger migration (read-only)
+        iteratorsShouldNotMigrateData();
+        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+
+        rocksDBStore.close();
+
+        // Verify the final state of both column families
+        verifyOldAndNewColumnFamily();
+    }
+
+    private void iteratorsShouldNotMigrateData() {
+        // iterating should not migrate any data, but return all keys over both CFs
+        // Values from legacy CF are converted to header-aware format: [varint][headers][timestamp][value]
+        try (final KeyValueIterator<Bytes, byte[]> itAll = rocksDBStore.all()) {
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key1".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
+                // Total: 1 + 0 + 8 + 1 = 10 bytes
+                assertThat(keyValue.value.length, is(10));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key11".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'h', 'e', 'a', 'd', 'e', 'r', 's', '+', 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'}, keyValue.value);
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key2".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'t', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '2', '2'}, keyValue.value);
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key4".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
+                // Total: 1 + 0 + 8 + 4 = 13 bytes
+                assertThat(keyValue.value.length, is(13));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key5".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
+                // Total: 1 + 0 + 8 + 5 = 14 bytes
+                assertThat(keyValue.value.length, is(14));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key7".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('7777777')
+                // Total: 1 + 0 + 8 + 7 = 16 bytes
+                assertThat(keyValue.value.length, is(16));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key8".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'h', 'e', 'a', 'd', 'e', 'r', 's', '+', 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '8', '8', '8', '8', '8', '8', '8', '8'}, keyValue.value);
+            }
+            assertFalse(itAll.hasNext());
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> it =
+                          rocksDBStore.range(new Bytes("key2".getBytes()), new Bytes("key5".getBytes()))) {
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key2".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'t', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '2', '2'}, keyValue.value);
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key4".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
+                // Total: 1 + 0 + 8 + 4 = 13 bytes
+                assertThat(keyValue.value.length, is(13));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key5".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
+                // Total: 1 + 0 + 8 + 5 = 14 bytes
+                assertThat(keyValue.value.length, is(14));
+            }
+            assertFalse(it.hasNext());
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> itAll = rocksDBStore.reverseAll()) {
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key8".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'h', 'e', 'a', 'd', 'e', 'r', 's', '+', 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '8', '8', '8', '8', '8', '8', '8', '8'}, keyValue.value);
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key7".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('7777777')
+                // Total: 1 + 0 + 8 + 7 = 16 bytes
+                assertThat(keyValue.value.length, is(16));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key5".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
+                // Total: 1 + 0 + 8 + 5 = 14 bytes
+                assertThat(keyValue.value.length, is(14));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key4".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
+                // Total: 1 + 0 + 8 + 4 = 13 bytes
+                assertThat(keyValue.value.length, is(13));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key2".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'t', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '2', '2'}, keyValue.value);
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key11".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'h', 'e', 'a', 'd', 'e', 'r', 's', '+', 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'}, keyValue.value);
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = itAll.next();
+                assertArrayEquals("key1".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
+                // Total: 1 + 0 + 8 + 1 = 10 bytes
+                assertThat(keyValue.value.length, is(10));
+            }
+            assertFalse(itAll.hasNext());
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> it =
+                          rocksDBStore.reverseRange(new Bytes("key2".getBytes()), new Bytes("key5".getBytes()))) {
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key5".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
+                // Total: 1 + 0 + 8 + 5 = 14 bytes
+                assertThat(keyValue.value.length, is(14));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key4".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
+                // Total: 1 + 0 + 8 + 4 = 13 bytes
+                assertThat(keyValue.value.length, is(13));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key2".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'t', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '2', '2'}, keyValue.value);
+            }
+            assertFalse(it.hasNext());
+        }
+
+        try (final KeyValueIterator<Bytes, byte[]> it = rocksDBStore.prefixScan("key1", stringSerializer)) {
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key1".getBytes(), keyValue.key.get());
+                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
+                // Total: 1 + 0 + 8 + 1 = 10 bytes
+                assertThat(keyValue.value.length, is(10));
+            }
+            {
+                final KeyValue<Bytes, byte[]> keyValue = it.next();
+                assertArrayEquals("key11".getBytes(), keyValue.key.get());
+                assertArrayEquals(new byte[]{'h', 'e', 'a', 'd', 'e', 'r', 's', '+', 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', '+', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'}, keyValue.value);
+            }
+            assertFalse(it.hasNext());
+        }
+    }
+
+    private void verifyOldAndNewColumnFamily() throws Exception {
+        final DBOptions dbOptions = new DBOptions();
+        final ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
+
+        // In upgrade scenario from RocksDBTimestampedStore,
+        // we expect 3 CFs: DEFAULT (closed on open), keyValueWithTimestamp (legacy), keyValueWithTimestampAndHeaders (new)
+        final List<ColumnFamilyDescriptor> columnFamilyDescriptors = asList(
+                new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions),
+                new ColumnFamilyDescriptor("keyValueWithTimestamp".getBytes(StandardCharsets.UTF_8), columnFamilyOptions),
+                new ColumnFamilyDescriptor("keyValueWithTimestampAndHeaders".getBytes(StandardCharsets.UTF_8), columnFamilyOptions));
+
+        verifyColumnFamilyContents(dbOptions, columnFamilyDescriptors, columnFamilyOptions);
+        verifyStillInUpgradeMode();
+        clearLegacyColumnFamily(dbOptions, columnFamilyDescriptors, columnFamilyOptions);
+        verifyInHeadersAwareMode();
+    }
+
+    private void verifyColumnFamilyContents(
+            final DBOptions dbOptions,
+            final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
+            final ColumnFamilyOptions columnFamilyOptions) throws Exception {
+        final List<ColumnFamilyHandle> columnFamilies = new ArrayList<>(columnFamilyDescriptors.size());
+        RocksDB db = null;
+        ColumnFamilyHandle defaultColumnFamily = null;
+        ColumnFamilyHandle legacyTimestampedColumnFamily = null;
+        ColumnFamilyHandle headersColumnFamily = null;
+        boolean errorOccurred = false;
+        try {
+            db = RocksDB.open(
+                    dbOptions,
+                    new File(new File(context.stateDir(), "rocksdb"), DB_NAME).getAbsolutePath(),
+                    columnFamilyDescriptors,
+                    columnFamilies);
+
+            defaultColumnFamily = columnFamilies.get(0);
+            legacyTimestampedColumnFamily = columnFamilies.get(1);
+            headersColumnFamily = columnFamilies.get(2);
+
+            verifyDefaultColumnFamily(db, defaultColumnFamily);
+            verifyLegacyTimestampedColumnFamily(db, legacyTimestampedColumnFamily);
+            verifyHeadersColumnFamily(db, headersColumnFamily);
+        } catch (final RuntimeException fatal) {
+            errorOccurred = true;
+        } finally {
+            closeColumnFamilies(db, defaultColumnFamily, legacyTimestampedColumnFamily, headersColumnFamily,
+                    dbOptions, columnFamilyOptions, errorOccurred);
+        }
+    }
+
+    private void verifyDefaultColumnFamily(final RocksDB db, final ColumnFamilyHandle defaultColumnFamily) throws Exception {
+        // DEFAULT CF should be empty (closed on open)
+        assertThat(db.get(defaultColumnFamily, "unknown".getBytes()), new IsNull<>());
+        assertThat(db.get(defaultColumnFamily, "key1".getBytes()), new IsNull<>());
+    }
+
+    private void verifyLegacyTimestampedColumnFamily(final RocksDB db, final ColumnFamilyHandle legacyTimestampedColumnFamily) throws Exception {
+        // Legacy timestamped CF should have migrated keys as null, un-migrated as timestamped values
+        assertThat(db.get(legacyTimestampedColumnFamily, "unknown".getBytes()), new IsNull<>());
+        assertThat(db.get(legacyTimestampedColumnFamily, "key1".getBytes()), new IsNull<>()); // migrated
+        assertThat(db.get(legacyTimestampedColumnFamily, "key2".getBytes()), new IsNull<>()); // migrated
+        assertThat(db.get(legacyTimestampedColumnFamily, "key3".getBytes()), new IsNull<>()); // deleted
+        assertThat(db.get(legacyTimestampedColumnFamily, "key4".getBytes()), new IsNull<>()); // migrated
+        assertThat(db.get(legacyTimestampedColumnFamily, "key5".getBytes()), new IsNull<>()); // migrated
+        assertThat(db.get(legacyTimestampedColumnFamily, "key6".getBytes()), new IsNull<>()); // migrated
+        assertThat(db.get(legacyTimestampedColumnFamily, "key7".getBytes()).length, is(8 + 7)); // not migrated
+        assertThat(db.get(legacyTimestampedColumnFamily, "key8".getBytes()), new IsNull<>());
+    }
+
+    private void verifyHeadersColumnFamily(final RocksDB db, final ColumnFamilyHandle headersColumnFamily) throws Exception {
+        // Headers CF should have all migrated/new keys with header-aware format
+        assertThat(db.get(headersColumnFamily, "unknown".getBytes()), new IsNull<>());
+        assertThat(db.get(headersColumnFamily, "key1".getBytes()).length, is(1 + 0 + 8 + 1)); // varint + headers + ts + value
+        assertThat(db.get(headersColumnFamily, "key2".getBytes()).length, is(12));
+        assertThat(db.get(headersColumnFamily, "key3".getBytes()), new IsNull<>());
+        assertThat(db.get(headersColumnFamily, "key4".getBytes()).length, is(1 + 0 + 8 + 4));
+        assertThat(db.get(headersColumnFamily, "key5".getBytes()).length, is(1 + 0 + 8 + 5));
+        assertThat(db.get(headersColumnFamily, "key6".getBytes()), new IsNull<>());
+        assertThat(db.get(headersColumnFamily, "key7".getBytes()), new IsNull<>());
+        assertThat(db.get(headersColumnFamily, "key8".getBytes()).length, is(26));
+        assertThat(db.get(headersColumnFamily, "key11".getBytes()).length, is(29));
+        assertThat(db.get(headersColumnFamily, "key12".getBytes()), new IsNull<>());
+    }
+
+    private void closeColumnFamilies(
+            final RocksDB db,
+            final ColumnFamilyHandle defaultColumnFamily,
+            final ColumnFamilyHandle legacyTimestampedColumnFamily,
+            final ColumnFamilyHandle headersColumnFamily,
+            final DBOptions dbOptions,
+            final ColumnFamilyOptions columnFamilyOptions,
+            final boolean errorOccurred) {
+        // Order of closing must follow: ColumnFamilyHandle > RocksDB > DBOptions > ColumnFamilyOptions
+        if (defaultColumnFamily != null) {
+            defaultColumnFamily.close();
+        }
+        if (legacyTimestampedColumnFamily != null) {
+            legacyTimestampedColumnFamily.close();
+        }
+        if (headersColumnFamily != null) {
+            headersColumnFamily.close();
+        }
+        if (db != null) {
+            db.close();
+        }
+        if (errorOccurred) {
+            dbOptions.close();
+            columnFamilyOptions.close();
+        }
+    }
+
+    private void verifyStillInUpgradeMode() {
+        // check that still in upgrade mode
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+        } finally {
+            rocksDBStore.close();
+        }
+    }
+
+    private void clearLegacyColumnFamily(
+            final DBOptions dbOptions,
+            final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
+            final ColumnFamilyOptions columnFamilyOptions) throws Exception {
+        // clear legacy timestamped CF by deleting remaining key
+        final List<ColumnFamilyHandle> columnFamilies = new ArrayList<>(columnFamilyDescriptors.size());
+        RocksDB db = null;
+        ColumnFamilyHandle defaultCF2 = null;
+        ColumnFamilyHandle legacyCF2 = null;
+        ColumnFamilyHandle headersCF2 = null;
+        try {
+            db = RocksDB.open(
+                    dbOptions,
+                    new File(new File(context.stateDir(), "rocksdb"), DB_NAME).getAbsolutePath(),
+                    columnFamilyDescriptors,
+                    columnFamilies);
+
+            defaultCF2 = columnFamilies.get(0);
+            legacyCF2 = columnFamilies.get(1);
+            headersCF2 = columnFamilies.get(2);
+            db.delete(legacyCF2, "key7".getBytes());
+        } finally {
+            // Order of closing must follow: ColumnFamilyHandle > RocksDB > DBOptions > ColumnFamilyOptions
+            if (defaultCF2 != null) {
+                defaultCF2.close();
+            }
+            if (legacyCF2 != null) {
+                legacyCF2.close();
+            }
+            if (headersCF2 != null) {
+                headersCF2.close();
+            }
+            if (db != null) {
+                db.close();
+            }
+            dbOptions.close();
+            columnFamilyOptions.close();
+        }
+    }
+
+    private void verifyInHeadersAwareMode() {
+        // check that now in regular header-aware mode (all legacy data migrated)
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStoreWithHeaders.class)) {
+            rocksDBStore.init(context, rocksDBStore);
+
+            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular headers-aware mode"));
+        }
+    }
+
+    private void prepareOldStore() {
+        // Create a legacy RocksDBTimestampedStore to test upgrade scenario
+        final RocksDBTimestampedStore timestampedStore = new RocksDBTimestampedStore(DB_NAME, METRICS_SCOPE);
+        try {
+            timestampedStore.init(context, timestampedStore);
+
+            // Write timestamped values (timestamp = -1 for unknown timestamp)
+            timestampedStore.put(new Bytes("key1".getBytes()), wrapTimestampedValue("1".getBytes()));
+            timestampedStore.put(new Bytes("key2".getBytes()), wrapTimestampedValue("22".getBytes()));
+            timestampedStore.put(new Bytes("key3".getBytes()), wrapTimestampedValue("333".getBytes()));
+            timestampedStore.put(new Bytes("key4".getBytes()), wrapTimestampedValue("4444".getBytes()));
+            timestampedStore.put(new Bytes("key5".getBytes()), wrapTimestampedValue("55555".getBytes()));
+            timestampedStore.put(new Bytes("key6".getBytes()), wrapTimestampedValue("666666".getBytes()));
+            timestampedStore.put(new Bytes("key7".getBytes()), wrapTimestampedValue("7777777".getBytes()));
+        } finally {
+            timestampedStore.close();
+        }
+    }
+
+    private byte[] wrapTimestampedValue(final byte[] value) {
+        // Format: [timestamp(8 bytes)][value]
+        // Use the numeric value as timestamp
+        final long timestamp = Long.parseLong(new String(value));
+        final byte[] result = new byte[8 + value.length];
+
+        // Convert timestamp to big-endian 8-byte array
+        result[0] = (byte) (timestamp >> 56);
+        result[1] = (byte) (timestamp >> 48);
+        result[2] = (byte) (timestamp >> 40);
+        result[3] = (byte) (timestamp >> 32);
+        result[4] = (byte) (timestamp >> 24);
+        result[5] = (byte) (timestamp >> 16);
+        result[6] = (byte) (timestamp >> 8);
+        result[7] = (byte) timestamp;
+
+        System.arraycopy(value, 0, result, 8, value.length);
+        return result;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
@@ -122,7 +122,6 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
 
     @Test
     public void shouldMigrateFromTimestampedToHeadersAwareColumnFamily() throws Exception {
-        // Prepare legacy RocksDBTimestampedStore with timestamped values
         prepareOldStore();
 
         // Open with RocksDBTimestampedStoreWithHeaders - should detect legacy CF and enter upgrade mode
@@ -132,79 +131,52 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in upgrade mode"));
         }
 
-        // approx: 7 entries on legacy timestamped CF, 0 in new headers-aware CF
-        assertEquals(7L, rocksDBStore.approximateNumEntries());
+        assertEquals(7L, rocksDBStore.approximateNumEntries(), "Expected 7 entries in legacy CF and 0 in headers-aware CF before migration");
 
         // get() - tests lazy migration on read
 
-        // should be no-op on both CFs
-        assertNull(rocksDBStore.get(new Bytes("unknown".getBytes())));
-        // approx: 7 entries on legacy CF, 0 in headers-aware CF
-        assertEquals(7L, rocksDBStore.approximateNumEntries());
+        assertNull(rocksDBStore.get(new Bytes("unknown".getBytes())), "Expected null for unknown key");
+        assertEquals(7L, rocksDBStore.approximateNumEntries(), "Expected 7 entries on legacy CF, 0 in headers-aware CF");
 
-        // should migrate key1 from legacy timestamped CF to headers-aware CF
-        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(1) = 10 bytes
-        assertEquals(1 + 0 + 8 + 1, rocksDBStore.get(new Bytes("key1".getBytes())).length);
-        // one delete on legacy CF, one put on headers-aware CF
-        // approx: 6 entries on legacy CF, 1 in headers-aware CF
-        assertEquals(7L, rocksDBStore.approximateNumEntries());
+        assertEquals(1 + 0 + 8 + 1, rocksDBStore.get(new Bytes("key1".getBytes())).length,
+            "Expected header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(1) = 10 bytes");
+        assertEquals(7L, rocksDBStore.approximateNumEntries(), "Expected 6 entries on legacy CF, 1 in headers-aware CF after migrating key1");
 
         // put() - tests migration on write
 
-        // should migrate key2 from legacy CF to headers-aware CF with new value
         rocksDBStore.put(new Bytes("key2".getBytes()), "timestamp+22".getBytes());
-        // one delete on legacy CF, one put on headers-aware CF
-        // approx: 5 entries on legacy CF, 2 in headers-aware CF
-        assertEquals(7L, rocksDBStore.approximateNumEntries());
+        assertEquals(7L, rocksDBStore.approximateNumEntries(), "Expected 5 entries on legacy CF, 2 in headers-aware CF after migrating key2 with put()");
 
-        // should delete key3 from both legacy and headers-aware CF
         rocksDBStore.put(new Bytes("key3".getBytes()), null);
         // count is off by one, due to two delete operations (even if one does not delete anything)
-        // approx: 4 entries on legacy CF, 1 in headers-aware CF
-        assertEquals(5L, rocksDBStore.approximateNumEntries());
+        assertEquals(5L, rocksDBStore.approximateNumEntries(), "Expected 4 entries on legacy CF, 1 in headers-aware CF after deleting key3 with put()");
 
-        // should add new key8 to headers-aware CF only
         rocksDBStore.put(new Bytes("key8".getBytes()), "headers+timestamp+88888888".getBytes());
-        // one delete on legacy CF (no-op), one put on headers-aware CF
-        // approx: 3 entries on legacy CF, 2 in headers-aware CF
-        assertEquals(5L, rocksDBStore.approximateNumEntries());
+        assertEquals(5L, rocksDBStore.approximateNumEntries(), "Expected 3 entries on legacy CF, 2 in headers-aware CF after adding new key8 with put()");
 
         // putIfAbsent() - tests migration on conditional write
 
-        // should migrate key4 from legacy CF to headers-aware CF with old value (not new value)
-        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(4) = 13 bytes
-        assertEquals(1 + 0 + 8 + 4, rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "headers+timestamp+4444".getBytes()).length);
-        // one delete on legacy CF, one put on headers-aware CF
-        // approx: 2 entries on legacy CF, 3 in headers-aware CF
-        assertEquals(5L, rocksDBStore.approximateNumEntries());
+        assertEquals(1 + 0 + 8 + 4,
+            rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "headers+timestamp+4444".getBytes()).length,
+            "Expected header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(4) = 13 bytes");
+        assertEquals(5L, rocksDBStore.approximateNumEntries(), "Expected 2 entries on legacy CF, 3 in headers-aware CF after migrating key4 with putIfAbsent()");
 
-        // should add new key11 to headers-aware CF only (returns null because key doesn't exist)
-        assertNull(rocksDBStore.putIfAbsent(new Bytes("key11".getBytes()), "headers+timestamp+11111111111".getBytes()));
-        // one delete on legacy CF (no-op), one put on headers-aware CF
-        // approx: 1 entries on legacy CF, 4 in headers-aware CF
-        assertEquals(5L, rocksDBStore.approximateNumEntries());
+        assertNull(rocksDBStore.putIfAbsent(new Bytes("key11".getBytes()), "headers+timestamp+11111111111".getBytes()),
+            "Expected null return value for putIfAbsent on non-existing key11, and new key should be added to headers-aware CF");
+        assertEquals(5L, rocksDBStore.approximateNumEntries(), "Expected 1 entry on legacy CF, 4 in headers-aware CF after adding new key11 with putIfAbsent()");
 
-        // should not delete key5 but migrate to headers-aware CF (putIfAbsent with null doesn't delete)
-        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(5) = 14 bytes
-        assertEquals(1 + 0 + 8 + 5, rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length);
-        // one delete on legacy CF, one put on headers-aware CF
-        // approx: 0 entries on legacy CF, 5 in headers-aware CF
-        assertEquals(5L, rocksDBStore.approximateNumEntries());
+        assertEquals(1 + 0 + 8 + 5, rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length,
+            "Expected header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(5) = 14 bytes for putIfAbsent with null on existing key5");
+        assertEquals(5L, rocksDBStore.approximateNumEntries(), "Expected 0 entries on legacy CF, 5 in headers-aware CF after migrating key5 with putIfAbsent(null)");
 
-        // should be no-op on both CFs (key doesn't exist)
         assertNull(rocksDBStore.putIfAbsent(new Bytes("key12".getBytes()), null));
-        // two delete operations, however, only one is counted because legacy CF count was zero before already
-        // approx: 0 entries on legacy CF, 4 in headers-aware CF
-        assertEquals(4L, rocksDBStore.approximateNumEntries());
+        assertEquals(4L, rocksDBStore.approximateNumEntries(), "Expected 0 entries on legacy CF, 4 in headers-aware CF after putIfAbsent with null on non-existing key12");
 
         // delete() - tests migration on delete
 
-        // should delete key6 from both legacy and headers-aware CF
-        // returns header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(6) = 15 bytes
-        assertEquals(1 + 0 + 8 + 6, rocksDBStore.delete(new Bytes("key6".getBytes())).length);
-        // two delete operations, however, only one is counted because legacy CF count was zero before already
-        // approx: 0 entries on legacy CF, 3 in headers-aware CF
-        assertEquals(3L, rocksDBStore.approximateNumEntries());
+        assertEquals(1 + 0 + 8 + 6, rocksDBStore.delete(new Bytes("key6".getBytes())).length,
+            "Expected header-aware format: varint(1) + empty headers(0) + timestamp(8) + value(6) = 15 bytes for delete() on existing key6");
+        assertEquals(3L, rocksDBStore.approximateNumEntries(), "Expected 0 entries on legacy CF, 3 in headers-aware CF after deleting key6 with delete()");
 
         // iterators should not trigger migration (read-only)
         iteratorsShouldNotMigrateData();
@@ -223,9 +195,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key1".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
-                // Total: 1 + 0 + 8 + 1 = 10 bytes
-                assertEquals(10, keyValue.value.length);
+                assertEquals(10, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(1) = 10 bytes for key1 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
@@ -240,23 +210,17 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
-                // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertEquals(13, keyValue.value.length);
+                assertEquals(13, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(4) = 13 bytes for key4 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
-                // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertEquals(14, keyValue.value.length);
+                assertEquals(14, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(5) = 14 bytes for key5 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key7".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('7777777')
-                // Total: 1 + 0 + 8 + 7 = 16 bytes
-                assertEquals(16, keyValue.value.length);
+                assertEquals(16, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(7) = 16 bytes for key7 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
@@ -276,16 +240,12 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
-                // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertEquals(13, keyValue.value.length);
+                assertEquals(13, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(4) = 13 bytes for key4 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
-                // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertEquals(14, keyValue.value.length);
+                assertEquals(14, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(5) = 14 bytes for key5 from legacy CF");
             }
             assertFalse(it.hasNext());
         }
@@ -299,23 +259,17 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key7".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('7777777')
-                // Total: 1 + 0 + 8 + 7 = 16 bytes
-                assertEquals(16, keyValue.value.length);
+                assertEquals(16, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(7) = 16 bytes for key7 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
-                // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertEquals(14, keyValue.value.length);
+                assertEquals(14, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(5) = 14 bytes for key5 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
-                // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertEquals(13, keyValue.value.length);
+                assertEquals(13, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(4) = 13 bytes for key4 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
@@ -330,9 +284,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = itAll.next();
                 assertArrayEquals("key1".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
-                // Total: 1 + 0 + 8 + 1 = 10 bytes
-                assertEquals(10, keyValue.value.length);
+                assertEquals(10, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(1) = 10 bytes for key1 from legacy CF");
             }
             assertFalse(itAll.hasNext());
         }
@@ -342,16 +294,12 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key5".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('55555')
-                // Total: 1 + 0 + 8 + 5 = 14 bytes
-                assertEquals(14, keyValue.value.length);
+                assertEquals(14, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(5) = 14 bytes for key5 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key4".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('4444')
-                // Total: 1 + 0 + 8 + 4 = 13 bytes
-                assertEquals(13, keyValue.value.length);
+                assertEquals(13, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(4) = 13 bytes for key4 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
@@ -365,9 +313,7 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();
                 assertArrayEquals("key1".getBytes(), keyValue.key.get());
-                // header-aware format: varint(0) + empty headers + timestamp(8 bytes) + value('1')
-                // Total: 1 + 0 + 8 + 1 = 10 bytes
-                assertEquals(10, keyValue.value.length);
+                assertEquals(10, keyValue.value.length, "Expected header-aware format: varint(0) + empty headers(0) + timestamp(8) + value(1) = 10 bytes for key1 from legacy CF");
             }
             {
                 final KeyValue<Bytes, byte[]> keyValue = it.next();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeadersTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class TimestampedSegmentWithHeadersTest {
+
+    private final RocksDBMetricsRecorder metricsRecorder =
+        new RocksDBMetricsRecorder("metrics-scope", "store-name");
+
+    @BeforeEach
+    public void setUp() {
+        metricsRecorder.init(
+            new StreamsMetricsImpl(new Metrics(), "test-client", new MockTime()),
+            new TaskId(0, 0)
+        );
+    }
+
+    @Test
+    public void shouldDeleteStateDirectoryOnDestroy() throws Exception {
+        final TimestampedSegmentWithHeaders segment =
+            new TimestampedSegmentWithHeaders("segment", "window", 0L, Position.emptyPosition(), metricsRecorder);
+        final String directoryPath = TestUtils.tempDirectory().getAbsolutePath();
+        final File directory = new File(directoryPath);
+
+        segment.openDB(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")), directory);
+
+        assertTrue(new File(directoryPath, "window").exists());
+        assertTrue(new File(directoryPath + File.separator + "window", "segment").exists());
+        assertTrue(new File(directoryPath + File.separator + "window", "segment").list().length > 0);
+        segment.destroy();
+        assertFalse(new File(directoryPath + File.separator + "window", "segment").exists());
+        assertTrue(new File(directoryPath, "window").exists());
+
+        segment.close();
+    }
+
+    @Test
+    public void shouldBeEqualIfIdIsEqual() {
+        final TimestampedSegmentWithHeaders segment =
+            new TimestampedSegmentWithHeaders("anyName", "anyName", 0L, Position.emptyPosition(), metricsRecorder);
+        final TimestampedSegmentWithHeaders segmentSameId =
+            new TimestampedSegmentWithHeaders("someOtherName", "someOtherName", 0L, Position.emptyPosition(), metricsRecorder);
+        final TimestampedSegmentWithHeaders segmentDifferentId =
+            new TimestampedSegmentWithHeaders("anyName", "anyName", 1L, Position.emptyPosition(), metricsRecorder);
+
+        assertEquals(segment, segment);
+        assertEquals(segment, segmentSameId);
+        assertNotEquals(segment, segmentDifferentId);
+        assertNotEquals(segment, null);
+        assertNotEquals(segment, "anyName");
+
+        segment.close();
+        segmentSameId.close();
+        segmentDifferentId.close();
+    }
+
+    @Test
+    public void shouldHashOnSegmentIdOnly() {
+        final TimestampedSegmentWithHeaders segment =
+            new TimestampedSegmentWithHeaders("anyName", "anyName", 0L, Position.emptyPosition(), metricsRecorder);
+        final TimestampedSegmentWithHeaders segmentSameId =
+            new TimestampedSegmentWithHeaders("someOtherName", "someOtherName", 0L, Position.emptyPosition(), metricsRecorder);
+        final TimestampedSegmentWithHeaders segmentDifferentId =
+            new TimestampedSegmentWithHeaders("anyName", "anyName", 1L, Position.emptyPosition(), metricsRecorder);
+
+        final Set<TimestampedSegmentWithHeaders> set = new HashSet<>();
+        assertTrue(set.add(segment));
+        assertFalse(set.add(segmentSameId));
+        assertTrue(set.add(segmentDifferentId));
+
+        segment.close();
+        segmentSameId.close();
+        segmentDifferentId.close();
+    }
+
+    @Test
+    public void shouldCompareSegmentIdOnly() {
+        final TimestampedSegmentWithHeaders segment1 =
+            new TimestampedSegmentWithHeaders("a", "C", 50L, Position.emptyPosition(), metricsRecorder);
+        final TimestampedSegmentWithHeaders segment2 =
+            new TimestampedSegmentWithHeaders("b", "B", 100L, Position.emptyPosition(), metricsRecorder);
+        final TimestampedSegmentWithHeaders segment3 =
+            new TimestampedSegmentWithHeaders("c", "A", 0L, Position.emptyPosition(), metricsRecorder);
+
+        assertEquals(0, segment1.compareTo(segment1));
+        assertEquals(-1, segment1.compareTo(segment2));
+        assertEquals(1, segment2.compareTo(segment1));
+        assertEquals(1, segment1.compareTo(segment3));
+        assertEquals(-1, segment3.compareTo(segment1));
+        assertEquals(1, segment2.compareTo(segment3));
+        assertEquals(-1, segment3.compareTo(segment2));
+
+        segment1.close();
+        segment2.close();
+        segment3.close();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeadersTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockRecordCollector;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TimestampedSegmentsWithHeadersTest {
+
+    private static final long SEGMENT_INTERVAL = 100L;
+    private static final long RETENTION_PERIOD = 4 * SEGMENT_INTERVAL;
+    private static final String METRICS_SCOPE = "test-state-id";
+    private InternalMockProcessorContext context;
+    private TimestampedSegmentsWithHeaders segments;
+    private File stateDirectory;
+    private final String storeName = "test";
+
+    @BeforeEach
+    public void createContext() {
+        stateDirectory = TestUtils.tempDirectory();
+        context = new InternalMockProcessorContext<>(
+            stateDirectory,
+            Serdes.String(),
+            Serdes.Long(),
+            new MockRecordCollector(),
+            new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics()))
+        );
+        segments = new TimestampedSegmentsWithHeaders(storeName, METRICS_SCOPE, RETENTION_PERIOD, SEGMENT_INTERVAL);
+        segments.openExisting(context, -1L);
+    }
+
+    @AfterEach
+    public void close() {
+        segments.close();
+    }
+
+    @Test
+    public void shouldGetSegmentIdsFromTimestamp() {
+        assertEquals(0, segments.segmentId(0));
+        assertEquals(1, segments.segmentId(SEGMENT_INTERVAL));
+        assertEquals(2, segments.segmentId(2 * SEGMENT_INTERVAL));
+        assertEquals(3, segments.segmentId(3 * SEGMENT_INTERVAL));
+    }
+
+    @Test
+    public void shouldGetSegmentNameFromId() {
+        assertEquals("test.0", segments.segmentName(0));
+        assertEquals("test." + SEGMENT_INTERVAL, segments.segmentName(1));
+        assertEquals("test." + 2 * SEGMENT_INTERVAL, segments.segmentName(2));
+    }
+
+    @Test
+    public void shouldCreateSegments() {
+        final TimestampedSegmentWithHeaders segment1 = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        final TimestampedSegmentWithHeaders segment2 = segments.getOrCreateSegmentIfLive(1, context, -1L);
+        final TimestampedSegmentWithHeaders segment3 = segments.getOrCreateSegmentIfLive(2, context, -1L);
+
+        assertTrue(new File(context.stateDir(), "test/test.0").isDirectory());
+        assertTrue(new File(context.stateDir(), "test/test." + SEGMENT_INTERVAL).isDirectory());
+        assertTrue(new File(context.stateDir(), "test/test." + 2 * SEGMENT_INTERVAL).isDirectory());
+        assertTrue(segment1.isOpen());
+        assertTrue(segment2.isOpen());
+        assertTrue(segment3.isOpen());
+    }
+
+    @Test
+    public void shouldNotCreateSegmentThatIsAlreadyExpired() {
+        final long streamTime = updateStreamTimeAndCreateSegment(7);
+        assertNull(segments.getOrCreateSegmentIfLive(0, context, streamTime));
+        assertFalse(new File(context.stateDir(), "test/test.0").exists());
+    }
+
+    @Test
+    public void shouldCleanupSegmentsThatHaveExpired() {
+        final TimestampedSegmentWithHeaders segment1 = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        final TimestampedSegmentWithHeaders segment2 = segments.getOrCreateSegmentIfLive(1, context, -1L);
+        final TimestampedSegmentWithHeaders segment3 = segments.getOrCreateSegmentIfLive(7, context, SEGMENT_INTERVAL * 7L);
+
+        assertFalse(segment1.isOpen());
+        assertFalse(segment2.isOpen());
+        assertTrue(segment3.isOpen());
+        assertFalse(new File(context.stateDir(), "test/test.0").exists());
+        assertFalse(new File(context.stateDir(), "test/test." + SEGMENT_INTERVAL).exists());
+        assertTrue(new File(context.stateDir(), "test/test." + 7 * SEGMENT_INTERVAL).exists());
+    }
+
+    @Test
+    public void shouldGetSegmentForTimestamp() {
+        final TimestampedSegmentWithHeaders segment = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        segments.getOrCreateSegmentIfLive(1, context, -1L);
+        assertEquals(segment, segments.segmentForTimestamp(0L));
+    }
+
+    @Test
+    public void shouldGetCorrectSegmentString() {
+        final TimestampedSegmentWithHeaders segment = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        assertEquals("TimestampedSegmentWithHeaders(id=0, name=test.0)", segment.toString());
+    }
+
+    @Test
+    public void shouldCloseAllOpenSegments() {
+        final TimestampedSegmentWithHeaders first = segments.getOrCreateSegmentIfLive(0, context, -1L);
+        final TimestampedSegmentWithHeaders second = segments.getOrCreateSegmentIfLive(1, context, -1L);
+        final TimestampedSegmentWithHeaders third = segments.getOrCreateSegmentIfLive(2, context, -1L);
+        segments.close();
+
+        assertFalse(first.isOpen());
+        assertFalse(second.isOpen());
+        assertFalse(third.isOpen());
+    }
+
+    @Test
+    public void shouldOpenExistingSegments() {
+        segments = new TimestampedSegmentsWithHeaders("test", METRICS_SCOPE, 4, 1);
+        segments.openExisting(context, -1L);
+        segments.getOrCreateSegmentIfLive(0, context, -1L);
+        segments.getOrCreateSegmentIfLive(1, context, -1L);
+        segments.getOrCreateSegmentIfLive(2, context, -1L);
+        segments.getOrCreateSegmentIfLive(3, context, -1L);
+        segments.getOrCreateSegmentIfLive(4, context, -1L);
+        // close existing.
+        segments.close();
+
+        segments = new TimestampedSegmentsWithHeaders("test", METRICS_SCOPE, 4, 1);
+        segments.openExisting(context, -1L);
+
+        assertTrue(segments.segmentForTimestamp(0).isOpen());
+        assertTrue(segments.segmentForTimestamp(1).isOpen());
+        assertTrue(segments.segmentForTimestamp(2).isOpen());
+        assertTrue(segments.segmentForTimestamp(3).isOpen());
+        assertTrue(segments.segmentForTimestamp(4).isOpen());
+    }
+
+    @Test
+    public void shouldGetSegmentsWithinTimeRange() {
+        updateStreamTimeAndCreateSegment(0);
+        updateStreamTimeAndCreateSegment(1);
+        updateStreamTimeAndCreateSegment(2);
+        updateStreamTimeAndCreateSegment(3);
+        final long streamTime = updateStreamTimeAndCreateSegment(4);
+        segments.getOrCreateSegmentIfLive(0, context, streamTime);
+        segments.getOrCreateSegmentIfLive(1, context, streamTime);
+        segments.getOrCreateSegmentIfLive(2, context, streamTime);
+        segments.getOrCreateSegmentIfLive(3, context, streamTime);
+        segments.getOrCreateSegmentIfLive(4, context, streamTime);
+
+        final List<TimestampedSegmentWithHeaders> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
+        assertEquals(3, segments.size());
+        assertEquals(0, segments.get(0).id);
+        assertEquals(1, segments.get(1).id);
+        assertEquals(2, segments.get(2).id);
+    }
+
+    @Test
+    public void shouldClearSegmentsOnClose() {
+        segments.getOrCreateSegmentIfLive(0, context, -1L);
+        segments.close();
+        assertNull(segments.segmentForTimestamp(0));
+    }
+
+    private long updateStreamTimeAndCreateSegment(final int segment) {
+        final long streamTime = SEGMENT_INTERVAL * segment;
+        segments.getOrCreateSegmentIfLive(segment, context, streamTime);
+        return streamTime;
+    }
+}


### PR DESCRIPTION
This PR add `RocksDBTimestampedSegmentedBytesStoreWithHeaders` and the
corresponding unit tests for  the TimestampedWindowStoreWithHeaders
introduced in KIP-1271.
