### PR TITLE
MINOR: remove `mapKey: true` from BrokerRegistrationRequest

### DIFF
--- a/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
@@ -34,7 +34,7 @@
       "about": "The incarnation id of the broker process." },
     { "name": "Listeners", "type": "[]Listener",
       "about": "The listeners of this broker.", "versions": "0+", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+      { "name": "Name", "type": "string", "versions": "0+",
         "about": "The name of the endpoint." },
       { "name": "Host", "type": "string", "versions": "0+",
         "about": "The hostname." },

--- a/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -57,7 +58,7 @@ class BrokerRegistrationRequestTest {
             .setClusterId("test")
             .setFeatures(new BrokerRegistrationRequestData.FeatureCollection())
             .setIncarnationId(incarnationId)
-            .setListeners(new BrokerRegistrationRequestData.ListenerCollection())
+            .setListeners(List.of())
             .setRack("a")
             .setPreviousBrokerEpoch(1L);
         BrokerRegistrationRequestData data2 = readSerializedRequest(version, data);
@@ -102,7 +103,7 @@ class BrokerRegistrationRequestTest {
                             setMaxSupportedVersion((short) 1)
                     ).iterator())).
                 setIncarnationId(Uuid.fromString("EfIEKywJSaWl5yWDwlop1Q")).
-                setListeners(new BrokerRegistrationRequestData.ListenerCollection()).
+                setListeners(List.of()).
                 setPreviousBrokerEpoch(1L));
         assertEquals(1, data.brokerId());
         assertNull(data.rack());

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -3539,8 +3539,7 @@ public class RequestResponseTest {
                 .setRack("1")
                 .setFeatures(new BrokerRegistrationRequestData.FeatureCollection(singletonList(
                         new BrokerRegistrationRequestData.Feature()).iterator()))
-                .setListeners(new BrokerRegistrationRequestData.ListenerCollection(singletonList(
-                        new BrokerRegistrationRequestData.Listener()).iterator()))
+                .setListeners(singletonList(new BrokerRegistrationRequestData.Listener()))
                 .setIncarnationId(Uuid.randomUuid())
                 .setLogDirs(singletonList(Uuid.fromString("qaJjNJ05Q36kEgeTBDcj0Q")))
                 .setPreviousBrokerEpoch(123L);

--- a/core/src/test/scala/unit/kafka/server/RegistrationTestContext.scala
+++ b/core/src/test/scala/unit/kafka/server/RegistrationTestContext.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion
-import org.apache.kafka.common.message.BrokerRegistrationRequestData.{Listener, ListenerCollection}
+import org.apache.kafka.common.message.BrokerRegistrationRequestData.Listener
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.ApiKeys.{BROKER_HEARTBEAT, BROKER_REGISTRATION, CONTROLLER_REGISTRATION}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -64,14 +64,13 @@ class RegistrationTestContext(
   val mockChannelManager = new MockNodeToControllerChannelManager(mockClient,
     time, controllerNodeProvider, nodeApiVersions)
   val clusterId = "x4AJGXQSRnephtTZzujw4w"
-  val advertisedListeners = new ListenerCollection()
-  val controllerEpoch = new AtomicInteger(123)
-  config.effectiveAdvertisedBrokerListeners.foreach { ep =>
-    advertisedListeners.add(new Listener().setHost(ep.host).
+  val advertisedListeners: java.util.List[Listener] = config.effectiveAdvertisedBrokerListeners.map { ep =>
+    new Listener().setHost(ep.host).
       setName(ep.listener).
       setPort(ep.port.shortValue()).
-      setSecurityProtocol(ep.securityProtocol.id))
-  }
+      setSecurityProtocol(ep.securityProtocol.id)
+  }.asJava
+  val controllerEpoch = new AtomicInteger(123)
 
   def poll(): Unit = {
     mockClient.wakeup()

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import java.util
 import java.util.AbstractMap.SimpleImmutableEntry
 import java.util.{Collections, Properties}
 import java.util.Map.Entry
@@ -29,7 +30,7 @@ import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, TOPIC}
 import org.apache.kafka.common.message.BrokerRegistrationRequestData
-import org.apache.kafka.common.message.BrokerRegistrationRequestData.{Listener, ListenerCollection}
+import org.apache.kafka.common.message.BrokerRegistrationRequestData.Listener
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT
 import org.apache.kafka.controller.ControllerRequestContextUtil
@@ -270,8 +271,7 @@ class ReplicationQuotasTest extends QuorumTestHarness {
   }
 
   private def registerBroker(id: Int): Unit = {
-    val listeners = new ListenerCollection()
-    listeners.add(new Listener().setName(PLAINTEXT.name).setHost("localhost").setPort(9092 + id))
+    val listeners = util.List.of(new Listener().setName(PLAINTEXT.name).setHost("localhost").setPort(9092 + id))
     val features = new BrokerRegistrationRequestData.FeatureCollection()
     features.add(new BrokerRegistrationRequestData.Feature()
       .setName(MetadataVersion.FEATURE_NAME)

--- a/metadata/src/main/java/org/apache/kafka/metadata/ListenerInfo.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/ListenerInfo.java
@@ -134,7 +134,7 @@ public final class ListenerInfo {
      * @return              The ListenerInfo object.
      */
     public static ListenerInfo fromBrokerRegistrationRequest(
-        BrokerRegistrationRequestData.ListenerCollection collection
+        List<BrokerRegistrationRequestData.Listener> collection
     ) {
         LinkedHashMap<String, Endpoint> listeners = new LinkedHashMap<>();
         collection.forEach(listener -> {
@@ -331,19 +331,16 @@ public final class ListenerInfo {
         return collection;
     }
 
-    public BrokerRegistrationRequestData.ListenerCollection toBrokerRegistrationRequest() {
-        BrokerRegistrationRequestData.ListenerCollection collection =
-                new BrokerRegistrationRequestData.ListenerCollection();
-        listeners.values().forEach(endpoint -> {
+    public List<BrokerRegistrationRequestData.Listener> toBrokerRegistrationRequest() {
+        return listeners.values().stream().map(endpoint -> {
             checkPortIsSerializable(endpoint.port());
             checkHostIsSerializable(endpoint.host());
-            collection.add(new BrokerRegistrationRequestData.Listener().
+            return new BrokerRegistrationRequestData.Listener().
                 setHost(endpoint.host()).
                 setName(endpoint.listener()).
                 setPort(endpoint.port()).
-                setSecurityProtocol(endpoint.securityProtocol().id));
-        });
-        return collection;
+                setSecurityProtocol(endpoint.securityProtocol().id);
+        }).toList();
     }
 
     public RegisterBrokerRecord.BrokerEndpointCollection toBrokerRegistrationRecord() {

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerIntegrationTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerIntegrationTestUtils.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData.Listener;
-import org.apache.kafka.common.message.BrokerRegistrationRequestData.ListenerCollection;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
@@ -122,15 +121,12 @@ public class QuorumControllerIntegrationTestUtils {
                     .setLogDirs(List.of(
                         Uuid.fromString("TESTBROKER" + Integer.toString(100000 + brokerId).substring(1) + "DIRAAAA")
                     ))
-                    .setListeners(new ListenerCollection(
-                        List.of(
-                            new Listener()
-                                .setName("PLAINTEXT")
-                                .setHost("localhost")
-                                .setPort(9092 + brokerId)
-                            ).iterator()
-                        )
-                    )
+                    .setListeners(List.of(
+                        new Listener()
+                            .setName("PLAINTEXT")
+                            .setHost("localhost")
+                            .setPort(9092 + brokerId)
+                    ))
             ).get();
             brokerEpochs.put(brokerId, reply.epoch());
 

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.message.AlterPartitionRequestData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData.Listener;
-import org.apache.kafka.common.message.BrokerRegistrationRequestData.ListenerCollection;
 import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
@@ -271,8 +270,7 @@ public class QuorumControllerTest {
                 setBootstrapMetadata(SIMPLE_BOOTSTRAP).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             Map<Integer, Long> brokerEpochs = new HashMap<>();
 
@@ -389,8 +387,7 @@ public class QuorumControllerTest {
                 setBootstrapMetadata(BootstrapMetadata.fromVersion(MetadataVersion.IBP_4_0_IV1, "test-provided bootstrap ELR enabled")).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             Map<Integer, Long> brokerEpochs = new HashMap<>();
             BrokerRegistrationRequestData.FeatureCollection features =
@@ -528,8 +525,7 @@ public class QuorumControllerTest {
                 .setBootstrapMetadata(BootstrapMetadata.fromVersion(MetadataVersion.IBP_4_0_IV0, "test-provided bootstrap ELR not supported"))
                 .build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             Map<Integer, Long> brokerEpochs = new HashMap<>();
             BrokerRegistrationRequestData.FeatureCollection features =
@@ -622,8 +618,7 @@ public class QuorumControllerTest {
                 setBootstrapMetadata(BootstrapMetadata.fromVersion(MetadataVersion.IBP_4_0_IV1, "test-provided bootstrap ELR enabled")).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             Map<Integer, Long> brokerEpochs = new HashMap<>();
 
@@ -753,8 +748,7 @@ public class QuorumControllerTest {
                 setBootstrapMetadata(SIMPLE_BOOTSTRAP).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             Map<Integer, Long> brokerEpochs = new HashMap<>();
 
@@ -892,8 +886,6 @@ public class QuorumControllerTest {
                 ).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
 
             MockRaftClient mockRaftClient = clientEnv
@@ -936,9 +928,7 @@ public class QuorumControllerTest {
                 setBootstrapMetadata(SIMPLE_BOOTSTRAP).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").
-                setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             BrokerRegistrationRequestData.FeatureCollection brokerFeatures = new BrokerRegistrationRequestData.FeatureCollection();
             brokerFeatures.add(new BrokerRegistrationRequestData.Feature()
@@ -986,9 +976,7 @@ public class QuorumControllerTest {
             QuorumControllerTestEnv controlEnv = new QuorumControllerTestEnv.Builder(clientEnv).
                 build()
         ) {
-            ListenerCollection listeners = new ListenerCollection();
-            listeners.add(new Listener().setName("PLAINTEXT").
-                setHost("localhost").setPort(9092));
+            List<Listener> listeners = List.of(new Listener().setName("PLAINTEXT").setHost("localhost").setPort(9092));
             QuorumController active = controlEnv.activeController();
             CompletableFuture<BrokerRegistrationReply> reply = active.registerBroker(
                 ANONYMOUS_CONTEXT,
@@ -1100,9 +1088,9 @@ public class QuorumControllerTest {
                         setClusterId(active.clusterId()).
                         setFeatures(brokerFeatures(MetadataVersion.MINIMUM_VERSION, MetadataVersion.IBP_3_7_IV0)).
                         setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB" + i)).
-                        setListeners(new ListenerCollection(List.of(new Listener().
+                        setListeners(List.of(new Listener().
                             setName("PLAINTEXT").setHost("localhost").
-                            setPort(9092 + i)).iterator()))).get();
+                            setPort(9092 + i)))).get();
                 brokerEpochs.put(i, reply.epoch());
             }
             for (int i = 0; i < numBrokers - 1; i++) {

--- a/server/src/main/java/org/apache/kafka/server/BrokerLifecycleManager.java
+++ b/server/src/main/java/org/apache/kafka/server/BrokerLifecycleManager.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerHeartbeatResponseData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
-import org.apache.kafka.common.message.BrokerRegistrationRequestData.ListenerCollection;
+import org.apache.kafka.common.message.BrokerRegistrationRequestData.Listener;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.BrokerHeartbeatRequest;
 import org.apache.kafka.common.requests.BrokerHeartbeatResponse;
@@ -194,7 +194,7 @@ public class BrokerLifecycleManager {
      * The listeners which this broker advertises.  This variable can only be read or
      * written from the event queue thread.
      */
-    private ListenerCollection advertisedListeners;
+    private List<Listener> advertisedListeners;
 
     /**
      * The features supported by this broker.  This variable can only be read or written
@@ -258,7 +258,7 @@ public class BrokerLifecycleManager {
     public void start(Supplier<Long> highestMetadataOffsetProvider,
                NodeToControllerChannelManager channelManager,
                String clusterId,
-               ListenerCollection advertisedListeners,
+               List<Listener> advertisedListeners,
                Map<String, VersionRange> supportedFeatures,
                OptionalLong previousBrokerEpoch,
                Set<Uuid> cordonedLogDirs) {
@@ -475,13 +475,13 @@ public class BrokerLifecycleManager {
         private final Supplier<Long> highestMetadataOffsetProvider;
         private final NodeToControllerChannelManager channelManager;
         private final String clusterId;
-        private final ListenerCollection advertisedListeners;
+        private final List<Listener> advertisedListeners;
         private final Map<String, VersionRange> supportedFeatures;
 
         StartupEvent(Supplier<Long> highestMetadataOffsetProvider,
                      NodeToControllerChannelManager channelManager,
                      String clusterId,
-                     ListenerCollection advertisedListeners,
+                     List<Listener> advertisedListeners,
                      Map<String, VersionRange> supportedFeatures) {
             this.highestMetadataOffsetProvider = highestMetadataOffsetProvider;
             this.channelManager = channelManager;
@@ -497,7 +497,7 @@ public class BrokerLifecycleManager {
             BrokerLifecycleManager.this.channelManager.start();
             state = BrokerState.STARTING;
             BrokerLifecycleManager.this.clusterId = clusterId;
-            BrokerLifecycleManager.this.advertisedListeners = advertisedListeners.duplicate();
+            BrokerLifecycleManager.this.advertisedListeners = List.copyOf(advertisedListeners);
             BrokerLifecycleManager.this.supportedFeatures = Map.copyOf(supportedFeatures);
             eventQueue.scheduleDeferred("initialRegistrationTimeout",
                     new EventQueue.DeadlineFunction(time.nanoseconds() + initialTimeoutNs),

--- a/server/src/test/java/org/apache/kafka/server/BrokerRegistrationRequestTest.java
+++ b/server/src/test/java/org/apache/kafka/server/BrokerRegistrationRequestTest.java
@@ -200,7 +200,7 @@ class BrokerRegistrationRequestTest {
                 .setIncarnationId(Uuid.randomUuid())
                 .setIsMigratingZkBroker(zkEpoch != null)
                 .setFeatures(features)
-                .setListeners(new BrokerRegistrationRequestData.ListenerCollection(List.of(listener).iterator()));
+                .setListeners(List.of(listener));
 
         BrokerRegistrationResponse resp = this.sendAndReceive(
                 channelManager,


### PR DESCRIPTION
No caller uses find() on ListenerCollection. Removing mapKey=true
changes the generated type to List<Listener>, which lets
BrokerLifecycleManager store an immutable copy via List.copyOf() instead
of the mutable .duplicate(), and avoids wrapping the list  back into a
ListenerCollection when building BrokerRegistrationRequestData.

mapKey is a codegen-only annotation with no effect on the wire format,
so RPC compatibility is unaffected.
