### PR TITLE
MINOR: Upgrade dependencies versions for bouncycastle and jgit-related libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1847,12 +1847,9 @@ project(':generator') {
     implementation libs.jacksonDatabind
     implementation libs.jacksonJDK8Datatypes
     implementation libs.jacksonJakartarsJsonProvider
-
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.2.0.202503040940-r'
-    // SSH support for JGit based on Apache MINA sshd
-    implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:7.2.0.202503040940-r'
-    // GPG support for JGit based on BouncyCastle (commit signing)
-    implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:7.2.0.202503040940-r'
+    implementation libs.jgit
+    implementation libs.jgitSshApache
+    implementation libs.jgitGpgBc
 
     testImplementation libs.junitJupiter
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.80",
+  bcpkix: "1.83",
   caffeine: "3.2.0",
   bndlib: "7.1.0",
   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.2.0",
@@ -72,6 +72,7 @@ versions += [
   // SLF4J 2.x fluent API in test code, avoiding the runtime incompatibility.
   jetty: "12.0.25",
   jersey: "3.1.10",
+  jgit: "7.5.0.202512021534-r",
   jline: "3.30.4",
   jmh: "1.37",
   hamcrest: "3.0",
@@ -176,6 +177,11 @@ libs += [
   jettyServlets: "org.eclipse.jetty.ee10:jetty-ee10-servlets:$versions.jetty",
   jerseyContainerServlet: "org.glassfish.jersey.containers:jersey-container-servlet:$versions.jersey",
   jerseyHk2: "org.glassfish.jersey.inject:jersey-hk2:$versions.jersey",
+  jgit: "org.eclipse.jgit:org.eclipse.jgit:$versions.jgit",
+  // SSH support for JGit based on Apache MINA sshd
+  jgitSshApache: "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit",
+  // GPG support for JGit based on BouncyCastle (commit signing)
+  jgitGpgBc: "org.eclipse.jgit:org.eclipse.jgit.gpg.bc:$versions.jgit",
   jline: "org.jline:jline:$versions.jline",
   jmhCore: "org.openjdk.jmh:jmh-core:$versions.jmh",
   jmhCoreBenchmarks: "org.openjdk.jmh:jmh-core-benchmarks:$versions.jmh",


### PR DESCRIPTION
**Details:**
 - jgit, jgitSshApache and jgitGpgBc: 7.2.0 -->> 7.5.0 - upgrade to the
latest version (7.5.0.202512021534-r) to address CVE-2025-4949
 - bouncycastle: 1.80 -->> 1.83

**Related links:**

jgit:
- CVE-2025-4949
- https://nvd.nist.gov/vuln/detail/CVE-2025-4949
- https://www.cve.org/CVERecord?id=CVE-2025-4949
- https://www.cve.org/CVERecord?id=CVE-2025-4949
- https://projects.eclipse.org/projects/technology.jgit/releases/7.2.1
- https://projects.eclipse.org/projects/technology.jgit/releases/7.3.0
- https://projects.eclipse.org/projects/technology.jgit/releases/7.4.0
- https://projects.eclipse.org/projects/technology.jgit/releases/7.5.0

bouncycastle:
-
https://www.bouncycastle.org/resources/bouncy-castle-releases-java-1-81-and-c-net-2-6-1
-
https://www.bouncycastle.org/resources/new-releases-bouncy-castle-java-1-82-and-bouncy-castle-java-lts-2-73-9
-
https://www.bouncycastle.org/resources/new-release-composite-signatures_unsigned-certificates_and_crmf-cmp-challenge-response

Reviewers: Christo Lolov <lolovc@amazon.com>
