### PR TITLE
Add ZSTD compression configuration options 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -565,6 +565,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             case ZSTD: {
                 return Compression.zstd()
                         .level(config.getInt(ProducerConfig.COMPRESSION_ZSTD_LEVEL_CONFIG))
+                        .windowLog(config.getInt(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG))
+                        .checksum(config.getBoolean(ProducerConfig.COMPRESSION_ZSTD_CHECKSUM_CONFIG))
+                        .longRangeMode(config.getBoolean(ProducerConfig.COMPRESSION_ZSTD_LONG_CONFIG))
                         .build();
             }
             default:

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -391,7 +391,7 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(COMPRESSION_GZIP_LEVEL_CONFIG, Type.INT, CompressionType.GZIP.defaultLevel(), CompressionType.GZIP.levelValidator(), Importance.MEDIUM, COMPRESSION_GZIP_LEVEL_DOC)
                                 .define(COMPRESSION_LZ4_LEVEL_CONFIG, Type.INT, CompressionType.LZ4.defaultLevel(), CompressionType.LZ4.levelValidator(), Importance.MEDIUM, COMPRESSION_LZ4_LEVEL_DOC)
                                 .define(COMPRESSION_ZSTD_LEVEL_CONFIG, Type.INT, CompressionType.ZSTD.defaultLevel(), CompressionType.ZSTD.levelValidator(), Importance.MEDIUM, COMPRESSION_ZSTD_LEVEL_DOC)
-                                .define(COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, Type.INT, CompressionType.ZSTD.windowLog(), atLeast(10), Importance.HIGH, COMPRESSION_ZSTD_WINDOW_LOG_DOC)
+                                .define(COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, Type.INT, CompressionType.ZSTD.windowLog(), between(10, 31), Importance.MEDIUM, COMPRESSION_ZSTD_WINDOW_LOG_DOC)
                                 .define(COMPRESSION_ZSTD_LONG_CONFIG, Type.BOOLEAN, CompressionType.ZSTD.longRangeMode(), Importance.MEDIUM, COMPRESSION_ZSTD_LONG_DOC)
                                 .define(COMPRESSION_ZSTD_CHECKSUM_CONFIG, Type.BOOLEAN, CompressionType.ZSTD.checksum(), Importance.MEDIUM, COMPRESSION_ZSTD_CHECKSUM_DOC)
                                 .define(BATCH_SIZE_CONFIG, Type.INT, 16384, atLeast(0), Importance.MEDIUM, BATCH_SIZE_DOC)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -238,6 +238,17 @@ public class ProducerConfig extends AbstractConfig {
     public static final String COMPRESSION_ZSTD_LEVEL_CONFIG = "compression.zstd.level";
     private static final String COMPRESSION_ZSTD_LEVEL_DOC = "The compression level to use if " + COMPRESSION_TYPE_CONFIG + " is set to <code>zstd</code>.";
 
+    /** <code>compression.zstd.window.log</code> */
+    public static final String COMPRESSION_ZSTD_WINDOW_LOG_CONFIG = "compression.zstd.window.log";
+    public static final String COMPRESSION_ZSTD_WINDOW_LOG_DOC = "The window log size to use if " + COMPRESSION_TYPE_CONFIG + " is set to <code>zstd</code>.";
+
+    /** <code>compression.zstd.checksum</code> */
+    public static final String COMPRESSION_ZSTD_CHECKSUM_CONFIG = "compression.zstd.checksum";
+    public static final String COMPRESSION_ZSTD_CHECKSUM_DOC = "The checksum configuration to use if " + COMPRESSION_TYPE_CONFIG + " is set to <code>zstd</code>.";
+
+    public static final String COMPRESSION_ZSTD_LONG_CONFIG = "compression.zstd.long";
+    public static final String COMPRESSION_ZSTD_LONG_DOC = "The long range mode configuration to use if " + COMPRESSION_TYPE_CONFIG + " is set to <code>zstd</code>.";
+
     /** <code>metrics.sample.window.ms</code> */
     public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
 
@@ -380,6 +391,9 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(COMPRESSION_GZIP_LEVEL_CONFIG, Type.INT, CompressionType.GZIP.defaultLevel(), CompressionType.GZIP.levelValidator(), Importance.MEDIUM, COMPRESSION_GZIP_LEVEL_DOC)
                                 .define(COMPRESSION_LZ4_LEVEL_CONFIG, Type.INT, CompressionType.LZ4.defaultLevel(), CompressionType.LZ4.levelValidator(), Importance.MEDIUM, COMPRESSION_LZ4_LEVEL_DOC)
                                 .define(COMPRESSION_ZSTD_LEVEL_CONFIG, Type.INT, CompressionType.ZSTD.defaultLevel(), CompressionType.ZSTD.levelValidator(), Importance.MEDIUM, COMPRESSION_ZSTD_LEVEL_DOC)
+                                .define(COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, Type.INT, CompressionType.ZSTD.windowLog(), atLeast(10), Importance.HIGH, COMPRESSION_ZSTD_WINDOW_LOG_DOC)
+                                .define(COMPRESSION_ZSTD_LONG_CONFIG, Type.BOOLEAN, CompressionType.ZSTD.longRangeMode(), Importance.MEDIUM, COMPRESSION_ZSTD_LONG_DOC)
+                                .define(COMPRESSION_ZSTD_CHECKSUM_CONFIG, Type.BOOLEAN, CompressionType.ZSTD.checksum(), Importance.MEDIUM, COMPRESSION_ZSTD_CHECKSUM_DOC)
                                 .define(BATCH_SIZE_CONFIG, Type.INT, 16384, atLeast(0), Importance.MEDIUM, BATCH_SIZE_DOC)
                                 .define(PARTITIONER_ADPATIVE_PARTITIONING_ENABLE_CONFIG, Type.BOOLEAN, true, Importance.LOW, PARTITIONER_ADPATIVE_PARTITIONING_ENABLE_DOC)
                                 .define(PARTITIONER_AVAILABILITY_TIMEOUT_MS_CONFIG, Type.LONG, 0, atLeast(0), Importance.LOW, PARTITIONER_AVAILABILITY_TIMEOUT_MS_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/compress/ZstdCompression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/ZstdCompression.java
@@ -40,9 +40,15 @@ import static org.apache.kafka.common.record.CompressionType.ZSTD;
 public class ZstdCompression implements Compression {
 
     private final int level;
+    private final int windowLog;
+    private boolean longRangeMode;
+    private boolean checksum;
 
-    private ZstdCompression(int level) {
+    private ZstdCompression(int level, int windowLog, boolean longRangeMode, boolean checksum) {
         this.level = level;
+        this.windowLog = windowLog;
+        this.longRangeMode = longRangeMode;
+        this.checksum = checksum;
     }
 
     @Override
@@ -55,7 +61,11 @@ public class ZstdCompression implements Compression {
         try {
             // Set input buffer (uncompressed) to 16 KB (none by default) to ensure reasonable performance
             // in cases where the caller passes a small number of bytes to write (potentially a single byte).
-            return new BufferedOutputStream(new ZstdOutputStreamNoFinalizer(bufferStream, RecyclingBufferPool.INSTANCE, level), 16 * 1024);
+            ZstdOutputStreamNoFinalizer zos = new ZstdOutputStreamNoFinalizer(bufferStream, RecyclingBufferPool.INSTANCE, level);
+            zos.setChecksum(checksum);
+            zos.setWindowLog(windowLog);
+            zos.setLong(longRangeMode ? windowLog : 0);
+            return new BufferedOutputStream(zos, 16 * 1024);
         } catch (Throwable e) {
             throw new KafkaException(e);
         }
@@ -122,19 +132,39 @@ public class ZstdCompression implements Compression {
 
     public static class Builder implements Compression.Builder<ZstdCompression> {
         private int level = ZSTD.defaultLevel();
+        private int windowLog = ZSTD.windowLog();
+        private boolean longRangeMode = ZSTD.longRangeMode();
+        private boolean checksum = ZSTD.checksum();
 
         public Builder level(int level) {
             if (level < ZSTD.minLevel() || ZSTD.maxLevel() < level) {
                 throw new IllegalArgumentException("zstd doesn't support given compression level: " + level);
             }
-
             this.level = level;
+            return this;
+        }
+
+        public Builder windowLog(int windowLog) {
+            if (windowLog < 10 || 31 < windowLog) {
+                throw new IllegalArgumentException("zstd doesn't support given windowlog: " + windowLog);
+            }
+            this.windowLog = windowLog;
+            return this;
+        }
+
+        public Builder longRangeMode(boolean longRangeMode) {
+            this.longRangeMode = longRangeMode;
+            return this;
+        }
+
+        public Builder checksum(boolean checksum) {
+            this.checksum = checksum;
             return this;
         }
 
         @Override
         public ZstdCompression build() {
-            return new ZstdCompression(level);
+            return new ZstdCompression(level, windowLog, longRangeMode, checksum);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -115,11 +115,15 @@ public enum CompressionType {
         private static final int MAX_LEVEL = 22;
         // See ZSTD_CLEVEL_DEFAULT in https://github.com/facebook/zstd/blob/dev/lib/zstd.h#L129
         private static final int DEFAULT_LEVEL = 3;
-        // See ZSTD_c_windowLog in https://github.com/facebook/zstd/blob/lib/zstd.h#L368
-        private static final int WINDOW_LOG = 12; // 4KB — safe and memory-efficient
+        // Window log for zstd-jni (Zstd#setCompressionParameters).
+        // See ZSTD_c_windowLog in https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/Zstd.java
+        private static final int WINDOW_LOG = 12; // 4KB -- safe and memory-efficient
+        // Long range mode for zstd-jni (Zstd#setCompressionParameters).
+        // See ZSTD_c_enableLongDistanceMatching in https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/Zstd.java
         private static final boolean LONG_RANGE_MODE = false;
+        //Checksum for zstd-jni (Zstd#setCompressionParameters).
+        // See ZSTD_c_checksumFlag in https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/Zstd.java
         private static final boolean CHECKSUM = true;
-
 
         @Override
         public int defaultLevel() {

--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -115,6 +115,11 @@ public enum CompressionType {
         private static final int MAX_LEVEL = 22;
         // See ZSTD_CLEVEL_DEFAULT in https://github.com/facebook/zstd/blob/dev/lib/zstd.h#L129
         private static final int DEFAULT_LEVEL = 3;
+        // See ZSTD_c_windowLog in https://github.com/facebook/zstd/blob/lib/zstd.h#L368
+        private static final int WINDOW_LOG = 12; // 4KB — safe and memory-efficient
+        private static final boolean LONG_RANGE_MODE = false;
+        private static final boolean CHECKSUM = true;
+
 
         @Override
         public int defaultLevel() {
@@ -129,6 +134,21 @@ public enum CompressionType {
         @Override
         public int minLevel() {
             return MIN_LEVEL;
+        }
+
+        @Override
+        public int windowLog() {
+            return WINDOW_LOG;
+        }
+
+        @Override
+        public boolean longRangeMode() {
+            return LONG_RANGE_MODE;
+        }
+
+        @Override
+        public boolean checksum() {
+            return CHECKSUM;
         }
 
         @Override
@@ -191,6 +211,18 @@ public enum CompressionType {
 
     public int minLevel() {
         throw new UnsupportedOperationException("Compression levels are not defined for this compression type: " + name);
+    }
+
+    public int windowLog() {
+        throw new UnsupportedOperationException("Window log is not defined for this compression type: " + name);
+    }
+
+    public boolean longRangeMode() {
+        throw new UnsupportedOperationException("Long range mode is not defined for this compression type: " + name);
+    }
+
+    public boolean checksum() {
+        throw new UnsupportedOperationException("Checksum is not defined for this compression type: " + name);
     }
 
     public ConfigDef.Validator levelValidator() {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/ProducerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/ProducerConfigTest.java
@@ -128,4 +128,78 @@ public class ProducerConfigTest {
         final ProducerConfig producerConfig = new ProducerConfig(configs);
         assertEquals(saslSslLowerCase, producerConfig.originals().get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
     }
+
+    @Test
+    public void testZstdWindowLogDefault() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        ProducerConfig producerConfig = new ProducerConfig(configs);
+        assertEquals(12, producerConfig.getInt(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG));
+    }
+
+    @Test
+    public void testZstdChecksumDefault() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        ProducerConfig producerConfig = new ProducerConfig(configs);
+        assertTrue(producerConfig.getBoolean(ProducerConfig.COMPRESSION_ZSTD_CHECKSUM_CONFIG));
+    }
+
+    @Test
+    public void testZstdLongRangeModeDefault() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        ProducerConfig producerConfig = new ProducerConfig(configs);
+        assertEquals(false, producerConfig.getBoolean(ProducerConfig.COMPRESSION_ZSTD_LONG_CONFIG));
+    }
+
+    @Test
+    public void testInvalidZstdWindowLogTooLow() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, 9);
+        assertThrows(ConfigException.class, () -> new ProducerConfig(configs));
+    }
+
+    @Test
+    public void testInvalidZstdWindowLogTooHigh() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, 32);
+        assertThrows(ConfigException.class, () -> new ProducerConfig(configs));
+    }
+
+    @Test
+    public void testValidZstdWindowLogBoundaries() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, 10);
+        ProducerConfig producerConfig = new ProducerConfig(configs);
+        assertEquals(10, producerConfig.getInt(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG));
+
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, 31);
+        producerConfig = new ProducerConfig(configs);
+        assertEquals(31, producerConfig.getInt(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG));
+    }
+
+    @Test
+    public void testCustomZstdOptions() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG, 20);
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_CHECKSUM_CONFIG, false);
+        configs.put(ProducerConfig.COMPRESSION_ZSTD_LONG_CONFIG, true);
+        ProducerConfig producerConfig = new ProducerConfig(configs);
+        assertEquals(20, producerConfig.getInt(ProducerConfig.COMPRESSION_ZSTD_WINDOW_LOG_CONFIG));
+        assertEquals(false, producerConfig.getBoolean(ProducerConfig.COMPRESSION_ZSTD_CHECKSUM_CONFIG));
+        assertEquals(true, producerConfig.getBoolean(ProducerConfig.COMPRESSION_ZSTD_LONG_CONFIG));
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/compress/ZstdCompressionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/compress/ZstdCompressionTest.java
@@ -20,6 +20,8 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,9 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.kafka.common.record.CompressionType.ZSTD;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ZstdCompressionTest {
 
@@ -69,5 +69,158 @@ public class ZstdCompressionTest {
 
         builder.level(ZSTD.minLevel());
         builder.level(ZSTD.maxLevel());
+    }
+
+    @Test
+    public void testWindowLogValidation() {
+        ZstdCompression.Builder builder = Compression.zstd();
+
+        assertThrows(IllegalArgumentException.class, () -> builder.windowLog(9));
+        assertThrows(IllegalArgumentException.class, () -> builder.windowLog(32));
+
+        // Valid boundary values should not throw
+        builder.windowLog(10);
+        builder.windowLog(31);
+    }
+
+    @Test
+    public void testWindowLogDefaultValue() {
+        assertEquals(12, ZSTD.windowLog());
+    }
+
+    @Test
+    public void testLongRangeModeDefaultValue() {
+        assertFalse(ZSTD.longRangeMode());
+    }
+
+    @Test
+    public void testChecksumDefaultValue() {
+        assertTrue(ZSTD.checksum());
+    }
+
+    @Test
+    public void testCompressionDecompressionWithCustomWindowLog() throws IOException {
+        byte[] data = String.join("", Collections.nCopies(256, "data")).getBytes(StandardCharsets.UTF_8);
+
+        for (int windowLog : Arrays.asList(10, 15, 20)) {
+            ZstdCompression compression = Compression.zstd()
+                    .level(ZSTD.defaultLevel())
+                    .windowLog(windowLog)
+                    .build();
+            ByteBufferOutputStream bufferStream = new ByteBufferOutputStream(4);
+            try (OutputStream out = compression.wrapForOutput(bufferStream, RecordBatch.MAGIC_VALUE_V2)) {
+                out.write(data);
+                out.flush();
+            }
+            bufferStream.buffer().flip();
+
+            try (InputStream inputStream = compression.wrapForInput(bufferStream.buffer(), RecordBatch.MAGIC_VALUE_V2, BufferSupplier.create())) {
+                byte[] result = new byte[data.length];
+                int read = inputStream.read(result);
+                assertEquals(data.length, read);
+                assertArrayEquals(data, result);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testCompressionDecompressionWithChecksum(boolean checksumEnabled) throws IOException {
+        byte[] data = String.join("", Collections.nCopies(256, "data")).getBytes(StandardCharsets.UTF_8);
+
+        ZstdCompression compression = Compression.zstd()
+                .level(ZSTD.defaultLevel())
+                .checksum(checksumEnabled)
+                .build();
+        ByteBufferOutputStream bufferStream = new ByteBufferOutputStream(4);
+        try (OutputStream out = compression.wrapForOutput(bufferStream, RecordBatch.MAGIC_VALUE_V2)) {
+            out.write(data);
+            out.flush();
+        }
+        bufferStream.buffer().flip();
+
+        try (InputStream inputStream = compression.wrapForInput(bufferStream.buffer(), RecordBatch.MAGIC_VALUE_V2, BufferSupplier.create())) {
+            byte[] result = new byte[data.length];
+            int read = inputStream.read(result);
+            assertEquals(data.length, read);
+            assertArrayEquals(data, result);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testCompressionDecompressionWithLongRangeMode(boolean longRangeMode) throws IOException {
+        byte[] data = String.join("", Collections.nCopies(256, "data")).getBytes(StandardCharsets.UTF_8);
+
+        ZstdCompression compression = Compression.zstd()
+                .level(ZSTD.defaultLevel())
+                .windowLog(15)
+                .longRangeMode(longRangeMode)
+                .build();
+        ByteBufferOutputStream bufferStream = new ByteBufferOutputStream(4);
+        try (OutputStream out = compression.wrapForOutput(bufferStream, RecordBatch.MAGIC_VALUE_V2)) {
+            out.write(data);
+            out.flush();
+        }
+        bufferStream.buffer().flip();
+
+        try (InputStream inputStream = compression.wrapForInput(bufferStream.buffer(), RecordBatch.MAGIC_VALUE_V2, BufferSupplier.create())) {
+            byte[] result = new byte[data.length];
+            int read = inputStream.read(result);
+            assertEquals(data.length, read);
+            assertArrayEquals(data, result);
+        }
+    }
+
+    @Test
+    public void testCompressionDecompressionWithAllOptions() throws IOException {
+        byte[] data = String.join("", Collections.nCopies(256, "data")).getBytes(StandardCharsets.UTF_8);
+
+        for (byte magic : Arrays.asList(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1, RecordBatch.MAGIC_VALUE_V2)) {
+            ZstdCompression compression = Compression.zstd()
+                    .level(ZSTD.defaultLevel())
+                    .windowLog(15)
+                    .checksum(true)
+                    .longRangeMode(true)
+                    .build();
+            ByteBufferOutputStream bufferStream = new ByteBufferOutputStream(4);
+            try (OutputStream out = compression.wrapForOutput(bufferStream, magic)) {
+                out.write(data);
+                out.flush();
+            }
+            bufferStream.buffer().flip();
+
+            try (InputStream inputStream = compression.wrapForInput(bufferStream.buffer(), magic, BufferSupplier.create())) {
+                byte[] result = new byte[data.length];
+                int read = inputStream.read(result);
+                assertEquals(data.length, read);
+                assertArrayEquals(data, result);
+            }
+        }
+    }
+
+    @Test
+    public void testCompressionDecompressionWithNoChecksumAndNoLongRange() throws IOException {
+        byte[] data = String.join("", Collections.nCopies(256, "data")).getBytes(StandardCharsets.UTF_8);
+
+        ZstdCompression compression = Compression.zstd()
+                .level(ZSTD.defaultLevel())
+                .windowLog(12)
+                .checksum(false)
+                .longRangeMode(false)
+                .build();
+        ByteBufferOutputStream bufferStream = new ByteBufferOutputStream(4);
+        try (OutputStream out = compression.wrapForOutput(bufferStream, RecordBatch.MAGIC_VALUE_V2)) {
+            out.write(data);
+            out.flush();
+        }
+        bufferStream.buffer().flip();
+
+        try (InputStream inputStream = compression.wrapForInput(bufferStream.buffer(), RecordBatch.MAGIC_VALUE_V2, BufferSupplier.create())) {
+            byte[] result = new byte[data.length];
+            int read = inputStream.read(result);
+            assertEquals(data.length, read);
+            assertArrayEquals(data, result);
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CompressionTypeTest {
+
+    @Test
+    public void testZstdWindowLogDefault() {
+        assertEquals(12, CompressionType.ZSTD.windowLog());
+    }
+
+    @Test
+    public void testZstdLongRangeModeDefault() {
+        assertFalse(CompressionType.ZSTD.longRangeMode());
+    }
+
+    @Test
+    public void testZstdChecksumDefault() {
+        assertTrue(CompressionType.ZSTD.checksum());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class, names = {"NONE", "GZIP", "SNAPPY", "LZ4"})
+    public void testWindowLogNotSupportedForNonZstdTypes(CompressionType type) {
+        assertThrows(UnsupportedOperationException.class, type::windowLog);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class, names = {"NONE", "GZIP", "SNAPPY", "LZ4"})
+    public void testLongRangeModeNotSupportedForNonZstdTypes(CompressionType type) {
+        assertThrows(UnsupportedOperationException.class, type::longRangeMode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class, names = {"NONE", "GZIP", "SNAPPY", "LZ4"})
+    public void testChecksumNotSupportedForNonZstdTypes(CompressionType type) {
+        assertThrows(UnsupportedOperationException.class, type::checksum);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class, names = {"NONE", "SNAPPY"})
+    public void testLevelsNotSupportedForNoneAndSnappy(CompressionType type) {
+        assertThrows(UnsupportedOperationException.class, type::defaultLevel);
+        assertThrows(UnsupportedOperationException.class, type::maxLevel);
+        assertThrows(UnsupportedOperationException.class, type::minLevel);
+        assertThrows(UnsupportedOperationException.class, type::levelValidator);
+    }
+
+    @Test
+    public void testZstdLevelDefaults() {
+        assertEquals(3, CompressionType.ZSTD.defaultLevel());
+        assertEquals(-131072, CompressionType.ZSTD.minLevel());
+        assertEquals(22, CompressionType.ZSTD.maxLevel());
+    }
+}


### PR DESCRIPTION
Summary:
When using ZSTD compression, since no ZSTD specific configuration options are exposed, memory utilization due to default winddowLog configuration causes extremely high memory utilization and causes OOM. The idea is to expose configuration options that enables one to control memory usage and also enable and disable zstd features based on requirements.