### PR TITLE
MINOR: Use wildcard generics instead of defensive copies in TaskManager 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -333,7 +333,7 @@ public class TaskManager {
         }
     }
 
-    private Collection<Task> assignStartupTasks(final Map<TaskId, Set<TopicPartition>> tasksToAssign) {
+    private Collection<? extends Task> assignStartupTasks(final Map<TaskId, Set<TopicPartition>> tasksToAssign) {
         if (stateDirectory.hasStartupTasks()) {
             final Map<TaskId, Set<TopicPartition>> assignedTasks = new HashMap<>(tasksToAssign.size());
             for (final Map.Entry<TaskId, Set<TopicPartition>> entry : tasksToAssign.entrySet()) {
@@ -343,7 +343,7 @@ public class TaskManager {
                     assignedTasks.put(taskId, inputPartitions);
                 }
             }
-            return new ArrayList<>(standbyTaskCreator.createTasks(assignedTasks));
+            return standbyTaskCreator.createTasks(assignedTasks);
         } else {
             return Collections.emptySet();
         }
@@ -516,7 +516,7 @@ public class TaskManager {
         for (final Task activeTask : activeTasks) {
             activeTasksToCreate.remove(activeTask.id());
         }
-        final Collection<Task> standbyTasks = assignStartupTasks(standbyTasksToCreate);
+        final Collection<? extends Task> standbyTasks = assignStartupTasks(standbyTasksToCreate);
         for (final Task standbyTask : standbyTasks) {
             standbyTasksToCreate.remove(standbyTask.id());
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -318,7 +318,7 @@ public class TaskManager {
         }
     }
 
-    private Collection<Task> assignActiveTaskFromStartupState(final Map<TaskId, Set<TopicPartition>> tasksToAssign) {
+    private Collection<? extends Task> assignActiveTaskFromStartupState(final Map<TaskId, Set<TopicPartition>> tasksToAssign) {
         if (stateDirectory.hasStartupTasks()) {
             final Map<TaskId, Set<TopicPartition>> assignedTasks = new HashMap<>(tasksToAssign.size());
             for (final Map.Entry<TaskId, Set<TopicPartition>> entry : tasksToAssign.entrySet()) {
@@ -327,7 +327,7 @@ public class TaskManager {
                     assignedTasks.put(taskId, entry.getValue());
                 }
             }
-            return new ArrayList<>(activeTaskCreator.createTasks(mainConsumer, assignedTasks));
+            return activeTaskCreator.createTasks(mainConsumer, assignedTasks);
         } else {
             return Collections.emptySet();
         }
@@ -512,7 +512,7 @@ public class TaskManager {
 
     private void handleExistingStateForTasks(final Map<TaskId, Set<TopicPartition>> activeTasksToCreate,
                                              final Map<TaskId, Set<TopicPartition>> standbyTasksToCreate) {
-        final Collection<Task> activeTasks = assignActiveTaskFromStartupState(activeTasksToCreate);
+        final Collection<? extends Task> activeTasks = assignActiveTaskFromStartupState(activeTasksToCreate);
         for (final Task activeTask : activeTasks) {
             activeTasksToCreate.remove(activeTask.id());
         }


### PR DESCRIPTION
Use `Collection<? extends Task>` return type with wildcard bounds
instead    of creating `ArrayList` copies to handle generic covariance.

Reviewers: PoAn Yang <FrankYang0529@apache.org>, Matthias Sax
 <mjsax@apache.org>
