### PR TITLE
KAFKA-10731: Add support for SSL hot reload

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -98,6 +98,24 @@ public class SslConfigs {
         + "If a password is not set, trust store file configured will still be used, but integrity checking is disabled. "
         + "Trust store password is not supported for PEM format.";
 
+
+    public static final String SSL_HOT_RELOAD_ENABLE_CONFIG = "ssl.hotreload.enable";
+    public static final String SSL_HOT_RELOAD_ENABLE_DOC = "Enable periodic polling of keystore and truststore files to support SSL hot reload.";
+    public static final boolean DEFAULT_SSL_HOT_RELOAD_ENABLE = false;
+
+    public static final String SSL_HOT_RELOAD_POLL_INTERVAL_CONFIG = "ssl.hotreload.poll.interval.seconds";
+    public static final String SSL_HOT_RELOAD_POLL_INTERVAL_DOC = "Polling interval in seconds used to check for modifications in keystore and truststore files when SSL hot reload is enabled.";
+    public static final int DEFAULT_SSL_HOT_RELOAD_POLL_INTERVAL_SECONDS = 60;
+
+    public static final String SSL_HOT_RELOAD_DEBOUNCE_CONFIG = "ssl.hotreload.debounce.seconds";
+    public static final String SSL_HOT_RELOAD_DEBOUNCE_DOC = "Grace period in seconds after a keystore or truststore file change is detected before " +
+                    "listeners are notified. During certificate rotation an operator may update the keystore " +
+                    "and truststore with some delay between them; this window prevents a reload from firing " +
+                    "while the configuration is only half-updated, which would cause transient TLS handshake " +
+                    "failures. The timer resets each time a new file change is detected within the window. " +
+                    "Set to 0 to disable debouncing and notify listeners immediately on the first detected change.";
+    public static final int DEFAULT_SSL_HOT_RELOAD_DEBOUNCE_SECONDS = 5;
+
     public static final String SSL_KEYMANAGER_ALGORITHM_CONFIG = "ssl.keymanager.algorithm";
     public static final String SSL_KEYMANAGER_ALGORITHM_DOC = "The algorithm used by key manager factory for SSL connections. "
             + "Default value is the key manager factory algorithm configured for the Java Virtual Machine.";
@@ -138,6 +156,9 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_TRUSTSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC)
+                .define(SslConfigs.SSL_HOT_RELOAD_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, SslConfigs.DEFAULT_SSL_HOT_RELOAD_ENABLE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_HOT_RELOAD_ENABLE_DOC)
+                .define(SSL_HOT_RELOAD_POLL_INTERVAL_CONFIG, ConfigDef.Type.INT, DEFAULT_SSL_HOT_RELOAD_POLL_INTERVAL_SECONDS, ConfigDef.Range.atLeast(1), ConfigDef.Importance.MEDIUM, SSL_HOT_RELOAD_POLL_INTERVAL_DOC)
+                .define(SSL_HOT_RELOAD_DEBOUNCE_CONFIG, ConfigDef.Type.INT, DEFAULT_SSL_HOT_RELOAD_DEBOUNCE_SECONDS, ConfigDef.Range.atLeast(0), ConfigDef.Importance.MEDIUM, SSL_HOT_RELOAD_DEBOUNCE_DOC)
                 .define(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_KEYMANGER_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTMANAGER_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC)
                 .define(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, ConfigDef.Importance.LOW, SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -60,6 +60,9 @@ public class SslFactory implements Reconfigurable, Closeable {
     private final String clientAuthConfigOverride;
     private final boolean keystoreVerifiableUsingTruststore;
     private String endpointIdentification;
+    private boolean sslHotReload;
+    private SslMaterialPoller sslMaterialPoller;
+    private Runnable onSslMaterialChange;
     private SslEngineFactory sslEngineFactory;
     private Map<String, Object> sslEngineFactoryConfig;
 
@@ -107,6 +110,23 @@ public class SslFactory implements Reconfigurable, Closeable {
             }
         }
         this.sslEngineFactory = builder;
+
+        this.sslHotReload = ConfigUtils.getBoolean(nextConfigs, SslConfigs.SSL_HOT_RELOAD_ENABLE_CONFIG, SslConfigs.DEFAULT_SSL_HOT_RELOAD_ENABLE);
+
+        this.sslHotReload = ConfigUtils.getBoolean(nextConfigs,
+           SslConfigs.SSL_HOT_RELOAD_ENABLE_CONFIG,
+           SslConfigs.DEFAULT_SSL_HOT_RELOAD_ENABLE);
+
+        if (this.sslHotReload) {
+            // Deregister any listener from a previous configure() call before re-registering
+            // with potentially new configs (e.g., after a dynamic reconfiguration).
+            if (this.onSslMaterialChange != null) {
+                SslMaterialPollerRegistry.getInstance().deregister(this.sslEngineFactoryConfig, this.onSslMaterialChange);
+            }
+            this.onSslMaterialChange = () -> reconfigure(this.sslEngineFactoryConfig);
+            SslMaterialPollerRegistry.getInstance().register(nextConfigs, this.onSslMaterialChange);
+        }
+
     }
 
     @Override
@@ -131,6 +151,8 @@ public class SslFactory implements Reconfigurable, Closeable {
             this.sslEngineFactory = newSslEngineFactory;
             log.info("Created new {} SSL engine builder with keystore {} truststore {}", connectionMode,
                     newSslEngineFactory.keystore(), newSslEngineFactory.truststore());
+        } else {
+            log.trace("SSL configuration unchanged, no reconfiguration needed");
         }
     }
 
@@ -292,6 +314,10 @@ public class SslFactory implements Reconfigurable, Closeable {
 
     @Override
     public void close() {
+        if (this.sslHotReload && this.onSslMaterialChange != null) {
+            SslMaterialPollerRegistry.getInstance().deregister(this.sslEngineFactoryConfig, this.onSslMaterialChange);
+            this.onSslMaterialChange = null;
+        }
         Utils.closeQuietly(sslEngineFactory, "close engine factory");
     }
 
@@ -327,6 +353,7 @@ public class SslFactory implements Reconfigurable, Closeable {
 
         private static void ensureCompatibleDNs(List<CertificateEntries> newEntries, List<CertificateEntries> oldEntries) {
             if (newEntries.size() != oldEntries.size()) {
+                log.debug("new entries={}, old entries={}", newEntries, oldEntries);
                 throw new ConfigException(String.format("Keystore entries do not match, existing store contains %d entries, new store contains %d entries",
                     oldEntries.size(), newEntries.size()));
             }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslMaterialPoller.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslMaterialPoller.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.utils.ConfigUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Polls a set of SSL material files (keystore, truststore) at a fixed interval and notifies
+ * all registered listeners when a modification is detected.
+ *
+ * <h3>Debounce</h3>
+ * During certificate rotation an operator may update the keystore and the truststore with some
+ * delay between them. Without a grace period the poller would fire between the two writes,
+ * loading a half-updated, inconsistent TLS configuration that can cause transient handshake
+ * failures.
+ *
+ * <p>When {@code ssl.hotreload.debounce.seconds} is greater than zero the poller waits that long
+ * after detecting the <em>first</em> changed file before notifying listeners. If another file
+ * change arrives within the debounce window the timer is reset, so listeners are always called
+ * after a quiet period — once both files have been written and the filesystem has settled.
+ *
+ * <p>Setting {@code ssl.hotreload.debounce.seconds=0} disables debouncing entirely and restores
+ * the immediate-fire behaviour.
+ *
+ * <h3>Sharing</h3>
+ * A single instance may be shared by multiple {@link SslFactory} instances that watch the same
+ * set of files (see {@link SslMaterialPollerRegistry}). Listeners are managed via
+ * {@link #addListener(Runnable)} and {@link #removeListener(Runnable)}.
+ */
+public final class SslMaterialPoller {
+
+    private static final Logger log = LoggerFactory.getLogger(SslMaterialPoller.class);
+
+    private final List<Path> files;
+    private final Duration pollInterval;
+    private final Duration debounceDelay;
+
+    /** Thread-safe listener list; iterated after the debounce period expires. */
+    private final CopyOnWriteArrayList<Runnable> listeners = new CopyOnWriteArrayList<>();
+
+    private final Map<Path, FileTime> lastModifiedTimes;
+
+    private final ScheduledExecutorService scheduler;
+
+    /**
+     * Tracks the pending debounce task so it can be cancelled when a new change is detected
+     * within the debounce window. Only ever accessed from the single scheduler thread.
+     */
+    private Future<?> pendingDebounce;
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    /**
+     * Creates a poller for the keystore/truststore paths found in {@code configs}.
+     * No listener is wired at construction time; use {@link #addListener(Runnable)}.
+     *
+     * @param configs Kafka SSL configuration map; must contain at least one of
+     *                {@code ssl.keystore.location} or {@code ssl.truststore.location}.
+     */
+    public SslMaterialPoller(Map<String, Object> configs) {
+        List<Path> files = new ArrayList<>();
+        if (configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG) != null) {
+            files.add(Paths.get((String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG)));
+        }
+        if (configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG) != null) {
+            files.add(Paths.get((String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG)));
+        }
+        if (files.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "At least one of ssl.keystore.location or ssl.truststore.location must be set");
+        }
+
+        this.files = files.stream()
+                .map(f -> Objects.requireNonNull(f, "file path must not be null"))
+                .collect(Collectors.toUnmodifiableList());
+
+        this.pollInterval = Duration.ofSeconds(ConfigUtils.getInt(
+                configs,
+                SslConfigs.SSL_HOT_RELOAD_POLL_INTERVAL_CONFIG,
+                SslConfigs.DEFAULT_SSL_HOT_RELOAD_POLL_INTERVAL_SECONDS));
+
+        int debounceSeconds = ConfigUtils.getInt(
+                configs,
+                SslConfigs.SSL_HOT_RELOAD_DEBOUNCE_CONFIG,
+                SslConfigs.DEFAULT_SSL_HOT_RELOAD_DEBOUNCE_SECONDS);
+        this.debounceDelay = Duration.ofSeconds(debounceSeconds);
+
+        this.lastModifiedTimes = new ConcurrentHashMap<>();
+
+        ThreadFactory tf = r -> {
+            Thread t = new Thread(r, "ssl-material-poller");
+            t.setDaemon(true);
+            return t;
+        };
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(tf);
+
+        log.debug("SslMaterialPoller created [files={}, pollInterval={}s, debounce={}s]",
+                this.files, pollInterval.toSeconds(), debounceDelay.toSeconds());
+    }
+
+    // -------------------------------------------------------------------------
+    // Listener management
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a listener to be called after the debounce period expires following a file change.
+     * Safe to call at any time, including before {@link #start()}.
+     */
+    public void addListener(Runnable listener) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        listeners.add(listener);
+        log.debug("Listener added [files={}, totalListeners={}]", files, listeners.size());
+    }
+
+    /**
+     * Removes a previously registered listener. Uses reference equality.
+     * No-op if the listener is not currently registered.
+     */
+    public void removeListener(Runnable listener) {
+        boolean removed = listeners.remove(listener);
+        if (removed) {
+            log.debug("Listener removed [files={}, totalListeners={}]", files, listeners.size());
+        }
+    }
+
+    /** Returns the current number of registered listeners. Intended for testing. */
+    public int listenerCount() {
+        return listeners.size();
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Starts the poller. Safe to call multiple times; the scheduling task is only registered once.
+     */
+    public void start() {
+        if (!started.compareAndSet(false, true)) {
+            log.debug("SslMaterialPoller already started for files {}", files);
+            return;
+        }
+
+        log.debug("Starting SslMaterialPoller for files {}", files);
+
+        for (Path file : files) {
+            try {
+                if (Files.exists(file)) {
+                    FileTime lastModified = Files.getLastModifiedTime(file);
+                    lastModifiedTimes.put(file, lastModified);
+                    log.debug("Initial lastModified for {} is {}", file, lastModified);
+                } else {
+                    log.debug("Watched file {} does not exist at startup", file);
+                }
+            } catch (IOException e) {
+                log.debug("Failed to read initial lastModified for {}", file, e);
+                lastModifiedTimes.put(file, FileTime.fromMillis(0));
+            }
+        }
+
+        scheduler.scheduleAtFixedRate(
+                this::poll,
+                pollInterval.toMillis(),
+                pollInterval.toMillis(),
+                TimeUnit.MILLISECONDS);
+
+        log.debug("SslMaterialPoller scheduled [rate={}ms, debounce={}ms]",
+                pollInterval.toMillis(), debounceDelay.toMillis());
+    }
+
+    /**
+     * Stops the poller and shuts down the underlying scheduler. Any pending debounce task is
+     * cancelled. Safe to call multiple times.
+     */
+    public void stop() {
+        if (!started.compareAndSet(true, false)) {
+            log.debug("SslMaterialPoller not running (or already stopped) for files {}", files);
+        } else {
+            log.debug("Stopping SslMaterialPoller for files {}", files);
+        }
+        scheduler.shutdownNow();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    /**
+     * Called by the scheduler at every poll interval. Detects whether any watched file has been
+     * modified since the last check. If a change is found and debouncing is enabled, schedules
+     * (or reschedules) a one-shot notification task. If debouncing is disabled, notifies
+     * listeners immediately.
+     *
+     * <p>All interactions with {@code pendingDebounce} happen on the single scheduler thread,
+     * so no additional synchronization is needed for that field.
+     */
+    private void poll() {
+        log.debug("Polling files {}", files);
+
+        boolean changeDetected = false;
+
+        for (Path file : files) {
+            try {
+                if (!Files.exists(file)) {
+                    log.debug("File {} does not exist, skipping", file);
+                    continue;
+                }
+
+                FileTime current = Files.getLastModifiedTime(file);
+                FileTime previous = lastModifiedTimes.get(file);
+
+                if (previous == null) {
+                    log.debug("No previous lastModified for {}, recording {}", file, current);
+                    lastModifiedTimes.put(file, current);
+                    continue;
+                }
+
+                if (current.compareTo(previous) > 0) {
+                    log.debug("Change detected for {} ({} -> {})", file, previous, current);
+                    lastModifiedTimes.put(file, current);
+                    changeDetected = true;
+                    break; // one change is enough to launch the debounce; remaining files checked next cycle
+                }
+
+            } catch (IOException e) {
+                log.debug("IOException while polling {}", file, e);
+            } catch (RuntimeException e) {
+                log.debug("Unexpected error while polling {}", file, e);
+            }
+        }
+
+        if (!changeDetected) {
+            log.trace("No changes detected");
+            return;
+        }
+
+        if (debounceDelay.isZero() || files.size() == 1 ) {
+            // Debouncing disabled so we notify immediately.
+            log.debug("Change detected, debounce disabled - notifying listeners immediately");
+            notifyListeners();
+        } else {
+            scheduleOrResetDebounce();
+        }
+    }
+
+    /**
+     * Cancels any pending debounce task and schedules a fresh one. Only ever called from the
+     * single scheduler thread, so {@code pendingDebounce} needs no additional lock.
+     */
+    private void scheduleOrResetDebounce() {
+        if (pendingDebounce != null && !pendingDebounce.isDone()) {
+            pendingDebounce.cancel(false);
+            log.debug("Debounce timer reset (new change detected within window) [debounce={}ms]",
+                    debounceDelay.toMillis());
+        } else {
+            log.debug("Debounce timer armed [debounce={}ms]", debounceDelay.toMillis());
+        }
+
+        // Schedule a one-shot task on the same single-threaded scheduler so notifyListeners()
+        // always runs on the poller thread, consistent with the no-debounce path.
+        pendingDebounce = scheduler.schedule(
+                this::notifyListeners,
+                debounceDelay.toMillis(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    /** Invokes all registered listeners, isolating each from exceptions thrown by others. */
+    private void notifyListeners() {
+        log.debug("Notifying {} listener(s)", listeners.size());
+        for (Runnable listener : listeners) {
+            try {
+                listener.run();
+            } catch (RuntimeException e) {
+                // Protect the scheduler thread and other listeners from a misbehaving one.
+                log.warn("onChange listener threw an exception", e);
+            }
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslMaterialPollerRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslMaterialPollerRegistry.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.utils.ConfigUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A process-wide registry that ensures at most one {@link SslMaterialPoller} is created per
+ * unique set of SSL material paths + poll interval.
+ *
+ * <h3>Motivation</h3>
+ * A Kafka application typically configures SSL once, yet may create many consumers/producers,
+ * each owning its own {@link SslFactory}. Without sharing, each factory would spawn its own
+ * polling thread watching the same files — wasteful and noisy.
+ * The registry solves this by deduplicating pollers: factories that share the same SSL paths
+ * subscribe to the same underlying poller, while factories with distinct paths (e.g., connecting
+ * to different clusters with different certificates) receive independent pollers.
+ *
+ * <h3>Lifecycle</h3>
+ * A poller is started when its first subscriber registers and stopped (and removed from the
+ * registry) when its last subscriber deregisters. All operations are synchronized on the registry
+ * instance itself; this is intentionally coarse-grained since registration/deregistration are
+ * infrequent operations.
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ * // In SslFactory#configure():
+ * this.onSslMaterialChange = () -> reconfigure(this.sslEngineFactoryConfig);
+ * SslMaterialPollerRegistry.getInstance().register(configs, this.onSslMaterialChange);
+ *
+ * // In SslFactory#close():
+ * SslMaterialPollerRegistry.getInstance().deregister(configs, this.onSslMaterialChange);
+ * }</pre>
+ */
+public final class SslMaterialPollerRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(SslMaterialPollerRegistry.class);
+
+    private static final class Holder {
+        static final SslMaterialPollerRegistry INSTANCE = new SslMaterialPollerRegistry();
+    }
+
+    public static SslMaterialPollerRegistry getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    // -------------------------------------------------------------------------
+    // Registry key
+    // -------------------------------------------------------------------------
+
+    /**
+     * Identifies a unique poller by the exact set of files it watches and its poll interval.
+     * Two {@link SslFactory} instances are eligible to share a poller iff their keys are equal.
+     */
+    static final class PollerKey {
+        private final String keystorePath;    // nullable
+        private final String truststorePath;  // nullable
+        private final int pollIntervalSeconds;
+        private final int debounceSeconds;
+
+        PollerKey(Map<String, Object> configs) {
+            this.keystorePath = (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+            this.truststorePath = (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+            this.pollIntervalSeconds = ConfigUtils.getInt(
+                    configs,
+                    SslConfigs.SSL_HOT_RELOAD_POLL_INTERVAL_CONFIG,
+                    SslConfigs.DEFAULT_SSL_HOT_RELOAD_POLL_INTERVAL_SECONDS);
+            this.debounceSeconds = ConfigUtils.getInt(
+                    configs,
+                    SslConfigs.SSL_HOT_RELOAD_DEBOUNCE_CONFIG,
+                    SslConfigs.DEFAULT_SSL_HOT_RELOAD_DEBOUNCE_SECONDS);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof PollerKey)) return false;
+            PollerKey other = (PollerKey) o;
+            return pollIntervalSeconds == other.pollIntervalSeconds
+                    && debounceSeconds == other.debounceSeconds
+                    && Objects.equals(keystorePath, other.keystorePath)
+                    && Objects.equals(truststorePath, other.truststorePath);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(keystorePath, truststorePath, pollIntervalSeconds, debounceSeconds);
+        }
+
+        @Override
+        public String toString() {
+            return "PollerKey{keystore=" + keystorePath
+                    + ", truststore=" + truststorePath
+                    + ", pollInterval=" + pollIntervalSeconds + "s"
+                    + ", debounce=" + debounceSeconds + "s}";
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal entry (poller + its active listeners)
+    // -------------------------------------------------------------------------
+
+    private static final class PollerEntry {
+        final SslMaterialPoller poller;
+
+        PollerEntry(Map<String, Object> configs) {
+            this.poller = new SslMaterialPoller(configs);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /**
+     * Guarded by {@code this}. Plain HashMap is fine since all access is synchronized.
+     * Using a HashMap rather than ConcurrentHashMap because the register/deregister
+     * operations need a compound check-then-act that must be atomic.
+     */
+    private final Map<PollerKey, PollerEntry> entries = new HashMap<>();
+
+    private SslMaterialPollerRegistry() {
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers {@code listener} as a subscriber for the SSL material paths described in
+     * {@code configs}. If a poller for the same paths and interval already exists it is reused;
+     * otherwise a new one is created and started.
+     *
+     * @param configs  Kafka SSL configuration map (read-only).
+     * @param listener Callback invoked when a watched file changes. The caller must keep a
+     *                 reference to the exact same {@code Runnable} instance to pass to
+     *                 {@link #deregister} later.
+     */
+    public synchronized void register(Map<String, Object> configs, Runnable listener) {
+        Objects.requireNonNull(configs, "configs must not be null");
+        Objects.requireNonNull(listener, "listener must not be null");
+
+        PollerKey key = new PollerKey(configs);
+        PollerEntry entry = entries.computeIfAbsent(key, k -> {
+            log.debug("Creating new SslMaterialPoller for {}", k);
+            PollerEntry newEntry = new PollerEntry(configs);
+            newEntry.poller.start();
+            return newEntry;
+        });
+
+        entry.poller.addListener(listener);
+        log.debug("Registered SSL material listener [key={}, totalListeners={}]",
+                key, entry.poller.listenerCount());
+    }
+
+    /**
+     * Removes {@code listener} from the poller identified by {@code configs}.
+     * If this was the last listener for that poller, the poller is stopped and removed
+     * from the registry, freeing its polling thread.
+     *
+     * <p>Uses reference equality to find the listener — pass the exact same {@code Runnable}
+     * instance that was given to {@link #register}.
+     *
+     * @param configs  Kafka SSL configuration map (same as the one used in {@link #register}).
+     * @param listener The exact listener instance previously passed to {@link #register}.
+     */
+    public synchronized void deregister(Map<String, Object> configs, Runnable listener) {
+        Objects.requireNonNull(configs, "configs must not be null");
+        Objects.requireNonNull(listener, "listener must not be null");
+
+        PollerKey key = new PollerKey(configs);
+        PollerEntry entry = entries.get(key);
+        if (entry == null) {
+            log.debug("deregister called for unknown key {}, nothing to do", key);
+            return;
+        }
+
+        entry.poller.removeListener(listener);
+        log.debug("Deregistered SSL material listener [key={}, remainingListeners={}]",
+                key, entry.poller.listenerCount());
+
+        if (entry.poller.listenerCount() == 0) {
+            log.debug("No more listeners for {}, stopping and removing poller", key);
+            entry.poller.stop();
+            entries.remove(key);
+        }
+    }
+
+    /**
+     * Returns the number of active pollers in the registry. Intended for testing.
+     */
+    synchronized int pollerCount() {
+        return entries.size();
+    }
+
+    /**
+     * Returns the number of listeners registered against the poller for the given config,
+     * or {@code 0} if no such poller exists. Intended for testing.
+     */
+    synchronized int listenerCount(Map<String, Object> configs) {
+        PollerKey key = new PollerKey(configs);
+        PollerEntry entry = entries.get(key);
+        return entry == null ? 0 : entry.poller.listenerCount();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/ConfigUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ConfigUtils.java
@@ -80,4 +80,36 @@ public class ConfigUtils {
             return defaultValue;
         }
     }
+
+    /**
+     * Finds and returns an integer configuration option from the configuration map
+     * or the default value if the option is not set.
+     *
+     * @param configs Map with the configuration options
+     * @param key Configuration option for which the integer value will be returned
+     * @param defaultValue The default value that will be used when the key is not present
+     * @return An integer value of the configuration option or the default value
+     */
+    public static int getInt(final Map<String, Object> configs,
+                             final String key,
+                             final int defaultValue) {
+
+        final Object value = configs.getOrDefault(key, defaultValue);
+
+        if (value instanceof Integer) {
+            return (Integer) value;
+        } else if (value instanceof String) {
+            try {
+                return Integer.parseInt((String) value);
+            } catch (NumberFormatException e) {
+                log.error("Invalid integer value ({}) on configuration '{}'. The default value '{}' will be used instead.",
+                        value, key, defaultValue);
+                return defaultValue;
+            }
+        } else {
+            log.error("Invalid value ({}) on configuration '{}'. The default value '{}' will be used instead. Please specify an integer value.",
+                    value, key, defaultValue);
+            return defaultValue;
+        }
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -607,6 +607,274 @@ public abstract class SslFactoryTest {
         return store.get();
     }
 
+
+    @Test
+    public void testFileChangeTriggersReconfigure() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)
+                .sslHotReloadDebounce(0)  // disabled
+                .build();
+
+        try (SslFactory sslFactory = new SslFactory(ConnectionMode.SERVER, null, true)) {
+            sslFactory.configure(serverSslConfig);
+            SslEngineFactory sslEngineFactory = sslFactory.sslEngineFactory();
+
+            trustStoreFile.setLastModified(System.currentTimeMillis() + 10000);
+            Thread.sleep(3000);
+
+            assertNotSame(sslEngineFactory, sslFactory.sslEngineFactory(),
+                    "SslEngineFactory not recreated");
+        }
+    }
+
+    @Test
+    public void testNoReloadWhenHotReloadDisabled() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(false)
+                .build();
+
+        try (SslFactory sslFactory = new SslFactory(ConnectionMode.SERVER, null, true)) {
+            sslFactory.configure(serverSslConfig);
+            SslEngineFactory original = sslFactory.sslEngineFactory();
+
+            trustStoreFile.setLastModified(System.currentTimeMillis() + 10000);
+            Thread.sleep(3000);
+
+            assertSame(original, sslFactory.sslEngineFactory(),
+                    "SslEngineFactory should not be recreated when hot reload is disabled");
+        }
+    }
+
+    @Test
+    public void testNoReloadIfFileUnchanged() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+        Map<String, Object> config = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)
+                .sslHotReloadDebounce(0)  // disabled
+                .build();
+
+        try (SslFactory sslFactory = new SslFactory(ConnectionMode.SERVER, null, true)) {
+            sslFactory.configure(config);
+            SslEngineFactory original = sslFactory.sslEngineFactory();
+
+            Thread.sleep(3000);
+
+            assertSame(original, sslFactory.sslEngineFactory(),
+                    "SslEngineFactory should not be recreated when file unchanged");
+        }
+    }
+
+    @Test
+    public void testMultipleFactoriesIsolatedReload() throws Exception {
+        // Two factories with distinct truststores → each gets its own poller entry.
+        File trustStoreFile1 = TestUtils.tempFile("truststore1", ".jks");
+        File trustStoreFile2 = TestUtils.tempFile("truststore2", ".jks");
+
+        Map<String, Object> config1 = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile1)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)
+                .sslHotReloadDebounce(0)  // disabled
+                .build();
+
+        Map<String, Object> config2 = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile2)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)
+                .sslHotReloadDebounce(0)  // disabled
+                .build();
+
+        try (SslFactory factory1 = new SslFactory(ConnectionMode.SERVER, null, true);
+             SslFactory factory2 = new SslFactory(ConnectionMode.SERVER, null, true)) {
+
+            factory1.configure(config1);
+            factory2.configure(config2);
+
+            SslEngineFactory original1 = factory1.sslEngineFactory();
+            SslEngineFactory original2 = factory2.sslEngineFactory();
+
+            // Modify only file1 → only factory1 should reload.
+            trustStoreFile1.setLastModified(System.currentTimeMillis() + 10000);
+            Thread.sleep(3000);
+
+            assertNotSame(original1, factory1.sslEngineFactory(),
+                    "Factory1 should reload after file1 change");
+            assertSame(original2, factory2.sslEngineFactory(),
+                    "Factory2 should NOT reload after file1 change");
+
+            SslEngineFactory afterFirstReload1 = factory1.sslEngineFactory();
+
+            // Modify only file2 → only factory2 should reload.
+            trustStoreFile2.setLastModified(System.currentTimeMillis() + 10000);
+            Thread.sleep(2000);
+
+            assertNotSame(original2, factory2.sslEngineFactory(),
+                    "Factory2 should reload after file2 change");
+            assertSame(afterFirstReload1, factory1.sslEngineFactory(),
+                    "Factory1 should NOT reload again after file2 change");
+        }
+    }
+
+    /**
+     * Two factories sharing identical SSL paths must reuse a single poller entry in the registry.
+     * This verifies the efficiency guarantee: only one polling thread for identical configurations.
+     */
+    @Test
+    public void testSharedPollerForIdenticalConfigs() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+
+        Map<String, Object> config = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)
+                .sslHotReloadDebounce(0)  // disabled
+                .build();
+
+        SslMaterialPollerRegistry registry = SslMaterialPollerRegistry.getInstance();
+
+        try (SslFactory factory1 = new SslFactory(ConnectionMode.SERVER, null, true);
+             SslFactory factory2 = new SslFactory(ConnectionMode.SERVER, null, true)) {
+
+            factory1.configure(config);
+            factory2.configure(config);
+
+            // Both factories share the same config → exactly one poller, two listeners.
+            assertEquals(1, registry.pollerCount(),
+                    "Registry should contain exactly one shared poller");
+            assertEquals(2, registry.listenerCount(config),
+                    "Shared poller should have two listeners");
+
+            // Both factories should reload when the file changes.
+            SslEngineFactory original1 = factory1.sslEngineFactory();
+            SslEngineFactory original2 = factory2.sslEngineFactory();
+
+            trustStoreFile.setLastModified(System.currentTimeMillis() + 10000);
+            Thread.sleep(3000);
+
+            assertNotSame(original1, factory1.sslEngineFactory(),
+                    "Factory1 should reload");
+            assertNotSame(original2, factory2.sslEngineFactory(),
+                    "Factory2 should reload");
+        }
+
+        // After both factories are closed, the registry must be empty again.
+        assertEquals(0, registry.pollerCount(),
+                "Registry should be empty after all factories are closed");
+    }
+
+    /**
+     * Closing a factory must deregister it from the registry. If it was the last subscriber,
+     * the poller is stopped and removed.
+     */
+    @Test
+    public void testRegistryCleanupOnFactoryClose() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+
+        Map<String, Object> config = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)
+                .sslHotReloadDebounce(0)  // disabled
+                .build();
+
+        SslMaterialPollerRegistry registry = SslMaterialPollerRegistry.getInstance();
+
+        SslFactory factory = new SslFactory(ConnectionMode.SERVER, null, true);
+        factory.configure(config);
+
+        assertEquals(1, registry.pollerCount(), "Poller should be registered");
+
+        factory.close();
+
+        assertEquals(0, registry.pollerCount(),
+                "Registry should be empty after the sole factory is closed");
+    }
+
+    /**
+     * With debouncing enabled, updating both files within the debounce window must produce
+     * exactly one reload, not two.
+     */
+    @Test
+    public void testDebounceCoalescesRapidUpdatesIntoSingleReload() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+
+        Map<String, Object> config = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(1)   // poll every 1 s
+                .sslHotReloadDebounce(3)        // notify 3 s after last change
+                .build();
+
+        File keystoreFile = new File(config.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG).toString());
+
+        try (SslFactory sslFactory = new SslFactory(ConnectionMode.SERVER, null, true)) {
+            sslFactory.configure(config);
+            SslEngineFactory original = sslFactory.sslEngineFactory();
+
+            // Simulate operator updating keystore then truststore 1 s apart.
+            keystoreFile.setLastModified(System.currentTimeMillis() + 10_000);
+            Thread.sleep(1500); // poller fires, detects keystore change, arms debounce for 3 s
+            trustStoreFile.setLastModified(System.currentTimeMillis() + 10_000);
+            // poller fires again, detects truststore change, resets debounce for 3 s
+
+            // Wait for debounce to expire (3 s) + poll margin (1 s) + buffer (1 s)
+            Thread.sleep(5000);
+
+            assertNotSame(original, sslFactory.sslEngineFactory(),
+                    "SslEngineFactory should have been reloaded after both files changed");
+        }
+    }
+
+    /**
+     * A change detected just before the debounce expires must reset the timer, so listeners
+     * are not called until the full debounce window has passed since the *last* change.
+     */
+    @Test
+    public void testDebounceTimerResetsOnSubsequentChange() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+
+        int debounceSeconds = 4;
+        int pollSeconds     = 1;
+
+        Map<String, Object> config = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .sslHotReload(true)
+                .sslHotReloadPollInterval(pollSeconds)
+                .sslHotReloadDebounce(debounceSeconds)
+                .build();
+
+        File keystoreFile = new File(config.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG).toString());
+
+        try (SslFactory sslFactory = new SslFactory(ConnectionMode.SERVER, null, true)) {
+            sslFactory.configure(config);
+            SslEngineFactory original = sslFactory.sslEngineFactory();
+
+            // t=0: keystore changes → debounce armed for 4 s
+            keystoreFile.setLastModified(System.currentTimeMillis() + 10_000);
+
+            // t=3s: truststore changes within debounce window → timer reset to t+4=7 s
+            Thread.sleep(3000);
+            trustStoreFile.setLastModified(System.currentTimeMillis() + 10_000);
+
+            // t=5s: debounce has NOT expired yet (was reset to t=7) → no reload expected
+            Thread.sleep(2000);
+            assertSame(original, sslFactory.sslEngineFactory(),
+                    "SslEngineFactory must NOT reload before debounce expires after timer reset");
+
+            // t=9s: debounce window (4 s after last change at t=3s) has now expired
+            Thread.sleep(4000);
+            assertNotSame(original, sslFactory.sslEngineFactory(),
+                    "SslEngineFactory must reload after debounce expires");
+        }
+    }
+
     private TestSslUtils.SslConfigsBuilder sslConfigsBuilder(ConnectionMode connectionMode) {
         return new TestSslUtils.SslConfigsBuilder(connectionMode).tlsProtocol(tlsProtocol);
     }

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -588,6 +588,9 @@ public class TestSslUtils {
         String algorithm;
         CertificateBuilder certBuilder;
         boolean usePem;
+        boolean sslHotReload;
+        int sslHotReloadPollInterval;
+        int debounceDelaySeconds;
 
         public SslConfigsBuilder(ConnectionMode connectionMode) {
             this.connectionMode = connectionMode;
@@ -600,6 +603,9 @@ public class TestSslUtils {
             this.certAlias = connectionMode.name().toLowerCase(Locale.ROOT);
             this.algorithm = "RSA";
             this.createTrustStore = true;
+            this.sslHotReload = false;
+            this.sslHotReloadPollInterval = SslConfigs.DEFAULT_SSL_HOT_RELOAD_POLL_INTERVAL_SECONDS;
+            this.debounceDelaySeconds = SslConfigs.DEFAULT_SSL_HOT_RELOAD_DEBOUNCE_SECONDS;
         }
 
         public SslConfigsBuilder tlsProtocol(String tlsProtocol) {
@@ -646,6 +652,21 @@ public class TestSslUtils {
 
         public SslConfigsBuilder usePem(boolean usePem) {
             this.usePem = usePem;
+            return this;
+        }
+
+        public SslConfigsBuilder sslHotReload(boolean sslHotReload) {
+            this.sslHotReload = sslHotReload;
+            return this;
+        }
+
+        public SslConfigsBuilder sslHotReloadPollInterval(int sslHotReloadPollInterval) {
+            this.sslHotReloadPollInterval = sslHotReloadPollInterval;
+            return this;
+        }
+
+        public SslConfigsBuilder sslHotReloadDebounce(int debounceDelaySeconds) {
+            this.debounceDelaySeconds = debounceDelaySeconds;
             return this;
         }
 
@@ -701,6 +722,10 @@ public class TestSslUtils {
             List<String> enabledProtocols  = new ArrayList<>();
             enabledProtocols.add(tlsProtocol);
             sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
+
+            sslConfigs.put(SslConfigs.SSL_HOT_RELOAD_ENABLE_CONFIG, sslHotReload);
+            sslConfigs.put(SslConfigs.SSL_HOT_RELOAD_POLL_INTERVAL_CONFIG, sslHotReloadPollInterval);
+            sslConfigs.put(SslConfigs.SSL_HOT_RELOAD_DEBOUNCE_CONFIG, debounceDelaySeconds);
 
             return sslConfigs;
         }


### PR DESCRIPTION
This PR introduces support for SSL hot reload in the Kafka client.

This feature has been requested since 2020 in KAFKA-10731

See [KIP-1288](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1288%3A+SSL+Hot+Reload+for+Kafka+Clients), for full details.

## New Configuration Properties

- `ssl.hotreload.enable`
Enables or disables the hot reload mechanism.
Default: false (to preserve backward compatibility).
- `ssl.hotreload.poll.interval.seconds`
Polling interval in seconds used to detect material changes.
Default: 60.
- `ssl.hotreload.debounce.seconds`
How long the poller waits after detecting the first file change before notifying listeners. If another file changes within this window, the timer resets. Set to 0 to disable debouncing and reload immediately on the first change.
Default: 5