### PR TITLE
KAFKA-20152: Remove unused CoordinatorMetrics#registry

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorMetrics.java
@@ -21,7 +21,6 @@ import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import com.yammer.metrics.core.MetricName;
-import com.yammer.metrics.core.MetricsRegistry;
 
 /**
  * CoordinatorMetrics contain all coordinator related metrics. It delegates metrics collection to
@@ -51,11 +50,6 @@ public abstract class CoordinatorMetrics {
      * @param shard  The metrics shard.
      */
     public abstract void deactivateMetricsShard(CoordinatorMetricsShard shard);
-
-    /**
-     * @return The metrics registry.
-     */
-    public abstract MetricsRegistry registry();
 
     /**
      * Generate the Yammer MetricName.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -423,11 +423,6 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     }
 
     @Override
-    public MetricsRegistry registry() {
-        return this.registry;
-    }
-
-    @Override
     public void onUpdateLastCommittedOffset(TopicPartition tp, long offset) {
         CoordinatorMetricsShard shard = shards.get(tp);
         if (shard != null) {

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -29,8 +29,6 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorMetrics;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetricsShard;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
-import com.yammer.metrics.core.MetricsRegistry;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -117,13 +115,6 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             throw new IllegalArgumentException("ShareCoordinatorMetrics can only deactivate ShareCoordinatorMetricShard");
         }
         shards.remove(shard.topicPartition());
-    }
-
-    @Override
-    public MetricsRegistry registry() {
-        // we are not using MetricsRegistry in share coordinator
-        // but this method is part for implemented interface
-        return null;
     }
 
     @Override


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/KAFKA-20152

These methods are currently unused, and we should remove them.

Reviewers: David Jacot <djacot@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
