### PR TITLE
KAFKA-20134: Implement TimestampedWindowStoreWithHeaders (3/N)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/TimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/TimestampedWindowStoreWithHeaders.java
@@ -17,20 +17,16 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
-import org.apache.kafka.streams.kstream.Windowed;
-
-import java.time.Instant;
 
 /**
- * Interface for storing the aggregated values of fixed-size time windows.
+ * Interface for storing the aggregated values of fixed-size time windows with headers support.
  * <p>
- * Note, that the stores's physical key type is {@link Windowed Windowed&lt;K&gt;}.
- * In contrast to a {@link WindowStore} that stores plain windowedKeys-value pairs,
- * a {@code TimestampedWindowStore} stores windowedKeys-(value/timestamp) pairs.
+ * In contrast to a {@link TimestampedWindowStore} that stores windowedKey-(value/timestamp) pairs,
+ * a {@code TimestampedWindowStoreWithHeaders} stores windowedKey-(value/timestamp/headers) tuples.
  * <p>
  * While the window start- and end-timestamp are fixed per window, the value-side timestamp is used
- * to store the last update timestamp of the corresponding window.
+ * to store the last update timestamp of the corresponding window, and headers preserve the record
+ * metadata (e.g., schema registry information).
  *
  * @param <K> Type of keys
  * @param <V> Type of values
@@ -38,117 +34,18 @@ import java.time.Instant;
 public interface TimestampedWindowStoreWithHeaders<K, V> extends WindowStore<K, ValueTimestampHeaders<V>> {
 
     /**
-     * Put a key-value-timestamp pair, along with its associated Kafka headers, into the window
-     * with the given window start timestamp.
+     * Convenience method to put a key-value-timestamp pair with headers into the window store.
      * <p>
-     * This method is the header-aware extension of the base TimestampedWindowStore#put.
+     * This is a convenience wrapper around {@link #put(Object, Object, long)} that constructs
+     * the {@link ValueTimestampHeaders} instance for you.
      *
      * @param key                  The key to associate the value to
      * @param value                The value; can be null
      * @param windowStartTimestamp The timestamp of the beginning of the window
      * @param timestamp            The record timestamp
-     * @param headers              The Kafka headers associated with the record (contains Schema ID)
-     * @throws InvalidStateStoreException if the store is not initialized
-     * @throws NullPointerException if the given key or headers are {@code null}
+     * @param headers              The Kafka headers associated with the record
      */
-    void put(K key, V value, long windowStartTimestamp, long timestamp, Headers headers);
-
-    /**
-     * Get all the key-value-timestamp pairs with the given key and time range,
-     * including the associated headers.
-     * <p>
-     * This iterator must be closed after use.
-     *
-     * @param key      the key to fetch
-     * @param timeFrom time range start (inclusive)
-     * @param timeTo   time range end (inclusive)
-     * @return an iterator over key-value-timestamp-header pairs {@code <timestamp, ValueTimestampHeaders<V>>}
-     * @throws InvalidStateStoreException if the store is not initialized
-     * @throws NullPointerException       if the given key is {@code null}
-     */
-    WindowStoreIterator<ValueTimestampHeaders<V>> fetchWithHeaders(K key, long timeFrom, long timeTo);
-
-    default WindowStoreIterator<ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K key,
-                                                                                   final long timeFrom,
-                                                                                   final long timeTo) {
-        throw new UnsupportedOperationException("This API is not supported by this implementation of TimestampedWindowStoreWithHeaders.");
-    }
-
-    /**
-     * Get all the key-value-timestamp pairs in the given key range and time range,
-     * including the associated headers.
-     * <p>
-     * This iterator must be closed after use.
-     *
-     * @param keyFrom  the first key in the range (inclusive)
-     * @param keyTo    the last key in the range (inclusive)
-     * @param timeFrom time range start (inclusive)
-     * @param timeTo   time range end (inclusive)
-     * @return an iterator over windowed key-value-timestamp-header pairs {@code <Windowed<K>, ValueTimestampHeaders<V>>}
-     * @throws InvalidStateStoreException if the store is not initialized
-     */
-    KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchWithHeaders(K keyFrom, K keyTo, long timeFrom, long timeTo);
-
-    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K keyFrom,
-                                                                                             final K keyTo,
-                                                                                             final long timeFrom,
-                                                                                             final long timeTo) {
-        throw new UnsupportedOperationException("This API is not supported by this implementation of TimestampedWindowStoreWithHeaders.");
-    }
-
-    /**
-     * Gets all the key-value-timestamp pairs that belong to the windows within the given time range,
-     * including the associated headers.
-     * <p>
-     * This iterator must be closed after use.
-     *
-     * @param timeFrom the beginning of the time slot from which to search (inclusive)
-     * @param timeTo   the end of the time slot from which to search (inclusive)
-     * @return an iterator over windowed key-value-timestamp-header pairs {@code <Windowed<K>, ValueTimestampHeaders<V>>}
-     * @throws InvalidStateStoreException if the store is not initialized
-     */
-    KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchAllWithHeaders(long timeFrom, long timeTo);
-
-    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchAllWithHeaders(final long timeFrom,
-                                                                                                final long timeTo) {
-        throw new UnsupportedOperationException("This API is not supported by this implementation of TimestampedWindowStoreWithHeaders.");
-    }
-
-    // The default Instant methods rely on the long-based methods above, simplifying the implementation.
-
-    default WindowStoreIterator<ValueTimestampHeaders<V>> fetchWithHeaders(final K key,
-                                                                           final Instant timeFrom,
-                                                                           final Instant timeTo) throws IllegalArgumentException {
-        return fetchWithHeaders(key, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
-    }
-
-    default WindowStoreIterator<ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K key,
-                                                                                   final Instant timeFrom,
-                                                                                   final Instant timeTo) throws IllegalArgumentException {
-        return backwardFetchWithHeaders(key, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
-    }
-
-    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchWithHeaders(final K keyFrom,
-                                                                                     final K keyTo,
-                                                                                     final Instant timeFrom,
-                                                                                     final Instant timeTo) throws IllegalArgumentException {
-        return fetchWithHeaders(keyFrom, keyTo, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
-    }
-
-    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K keyFrom,
-                                                                                             final K keyTo,
-                                                                                             final Instant timeFrom,
-                                                                                             final Instant timeTo) throws IllegalArgumentException {
-        return backwardFetchWithHeaders(keyFrom, keyTo, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
-    }
-
-    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchAllWithHeaders(final Instant timeFrom,
-                                                                                        final Instant timeTo) throws IllegalArgumentException {
-        return fetchAllWithHeaders(timeFrom.toEpochMilli(), timeTo.toEpochMilli());
-    }
-
-    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchAllWithHeaders(final Instant timeFrom,
-                                                                                                final Instant timeTo) throws IllegalArgumentException {
-        return backwardFetchAllWithHeaders(timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    default void put(final K key, final V value, final long windowStartTimestamp, final long timestamp, final Headers headers) {
+        put(key, ValueTimestampHeaders.make(value, timestamp, headers), windowStartTimestamp);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/TimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/TimestampedWindowStoreWithHeaders.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.state;
 
-import org.apache.kafka.common.header.Headers;
 
 /**
  * Interface for storing the aggregated values of fixed-size time windows with headers support.
@@ -32,20 +31,4 @@ import org.apache.kafka.common.header.Headers;
  * @param <V> Type of values
  */
 public interface TimestampedWindowStoreWithHeaders<K, V> extends WindowStore<K, ValueTimestampHeaders<V>> {
-
-    /**
-     * Convenience method to put a key-value-timestamp pair with headers into the window store.
-     * <p>
-     * This is a convenience wrapper around {@link #put(Object, Object, long)} that constructs
-     * the {@link ValueTimestampHeaders} instance for you.
-     *
-     * @param key                  The key to associate the value to
-     * @param value                The value; can be null
-     * @param windowStartTimestamp The timestamp of the beginning of the window
-     * @param timestamp            The record timestamp
-     * @param headers              The Kafka headers associated with the record
-     */
-    default void put(final K key, final V value, final long windowStartTimestamp, final long timestamp, final Headers headers) {
-        put(key, ValueTimestampHeaders.make(value, timestamp, headers), windowStartTimestamp);
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/TimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/TimestampedWindowStoreWithHeaders.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.kstream.Windowed;
+
+import java.time.Instant;
+
+/**
+ * Interface for storing the aggregated values of fixed-size time windows.
+ * <p>
+ * Note, that the stores's physical key type is {@link Windowed Windowed&lt;K&gt;}.
+ * In contrast to a {@link WindowStore} that stores plain windowedKeys-value pairs,
+ * a {@code TimestampedWindowStore} stores windowedKeys-(value/timestamp) pairs.
+ * <p>
+ * While the window start- and end-timestamp are fixed per window, the value-side timestamp is used
+ * to store the last update timestamp of the corresponding window.
+ *
+ * @param <K> Type of keys
+ * @param <V> Type of values
+ */
+public interface TimestampedWindowStoreWithHeaders<K, V> extends WindowStore<K, ValueTimestampHeaders<V>> {
+
+    /**
+     * Put a key-value-timestamp pair, along with its associated Kafka headers, into the window
+     * with the given window start timestamp.
+     * <p>
+     * This method is the header-aware extension of the base TimestampedWindowStore#put.
+     *
+     * @param key                  The key to associate the value to
+     * @param value                The value; can be null
+     * @param windowStartTimestamp The timestamp of the beginning of the window
+     * @param timestamp            The record timestamp
+     * @param headers              The Kafka headers associated with the record (contains Schema ID)
+     * @throws InvalidStateStoreException if the store is not initialized
+     * @throws NullPointerException if the given key or headers are {@code null}
+     */
+    void put(K key, V value, long windowStartTimestamp, long timestamp, Headers headers);
+
+    /**
+     * Get all the key-value-timestamp pairs with the given key and time range,
+     * including the associated headers.
+     * <p>
+     * This iterator must be closed after use.
+     *
+     * @param key      the key to fetch
+     * @param timeFrom time range start (inclusive)
+     * @param timeTo   time range end (inclusive)
+     * @return an iterator over key-value-timestamp-header pairs {@code <timestamp, ValueTimestampHeaders<V>>}
+     * @throws InvalidStateStoreException if the store is not initialized
+     * @throws NullPointerException       if the given key is {@code null}
+     */
+    WindowStoreIterator<ValueTimestampHeaders<V>> fetchWithHeaders(K key, long timeFrom, long timeTo);
+
+    default WindowStoreIterator<ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K key,
+                                                                                   final long timeFrom,
+                                                                                   final long timeTo) {
+        throw new UnsupportedOperationException("This API is not supported by this implementation of TimestampedWindowStoreWithHeaders.");
+    }
+
+    /**
+     * Get all the key-value-timestamp pairs in the given key range and time range,
+     * including the associated headers.
+     * <p>
+     * This iterator must be closed after use.
+     *
+     * @param keyFrom  the first key in the range (inclusive)
+     * @param keyTo    the last key in the range (inclusive)
+     * @param timeFrom time range start (inclusive)
+     * @param timeTo   time range end (inclusive)
+     * @return an iterator over windowed key-value-timestamp-header pairs {@code <Windowed<K>, ValueTimestampHeaders<V>>}
+     * @throws InvalidStateStoreException if the store is not initialized
+     */
+    KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchWithHeaders(K keyFrom, K keyTo, long timeFrom, long timeTo);
+
+    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K keyFrom,
+                                                                                             final K keyTo,
+                                                                                             final long timeFrom,
+                                                                                             final long timeTo) {
+        throw new UnsupportedOperationException("This API is not supported by this implementation of TimestampedWindowStoreWithHeaders.");
+    }
+
+    /**
+     * Gets all the key-value-timestamp pairs that belong to the windows within the given time range,
+     * including the associated headers.
+     * <p>
+     * This iterator must be closed after use.
+     *
+     * @param timeFrom the beginning of the time slot from which to search (inclusive)
+     * @param timeTo   the end of the time slot from which to search (inclusive)
+     * @return an iterator over windowed key-value-timestamp-header pairs {@code <Windowed<K>, ValueTimestampHeaders<V>>}
+     * @throws InvalidStateStoreException if the store is not initialized
+     */
+    KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchAllWithHeaders(long timeFrom, long timeTo);
+
+    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchAllWithHeaders(final long timeFrom,
+                                                                                                final long timeTo) {
+        throw new UnsupportedOperationException("This API is not supported by this implementation of TimestampedWindowStoreWithHeaders.");
+    }
+
+    // The default Instant methods rely on the long-based methods above, simplifying the implementation.
+
+    default WindowStoreIterator<ValueTimestampHeaders<V>> fetchWithHeaders(final K key,
+                                                                           final Instant timeFrom,
+                                                                           final Instant timeTo) throws IllegalArgumentException {
+        return fetchWithHeaders(key, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    }
+
+    default WindowStoreIterator<ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K key,
+                                                                                   final Instant timeFrom,
+                                                                                   final Instant timeTo) throws IllegalArgumentException {
+        return backwardFetchWithHeaders(key, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    }
+
+    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchWithHeaders(final K keyFrom,
+                                                                                     final K keyTo,
+                                                                                     final Instant timeFrom,
+                                                                                     final Instant timeTo) throws IllegalArgumentException {
+        return fetchWithHeaders(keyFrom, keyTo, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    }
+
+    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K keyFrom,
+                                                                                             final K keyTo,
+                                                                                             final Instant timeFrom,
+                                                                                             final Instant timeTo) throws IllegalArgumentException {
+        return backwardFetchWithHeaders(keyFrom, keyTo, timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    }
+
+    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchAllWithHeaders(final Instant timeFrom,
+                                                                                        final Instant timeTo) throws IllegalArgumentException {
+        return fetchAllWithHeaders(timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    }
+
+    default KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchAllWithHeaders(final Instant timeFrom,
+                                                                                                final Instant timeTo) throws IllegalArgumentException {
+        return backwardFetchAllWithHeaders(timeFrom.toEpochMilli(), timeTo.toEpochMilli());
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
@@ -16,17 +16,13 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.streams.state.WindowStoreIterator;
 
 /**
  * A Metered {@link TimestampedWindowStoreWithHeaders} wrapper that is used for recording operation metrics,
@@ -58,40 +54,5 @@ class MeteredTimestampedWindowStoreWithHeaders<K, V>
         } else {
             return super.prepareValueSerde(valueSerde, getter);
         }
-    }
-
-    @Override
-    public void put(final K key, final V value, final long windowStartTimestamp, final long timestamp, final Headers headers) {
-        put(key, ValueTimestampHeaders.make(value, timestamp, headers), windowStartTimestamp);
-    }
-
-    @Override
-    public WindowStoreIterator<ValueTimestampHeaders<V>> fetchWithHeaders(final K key, final long timeFrom, final long timeTo) {
-        return fetch(key, timeFrom, timeTo);
-    }
-
-    @Override
-    public WindowStoreIterator<ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K key, final long timeFrom, final long timeTo) {
-        return backwardFetch(key, timeFrom, timeTo);
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchWithHeaders(final K keyFrom, final K keyTo, final long timeFrom, final long timeTo) {
-        return fetch(keyFrom, keyTo, timeFrom, timeTo);
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K keyFrom, final K keyTo, final long timeFrom, final long timeTo) {
-        return backwardFetch(keyFrom, keyTo, timeFrom, timeTo);
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchAllWithHeaders(final long timeFrom, final long timeTo) {
-        return fetchAll(timeFrom, timeTo);
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchAllWithHeaders(final long timeFrom, final long timeTo) {
-        return backwardFetchAll(timeFrom, timeTo);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
@@ -16,13 +16,20 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowStore;
+
+import java.util.Objects;
+
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 /**
  * A Metered {@link TimestampedWindowStoreWithHeaders} wrapper that is used for recording operation metrics,
@@ -54,5 +61,26 @@ class MeteredTimestampedWindowStoreWithHeaders<K, V>
         } else {
             return super.prepareValueSerde(valueSerde, getter);
         }
+    }
+
+    @Override
+    public void put(final K key, final ValueTimestampHeaders<V> value, final long windowStartTimestamp) {
+        Objects.requireNonNull(key, "key cannot be null");
+        final Headers headers = value.headers() == null ? new RecordHeaders() : value.headers();
+        try {
+            maybeMeasureLatency(
+                () -> wrapped().put(keyBytes(key, headers), serdes.rawValue(value, headers), windowStartTimestamp),
+                time,
+                putSensor
+            );
+            maybeRecordE2ELatency();
+        } catch (final ProcessorStateException e) {
+            final String message = String.format(e.getMessage(), key, value);
+            throw new ProcessorStateException(message, e);
+        }
+    }
+
+    protected Bytes keyBytes(final K key, final Headers headers) {
+        return Bytes.wrap(serdes.rawKey(key, headers));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+
+/**
+ * A Metered {@link TimestampedWindowStoreWithHeaders} wrapper that is used for recording operation metrics,
+ * and hence its inner WindowStore implementation does not need to provide its own metrics collecting functionality.
+ * The inner {@link WindowStore} of this class is of type &lt;Bytes,byte[]&gt;, hence we use {@link Serde}s
+ * to convert from &lt;K,ValueTimestampHeaders&lt;V&gt;&gt; to &lt;Bytes,byte[]&gt;.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+class MeteredTimestampedWindowStoreWithHeaders<K, V>
+    extends MeteredWindowStore<K, ValueTimestampHeaders<V>>
+    implements TimestampedWindowStoreWithHeaders<K, V> {
+
+    MeteredTimestampedWindowStoreWithHeaders(final WindowStore<Bytes, byte[]> inner,
+                                             final long windowSizeMs,
+                                             final String metricScope,
+                                             final Time time,
+                                             final Serde<K> keySerde,
+                                             final Serde<ValueTimestampHeaders<V>> valueSerde) {
+        super(inner, windowSizeMs, metricScope, time, keySerde, valueSerde);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Serde<ValueTimestampHeaders<V>> prepareValueSerde(final Serde<ValueTimestampHeaders<V>> valueSerde, final SerdeGetter getter) {
+        if (valueSerde == null) {
+            return new ValueTimestampHeadersSerde<>((Serde<V>) getter.valueSerde());
+        } else {
+            return super.prepareValueSerde(valueSerde, getter);
+        }
+    }
+
+    @Override
+    public void put(final K key, final V value, final long windowStartTimestamp, final long timestamp, final Headers headers) {
+        put(key, ValueTimestampHeaders.make(value, timestamp, headers), windowStartTimestamp);
+    }
+
+    @Override
+    public WindowStoreIterator<ValueTimestampHeaders<V>> fetchWithHeaders(final K key, final long timeFrom, final long timeTo) {
+        return fetch(key, timeFrom, timeTo);
+    }
+
+    @Override
+    public WindowStoreIterator<ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K key, final long timeFrom, final long timeTo) {
+        return backwardFetch(key, timeFrom, timeTo);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchWithHeaders(final K keyFrom, final K keyTo, final long timeFrom, final long timeTo) {
+        return fetch(keyFrom, keyTo, timeFrom, timeTo);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchWithHeaders(final K keyFrom, final K keyTo, final long timeFrom, final long timeTo) {
+        return backwardFetch(keyFrom, keyTo, timeFrom, timeTo);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> fetchAllWithHeaders(final long timeFrom, final long timeTo) {
+        return fetchAll(timeFrom, timeTo);
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> backwardFetchAllWithHeaders(final long timeFrom, final long timeTo) {
+        return backwardFetchAll(timeFrom, timeTo);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -69,12 +69,12 @@ public class MeteredWindowStore<K, V>
 
     private final long windowSizeMs;
     private final String metricsScope;
-    private final Time time;
+    protected final Time time;
     private final Serde<K> keySerde;
     private final Serde<V> valueSerde;
-    private StateSerdes<K, V> serdes;
+    protected StateSerdes<K, V> serdes;
     private StreamsMetricsImpl streamsMetrics;
-    private Sensor putSensor;
+    protected Sensor putSensor;
     private Sensor fetchSensor;
     private Sensor flushSensor;
     private Sensor e2eLatencySensor;
@@ -520,7 +520,7 @@ public class MeteredWindowStore<K, V>
         return value != null ? serdes.valueFrom(value, new RecordHeaders()) : null;
     }
 
-    private void maybeRecordE2ELatency() {
+    protected void maybeRecordE2ELatency() {
         // Context is null if the provided context isn't an implementation of InternalProcessorContext.
         // In that case, we _can't_ get the current timestamp, so we don't record anything.
         if (e2eLatencySensor.shouldRecord() && internalContext != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
@@ -181,8 +182,8 @@ public class MeteredWindowStore<K, V>
                 record -> listener.apply(
                     record.withKey(WindowKeySchema.fromStoreKey(record.key(), windowSizeMs, serdes.keyDeserializer(), serdes.topic()))
                         .withValue(new Change<>(
-                            record.value().newValue != null ? serdes.valueFrom(record.value().newValue) : null,
-                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue) : null,
+                            record.value().newValue != null ? serdes.valueFrom(record.value().newValue, new RecordHeaders()) : null,
+                            record.value().oldValue != null ? serdes.valueFrom(record.value().oldValue, new RecordHeaders()) : null,
                             record.value().isLatest
                         ))
                 ),
@@ -198,7 +199,7 @@ public class MeteredWindowStore<K, V>
         Objects.requireNonNull(key, "key cannot be null");
         try {
             maybeMeasureLatency(
-                () -> wrapped().put(keyBytes(key), serdes.rawValue(value), windowStartTimestamp),
+                () -> wrapped().put(keyBytes(key), serdes.rawValue(value, new RecordHeaders()), windowStartTimestamp),
                 time,
                 putSensor
             );
@@ -219,7 +220,7 @@ public class MeteredWindowStore<K, V>
                 if (result == null) {
                     return null;
                 }
-                return serdes.valueFrom(result);
+                return serdes.valueFrom(result, new RecordHeaders());
             },
             time,
             fetchSensor
@@ -512,11 +513,11 @@ public class MeteredWindowStore<K, V>
     }
 
     private Bytes keyBytes(final K key) {
-        return Bytes.wrap(serdes.rawKey(key));
+        return Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
     }
 
     protected V outerValue(final byte[] value) {
-        return value != null ? serdes.valueFrom(value) : null;
+        return value != null ? serdes.valueFrom(value, new RecordHeaders()) : null;
     }
 
     private void maybeRecordE2ELatency() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
@@ -226,11 +226,15 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
         final Deserializer<ValueTimestampHeaders<String>> valueDeserializer = mock(Deserializer.class);
         final Serializer<ValueTimestampHeaders<String>> valueSerializer = mock(Serializer.class);
         when(keySerde.serializer()).thenReturn(keySerializer);
+        // For fetch: key serialization uses empty headers (no value context available)
         when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
+        // For put: key serialization uses value's headers
+        when(keySerializer.serialize(topic, HEADERS, KEY)).thenReturn(KEY.getBytes());
         when(valueSerde.deserializer()).thenReturn(valueDeserializer);
         when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_TIMESTAMP_HEADERS_BYTES)).thenReturn(VALUE_TIMESTAMP_HEADERS);
         when(valueSerde.serializer()).thenReturn(valueSerializer);
-        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE_TIMESTAMP_HEADERS)).thenReturn(VALUE_TIMESTAMP_HEADERS_BYTES);
+        // For put: value serialization uses value's headers
+        when(valueSerializer.serialize(topic, HEADERS, VALUE_TIMESTAMP_HEADERS)).thenReturn(VALUE_TIMESTAMP_HEADERS_BYTES);
         when(innerStoreMock.fetch(KEY_BYTES, TIMESTAMP)).thenReturn(VALUE_TIMESTAMP_HEADERS_BYTES);
         store = new MeteredTimestampedWindowStoreWithHeaders<>(
             innerStoreMock,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
@@ -184,6 +184,30 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
     }
 
     @Test
+    public void shouldNotThrowExceptionIfSerdesCorrectlySetFromProcessorContext() {
+        setUp();
+        when(innerStoreMock.name()).thenReturn("mocked-store");
+        final MeteredTimestampedWindowStoreWithHeaders<String, Long> store = new MeteredTimestampedWindowStoreWithHeaders<>(
+            innerStoreMock,
+            10L, // any size
+            "scope",
+            new MockTime(),
+            null,
+            null
+        );
+        store.init(context, innerStoreMock);
+
+        try {
+            store.put("key", ValueTimestampHeaders.make(42L, 60000, new RecordHeaders()), 60000L);
+        } catch (final StreamsException exception) {
+            if (exception.getCause() instanceof ClassCastException) {
+                fail("Serdes are not correctly set from processor context.");
+            }
+            throw exception;
+        }
+    }
+
+    @Test
     public void shouldNotThrowExceptionIfSerdesCorrectlySetFromConstructorParameters() {
         setUp();
         when(innerStoreMock.name()).thenReturn("mocked-store");

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.MockRecordCollector;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class MeteredTimestampedWindowStoreWithHeadersTest {
+    private static final String STORE_NAME = "mocked-store";
+    private static final String STORE_TYPE = "scope";
+    private static final String CHANGELOG_TOPIC = "changelog-topic";
+    private static final String KEY = "key";
+    private static final Bytes KEY_BYTES = Bytes.wrap(KEY.getBytes());
+    // timestamp is 97 what is ASCII of 'a'
+    private static final long TIMESTAMP = 97L;
+    private static final RecordHeaders HEADERS = makeHeaders();
+    private static final ValueTimestampHeaders<String> VALUE_TIMESTAMP_HEADERS =
+        ValueTimestampHeaders.make("value", TIMESTAMP, HEADERS);
+    private static final byte[] VALUE_TIMESTAMP_HEADERS_BYTES = serializeValueTimestampHeaders();
+    private static final int WINDOW_SIZE_MS = 10;
+
+    private InternalMockProcessorContext<String, Long> context;
+    private final TaskId taskId = new TaskId(0, 0, "My-Topology");
+    @Mock
+    private WindowStore<Bytes, byte[]> innerStoreMock;
+    private final Metrics metrics = new Metrics(new MetricConfig().recordLevel(Sensor.RecordingLevel.DEBUG));
+    private MeteredTimestampedWindowStoreWithHeaders<String, String> store;
+
+    public void setUp() {
+        final StreamsMetricsImpl streamsMetrics =
+            new StreamsMetricsImpl(metrics, "test", new MockTime());
+
+        context = new InternalMockProcessorContext<>(
+            TestUtils.tempDirectory(),
+            Serdes.String(),
+            Serdes.Long(),
+            streamsMetrics,
+            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            MockRecordCollector::new,
+            new ThreadCache(new LogContext("testCache "), 0, streamsMetrics),
+            Time.SYSTEM,
+            taskId
+        );
+
+        when(innerStoreMock.name()).thenReturn(STORE_NAME);
+
+        store = new MeteredTimestampedWindowStoreWithHeaders<>(
+            innerStoreMock,
+            WINDOW_SIZE_MS, // any size
+            STORE_TYPE,
+            new MockTime(),
+            Serdes.String(),
+            new ValueTimestampHeadersSerde<>(new SerdeThatDoesntHandleNull())
+        );
+    }
+
+    public void setUpWithoutContextName() {
+        final StreamsMetricsImpl streamsMetrics =
+            new StreamsMetricsImpl(metrics, "test", new MockTime());
+
+        context = new InternalMockProcessorContext<>(
+            TestUtils.tempDirectory(),
+            Serdes.String(),
+            Serdes.Long(),
+            streamsMetrics,
+            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            MockRecordCollector::new,
+            new ThreadCache(new LogContext("testCache "), 0, streamsMetrics),
+            Time.SYSTEM,
+            taskId
+        );
+
+        store = new MeteredTimestampedWindowStoreWithHeaders<>(
+            innerStoreMock,
+            WINDOW_SIZE_MS, // any size
+            STORE_TYPE,
+            new MockTime(),
+            Serdes.String(),
+            new ValueTimestampHeadersSerde<>(new SerdeThatDoesntHandleNull())
+        );
+    }
+
+    @Test
+    public void shouldDelegateInit() {
+        setUpWithoutContextName();
+        @SuppressWarnings("unchecked")
+        final WindowStore<Bytes, byte[]> inner = mock(WindowStore.class);
+        final MeteredTimestampedWindowStoreWithHeaders<String, String> outer = new MeteredTimestampedWindowStoreWithHeaders<>(
+            inner,
+            WINDOW_SIZE_MS, // any size
+            STORE_TYPE,
+            new MockTime(),
+            Serdes.String(),
+            new ValueTimestampHeadersSerde<>(new SerdeThatDoesntHandleNull())
+        );
+        when(inner.name()).thenReturn("store");
+
+        outer.init(context, outer);
+
+        verify(inner).init(context, outer);
+    }
+
+    @Test
+    public void shouldPassChangelogTopicNameToStateStoreSerde() {
+        setUp();
+        context.addChangelogForStore(STORE_NAME, CHANGELOG_TOPIC);
+        doShouldPassChangelogTopicNameToStateStoreSerde(CHANGELOG_TOPIC);
+    }
+
+    @Test
+    public void shouldPassDefaultChangelogTopicNameToStateStoreSerdeIfLoggingDisabled() {
+        setUp();
+        final String defaultChangelogTopicName =
+            ProcessorStateManager.storeChangelogTopic(context.applicationId(), STORE_NAME, taskId.topologyName());
+        doShouldPassChangelogTopicNameToStateStoreSerde(defaultChangelogTopicName);
+    }
+
+    @Test
+    public void shouldCloseUnderlyingStore() {
+        setUp();
+        store.init(context, store);
+        store.close();
+
+        verify(innerStoreMock).close();
+    }
+
+    @Test
+    public void shouldNotExceptionIfFetchReturnsNull() {
+        setUp();
+        when(innerStoreMock.fetch(Bytes.wrap("a".getBytes()), 0)).thenReturn(null);
+
+        store.init(context, store);
+        assertNull(store.fetch("a", 0));
+    }
+
+    @Test
+    public void shouldNotThrowExceptionIfSerdesCorrectlySetFromConstructorParameters() {
+        setUp();
+        when(innerStoreMock.name()).thenReturn("mocked-store");
+        final MeteredTimestampedWindowStoreWithHeaders<String, Long> store = new MeteredTimestampedWindowStoreWithHeaders<>(
+            innerStoreMock,
+            10L, // any size
+            "scope",
+            new MockTime(),
+            Serdes.String(),
+            new ValueTimestampHeadersSerde<>(Serdes.Long())
+        );
+        store.init(context, innerStoreMock);
+
+        try {
+            store.put("key", ValueTimestampHeaders.make(42L, 60000, new RecordHeaders()), 60000L);
+        } catch (final StreamsException exception) {
+            if (exception.getCause() instanceof ClassCastException) {
+                fail("Serdes are not correctly set from constructor parameters.");
+            }
+            throw exception;
+        }
+    }
+
+    private static RecordHeaders makeHeaders() {
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add("header-key", "header-value".getBytes());
+        return headers;
+    }
+
+    private static byte[] serializeValueTimestampHeaders() {
+        final ValueTimestampHeadersSerializer<String> serializer = new ValueTimestampHeadersSerializer<>(Serdes.String().serializer());
+        return serializer.serialize("topic", VALUE_TIMESTAMP_HEADERS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void doShouldPassChangelogTopicNameToStateStoreSerde(final String topic) {
+        final Serde<String> keySerde = mock(Serde.class);
+        final Serializer<String> keySerializer = mock(Serializer.class);
+        final Serde<ValueTimestampHeaders<String>> valueSerde = mock(Serde.class);
+        final Deserializer<ValueTimestampHeaders<String>> valueDeserializer = mock(Deserializer.class);
+        final Serializer<ValueTimestampHeaders<String>> valueSerializer = mock(Serializer.class);
+        when(keySerde.serializer()).thenReturn(keySerializer);
+        when(keySerializer.serialize(topic, new RecordHeaders(), KEY)).thenReturn(KEY.getBytes());
+        when(valueSerde.deserializer()).thenReturn(valueDeserializer);
+        when(valueDeserializer.deserialize(topic, new RecordHeaders(), VALUE_TIMESTAMP_HEADERS_BYTES)).thenReturn(VALUE_TIMESTAMP_HEADERS);
+        when(valueSerde.serializer()).thenReturn(valueSerializer);
+        when(valueSerializer.serialize(topic, new RecordHeaders(), VALUE_TIMESTAMP_HEADERS)).thenReturn(VALUE_TIMESTAMP_HEADERS_BYTES);
+        when(innerStoreMock.fetch(KEY_BYTES, TIMESTAMP)).thenReturn(VALUE_TIMESTAMP_HEADERS_BYTES);
+        store = new MeteredTimestampedWindowStoreWithHeaders<>(
+            innerStoreMock,
+            WINDOW_SIZE_MS,
+            STORE_TYPE,
+            new MockTime(),
+            keySerde,
+            valueSerde
+        );
+
+        store.init(context, store);
+        store.fetch(KEY, TIMESTAMP);
+        store.put(KEY, VALUE_TIMESTAMP_HEADERS, TIMESTAMP);
+
+        verify(innerStoreMock).fetch(KEY_BYTES, TIMESTAMP);
+        verify(innerStoreMock).put(KEY_BYTES, VALUE_TIMESTAMP_HEADERS_BYTES, TIMESTAMP);
+    }
+}


### PR DESCRIPTION
This PR adds `TimestampedWindowStoreWithHeaders`,
`MeteredTimestampedWindowStoreWithHeaders` and the corresponding unit
tests for  the TimestampedWindowStoreWithHeaders introduced in KIP-1271.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, Matthias J. Sax
 <matthias@confluent.io>
