### PR TITLE
KAFKA-19830 [1/N]: refactor KafkaRaftClient to use event-based scheduling

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
+++ b/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
@@ -21,7 +21,7 @@ import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.{OptionalInt, Collection => JCollection, Map => JMap}
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{CompletableFuture, Executors}
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, MetadataRecoveryStrategy, NetworkClient}
@@ -41,7 +41,7 @@ import org.apache.kafka.raft.{Endpoints, ExternalKRaftMetrics, FileQuorumStateSt
 import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.common.Feature
 import org.apache.kafka.server.common.serialization.RecordSerde
-import org.apache.kafka.server.util.{FileLock, KafkaScheduler}
+import org.apache.kafka.server.util.{DefaultEventExecutor, FileLock, KafkaScheduler}
 import org.apache.kafka.server.fault.FaultHandler
 import org.apache.kafka.server.util.timer.SystemTimer
 import org.apache.kafka.storage.internals.log.{LogManager, UnifiedLog}
@@ -128,7 +128,11 @@ class KafkaRaftManager[T](
   private val expirationTimer = new SystemTimer("raft-expiration-executor")
   private val expirationService = new TimingWheelExpirationService(expirationTimer)
   override val client: KafkaRaftClient[T] = buildRaftClient()
-  private val clientDriver = new KafkaRaftClientDriver[T](client, threadNamePrefix, fatalFaultHandler, logContext)
+  private val eventExecutor = new DefaultEventExecutor(
+    Executors.defaultThreadFactory(),
+    Integer.MAX_VALUE
+  )
+  private val clientDriver = new KafkaRaftClientDriver[T](client, eventExecutor, fatalFaultHandler, logContext)
 
   def startup(): Unit = {
     client.initialize(

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClientDriver.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClientDriver.java
@@ -21,84 +21,100 @@ import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.server.fault.FaultHandler;
-import org.apache.kafka.server.util.ShutdownableThread;
+import org.apache.kafka.server.util.EventExecutor;
 
 import org.slf4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * A single-threaded driver for {@link KafkaRaftClient}. Client APIs will only do useful work
- * as long as the driver's thread is active. To start the thread, use {@link #start()}. To
- * stop it, use {@link #shutdown()}.
+ * as long as the driver is active. To start it, use {@link #start()}. To stop it, use
+ * {@link #shutdown()}.
  *
- * Note that the driver is responsible for the lifecycle of the {@link KafkaRaftClient} instance.
+ * <p>The driver uses an {@link EventExecutor} to schedule poll events. Each poll event calls
+ * {@link KafkaRaftClient#poll()} and then re-submits itself for the next iteration, forming
+ * a self-rescheduling loop.
+ *
+ * <p>Note that the driver is responsible for the lifecycle of the {@link KafkaRaftClient} instance.
  * Shutdown of the driver through {@link #shutdown()} ensures that the client itself is properly
  * shutdown and closed.
  *
- * @param <T> See {@link KafkaRaftClient<T>}
+ * @param <T> See {@link KafkaRaftClient}
  */
-public class KafkaRaftClientDriver<T> extends ShutdownableThread {
+public class KafkaRaftClientDriver<T> {
     /**
      * Closed in {@link #shutdown()} after shutdown completes.
      */
     private final KafkaRaftClient<T> client;
+    private final EventExecutor eventExecutor;
     private final Logger log;
     private final FaultHandler fatalFaultHandler;
 
     public KafkaRaftClientDriver(
         KafkaRaftClient<T> client,
-        String threadNamePrefix,
+        EventExecutor eventExecutor,
         FaultHandler fatalFaultHandler,
         LogContext logContext
     ) {
-        super(threadNamePrefix + "-io-thread", false);
         this.client = client;
+        this.eventExecutor = eventExecutor;
         this.fatalFaultHandler = fatalFaultHandler;
         this.log = logContext.logger(KafkaRaftClientDriver.class);
     }
 
-    @Override
-    public void doWork() {
+    /**
+     * Start the driver by submitting the first poll event to the event executor.
+     */
+    public void start() {
+        schedulePoll();
+    }
+
+    private void schedulePoll() {
         try {
-            client.poll();
-        } catch (Throwable t) {
-            throw fatalFaultHandler.handleFault("Unexpected error in raft IO thread", t);
+            eventExecutor.submit(this::doPoll);
+        } catch (RejectedExecutionException e) {
+            // Event executor has been shut down; stop polling
         }
     }
 
-    @Override
-    public boolean initiateShutdown() {
-        if (super.initiateShutdown()) {
-            client.shutdown(5000).whenComplete((na, exception) -> {
-                if (exception != null) {
-                    log.error("Graceful shutdown of RaftClient failed", exception);
-                } else {
-                    log.info("Completed graceful shutdown of RaftClient");
-                }
-            });
-            return true;
-        } else {
-            return false;
+    private void doPoll() {
+        try {
+            client.poll();
+        } catch (Throwable t) {
+            fatalFaultHandler.handleFault("Unexpected error in raft IO thread", t);
+            return;
+        }
+        if (client.isRunning()) {
+            schedulePoll();
         }
     }
 
     /**
-     * Shutdown the thread. In addition to stopping any utilized threads, this will
-     * close the {@link KafkaRaftClient} instance.
+     * Shutdown the driver. This initiates a graceful shutdown of the {@link KafkaRaftClient},
+     * waits for the event executor to drain all pending events, and then closes the client.
      */
-    @Override
     public void shutdown() throws InterruptedException {
+        client.shutdown(5000).whenComplete((v, ex) -> {
+            if (ex != null) {
+                log.error("Graceful shutdown of RaftClient failed", ex);
+            } else {
+                log.info("Completed graceful shutdown of RaftClient");
+            }
+        });
         try {
-            super.shutdown();
+            eventExecutor.shutdown().get();
+        } catch (ExecutionException e) {
+            log.error("Error while shutting down event executor", e);
         } finally {
             client.close();
         }
     }
 
-    @Override
     public boolean isRunning() {
-        return client.isRunning() && !isThreadFailed();
+        return client.isRunning();
     }
 
     public CompletableFuture<ApiMessage> handleRequest(
@@ -123,5 +139,4 @@ public class KafkaRaftClientDriver<T> extends ShutdownableThread {
     public KafkaRaftClient<T> client() {
         return client;
     }
-
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientDriverTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientDriverTest.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.server.fault.MockFaultHandler;
+import org.apache.kafka.server.util.MockEventExecutor;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -38,9 +40,10 @@ class KafkaRaftClientDriverTest {
         @SuppressWarnings("unchecked")
         KafkaRaftClient<String> raftClient = (KafkaRaftClient<String>) Mockito.mock(KafkaRaftClient.class);
         MockFaultHandler faultHandler = new MockFaultHandler("TestFaultHandler");
+        MockEventExecutor eventExecutor = new MockEventExecutor(new MockTime());
         KafkaRaftClientDriver<String> driver = new KafkaRaftClientDriver<>(
             raftClient,
-            "test-raft",
+            eventExecutor,
             faultHandler,
             new LogContext()
         );
@@ -48,23 +51,33 @@ class KafkaRaftClientDriverTest {
         when(raftClient.isRunning()).thenReturn(true);
         assertTrue(driver.isRunning());
 
+        // Start the driver — this submits the first poll event
+        driver.start();
+
+        // Execute the poll event — client.poll() is called, then re-submits since isRunning=true
+        assertTrue(eventExecutor.poll());
+        verify(raftClient).poll();
+
+        // Set up shutdown
         CompletableFuture<Void> shutdownFuture = new CompletableFuture<>();
         when(raftClient.shutdown(5000)).thenReturn(shutdownFuture);
-
-        driver.initiateShutdown();
-        assertTrue(driver.isRunning());
-        assertTrue(driver.isShutdownInitiated());
-        verify(raftClient).shutdown(5000);
-
         shutdownFuture.complete(null);
         when(raftClient.isRunning()).thenReturn(false);
-        driver.run();
-        assertFalse(driver.isRunning());
-        assertTrue(driver.isShutdownComplete());
-        assertNull(faultHandler.firstException());
 
+        // Drain the re-submitted poll event — client.poll() is called again,
+        // but isRunning=false so doPoll won't re-submit. This is needed because
+        // MockEventExecutor requires manual polling to drain pending tasks (unlike
+        // DefaultEventExecutor which has a background thread).
+        assertTrue(eventExecutor.poll());
+
+        // Shutdown the driver — this calls client.shutdown() and eventExecutor.shutdown()
         driver.shutdown();
+
+        assertFalse(driver.isRunning());
+        verify(raftClient, Mockito.times(2)).poll();
+        verify(raftClient).shutdown(5000);
         verify(raftClient).close();
+        assertNull(faultHandler.firstException());
     }
 
     @Test
@@ -72,9 +85,10 @@ class KafkaRaftClientDriverTest {
         @SuppressWarnings("unchecked")
         KafkaRaftClient<String> raftClient = (KafkaRaftClient<String>) Mockito.mock(KafkaRaftClient.class);
         MockFaultHandler faultHandler = new MockFaultHandler("TestFaultHandler");
+        MockEventExecutor eventExecutor = new MockEventExecutor(new MockTime());
         KafkaRaftClientDriver<String> driver = new KafkaRaftClientDriver<>(
             raftClient,
-            "test-raft",
+            eventExecutor,
             faultHandler,
             new LogContext()
         );
@@ -82,16 +96,19 @@ class KafkaRaftClientDriverTest {
         when(raftClient.isRunning()).thenReturn(true);
         assertTrue(driver.isRunning());
 
+        // Make client.poll() throw an exception
         RuntimeException exception = new RuntimeException();
         Mockito.doThrow(exception).when(raftClient).poll();
-        driver.run();
 
-        assertTrue(driver.isShutdownComplete());
-        assertTrue(driver.isThreadFailed());
-        assertFalse(driver.isRunning());
+        // Start the driver and execute the poll event
+        driver.start();
+        assertTrue(eventExecutor.poll());
 
+        // The fault handler should have recorded the exception
         Throwable caughtException = faultHandler.firstException().getCause();
         assertEquals(exception, caughtException);
-    }
 
+        // The poll event should not have been re-submitted (doPoll returns after fault)
+        assertFalse(eventExecutor.poll());
+    }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/util/DefaultEventExecutor.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/DefaultEventExecutor.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import java.util.OptionalInt;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class DefaultEventExecutor implements EventExecutor {
+    private final ScheduledThreadPoolExecutor scheduler;
+    private final int pendingTasksCapacity;
+
+    private final AtomicInteger pendingTasksCounter = new AtomicInteger(0);
+
+    // variables used to reliably shutdown the scheduler
+    private OptionalInt prevQueueSize = OptionalInt.empty();
+    private final AtomicReference<CompletableFuture<Void>> shutdownFuture = new AtomicReference<>(null);
+
+    public DefaultEventExecutor(
+        ThreadFactory threadFactory,
+        int pendingTasksCapacity
+    ) {
+        scheduler = new ScheduledThreadPoolExecutor(1, threadFactory);
+        scheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        scheduler.setRemoveOnCancelPolicy(true);
+
+        this.pendingTasksCapacity = pendingTasksCapacity;
+    }
+
+    @Override
+    public CompletableFuture<Void> submit(Runnable task) {
+        return submit(new VoidCallable(task));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submit(Callable<T> task) {
+        ensureAccepting();
+
+        Task<T> submitter = new Task<>(task);
+        Future<?> scheduledFuture = scheduler.submit(submitter);
+        pendingTasksCounter.incrementAndGet();
+        hookupCancellation(scheduledFuture, submitter);
+
+        return submitter.future();
+    }
+
+    @Override
+    public CompletableFuture<Void> schedule(Runnable task, long delay, TimeUnit unit) {
+        return schedule(new VoidCallable(task), delay, unit);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> schedule(Callable<T> task, long delay, TimeUnit unit) {
+        ensureAccepting();
+
+        Task<T> submitter = new Task<>(task);
+        ScheduledFuture<?> scheduledFuture = scheduler.schedule(submitter, delay, unit);
+        pendingTasksCounter.incrementAndGet();
+        hookupCancellation(scheduledFuture, submitter);
+
+        return submitter.future();
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        if (shutdownFuture.compareAndSet(null, new CompletableFuture<>())) {
+            scheduleShutdown();
+        }
+
+        // must be non-null
+        return shutdownFuture.get();
+    }
+
+    private void scheduleShutdown() {
+        scheduler.submit(() -> {
+            int currentSize = scheduler.getQueue().size();
+            if (prevQueueSize.isPresent() && currentSize == prevQueueSize.getAsInt()) {
+                scheduler.shutdown();
+                shutdownFuture.get().complete(null);
+                return;
+            }
+
+            prevQueueSize = OptionalInt.of(currentSize);
+            scheduleShutdown();
+        });
+    }
+
+    private void hookupCancellation(Future<?> scheduledFuture, Task<?> submitter) {
+        submitter
+            .future()
+            .whenComplete((value, exception) -> {
+                if (exception instanceof CancellationException) {
+                    if (scheduledFuture.cancel(false)) {
+                        pendingTasksCounter.decrementAndGet();
+                    }
+                }
+            });
+    }
+
+    private void ensureAccepting() {
+        if (shutdownFuture.get() != null) {
+            throw new RejectedExecutionException("event executor was shutdown");
+        } else if (pendingTasksCounter.get() >= pendingTasksCapacity) {
+            throw new RejectedExecutionException(String.format("pending task capacity reached %s", pendingTasksCapacity));
+        }
+    }
+
+    private final class Task<T> implements Runnable {
+        private final Callable<T> task;
+        private final CompletableFuture<T> future = new CompletableFuture<>();
+
+        Task(Callable<T> task) {
+            this.task = task;
+        }
+
+        CompletableFuture<T> future() {
+            return future;
+        }
+
+        @Override
+        public void run() {
+            try {
+                pendingTasksCounter.decrementAndGet();
+                if (!future.isDone()) {
+                    future.complete(task.call());
+                }
+            } catch (Throwable e) {
+                future.completeExceptionally(e);
+            }
+        }
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/EventExecutor.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/EventExecutor.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Single threaded executor.
+ * <p>
+ * Handle the all events submitted and schedule to the executor.
+ * <p>
+ * All Runnable and Callable submitted to an executor are guaranteed to be executed by the same thread. This means
+ * that the events don't need to handle concurrent access to shared state.
+ * <p>
+ * When canceling the futures returned by the submit and schedule methods the Runnable and Callable will not be
+ * executed. This is a best effort. If the task is already running then the Runnable and Callable will execute but the
+ * future may not get updated.
+ * <p>
+ * Shutting down the event executor will make it so that it will stop accepting new tasks for execution. The methods
+ * submit and schedule will throw a RejectedExecutionException when called after calling shutdown. All scheduled tasks
+ * that have not expired will not be executed by the event executor.
+ */
+public interface EventExecutor {
+    /**
+     * Submits a task for immediate execution.
+     *
+     * @param task runnable to execute
+     * @return a completable future that will complete when the task as finished executing
+     */
+    CompletableFuture<Void> submit(Runnable task);
+
+    /**
+     * Submits a task for immediate execution.
+     *
+     * @param task callable to execute
+     * @return a completable future that will complete with the task's value
+     */
+    <T> CompletableFuture<T> submit(Callable<T> task);
+
+    /**
+     * Submits a task for delayed execution.
+     *
+     * @param task runnable to execute
+     * @param delay the time from now to delay execution
+     * @param unit the time unit of the delay parameter
+     * @return a completable future that will complete when the task as finished executing
+     */
+    CompletableFuture<Void> schedule(Runnable task, long delay, TimeUnit unit);
+
+    /**
+     * Submits a task for delayed execution.
+     *
+     * @param task runnable to execute
+     * @param delay the time from now to delay execution
+     * @param unit the time unit of the delay parameter
+     * @return a completable future that will complete with the task's value
+     */
+    <T> CompletableFuture<T> schedule(Callable<T> task, long delay, TimeUnit unit);
+
+    /**
+     * Shuts down the event executor.
+     * <p>
+     * No additional task will be accepted by the submit and schedule methods. Both methods will throw a
+     * RejectedExecutionException after this method is called.
+     * <p>
+     * All scheduled tasks that have not expired will not be executed by the event executor.
+     *
+     * @return a completable future that will complete when all pending tasks have executed
+     */
+    CompletableFuture<Void> shutdown();
+}

--- a/server-common/src/main/java/org/apache/kafka/server/util/VoidCallable.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/VoidCallable.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import java.util.concurrent.Callable;
+
+public final class VoidCallable implements Callable<Void> {
+    private final Runnable runnable;
+
+    public VoidCallable(Runnable runnable) {
+        this.runnable = runnable;
+    }
+
+    @Override
+    public Void call() {
+        runnable.run();
+        return null;
+    }
+}

--- a/server-common/src/test/java/org/apache/kafka/server/util/DefaultEventExecutorTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/DefaultEventExecutorTest.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class DefaultEventExecutorTest {
+    int defaultTimeoutSec = 10;
+
+    private DefaultEventExecutor createExecutor(int capacity) {
+        return new DefaultEventExecutor(Executors.defaultThreadFactory(), capacity);
+    }
+
+    @Test
+    void testSubmitRunnable() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            AtomicBoolean executed = new AtomicBoolean(false);
+            CompletableFuture<Void> future = executor.submit(() -> executed.set(true));
+
+            // await until future finishes
+            assertNull(future.get(defaultTimeoutSec, TimeUnit.SECONDS));
+            assertTrue(executed.get());
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testSubmitRunnableException() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            CompletableFuture<Void> future = executor.submit(() -> {
+                throw new RuntimeException();
+            });
+
+            ExecutionException exception = assertThrows(
+                ExecutionException.class,
+                () -> future.get(defaultTimeoutSec, TimeUnit.SECONDS)
+            );
+            assertEquals(RuntimeException.class, exception.getCause().getClass());
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testSubmitCallable() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            int expected = 42;
+            CompletableFuture<Integer> future = executor.submit(() -> expected);
+
+            // await until future finishes
+            assertEquals(expected, future.get(defaultTimeoutSec, TimeUnit.SECONDS));
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testScheduleRunnable() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            AtomicBoolean executed = new AtomicBoolean(false);
+            long delaySec = 1;
+            long start = Time.SYSTEM.milliseconds();
+            CompletableFuture<Void> future = executor.schedule(() -> executed.set(true), delaySec, TimeUnit.SECONDS);
+
+            // await until future finishes
+            assertNull(future.get(defaultTimeoutSec, TimeUnit.SECONDS));
+            long now = Time.SYSTEM.milliseconds();
+            assertTrue(
+                now - start >= TimeUnit.SECONDS.toMillis(delaySec),
+                String.format(
+                    "now (%s) ms - start (%s) ms (%s) is not greater than delay (%s) seconds",
+                    now,
+                    start,
+                    now - start,
+                    delaySec
+                )
+            );
+            assertTrue(executed.get());
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testScheduleCallable() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            long delaySec = 1;
+            int expected = 42;
+            long start = Time.SYSTEM.milliseconds();
+            CompletableFuture<Integer> future = executor.schedule(() -> expected, delaySec, TimeUnit.SECONDS);
+
+            // await until future finishes
+            assertEquals(expected, future.get(defaultTimeoutSec, TimeUnit.SECONDS));
+            long now = Time.SYSTEM.milliseconds();
+            assertTrue(
+                now - start >= TimeUnit.SECONDS.toMillis(delaySec),
+                String.format(
+                    "now (%s) ms - start (%s) ms (%s) is not greater than delay (%s) seconds",
+                    now,
+                    start,
+                    now - start,
+                    delaySec
+                )
+            );
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testScheduleCallableException() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            long delaySec = 1;
+            long start = Time.SYSTEM.milliseconds();
+            CompletableFuture<Integer> future = executor.schedule(
+                () -> {
+                    throw new RuntimeException();
+                },
+                delaySec,
+                TimeUnit.SECONDS
+            );
+
+            // await until future finishes
+            ExecutionException exception = assertThrows(
+                ExecutionException.class,
+                () -> future.get(defaultTimeoutSec, TimeUnit.SECONDS)
+            );
+            assertEquals(RuntimeException.class, exception.getCause().getClass());
+            long now = Time.SYSTEM.milliseconds();
+            assertTrue(
+                now - start >= TimeUnit.SECONDS.toMillis(delaySec),
+                String.format(
+                    "now (%s) ms - start (%s) ms (%s) is not greater than delay (%s) seconds",
+                    now,
+                    start,
+                    now - start,
+                    delaySec
+                )
+            );
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testCancelSubmit() throws Exception {
+        DefaultEventExecutor executor = createExecutor(2);
+        CompletableFuture<Void> shutdown;
+        try {
+            // block the executor so that the next task is not picked up
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CompletableFuture<Void> latchFuture = executor.submit(() -> assertDoesNotThrow(() -> startLatch.await()));
+
+            AtomicBoolean executed = new AtomicBoolean(false);
+            CompletableFuture<Void> future = executor.submit(() -> executed.set(true));
+
+            assertFalse(executed.get());
+            assertFalse(future.isDone());
+
+            future.cancel(false);
+            startLatch.countDown();
+
+            // the blocking future finished
+            assertNull(latchFuture.get(defaultTimeoutSec, TimeUnit.SECONDS));
+
+            // the future was canceled and didn't execute
+            assertFalse(executed.get());
+            assertTrue(future.isDone());
+            assertTrue(future.isCancelled());
+            assertTrue(future.isCompletedExceptionally());
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testCancelSchedule() throws Exception {
+        DefaultEventExecutor executor = createExecutor(2);
+        CompletableFuture<Void> shutdown;
+        try {
+            // block the executor so that the next task is not picked up
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CompletableFuture<Void> latchFuture = executor.submit(() -> assertDoesNotThrow(() -> startLatch.await()));
+
+            AtomicBoolean executed = new AtomicBoolean(false);
+            long delayMs = 100;
+            CompletableFuture<Void> future = executor.schedule(() -> executed.set(true), delayMs, TimeUnit.MILLISECONDS);
+
+            assertFalse(executed.get());
+            assertFalse(future.isDone());
+
+            future.cancel(false);
+            startLatch.countDown();
+
+            // the blocking future finished
+            assertNull(latchFuture.get(defaultTimeoutSec, TimeUnit.SECONDS));
+
+            // the future didn't execute and was canceled
+            assertFalse(executed.get());
+            assertTrue(future.isDone());
+            assertTrue(future.isCancelled());
+            assertTrue(future.isCompletedExceptionally());
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testCapacitySubmit() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            // block the executor so that the next task is not picked up
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch scheduledLatch = new CountDownLatch(1);
+            CompletableFuture<Void> latchFuture = executor.submit(() -> {
+                scheduledLatch.countDown();
+                assertDoesNotThrow(() -> startLatch.await());
+            });
+
+            // wait for the blocking task to get removed from the queue
+            scheduledLatch.await();
+            // add task to queue
+            CompletableFuture<Void> future = executor.submit(() -> null);
+            // show that capacity is reached
+            assertThrows(RejectedExecutionException.class, () -> executor.submit(() -> null));
+            assertThrows(RejectedExecutionException.class, () -> executor.schedule(() -> null, 1, TimeUnit.NANOSECONDS));
+
+            startLatch.countDown();
+
+            // wait for all futures to finish
+            assertNull(latchFuture.get(defaultTimeoutSec, TimeUnit.SECONDS));
+            assertNull(future.get(defaultTimeoutSec, TimeUnit.SECONDS));
+
+            // executor is able to accept new tasks
+            executor.submit(() -> null);
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testCapacitySchedule() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            // block the executor so that the next task is not picked up
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch scheduledLatch = new CountDownLatch(1);
+            CompletableFuture<Void> latchFuture = executor.schedule(
+                () -> {
+                    scheduledLatch.countDown();
+                    assertDoesNotThrow(() -> startLatch.await());
+                },
+                1,
+                TimeUnit.NANOSECONDS
+            );
+
+            // wait for the blocking task to get removed from the queue
+            scheduledLatch.await();
+            // add task to queue
+            CompletableFuture<Void> future = executor.schedule(() -> null, 1, TimeUnit.NANOSECONDS);
+            // show that capacity is reached
+            assertThrows(RejectedExecutionException.class, () -> executor.submit(() -> null));
+            assertThrows(RejectedExecutionException.class, () -> executor.schedule(() -> null, 1, TimeUnit.NANOSECONDS));
+
+            startLatch.countDown();
+
+            // wait for all futures to finish
+            assertNull(latchFuture.get(defaultTimeoutSec, TimeUnit.SECONDS));
+            assertNull(future.get(defaultTimeoutSec, TimeUnit.SECONDS));
+
+            // executor is able to accept new tasks
+            executor.submit(() -> null);
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testShutdown() throws Exception {
+        DefaultEventExecutor executor = createExecutor(1);
+        CompletableFuture<Void> shutdown;
+        try {
+            // schedule a task far in the future
+            AtomicBoolean executed = new AtomicBoolean(false);
+            long delaySec = 1000;
+            CompletableFuture<Void> future = executor.schedule(
+                () -> executed.set(true),
+                delaySec,
+                TimeUnit.SECONDS
+            );
+
+            // shutdown executor
+            shutdown = executor.shutdown();
+
+            // scheduling new tasks is not allowed
+            assertThrows(RejectedExecutionException.class, () -> executor.submit(() -> null));
+
+            // wait for the executor to shutdown
+            assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+
+            // verify that the delayed task didn't execute and wasn't canceled
+            assertFalse(executed.get());
+            assertFalse(future.isDone());
+            assertFalse(future.isCancelled());
+            assertFalse(future.isCompletedExceptionally());
+        } finally {
+            shutdown = executor.shutdown();
+        }
+
+        // wait for the executor to shutdown
+        assertNull(shutdown.get(defaultTimeoutSec, TimeUnit.SECONDS));
+    }
+}

--- a/server-common/src/test/java/org/apache/kafka/server/util/MockEventExecutor.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/MockEventExecutor.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.common.utils.MockTime;
+
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Non-concurrent implementation of an event executor.
+ *
+ * This implementation if useful for testing functionality that uses an event executor.
+ *
+ * Tasks submitted to this event executor will be executed when poll is called. To executed delay
+ *  tasks make sure to sleep the mock time before calling poll.
+ */
+public final class MockEventExecutor implements EventExecutor {
+    private final MockTime time;
+    private final Queue<Runnable> fifo = new ArrayDeque<>();
+    private final PriorityQueue<ScheduledRunnable> delayed = new PriorityQueue<>();
+    private Optional<CompletableFuture<Void>> shutdownFuture = Optional.empty();
+
+    private final class ScheduledRunnable implements Runnable, Delayed {
+        private final Runnable runnable;
+        private final long expires;
+        private final CompletableFuture<?> future;
+
+        ScheduledRunnable(CompletableFuture<?> future, Runnable runnable, long delay, TimeUnit timeUnit) {
+            this.runnable = runnable;
+            this.expires = time.milliseconds() + timeUnit.toMillis(delay);
+            this.future = future;
+        }
+
+        @Override
+        public void run() {
+            runnable.run();
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(expires - time.milliseconds(), TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            ScheduledRunnable that = (ScheduledRunnable) other;
+            return Long.compare(expires, that.expires);
+        }
+
+        public CompletableFuture<?> future() {
+            return future;
+        }
+    }
+
+
+    public MockEventExecutor(MockTime time) {
+        this.time = time;
+    }
+
+    @Override
+    public CompletableFuture<Void> submit(Runnable task) {
+        return submit(new VoidCallable(task));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submit(Callable<T> task) {
+        ensureAccepting();
+
+        CompletableFuture<T> future = new CompletableFuture<>();
+        fifo.add(completioner(future, task));
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> schedule(Runnable task, long delay, TimeUnit unit) {
+        return schedule(new VoidCallable(task), delay, unit);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> schedule(Callable<T> task, long delay, TimeUnit unit) {
+        ensureAccepting();
+
+        CompletableFuture<T> future = new CompletableFuture<>();
+        delayed.add(new ScheduledRunnable(future, completioner(future, task), delay, unit));
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        if (!shutdownFuture.isPresent()) {
+            shutdownFuture = Optional.of(new CompletableFuture<>());
+        }
+
+        // forget all the tasks and do not cancel them
+        delayed.clear();
+
+        // immediately complete the shutdown future if the fifo queue is empty
+        if (fifo.isEmpty()) {
+            shutdownFuture.get().complete(null);
+        }
+
+        return shutdownFuture.get();
+    }
+
+    /**
+     * Executes a task.
+     *
+     * @return true if a task was executed by this call; false otherwise
+     */
+    public boolean poll() {
+        // Add to the fifo queue any task with an expired delay
+        while (!delayed.isEmpty() && delayed.peek().getDelay(TimeUnit.MILLISECONDS) <= 0) {
+            fifo.add(delayed.poll());
+        }
+
+        Runnable runnable = fifo.poll();
+        boolean ranTask = false;
+        if (runnable != null) {
+            runnable.run();
+            ranTask = true;
+        }
+
+        if (shutdownFuture.isPresent() && fifo.isEmpty()) {
+            shutdownFuture.get().complete(null);
+        }
+
+        return ranTask;
+    }
+
+    private void ensureAccepting() {
+        if (shutdownFuture.isPresent()) {
+            throw new RejectedExecutionException("event executor shutting down");
+        }
+    }
+
+    private static <T> Runnable completioner(CompletableFuture<T> future, Callable<T> task) {
+        return () -> {
+            try {
+                if (!future.isDone()) {
+                    future.complete(task.call());
+                }
+            } catch (Throwable e) {
+                future.completeExceptionally(e);
+            }
+        };
+    }
+}

--- a/server-common/src/test/java/org/apache/kafka/server/util/MockEventExecutorTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/MockEventExecutorTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.util;
+
+import org.apache.kafka.common.utils.MockTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class MockEventExecutorTest {
+    private MockTime time;
+    private MockEventExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        time = new MockTime();
+        executor = new MockEventExecutor(time);
+    }
+
+    @Test
+    void testSubmitRunnable() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        CompletableFuture<Void> future = executor.submit(() -> executed.set(true));
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        assertTrue(executor.poll());
+
+        assertTrue(executed.get());
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertFalse(future.isCompletedExceptionally());
+    }
+
+    @Test
+    void testSubmitRunnableException() {
+        CompletableFuture<Void> future = executor.submit(() -> {
+            throw new RuntimeException();
+        });
+
+        assertFalse(future.isDone());
+
+        assertTrue(executor.poll());
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertTrue(future.isCompletedExceptionally());
+        CompletionException exception = assertThrows(CompletionException.class, future::join);
+        assertEquals(RuntimeException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void testSubmitCallable() {
+        int expected = 42;
+        CompletableFuture<Integer> future = executor.submit(() -> expected);
+
+        assertFalse(future.isDone());
+
+        assertTrue(executor.poll());
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertFalse(future.isCompletedExceptionally());
+        assertEquals(expected, future.join());
+    }
+
+    @Test
+    void testScheduleRunnable() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        long delayMs = 100;
+        CompletableFuture<Void> future = executor.schedule(() -> executed.set(true), delayMs, TimeUnit.MILLISECONDS);
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        assertFalse(executor.poll());
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        time.sleep(delayMs - 1);
+        assertFalse(executor.poll());
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        time.sleep(1);
+        assertTrue(executor.poll());
+
+        assertTrue(executed.get());
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertFalse(future.isCompletedExceptionally());
+    }
+
+    @Test
+    void testScheduleCallable() {
+        long delayMs = 100;
+        int expected = 42;
+        CompletableFuture<Integer> future = executor.schedule(() -> expected, delayMs, TimeUnit.MILLISECONDS);
+
+        assertFalse(future.isDone());
+
+        assertFalse(executor.poll());
+
+        assertFalse(future.isDone());
+
+        time.sleep(delayMs - 1);
+        assertFalse(executor.poll());
+
+        assertFalse(future.isDone());
+
+        time.sleep(1);
+        assertTrue(executor.poll());
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertFalse(future.isCompletedExceptionally());
+        assertEquals(expected, future.join());
+    }
+
+    @Test
+    void testScheduleCallableException() {
+        long delayMs = 100;
+        CompletableFuture<Integer> future = executor.schedule(
+            () -> {
+                throw new RuntimeException();
+            },
+            delayMs,
+            TimeUnit.MILLISECONDS
+        );
+
+        assertFalse(future.isDone());
+
+        assertFalse(executor.poll());
+
+        assertFalse(future.isDone());
+
+        time.sleep(delayMs - 1);
+        assertFalse(executor.poll());
+
+        assertFalse(future.isDone());
+
+        time.sleep(1);
+        assertTrue(executor.poll());
+
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertTrue(future.isCompletedExceptionally());
+        CompletionException exception = assertThrows(CompletionException.class, future::join);
+        assertEquals(RuntimeException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void testCancelSubmit() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        CompletableFuture<Void> future = executor.submit(() -> executed.set(true));
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        future.cancel(false);
+        assertTrue(executor.poll());
+
+        assertFalse(executed.get());
+        assertTrue(future.isDone());
+        assertTrue(future.isCancelled());
+        assertTrue(future.isCompletedExceptionally());
+    }
+
+    @Test
+    void testCancelSchedule() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        long delayMs = 100;
+        CompletableFuture<Void> future = executor.schedule(() -> executed.set(true), delayMs, TimeUnit.MILLISECONDS);
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        time.sleep(delayMs - 1);
+        assertFalse(executor.poll());
+
+        assertFalse(executed.get());
+        assertFalse(future.isDone());
+
+        future.cancel(false);
+        time.sleep(1);
+        assertTrue(executor.poll());
+
+        assertFalse(executed.get());
+        assertTrue(future.isDone());
+        assertTrue(future.isCancelled());
+        assertTrue(future.isCompletedExceptionally());
+    }
+
+    @Test
+    void testShutdown() {
+        AtomicBoolean delayedExecuted = new AtomicBoolean(false);
+        long delayMs = 100;
+        CompletableFuture<Void> delayed = executor.schedule(
+            () -> delayedExecuted.set(true),
+            delayMs,
+            TimeUnit.MILLISECONDS
+        );
+
+        AtomicBoolean veryDelayedExecuted = new AtomicBoolean(false);
+        long veryDelayMs = 2 * delayMs;
+        CompletableFuture<Void> veryDelayed = executor.schedule(
+            () -> veryDelayedExecuted.set(true),
+            veryDelayMs,
+            TimeUnit.MILLISECONDS
+        );
+
+        AtomicBoolean submittedExecuted = new AtomicBoolean(false);
+        CompletableFuture<Void> submitted = executor.submit(() -> submittedExecuted.set(true));
+
+        time.sleep(delayMs);
+        // executes submitted and queues delayed
+        assertTrue(executor.poll());
+
+        // cancels veryDelayed
+        CompletableFuture<Void> shutdown = executor.shutdown();
+        // executes delayed
+        assertTrue(executor.poll());
+
+        // the delayed task should have executed
+        assertTrue(delayedExecuted.get());
+        assertTrue(delayed.isDone());
+        assertFalse(delayed.isCancelled());
+
+        // the submitted task should have executed
+        assertTrue(submittedExecuted.get());
+        assertTrue(submitted.isDone());
+        assertFalse(submitted.isCancelled());
+
+        // the very delayed task didn't execute and was not canceled
+        assertFalse(veryDelayedExecuted.get());
+        assertFalse(veryDelayed.isDone());
+        assertFalse(veryDelayed.isCancelled());
+        assertFalse(veryDelayed.isCompletedExceptionally());
+
+        // check that the shutdown future completed
+        assertTrue(shutdown.isDone());
+        assertFalse(shutdown.isCancelled());
+        assertFalse(shutdown.isCompletedExceptionally());
+    }
+
+    @Test
+    void testNoOpPoll() {
+        assertFalse(executor.poll());
+    }
+}


### PR DESCRIPTION
This PR implements step 1 of the incremental refactor: wrapping the existing `poll()` call in an EventExecutor-based self-rescheduling loop. The `KafkaRaftClient` operates the same as before, but now the `KafkaRaftClientDriver` holds an `EventExecutor` instead of extending `ShutdownableThread`.

###   What changed

 - Adds `EventExecutor` as a constructor parameter to `KafkaRaftClient`, so the client holds a direct reference to the executor alongside `KafkaRaftClientDriver`. This positions the client to schedule its own events (election timeouts, heartbeats, batch drains, etc.) directly in future PRs, without introducing a circular dependency between the client and driver.
  - Refactors `KafkaRaftClient` to use event-based scheduling via `KafkaRaftClientDriver`, replacing the previous `ShutdownableThread` polling loop. The driver submits a self-rescheduling poll event to an `EventExecutor`, with identical runtime behavior to the old thread-based approach.
  - Introduces the `EventExecutor` interface and `DefaultEventExecutor` implementation in server-common, providing a single-threaded executor with submit(), schedule(), and graceful shutdown() semantics. Adds `MockEventExecutor` for deterministic testing with manual poll() and MockTime-driven scheduled task expiration.

  Test plan

  - `KafkaRaftClientDriverTest` — verifies the self-rescheduling poll loop, graceful shutdown, and fault handler invocation on uncaught exceptions
  - `DefaultEventExecutorTest` — covers submit()/schedule() for runnables and callables, exception propagation, cancellation, capacity enforcement, and shutdown semantics
  - `MockEventExecutorTest` — validates deterministic polling, scheduled task expiration via MockTime, cancellation, shutdown rejection, and no-op poll()

### Proposed next steps of refactor

Prior to this PR, an invoke of `KafkaRaftClient#poll()` can be thought of as appending 3 distinct "events":

1. A poll state event: this brings the local client state "up-to-date" and potentially sends outgoing RPCs
2. A blocking inbound message handling event: the client waits for a inbound message to handle and update more state
3. Polling listeners event: update raft listener states

After this PR, we will only have 1 event (`poll()`) on the event queue, so the behavior of the system should be identical. However, subsequent PRs will break up what currently goes on in poll into distinct events. We may also want to write some benchmarks to make sure performance regressions aren't happening due to this refactor.

I think the most natural iteration in the next PR will be breaking things up into the events mentioned above. What this might look like is: 

- the event queue initially starts empty and the client periodically schedule a "poll state event" to kick off KRaft 
- whenever an inbound message comes, the client can first submit a "poll state event" if we consider the last poll state to be too out of date, then a "handle inbound message event", and finally a "poll listeners" event

This way the behavior should also be the same as currently, except we could remove the `RaftMessageQueue` at that point, and start using the `EventExecutor` directly in unit tests. Then follow-on PRs can break the "poll state event" down further.