### PR TITLE
KAFKA-20210: Add group.coordinator.background.threads config

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1036,6 +1036,7 @@ class KafkaConfigTest {
 
         /** New group coordinator configs */
         case GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
+        case GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", -2, -0.5)
         case GroupCoordinatorConfig.CACHED_BUFFER_MAX_BYTES_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1, 512 * 1024 - 1)
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1036,7 +1036,7 @@ class KafkaConfigTest {
 
         /** New group coordinator configs */
         case GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
-        case GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
+        case GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", -2, -0.5)
         case GroupCoordinatorConfig.CACHED_BUFFER_MAX_BYTES_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1, 512 * 1024 - 1)
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -83,6 +83,10 @@ public class GroupCoordinatorConfig {
     public static final String GROUP_COORDINATOR_NUM_THREADS_DOC = "The number of threads used by the group coordinator.";
     public static final int GROUP_COORDINATOR_NUM_THREADS_DEFAULT = 4;
 
+    public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG = "group.coordinator.executor.threads";
+    public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DOC = "The number of executor threads used by the group coordinator.";
+    public static final int GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DEFAULT = 2;
+
     public static final String OFFSETS_LOAD_BUFFER_SIZE_CONFIG = "offsets.load.buffer.size";
     public static final int OFFSETS_LOAD_BUFFER_SIZE_DEFAULT = 5 * 1024 * 1024;
     public static final String OFFSETS_LOAD_BUFFER_SIZE_DOC = "Batch size for reading from the offsets segments when loading group metadata " +
@@ -317,6 +321,7 @@ public class GroupCoordinatorConfig {
         .define(GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, LIST, GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DEFAULT, 
             ConfigDef.ValidList.in(false, Group.GroupType.documentValidValues()), MEDIUM, GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DOC)
         .define(GROUP_COORDINATOR_NUM_THREADS_CONFIG, INT, GROUP_COORDINATOR_NUM_THREADS_DEFAULT, atLeast(1), HIGH, GROUP_COORDINATOR_NUM_THREADS_DOC)
+        .define(GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG, INT, GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DEFAULT, atLeast(1), HIGH, GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DOC)
         .define(GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, INT, GROUP_COORDINATOR_APPEND_LINGER_MS_DEFAULT, atLeast(-1), MEDIUM, GROUP_COORDINATOR_APPEND_LINGER_MS_DOC)
         .define(OFFSET_COMMIT_TIMEOUT_MS_CONFIG, INT, OFFSET_COMMIT_TIMEOUT_MS_DEFAULT, atLeast(1), HIGH, OFFSET_COMMIT_TIMEOUT_MS_DOC)
         .define(OFFSETS_LOAD_BUFFER_SIZE_CONFIG, INT, OFFSETS_LOAD_BUFFER_SIZE_DEFAULT, atLeast(1), HIGH, OFFSETS_LOAD_BUFFER_SIZE_DOC)
@@ -382,6 +387,7 @@ public class GroupCoordinatorConfig {
     public static final int CLASSIC_GROUP_NEW_MEMBER_JOIN_TIMEOUT_MS = 5 * 60 * 1000;
 
     private final int numThreads;
+    private final int numExecutorThreads;
     private final int appendLingerMs;
     private final int consumerGroupSessionTimeoutMs;
     private final int consumerGroupHeartbeatIntervalMs;
@@ -433,6 +439,7 @@ public class GroupCoordinatorConfig {
     @SuppressWarnings("this-escape")
     public GroupCoordinatorConfig(AbstractConfig config) {
         this.numThreads = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG);
+        this.numExecutorThreads = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG);
         this.appendLingerMs = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG);
         this.consumerGroupSessionTimeoutMs = config.getInt(GroupCoordinatorConfig.CONSUMER_GROUP_SESSION_TIMEOUT_MS_CONFIG);
         this.consumerGroupHeartbeatIntervalMs = config.getInt(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG);
@@ -669,6 +676,13 @@ public class GroupCoordinatorConfig {
      */
     public int numThreads() {
         return numThreads;
+    }
+
+    /**
+     * The number of executor threads.
+     */
+    public int numExecutorThreads() {
+        return numExecutorThreads;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -80,11 +80,12 @@ public class GroupCoordinatorConfig {
     public static final int GROUP_COORDINATOR_APPEND_LINGER_MS_DEFAULT = -1;
 
     public static final String GROUP_COORDINATOR_NUM_THREADS_CONFIG = "group.coordinator.threads";
-    public static final String GROUP_COORDINATOR_NUM_THREADS_DOC = "The number of threads used by the group coordinator.";
+    public static final String GROUP_COORDINATOR_NUM_THREADS_DOC = "The number of threads used by the group coordinator for processing requests.";
     public static final int GROUP_COORDINATOR_NUM_THREADS_DEFAULT = 4;
 
     public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG = "group.coordinator.executor.threads";
-    public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DOC = "The number of executor threads used by the group coordinator.";
+    public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DOC = "The number of executor threads used by the group coordinator for " +
+        "updating the list of topics for regex subscriptions and metadata changes and offloaded assignments.";
     public static final int GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DEFAULT = 2;
 
     public static final String OFFSETS_LOAD_BUFFER_SIZE_CONFIG = "offsets.load.buffer.size";

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -83,10 +83,10 @@ public class GroupCoordinatorConfig {
     public static final String GROUP_COORDINATOR_NUM_THREADS_DOC = "The number of threads used by the group coordinator for processing requests.";
     public static final int GROUP_COORDINATOR_NUM_THREADS_DEFAULT = 4;
 
-    public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG = "group.coordinator.executor.threads";
-    public static final String GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DOC = "The number of executor threads used by the group coordinator for " +
+    public static final String GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_CONFIG = "group.coordinator.background.threads";
+    public static final String GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DOC = "The number of background threads used by the group coordinator for " +
         "updating the list of topics for regex subscriptions and metadata changes and offloaded assignments.";
-    public static final int GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DEFAULT = 2;
+    public static final int GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DEFAULT = 2;
 
     public static final String OFFSETS_LOAD_BUFFER_SIZE_CONFIG = "offsets.load.buffer.size";
     public static final int OFFSETS_LOAD_BUFFER_SIZE_DEFAULT = 5 * 1024 * 1024;
@@ -322,7 +322,7 @@ public class GroupCoordinatorConfig {
         .define(GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, LIST, GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DEFAULT, 
             ConfigDef.ValidList.in(false, Group.GroupType.documentValidValues()), MEDIUM, GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DOC)
         .define(GROUP_COORDINATOR_NUM_THREADS_CONFIG, INT, GROUP_COORDINATOR_NUM_THREADS_DEFAULT, atLeast(1), HIGH, GROUP_COORDINATOR_NUM_THREADS_DOC)
-        .define(GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG, INT, GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DEFAULT, atLeast(1), HIGH, GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_DOC)
+        .define(GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_CONFIG, INT, GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DEFAULT, atLeast(1), HIGH, GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DOC)
         .define(GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, INT, GROUP_COORDINATOR_APPEND_LINGER_MS_DEFAULT, atLeast(-1), MEDIUM, GROUP_COORDINATOR_APPEND_LINGER_MS_DOC)
         .define(OFFSET_COMMIT_TIMEOUT_MS_CONFIG, INT, OFFSET_COMMIT_TIMEOUT_MS_DEFAULT, atLeast(1), HIGH, OFFSET_COMMIT_TIMEOUT_MS_DOC)
         .define(OFFSETS_LOAD_BUFFER_SIZE_CONFIG, INT, OFFSETS_LOAD_BUFFER_SIZE_DEFAULT, atLeast(1), HIGH, OFFSETS_LOAD_BUFFER_SIZE_DOC)
@@ -388,7 +388,7 @@ public class GroupCoordinatorConfig {
     public static final int CLASSIC_GROUP_NEW_MEMBER_JOIN_TIMEOUT_MS = 5 * 60 * 1000;
 
     private final int numThreads;
-    private final int numExecutorThreads;
+    private final int numBackgroundThreads;
     private final int appendLingerMs;
     private final int consumerGroupSessionTimeoutMs;
     private final int consumerGroupHeartbeatIntervalMs;
@@ -440,7 +440,7 @@ public class GroupCoordinatorConfig {
     @SuppressWarnings("this-escape")
     public GroupCoordinatorConfig(AbstractConfig config) {
         this.numThreads = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG);
-        this.numExecutorThreads = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG);
+        this.numBackgroundThreads = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_CONFIG);
         this.appendLingerMs = config.getInt(GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG);
         this.consumerGroupSessionTimeoutMs = config.getInt(GroupCoordinatorConfig.CONSUMER_GROUP_SESSION_TIMEOUT_MS_CONFIG);
         this.consumerGroupHeartbeatIntervalMs = config.getInt(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG);
@@ -680,10 +680,10 @@ public class GroupCoordinatorConfig {
     }
 
     /**
-     * The number of executor threads.
+     * The number of background threads.
      */
-    public int numExecutorThreads() {
-        return numExecutorThreads;
+    public int numBackgroundThreads() {
+        return numBackgroundThreads;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -84,8 +84,8 @@ public class GroupCoordinatorConfig {
     public static final int GROUP_COORDINATOR_NUM_THREADS_DEFAULT = 4;
 
     public static final String GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_CONFIG = "group.coordinator.background.threads";
-    public static final String GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DOC = "The number of background threads used by the group coordinator for " +
-        "updating the list of topics for regex subscriptions and metadata changes and offloaded assignments.";
+    public static final String GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DOC = "The number of threads used by the group coordinator for " +
+        "processing background tasks (e.g. updating regular expression subscriptions and offloaded assignments).";
     public static final int GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_DEFAULT = 2;
 
     public static final String OFFSETS_LOAD_BUFFER_SIZE_CONFIG = "offsets.load.buffer.size";

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -276,7 +276,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withSerializer(new GroupCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.offsetTopicCompressionType()).build())
                     .withAppendLingerMs(config.appendLingerMs())
-                    .withExecutorService(Executors.newFixedThreadPool(config.numExecutorThreads()))
+                    .withExecutorService(Executors.newFixedThreadPool(config.numBackgroundThreads()))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -276,7 +276,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withSerializer(new GroupCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.offsetTopicCompressionType()).build())
                     .withAppendLingerMs(config.appendLingerMs())
-                    .withExecutorService(Executors.newSingleThreadExecutor())
+                    .withExecutorService(Executors.newFixedThreadPool(config.numExecutorThreads()))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -80,8 +80,8 @@ import org.apache.kafka.common.requests.StreamsGroupDescribeRequest;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
-import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorEventProcessor;
@@ -142,7 +142,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 
@@ -262,8 +261,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 coordinatorRuntimeMetrics
             );
 
-            AtomicInteger backgroundThreadId = new AtomicInteger(0);
-
             CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime =
                 new CoordinatorRuntime.Builder<GroupCoordinatorShard, CoordinatorRecord>()
                     .withTime(time)
@@ -282,11 +279,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withAppendLingerMs(config.appendLingerMs())
                     .withExecutorService(Executors.newFixedThreadPool(
                         config.numBackgroundThreads(),
-                        runnable -> new KafkaThread(
-                            "group-coordinator-background-" + backgroundThreadId.getAndIncrement(),
-                            runnable,
-                            false
-                        )
+                        ThreadUtils.createThreadFactory("group-coordinator-background-%d", false)
                     ))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -80,7 +80,6 @@ import org.apache.kafka.common.requests.StreamsGroupDescribeRequest;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
-import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -142,7 +141,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 
@@ -262,8 +260,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 coordinatorRuntimeMetrics
             );
 
-            AtomicInteger backgroundThreadId = new AtomicInteger(0);
-
             CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime =
                 new CoordinatorRuntime.Builder<GroupCoordinatorShard, CoordinatorRecord>()
                     .withTime(time)
@@ -282,11 +278,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withAppendLingerMs(config.appendLingerMs())
                     .withExecutorService(Executors.newFixedThreadPool(
                         config.numBackgroundThreads(),
-                        runnable -> new KafkaThread(
-                            "group-coordinator-background-" + backgroundThreadId.getAndIncrement(),
-                            runnable,
-                            false
-                        )
+                        Thread.ofPlatform()
+                            .name("group-coordinator-background-", 0)
+                            .factory()
                     ))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -80,6 +80,7 @@ import org.apache.kafka.common.requests.StreamsGroupDescribeRequest;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -141,6 +142,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 
@@ -260,6 +262,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 coordinatorRuntimeMetrics
             );
 
+            AtomicInteger backgroundThreadId = new AtomicInteger(0);
+
             CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime =
                 new CoordinatorRuntime.Builder<GroupCoordinatorShard, CoordinatorRecord>()
                     .withTime(time)
@@ -278,9 +282,11 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withAppendLingerMs(config.appendLingerMs())
                     .withExecutorService(Executors.newFixedThreadPool(
                         config.numBackgroundThreads(),
-                        Thread.ofPlatform()
-                            .name("group-coordinator-background-", 0)
-                            .factory()
+                        runnable -> new KafkaThread(
+                            "group-coordinator-background-" + backgroundThreadId.getAndIncrement(),
+                            runnable,
+                            false
+                        )
                     ))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -175,7 +175,7 @@ public class GroupCoordinatorConfigTest {
     public void testConfigs() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG, 10);
-        configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG, 3);
+        configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_BACKGROUND_THREADS_CONFIG, 3);
         configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, 10);
         configs.put(GroupCoordinatorConfig.CONSUMER_GROUP_SESSION_TIMEOUT_MS_CONFIG, 555);
         configs.put(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, 200);
@@ -206,7 +206,7 @@ public class GroupCoordinatorConfigTest {
         GroupCoordinatorConfig config = createConfig(configs);
 
         assertEquals(10, config.numThreads());
-        assertEquals(3, config.numExecutorThreads());
+        assertEquals(3, config.numBackgroundThreads());
         assertEquals(555, config.consumerGroupSessionTimeoutMs());
         assertEquals(200, config.consumerGroupHeartbeatIntervalMs());
         assertEquals(55, config.consumerGroupMaxSize());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -175,6 +175,7 @@ public class GroupCoordinatorConfigTest {
     public void testConfigs() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_THREADS_CONFIG, 10);
+        configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_NUM_EXECUTOR_THREADS_CONFIG, 3);
         configs.put(GroupCoordinatorConfig.GROUP_COORDINATOR_APPEND_LINGER_MS_CONFIG, 10);
         configs.put(GroupCoordinatorConfig.CONSUMER_GROUP_SESSION_TIMEOUT_MS_CONFIG, 555);
         configs.put(GroupCoordinatorConfig.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, 200);
@@ -205,6 +206,7 @@ public class GroupCoordinatorConfigTest {
         GroupCoordinatorConfig config = createConfig(configs);
 
         assertEquals(10, config.numThreads());
+        assertEquals(3, config.numExecutorThreads());
         assertEquals(555, config.consumerGroupSessionTimeoutMs());
         assertEquals(200, config.consumerGroupHeartbeatIntervalMs());
         assertEquals(55, config.consumerGroupMaxSize());


### PR DESCRIPTION
Add the group.coordinator.background.threads config option to control
the  number of threads in the group coordinator's CoordinatorExecutor
thread  pool.

Reviewers: Dongnuo Lyu <dlyu@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>, PoAn Yang <payang@apache.org>, David Jacot
 <djacot@confluent.io>
