### PR TITLE
MINOR:  Keep pendingTask as WakeupFuture if currentTask is completed already. 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
@@ -78,8 +78,12 @@ public class WakeupTrigger {
             if (task == null) {
                 return new ActiveFuture(currentTask);
             } else if (task instanceof WakeupFuture) {
-                currentTask.completeExceptionally(new WakeupException());
-                return null;
+                boolean wasTriggered = currentTask.completeExceptionally(new WakeupException());
+
+                // If the Future was *already* completed when we invoke completeExceptionally, the WakeupException
+                // will be ignored. If it was already completed, we then need to return a new WakeupFuture so that the
+                // next call to setActiveTask will throw the WakeupException.
+                return wasTriggered ? null : new WakeupFuture();
             } else if (task instanceof DisabledWakeups) {
                 return task;
             }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -219,6 +219,39 @@ public class WakeupTriggerTest {
         assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
     }
 
+    @Test
+    public void testExceptionTriggeredWhenTaskAsynchronouslyCompletedBeforeSet() {
+        final CompletableFuture<Void> task = new CompletableFuture<>();
+        task.complete(null);
+        wakeupTrigger.wakeup();
+        wakeupTrigger.setActiveTask(task);
+        assertNotNull(wakeupTrigger.getPendingTask());
+        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupTrigger.getPendingTask());
+        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testExceptionTriggeredWhenTaskAsynchronouslyFailedBeforeSet() {
+        final CompletableFuture<Void> task = new CompletableFuture<>();
+        task.completeExceptionally(new RuntimeException("Simulated error"));
+        wakeupTrigger.wakeup();
+        wakeupTrigger.setActiveTask(task);
+        assertNotNull(wakeupTrigger.getPendingTask());
+        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupTrigger.getPendingTask());
+        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testExceptionTriggeredWhenTaskAsynchronouslyCancelledBeforeSet() {
+        final CompletableFuture<Void> task = new CompletableFuture<>();
+        task.cancel(true);
+        wakeupTrigger.wakeup();
+        wakeupTrigger.setActiveTask(task);
+        assertNotNull(wakeupTrigger.getPendingTask());
+        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupTrigger.getPendingTask());
+        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
     private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
         assertTrue(future.isCompletedExceptionally());
         assertInstanceOf(WakeupException.class,

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -352,6 +352,8 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                         handler.handle_partitions_revoked(event, node, self.logger)
                     elif name == "partitions_assigned":
                         handler.handle_partitions_assigned(event, node, self.logger)
+                    elif name == "shutdown_requested":
+                        self.logger.debug("Shutdown has been requested")
                     else:
                         self.logger.debug("%s: ignoring unknown event: %s" % (str(node.account), event))
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -102,6 +102,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     private final int maxMessages;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
     private int consumedMessages = 0;
+    private boolean shutdownRequested = false;
 
     public VerifiableConsumer(KafkaConsumer<String, String> consumer,
                               PrintStream out,
@@ -232,7 +233,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             printJson(new StartupComplete());
             consumer.subscribe(List.of(topic), this);
 
-            while (!isFinished()) {
+            while (!isFinished() && !shutdownRequested) {
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
                 Map<TopicPartition, OffsetAndMetadata> offsets = onRecordsReceived(records);
 
@@ -259,6 +260,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     public void close() {
         boolean interrupted = false;
         try {
+            printJson(new ShutdownRequested());
+            shutdownRequested = true;
             consumer.wakeup();
             while (true) {
                 try {
@@ -292,6 +295,14 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         @Override
         public String name() {
             return "startup_complete";
+        }
+    }
+
+    private static class ShutdownRequested extends ConsumerEvent {
+
+        @Override
+        public String name() {
+            return "shutdown_requested";
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -102,7 +102,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     private final int maxMessages;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
     private int consumedMessages = 0;
-    private boolean shutdownRequested = false;
 
     public VerifiableConsumer(KafkaConsumer<String, String> consumer,
                               PrintStream out,
@@ -233,7 +232,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             printJson(new StartupComplete());
             consumer.subscribe(List.of(topic), this);
 
-            while (!isFinished() && !shutdownRequested) {
+            while (!isFinished()) {
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
                 Map<TopicPartition, OffsetAndMetadata> offsets = onRecordsReceived(records);
 
@@ -261,7 +260,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         boolean interrupted = false;
         try {
             printJson(new ShutdownRequested());
-            shutdownRequested = true;
             consumer.wakeup();
             while (true) {
                 try {


### PR DESCRIPTION
System tests that use VerifiableConsumer are flaky because
VerifiableConsumer isn't shutting down on request in certain situations.
There can be a race condition in the commitSync method, as the future
that we set as the active task to the wakeupTrigger can be already
completed by the time we are setting it. Which leads to the wakeup
request never being fulfilled.  Added a check if the task we are
receiving in setActiveTask was triggered when we complete it
exceptionally.

Also added additional logging when a shutdown is requested to make
debugging easier.

Reviewers: Kirk True <ktrue@confluent.io>, Bill Bejeck
 <bbejeck@apache.org>
