### PR TITLE
MINOR: Clean up checkstyle configuration

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -31,9 +31,7 @@
   <module name="TreeWalker">
 
     <!-- code cleanup -->
-    <module name="UnusedImports">
-      <property name="processJavadoc" value="true" />
-    </module>
+    <module name="UnusedImports"/>
     <module name="RedundantImport"/>
     <module name="IllegalImport" />
     <module name="EqualsHashCode"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -197,10 +197,7 @@
     <!-- Generated code -->
     <suppress checks="[a-zA-Z0-9]*" files="[\\/]generated[\\/]"/>
 
-    <suppress checks="ImportControl" files="FetchResponseData.java"/>
     <suppress checks="ImportControl" files="RecordsSerdeTest.java"/>
-    <suppress checks="ImportControl" files="ClientTelemetryTest.java"/>
-    <suppress checks="ImportControl" files="AdminFenceProducersTest.java"/>
 
     <!-- Streams tests -->
     <suppress checks="ClassFanOutComplexity"
@@ -221,7 +218,7 @@
     <suppress checks="NPathComplexity"
               files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|RelationalSmokeTest|MockProcessorContextStateStoreTest|TopologyTestDriverTest|IQv2StoreIntegrationTest).java"/>
 
-    <suppress checks="(FinalLocalVariable|WhitespaceAround|LocalVariableName|ImportControl|AvoidStarImport)"
+    <suppress checks="(FinalLocalVariable|WhitespaceAround|LocalVariableName|ImportControl)"
               files="Murmur3Test.java"/>
 
     <suppress checks="MethodLength"
@@ -245,8 +242,6 @@
               files="(StreamsResetter|DefaultMessageFormatter).java"/>
     <suppress checks="NPathComplexity"
               files="(AclCommand|DefaultMessageFormatter|ProducerPerformance|StreamsResetter|Agent|TransactionalMessageCopier|ReplicaVerificationTool|LineMessageReader|ConsoleProducer|DumpLogSegments).java"/>
-    <suppress checks="ImportControl|IllegalImport"
-              files="SignalLogger.java"/>
     <suppress checks="ParameterNumber"
               files="(ProduceBenchSpec|ConsumeBenchSpec|SustainedConnectionSpec).java"/>
     <suppress id="dontUseSystemExit"
@@ -254,9 +249,7 @@
 
     <!-- Shell -->
     <suppress checks="CyclomaticComplexity"
-              files="(GlobComponent|MetadataNodeManager).java"/>
-    <suppress checks="MethodLength|JavaNCSS"
-              files="(MetadataNodeManager).java"/>
+              files="GlobComponent.java"/>
 
     <!-- metadata -->
     <suppress checks="ClassDataAbstractionCoupling"
@@ -275,8 +268,6 @@
               files="(MetadataImage).java"/>
     <suppress checks="ImportControl"
               files="ApiVersionsResponse.java"/>
-    <suppress checks="AvoidStarImport"
-              files="MetadataVersionTest.java"/>
 
     <!-- group coordinator -->
     <suppress checks="CyclomaticComplexity"
@@ -286,7 +277,7 @@
     <suppress checks="ClassFanOutComplexity"
               files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"
-              files="(ConsumerGroupMember|GroupMetadataManager|GroupCoordinatorConfig).java"/>
+              files="(ConsumerGroupMember|GroupMetadataManager).java"/>
     <suppress checks="ClassDataAbstractionCoupling"
               files="(RecordHelpersTest|GroupCoordinatorRecordHelpers|GroupMetadataManager|GroupCoordinatorService|GroupMetadataManagerTest|OffsetMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest|GroupCoordinatorRecordSerde|StreamsGroupTest).java"/>
     <suppress checks="JavaNCSS"
@@ -308,14 +299,14 @@
 
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"
-              files="(LogLoader|LogValidator|RemoteLogManagerConfig|RemoteLogManager|UnifiedLog).java"/>
+              files="(LogLoader|LogValidator|RemoteLogManager|UnifiedLog).java"/>
     <suppress checks="NPathComplexity"
               files="(LocalLog|LogLoader|LogValidator|RemoteLogManager|RemoteIndexCache|UnifiedLog).java"/>
     <suppress checks="ParameterNumber"
-              files="(LogAppendInfo|LogLoader|RemoteLogManagerConfig|UnifiedLog).java"/>
+              files="(LogLoader|UnifiedLog).java"/>
     <suppress checks="(ClassDataAbstractionCoupling|ClassFanOutComplexity)"
               files="(UnifiedLog|RemoteLogManager|RemoteLogManagerTest).java"/>
-    <suppress checks="MethodLength" files="(RemoteLogManager|RemoteLogManagerConfig).java"/>
+    <suppress checks="MethodLength" files="RemoteLogManagerConfig.java"/>
     <suppress checks="JavaNCSS" files="RemoteLogManagerTest.java"/>
 
     <!-- benchmarks -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -46,7 +46,7 @@
     <suppress checks="CyclomaticComplexity" files="SharePartition.java"/>
 
     <!-- server tests -->
-    <suppress checks="MethodLength|JavaNCSS|NPath" files="DescribeTopicPartitionsRequestHandlerTest.java"/>
+    <suppress checks="MethodLength|JavaNCSS|NPathComplexity" files="DescribeTopicPartitionsRequestHandlerTest.java"/>
     <suppress checks="CyclomaticComplexity" files="ListConsumerGroupTest.java"/>
     <suppress checks="ClassFanOutComplexity|CyclomaticComplexity|MethodLength|ParameterNumber|JavaNCSS|ImportControl" files="RequestConvertToJson.java"/>
     <suppress checks="ImportControl" files="BrokerRegistrationRequestTest.java"/>
@@ -56,42 +56,18 @@
     <suppress id="dontUseSystemExit"
               files="Exit.java"/>
     <suppress checks="ClassFanOutComplexity"
-              files="(AbstractFetch|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|KafkaProducer|Utils|TransactionManager|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin|RaftClientTestContext|TestingMetricsInterceptingAdminClient).java"/>
-    <suppress checks="ClassFanOutComplexity"
-              files="(SaslServerAuthenticator|SaslAuthenticatorTest).java"/>
-    <suppress checks="NPath"
+              files="(AbstractFetch|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|KafkaProducer|Utils|TransactionManager|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin|RaftClientTestContext|TestingMetricsInterceptingAdminClient|SaslServerAuthenticator|SaslAuthenticatorTest|Errors|AbstractRequest|AbstractResponse).java"/>
+    <suppress checks="NPathComplexity"
               files="(SaslServerAuthenticator).java"/>
-    <suppress checks="ClassFanOutComplexity"
-              files="Errors.java"/>
-    <suppress checks="ClassFanOutComplexity"
-              files="Utils.java"/>
-    <suppress checks="ClassFanOutComplexity"
-              files="AbstractRequest.java"/>
-    <suppress checks="ClassFanOutComplexity"
-              files="AbstractResponse.java"/>
 
     <suppress checks="MethodLength"
               files="(KerberosLogin|RequestResponseTest|ConnectMetricsRegistry|KafkaConsumer|AbstractStickyAssignor|AbstractRequest|AbstractResponse).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(NetworkClient|FieldSpec|KafkaProducer).java"/>
-    <suppress checks="ParameterNumber"
-              files="(KafkaConsumer|ConsumerCoordinator).java"/>
-    <suppress checks="ParameterNumber"
-              files="(RecordAccumulator|Sender).java"/>
-    <suppress checks="ParameterNumber"
-              files="ConfigDef.java"/>
-    <suppress checks="ParameterNumber"
-              files="DefaultRecordBatch.java"/>
-    <suppress checks="ParameterNumber"
-              files="MemoryRecordsBuilder.java"/>
-    <suppress checks="ParameterNumber"
-              files="ClientUtils.java"/>
+              files="(NetworkClient|FieldSpec|KafkaProducer|KafkaConsumer|ConsumerCoordinator|RecordAccumulator|Sender|ConfigDef|DefaultRecordBatch|MemoryRecordsBuilder|ClientUtils).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(KafkaConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaNetworkChannelTest|ClientTelemetryReporterTest).java"/>
-    <suppress checks="ClassDataAbstractionCoupling"
-              files="(Errors|SaslAuthenticatorTest|AgentTest|CoordinatorTest|NetworkClientTest).java"/>
+              files="(KafkaConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaNetworkChannelTest|ClientTelemetryReporterTest|Errors|SaslAuthenticatorTest|AgentTest|CoordinatorTest|NetworkClientTest).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
               files="(Utils|Topic|Lz4BlockOutputStream|AclData|JoinGroupRequest).java"/>
@@ -107,9 +83,6 @@
 
     <suppress checks="(JavaNCSS|CyclomaticComplexity|MethodLength)"
               files="CoordinatorClient.java"/>
-    <suppress checks="(UnnecessaryParentheses|BooleanExpressionComplexity|CyclomaticComplexity|WhitespaceAfter|LocalVariableName)"
-              files="Murmur3.java"/>
-
     <suppress checks="NPathComplexity"
             files="MessageTest.java|OffsetFetchRequest.java"/>
 
@@ -132,12 +105,9 @@
     <suppress checks="NPathComplexity"
               files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils|AclAuthorizerBenchmark"/>
 
-    <suppress checks="(WhitespaceAround|LocalVariableName|ImportControl|AvoidStarImport)"
-              files="Murmur3Test.java"/>
-
     <!-- Connect -->
     <suppress checks="ClassFanOutComplexity"
-              files="(AbstractHerder|DistributedHerder|Worker).java"/>
+              files="(AbstractHerder|DistributedHerder).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="Worker(|Test).java"/>
     <suppress checks="MethodLength"
@@ -156,9 +126,7 @@
               files="JsonConverter.java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(FileStreamSourceTask|DistributedHerder|KafkaConfigBackingStore).java"/>
-    <suppress checks="CyclomaticComplexity"
-              files="(JsonConverter|ConnectHeaders).java"/>
+              files="(FileStreamSourceTask|DistributedHerder|KafkaConfigBackingStore|JsonConverter|ConnectHeaders).java"/>
 
     <suppress checks="JavaNCSS"
               files="(KafkaConfigBackingStore|ConnectMetricsRegistry).java"/>
@@ -222,11 +190,8 @@
     <suppress checks="(NPathComplexity|CyclomaticComplexity)"
               files="(KStreamSlidingWindowAggregate|RackAwareTaskAssignor).java"/>
 
-    <!-- suppress FinalLocalVariable and FinalParameters outside of the streams package. -->
+    <!-- suppress FinalLocalVariable outside of the streams package. -->
     <suppress checks="FinalLocalVariable"
-              files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
-
-    <suppress checks="FinalParameters"
               files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
 
     <!-- Generated code -->
@@ -262,13 +227,8 @@
     <suppress checks="MethodLength"
               files="(KStreamSlidingWindowAggregateTest|KStreamKStreamLeftJoinTest|KStreamKStreamOuterJoinTest|KTableKTableForeignKeyJoinIntegrationTest).java"/>
 
-    <suppress checks="ClassFanOutComplexity"
-              files="StreamTaskTest.java"/>
-
     <!-- Streams test-utils -->
-    <suppress checks="ClassFanOutComplexity"
-              files="TopologyTestDriver.java"/>
-    <suppress checks="ClassDataAbstractionCoupling"
+    <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files="TopologyTestDriver.java"/>
 
     <!-- Streams examples -->
@@ -285,29 +245,17 @@
               files="(StreamsResetter|DefaultMessageFormatter).java"/>
     <suppress checks="NPathComplexity"
               files="(AclCommand|DefaultMessageFormatter|ProducerPerformance|StreamsResetter|Agent|TransactionalMessageCopier|ReplicaVerificationTool|LineMessageReader|ConsoleProducer|DumpLogSegments).java"/>
-    <suppress checks="ImportControl"
-              files="SignalLogger.java"/>
-    <suppress checks="IllegalImport"
+    <suppress checks="ImportControl|IllegalImport"
               files="SignalLogger.java"/>
     <suppress checks="ParameterNumber"
-              files="ProduceBenchSpec.java"/>
-    <suppress checks="ParameterNumber"
-              files="ConsumeBenchSpec.java"/>
-    <suppress checks="ParameterNumber"
-              files="SustainedConnectionSpec.java"/>
+              files="(ProduceBenchSpec|ConsumeBenchSpec|SustainedConnectionSpec).java"/>
     <suppress id="dontUseSystemExit"
-              files="VerifiableConsumer.java"/>
-    <suppress id="dontUseSystemExit"
-              files="VerifiableProducer.java"/>
-    <suppress id="dontUseSystemExit"
-              files="VerifiableShareConsumer.java"/>
+              files="(VerifiableConsumer|VerifiableProducer|VerifiableShareConsumer).java"/>
 
     <!-- Shell -->
     <suppress checks="CyclomaticComplexity"
               files="(GlobComponent|MetadataNodeManager).java"/>
-    <suppress checks="MethodLength"
-              files="(MetadataNodeManager).java"/>
-    <suppress checks="JavaNCSS"
+    <suppress checks="MethodLength|JavaNCSS"
               files="(MetadataNodeManager).java"/>
 
     <!-- metadata -->
@@ -315,7 +263,7 @@
               files="(QuorumController|QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest|ClusterControlManagerTest|KRaftMigrationDriverTest).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(QuorumController|QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest).java"/>
-    <suppress checks="(ParameterNumber|ClassDataAbstractionCoupling)"
+    <suppress checks="ParameterNumber"
               files="(QuorumController).java"/>
     <suppress checks="(CyclomaticComplexity|NPathComplexity)"
               files="(ConfigurationControlManager|PartitionRegistration|PartitionChangeBuilder|ScramParser).java"/>
@@ -339,7 +287,7 @@
               files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager|GroupCoordinatorConfig).java"/>
-    <suppress checks="ClassDataAbstractionCouplingCheck"
+    <suppress checks="ClassDataAbstractionCoupling"
               files="(RecordHelpersTest|GroupCoordinatorRecordHelpers|GroupMetadataManager|GroupCoordinatorService|GroupMetadataManagerTest|OffsetMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest|GroupCoordinatorRecordSerde|StreamsGroupTest).java"/>
     <suppress checks="JavaNCSS"
               files="(GroupMetadataManager|GroupMetadataManagerTest).java"/>
@@ -351,12 +299,10 @@
               files="CoordinatorRuntime.java"/>
 
     <!-- share coordinator and persister-->
-    <suppress checks="NPathComplexity"
+    <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="ShareCoordinatorShard.java"/>
-    <suppress checks="ClassDataAbstractionCouplingCheck"
+    <suppress checks="ClassDataAbstractionCoupling"
               files="(ShareCoordinatorServiceTest|DefaultStatePersisterTest|PersisterStateManagerTest).java"/>
-    <suppress checks="CyclomaticComplexity"
-              files="ShareCoordinatorShard.java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(PersisterStateManagerTest|DefaultStatePersisterTest).java"/>
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -37,8 +37,6 @@
 
     <!-- core -->
     <suppress checks="NPathComplexity" files="(ClusterTestExtensions|KafkaApisBuilder|SharePartition|SharePartitionManager).java"/>
-    <suppress checks="MethodLength"
-              files="(KafkaClusterTestKit).java"/>
     <suppress checks="NPathComplexity" files="TestKitNodes.java"/>
     <suppress checks="JavaNCSS"
               files="(SharePartitionManagerTest|SharePartitionTest|ShareConsumerTest).java"/>
@@ -61,7 +59,7 @@
               files="(SaslServerAuthenticator).java"/>
 
     <suppress checks="MethodLength"
-              files="(KerberosLogin|RequestResponseTest|ConnectMetricsRegistry|KafkaConsumer|AbstractStickyAssignor|AbstractRequest|AbstractResponse).java"/>
+              files="(KerberosLogin|ConnectMetricsRegistry|AbstractRequest|AbstractResponse).java"/>
 
     <suppress checks="ParameterNumber"
               files="(NetworkClient|FieldSpec|KafkaProducer|KafkaConsumer|ConsumerCoordinator|RecordAccumulator|Sender|ConfigDef|DefaultRecordBatch|MemoryRecordsBuilder|ClientUtils).java"/>
@@ -70,7 +68,7 @@
               files="(KafkaConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaNetworkChannelTest|ClientTelemetryReporterTest|Errors|SaslAuthenticatorTest|AgentTest|CoordinatorTest|NetworkClientTest).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
-              files="(Utils|Topic|Lz4BlockOutputStream|AclData|JoinGroupRequest).java"/>
+              files="(Utils|Topic|Lz4BlockOutputStream|JoinGroupRequest).java"/>
 
     <suppress checks="CyclomaticComplexity"
               files="(AbstractFetch|ClientTelemetryReporter|ConsumerCoordinator|CommitRequestManager|FetchCollector|OffsetFetcherUtils|KafkaProducer|Sender|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler|MockAdminClient).java"/>
@@ -103,7 +101,7 @@
               files="RequestResponseTest.java|FetcherTest.java|FetchRequestManagerTest.java|KafkaAdminClientTest.java|ConsumerMembershipManagerTest.java"/>
 
     <suppress checks="NPathComplexity"
-              files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils|AclAuthorizerBenchmark"/>
+              files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils"/>
 
     <!-- Connect -->
     <suppress checks="ClassFanOutComplexity"
@@ -111,7 +109,7 @@
     <suppress checks="ClassFanOutComplexity"
               files="Worker(|Test).java"/>
     <suppress checks="MethodLength"
-              files="(DistributedHerder|DistributedConfig|KafkaConfigBackingStore|IncrementalCooperativeAssignor).java"/>
+              files="(DistributedHerder|DistributedConfig|IncrementalCooperativeAssignor).java"/>
     <suppress checks="ParameterNumber"
               files="Worker(SinkTask|SourceTask|Coordinator)?.java"/>
     <suppress checks="ParameterNumber"
@@ -139,15 +137,15 @@
 
     <!-- connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(DistributedHerder|KafkaBasedLog|WorkerSourceTaskWithTopicCreation|WorkerSourceTask)Test.java"/>
+              files="(DistributedHerder|KafkaBasedLog|WorkerSourceTask)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(WorkerSink|WorkerSource|ErrorHandling)Task(|WithTopicCreation|Mockito)Test.java"/>
+              files="(WorkerSink|WorkerSource|ErrorHandling)TaskTest.java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(AbstractHerderTest|DistributedHerderTest).java"/>
 
     <suppress checks="MethodLength"
-              files="(RequestResponse|WorkerSinkTask|WorkerSinkTaskMockito)Test.java"/>
+              files="WorkerSinkTaskTest.java"/>
 
     <suppress checks="JavaNCSS"
               files="(DistributedHerder|Worker)Test.java"/>
@@ -204,19 +202,19 @@
               files="(RecordCollectorTest|StreamsPartitionAssignorTest|StreamThreadTest|StreamTaskTest|TaskManagerTest|TopologyTestDriverTest|KafkaStreamsTest|EosIntegrationTest|RestoreIntegrationTest).java"/>
 
     <suppress checks="MethodLength"
-              files="(EosIntegrationTest|EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|RocksDBWindowStoreTest|StreamStreamJoinIntegrationTest).java"/>
+              files="(EosIntegrationTest|KStreamKStreamJoinTest|RocksDBWindowStoreTest).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files=".*[/\\]streams[/\\].*test[/\\].*.java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest|RelationalSmokeTest|MockProcessorContextStateStoreTest|IQv2StoreIntegrationTest|StreamsConfigTest).java"/>
+              files="(KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest|RelationalSmokeTest|MockProcessorContextStateStoreTest|IQv2StoreIntegrationTest|StreamsConfigTest).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|StreamThreadTest|TaskManagerTest|StreamTaskTest).java"/>
+              files="(KStreamKStreamJoinTest|StreamThreadTest|TaskManagerTest|StreamTaskTest).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|RelationalSmokeTest|MockProcessorContextStateStoreTest|TopologyTestDriverTest|IQv2StoreIntegrationTest).java"/>
+              files="(KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|RelationalSmokeTest|MockProcessorContextStateStoreTest|TopologyTestDriverTest|IQv2StoreIntegrationTest).java"/>
 
     <suppress checks="(FinalLocalVariable|WhitespaceAround|LocalVariableName|ImportControl)"
               files="Murmur3Test.java"/>
@@ -253,7 +251,7 @@
 
     <!-- metadata -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(QuorumController|QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest|ClusterControlManagerTest|KRaftMigrationDriverTest).java"/>
+              files="(QuorumController|QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest|ClusterControlManagerTest).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(QuorumController|QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest).java"/>
     <suppress checks="ParameterNumber"
@@ -261,9 +259,9 @@
     <suppress checks="(CyclomaticComplexity|NPathComplexity)"
               files="(ConfigurationControlManager|PartitionRegistration|PartitionChangeBuilder|ScramParser).java"/>
     <suppress checks="CyclomaticComplexity"
-              files="(ClientQuotasImage|KafkaEventQueue|MetadataDelta|QuorumController|ReplicationControlManager|KRaftMigrationDriver|ClusterControlManager|MetaPropertiesEnsemble).java"/>
+              files="(ClientQuotasImage|KafkaEventQueue|MetadataDelta|QuorumController|ReplicationControlManager|ClusterControlManager|MetaPropertiesEnsemble).java"/>
     <suppress checks="NPathComplexity"
-              files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager|FeatureControlManager|KRaftMigrationDriver|ScramControlManager|ClusterControlManager|MetadataDelta|MetaPropertiesEnsemble).java"/>
+              files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager|FeatureControlManager|ScramControlManager|ClusterControlManager|MetadataDelta|MetaPropertiesEnsemble).java"/>
     <suppress checks="BooleanExpressionComplexity"
               files="(MetadataImage).java"/>
     <suppress checks="ImportControl"
@@ -271,9 +269,9 @@
 
     <!-- group coordinator -->
     <suppress checks="CyclomaticComplexity"
-              files="(ConsumerGroupMember|GroupMetadataManager|GeneralUniformAssignmentBuilder|GroupCoordinatorRecordSerde|GroupMetadataManagerTestContext).java"/>
+              files="(ConsumerGroupMember|GroupMetadataManager|GroupCoordinatorRecordSerde|GroupMetadataManagerTestContext).java"/>
     <suppress checks="(NPathComplexity|MethodLength)"
-              files="(GroupMetadataManager|ConsumerGroupTest|ShareGroupTest|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GeneralUniformAssignmentBuilder|GroupCoordinatorShard).java"/>
+              files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorShard).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -23,7 +23,32 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.apache.kafka.server.common.MetadataVersion.*;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_3_IV3;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_4_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV1;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV2;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_6_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_6_IV1;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_6_IV2;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV1;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV2;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV3;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV4;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_8_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_3_9_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV1;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV2;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV3;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_1_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_1_IV1;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV1;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_3_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
+import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,7 +126,7 @@ class MetadataVersionTest {
         assertEquals("Unknown metadata.version '4.4-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
             + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, "
             + "4.1-IV1, 4.2-IV0, 4.2-IV1, 4.3-IV0",
-            assertThrows(IllegalArgumentException.class, () -> fromVersionString("4.4-IV0", false)).getMessage());
+            assertThrows(IllegalArgumentException.class, () -> MetadataVersion.fromVersionString("4.4-IV0", false)).getMessage());
     }
 
     @Test


### PR DESCRIPTION
No rules are relaxed or tightened — this is purely a cleanup of
redundant and dead rules in checkstyle configuration:

- Remove dead `FinalParameters` suppression (check is not enabled in
checkstyle.xml)
- Remove duplicate suppressions for Utils.java, Worker.java,
StreamTaskTest.java, QuorumController, Murmur3.java, and
Murmur3Test.java
- Normalize inconsistent check names: `NPath` → `NPathComplexity`,
`ClassDataAbstractionCouplingCheck` → `ClassDataAbstractionCoupling`
  - [NPathComplexity
reference](https://checkstyle.org/checks/metrics/npathcomplexity.html)
  - [ClassDataAbstractionCoupling
reference](https://checkstyle.org/checks/metrics/classdataabstractioncoupling.html)
- Consolidate multiple suppression entries with the same check or same
file into single patterns
- Remove redundant `processJavadoc` property from `UnusedImports`
(default is `true` since checkstyle 8.x)
  - https://checkstyle.sourceforge.io/checks/imports/unusedimports.html
- Remove suppressions for deleted classes (`MetadataNodeManager`,
`SignalLogger`,
  `AclData`, `AclAuthorizerBenchmark`, `EosV2UpgradeIntegrationTest`,
  `KRaftMigrationDriver`, `KRaftMigrationDriverTest`,
  `GeneralUniformAssignmentBuilder`,
`WorkerSourceTaskWithTopicCreation`,
  `WorkerSinkTaskMockito` and other Mockito/WithTopicCreation test
variants)
- Remove suppressions for refactored classes that no longer trigger
violations
  (`RemoteLogManagerConfig`, `GroupCoordinatorConfig`,
`RemoteLogManager`)
- Remove redundant `ImportControl` suppressions (`FetchResponseData`
covered by
  generated code rule, `AdminFenceProducersTest` and
`ClientTelemetryTest` have
  no actual violations)
- Remove `AvoidStarImport` from `Murmur3Test` (no star imports exist)
- Expand star import in `MetadataVersionTest` to explicit imports and
remove
  its `AvoidStarImport` suppression
- Remove unnecessary `MethodLength` suppressions for files now well
under
  the 150-line threshold (`KafkaClusterTestKit`, `KafkaConsumer`,
  `RequestResponseTest`, `AbstractStickyAssignor`,
`KafkaConfigBackingStore`,
  `StreamStreamJoinIntegrationTest`, `ConsumerGroupTest`,
`ShareGroupTest`)

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
