### PR TITLE
KAFKA-20169: Support static membership for Kafka Streams with the streams rebalance protocol at Client Side.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -222,6 +222,7 @@ public class RequestManagers implements Closeable {
                     if (streamsRebalanceData.isPresent()) {
                         streamsMembershipManager = new StreamsMembershipManager(
                             groupRebalanceConfig.groupId,
+                            groupRebalanceConfig.groupInstanceId,
                             streamsRebalanceData.get(),
                             subscriptions,
                             backgroundEventHandler,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -639,6 +639,11 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
                 heartbeatRequestState.reset();
                 break;
 
+            case UNRELEASED_INSTANCE_ID:
+                logger.error("StreamsGroupHeartbeatRequest failed due to {}: {}", error, errorMessage);
+                handleFatalFailure(error.exception(errorMessage));
+                break;
+                
             case UNSUPPORTED_VERSION:
                 logger.error("StreamsGroupHeartbeatRequest failed due to {}: {}", error, UNSUPPORTED_VERSION_ERROR_MESSAGE);
                 handleFatalFailure(error.exception(UNSUPPORTED_VERSION_ERROR_MESSAGE));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackCompletedEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackNeededEvent;
@@ -53,6 +54,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableList;
+import static org.apache.kafka.clients.consumer.CloseOptions.GroupMembershipOperation.LEAVE_GROUP;
+import static org.apache.kafka.clients.consumer.CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP;
 
 /**
  * Tracks the state of a single member in relationship to a group:
@@ -198,7 +201,7 @@ public class StreamsMembershipManager implements RequestManager {
     /**
      * Group instance ID to be used by a static member, provided when creating the current membership manager.
      */
-    private final Optional<String> groupInstanceId = Optional.empty();
+    private final Optional<String> groupInstanceId;
 
     /**
      * Current epoch of the member. It will be set to 0 by the member, and provided to the server
@@ -282,6 +285,14 @@ public class StreamsMembershipManager implements RequestManager {
     private boolean isPollTimerExpired;
 
     /**
+     * Indicate the operation on streams group membership that the consumer will perform when leaving the group.
+     * The property should remain {@code GroupMembershipOperation.DEFAULT} until the consumer is closing.
+     *
+     * @see CloseOptions.GroupMembershipOperation
+     */
+    protected CloseOptions.GroupMembershipOperation leaveGroupOperation = CloseOptions.GroupMembershipOperation.DEFAULT;
+
+    /**
      * Constructs the Streams membership manager.
      *
      * @param groupId                The ID of the group.
@@ -293,6 +304,7 @@ public class StreamsMembershipManager implements RequestManager {
      * @param metrics                The metrics.
      */
     public StreamsMembershipManager(final String groupId,
+                                    final Optional<String> groupInstanceId,
                                     final StreamsRebalanceData streamsRebalanceData,
                                     final SubscriptionState subscriptionState,
                                     final BackgroundEventHandler backgroundEventHandler,
@@ -302,6 +314,7 @@ public class StreamsMembershipManager implements RequestManager {
         log = logContext.logger(StreamsMembershipManager.class);
         this.state = MemberState.UNSUBSCRIBED;
         this.groupId = groupId;
+        this.groupInstanceId = groupInstanceId;
         this.backgroundEventHandler = backgroundEventHandler;
         this.streamsRebalanceData = streamsRebalanceData;
         this.subscriptionState = subscriptionState;
@@ -449,8 +462,23 @@ public class StreamsMembershipManager implements RequestManager {
     }
 
     private void finalizeLeaving() {
-        updateMemberEpoch(StreamsGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH);
+        updateMemberEpoch(leaveGroupEpoch());
         clearCurrentTaskAssignment();
+    }
+    
+    public int leaveGroupEpoch() {
+        boolean isStaticMember = groupInstanceId.isPresent();
+        // Currently, the server doesn't have a mechanism for static members to permanently leave the group.
+        // Therefore, we use LEAVE_GROUP_MEMBER_EPOCH to force the GroupMetadataManager to fence
+        // this member, effectively removing it from the group.
+        if (LEAVE_GROUP == leaveGroupOperation) {
+            return StreamsGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
+        }
+
+        if (isStaticMember && REMAIN_IN_GROUP == leaveGroupOperation) {
+            return StreamsGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH;
+        } 
+        return StreamsGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
     }
 
     /**
@@ -892,6 +920,11 @@ public class StreamsMembershipManager implements RequestManager {
      * @return future that will complete when the heartbeat to leave the group has been sent out.
      */
     public CompletableFuture<Void> leaveGroupOnClose() {
+        return leaveGroup(true);
+    }
+
+    public CompletableFuture<Void> leaveGroupOnClose(CloseOptions.GroupMembershipOperation membershipOperation) {
+        this.leaveGroupOperation = membershipOperation;
         return leaveGroup(true);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -483,7 +483,7 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
             future.whenComplete(complete(event.future()));
         } else if (requestManagers.streamsMembershipManager.isPresent()) {
             log.debug("Signal the StreamsMembershipManager to leave the streams group since the member is closing");
-            CompletableFuture<Void> future = requestManagers.streamsMembershipManager.get().leaveGroupOnClose();
+            CompletableFuture<Void> future = requestManagers.streamsMembershipManager.get().leaveGroupOnClose(event.membershipOperation());
             future.whenComplete(complete(event.future()));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -1225,6 +1225,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
         value = Errors.class,
         names = {
             "INVALID_REQUEST",
+            "UNRELEASED_INSTANCE_ID",
             "GROUP_MAX_SIZE_REACHED",
             "UNSUPPORTED_VERSION",
             "STREAMS_INVALID_TOPOLOGY",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackCompletedEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackNeededEvent;
@@ -124,6 +125,7 @@ public class StreamsMembershipManagerTest {
     public void setup() {
         membershipManager = new StreamsMembershipManager(
             GROUP_ID,
+            Optional.empty(),
             streamsRebalanceData, subscriptionState, backgroundEventHandler,
             new LogContext("test"),
             time,
@@ -1143,6 +1145,58 @@ public class StreamsMembershipManagerTest {
         onTasksAssignedCallbackExecuted.complete(null);
 
         assertNotEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+    }
+    
+    @Test
+    public void testStaticMemberRemainInGroupUsesStaticLeaveEpochOnClose() {
+        CloseOptions.GroupMembershipOperation operation = CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP;
+        MemberState expectedState = MemberState.LEAVING;
+        int expectedEpoch = StreamsGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH;
+        verifyStaticMemberLeaveOnClose(operation, expectedState, expectedEpoch);
+    }
+
+    @Test
+    public void testStaticMemberDefaultUsesLeaveGroupEpochOnClose() {
+        CloseOptions.GroupMembershipOperation operation = CloseOptions.GroupMembershipOperation.DEFAULT;
+        MemberState expectedState = MemberState.LEAVING;
+        int expectedEpoch = StreamsGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
+        verifyStaticMemberLeaveOnClose(operation, expectedState, expectedEpoch);
+    }
+
+    @Test
+    public void testStaticMemberLeaveGroupUsesLeaveGroupEpochOnClose() {
+        CloseOptions.GroupMembershipOperation operation = CloseOptions.GroupMembershipOperation.LEAVE_GROUP;
+        MemberState expectedState = MemberState.LEAVING;
+        int expectedEpoch = StreamsGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
+        verifyStaticMemberLeaveOnClose(operation, expectedState, expectedEpoch);
+    }
+    
+    private void verifyStaticMemberLeaveOnClose(
+            CloseOptions.GroupMembershipOperation membershipOperation,
+            MemberState expectedMemberState,
+            int expectedMemberEpoch
+    ) {
+        final Metrics localMetrics = new Metrics(time);
+        StreamsMembershipManager membershipManagerWithStaticMember = new StreamsMembershipManager(
+                GROUP_ID,
+                Optional.of("instance-1"),
+                streamsRebalanceData,
+                subscriptionState,
+                backgroundEventHandler,
+                new LogContext("test"),
+                time,
+                localMetrics
+        );
+        membershipManagerWithStaticMember.registerStateListener(memberStateListener);
+        joining(membershipManagerWithStaticMember);
+
+        // WHEN
+        CompletableFuture<Void> onGroupLeft = membershipManagerWithStaticMember.leaveGroupOnClose(membershipOperation);
+
+        // THEN        
+        assertEquals(expectedMemberState, membershipManagerWithStaticMember.state());
+        assertEquals(expectedMemberEpoch, membershipManagerWithStaticMember.memberEpoch());
+        assertFalse(onGroupLeft.isDone());
     }
 
     @Test
@@ -2486,6 +2540,12 @@ public class StreamsMembershipManagerTest {
         membershipManager.onSubscriptionUpdated();
         membershipManager.onConsumerPoll();
         verifyInStateJoining(membershipManager);
+    }
+
+    private void joining(StreamsMembershipManager givenMembershipManager) {
+        givenMembershipManager.onSubscriptionUpdated();
+        givenMembershipManager.onConsumerPoll();
+        verifyInStateJoining(givenMembershipManager);
     }
 
     private void reconcile(final StreamsGroupHeartbeatResponse response) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1501,12 +1501,6 @@ public class StreamsConfig extends AbstractConfig {
 
     private void verifyStreamsProtocolCompatibility(final boolean doLog) {
         if (doLog && isStreamsProtocolEnabled()) {
-            final Map<String, Object> mainConsumerConfigs = getMainConsumerConfigs("dummy", "dummy", -1);
-            final String instanceId = (String) mainConsumerConfigs.get(CommonClientConfigs.GROUP_INSTANCE_ID_CONFIG);
-            if (instanceId != null && !instanceId.isEmpty()) {
-                throw new ConfigException("Streams rebalance protocol does not support static membership. "
-                    + "Please set group.protocol=classic or remove group.instance.id from the configuration.");
-            }
             if (getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG) != 0) {
                 log.warn("Warmup replicas are not supported yet with the streams protocol and will be ignored. "
                     + "If you want to use warmup replicas, please set group.protocol=classic.");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1880,7 +1880,7 @@ public class StreamThread extends Thread implements ProcessingThread {
             final GroupMembershipOperation membershipOperation =
                 leaveGroupRequested.get() == org.apache.kafka.streams.CloseOptions.GroupMembershipOperation.LEAVE_GROUP ? LEAVE_GROUP : REMAIN_IN_GROUP;
             if (membershipOperation == REMAIN_IN_GROUP && streamsRebalanceData.isPresent()) {
-                log.info("The consumer will leave the group since the streams group protocol is used");
+                log.info("The consumer will not leave the group since the streams group protocol is used and membershipOperation is REMAIN_IN_GROUP.");
             }
             mainConsumer.close(CloseOptions.groupMembershipOperation(membershipOperation));
         } catch (final Throwable e) {

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -48,8 +48,6 @@ import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -239,6 +237,20 @@ public class StreamsConfigTest {
 
         returnedProps = streamsConfig.getGlobalConsumerConfigs(clientId);
         assertNull(returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
+    }
+
+    @Test
+    public void shouldAllowStaticMembershipWhenStreamsProtocolUsed() {
+        props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
+        props.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "static-member-1");
+
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+        final Map<String, Object> mainConsumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
+
+        assertThat(
+            mainConsumerConfigs.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG),
+            equalTo("static-member-1-" + threadIdx)
+        );
     }
 
     @Test
@@ -1716,23 +1728,6 @@ public class StreamsConfigTest {
                     "protocol and will be ignored. Please use the admin client or kafka-configs.sh to set the streams " +
                     "groups's standby replicas.")));
         }
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"", StreamsConfig.CONSUMER_PREFIX, StreamsConfig.MAIN_CONSUMER_PREFIX})
-    public void shouldThrowConfigExceptionWhenStreamsProtocolUsedWithStaticMembership(final String prefix) {
-        final Properties props = new Properties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-app");
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:9092");
-        props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
-        props.put(prefix + ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "static-member-1");
-
-        final ConfigException exception = assertThrows(
-            ConfigException.class,
-            () -> new StreamsConfig(props)
-        );
-        assertTrue(exception.getMessage().contains("Streams rebalance protocol does not support static membership. " +
-            "Please set group.protocol=classic or remove group.instance.id from the configuration."));
     }
 
     public void shouldSetDefaultDeadLetterQueue() {


### PR DESCRIPTION
###  Description
This PR adds client-side support for static membership in the Streams group protocol, aligned with [KIP-1071](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1071%3A+Streams+Rebalance+Protocol).

### What changed
- Allowed `group.instance.id` with `group.protocol=streams` in Streams config validation.
- Wired `group.instance.id` into `StreamsMembershipManager` creation path.
- Updated Streams close flow to honor `CloseOptions.GroupMembershipOperation` and support static member leave epoch handling (`-2` for `remain-in-group` path).
- Added `UNRELEASED_INSTANCE_ID` handling in `StreamsGroupHeartbeatRequestManager` as a fatal error path.
- Added/updated unit tests:
  - `StreamsMembershipManagerTest` for static member close/leave epoch behavior.
  - `StreamsConfigTest` for `group.protocol=streams` + `group.instance.id` acceptance.

### Scope
- Client-side changes only.
- Client↔Server integration tests are out of scope for this PR (server-side is in a separate PR).
- There is a mismatch in the Javadocs for the `close()` method here. This will be aligned in [KIP-1284](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1284+Introduce+CloseOptions.DEFAULT+for+Kafka+Streams).

### Related PR
- Server Side - #21565

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
