### PR TITLE
MINOR: Remove Evolving annotation from GroupState

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/GroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/GroupState.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
  *     </tbody>
  * </table>
  */
-@InterfaceStability.Evolving
 public enum GroupState {
     UNKNOWN("Unknown"),
     PREPARING_REBALANCE("PreparingRebalance"),

--- a/clients/src/main/java/org/apache/kafka/common/GroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/GroupState.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.common;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;


### PR DESCRIPTION
Removal of the `InterfaceStability.Evolving` from
`o.a.k.common.GroupState` was missed when the other group-related
interfaces stabilised.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
