### PR TITLE
KAFKA-20211 [1/2]: Change CoordinatorRuntime executor type from ExecutorService to ThreadPoolExecutor

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -25,20 +25,20 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 
 public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
     private record TaskResult<R>(R result, Throwable exception) { }
 
     private final Logger log;
-    private final ExecutorService executor;
+    private final ThreadPoolExecutor executor;
     private final CoordinatorShardScheduler<U> scheduler;
     private final Map<String, TaskRunnable<?>> tasks = new ConcurrentHashMap<>();
 
     public CoordinatorExecutorImpl(
         LogContext logContext,
-        ExecutorService executor,
+        ThreadPoolExecutor executor,
         CoordinatorShardScheduler<U> scheduler
     ) {
         this.log = logContext.logger(CoordinatorExecutorImpl.class);

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -56,8 +56,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -116,7 +116,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private Serializer<U> serializer;
         private Compression compression;
         private OptionalInt appendLingerMs;
-        private ExecutorService executorService;
+        private ThreadPoolExecutor executorService;
         private Supplier<Integer> cachedBufferMaxBytesSupplier;
 
         public Builder<S, U> withLogPrefix(String logPrefix) {
@@ -189,7 +189,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             return this;
         }
 
-        public Builder<S, U> withExecutorService(ExecutorService executorService) {
+        public Builder<S, U> withExecutorService(ThreadPoolExecutor executorService) {
             this.executorService = executorService;
             return this;
         }
@@ -1873,7 +1873,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * The executor service used by the coordinator runtime to schedule
      * asynchronous tasks.
      */
-    private final ExecutorService executorService;
+    private final ThreadPoolExecutor executorService;
 
     /**
      * The maximum buffer size that the coordinator can cache.
@@ -1926,7 +1926,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         Serializer<U> serializer,
         Compression compression,
         OptionalInt appendLingerMs,
-        ExecutorService executorService,
+        ThreadPoolExecutor executorService,
         Supplier<Integer> cachedBufferMaxBytesSupplier
     ) {
         this.logPrefix = logPrefix;

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -49,7 +49,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskSuccessfulLifecycle() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -103,7 +103,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskFailedLifecycle() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -156,7 +156,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskCancelledBeforeBeingExecuted() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -198,7 +198,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -248,7 +248,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskSchedulingWriteOperationFailed() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -292,7 +292,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testCancelAllTasks() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -59,7 +59,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -126,7 +126,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -199,7 +199,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -252,7 +252,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -309,7 +309,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -383,7 +383,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -440,7 +440,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -497,7 +497,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -542,7 +542,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -593,7 +593,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(metrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -650,7 +650,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -738,7 +738,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -861,7 +861,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -887,7 +887,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -917,7 +917,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -979,7 +979,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1033,7 +1033,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1072,7 +1072,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1145,7 +1145,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1241,7 +1241,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1304,7 +1304,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1431,7 +1431,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1493,7 +1493,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1560,7 +1560,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1660,7 +1660,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1745,7 +1745,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1805,7 +1805,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1832,7 +1832,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1880,7 +1880,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1922,7 +1922,7 @@ public class CoordinatorRuntimeTest {
     public void testClose() throws Exception {
         MockCoordinatorLoader loader = spy(new MockCoordinatorLoader());
         MockTimer timer = new MockTimer();
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
@@ -2001,7 +2001,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2029,7 +2029,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2057,7 +2057,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2092,7 +2092,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2127,7 +2127,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2155,7 +2155,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2191,7 +2191,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2257,7 +2257,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2315,7 +2315,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2392,7 +2392,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2466,7 +2466,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2528,7 +2528,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2604,7 +2604,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2649,7 +2649,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2702,7 +2702,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2761,7 +2761,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2842,7 +2842,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2901,7 +2901,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2961,7 +2961,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3008,7 +3008,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3084,7 +3084,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3163,7 +3163,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3238,7 +3238,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3309,7 +3309,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3363,7 +3363,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3412,7 +3412,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> cachedBufferMaxBytes)
                 .build();
 
@@ -3466,7 +3466,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(maxBufferSizeSupplierMock)
                 .build();
 
@@ -3540,7 +3540,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3676,7 +3676,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3729,7 +3729,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3816,7 +3816,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3915,7 +3915,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4049,7 +4049,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.empty())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4158,7 +4158,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.empty())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4348,7 +4348,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.empty())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4509,7 +4509,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4625,7 +4625,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4675,7 +4675,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4785,7 +4785,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4882,7 +4882,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4970,7 +4970,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5041,7 +5041,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5155,7 +5155,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5267,7 +5267,7 @@ public class CoordinatorRuntimeTest {
                 .withCompression(compression)
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5354,7 +5354,7 @@ public class CoordinatorRuntimeTest {
                 .withCompression(compression)
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5441,7 +5441,7 @@ public class CoordinatorRuntimeTest {
                 .withCompression(compression)
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5533,7 +5533,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5621,7 +5621,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5689,7 +5689,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5749,7 +5749,7 @@ public class CoordinatorRuntimeTest {
         MockPartitionWriter writer = new MockPartitionWriter();
         ManualEventProcessor processor = new ManualEventProcessor();
         CoordinatorRuntimeMetrics runtimeMetrics = mock(CoordinatorRuntimeMetrics.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
 
         when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
             Runnable op = args.getArgument(0);
@@ -5853,7 +5853,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -140,7 +140,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
@@ -277,8 +279,12 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withSerializer(new GroupCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.offsetTopicCompressionType()).build())
                     .withAppendLingerMs(config.appendLingerMs())
-                    .withExecutorService(Executors.newFixedThreadPool(
+                    .withExecutorService(new ThreadPoolExecutor(
                         config.numBackgroundThreads(),
+                        config.numBackgroundThreads(),
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        new LinkedBlockingQueue<>(),
                         ThreadUtils.createThreadFactory("group-coordinator-background-%d", false)
                     ))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.requests.ReadShareGroupStateSummaryResponse;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorEventProcessor;
@@ -75,7 +76,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
@@ -205,7 +208,14 @@ public class ShareCoordinatorService implements ShareCoordinator {
                     .withSerializer(new ShareCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.shareCoordinatorStateTopicCompressionType()).build())
                     .withAppendLingerMs(config.shareCoordinatorAppendLingerMs())
-                    .withExecutorService(Executors.newSingleThreadExecutor())
+                    .withExecutorService(new ThreadPoolExecutor(
+                        1,
+                        1,
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        new LinkedBlockingQueue<>(),
+                        ThreadUtils.createThreadFactory("share-coordinator-background-%d", false)
+                    ))
                     .withCachedBufferMaxBytesSupplier(config::shareCoordinatorCachedBufferMaxBytes)
                     .build();
 


### PR DESCRIPTION
To implement the background thread idle ratio metric, the coordinator
executor needs to know the size of the executor thread pool. Switch the
executor type from ExecutorService to the ThreadPoolExecutor subclass,
to allow querying the thread pool size directly via getCorePoolSize().