### PR TITLE
KAFKA-20189: Add character class support to GlobComponent

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/glob/GlobComponent.java
+++ b/shell/src/main/java/org/apache/kafka/shell/glob/GlobComponent.java
@@ -43,7 +43,7 @@ public final class GlobComponent {
      */
     private static boolean isGlobSpecialCharacter(char ch) {
         return switch (ch) {
-            case '*', '?', '\\', '{', '}' -> true;
+            case '*', '?', '\\', '{', '}', '[', ']' -> true;
             default -> false;
         };
     }
@@ -107,7 +107,11 @@ public final class GlobComponent {
                         output.append(c);
                     }
                     break;
-                // TODO: handle character ranges
+                case '[':
+                    literal = false;
+                    i = handleCharacterClass(glob, i, output);
+                    break;
+
                 default:
                     if (isRegularExpressionSpecialCharacter(c)) {
                         output.append('\\');
@@ -123,6 +127,83 @@ public final class GlobComponent {
         }
         output.append('$');
         return output.toString();
+    }
+
+    /**
+     * Parses a glob character class starting at the given index and appends the
+     * equivalent regular expression representation to the provided {@code output}.
+     *
+     * <p>The {@code startIdx} must point to the first character inside the
+     * character class (i.e., immediately after the opening '[').</p>
+     *
+     * <p>This method supports:
+     * <ul>
+     *   <li>Leading ']' as a literal</li>
+     *   <li>Negation using '!' or '^'</li>
+     *   <li>Escaped characters using backslash</li>
+     * </ul>
+     *
+     * @param glob the full glob pattern
+     * @param startIdx index of the first character inside the character class
+     * @param output the {@link StringBuilder} to append the regex representation to
+     * @return the index immediately after the closing ']'
+     * @throws RuntimeException if the character class is empty or doesn't close properly
+     */
+    private static int handleCharacterClass(String glob, int startIdx, StringBuilder output) {
+        int idx = startIdx;
+
+        if (idx >= glob.length()) {
+            throw new RuntimeException("Glob has '[' but no ']'.");
+        }
+        output.append("[");
+
+        boolean hasContent = false;
+        char first = glob.charAt(idx);
+        if (first == ']') {
+            output.append(']');
+            hasContent = true;
+            idx++;
+        } else if (first == '!' || first == '^') {
+            output.append('^');
+            idx++;
+        }
+
+        while (idx < glob.length() && glob.charAt(idx) != ']') {
+            char ch = glob.charAt(idx);
+            if (ch == '\\') {
+                idx++;
+                if (idx >= glob.length()) {
+                    throw new RuntimeException("Trailing backslash in character class.");
+                }
+                char escaped = glob.charAt(idx);
+
+                // Escape for regex safety only if needed
+                if (escaped == '\\' || escaped == '[' || escaped == ']') {
+                    output.append('\\');
+                }
+                output.append(escaped);
+                hasContent = true;
+            } else {
+                // Converting [[] to [\[] for regex safety
+                if (ch == '[') {
+                    output.append('\\');
+                }
+                output.append(ch);
+                hasContent = true;
+            }
+
+            idx++;
+        }
+        if (idx >= glob.length()) {
+            throw new RuntimeException("Unterminated character class opened '[' but never closed.");
+        }
+
+        if (!hasContent) {
+            throw new RuntimeException("Empty glob character class.");
+        }
+
+        output.append(']');
+        return idx + 1;
     }
 
     private final String component;

--- a/shell/src/test/java/org/apache/kafka/shell/glob/GlobComponentTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/glob/GlobComponentTest.java
@@ -72,4 +72,100 @@ public class GlobComponentTest {
         assertFalse(foobarOrFoobaz.matches("foo"));
         assertFalse(foobarOrFoobaz.matches("baz"));
     }
+
+    // ---------- CHARACTER CLASS TESTS ----------
+
+    @Test
+    public void testSimpleCharacterClass() {
+        GlobComponent g = new GlobComponent("[abc]");
+        assertTrue(g.matches("a"));
+        assertTrue(g.matches("b"));
+        assertTrue(g.matches("c"));
+        assertFalse(g.matches("d"));
+    }
+
+    @Test
+    public void testNegatedCharacterClass() {
+        GlobComponent g = new GlobComponent("[!abc]");
+        GlobComponent g2 = new GlobComponent("[^abc]");
+        assertTrue(g.matches("d"));
+        assertTrue(g2.matches("d"));
+        assertFalse(g.matches("a"));
+        assertFalse(g2.matches("a"));
+    }
+
+    @Test
+    public void testLeadingRightBracketInClass() {
+        GlobComponent g = new GlobComponent("[]]");
+        assertTrue(g.matches("]"));
+        assertFalse(g.matches("a"));
+    }
+
+    @Test
+    public void testLiteralLeftBracketInClass() {
+        GlobComponent g = new GlobComponent("[[]");
+        assertTrue(g.matches("["));
+        assertFalse(g.matches("a"));
+    }
+
+    @Test
+    public void testRangeCharacterClass() {
+        GlobComponent g = new GlobComponent("[a-c]");
+        assertTrue(g.matches("a"));
+        assertTrue(g.matches("b"));
+        assertTrue(g.matches("c"));
+        assertFalse(g.matches("d"));
+    }
+
+    @Test
+    public void testDashLiteralAtEnd() {
+        GlobComponent g = new GlobComponent("[ab-]");
+        assertTrue(g.matches("-"));
+        assertTrue(g.matches("a"));
+        assertFalse(g.matches("c"));
+    }
+
+    @Test
+    public void testSingleBackslashInCharacterClass() {
+        GlobComponent g = new GlobComponent("[\\\\]");
+        assertTrue(g.matches("\\"));
+        assertFalse(g.matches("a"));
+    }
+
+    @Test
+    public void testEscapedLeftBracketInCharacterClass() {
+        GlobComponent g = new GlobComponent("[\\[]");
+        assertTrue(g.matches("["));
+        assertFalse(g.matches("\\"));
+    }
+
+    @Test
+    public void testBackslashDoesNotCreateRegexEscape() {
+        GlobComponent g = new GlobComponent("[\\d]");
+
+        // Should match literal 'd'
+        assertTrue(g.matches("d"));
+
+        // Should NOT match digit (ensures \d is not interpreted as regex digit class)
+        assertFalse(g.matches("5"));
+    }
+
+    @Test
+    public void testUnterminatedCharacterClass() {
+        GlobComponent g = new GlobComponent("[abc");
+        assertTrue(g.literal());
+        assertFalse(g.matches("a"));
+    }
+
+    @Test
+    public void testEmptyCharacterClass() {
+        GlobComponent g = new GlobComponent("[]");
+        assertTrue(g.literal());
+    }
+
+    @Test
+    public void testOnlyNegationCharacterClass() {
+        GlobComponent g = new GlobComponent("[!]");
+        assertTrue(g.literal());
+    }
 }


### PR DESCRIPTION
This patch adds support for glob character classes ([...]) in **GlobComponent**.

Changes:
- Implement parsing for character classes
- Support negation using '!' or '^'
- Support escaped characters within character classes
- Extract character class handling into a helper method to reduce NPath complexity
- Add unit tests covering valid and malformed patterns

Validation is intentionally minimal to preserve existing
**toRegularExpression** semantics. Malformed character classes
that are not explicitly detected will continue to fail during
regular expression compilation, consistent with the previous behavior.

Please review.