### PR TITLE
KAFKA-9651: Handle edge case when partition metadata contains zero partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
@@ -327,6 +327,9 @@ public class BuiltInPartitioner {
      * Default hashing function to choose a partition from the serialized key bytes
      */
     public static int partitionForKey(final byte[] serializedKey, final int numPartitions) {
+        if (numPartitions <= 0) {
+            throw new IllegalArgumentException("numPartitions must be > 0, but was " + numPartitions);
+        }
         return Utils.toPositive(Utils.murmur2(serializedKey)) % numPartitions;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BuiltInPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BuiltInPartitionerTest.java
@@ -191,6 +191,21 @@ public class BuiltInPartitionerTest {
         assertDoesNotThrow(() -> new BuiltInPartitioner(logContext, TOPIC_A, 1));
     }
 
+    @Test
+    void testPartitionForKeyReturnsValidPartition() {
+        final byte[] key = "key".getBytes();
+        final int numPartitions = 8;
+        final int partition = BuiltInPartitioner.partitionForKey(key, numPartitions);
+        assertTrue(partition >= 0 && partition < numPartitions);
+    }
+
+    @Test
+    void testPartitionForKeyThrowsIfNumPartitionsNotPositive() {
+        final byte[] key = "key".getBytes();
+        assertThrows(IllegalArgumentException.class, () -> BuiltInPartitioner.partitionForKey(key, 0));
+        assertThrows(IllegalArgumentException.class, () -> BuiltInPartitioner.partitionForKey(key, -1));
+    }
+
 
     private static class SequentialPartitioner extends BuiltInPartitioner {
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1544,7 +1544,6 @@ public class StreamThread extends Thread implements ProcessingThread {
             } else {
                 log.info("Skipping streams metadata update because partition metadata is missing for source topics {}. " +
                         "Will retry after metadata is refreshed.", missingSourceTopics);
-                streamsMetadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1533,11 +1533,19 @@ public class StreamThread extends Thread implements ProcessingThread {
                 activeHostInfoMap.put(new HostInfo(hostInfo.host(), hostInfo.port()), new HashSet<>(endpointPartitions.activePartitions()));
                 standbyHostInfoMap.put(new HostInfo(hostInfo.host(), hostInfo.port()), new HashSet<>(endpointPartitions.standbyPartitions()));
             });
-            streamsMetadataState.onChange(
-                    activeHostInfoMap,
-                    standbyHostInfoMap,
-                    getTopicPartitionInfo(activeHostInfoMap)
-            );
+            final Map<TopicPartition, PartitionInfo> topicPartitionInfo = getTopicPartitionInfo(activeHostInfoMap);
+            final Set<String> missingSourceTopics = StreamsMetadataState.missingSourceTopicsForMetadata(topicPartitionInfo, topologyMetadata);
+            if (missingSourceTopics.isEmpty()) {
+                streamsMetadataState.onChange(
+                        activeHostInfoMap,
+                        standbyHostInfoMap,
+                        topicPartitionInfo
+                );
+            } else {
+                log.info("Skipping streams metadata update because partition metadata is missing for source topics {}. " +
+                        "Will retry after metadata is refreshed.", missingSourceTopics);
+                streamsMetadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -88,6 +88,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -1534,17 +1535,21 @@ public class StreamThread extends Thread implements ProcessingThread {
                 standbyHostInfoMap.put(new HostInfo(hostInfo.host(), hostInfo.port()), new HashSet<>(endpointPartitions.standbyPartitions()));
             });
             final Map<TopicPartition, PartitionInfo> topicPartitionInfo = getTopicPartitionInfo(activeHostInfoMap);
-            final Set<String> missingSourceTopics = StreamsMetadataState.missingSourceTopicsForMetadata(topicPartitionInfo, topologyMetadata);
-            if (missingSourceTopics.isEmpty()) {
-                streamsMetadataState.onChange(
-                        activeHostInfoMap,
-                        standbyHostInfoMap,
-                        topicPartitionInfo
-                );
-            } else {
-                log.info("Skipping streams metadata update because partition metadata is missing for source topics {}. " +
-                        "Will retry after metadata is refreshed.", missingSourceTopics);
+            final Map<String, List<String>> storeToSourceTopics = topologyMetadata.stateStoreNameToSourceTopics();
+            final Set<String> globalStores = topologyMetadata.globalStateStores().keySet();
+            final Map<String, List<String>> filteredStoreToSourceTopics =
+                StreamsMetadataState.storeToSourceTopicsWithMetadata(storeToSourceTopics, globalStores, topicPartitionInfo);
+            final Set<String> missingSourceTopics =
+                StreamsMetadataState.missingSourceTopicsForMetadata(storeToSourceTopics, globalStores, filteredStoreToSourceTopics);
+            if (!missingSourceTopics.isEmpty()) {
+                log.warn("Missing partition metadata for source topics {} while updating streams metadata; " +
+                        "continuing with stores/topics that have metadata.", missingSourceTopics);
             }
+            streamsMetadataState.onChange(
+                    activeHostInfoMap,
+                    standbyHostInfoMap,
+                    topicPartitionInfo
+            );
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -476,7 +476,6 @@ public class StreamsMetadataState {
                                                         final K key,
                                                         final StreamPartitioner<? super K, ?> partitioner,
                                                         final SourceTopicsInfo sourceTopicsInfo) {
-        validateSourceTopicsInfo(storeName, sourceTopicsInfo);
 
         final Integer partition = getPartition.apply(partitioner.partitions(sourceTopicsInfo.topicWithMostPartitions, key, null, sourceTopicsInfo.maxPartitions));
         final Set<TopicPartition> matchingPartitions = new HashSet<>();
@@ -512,8 +511,6 @@ public class StreamsMetadataState {
                                                         final SourceTopicsInfo sourceTopicsInfo,
                                                         final String topologyName) {
         Objects.requireNonNull(topologyName, "topology name must not be null");
-        validateSourceTopicsInfo(storeName, sourceTopicsInfo);
-
         final Integer partition = getPartition.apply(partitioner.partitions(sourceTopicsInfo.topicWithMostPartitions, key, null, sourceTopicsInfo.maxPartitions));
         final Set<TopicPartition> matchingPartitions = new HashSet<>();
         for (final String sourceTopic : sourceTopicsInfo.sourceTopics) {
@@ -557,17 +554,6 @@ public class StreamsMetadataState {
             return null;
         }
         return new SourceTopicsInfo(sourceTopics);
-    }
-
-    private void validateSourceTopicsInfo(final String storeName,
-                                          final SourceTopicsInfo sourceTopicsInfo) {
-        if (sourceTopicsInfo.maxPartitions <= 0 || sourceTopicsInfo.topicWithMostPartitions == null) {
-            throw new IllegalStateException(
-                "Unable to determine a valid partition for store " + storeName +
-                    " because no source topic partitions are currently available. " +
-                    "Metadata may be stale; try again after metadata is refreshed."
-            );
-        }
     }
 
     private boolean isInitialized() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -476,6 +476,7 @@ public class StreamsMetadataState {
                                                         final K key,
                                                         final StreamPartitioner<? super K, ?> partitioner,
                                                         final SourceTopicsInfo sourceTopicsInfo) {
+        validateSourceTopicsInfo(storeName, sourceTopicsInfo);
 
         final Integer partition = getPartition.apply(partitioner.partitions(sourceTopicsInfo.topicWithMostPartitions, key, null, sourceTopicsInfo.maxPartitions));
         final Set<TopicPartition> matchingPartitions = new HashSet<>();
@@ -511,6 +512,8 @@ public class StreamsMetadataState {
                                                         final SourceTopicsInfo sourceTopicsInfo,
                                                         final String topologyName) {
         Objects.requireNonNull(topologyName, "topology name must not be null");
+        validateSourceTopicsInfo(storeName, sourceTopicsInfo);
+
         final Integer partition = getPartition.apply(partitioner.partitions(sourceTopicsInfo.topicWithMostPartitions, key, null, sourceTopicsInfo.maxPartitions));
         final Set<TopicPartition> matchingPartitions = new HashSet<>();
         for (final String sourceTopic : sourceTopicsInfo.sourceTopics) {
@@ -554,6 +557,17 @@ public class StreamsMetadataState {
             return null;
         }
         return new SourceTopicsInfo(sourceTopics);
+    }
+
+    private void validateSourceTopicsInfo(final String storeName,
+                                          final SourceTopicsInfo sourceTopicsInfo) {
+        if (sourceTopicsInfo.maxPartitions <= 0 || sourceTopicsInfo.topicWithMostPartitions == null) {
+            throw new IllegalStateException(
+                "Unable to determine a valid partition for store " + storeName +
+                    " because no source topic partitions are currently available. " +
+                    "Metadata may be stale; try again after metadata is refreshed."
+            );
+        }
     }
 
     private boolean isInitialized() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -320,15 +320,32 @@ public class StreamsMetadataState {
         rebuildMetadata(activePartitionHostMap, standbyPartitionHostMap);
     }
 
-    static Set<String> missingSourceTopicsForMetadata(final Map<TopicPartition, PartitionInfo> topicPartitionInfo,
-                                                      final TopologyMetadata topologyMetadata) {
+    static Map<String, List<String>> storeToSourceTopicsWithMetadata(final Map<String, List<String>> storeToSourceTopics,
+                                                                     final Set<String> globalStores,
+                                                                     final Map<TopicPartition, PartitionInfo> topicPartitionInfo) {
         final Set<String> topicsWithMetadata = topicPartitionInfo.keySet().stream()
             .map(TopicPartition::topic)
             .collect(Collectors.toSet());
-        final Set<String> globalStores = topologyMetadata.globalStateStores().keySet();
-        final Set<String> missingSourceTopics = new LinkedHashSet<>();
+        return storeToSourceTopicsWithMetadata(storeToSourceTopics, globalStores, topicsWithMetadata);
+    }
 
-        topologyMetadata.stateStoreNameToSourceTopics().forEach((storeName, sourceTopics) -> {
+    static Set<String> missingSourceTopicsForMetadata(final Map<TopicPartition, PartitionInfo> topicPartitionInfo,
+                                                      final TopologyMetadata topologyMetadata) {
+        final Map<String, List<String>> storeToSourceTopics = topologyMetadata.stateStoreNameToSourceTopics();
+        final Set<String> globalStores = topologyMetadata.globalStateStores().keySet();
+        final Map<String, List<String>> filteredStoreToSourceTopics =
+            storeToSourceTopicsWithMetadata(storeToSourceTopics, globalStores, topicPartitionInfo);
+        return missingSourceTopicsForMetadata(storeToSourceTopics, globalStores, filteredStoreToSourceTopics);
+    }
+
+    static Set<String> missingSourceTopicsForMetadata(final Map<String, List<String>> storeToSourceTopics,
+                                                      final Set<String> globalStores,
+                                                      final Map<String, List<String>> filteredStoreToSourceTopics) {
+        final Set<String> topicsWithMetadata = filteredStoreToSourceTopics.values().stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+        final Set<String> missingSourceTopics = new LinkedHashSet<>();
+        storeToSourceTopics.forEach((storeName, sourceTopics) -> {
             if (!globalStores.contains(storeName)) {
                 sourceTopics.stream()
                     .filter(sourceTopic -> !topicsWithMetadata.contains(sourceTopic))
@@ -336,6 +353,23 @@ public class StreamsMetadataState {
             }
         });
         return missingSourceTopics;
+    }
+
+    private static Map<String, List<String>> storeToSourceTopicsWithMetadata(final Map<String, List<String>> storeToSourceTopics,
+                                                                              final Set<String> globalStores,
+                                                                              final Set<String> topicsWithMetadata) {
+        final Map<String, List<String>> filteredStoreToSourceTopics = new HashMap<>();
+        storeToSourceTopics.forEach((storeName, sourceTopics) -> {
+            if (!globalStores.contains(storeName)) {
+                final List<String> sourceTopicsWithMetadata = sourceTopics.stream()
+                    .filter(topicsWithMetadata::contains)
+                    .collect(Collectors.toList());
+                if (!sourceTopicsWithMetadata.isEmpty()) {
+                    filteredStoreToSourceTopics.put(storeName, sourceTopicsWithMetadata);
+                }
+            }
+        });
+        return filteredStoreToSourceTopics;
     }
 
     private boolean hasPartitionsForAnyTopics(final List<String> topicNames, final Set<TopicPartition> partitionForHost) {
@@ -357,6 +391,10 @@ public class StreamsMetadataState {
             }
         }
         return storesOnHost;
+    }
+
+    private Map<String, List<String>> storeToSourceTopicsWithMetadata(final Map<String, List<String>> storeToSourceTopics) {
+        return storeToSourceTopicsWithMetadata(storeToSourceTopics, globalStores, partitionsByTopic.keySet());
     }
 
     private void rebuildMetadata(final Map<HostInfo, Set<TopicPartition>> activePartitionHostMap,
@@ -387,7 +425,7 @@ public class StreamsMetadataState {
             .forEach(hostInfo -> {
                 for (final String topologyName : topologyMetadata.namedTopologiesView()) {
                     final Map<String, List<String>> storeToSourceTopics =
-                        topologyMetadata.stateStoreNameToSourceTopicsForTopology(topologyName);
+                        storeToSourceTopicsWithMetadata(topologyMetadata.stateStoreNameToSourceTopicsForTopology(topologyName));
 
                     final Set<TopicPartition> activePartitionsOnHost = new HashSet<>();
                     final Set<String> activeStoresOnHost = new HashSet<>();
@@ -427,7 +465,8 @@ public class StreamsMetadataState {
                 }
 
                 // Construct metadata across all topologies on this host for the `localMetadata` field
-                final Map<String, List<String>> storeToSourceTopics = topologyMetadata.stateStoreNameToSourceTopics();
+                final Map<String, List<String>> storeToSourceTopics =
+                    storeToSourceTopicsWithMetadata(topologyMetadata.stateStoreNameToSourceTopics());
                 final Set<TopicPartition> localActivePartitions = activePartitionHostMap.get(thisHost);
                 final Set<TopicPartition> localStandbyPartitions = standbyPartitionHostMap.get(thisHost);
 
@@ -445,7 +484,8 @@ public class StreamsMetadataState {
     private List<StreamsMetadata> rebuildMetadataForSingleTopology(final Map<HostInfo, Set<TopicPartition>> activePartitionHostMap,
                                                                    final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap) {
         final List<StreamsMetadata> rebuiltMetadata = new ArrayList<>();
-        final Map<String, List<String>> storeToSourceTopics = topologyMetadata.stateStoreNameToSourceTopics();
+        final Map<String, List<String>> storeToSourceTopics =
+            storeToSourceTopicsWithMetadata(topologyMetadata.stateStoreNameToSourceTopics());
         Stream.concat(activePartitionHostMap.keySet().stream(), standbyPartitionHostMap.keySet().stream())
             .distinct()
             .sorted(Comparator.comparing(HostInfo::host).thenComparingInt(HostInfo::port))

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -317,6 +318,24 @@ public class StreamsMetadataState {
                 .add(value));
 
         rebuildMetadata(activePartitionHostMap, standbyPartitionHostMap);
+    }
+
+    static Set<String> missingSourceTopicsForMetadata(final Map<TopicPartition, PartitionInfo> topicPartitionInfo,
+                                                      final TopologyMetadata topologyMetadata) {
+        final Set<String> topicsWithMetadata = topicPartitionInfo.keySet().stream()
+            .map(TopicPartition::topic)
+            .collect(Collectors.toSet());
+        final Set<String> globalStores = topologyMetadata.globalStateStores().keySet();
+        final Set<String> missingSourceTopics = new LinkedHashSet<>();
+
+        topologyMetadata.stateStoreNameToSourceTopics().forEach((storeName, sourceTopics) -> {
+            if (!globalStores.contains(storeName)) {
+                sourceTopics.stream()
+                    .filter(sourceTopic -> !topicsWithMetadata.contains(sourceTopic))
+                    .forEach(missingSourceTopics::add);
+            }
+        });
+        return missingSourceTopics;
     }
 
     private boolean hasPartitionsForAnyTopics(final List<String> topicNames, final Set<TopicPartition> partitionForHost) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1548,7 +1548,15 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             partitionsByHost.keySet()
         );
 
-        streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, topicToPartitionInfo);
+        final Set<String> missingSourceTopics =
+            StreamsMetadataState.missingSourceTopicsForMetadata(topicToPartitionInfo, taskManager.topologyMetadata());
+        if (missingSourceTopics.isEmpty()) {
+            streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, topicToPartitionInfo);
+        } else {
+            log.info("Skipping streams metadata update because partition metadata is missing for source topics {}. " +
+                    "Will retry after metadata is refreshed.", missingSourceTopics);
+            streamsMetadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+        }
 
         // we do not capture any exceptions but just let the exception thrown from consumer.poll directly
         // since when stream thread captures it, either we close all tasks as dirty or we close thread

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1555,7 +1555,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         } else {
             log.info("Skipping streams metadata update because partition metadata is missing for source topics {}. " +
                     "Will retry after metadata is refreshed.", missingSourceTopics);
-            streamsMetadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         }
 
         // we do not capture any exceptions but just let the exception thrown from consumer.poll directly

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1550,12 +1550,11 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
         final Set<String> missingSourceTopics =
             StreamsMetadataState.missingSourceTopicsForMetadata(topicToPartitionInfo, taskManager.topologyMetadata());
-        if (missingSourceTopics.isEmpty()) {
-            streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, topicToPartitionInfo);
-        } else {
-            log.info("Skipping streams metadata update because partition metadata is missing for source topics {}. " +
-                    "Will retry after metadata is refreshed.", missingSourceTopics);
+        if (!missingSourceTopics.isEmpty()) {
+            log.info("Missing partition metadata for source topics {} while updating streams metadata; " +
+                    "continuing with stores/topics that have metadata.", missingSourceTopics);
         }
+        streamsMetadataState.onChange(partitionsByHost, standbyPartitionsByHost, topicToPartitionInfo);
 
         // we do not capture any exceptions but just let the exception thrown from consumer.poll directly
         // since when stream thread captures it, either we close all tasks as dirty or we close thread

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -404,4 +404,34 @@ public class StreamsMetadataStateTest {
 
         assertFalse(metadataState.allMetadata().isEmpty(), "encapsulation broken");
     }
+
+    @Test
+    public void shouldUpdateMetadataForStoreWithCompleteTopicMetadataWhenAnotherStoreTopicIsMissing() {
+        final Map<TopicPartition, PartitionInfo> topicOneOnlyPartitionInfo = new HashMap<>();
+        topicOneOnlyPartitionInfo.put(topic1P0, new PartitionInfo("topic-one", 0, null, null, null));
+
+        metadataState.onChange(
+            Collections.singletonMap(hostOne, Collections.singleton(topic1P0)),
+            Collections.emptyMap(),
+            topicOneOnlyPartitionInfo
+        );
+
+        Set<HostInfo> hostsForCompleteStore = metadataState.allMetadataForStore("table-one").stream()
+            .map(StreamsMetadata::hostInfo)
+            .collect(Collectors.toSet());
+        assertEquals(Collections.singleton(hostOne), hostsForCompleteStore);
+        assertTrue(metadataState.allMetadataForStore("table-three").isEmpty());
+
+        metadataState.onChange(
+            Collections.singletonMap(hostTwo, Collections.singleton(topic1P0)),
+            Collections.emptyMap(),
+            topicOneOnlyPartitionInfo
+        );
+
+        hostsForCompleteStore = metadataState.allMetadataForStore("table-one").stream()
+            .map(StreamsMetadata::hostInfo)
+            .collect(Collectors.toSet());
+        assertEquals(Collections.singleton(hostTwo), hostsForCompleteStore);
+        assertTrue(metadataState.allMetadataForStore("table-three").isEmpty());
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -275,19 +275,6 @@ public class StreamsMetadataStateTest {
     }
 
     @Test
-    public void shouldFailWhenSourceTopicHasNoPartitionsInMetadata() {
-        final Map<TopicPartition, PartitionInfo> partitionInfosMissingSourceTopic = new HashMap<>(partitionInfos);
-        partitionInfosMissingSourceTopic.remove(topic3P0);
-        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, partitionInfosMissingSourceTopic);
-
-        assertThrows(IllegalStateException.class, () -> metadataState.keyQueryMetadataForKey(
-            "table-three",
-            "the-key",
-            Serdes.String().serializer())
-        );
-    }
-
-    @Test
     public void shouldReturnNotAvailableWhenClusterIsEmpty() {
         metadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         final KeyQueryMetadata result = metadataState.keyQueryMetadataForKey("table-one", "a", Serdes.String().serializer());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -275,6 +275,19 @@ public class StreamsMetadataStateTest {
     }
 
     @Test
+    public void shouldFailWhenSourceTopicHasNoPartitionsInMetadata() {
+        final Map<TopicPartition, PartitionInfo> partitionInfosMissingSourceTopic = new HashMap<>(partitionInfos);
+        partitionInfosMissingSourceTopic.remove(topic3P0);
+        metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, partitionInfosMissingSourceTopic);
+
+        assertThrows(IllegalStateException.class, () -> metadataState.keyQueryMetadataForKey(
+            "table-three",
+            "the-key",
+            Serdes.String().serializer())
+        );
+    }
+
+    @Test
     public void shouldReturnNotAvailableWhenClusterIsEmpty() {
         metadataState.onChange(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         final KeyQueryMetadata result = metadataState.keyQueryMetadataForKey("table-one", "a", Serdes.String().serializer());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -168,7 +168,6 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1476,7 +1475,7 @@ public class StreamsPartitionAssignorTest {
 
     @ParameterizedTest
     @MethodSource("parameter")
-    public void shouldSkipMetadataUpdateWhenAssignmentMissesStoreSourceTopicMetadata(final Map<String, Object> parameterizedConfig) {
+    public void shouldUpdateMetadataWhenAssignmentMissesStoreSourceTopicMetadata(final Map<String, Object> parameterizedConfig) {
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
         streamsBuilder.table("topic1", Materialized.as("store"));
         builder = TopologyWrapper.getInternalTopologyBuilder(streamsBuilder.build());
@@ -1501,7 +1500,7 @@ public class StreamsPartitionAssignorTest {
 
         partitionAssignor.onAssignment(assignment, null);
 
-        verify(streamsMetadataState, never()).onChange(anyMap(), anyMap(), anyMap());
+        verify(streamsMetadataState).onChange(eq(hostState), anyMap(), anyMap());
     }
 
     @ParameterizedTest

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1441,6 +1441,7 @@ public class StreamsPartitionAssignorTest {
     public void testOnAssignment(final Map<String, Object> parameterizedConfig) {
         setUp(parameterizedConfig, false);
         taskManager = mock(TaskManager.class);
+        lenient().when(taskManager.topologyMetadata()).thenReturn(topologyMetadata);
 
         final Map<HostInfo, Set<TopicPartition>> hostState = Collections.singletonMap(
             new HostInfo("localhost", 9090),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -163,10 +163,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1474,7 +1476,7 @@ public class StreamsPartitionAssignorTest {
 
     @ParameterizedTest
     @MethodSource("parameter")
-    public void shouldPublishEmptyMetadataWhenAssignmentMissesStoreSourceTopicMetadata(final Map<String, Object> parameterizedConfig) {
+    public void shouldSkipMetadataUpdateWhenAssignmentMissesStoreSourceTopicMetadata(final Map<String, Object> parameterizedConfig) {
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
         streamsBuilder.table("topic1", Materialized.as("store"));
         builder = TopologyWrapper.getInternalTopologyBuilder(streamsBuilder.build());
@@ -1499,11 +1501,7 @@ public class StreamsPartitionAssignorTest {
 
         partitionAssignor.onAssignment(assignment, null);
 
-        verify(streamsMetadataState).onChange(
-            eq(Collections.emptyMap()),
-            eq(Collections.emptyMap()),
-            eq(Collections.emptyMap())
-        );
+        verify(streamsMetadataState, never()).onChange(anyMap(), anyMap(), anyMap());
     }
 
     @ParameterizedTest

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1473,6 +1473,40 @@ public class StreamsPartitionAssignorTest {
 
     @ParameterizedTest
     @MethodSource("parameter")
+    public void shouldPublishEmptyMetadataWhenAssignmentMissesStoreSourceTopicMetadata(final Map<String, Object> parameterizedConfig) {
+        final StreamsBuilder streamsBuilder = new StreamsBuilder();
+        streamsBuilder.table("topic1", Materialized.as("store"));
+        builder = TopologyWrapper.getInternalTopologyBuilder(streamsBuilder.build());
+
+        setUp(parameterizedConfig, false);
+        createDefaultMockTaskManager();
+        configureDefaultPartitionAssignor(parameterizedConfig);
+
+        final Map<HostInfo, Set<TopicPartition>> hostState = Collections.singletonMap(
+            new HostInfo("localhost", 9090),
+            Collections.singleton(t2p0)
+        );
+        final AssignmentInfo info = new AssignmentInfo(
+            LATEST_SUPPORTED_VERSION,
+            Collections.singletonList(TASK_0_0),
+            Collections.emptyMap(),
+            hostState,
+            emptyMap(),
+            0
+        );
+        final Assignment assignment = new Assignment(Collections.singletonList(t2p0), info.encode());
+
+        partitionAssignor.onAssignment(assignment, null);
+
+        verify(streamsMetadataState).onChange(
+            eq(Collections.emptyMap()),
+            eq(Collections.emptyMap()),
+            eq(Collections.emptyMap())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameter")
     public void testAssignWithInternalTopics(final Map<String, Object> parameterizedConfig) {
         setUp(parameterizedConfig, true);
         builder.addInternalTopic("topicX", InternalTopicProperties.empty());


### PR DESCRIPTION
Handle edge case where partition metadata contains zero partitions.  Add
a defensive check in the producer partition selection path to avoid
operating on an empty partition list.  This improves robustness during
transient metadata states.
