### PR TITLE
KAFKA-20193: Remove unused code

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializer.java
@@ -95,13 +95,5 @@ class ValueTimestampHeadersDeserializer<V> implements WrappingNullableDeserializ
         initNullableDeserializer(valueDeserializer, getter);
     }
 
-    /**
-     * Extract value from serialized ValueTimestampHeaders.
-     */
-    static <T> T value(final byte[] rawValueTimestampHeaders, final Deserializer<T> deserializer) {
-        if (rawValueTimestampHeaders == null) {
-            return null;
-        }
-        return deserializer.deserialize("", Utils.rawPlainValue(rawValueTimestampHeaders));
-    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersDeserializerTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 
@@ -182,28 +181,6 @@ public class ValueTimestampHeadersDeserializerTest {
         assertNotNull(header);
         assertEquals("key1", header.key());
         assertNull(header.value());
-    }
-
-    @Test
-    public void shouldExtractValue() {
-        final Headers headers = new RecordHeaders()
-            .add("key1", "value1".getBytes());
-        final ValueTimestampHeaders<String> original =
-            ValueTimestampHeaders.make("test-value", 123456789L, headers);
-
-        final byte[] serialized = serializer.serialize(TOPIC, original);
-
-        try (final Serde<String> stringSerde = Serdes.String()) {
-            final String value = ValueTimestampHeadersDeserializer.value(serialized, stringSerde.deserializer());
-            assertNotNull(value);
-            assertEquals("test-value", value);
-        }
-    }
-
-    @Test
-    public void shouldReturnNullForRawValueWhenInputIsNull() {
-        final ValueTimestampHeaders<String> value = ValueTimestampHeadersDeserializer.value(null, deserializer);
-        assertNull(value);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Removes static <T> T value(...) method from
ValueTimestampHeadersDeserializer.

Reviewers: Zheguang Zhao <zheguang.zhao@alumni.brown.edu>, Matthias J.
 Sax <matthias@confluent.io>
