### PR TITLE
KAFKA-20066: Implement KIP-1251: Assignment epochs for consumer groups [1/N]

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2828,7 +2828,7 @@ public class GroupMetadataManager {
         //    (subscribedTopicNames) to detect a full request as those must be set in a full request.
         // 2. The member's assignment has been updated.
         boolean isFullRequest = subscribedTopicNames != null;
-        if (memberEpoch == 0 || isFullRequest || hasAssignedPartitionsChanged(member, updatedMember)) {
+        if (memberEpoch == 0 || isFullRequest || ShareGroupMember.hasAssignedPartitionsChanged(member, updatedMember)) {
             response.setAssignment(ShareGroupHeartbeatResponse.createAssignment(updatedMember.assignedPartitions()));
         }
         return new CoordinatorResult<>(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -240,7 +240,6 @@ import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CONSUMER_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.SHARE_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.STREAMS_GROUP_REBALANCES_SENSOR_NAME;
-import static org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember.hasAssignedPartitionsChanged;
 import static org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers.convertToStreamsGroupTopologyRecord;
 import static org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord;
 import static org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentTombstoneRecord;
@@ -2456,7 +2455,7 @@ public class GroupMetadataManager {
         //    to detect a full request as those must be set in a full request.
         // 2. The member's assignment has been updated.
         boolean isFullRequest = rebalanceTimeoutMs != -1 && (subscribedTopicNames != null || subscribedTopicRegex != null) && ownedTopicPartitions != null;
-        if (memberEpoch == 0 || isFullRequest || hasAssignedPartitionsChanged(member, updatedMember)) {
+        if (memberEpoch == 0 || isFullRequest || ConsumerGroupMember.hasAssignedPartitionsChanged(member, updatedMember)) {
             response.setAssignment(ConsumerGroupHeartbeatResponse.createAssignment(updatedMember.assignedPartitions()));
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroupMember.java
@@ -16,9 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.modern;
 
-import org.apache.kafka.common.Uuid;
-
-import java.util.Map;
 import java.util.Set;
 
 /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroupMember.java
@@ -71,11 +71,6 @@ public abstract class ModernGroupMember {
      */
     protected Set<String> subscribedTopicNames;
 
-    /**
-     * The partitions assigned to this member.
-     */
-    protected Map<Uuid, Set<Integer>> assignedPartitions;
-
     protected ModernGroupMember(
         String memberId,
         int memberEpoch,
@@ -85,8 +80,7 @@ public abstract class ModernGroupMember {
         String clientId,
         String clientHost,
         Set<String> subscribedTopicNames,
-        MemberState state,
-        Map<Uuid, Set<Integer>> assignedPartitions
+        MemberState state
     ) {
         this.memberId = memberId;
         this.memberEpoch = memberEpoch;
@@ -97,7 +91,6 @@ public abstract class ModernGroupMember {
         this.clientId = clientId;
         this.clientHost = clientHost;
         this.subscribedTopicNames = subscribedTopicNames;
-        this.assignedPartitions = assignedPartitions;
     }
 
     /**
@@ -170,20 +163,20 @@ public abstract class ModernGroupMember {
         return state == MemberState.STABLE && memberEpoch == targetAssignmentEpoch;
     }
 
-    /**
-     * @return The set of assigned partitions.
-     */
-    public Map<Uuid, Set<Integer>> assignedPartitions() {
-        return assignedPartitions;
-    }
-
-    /**
-     * @return True of the two provided members have different assigned partitions.
-     */
-    public static boolean hasAssignedPartitionsChanged(
-        ModernGroupMember member1,
-        ModernGroupMember member2
-    ) {
-        return !member1.assignedPartitions().equals(member2.assignedPartitions());
-    }
+//    /**
+//     * @return The set of assigned partitions.
+//     */
+//    public Map<Uuid, Set<Integer>> assignedPartitions() {
+//        return assignedPartitions;
+//    }
+//
+//    /**
+//     * @return True of the two provided members have different assigned partitions.
+//     */
+//    public static boolean hasAssignedPartitionsChanged(
+//        ModernGroupMember member1,
+//        ModernGroupMember member2
+//    ) {
+//        return !member1.assignedPartitions().equals(member2.assignedPartitions());
+//    }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/ModernGroupMember.java
@@ -162,21 +162,4 @@ public abstract class ModernGroupMember {
     public boolean isReconciledTo(int targetAssignmentEpoch) {
         return state == MemberState.STABLE && memberEpoch == targetAssignmentEpoch;
     }
-
-//    /**
-//     * @return The set of assigned partitions.
-//     */
-//    public Map<Uuid, Set<Integer>> assignedPartitions() {
-//        return assignedPartitions;
-//    }
-//
-//    /**
-//     * @return True of the two provided members have different assigned partitions.
-//     */
-//    public static boolean hasAssignedPartitionsChanged(
-//        ModernGroupMember member1,
-//        ModernGroupMember member2
-//    ) {
-//        return !member1.assignedPartitions().equals(member2.assignedPartitions());
-//    }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -350,6 +350,16 @@ public class ConsumerGroupMember extends ModernGroupMember {
     }
 
     /**
+     * @return True if the two provided members have different assigned partitions.
+     */
+    public static boolean hasAssignedPartitionsChanged(
+        ConsumerGroupMember member1,
+        ConsumerGroupMember member2
+    ) {
+        return !member1.assignedPartitions().equals(member2.assignedPartitions());
+    }
+
+    /**
      * @return The supported classic protocols converted to JoinGroupRequestProtocolCollection.
      */
     public JoinGroupRequestData.JoinGroupRequestProtocolCollection supportedJoinGroupRequestProtocols() {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -264,6 +264,11 @@ public class ConsumerGroupMember extends ModernGroupMember {
     private final String serverAssignorName;
 
     /**
+     * The partitions assigned to this member.
+     */
+    private final Map<Uuid, Set<Integer>> assignedPartitions;
+
+    /**
      * The partitions being revoked by this member.
      */
     private final Map<Uuid, Set<Integer>> partitionsPendingRevocation;
@@ -299,12 +304,12 @@ public class ConsumerGroupMember extends ModernGroupMember {
             clientId,
             clientHost,
             subscribedTopicNames,
-            state,
-            assignedPartitions
+            state
         );
         this.rebalanceTimeoutMs = rebalanceTimeoutMs;
         this.subscribedTopicRegex = subscribedTopicRegex;
         this.serverAssignorName = serverAssignorName;
+        this.assignedPartitions = assignedPartitions;
         this.partitionsPendingRevocation = partitionsPendingRevocation;
         this.classicMemberMetadata = classicMemberMetadata;
     }
@@ -328,6 +333,13 @@ public class ConsumerGroupMember extends ModernGroupMember {
      */
     public Optional<String> serverAssignorName() {
         return Optional.ofNullable(serverAssignorName);
+    }
+
+    /**
+     * @return The set of assigned partitions.
+     */
+    public Map<Uuid, Set<Integer>> assignedPartitions() {
+        return assignedPartitions;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupMember.java
@@ -190,9 +190,21 @@ public class ShareGroupMember extends ModernGroupMember {
             clientId,
             clientHost,
             subscribedTopicNames,
-            state,
-            assignedPartitions
+            state
         );
+        this.assignedPartitions = assignedPartitions;
+    }
+
+    /**
+     * The partitions assigned to this member.
+     */
+    private final Map<Uuid, Set<Integer>> assignedPartitions;
+
+    /**
+     * @return The partitions assigned to this member.
+     */
+    public Map<Uuid, Set<Integer>> assignedPartitions() {
+        return assignedPartitions;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupMember.java
@@ -208,6 +208,16 @@ public class ShareGroupMember extends ModernGroupMember {
     }
 
     /**
+     * @return True if the two provided members have different assigned partitions.
+     */
+    public static boolean hasAssignedPartitionsChanged(
+        ShareGroupMember member1,
+        ShareGroupMember member2
+    ) {
+        return !member1.assignedPartitions().equals(member2.assignedPartitions());
+    }
+
+    /**
      * Converts this ShareGroupMember to a ShareGroupDescribeResponseData.Member.
      *
      * @param image : Topics image object to search for a specific topic id

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/share/ShareGroupMember.java
@@ -170,6 +170,11 @@ public class ShareGroupMember extends ModernGroupMember {
         }
     }
 
+    /**
+     * The partitions assigned to this member.
+     */
+    private final Map<Uuid, Set<Integer>> assignedPartitions;
+
     private ShareGroupMember(
           String memberId,
           int memberEpoch,
@@ -194,11 +199,6 @@ public class ShareGroupMember extends ModernGroupMember {
         );
         this.assignedPartitions = assignedPartitions;
     }
-
-    /**
-     * The partitions assigned to this member.
-     */
-    private final Map<Uuid, Set<Integer>> assignedPartitions;
 
     /**
      * @return The partitions assigned to this member.

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/AssignorBenchmarkUtils.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/AssignorBenchmarkUtils.java
@@ -28,7 +28,6 @@ import org.apache.kafka.coordinator.group.api.assignor.SubscriptionType;
 import org.apache.kafka.coordinator.group.modern.Assignment;
 import org.apache.kafka.coordinator.group.modern.GroupSpecImpl;
 import org.apache.kafka.coordinator.group.modern.MemberSubscriptionAndAssignmentImpl;
-import org.apache.kafka.coordinator.group.modern.ModernGroupMember;
 import org.apache.kafka.coordinator.group.modern.TopicIds;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
@@ -38,11 +37,13 @@ import org.apache.kafka.image.MetadataProvenance;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 public class AssignorBenchmarkUtils {
@@ -115,38 +116,63 @@ public class AssignorBenchmarkUtils {
     }
 
     /**
-     * Creates a GroupSpec from the given ModernGroupMembers.
+     * Creates a GroupSpec from the given ConsumerGroupMembers.
      *
-     * @param members               The ModernGroupMembers.
+     * @param members               The ConsumerGroupMembers.
      * @param subscriptionType      The group's subscription type.
      * @param topicResolver         The TopicResolver to use.
      * @return The new GroupSpec.
      */
-    public static GroupSpec createGroupSpec(
-        Map<String, ? extends ModernGroupMember> members,
+    public static GroupSpec createConsumerGroupSpec(
+        Map<String, ConsumerGroupMember> members,
         SubscriptionType subscriptionType,
         TopicIds.TopicResolver topicResolver
     ) {
         Map<String, MemberSubscriptionAndAssignmentImpl> memberSpecs = new HashMap<>();
 
-        // Prepare the member spec for all members.
-        for (Map.Entry<String, ? extends ModernGroupMember> memberEntry : members.entrySet()) {
+        for (Map.Entry<String, ConsumerGroupMember> memberEntry : members.entrySet()) {
             String memberId = memberEntry.getKey();
-            ModernGroupMember member = memberEntry.getValue();
-            Map<Uuid, Set<Integer>> partitions;
-            if (member instanceof ConsumerGroupMember) {
-                partitions = ((ConsumerGroupMember) member).assignedPartitions();
-            } else if (member instanceof ShareGroupMember) {
-                partitions = ((ShareGroupMember) member).assignedPartitions();
-            } else {
-                partitions = Map.of();
-            }
+            ConsumerGroupMember member = memberEntry.getValue();
 
             memberSpecs.put(memberId, new MemberSubscriptionAndAssignmentImpl(
                 Optional.ofNullable(member.rackId()),
                 Optional.ofNullable(member.instanceId()),
                 new TopicIds(member.subscribedTopicNames(), topicResolver),
-                new Assignment(partitions)
+                new Assignment(member.assignedPartitions())
+            ));
+        }
+
+        return new GroupSpecImpl(
+            memberSpecs,
+            subscriptionType,
+            Map.of()
+        );
+    }
+
+    /**
+     * Creates a GroupSpec from the given ShareGroupMembers.
+     *
+     * @param members               The ShareGroupMembers.
+     * @param subscriptionType      The group's subscription type.
+     * @param topicResolver         The TopicResolver to use.
+     * @return The new GroupSpec.
+     */
+    public static GroupSpec createShareGroupSpec(
+        Map<String, ShareGroupMember> members,
+        SubscriptionType subscriptionType,
+        TopicIds.TopicResolver topicResolver
+    ) {
+        Map<String, MemberSubscriptionAndAssignmentImpl> memberSpecs = new HashMap<>();
+
+        for (Map.Entry<String, ShareGroupMember> memberEntry : members.entrySet()) {
+            String memberId = memberEntry.getKey();
+            ShareGroupMember member = memberEntry.getValue();
+
+            memberSpecs.put(memberId, new MemberSubscriptionAndAssignmentImpl(
+                Optional.ofNullable(member.rackId()),
+                Optional.empty(),
+                new TopicIds(member.subscribedTopicNames(), topicResolver),
+                new Assignment(member.assignedPartitions())
             ));
         }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/AssignorBenchmarkUtils.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/AssignorBenchmarkUtils.java
@@ -37,13 +37,11 @@ import org.apache.kafka.image.MetadataProvenance;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 
 public class AssignorBenchmarkUtils {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/AssignorBenchmarkUtils.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/AssignorBenchmarkUtils.java
@@ -133,12 +133,20 @@ public class AssignorBenchmarkUtils {
         for (Map.Entry<String, ? extends ModernGroupMember> memberEntry : members.entrySet()) {
             String memberId = memberEntry.getKey();
             ModernGroupMember member = memberEntry.getValue();
+            Map<Uuid, Set<Integer>> partitions;
+            if (member instanceof ConsumerGroupMember) {
+                partitions = ((ConsumerGroupMember) member).assignedPartitions();
+            } else if (member instanceof ShareGroupMember) {
+                partitions = ((ShareGroupMember) member).assignedPartitions();
+            } else {
+                partitions = Map.of();
+            }
 
             memberSpecs.put(memberId, new MemberSubscriptionAndAssignmentImpl(
                 Optional.ofNullable(member.rackId()),
                 Optional.ofNullable(member.instanceId()),
                 new TopicIds(member.subscribedTopicNames(), topicResolver),
-                new Assignment(member.assignedPartitions())
+                new Assignment(partitions)
             ));
         }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/ServerSideAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/ServerSideAssignorBenchmark.java
@@ -135,7 +135,7 @@ public class ServerSideAssignorBenchmark {
         setupTopics();
 
         Map<String, ConsumerGroupMember> members = createMembers();
-        this.groupSpec = AssignorBenchmarkUtils.createGroupSpec(members, subscriptionType, topicResolver);
+        this.groupSpec = AssignorBenchmarkUtils.createConsumerGroupSpec(members, subscriptionType, topicResolver);
 
         if (assignmentType == AssignmentType.INCREMENTAL) {
             simulateIncrementalRebalance();

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/ShareGroupAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/ShareGroupAssignorBenchmark.java
@@ -126,7 +126,7 @@ public class ShareGroupAssignorBenchmark {
         setupTopics();
 
         Map<String, ShareGroupMember> members = createMembers();
-        this.groupSpec = AssignorBenchmarkUtils.createGroupSpec(members, subscriptionType, topicResolver);
+        this.groupSpec = AssignorBenchmarkUtils.createShareGroupSpec(members, subscriptionType, topicResolver);
 
         if (assignmentType == AssignmentType.INCREMENTAL) {
             simulateIncrementalRebalance();

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
@@ -135,7 +135,7 @@ public class TargetAssignmentBuilderBenchmark {
     private Map<String, Assignment> generateMockInitialTargetAssignmentAndUpdateInvertedTargetAssignment(
         Map<String, ConsumerGroupMember> members
     ) {
-        this.groupSpec = AssignorBenchmarkUtils.createGroupSpec(
+        this.groupSpec = AssignorBenchmarkUtils.createConsumerGroupSpec(
             members,
             subscriptionType,
             topicResolver


### PR DESCRIPTION
# Summary
This PR moves `assignedPartitions` out of `ModernConsumerMember`
interface, add it as independent properties for `ShareGroupMember` and
`ConsumerGroupMember`.

## Reason for the change
In an upcoming PR, the structure of
`ConsumerGroupMember#assignedPartitions` and
`ConsumerGroupMember#partitionsPendingRevocation` will be changed to
include epoch information as
```
Map<Uuid, Map<Integer, Integer>>
```
This differs from the `ShareGroupMember#assignedPartitions` structure,
which remains `Map<Uuid, Set<Integer>>`. Therefore, it is no longer
appropriate to have this as a shared field in the base class.

Reviewers: Sean Quah <squah@confluent.io>, Lucas Brutschy
 <lbrutschy@confluent.io>
