### PR TITLE
KAFKA-13819: Add application.server to Streams assignor logs when set

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -53,8 +53,15 @@ public final class AssignorConfiguration {
         streamsConfig = new ClientUtils.QuietStreamsConfig(configs);
         internalConfigs = configs;
 
+        final String appServerPrefix;
+        final String applicationServerEndpoint = streamsConfig.getString(StreamsConfig.APPLICATION_SERVER_CONFIG);
+        if (applicationServerEndpoint != null && !applicationServerEndpoint.isEmpty()) {
+            appServerPrefix = String.format("app-server [%s] ", applicationServerEndpoint);
+        } else {
+            appServerPrefix = "";
+        }
         // Setting the logger with the passed in client thread name
-        logPrefix = String.format("stream-thread [%s] ", streamsConfig.getString(CommonClientConfigs.CLIENT_ID_CONFIG));
+        logPrefix = String.format("stream-thread [%s] %s", streamsConfig.getString(CommonClientConfigs.CLIENT_ID_CONFIG), appServerPrefix);
         final LogContext logContext = new LogContext(logPrefix);
         log = logContext.logger(getClass());
 


### PR DESCRIPTION
Add application.server in Stream assignor logs.

Reviewers: Matthias J. Sax <matthias@confluent.io>
