### PR TITLE
MINOR: Fix lost custom error message in CoordinatorPartitionWriter#append

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
@@ -159,7 +159,7 @@ class CoordinatorPartitionWriter(
       throw new IllegalStateException(s"Append status $appendResults should have partition $tp."))
 
     if (partitionResult.error != Errors.NONE) {
-      throw partitionResult.error.exception()
+      throw partitionResult.error.exception(partitionResult.errorMessage)
     }
 
     // Required offset.


### PR DESCRIPTION
Ensure custom error message is not lost in
`CoordinatorPartitionWriter#append` when throwing exception from
`LogAppendResult`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
