### PR TITLE
MINOR: Fix typo 'propogation' to 'propagation' in TopicCommandTest

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -1115,7 +1115,7 @@ public class TopicCommandTest {
                                         broker.metadataCache().getLeaderAndIsr(testTopicName, 0).orElseGet(null));
                                 return partitionState.map(s -> FetchRequest.isValidBrokerId(s.leader())).orElse(false);
                             }
-                    ), CLUSTER_WAIT_MS, String.format("Meta data propagation fail in %s ms", CLUSTER_WAIT_MS));
+                    ), CLUSTER_WAIT_MS, String.format("Metadata propagation fail in %s ms", CLUSTER_WAIT_MS));
 
             String output = captureDescribeTopicStandardOut(clusterInstance, buildTopicCommandOptionsWithBootstrap(clusterInstance, "--describe", "--under-replicated-partitions"));
             String[] rows = output.split(System.lineSeparator());

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -1115,7 +1115,7 @@ public class TopicCommandTest {
                                         broker.metadataCache().getLeaderAndIsr(testTopicName, 0).orElseGet(null));
                                 return partitionState.map(s -> FetchRequest.isValidBrokerId(s.leader())).orElse(false);
                             }
-                    ), CLUSTER_WAIT_MS, String.format("Meta data propogation fail in %s ms", CLUSTER_WAIT_MS));
+                    ), CLUSTER_WAIT_MS, String.format("Meta data propagation fail in %s ms", CLUSTER_WAIT_MS));
 
             String output = captureDescribeTopicStandardOut(clusterInstance, buildTopicCommandOptionsWithBootstrap(clusterInstance, "--describe", "--under-replicated-partitions"));
             String[] rows = output.split(System.lineSeparator());


### PR DESCRIPTION
Fix typos in TopicCommandTest:
- `propogation` -> `propagation`
- `Meta data` -> `Metadata` for consistency with the rest of the
codebase

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
