### PR TITLE
MINOR: Change scala version from 2.12 to 2.13 for 3.9.3

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -172,7 +172,7 @@ get_kafka 3.7.2 2.12
 chmod a+rw /opt/kafka-3.7.2
 get_kafka 3.8.1 2.12
 chmod a+rw /opt/kafka-3.8.1
-get_kafka 3.9.2 2.12
+get_kafka 3.9.2 2.13
 chmod a+rw /opt/kafka-3.9.2
 get_kafka 4.0.1 2.13
 chmod a+rw /opt/kafka-4.0.1


### PR DESCRIPTION
Change scala version from 2.12 to 2.13 for 3.9.3 in `vagrant/base.sh`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
