### PR TITLE
MINOR: remove unnecessary empty statement in ProcessingExceptionHandler

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/ProcessingExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/ProcessingExceptionHandler.java
@@ -44,7 +44,7 @@ public interface ProcessingExceptionHandler extends Configurable {
     @Deprecated
     default ProcessingHandlerResponse handle(final ErrorHandlerContext context, final Record<?, ?> record, final Exception exception) {
         throw new UnsupportedOperationException();
-    };
+    }
 
     /**
      * Inspects a record and the exception received during processing.


### PR DESCRIPTION
Remove unnecessary semicolon.

Reviewers: Kirk True <kirk@kirktrue.pro>, Matthias J. Sax
 <matthias@confluent.io>
