### PR TITLE
MINOR: Refine documentation for `--override` option

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -31,6 +31,7 @@ object Kafka extends Logging {
     val optionParser = new OptionParser(false)
     val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file")
       .withRequiredArg()
+      .describedAs("key=value")
       .ofType(classOf[String])
     // This is just to make the parameter show up in the help output, we are not actually using this due the
     // fact that this class ignores the first parameter which is interpreted as positional and mandatory

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -29,7 +29,7 @@ object Kafka extends Logging {
 
   def getPropsFromArgs(args: Array[String]): Properties = {
     val optionParser = new OptionParser(false)
-    val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file")
+    val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file (e.g. Key=value")
       .withRequiredArg()
       .describedAs("key=value")
       .ofType(classOf[String])

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -29,7 +29,7 @@ object Kafka extends Logging {
 
   def getPropsFromArgs(args: Array[String]): Properties = {
     val optionParser = new OptionParser(false)
-    val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file (e.g. Key=value")
+    val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file (e.g. Key=value)")
       .withRequiredArg()
       .ofType(classOf[String])
     // This is just to make the parameter show up in the help output, we are not actually using this due the

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -31,7 +31,6 @@ object Kafka extends Logging {
     val optionParser = new OptionParser(false)
     val overrideOpt = optionParser.accepts("override", "Optional property that should override values set in server.properties file (e.g. Key=value")
       .withRequiredArg()
-      .describedAs("key=value")
       .ofType(classOf[String])
     // This is just to make the parameter show up in the help output, we are not actually using this due the
     // fact that this class ignores the first parameter which is interpreted as positional and mandatory


### PR DESCRIPTION
This change adds a describedAs placeholder to the --override option so
that the expected argument format is clearer in the command-line help
output.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
