### PR TITLE
KAFKA-20201: Connect Transforms: SchemaUtil.copySchemaBasics(Schema) does not preserve keySchema and valueSchema for MAP type

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/SchemaUtil.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/SchemaUtil.java
@@ -27,6 +27,8 @@ public class SchemaUtil {
         SchemaBuilder builder;
         if (source.type() == Schema.Type.ARRAY) {
             builder = SchemaBuilder.array(source.valueSchema());
+        } else if (source.type() == Schema.Type.MAP) {
+            builder = SchemaBuilder.map(source.keySchema(), source.valueSchema());
         } else {
             builder = new SchemaBuilder(source.type());
         }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/util/SchemaUtilTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/util/SchemaUtilTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.util;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SchemaUtilTest {
+
+    @Test
+    public void testCopyMapSchemaPreservesKeyAndValue() {
+        // Given
+        Schema source = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
+
+        // When
+        SchemaBuilder result = SchemaUtil.copySchemaBasics(source);
+
+        // Then
+        assertEquals(Schema.Type.MAP, result.type());
+        assertEquals(source.keySchema(), result.keySchema());
+        assertEquals(source.valueSchema(), result.valueSchema());
+    }
+
+    @Test
+    public void testCopyMapSchemaWithComplexValue() {
+        // Given
+        Schema arrayValueSchema = SchemaBuilder.array(Schema.STRING_SCHEMA).build();
+        Schema source = SchemaBuilder.map(Schema.STRING_SCHEMA, arrayValueSchema).build();
+
+        // When
+        SchemaBuilder result = SchemaUtil.copySchemaBasics(source);
+
+        // Then
+        assertEquals(Schema.Type.MAP, result.type());
+        assertEquals(source.keySchema(), result.keySchema());
+        assertEquals(source.valueSchema(), result.valueSchema());
+        assertEquals(arrayValueSchema.valueSchema(), result.valueSchema().valueSchema());
+    }
+
+    @Test
+    public void testCopyMapSchemaWithNonStringKey() {
+        // Given
+        Schema source = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.STRING_SCHEMA).build();
+
+        // When
+        SchemaBuilder result = SchemaUtil.copySchemaBasics(source);
+
+        // Then
+        assertEquals(Schema.Type.MAP, result.type());
+        assertEquals(source.keySchema(), result.keySchema());
+        assertEquals(source.valueSchema(), result.valueSchema());
+    }
+}


### PR DESCRIPTION
**Description:**

Fixes a latent bug in `SchemaUtil.copySchemaBasics(Schema)` where passing a MAP schema would result in a broken `SchemaBuilder` with null `keySchema` and `valueSchema`.

Added a MAP type branch to correctly copy the key and value schemas, and included corresponding unit tests.

**Note:**

Currently, no callers within the codebase pass a MAP schema to this method, so there are no active runtime failures. However, since SchemaUtil#copySchemaBasics is a public utility method, this is a latent bug. This proactive fix ensures that if any future transforms or external connectors pass a MAP schema, it will be handled correctly.