### PR TITLE
refactor: simplify code

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
+++ b/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
@@ -20,7 +20,7 @@ import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.{OptionalInt, Collection => JCollection, Map => JMap}
+import java.util.{OptionalInt, Map => JMap}
 import java.util.concurrent.CompletableFuture
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
@@ -93,7 +93,6 @@ class KafkaRaftManager[T](
   externalKRaftMetrics: ExternalKRaftMetrics,
   threadNamePrefixOpt: Option[String],
   val controllerQuorumVotersFuture: CompletableFuture[JMap[Integer, InetSocketAddress]],
-  bootstrapServers: JCollection[InetSocketAddress],
   localListeners: Endpoints,
   fatalFaultHandler: FaultHandler
 ) extends RaftManager[T] with Logging {
@@ -173,7 +172,6 @@ class KafkaRaftManager[T](
       // Controllers should always flush the log on replication because they may become voters
       config.processRoles.contains(ProcessRole.ControllerRole),
       clusterId,
-      bootstrapServers,
       localListeners,
       Feature.KRAFT_VERSION.supportedVersionRange(),
       raftConfig

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -66,7 +66,6 @@ class KafkaRaftServer(
     time,
     metrics,
     CompletableFuture.completedFuture(QuorumConfig.parseVoterConnections(config.quorumConfig.voters)),
-    QuorumConfig.parseBootstrapServers(config.quorumConfig.bootstrapServers),
     new StandardFaultHandlerFactory(),
     ServerSocketFactory.INSTANCE,
   )

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -44,7 +44,6 @@ import java.util.Arrays
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{CompletableFuture, TimeUnit}
-import java.util.{Collection => JCollection}
 import java.util.{Map => JMap}
 import scala.jdk.CollectionConverters._
 
@@ -98,7 +97,6 @@ class SharedServer(
   val time: Time,
   private val _metrics: Metrics,
   val controllerQuorumVotersFuture: CompletableFuture[JMap[Integer, InetSocketAddress]],
-  val bootstrapServers: JCollection[InetSocketAddress],
   val faultHandlerFactory: FaultHandlerFactory,
   val socketFactory: ServerSocketFactory
 ) extends Logging {
@@ -299,7 +297,6 @@ class SharedServer(
           externalKRaftMetrics,
           Some(s"kafka-${sharedServerConfig.nodeId}-raft"), // No dash expected at the end
           controllerQuorumVotersFuture,
-          bootstrapServers,
           listenerEndpoints,
           raftManagerFaultHandler
         )

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -106,7 +106,6 @@ class TestRaftServer(
       _ => {},
       Some(threadNamePrefix),
       CompletableFuture.completedFuture(QuorumConfig.parseVoterConnections(config.quorumConfig.voters)),
-      QuorumConfig.parseBootstrapServers(config.quorumConfig.bootstrapServers),
       endpoints,
       new ProcessTerminatingFaultHandler.Builder().build()
     )

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -108,7 +108,6 @@ class KRaftQuorumImplementation(
       time,
       new Metrics(),
       controllerQuorumVotersFuture,
-      controllerQuorumVotersFuture.get().values(),
       faultHandlerFactory,
       ServerSocketFactory.INSTANCE,
     )
@@ -303,7 +302,6 @@ abstract class QuorumTestHarness extends Logging {
       Time.SYSTEM,
       new Metrics(),
       controllerQuorumVotersFuture,
-      util.List.of,
       faultHandlerFactory,
       ServerSocketFactory.INSTANCE,
     )

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -108,7 +108,6 @@ class RaftManagerTest {
       _ => {},
       Option.empty,
       CompletableFuture.completedFuture(QuorumConfig.parseVoterConnections(config.quorumConfig.voters)),
-      QuorumConfig.parseBootstrapServers(config.quorumConfig.bootstrapServers),
       endpoints,
       mock(classOf[FaultHandler])
     )

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -242,7 +242,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         LogContext logContext,
         boolean canBecomeVoter,
         String clusterId,
-        Collection<InetSocketAddress> bootstrapServers,
         Endpoints localListeners,
         SupportedVersionRange localSupportedKRaftVersion,
         QuorumConfig quorumConfig
@@ -260,7 +259,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             MAX_FETCH_WAIT_MS,
             canBecomeVoter,
             clusterId,
-            bootstrapServers,
             localListeners,
             localSupportedKRaftVersion,
             logContext,
@@ -282,7 +280,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         int fetchMaxWaitMs,
         boolean canBecomeVoter,
         String clusterId,
-        Collection<InetSocketAddress> bootstrapServers,
         Endpoints localListeners,
         SupportedVersionRange localSupportedKRaftVersion,
         LogContext logContext,
@@ -314,6 +311,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         this.quorumConfig = quorumConfig;
         this.snapshotCleaner = new RaftMetadataLogCleanerManager(logger, time, 60000, log::maybeClean);
 
+        List<InetSocketAddress> bootstrapServers = QuorumConfig.parseBootstrapServers(quorumConfig.bootstrapServers());
         if (!bootstrapServers.isEmpty()) {
             // generate Node objects from network addresses by using decreasing negative ids
             AtomicInteger id = new AtomicInteger(-2);

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -423,18 +423,6 @@ public final class RaftClientTestContext {
             configMap.put(QuorumConfig.QUORUM_AUTO_JOIN_ENABLE_CONFIG, autoJoin);
             QuorumConfig quorumConfig = new QuorumConfig(new AbstractConfig(QuorumConfig.CONFIG_DEF, configMap));
 
-            List<InetSocketAddress> computedBootstrapServers = bootstrapServers.orElseGet(() -> {
-                if (isStartingVotersStatic) {
-                    return List.of();
-                } else {
-                    return startingVoters
-                        .voterNodes(startingVoters.voterIds().stream(), channel.listenerName())
-                        .stream()
-                        .map(node -> InetSocketAddress.createUnresolved(node.host(), node.port()))
-                        .collect(Collectors.toList());
-                }
-            });
-
             KafkaRaftClient<String> client = new KafkaRaftClient<>(
                 localId,
                 localDirectoryId,
@@ -448,7 +436,6 @@ public final class RaftClientTestContext {
                 FETCH_MAX_WAIT_MS,
                 canBecomeVoter,
                 clusterId,
-                computedBootstrapServers,
                 localListeners,
                 Feature.KRAFT_VERSION.supportedVersionRange(),
                 logContext,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -896,7 +896,6 @@ public class RaftEventSimulationTest {
                 FETCH_MAX_WAIT_MS,
                 true,
                 clusterId,
-                List.of(),
                 endpointsFromId(nodeId, channel.listenerName()),
                 Feature.KRAFT_VERSION.supportedVersionRange(),
                 logContext,

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/KafkaClusterTestKit.java
@@ -289,7 +289,6 @@ public class KafkaClusterTestKit implements AutoCloseable {
                         Time.SYSTEM,
                         new Metrics(),
                         CompletableFuture.completedFuture(QuorumConfig.parseVoterConnections(config.quorumConfig().voters())),
-                        QuorumConfig.parseBootstrapServers(config.quorumConfig().bootstrapServers()),
                         faultHandlerFactory,
                         socketFactoryManager.getOrCreateSocketFactory(node.id())
                     );
@@ -317,7 +316,6 @@ public class KafkaClusterTestKit implements AutoCloseable {
                             Time.SYSTEM,
                             new Metrics(),
                             CompletableFuture.completedFuture(QuorumConfig.parseVoterConnections(config.quorumConfig().voters())),
-                            QuorumConfig.parseBootstrapServers(config.quorumConfig().bootstrapServers()),
                             faultHandlerFactory,
                             socketFactoryManager.getOrCreateSocketFactory(node.id())
                         );


### PR DESCRIPTION
I think it is not necessary to pass the bootstrapServers separately from the config object.
The class constructors have so many parameters that it makes the classes quite hard to understand and use.

As the config is passed down into the call stack anyways, we can just obtain the list of bootstrap servers right before we actually need it.

Note that I was not able to run the `gradlew test` target because my resources are quite constrained and it overloads my PC so much that it freezes.

I also tried tried running with

```
./gradlew test \
        -PmaxParallelForks=2 \
        --max-workers=2
```

inside a VirtualBox VM with 10 Cores (i7 13700H on host) and 24 GB of memory assigned to the VM - the entire VM crashes