### PR TITLE
Add test scale up controller with "initial controllers" formatting

### DIFF
--- a/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
@@ -368,16 +368,12 @@ public class ReconfigurableQuorumIntegrationTest {
                 .setInitialVoterSet(initialThreeVoters)
                 .build()
         ) {
-            // doesn't work because cluster.format() formats all 4 controllers and cluster.startup() starts all 4 controllers
-            // cluster.format();
-            // cluster.startup();
-
             // manually format only first 3 controllers + all brokers
             // This leaves controller 3003 unformatted for later scale-up simulation
 
             // Format first 3 controllers with initial voter set
             for (int id : new int[]{3000, 3001, 3002}) {
-                cluster.formatController(id, initialThreeVoters); // formatController is a newly added method
+                cluster.formatController(id, initialThreeVoters);
             }
 
             // Format all brokers
@@ -415,10 +411,6 @@ public class ReconfigurableQuorumIntegrationTest {
                             "Quorum should have a stable leader from initial 3 controllers");
                 });
 
-                // Given all the above checks, the cluster should be stable and the quorum formed
-                // Give the initial cluster more time to stabilize (the following should not be needed)
-                // Thread.sleep(5000);
-
                 // Scale-up a new controller, format 4th controller with all 4 in voter set
                 // This simulates formatting a new controller with -I containing all controllers
                 final Map<Integer, Uuid> allFourVoters = new HashMap<>(initialThreeVoters);
@@ -444,9 +436,6 @@ public class ReconfigurableQuorumIntegrationTest {
                     assertEquals(Set.of(3000, 3001, 3002), voters.keySet(),
                             "Controller 3003 should NOT be in active quorum yet despite being formatted with all 4 in voter set");
                 });
-
-                // UP TO HERE everything seems to be ok then trying to add the new controller makes the test failing
-                // with nodes disconnections and more
 
                 int port = cluster.controllers().get(3003).socketServer().boundPort(new ListenerName("CONTROLLER"));
                 // Add 4th controller to active quorum via add-controller command

--- a/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.admin.RaftVoterEndpoint;
 import org.apache.kafka.clients.admin.RemoveRaftVoterOptions;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InconsistentClusterIdException;
+import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
 import org.apache.kafka.common.test.api.TestKitDefaults;
@@ -447,11 +448,12 @@ public class ReconfigurableQuorumIntegrationTest {
                 // UP TO HERE everything seems to be ok then trying to add the new controller makes the test failing
                 // with nodes disconnections and more
 
+                int port = cluster.controllers().get(3003).socketServer().boundPort(new ListenerName("CONTROLLER"));
                 // Add 4th controller to active quorum via add-controller command
                 admin.addRaftVoter(
-                        3003,
-                        nodes.controllerNodes().get(3003).metadataDirectoryId(),
-                        Set.of(new RaftVoterEndpoint("CONTROLLER", "example.com", 8080))
+                    3003,
+                    nodes.controllerNodes().get(3003).metadataDirectoryId(),
+                    Set.of(new RaftVoterEndpoint("CONTROLLER", "localhost", port))
                 ).all().get();
 
                 // Verify all 4 controllers are now in the active quorum

--- a/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
@@ -341,6 +341,142 @@ public class ReconfigurableQuorumIntegrationTest {
         }
     }
 
+    @Test
+    public void testAddNewControllerFormattedWithFullVoterSet() throws Exception {
+        // The test tries to validate that even in case of scale up, the new controller can be formatted with -I with all voters
+        // 1. Initial cluster: format 3 controllers with -I "0,1,2"
+        // 2. Start those 3 controllers so active quorum [0,1,2]
+        // 3. Scale up: format a new 4th controller with -I "0,1,2,3" (includes all)
+        // 4. Start the 4th controller so it's an observer (local voter set != active quorum)
+        // 5. Run add-controller so now active quorum has [0,1,2,3]
+
+        final var nodes = new TestKitNodes.Builder()
+                .setNumBrokerNodes(3)
+                // even if the cluster has 3 controllers at the beginning, setting 4 because TestKitNodes is immutable
+                // and when building the cluster instance it leverages the controller nodes configured here
+                .setNumControllerNodes(4)
+                .build();
+
+        // Initial voter set, only first 3 controllers
+        final Map<Integer, Uuid> initialThreeVoters = new HashMap<>();
+        for (int id : new int[]{3000, 3001, 3002}) {
+            initialThreeVoters.put(id, nodes.controllerNodes().get(id).metadataDirectoryId());
+        }
+
+        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(nodes)
+                .setInitialVoterSet(initialThreeVoters)
+                .build()
+        ) {
+            // doesn't work because cluster.format() formats all 4 controllers and cluster.startup() starts all 4 controllers
+            // cluster.format();
+            // cluster.startup();
+
+            // manually format only first 3 controllers + all brokers
+            // This leaves controller 3003 unformatted for later scale-up simulation
+
+            // Format first 3 controllers with initial voter set
+            for (int id : new int[]{3000, 3001, 3002}) {
+                cluster.formatController(id, initialThreeVoters); // formatController is a newly added method
+            }
+
+            // Format all brokers
+            for (int brokerId : cluster.brokers().keySet()) {
+                cluster.formatBroker(brokerId);
+            }
+
+            // Start only the formatted nodes (3 controllers + all brokers)
+            for (int id : new int[]{3000, 3001, 3002}) {
+                cluster.controllers().get(id).startup();
+            }
+            for (var broker : cluster.brokers().values()) {
+                broker.startup();
+            }
+
+            try (var admin = cluster.admin()) {
+                // Verify initial 3-controller quorum
+                retryOnExceptionWithTimeout(30_000, 10, () -> {
+                    Map<Integer, Uuid> voters = findVoterDirs(admin);
+                    assertEquals(Set.of(3000, 3001, 3002), voters.keySet(),
+                            "Initial quorum should only have 3 controllers");
+                    for (int replicaId : new int[]{3000, 3001, 3002}) {
+                        assertEquals(
+                                nodes.controllerNodes().get(replicaId).metadataDirectoryId(),
+                                voters.get(replicaId),
+                                "Directory ID should match for controller " + replicaId
+                        );
+                    }
+                });
+
+                // Ensure quorum has a stable leader before proceeding
+                retryOnExceptionWithTimeout(30_000, 10, () -> {
+                    QuorumInfo quorumInfo = admin.describeMetadataQuorum().quorumInfo().get();
+                    assertTrue(quorumInfo.leaderId() >= 3000 && quorumInfo.leaderId() <= 3002,
+                            "Quorum should have a stable leader from initial 3 controllers");
+                });
+
+                // Given all the above checks, the cluster should be stable and the quorum formed
+                // Give the initial cluster more time to stabilize (the following should not be needed)
+                // Thread.sleep(5000);
+
+                // Scale-up a new controller, format 4th controller with all 4 in voter set
+                // This simulates formatting a new controller with -I containing all controllers
+                final Map<Integer, Uuid> allFourVoters = new HashMap<>(initialThreeVoters);
+                allFourVoters.put(3003, nodes.controllerNodes().get(3003).metadataDirectoryId());
+
+                cluster.formatController(3003, allFourVoters);
+
+                // Start the 4th controller
+                cluster.controllers().get(3003).startup();
+
+                // Verify the quorum is stable with 3 voters and 4 observers (3 brokers + controller 3003)
+                // This also implicitly verifies controller 3003 is running and connected
+                retryOnExceptionWithTimeout(60_000, 10, () -> {
+                    QuorumInfo quorumInfo = admin.describeMetadataQuorum().quorumInfo().get();
+                    assertEquals(3, quorumInfo.voters().size(), "Should have 3 voters");
+                    assertEquals(4, quorumInfo.observers().size(), "Should have 4 observers (3 brokers + controller 3003)");
+                    assertTrue(quorumInfo.leaderId() >= 3000 && quorumInfo.leaderId() <= 3002,
+                            "Leader should be one of the 3 initial controllers");
+                    assertTrue(quorumInfo.observers().stream()
+                            .anyMatch(o -> o.replicaId() == 3003), "Controller 3003 should be an observer");
+                    Map<Integer, Uuid> voters = findVoterDirs(admin);
+                    // IMPORTANT!!! formatting with -I all doesn't auto-add to quorum
+                    assertEquals(Set.of(3000, 3001, 3002), voters.keySet(),
+                            "Controller 3003 should NOT be in active quorum yet despite being formatted with all 4 in voter set");
+                });
+
+                // UP TO HERE everything seems to be ok then trying to add the new controller makes the test failing
+                // with nodes disconnections and more
+
+                // Add 4th controller to active quorum via add-controller command
+                admin.addRaftVoter(
+                        3003,
+                        nodes.controllerNodes().get(3003).metadataDirectoryId(),
+                        Set.of(new RaftVoterEndpoint("CONTROLLER", "example.com", 8080))
+                ).all().get();
+
+                // Verify all 4 controllers are now in the active quorum
+                retryOnExceptionWithTimeout(30_000, 10, () -> {
+                    Map<Integer, Uuid> voters = findVoterDirs(admin);
+                    assertEquals(Set.of(3000, 3001, 3002, 3003), voters.keySet(),
+                            "All 4 controllers should be in active quorum after add-controller");
+                    for (int replicaId : new int[]{3000, 3001, 3002, 3003}) {
+                        assertEquals(
+                                nodes.controllerNodes().get(replicaId).metadataDirectoryId(),
+                                voters.get(replicaId),
+                                "Directory ID should match for controller " + replicaId
+                        );
+                    }
+                });
+
+                // Validate quorum health
+                QuorumInfo quorumInfo = admin.describeMetadataQuorum().quorumInfo().get();
+                assertEquals(4, quorumInfo.voters().size(), "Should have 4 voters");
+                assertTrue(quorumInfo.leaderId() >= 3000 && quorumInfo.leaderId() <= 3003,
+                        "Leader should be one of the 4 controllers");
+            }
+        }
+    }
+
     private static int port(Admin admin, int nodeId) throws Exception {
         return admin.describeMetadataQuorum().quorumInfo().get().nodes().get(nodeId).endpoints().stream()
             .findFirst().orElseThrow().port();

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
@@ -60,15 +60,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.*;
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -519,6 +513,82 @@ public class KafkaClusterTestKit implements AutoCloseable {
         } catch (Exception e) {
             throw new RuntimeException("Failed to format node " + ensemble.nodeId(), e);
         }
+    }
+
+    /**
+     * Format a single controller with optional initial voter set.
+     * Useful for testing scale-up scenarios where a new controller is formatted after the initial cluster is already running.
+     * MOSTLY COPIED FROM THE PRIVATE formatNode but allowing to pass a specific controller and voterSet
+     *
+     * @param controllerId The ID of the controller to format
+     * @param voterSet The voter set to use for formatting. If null, formats with --no-initial-controllers.
+     *                 If provided, formats with --initial-controllers containing the specified voters.
+     * @throws Exception if formatting fails
+     */
+    public void formatController(int controllerId, Map<Integer, Uuid> voterSet) throws Exception {
+        try {
+            ControllerServer controller = controllers.get(controllerId);
+            if (controller == null) {
+                throw new IllegalArgumentException("Controller " + controllerId + " not found");
+            }
+
+            MetaPropertiesEnsemble ensemble = controller.sharedServer().metaPropsEnsemble();
+            Formatter formatter = new Formatter();
+            formatter.setNodeId(controllerId);
+            formatter.setClusterId(ensemble.clusterId().get());
+            formatter.setDirectories(ensemble.logDirProps().keySet());
+            if (formatter.directories().isEmpty()) {
+                return;
+            }
+            formatter.setReleaseVersion(nodes.bootstrapMetadata().metadataVersion());
+            formatter.setUnstableFeatureVersionsEnabled(true);
+            formatter.setIgnoreFormatted(false);
+            formatter.setControllerListenerName(controllerListenerName);
+            formatter.setMetadataLogDirectory(ensemble.metadataLogDir().get());
+
+            // Set dynamic quorum mode
+            formatter.setHasDynamicQuorum(true);
+
+            // Handle voter set: null means --no-initial-controllers (-N)
+            if (voterSet != null && !voterSet.isEmpty()) {
+                StringBuilder dynamicVotersBuilder = new StringBuilder();
+                String prefix = "";
+                for (var controllerNode : voterSet.entrySet()) {
+                    final var voterId = controllerNode.getKey();
+                    final var voterDirectoryId = controllerNode.getValue();
+                    dynamicVotersBuilder.append(prefix);
+                    prefix = ",";
+                    dynamicVotersBuilder.append(String.format(
+                            "%d@localhost:%d:%s",
+                            voterId,
+                            socketFactoryManager.getOrCreatePortForListener(voterId, controllerListenerName),
+                            voterDirectoryId
+                    ));
+                }
+                formatter.setInitialControllers(DynamicVoters.parse(dynamicVotersBuilder.toString()));
+            }
+            // If voterSet is null, don't call setInitialControllers, which is equivalent to -N
+
+            formatter.run();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to format controller " + controllerId, e);
+        }
+    }
+
+    /**
+     * Format a single broker. Useful for testing scale-up scenarios.
+     *
+     * @param brokerId The broker ID to format
+     * @throws Exception if formatting fails
+     */
+    public void formatBroker(int brokerId) throws Exception {
+        BrokerServer broker = brokers.get(brokerId);
+        if (broker == null) {
+            throw new IllegalArgumentException("Broker " + brokerId + " not found");
+        }
+
+        MetaPropertiesEnsemble ensemble = broker.sharedServer().metaPropsEnsemble();
+        formatNode(ensemble);
     }
 
     public void startup() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
This PR adds an additional test to verify that the storage formatting of a new controller during a scale up operation works fine even when the `--initial-controllers` parameter is provided instead of the `--no-initial-controllers` one as documented.
It shows that a new cluster can be created with 3 controllers 3000, 3001, 3002 by formatting their storage with the initial controllers list as 3000, 3001, 3002. Then a new controller 3003 is added by formatting its storage with the full controllers list 3000, 3001, 3002, 3003. On start up, the new controller is able to get the current quorum by fetching metadata (and not using the local checkpoint file) but starting as observer only. A subsequent add Raft voter operation is needed to allow the new controller to join the quorum as expected.
