### PR TITLE
KAFKA-20184: Remove static jose4j references from DefaultJwtValidator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/DefaultJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/DefaultJwtValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.security.oauthbearer;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
 import org.apache.kafka.common.utils.Utils;
@@ -56,6 +57,11 @@ public class DefaultJwtValidator implements JwtValidator {
         this.verificationKeyResolver = Optional.empty();
     }
 
+    /**
+     * @param verificationKeyResolver The resolver (typed as Object to avoid
+     *        importing CloseableVerificationKeyResolver, which extends jose4j's
+     *        VerificationKeyResolver and would trigger class loading)
+     */
     public DefaultJwtValidator(Object verificationKeyResolver) {
         this.verificationKeyResolver = Optional.of(verificationKeyResolver);
     }
@@ -99,10 +105,10 @@ public class DefaultJwtValidator implements JwtValidator {
             Class<?> clazz = Class.forName(BROKER_JWT_VALIDATOR_CLASS);
             return (JwtValidator) clazz.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException(
-                "BrokerJwtValidator requires the jose4j library. Please add org.bitbucket.b_c:jose4j to your classpath.", e);
+            throw new KafkaException(
+                BROKER_JWT_VALIDATOR_CLASS + " requires the jose4j library. Please add org.bitbucket.b_c:jose4j to your classpath.", e);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException("Failed to create BrokerJwtValidator", e);
+            throw new KafkaException("Failed to create " + BROKER_JWT_VALIDATOR_CLASS, e);
         }
     }
 
@@ -113,10 +119,10 @@ public class DefaultJwtValidator implements JwtValidator {
             Constructor<?> ctor = clazz.getDeclaredConstructor(resolverClass);
             return (JwtValidator) ctor.newInstance(verificationKeyResolver);
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException(
-                "BrokerJwtValidator requires the jose4j library. Please add org.bitbucket.b_c:jose4j to your classpath.", e);
+            throw new KafkaException(
+                BROKER_JWT_VALIDATOR_CLASS + " requires the jose4j library. Please add org.bitbucket.b_c:jose4j to your classpath.", e);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException("Failed to create BrokerJwtValidator", e);
+            throw new KafkaException("Failed to create " + BROKER_JWT_VALIDATOR_CLASS, e);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/DefaultJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/DefaultJwtValidator.java
@@ -18,13 +18,12 @@
 package org.apache.kafka.common.security.oauthbearer;
 
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.CloseableVerificationKeyResolver;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
 import org.apache.kafka.common.utils.Utils;
 
-import org.jose4j.keys.resolvers.VerificationKeyResolver;
-
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,13 +32,23 @@ import javax.security.auth.login.AppConfigurationEntry;
 
 /**
  * This {@link JwtValidator} uses the delegation approach, instantiating and delegating calls to a
- * more concrete implementation. The underlying implementation is determined by the presence/absence
- * of the {@link VerificationKeyResolver}: if it's present, a {@link BrokerJwtValidator} is
- * created, otherwise a {@link ClientJwtValidator} is created.
+ * more concrete implementation. The underlying implementation is determined by the configuration:
+ * if a JWKS endpoint URL is configured or a verification key resolver is provided,
+ * a {@link BrokerJwtValidator} is created, otherwise a {@link ClientJwtValidator} is created.
+ *
+ * <p>Note: {@link BrokerJwtValidator} and its jose4j dependency are loaded lazily via reflection
+ * to avoid {@link ClassNotFoundException} in client-only environments where jose4j is not
+ * on the classpath.
  */
 public class DefaultJwtValidator implements JwtValidator {
 
-    private final Optional<CloseableVerificationKeyResolver> verificationKeyResolver;
+    private static final String BROKER_JWT_VALIDATOR_CLASS =
+        "org.apache.kafka.common.security.oauthbearer.BrokerJwtValidator";
+
+    private static final String CLOSEABLE_VERIFICATION_KEY_RESOLVER_CLASS =
+        "org.apache.kafka.common.security.oauthbearer.internals.secured.CloseableVerificationKeyResolver";
+
+    private final Optional<Object> verificationKeyResolver;
 
     private JwtValidator delegate;
 
@@ -47,19 +56,19 @@ public class DefaultJwtValidator implements JwtValidator {
         this.verificationKeyResolver = Optional.empty();
     }
 
-    public DefaultJwtValidator(CloseableVerificationKeyResolver verificationKeyResolver) {
+    public DefaultJwtValidator(Object verificationKeyResolver) {
         this.verificationKeyResolver = Optional.of(verificationKeyResolver);
     }
 
     @Override
     public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
         if (verificationKeyResolver.isPresent()) {
-            delegate = new BrokerJwtValidator(verificationKeyResolver.get());
+            delegate = createBrokerJwtValidator(verificationKeyResolver.get());
         } else {
             ConfigurationUtils cu = new ConfigurationUtils(configs, saslMechanism);
 
             if (cu.containsKey(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL)) {
-                delegate = new BrokerJwtValidator();
+                delegate = createBrokerJwtValidator();
             } else {
                 delegate = new ClientJwtValidator();
             }
@@ -83,5 +92,31 @@ public class DefaultJwtValidator implements JwtValidator {
 
     JwtValidator delegate() {
         return delegate;
+    }
+
+    private static JwtValidator createBrokerJwtValidator() {
+        try {
+            Class<?> clazz = Class.forName(BROKER_JWT_VALIDATOR_CLASS);
+            return (JwtValidator) clazz.getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                "BrokerJwtValidator requires the jose4j library. Please add org.bitbucket.b_c:jose4j to your classpath.", e);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Failed to create BrokerJwtValidator", e);
+        }
+    }
+
+    private static JwtValidator createBrokerJwtValidator(Object verificationKeyResolver) {
+        try {
+            Class<?> clazz = Class.forName(BROKER_JWT_VALIDATOR_CLASS);
+            Class<?> resolverClass = Class.forName(CLOSEABLE_VERIFICATION_KEY_RESOLVER_CLASS);
+            Constructor<?> ctor = clazz.getDeclaredConstructor(resolverClass);
+            return (JwtValidator) ctor.newInstance(verificationKeyResolver);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                "BrokerJwtValidator requires the jose4j library. Please add org.bitbucket.b_c:jose4j to your classpath.", e);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Failed to create BrokerJwtValidator", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary

`DefaultJwtValidator` previously had static references to jose4j classes (`CloseableVerificationKeyResolver` which extends `VerificationKeyResolver`), causing `ClassNotFoundException` in client-only environments where jose4j is not on the classpath.

**Fix:** Use `Class.forName()` reflection to lazily load `BrokerJwtValidator` only when broker mode is needed. This keeps jose4j as `compileOnly`, avoiding JAR bloat and CVE surface area for client users.

## Test plan

- [x] All OAuth-related tests in `:clients` pass
- [x] `DefaultJwtValidatorTest` confirms correct delegate selection
- [x] `OAuthBearerValidatorCallbackHandlerTest` confirms validation works

Reviewers: Luke Chen <showuon@gmail.com>
