### PR TITLE
KAFKA-14615: Use sizeCompare for collection size equality checks

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -118,7 +118,7 @@ class LogManager(logDirs: Seq[File],
   def currentDefaultConfig: LogConfig = _currentDefaultConfig
 
   def liveLogDirs: Seq[File] = {
-    if (_liveLogDirs.size == logDirs.size)
+    if (_liveLogDirs.asScala.sizeCompare(logDirs) == 0)
       logDirs
     else
       _liveLogDirs.asScala.toBuffer

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -836,8 +836,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   ): Seq[MetadataResponseTopic] = {
     val topicResponses = metadataCache.getTopicMetadata(topics.asJava, listenerName,
       errorUnavailableEndpoints, errorUnavailableListeners)
-
-    if (topics.isEmpty || topicResponses.size == topics.size || fetchAllTopics) {
+    if (topics.isEmpty || topics.sizeCompare(topicResponses.asScala) == 0 || fetchAllTopics) {
       topicResponses.asScala
     } else {
       val nonExistingTopics = topics.diff(topicResponses.asScala.map(_.name).toSet)
@@ -1877,7 +1876,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     def addResultAndMaybeSendResponse(result: AddPartitionsToTxnResult): Unit = {
       val canSend = responses.synchronized {
         responses.add(result)
-        responses.size == txns.size
+        responses.asScala.sizeCompare(txns.asScala) == 0
       }
       if (canSend) {
         requestHelper.sendResponseMaybeThrottle(request, createResponse)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -589,7 +589,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
       validateQuorumVotersAndQuorumBootstrapServerForKRaft()
       // listeners should only contain listeners also enumerated in the controller listener
       require(
-        effectiveAdvertisedControllerListeners.size == listeners.size,
+        effectiveAdvertisedControllerListeners.sizeCompare(listeners) == 0,
         s"The ${SocketServerConfigs.LISTENERS_CONFIG} config must only contain KRaft controller listeners from ${KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG} when ${KRaftConfigs.PROCESS_ROLES_CONFIG}=controller"
       )
       // controller.listener.names must not contain inter.broker.listener.name when inter.broker.listener.name is explicitly set


### PR DESCRIPTION
(IterableA.size == IterableB.size) has complexity of O(IterableA size + IterableB size) whereas sizeCompare() has complexity of O(min(IterableA size, IterableB size)).