### PR TITLE
KAFKA-20131: Clear end-offset request flag after failed list-offsets

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -1162,6 +1162,7 @@ public class SubscriptionState {
 
         private void requestFailed(long nextAllowedRetryTimeMs) {
             this.nextRetryTimeMs = nextAllowedRetryTimeMs;
+            this.endOffsetRequested = false;
         }
 
         private boolean hasValidPosition() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -1059,6 +1059,18 @@ public class SubscriptionStateTest {
     }
 
     @Test
+    public void testRequestFailedClearsEndOffsetRequested() {
+        state.assignFromUser(Set.of(tp0));
+        assertFalse(state.partitionEndOffsetRequested(tp0));
+
+        state.requestPartitionEndOffset(tp0);
+        assertTrue(state.partitionEndOffsetRequested(tp0));
+
+        state.requestFailed(Set.of(tp0), 1234L);
+        assertFalse(state.partitionEndOffsetRequested(tp0));
+    }
+
+    @Test
     public void testPositionOrNull() {
         state.assignFromUser(Set.of(tp0));
         final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);


### PR DESCRIPTION
Fixes KAFKA-20131.

When ListOffsets fails while currentLag() is trying to fetch the end offset, the partition state kept endOffsetRequested=true. That prevented subsequent currentLag() calls from issuing another ListOffsets request.

This patch clears endOffsetRequested on request failure so retries can proceed, and adds a focused unit test in SubscriptionStateTest.