### PR TITLE
MINOR: refactor Kafka Streams "segment" code

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -245,15 +245,6 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
     }
 
     @Override
-    public void remove(final Bytes key, final long timestamp) {
-        final Bytes keyBytes = keySchema.toStoreBinaryKeyPrefix(key, timestamp);
-        final S segment = segments.segmentForTimestamp(timestamp);
-        if (segment != null) {
-            segment.deleteRange(keyBytes, keyBytes);
-        }
-    }
-
-    @Override
     public void put(final Bytes key,
                     final byte[] value) {
         final long timestamp = keySchema.segmentTimestamp(key);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBTimeOrderedSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBTimeOrderedSegmentedBytesStore.java
@@ -244,12 +244,6 @@ public abstract class AbstractRocksDBTimeOrderedSegmentedBytesStore extends Abst
             forward);
     }
 
-
-    @Override
-    public void remove(final Bytes key, final long timestamp) {
-        throw new UnsupportedOperationException("Not supported operation");
-    }
-
     @Override
     public KeyValueIterator<Bytes, byte[]> fetchAll(final long timeFrom,
                                                     final long timeTo) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegment.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 
 class KeyValueSegment extends RocksDBStore implements Segment {
-    public final long id;
+    private final long id;
 
     KeyValueSegment(final String segmentName,
                     final String windowName,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegment.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-class KeyValueSegment extends RocksDBStore implements Comparable<KeyValueSegment>, Segment {
+class KeyValueSegment extends RocksDBStore implements Segment {
     public final long id;
 
     KeyValueSegment(final String segmentName,
@@ -40,6 +40,11 @@ class KeyValueSegment extends RocksDBStore implements Comparable<KeyValueSegment
     }
 
     @Override
+    public long id() {
+        return id;
+    }
+
+    @Override
     public void destroy() throws IOException {
         Utils.delete(dbDir);
     }
@@ -47,11 +52,6 @@ class KeyValueSegment extends RocksDBStore implements Comparable<KeyValueSegment
     @Override
     public synchronized void deleteRange(final Bytes keyFrom, final Bytes keyTo) {
         super.deleteRange(keyFrom, keyTo);
-    }
-
-    @Override
-    public int compareTo(final KeyValueSegment segment) {
-        return Long.compare(id, segment.id);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueSegments.java
@@ -36,30 +36,13 @@ class KeyValueSegments extends AbstractSegments<KeyValueSegment> {
     }
 
     @Override
-    public KeyValueSegment getOrCreateSegment(final long segmentId,
-                                              final StateStoreContext context) {
-        if (segments.containsKey(segmentId)) {
-            return segments.get(segmentId);
-        } else {
-            final KeyValueSegment newSegment =
-                new KeyValueSegment(segmentName(segmentId), name, segmentId, position, metricsRecorder);
-
-            if (segments.put(segmentId, newSegment) != null) {
-                throw new IllegalStateException("KeyValueSegment already exists. Possible concurrent access.");
-            }
-
-            newSegment.openDB(context.appConfigs(), context.stateDir());
-            return newSegment;
-        }
+    protected KeyValueSegment createSegment(final long segmentId, final String segmentName) {
+        return new KeyValueSegment(segmentName, name, segmentId, position, metricsRecorder);
     }
 
     @Override
-    public KeyValueSegment getOrCreateSegmentIfLive(final long segmentId,
-                                                    final StateStoreContext context,
-                                                    final long streamTime) {
-        final KeyValueSegment segment = super.getOrCreateSegmentIfLive(segmentId, context, streamTime);
-        cleanupExpiredSegments(streamTime);
-        return segment;
+    protected void openSegmentDB(final KeyValueSegment segment, final StateStoreContext context) {
+        segment.openDB(context.appConfigs(), context.stateDir());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
@@ -53,7 +53,7 @@ import static org.apache.kafka.streams.state.internals.RocksDBStore.incrementWit
  * stores a key into a shared physical store by prepending the key with a prefix (unique to
  * the specific logical segment), and storing the combined key into the physical store.
  */
-class LogicalKeyValueSegment implements Comparable<LogicalKeyValueSegment>, Segment, VersionedStoreSegment {
+class LogicalKeyValueSegment implements Segment, VersionedStoreSegment {
     private static final Logger log = LoggerFactory.getLogger(LogicalKeyValueSegment.class);
 
     private final long id;
@@ -76,11 +76,6 @@ class LogicalKeyValueSegment implements Comparable<LogicalKeyValueSegment>, Segm
     @Override
     public long id() {
         return id;
-    }
-
-    @Override
-    public int compareTo(final LogicalKeyValueSegment segment) {
-        return Long.compare(id, segment.id);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
@@ -62,25 +62,18 @@ public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSeg
     }
 
     @Override
-    public LogicalKeyValueSegment getOrCreateSegment(final long segmentId,
-                                                     final StateStoreContext context) {
-        if (segments.containsKey(segmentId)) {
-            return segments.get(segmentId);
-        } else {
-            if (segmentId < 0) {
-                throw new IllegalArgumentException(
-                    "Negative segment IDs are reserved for reserved segments, "
-                        + "and should be created through createReservedSegment() instead");
-            }
-
-            final LogicalKeyValueSegment newSegment = new LogicalKeyValueSegment(segmentId, segmentName(segmentId), physicalStore);
-
-            if (segments.put(segmentId, newSegment) != null) {
-                throw new IllegalStateException("LogicalKeyValueSegment already exists. Possible concurrent access.");
-            }
-
-            return newSegment;
+    protected LogicalKeyValueSegment createSegment(final long segmentId, final String segmentName) {
+        if (segmentId < 0) {
+            throw new IllegalArgumentException(
+                "Negative segment IDs are reserved for reserved segments, "
+                    + "and should be created through createReservedSegment() instead");
         }
+        return new LogicalKeyValueSegment(segmentId, segmentName, physicalStore);
+    }
+
+    @Override
+    protected void openSegmentDB(final LogicalKeyValueSegment segment, final StateStoreContext context) {
+        // no-op -- a logical segment is just a view on an underlying physical store
     }
 
     LogicalKeyValueSegment createReservedSegment(final long segmentId,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -21,9 +21,21 @@ import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.io.IOException;
 
-public interface Segment extends KeyValueStore<Bytes, byte[]>, BatchWritingStore {
+public interface Segment extends KeyValueStore<Bytes, byte[]>, BatchWritingStore, Comparable<Segment> {
+
+    /**
+     * Returns the unique identifier for this segment.
+     *
+     * @return the segment ID
+     */
+    long id();
 
     void destroy() throws IOException;
 
     void deleteRange(Bytes keyFrom, Bytes keyTo);
+
+    @Override
+    default int compareTo(final Segment segment) {
+        return Long.compare(id(), segment.id());
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -23,11 +23,6 @@ import java.io.IOException;
 
 public interface Segment extends KeyValueStore<Bytes, byte[]>, BatchWritingStore, Comparable<Segment> {
 
-    /**
-     * Returns the unique identifier for this segment.
-     *
-     * @return the segment ID
-     */
     long id();
 
     void destroy() throws IOException;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
@@ -110,14 +110,6 @@ public interface SegmentedBytesStore extends StateStore {
     void remove(Bytes key);
 
     /**
-     * Remove all duplicated records with the provided key in the specified timestamp.
-     *
-     * @param key   the segmented key to remove
-     * @param timestamp  the timestamp to match
-     */
-    void remove(Bytes key, long timestamp);
-
-    /**
      * Write a new value to the store with the provided key. The key
      * should be a composite of the record key, and the timestamp information etc
      * as described by the {@link KeySchema}
@@ -158,18 +150,6 @@ public interface SegmentedBytesStore extends StateStore {
          * @return      The key that represents the lower range to search for in the store
          */
         Bytes lowerRange(final Bytes key, final long from);
-
-        /**
-         * Given a record key and a time, construct a Segmented key to search when performing
-         * prefixed queries.
-         *
-         * @param key
-         * @param timestamp
-         * @return  The key that represents the prefixed Segmented key in bytes.
-         */
-        default Bytes toStoreBinaryKeyPrefix(final Bytes key, final long timestamp) {
-            throw new UnsupportedOperationException();
-        }
 
         /**
          * Given a range of fixed size record keys and a time, construct a Segmented key that represents

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegment.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 
 class TimestampedSegment extends RocksDBTimestampedStore implements Segment {
-    public final long id;
+    private final long id;
 
     TimestampedSegment(final String segmentName,
                        final String windowName,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegment.java
@@ -57,7 +57,6 @@ class TimestampedSegment extends RocksDBTimestampedStore implements Segment {
     @Override
     public void openDB(final Map<String, Object> configs, final File stateDir) {
         super.openDB(configs, stateDir);
-        // skip the registering step
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegment.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-class TimestampedSegment extends RocksDBTimestampedStore implements Comparable<TimestampedSegment>, Segment {
+class TimestampedSegment extends RocksDBTimestampedStore implements Segment {
     public final long id;
 
     TimestampedSegment(final String segmentName,
@@ -40,6 +40,11 @@ class TimestampedSegment extends RocksDBTimestampedStore implements Comparable<T
     }
 
     @Override
+    public long id() {
+        return id;
+    }
+
+    @Override
     public void destroy() throws IOException {
         Utils.delete(dbDir);
     }
@@ -47,11 +52,6 @@ class TimestampedSegment extends RocksDBTimestampedStore implements Comparable<T
     @Override
     public void deleteRange(final Bytes keyFrom, final Bytes keyTo) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareTo(final TimestampedSegment segment) {
-        return Long.compare(id, segment.id);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
@@ -64,7 +64,6 @@ class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders i
     @Override
     public void openDB(final Map<String, Object> configs, final File stateDir) {
         super.openDB(configs, stateDir);
-        // skip the registering step
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
@@ -33,10 +33,8 @@ import java.util.Objects;
  * header-aware storage with dual-column-family migration support from
  * timestamp-only format to timestamp+headers format.
  */
-class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders
-    implements Segment {
-
-    public final long id;
+class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders implements Segment {
+    private final long id;
 
     TimestampedSegmentWithHeaders(final String segmentName,
                                   final String windowName,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentWithHeaders.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * timestamp-only format to timestamp+headers format.
  */
 class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders
-    implements Comparable<TimestampedSegmentWithHeaders>, Segment {
+    implements Segment {
 
     public final long id;
 
@@ -49,6 +49,11 @@ class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders
     }
 
     @Override
+    public long id() {
+        return id;
+    }
+
+    @Override
     public void destroy() throws IOException {
         Utils.delete(dbDir);
     }
@@ -56,11 +61,6 @@ class TimestampedSegmentWithHeaders extends RocksDBTimestampedStoreWithHeaders
     @Override
     public void deleteRange(final Bytes keyFrom, final Bytes keyTo) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int compareTo(final TimestampedSegmentWithHeaders segment) {
-        return Long.compare(id, segment.id);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegments.java
@@ -36,30 +36,13 @@ class TimestampedSegments extends AbstractSegments<TimestampedSegment> {
     }
 
     @Override
-    public TimestampedSegment getOrCreateSegment(final long segmentId,
-                                                 final StateStoreContext context) {
-        if (segments.containsKey(segmentId)) {
-            return segments.get(segmentId);
-        } else {
-            final TimestampedSegment newSegment =
-                new TimestampedSegment(segmentName(segmentId), name, segmentId, position, metricsRecorder);
-
-            if (segments.put(segmentId, newSegment) != null) {
-                throw new IllegalStateException("TimestampedSegment already exists. Possible concurrent access.");
-            }
-
-            newSegment.openDB(context.appConfigs(), context.stateDir());
-            return newSegment;
-        }
+    protected TimestampedSegment createSegment(final long segmentId, final String segmentName) {
+        return new TimestampedSegment(segmentName, name, segmentId, position, metricsRecorder);
     }
 
     @Override
-    public TimestampedSegment getOrCreateSegmentIfLive(final long segmentId,
-                                                    final StateStoreContext context,
-                                                    final long streamTime) {
-        final TimestampedSegment segment = super.getOrCreateSegmentIfLive(segmentId, context, streamTime);
-        cleanupExpiredSegments(streamTime);
-        return segment;
+    protected void openSegmentDB(final TimestampedSegment segment, final StateStoreContext context) {
+        segment.openDB(context.appConfigs(), context.stateDir());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeaders.java
@@ -36,30 +36,13 @@ class TimestampedSegmentsWithHeaders extends AbstractSegments<TimestampedSegment
     }
 
     @Override
-    public TimestampedSegmentWithHeaders getOrCreateSegment(final long segmentId,
-                                                            final StateStoreContext context) {
-        if (segments.containsKey(segmentId)) {
-            return segments.get(segmentId);
-        } else {
-            final TimestampedSegmentWithHeaders newSegment =
-                new TimestampedSegmentWithHeaders(segmentName(segmentId), name, segmentId, position, metricsRecorder);
-
-            if (segments.put(segmentId, newSegment) != null) {
-                throw new IllegalStateException("TimestampedSegmentWithHeaders already exists. Possible concurrent access.");
-            }
-
-            newSegment.openDB(context.appConfigs(), context.stateDir());
-            return newSegment;
-        }
+    protected TimestampedSegmentWithHeaders createSegment(final long segmentId, final String segmentName) {
+        return new TimestampedSegmentWithHeaders(segmentName, name, segmentId, position, metricsRecorder);
     }
 
     @Override
-    public TimestampedSegmentWithHeaders getOrCreateSegmentIfLive(final long segmentId,
-                                                                   final StateStoreContext context,
-                                                                   final long streamTime) {
-        final TimestampedSegmentWithHeaders segment = super.getOrCreateSegmentIfLive(segmentId, context, streamTime);
-        cleanupExpiredSegments(streamTime);
-        return segment;
+    protected void openSegmentDB(final TimestampedSegmentWithHeaders segment, final StateStoreContext context) {
+        segment.openDB(context.appConfigs(), context.stateDir());
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
@@ -191,9 +191,9 @@ public class KeyValueSegmentsTest {
 
         final List<KeyValueSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(0).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(2).id);
+        assertEquals(0, segments.get(0).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(2).id());
     }
 
     @Test
@@ -211,9 +211,9 @@ public class KeyValueSegmentsTest {
 
         final List<KeyValueSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, false);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(2).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(0).id);
+        assertEquals(0, segments.get(2).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(0).id());
     }
 
     @Test
@@ -226,9 +226,9 @@ public class KeyValueSegmentsTest {
 
         final List<KeyValueSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(0).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(2).id);
+        assertEquals(0, segments.get(0).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(2).id());
     }
 
     @Test
@@ -241,9 +241,9 @@ public class KeyValueSegmentsTest {
 
         final List<KeyValueSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, false);
         assertEquals(3, segments.size());
-        assertEquals(2, segments.get(0).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(0, segments.get(2).id);
+        assertEquals(2, segments.get(0).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(0, segments.get(2).id());
     }
 
     @Test
@@ -349,7 +349,7 @@ public class KeyValueSegmentsTest {
         final List<KeyValueSegment> result = this.segments.segments(0, Long.MAX_VALUE, true);
         assertEquals(numSegments, result.size());
         for (int i = 0; i < numSegments; i++) {
-            assertEquals(i + first, result.get(i).id);
+            assertEquals(i + first, result.get(i).id());
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
@@ -192,9 +192,9 @@ public class TimestampedSegmentsTest {
 
         final List<TimestampedSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(0).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(2).id);
+        assertEquals(0, segments.get(0).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(2).id());
     }
 
     @Test
@@ -212,9 +212,9 @@ public class TimestampedSegmentsTest {
 
         final List<TimestampedSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, false);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(2).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(0).id);
+        assertEquals(0, segments.get(2).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(0).id());
     }
 
     @Test
@@ -227,9 +227,9 @@ public class TimestampedSegmentsTest {
 
         final List<TimestampedSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(0).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(2).id);
+        assertEquals(0, segments.get(0).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(2).id());
     }
 
     @Test
@@ -242,9 +242,9 @@ public class TimestampedSegmentsTest {
 
         final List<TimestampedSegment> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, false);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(2).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(0).id);
+        assertEquals(0, segments.get(2).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(0).id());
     }
 
     @Test
@@ -350,7 +350,7 @@ public class TimestampedSegmentsTest {
         final List<TimestampedSegment> result = this.segments.segments(0, Long.MAX_VALUE, true);
         assertEquals(numSegments, result.size());
         for (int i = 0; i < numSegments; i++) {
-            assertEquals(i + first, result.get(i).id);
+            assertEquals(i + first, result.get(i).id());
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsWithHeadersTest.java
@@ -177,9 +177,9 @@ public class TimestampedSegmentsWithHeadersTest {
 
         final List<TimestampedSegmentWithHeaders> segments = this.segments.segments(0, 2 * SEGMENT_INTERVAL, true);
         assertEquals(3, segments.size());
-        assertEquals(0, segments.get(0).id);
-        assertEquals(1, segments.get(1).id);
-        assertEquals(2, segments.get(2).id);
+        assertEquals(0, segments.get(0).id());
+        assertEquals(1, segments.get(1).id());
+        assertEquals(2, segments.get(2).id());
     }
 
     @Test


### PR DESCRIPTION
All implementations of Segment implement Comparable. We can let Segment
extend Comparable directly to reduce code duplication.

All sub-classes of AbstractSegments have very similar implementations of
getOrCreateSegment(). We can move the shared code into AbstractSegments.

This PR also removes unused methods from SegmentedByteStore.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, TengYao Chi
 <frankvicky@apache.org>, Bill Bejeck <bill@confluent.io>
