### PR TITLE
[WIP] KAFKA-20197: Headers support for StreamPartitioner

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
@@ -111,10 +111,10 @@ public class SessionWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
-    public byte[] serializeBaseKey(final String topic, final Windowed<T> data) {
+    public byte[] serializeBaseKey(final String topic, final Headers headers, final Windowed<T> data) {
         WindowedSerdes.verifyInnerSerializerNotNull(inner, this);
 
-        return inner.serialize(topic, data.key());
+        return inner.serialize(topic, headers, data.key());
     }
 
     // Only for testing

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
@@ -105,10 +106,10 @@ public class TimeWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
-    public byte[] serializeBaseKey(final String topic, final Windowed<T> data) {
+    public byte[] serializeBaseKey(final String topic, final Headers headers, final Windowed<T> data) {
         WindowedSerdes.verifyInnerSerializerNotNull(inner, this);
 
-        return inner.serialize(topic, data.key());
+        return inner.serialize(topic, headers, data.key());
     }
 
     // Only for testing

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
@@ -16,10 +16,11 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.kstream.Windowed;
 
 public interface WindowedSerializer<T> extends Serializer<Windowed<T>> {
 
-    byte[] serializeBaseKey(String topic, Windowed<T> data);
+    byte[] serializeBaseKey(String topic, Headers headers, Windowed<T> data);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -34,22 +34,23 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
         this.serializer = serializer;
     }
 
+    @Override
+    public Optional<Set<Integer>> partitions(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
+        return partitions(topic, new RecordHeaders(), windowedKey, value, numPartitions);
+    }
+
     /**
      * WindowedStreamPartitioner determines the partition number for a record with the given windowed key and value
      * and the current number of partitions. The partition number id determined by the original key of the windowed key
      * using the same logic as DefaultPartitioner so that the topic is partitioned by the original key.
      *
      * @param topic the topic name this record is sent to
+     * @param headers the record headers of the record
      * @param windowedKey the key of the record
      * @param value the value of the record
      * @param numPartitions the total number of partitions
      * @return an integer between 0 and {@code numPartitions-1}, or {@code null} if the default partitioning logic should be used
      */
-    @Override
-    public Optional<Set<Integer>> partitions(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
-        return partitions(topic, new RecordHeaders(), windowedKey, value, numPartitions);
-    }
-
     @Override
     public Optional<Set<Integer>> partitions(final String topic, final Headers headers, final Windowed<K> windowedKey, final V value, final int numPartitions) {
         // for windowed key, the key bytes should never be null

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
@@ -45,8 +47,13 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
      */
     @Override
     public Optional<Set<Integer>> partitions(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
+        return partitions(topic, new RecordHeaders(), windowedKey, value, numPartitions);
+    }
+
+    @Override
+    public Optional<Set<Integer>> partitions(final String topic, final Headers headers, final Windowed<K> windowedKey, final V value, final int numPartitions) {
         // for windowed key, the key bytes should never be null
-        final byte[] keyBytes = serializer.serializeBaseKey(topic, windowedKey);
+        final byte[] keyBytes = serializer.serializeBaseKey(topic, headers, windowedKey);
 
         // stick with the same built-in partitioner util functions that producer used
         // to make sure its behavior is consistent with the producer

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.Topology;
 
 import java.util.Optional;
@@ -66,4 +67,8 @@ public interface StreamPartitioner<K, V> {
      * Optional of Set of integers means the partitions to which the record should be sent to.
      * */
     Optional<Set<Integer>> partitions(String topic, K key, V value, int numPartitions);
+
+    default Optional<Set<Integer>> partitions(final String topic, final Headers headers, final K key, final V value, final int numPartitions) {
+        return partitions(topic, key, value, numPartitions);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
@@ -54,10 +54,13 @@ import java.util.Set;
 @FunctionalInterface
 public interface StreamPartitioner<K, V> {
 
+    Optional<Set<Integer>> partitions(String topic, K key, V value, int numPartitions);
+
     /**
-     * Determine the number(s) of the partition(s) to which a record with the given key and value should be sent, 
+     * Determine the number(s) of the partition(s) to which a record with the given key and value should be sent,
      * for the given topic and current partition count
      * @param topic the topic name this record is sent to
+     * @param headers the headers of the record
      * @param key the key of the record
      * @param value the value of the record
      * @param numPartitions the total number of partitions
@@ -66,8 +69,6 @@ public interface StreamPartitioner<K, V> {
      * Optional of an empty set means the record won't be sent to any partitions i.e drop it.
      * Optional of Set of integers means the partitions to which the record should be sent to.
      * */
-    Optional<Set<Integer>> partitions(String topic, K key, V value, int numPartitions);
-
     default Optional<Set<Integer>> partitions(final String topic, final Headers headers, final K key, final V value, final int numPartitions) {
         return partitions(topic, key, value, numPartitions);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
@@ -34,7 +36,12 @@ public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
 
     @Override
     public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final int numPartitions) {
-        final byte[] keyBytes = keySerializer.serialize(topic, key);
+        return partitions(topic, new RecordHeaders(), key, value, numPartitions);
+    }
+
+    @Override
+    public Optional<Set<Integer>> partitions(String topic, Headers headers, K key, V value, int numPartitions) {
+        final byte[] keyBytes = keySerializer.serialize(topic, headers, key);
 
         // if the key bytes are not available, we just return empty optional to let the producer decide
         // which partition to send internally; otherwise stick with the same built-in partitioner

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -159,7 +159,7 @@ public class RecordCollectorImpl implements RecordCollector {
                 );
             }
             if (!partitions.isEmpty()) {
-                final Optional<Set<Integer>> maybeMulticastPartitions = partitioner.partitions(topic, key, value, partitions.size());
+                final Optional<Set<Integer>> maybeMulticastPartitions = partitioner.partitions(topic, headers, key, value, partitions.size());
                 if (maybeMulticastPartitions.isEmpty()) {
                     // A null//empty partition indicates we should use the default partitioner
                     send(topic, key, value, headers, null, timestamp, keySerializer, valueSerializer, processorNodeId, context);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowedSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowedSerdesTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream;
 
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -87,7 +88,7 @@ public class WindowedSerdesTest {
         final TimeWindowedSerializer<byte[]> serializer = new TimeWindowedSerializer<>();
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> serializer.serializeBaseKey("topic", new Windowed<>(new byte[0], new TimeWindow(0, 1))));
+            () -> serializer.serializeBaseKey("topic", new RecordHeaders(), new Windowed<>(new byte[0], new TimeWindow(0, 1))));
         assertThat(
             exception.getMessage(),
             equalTo("Inner serializer is `null`. User code must use constructor " +
@@ -123,7 +124,7 @@ public class WindowedSerdesTest {
         final SessionWindowedSerializer<byte[]> serializer = new SessionWindowedSerializer<>();
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> serializer.serializeBaseKey("topic", new Windowed<>(new byte[0], new SessionWindow(0, 0))));
+            () -> serializer.serializeBaseKey("topic", new RecordHeaders(), new Windowed<>(new byte[0], new SessionWindow(0, 0))));
         assertThat(
             exception.getMessage(),
             equalTo("Inner serializer is `null`. User code must use constructor " +


### PR DESCRIPTION
Second MR from series: Propagate headers into serde

- Interface Update: Modified StreamPartitioner and its implementations (WindowedStreamPartitioner, DefaultStreamPartitioner) to support headers.
- Usage: Updated all callers of StreamPartitioner to propagate headers