### PR TITLE
MINOR: Improve ValueTimestampHeader Serdes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -132,11 +132,12 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
 
         final ByteBuffer buffer = ByteBuffer.wrap(rawValueTimestampHeaders);
         final int headersSize = ByteUtils.readVarint(buffer);
-        // skip headers plus timestamp
-        buffer.position(buffer.position() + headersSize + Long.BYTES);
+        final byte[] rawHeaders = readBytes(buffer, headersSize);
+        final Headers headers = HeadersDeserializer.deserialize(rawHeaders);
+        buffer.position(buffer.position() + Long.BYTES); // skip timestamp
         final byte[] bytes = readBytes(buffer, buffer.remaining());
 
-        return deserializer.deserialize("", bytes);
+        return deserializer.deserialize("", headers, bytes);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -66,6 +66,11 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
     }
 
     @Override
+    public ValueTimestampHeaders<V>  deserialize(final String topic, final Headers headers, final byte[] valueTimestampHeaders) {
+        throw new UnsupportedOperationException("Headers are encoded inside `valueTimestampHeaders` byte[] array and cannot be passed as parameter. Use `deserialize(String topic, byte[] valueTimestampHeaders)` instead.");
+    }
+
+    @Override
     public ValueTimestampHeaders<V> deserialize(final String topic, final byte[] valueTimestampHeaders) {
         if (valueTimestampHeaders == null) {
             return null;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -66,6 +66,11 @@ class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<V
     }
 
     @Override
+    public byte[] serialize(final String topic, final Headers headers, final ValueTimestampHeaders<V> valueTimestampHeaders) {
+        throw new UnsupportedOperationException("Headers need to be passed in via ValueTimestampHeaders type. Use `serialize(String topic, ValueTimestampHeaders<V> valueTimestampHeaders)` instead.");
+    }
+
+    @Override
     public byte[] serialize(final String topic, final ValueTimestampHeaders<V> valueTimestampHeaders) {
         if (valueTimestampHeaders == null) {
             return null;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -51,6 +52,7 @@ public class ValueTimestampHeadersDeserializerTest {
     private ValueTimestampHeadersSerializer<String> serializer;
     private ValueTimestampHeadersDeserializer<String> deserializer;
 
+    @SuppressWarnings("resource")
     @BeforeEach
     void setup() {
         serializer = new ValueTimestampHeadersSerializer<>(Serdes.String().serializer());
@@ -65,6 +67,12 @@ public class ValueTimestampHeadersDeserializerTest {
         if (deserializer != null) {
             deserializer.close();
         }
+    }
+
+    @Test
+    public void shouldNotAllowToPassInHeaders() {
+        assertThrows(UnsupportedOperationException.class, () -> deserializer.deserialize(null, null, (byte[]) null));
+        assertThrows(UnsupportedOperationException.class, () -> deserializer.deserialize(null, null, (ByteBuffer) null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializerTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,6 +48,7 @@ public class ValueTimestampHeadersSerializerTest {
     private ValueTimestampHeadersSerializer<String> serializer;
     private ValueTimestampHeadersDeserializer<String> deserializer;
 
+    @SuppressWarnings("resource")
     @BeforeEach
     void setup() {
         serializer = new ValueTimestampHeadersSerializer<>(Serdes.String().serializer());
@@ -61,6 +63,11 @@ public class ValueTimestampHeadersSerializerTest {
         if (deserializer != null) {
             deserializer.close();
         }
+    }
+
+    @Test
+    public void shouldNotAllowToPassInHeaders() {
+        assertThrows(UnsupportedOperationException.class, () -> serializer.serialize(null, null, null));
     }
 
     @Test


### PR DESCRIPTION
This PR disallows to pass in Headers objects into serialize() and
deserializer() to ensure we don't accidentally introduce bugs in our own
code.

It also fixes a small bug, and now correctly passed Headers into the
value deserizlier.

Co-authored-by: Uladzislau Blok <blokv75@gmail.com>  Reviewers: Alieh
Saeedi <asaeedi@confluent.io>, TengYao Chi <frankvicky@apache.org>
