### PR TITLE
KAFKA-20211 [2/2]: Add group coordinator executor metrics

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
 
 import org.slf4j.Logger;
 
@@ -32,16 +33,22 @@ public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
     private record TaskResult<R>(R result, Throwable exception) { }
 
     private final Logger log;
+    private final CoordinatorRuntimeMetrics metrics;
+    private final Time time;
     private final ThreadPoolExecutor executor;
     private final CoordinatorShardScheduler<U> scheduler;
     private final Map<String, TaskRunnable<?>> tasks = new ConcurrentHashMap<>();
 
     public CoordinatorExecutorImpl(
         LogContext logContext,
+        CoordinatorRuntimeMetrics metrics,
+        Time time,
         ThreadPoolExecutor executor,
         CoordinatorShardScheduler<U> scheduler
     ) {
         this.log = logContext.logger(CoordinatorExecutorImpl.class);
+        this.metrics = metrics;
+        this.time = time;
         this.executor = executor;
         this.scheduler = scheduler;
     }
@@ -63,14 +70,22 @@ public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
         // Put the task if the key is free. Otherwise, reject it.
         if (tasks.putIfAbsent(key, task) != null) return false;
 
+        var queuedTimeMs = time.milliseconds();
+
         // Submit the task.
         executor.submit(() -> {
             // If the task associated with the key is not us, it means
             // that the task was either replaced or cancelled. We stop.
             if (tasks.get(key) != task) return;
 
+            var dequeuedTimeMs = time.milliseconds();
+            metrics.recordExecutorQueueTime(dequeuedTimeMs - queuedTimeMs);
+
             // Execute the task.
             var result = executeTask(task);
+            long processingTimeMs = time.milliseconds() - dequeuedTimeMs;
+            metrics.recordExecutorProcessingTime(processingTimeMs);
+            metrics.recordExecutorThreadBusyTime((double) processingTimeMs / executor.getCorePoolSize());
 
             // Schedule the operation.
             scheduler.scheduleWriteOperation(

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -25,20 +25,20 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 
 public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
     private record TaskResult<R>(R result, Throwable exception) { }
 
     private final Logger log;
-    private final ExecutorService executor;
+    private final ThreadPoolExecutor executor;
     private final CoordinatorShardScheduler<U> scheduler;
     private final Map<String, TaskRunnable<?>> tasks = new ConcurrentHashMap<>();
 
     public CoordinatorExecutorImpl(
         LogContext logContext,
-        ExecutorService executor,
+        ThreadPoolExecutor executor,
         CoordinatorShardScheduler<U> scheduler
     ) {
         this.log = logContext.logger(CoordinatorExecutorImpl.class);

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImpl.java
@@ -79,13 +79,13 @@ public class CoordinatorExecutorImpl<U> implements CoordinatorExecutor<U> {
             if (tasks.get(key) != task) return;
 
             var dequeuedTimeMs = time.milliseconds();
-            metrics.recordExecutorQueueTime(dequeuedTimeMs - queuedTimeMs);
+            metrics.recordBackgroundQueueTime(dequeuedTimeMs - queuedTimeMs);
 
             // Execute the task.
             var result = executeTask(task);
             long processingTimeMs = time.milliseconds() - dequeuedTimeMs;
-            metrics.recordExecutorProcessingTime(processingTimeMs);
-            metrics.recordExecutorThreadBusyTime((double) processingTimeMs / executor.getCorePoolSize());
+            metrics.recordBackgroundProcessingTime(processingTimeMs);
+            metrics.recordBackgroundThreadBusyTime((double) processingTimeMs / executor.getCorePoolSize());
 
             // Schedule the operation.
             scheduler.scheduleWriteOperation(

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -490,6 +490,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             );
             this.executor = new CoordinatorExecutorImpl<>(
                 logContext,
+                runtimeMetrics,
+                time,
                 executorService,
                 (operationName, operation) -> scheduleWriteOperation(
                     operationName,

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -56,8 +56,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -116,7 +116,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private Serializer<U> serializer;
         private Compression compression;
         private OptionalInt appendLingerMs;
-        private ExecutorService executorService;
+        private ThreadPoolExecutor executorService;
         private Supplier<Integer> cachedBufferMaxBytesSupplier;
 
         public Builder<S, U> withLogPrefix(String logPrefix) {
@@ -189,7 +189,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             return this;
         }
 
-        public Builder<S, U> withExecutorService(ExecutorService executorService) {
+        public Builder<S, U> withExecutorService(ThreadPoolExecutor executorService) {
             this.executorService = executorService;
             return this;
         }
@@ -1873,7 +1873,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * The executor service used by the coordinator runtime to schedule
      * asynchronous tasks.
      */
-    private final ExecutorService executorService;
+    private final ThreadPoolExecutor executorService;
 
     /**
      * The maximum buffer size that the coordinator can cache.
@@ -1926,7 +1926,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         Serializer<U> serializer,
         Compression compression,
         OptionalInt appendLingerMs,
-        ExecutorService executorService,
+        ThreadPoolExecutor executorService,
         Supplier<Integer> cachedBufferMaxBytesSupplier
     ) {
         this.logPrefix = logPrefix;

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
@@ -81,24 +81,24 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void recordThreadIdleTime(double idleTimeMs);
 
     /**
-     * Update the executor queue time.
+     * Update the background queue time.
      *
      * @param durationMs The queue time.
      */
-    void recordExecutorQueueTime(long durationMs);
+    void recordBackgroundQueueTime(long durationMs);
 
     /**
-     * Update the executor processing time.
+     * Update the background processing time.
      *
-     * @param durationMs The executor processing time.
+     * @param durationMs The background processing time.
      */
-    void recordExecutorProcessingTime(long durationMs);
+    void recordBackgroundProcessingTime(long durationMs);
 
     /**
-     * Record the executor thread busy time.
+     * Record the background thread busy time.
      * @param busyTimeMs The busy time in milliseconds.
      */
-    void recordExecutorThreadBusyTime(double busyTimeMs);
+    void recordBackgroundThreadBusyTime(double busyTimeMs);
 
     /**
      * Register the event queue size gauge.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
@@ -81,6 +81,26 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void recordThreadIdleTime(double idleTimeMs);
 
     /**
+     * Update the executor queue time.
+     *
+     * @param durationMs The queue time.
+     */
+    void recordExecutorQueueTime(long durationMs);
+
+    /**
+     * Update the executor processing time.
+     *
+     * @param durationMs The executor processing time.
+     */
+    void recordExecutorProcessingTime(long durationMs);
+
+    /**
+     * Record the executor thread busy time.
+     * @param busyTimeMs The busy time in milliseconds.
+     */
+    void recordExecutorThreadBusyTime(double busyTimeMs);
+
+    /**
      * Register the event queue size gauge.
      *
      * @param sizeSupplier The size supplier.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.common.runtime;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
@@ -78,6 +79,16 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
      * The buffer cache discard count metric name.
      */
     public static final String BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME = "batch-buffer-cache-discard-count";
+
+    /**
+     * The executor queue time metric name.
+     */
+    public static final String EXECUTOR_QUEUE_TIME_METRIC_NAME = "executor-queue-time-ms";
+
+    /**
+     * The executor processing time metric name.
+     */
+    public static final String EXECUTOR_PROCESSING_TIME_METRIC_NAME = "executor-processing-time-ms";
 
     /**
      * Metric to count the number of partitions in Loading state.
@@ -153,7 +164,22 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
      */
     private final Sensor flushSensor;
 
-    public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup) {
+    /**
+     * The executor thread busy sensor. Null when executor metrics are not enabled.
+     */
+    private final Sensor executorThreadBusySensor;
+
+    /**
+     * The executor queue time sensor. Null when executor metrics are not enabled.
+     */
+    private final Sensor executorQueueTimeSensor;
+
+    /**
+     * The executor processing time sensor. Null when executor metrics are not enabled.
+     */
+    private final Sensor executorProcessingTimeSensor;
+
+    public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup, boolean enableExecutorMetrics) {
         this.metrics = Objects.requireNonNull(metrics);
         this.metricsGroup = Objects.requireNonNull(metricsGroup);
 
@@ -265,6 +291,44 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
                 this.metricsGroup,
                 "The flushes per second."),
             new Rate(TimeUnit.SECONDS, new WindowedCount()));
+
+        if (enableExecutorMetrics) {
+            this.executorThreadBusySensor = metrics.sensor(this.metricsGroup + "-ExecutorThreadBusyRatio");
+            this.executorThreadBusySensor.add(
+                metrics.metricName(
+                    "executor-thread-idle-ratio-avg",
+                    this.metricsGroup,
+                    "The fraction of time the executor threads are idle. This is an average across " +
+                        "all coordinator executor threads."),
+                new Rate(TimeUnit.MILLISECONDS) {
+                    @Override
+                    public double measure(MetricConfig config, long now) {
+                        return 1.0 - super.measure(config, now);
+                    }
+                });
+
+            KafkaMetricHistogram executorQueueTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
+                suffix -> kafkaMetricName(
+                    EXECUTOR_QUEUE_TIME_METRIC_NAME + "-" + suffix,
+                    "The " + suffix + " executor queue time in milliseconds"
+                )
+            );
+            this.executorQueueTimeSensor = metrics.sensor(this.metricsGroup + "-ExecutorQueueTime");
+            this.executorQueueTimeSensor.add(executorQueueTimeHistogram);
+
+            KafkaMetricHistogram executorProcessingTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
+                suffix -> kafkaMetricName(
+                    EXECUTOR_PROCESSING_TIME_METRIC_NAME + "-" + suffix,
+                    "The " + suffix + " executor processing time in milliseconds"
+                )
+            );
+            this.executorProcessingTimeSensor = metrics.sensor(this.metricsGroup + "-ExecutorProcessingTime");
+            this.executorProcessingTimeSensor.add(executorProcessingTimeHistogram);
+        } else {
+            this.executorThreadBusySensor = null;
+            this.executorQueueTimeSensor = null;
+            this.executorProcessingTimeSensor = null;
+        }
     }
 
     /**
@@ -298,6 +362,15 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
         metrics.removeSensor(eventPurgatoryTimeSensor.name());
         metrics.removeSensor(lingerTimeSensor.name());
         metrics.removeSensor(flushSensor.name());
+        if (executorThreadBusySensor != null) {
+            metrics.removeSensor(executorThreadBusySensor.name());
+        }
+        if (executorQueueTimeSensor != null) {
+            metrics.removeSensor(executorQueueTimeSensor.name());
+        }
+        if (executorProcessingTimeSensor != null) {
+            metrics.removeSensor(executorProcessingTimeSensor.name());
+        }
     }
 
     /**
@@ -370,6 +443,27 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     @Override
     public void recordThreadIdleTime(double idleTimeMs) {
         threadIdleSensor.record(idleTimeMs);
+    }
+
+    @Override
+    public void recordExecutorThreadBusyTime(double busyTimeMs) {
+        if (executorThreadBusySensor != null) {
+            executorThreadBusySensor.record(busyTimeMs);
+        }
+    }
+
+    @Override
+    public void recordExecutorQueueTime(long durationMs) {
+        if (executorQueueTimeSensor != null) {
+            executorQueueTimeSensor.record(durationMs);
+        }
+    }
+
+    @Override
+    public void recordExecutorProcessingTime(long durationMs) {
+        if (executorProcessingTimeSensor != null) {
+            executorProcessingTimeSensor.record(durationMs);
+        }
     }
 
     @Override

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
@@ -81,14 +81,14 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     public static final String BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME = "batch-buffer-cache-discard-count";
 
     /**
-     * The executor queue time metric name.
+     * The background queue time metric name.
      */
-    public static final String EXECUTOR_QUEUE_TIME_METRIC_NAME = "executor-queue-time-ms";
+    public static final String BACKGROUND_QUEUE_TIME_METRIC_NAME = "background-queue-time-ms";
 
     /**
-     * The executor processing time metric name.
+     * The background processing time metric name.
      */
-    public static final String EXECUTOR_PROCESSING_TIME_METRIC_NAME = "executor-processing-time-ms";
+    public static final String BACKGROUND_PROCESSING_TIME_METRIC_NAME = "background-processing-time-ms";
 
     /**
      * Metric to count the number of partitions in Loading state.
@@ -165,21 +165,21 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     private final Sensor flushSensor;
 
     /**
-     * The executor thread busy sensor. Null when executor metrics are not enabled.
+     * The background thread busy sensor. Null when background metrics are not enabled.
      */
-    private final Sensor executorThreadBusySensor;
+    private final Sensor backgroundThreadBusySensor;
 
     /**
-     * The executor queue time sensor. Null when executor metrics are not enabled.
+     * The background queue time sensor. Null when background metrics are not enabled.
      */
-    private final Sensor executorQueueTimeSensor;
+    private final Sensor backgroundQueueTimeSensor;
 
     /**
-     * The executor processing time sensor. Null when executor metrics are not enabled.
+     * The background processing time sensor. Null when background metrics are not enabled.
      */
-    private final Sensor executorProcessingTimeSensor;
+    private final Sensor backgroundProcessingTimeSensor;
 
-    public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup, boolean enableExecutorMetrics) {
+    public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup, boolean enableBackgroundMetrics) {
         this.metrics = Objects.requireNonNull(metrics);
         this.metricsGroup = Objects.requireNonNull(metricsGroup);
 
@@ -292,14 +292,14 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
                 "The flushes per second."),
             new Rate(TimeUnit.SECONDS, new WindowedCount()));
 
-        if (enableExecutorMetrics) {
-            this.executorThreadBusySensor = metrics.sensor(this.metricsGroup + "-ExecutorThreadBusyRatio");
-            this.executorThreadBusySensor.add(
+        if (enableBackgroundMetrics) {
+            this.backgroundThreadBusySensor = metrics.sensor(this.metricsGroup + "-BackgroundThreadBusyRatio");
+            this.backgroundThreadBusySensor.add(
                 metrics.metricName(
-                    "executor-thread-idle-ratio-avg",
+                    "background-thread-idle-ratio-avg",
                     this.metricsGroup,
-                    "The fraction of time the executor threads are idle. This is an average across " +
-                        "all coordinator executor threads."),
+                    "The fraction of time the background threads are idle. This is an average across " +
+                        "all coordinator background threads."),
                 new Rate(TimeUnit.MILLISECONDS) {
                     @Override
                     public double measure(MetricConfig config, long now) {
@@ -307,27 +307,27 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
                     }
                 });
 
-            KafkaMetricHistogram executorQueueTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
+            KafkaMetricHistogram backgroundQueueTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
                 suffix -> kafkaMetricName(
-                    EXECUTOR_QUEUE_TIME_METRIC_NAME + "-" + suffix,
-                    "The " + suffix + " executor queue time in milliseconds"
+                    BACKGROUND_QUEUE_TIME_METRIC_NAME + "-" + suffix,
+                    "The " + suffix + " background queue time in milliseconds"
                 )
             );
-            this.executorQueueTimeSensor = metrics.sensor(this.metricsGroup + "-ExecutorQueueTime");
-            this.executorQueueTimeSensor.add(executorQueueTimeHistogram);
+            this.backgroundQueueTimeSensor = metrics.sensor(this.metricsGroup + "-BackgroundQueueTime");
+            this.backgroundQueueTimeSensor.add(backgroundQueueTimeHistogram);
 
-            KafkaMetricHistogram executorProcessingTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
+            KafkaMetricHistogram backgroundProcessingTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
                 suffix -> kafkaMetricName(
-                    EXECUTOR_PROCESSING_TIME_METRIC_NAME + "-" + suffix,
-                    "The " + suffix + " executor processing time in milliseconds"
+                    BACKGROUND_PROCESSING_TIME_METRIC_NAME + "-" + suffix,
+                    "The " + suffix + " background processing time in milliseconds"
                 )
             );
-            this.executorProcessingTimeSensor = metrics.sensor(this.metricsGroup + "-ExecutorProcessingTime");
-            this.executorProcessingTimeSensor.add(executorProcessingTimeHistogram);
+            this.backgroundProcessingTimeSensor = metrics.sensor(this.metricsGroup + "-BackgroundProcessingTime");
+            this.backgroundProcessingTimeSensor.add(backgroundProcessingTimeHistogram);
         } else {
-            this.executorThreadBusySensor = null;
-            this.executorQueueTimeSensor = null;
-            this.executorProcessingTimeSensor = null;
+            this.backgroundThreadBusySensor = null;
+            this.backgroundQueueTimeSensor = null;
+            this.backgroundProcessingTimeSensor = null;
         }
     }
 
@@ -362,14 +362,14 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
         metrics.removeSensor(eventPurgatoryTimeSensor.name());
         metrics.removeSensor(lingerTimeSensor.name());
         metrics.removeSensor(flushSensor.name());
-        if (executorThreadBusySensor != null) {
-            metrics.removeSensor(executorThreadBusySensor.name());
+        if (backgroundThreadBusySensor != null) {
+            metrics.removeSensor(backgroundThreadBusySensor.name());
         }
-        if (executorQueueTimeSensor != null) {
-            metrics.removeSensor(executorQueueTimeSensor.name());
+        if (backgroundQueueTimeSensor != null) {
+            metrics.removeSensor(backgroundQueueTimeSensor.name());
         }
-        if (executorProcessingTimeSensor != null) {
-            metrics.removeSensor(executorProcessingTimeSensor.name());
+        if (backgroundProcessingTimeSensor != null) {
+            metrics.removeSensor(backgroundProcessingTimeSensor.name());
         }
     }
 
@@ -446,23 +446,23 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     }
 
     @Override
-    public void recordExecutorThreadBusyTime(double busyTimeMs) {
-        if (executorThreadBusySensor != null) {
-            executorThreadBusySensor.record(busyTimeMs);
+    public void recordBackgroundThreadBusyTime(double busyTimeMs) {
+        if (backgroundThreadBusySensor != null) {
+            backgroundThreadBusySensor.record(busyTimeMs);
         }
     }
 
     @Override
-    public void recordExecutorQueueTime(long durationMs) {
-        if (executorQueueTimeSensor != null) {
-            executorQueueTimeSensor.record(durationMs);
+    public void recordBackgroundQueueTime(long durationMs) {
+        if (backgroundQueueTimeSensor != null) {
+            backgroundQueueTimeSensor.record(durationMs);
         }
     }
 
     @Override
-    public void recordExecutorProcessingTime(long durationMs) {
-        if (executorProcessingTimeSensor != null) {
-            executorProcessingTimeSensor.record(durationMs);
+    public void recordBackgroundProcessingTime(long durationMs) {
+        if (backgroundProcessingTimeSensor != null) {
+            backgroundProcessingTimeSensor.record(durationMs);
         }
     }
 

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -416,8 +416,8 @@ public class CoordinatorExecutorImplTest {
             taskOperation
         );
 
-        verify(metrics, times(1)).recordExecutorQueueTime(100);
-        verify(metrics, times(1)).recordExecutorProcessingTime(500);
-        verify(metrics, times(1)).recordExecutorThreadBusyTime(250.0);
+        verify(metrics, times(1)).recordBackgroundQueueTime(100);
+        verify(metrics, times(1)).recordBackgroundProcessingTime(500);
+        verify(metrics, times(1)).recordBackgroundThreadBusyTime(250.0);
     }
 }

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.coordinator.common.runtime;
 
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 // Creating mocks of classes using generics creates unsafe assignment.
@@ -50,8 +54,11 @@ public class CoordinatorExecutorImplTest {
     public void testTaskSuccessfulLifecycle() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
         ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
+            metrics,
+            Time.SYSTEM,
             executorService,
             scheduler
         );
@@ -104,8 +111,11 @@ public class CoordinatorExecutorImplTest {
     public void testTaskFailedLifecycle() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
         ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
+            metrics,
+            Time.SYSTEM,
             executorService,
             scheduler
         );
@@ -157,8 +167,11 @@ public class CoordinatorExecutorImplTest {
     public void testTaskCancelledBeforeBeingExecuted() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
         ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
+            metrics,
+            Time.SYSTEM,
             executorService,
             scheduler
         );
@@ -199,8 +212,11 @@ public class CoordinatorExecutorImplTest {
     public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
         ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
+            metrics,
+            Time.SYSTEM,
             executorService,
             scheduler
         );
@@ -249,8 +265,11 @@ public class CoordinatorExecutorImplTest {
     public void testTaskSchedulingWriteOperationFailed() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
         ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
+            metrics,
+            Time.SYSTEM,
             executorService,
             scheduler
         );
@@ -293,8 +312,11 @@ public class CoordinatorExecutorImplTest {
     public void testCancelAllTasks() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
         ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
+            metrics,
+            Time.SYSTEM,
             executorService,
             scheduler
         );
@@ -348,5 +370,54 @@ public class CoordinatorExecutorImplTest {
 
         assertEquals(2, taskCallCount.get());
         assertEquals(0, operationCallCount.get());
+    }
+
+    @Test
+    public void testMetrics() {
+        CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
+        Time mockTime = new MockTime();
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
+        CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
+            LOG_CONTEXT,
+            metrics,
+            mockTime,
+            executorService,
+            scheduler
+        );
+
+        when(executorService.getCorePoolSize()).thenReturn(2);
+
+        when(scheduler.scheduleWriteOperation(
+            eq(TASK_KEY),
+            any()
+        )).thenAnswer(args -> CompletableFuture.completedFuture(null));
+
+        when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
+            mockTime.sleep(100);
+
+            Runnable op = args.getArgument(0);
+            op.run();
+            return CompletableFuture.completedFuture(null);
+        });
+
+        CoordinatorExecutor.TaskRunnable<String> taskRunnable = () -> {
+            mockTime.sleep(500);
+            return "Hello!";
+        };
+
+        CoordinatorExecutor.TaskOperation<String, String> taskOperation = (result, exception) -> {
+            return new CoordinatorResult<>(List.of("record"), null);
+        };
+
+        executor.schedule(
+            TASK_KEY,
+            taskRunnable,
+            taskOperation
+        );
+
+        verify(metrics, times(1)).recordExecutorQueueTime(100);
+        verify(metrics, times(1)).recordExecutorProcessingTime(500);
+        verify(metrics, times(1)).recordExecutorThreadBusyTime(250.0);
     }
 }

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorExecutorImplTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -49,7 +49,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskSuccessfulLifecycle() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -103,7 +103,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskFailedLifecycle() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -156,7 +156,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskCancelledBeforeBeingExecuted() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -198,7 +198,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskCancelledAfterBeingExecutedButBeforeWriteOperationIsExecuted() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -248,7 +248,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testTaskSchedulingWriteOperationFailed() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,
@@ -292,7 +292,7 @@ public class CoordinatorExecutorImplTest {
     @Test
     public void testCancelAllTasks() {
         CoordinatorShardScheduler<String> scheduler = mock(CoordinatorShardScheduler.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorExecutorImpl<String> executor = new CoordinatorExecutorImpl<>(
             LOG_CONTEXT,
             executorService,

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
@@ -33,6 +33,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BACKGROUND_PROCESSING_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BACKGROUND_QUEUE_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_BUFFER_CACHE_SIZE_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_FLUSH_TIME_METRIC_NAME;
@@ -40,8 +42,6 @@ import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetr
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_PROCESSING_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_PURGATORY_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_QUEUE_TIME_METRIC_NAME;
-import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EXECUTOR_PROCESSING_TIME_METRIC_NAME;
-import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EXECUTOR_QUEUE_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.NUM_PARTITIONS_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.KafkaMetricHistogram.MAX_LATENCY_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,36 +98,36 @@ public class CoordinatorRuntimeMetricsImplTest {
         );
     }
 
-    private static Set<MetricName> expectedExecutorMetricNames(Metrics metrics) {
+    private static Set<MetricName> expectedBackgroundMetricNames(Metrics metrics) {
         return Set.of(
-            kafkaMetricName(metrics, "executor-thread-idle-ratio-avg"),
-            kafkaMetricName(metrics, "executor-queue-time-ms-max"),
-            kafkaMetricName(metrics, "executor-queue-time-ms-p50"),
-            kafkaMetricName(metrics, "executor-queue-time-ms-p95"),
-            kafkaMetricName(metrics, "executor-queue-time-ms-p99"),
-            kafkaMetricName(metrics, "executor-queue-time-ms-p999"),
-            kafkaMetricName(metrics, "executor-processing-time-ms-max"),
-            kafkaMetricName(metrics, "executor-processing-time-ms-p50"),
-            kafkaMetricName(metrics, "executor-processing-time-ms-p95"),
-            kafkaMetricName(metrics, "executor-processing-time-ms-p99"),
-            kafkaMetricName(metrics, "executor-processing-time-ms-p999")
+            kafkaMetricName(metrics, "background-thread-idle-ratio-avg"),
+            kafkaMetricName(metrics, "background-queue-time-ms-max"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p50"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p95"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p99"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p999"),
+            kafkaMetricName(metrics, "background-processing-time-ms-max"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p50"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p95"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p99"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p999")
         );
     }
 
     @Test
-    public void testMetricNamesWithoutExecutorMetrics() {
+    public void testMetricNamesWithoutBackgroundMetrics() {
         Metrics metrics = new Metrics();
 
         Set<MetricName> expectedMetrics = expectedMetricNames(metrics);
-        Set<MetricName> executorMetrics = expectedExecutorMetricNames(metrics);
+        Set<MetricName> backgroundMetrics = expectedBackgroundMetricNames(metrics);
 
         try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, false)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
             expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
-            executorMetrics.forEach(metricName -> assertFalse(
+            backgroundMetrics.forEach(metricName -> assertFalse(
                 metrics.metrics().containsKey(metricName),
-                "metrics should not contain executor metricName: " + metricName + " when executor metrics are disabled."
+                "metrics should not contain background metricName: " + metricName + " when background metrics are disabled."
             ));
         }
 
@@ -138,26 +138,26 @@ public class CoordinatorRuntimeMetricsImplTest {
     }
 
     @Test
-    public void testMetricNamesWithExecutorMetrics() {
+    public void testMetricNamesWithBackgroundMetrics() {
         Metrics metrics = new Metrics();
 
         Set<MetricName> expectedMetrics = expectedMetricNames(metrics);
-        Set<MetricName> executorMetrics = expectedExecutorMetricNames(metrics);
+        Set<MetricName> backgroundMetrics = expectedBackgroundMetricNames(metrics);
 
         try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
             expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
-            executorMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            backgroundMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
         }
 
         expectedMetrics.forEach(metricName -> assertFalse(
             metrics.metrics().containsKey(metricName),
             "metrics did not expect to contain metricName: " + metricName + " after closing."
         ));
-        executorMetrics.forEach(metricName -> assertFalse(
+        backgroundMetrics.forEach(metricName -> assertFalse(
             metrics.metrics().containsKey(metricName),
-            "metrics did not expect to contain executor metricName: " + metricName + " after closing."
+            "metrics did not expect to contain background metricName: " + metricName + " after closing."
         ));
     }
 
@@ -182,7 +182,7 @@ public class CoordinatorRuntimeMetricsImplTest {
 
             // Check that all gauges were registered.
             expectedMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
-            expectedExecutorMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            expectedBackgroundMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
         }
 
         clearInvocations(metrics);
@@ -277,14 +277,14 @@ public class CoordinatorRuntimeMetricsImplTest {
 
 
     @Test
-    public void testExecutorThreadIdleSensor() {
+    public void testBackgroundThreadIdleSensor() {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
         CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
-        IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordExecutorThreadBusyTime((i + 1) * 1000.0));
+        IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordBackgroundThreadBusyTime((i + 1) * 1000.0));
 
-        org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "executor-thread-idle-ratio-avg");
+        org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "background-thread-idle-ratio-avg");
         KafkaMetric metric = metrics.metrics().get(metricName);
         assertEquals(1 - 6 / 30.0, metric.metricValue()); // '1 - busy_ms / window_ms'
     }
@@ -327,8 +327,8 @@ public class CoordinatorRuntimeMetricsImplTest {
         EVENT_PURGATORY_TIME_METRIC_NAME,
         BATCH_LINGER_TIME_METRIC_NAME,
         BATCH_FLUSH_TIME_METRIC_NAME,
-        EXECUTOR_QUEUE_TIME_METRIC_NAME,
-        EXECUTOR_PROCESSING_TIME_METRIC_NAME
+        BACKGROUND_QUEUE_TIME_METRIC_NAME,
+        BACKGROUND_PROCESSING_TIME_METRIC_NAME
     })
     public void testHistogramMetrics(String metricNamePrefix) {
         Time time = new MockTime();
@@ -353,11 +353,11 @@ public class CoordinatorRuntimeMetricsImplTest {
                 case BATCH_FLUSH_TIME_METRIC_NAME:
                     runtimeMetrics.recordFlushTime(i);
                     break;
-                case EXECUTOR_QUEUE_TIME_METRIC_NAME:
-                    runtimeMetrics.recordExecutorQueueTime(i);
+                case BACKGROUND_QUEUE_TIME_METRIC_NAME:
+                    runtimeMetrics.recordBackgroundQueueTime(i);
                     break;
-                case EXECUTOR_PROCESSING_TIME_METRIC_NAME:
-                    runtimeMetrics.recordExecutorProcessingTime(i);
+                case BACKGROUND_PROCESSING_TIME_METRIC_NAME:
+                    runtimeMetrics.recordBackgroundProcessingTime(i);
                     break;
             }
         });

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
@@ -40,6 +40,8 @@ import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetr
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_PROCESSING_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_PURGATORY_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EVENT_QUEUE_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EXECUTOR_PROCESSING_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.EXECUTOR_QUEUE_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.NUM_PARTITIONS_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.KafkaMetricHistogram.MAX_LATENCY_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,21 +98,66 @@ public class CoordinatorRuntimeMetricsImplTest {
         );
     }
 
+    private static Set<MetricName> expectedExecutorMetricNames(Metrics metrics) {
+        return Set.of(
+            kafkaMetricName(metrics, "executor-thread-idle-ratio-avg"),
+            kafkaMetricName(metrics, "executor-queue-time-ms-max"),
+            kafkaMetricName(metrics, "executor-queue-time-ms-p50"),
+            kafkaMetricName(metrics, "executor-queue-time-ms-p95"),
+            kafkaMetricName(metrics, "executor-queue-time-ms-p99"),
+            kafkaMetricName(metrics, "executor-queue-time-ms-p999"),
+            kafkaMetricName(metrics, "executor-processing-time-ms-max"),
+            kafkaMetricName(metrics, "executor-processing-time-ms-p50"),
+            kafkaMetricName(metrics, "executor-processing-time-ms-p95"),
+            kafkaMetricName(metrics, "executor-processing-time-ms-p99"),
+            kafkaMetricName(metrics, "executor-processing-time-ms-p999")
+        );
+    }
+
     @Test
-    public void testMetricNames() {
+    public void testMetricNamesWithoutExecutorMetrics() {
         Metrics metrics = new Metrics();
 
         Set<MetricName> expectedMetrics = expectedMetricNames(metrics);
+        Set<MetricName> executorMetrics = expectedExecutorMetricNames(metrics);
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, false)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
             expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            executorMetrics.forEach(metricName -> assertFalse(
+                metrics.metrics().containsKey(metricName),
+                "metrics should not contain executor metricName: " + metricName + " when executor metrics are disabled."
+            ));
         }
 
         expectedMetrics.forEach(metricName -> assertFalse(
             metrics.metrics().containsKey(metricName),
             "metrics did not expect to contain metricName: " + metricName + " after closing."
+        ));
+    }
+
+    @Test
+    public void testMetricNamesWithExecutorMetrics() {
+        Metrics metrics = new Metrics();
+
+        Set<MetricName> expectedMetrics = expectedMetricNames(metrics);
+        Set<MetricName> executorMetrics = expectedExecutorMetricNames(metrics);
+
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
+            runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
+            runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
+            expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            executorMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+        }
+
+        expectedMetrics.forEach(metricName -> assertFalse(
+            metrics.metrics().containsKey(metricName),
+            "metrics did not expect to contain metricName: " + metricName + " after closing."
+        ));
+        executorMetrics.forEach(metricName -> assertFalse(
+            metrics.metrics().containsKey(metricName),
+            "metrics did not expect to contain executor metricName: " + metricName + " after closing."
         ));
     }
 
@@ -121,7 +168,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         // Create first CoordinatorRuntimeMetricsImpl instance and capture sensor and metric names.
         Set<String> sensorNames;
         Set<MetricName> metricNames;
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
 
@@ -135,6 +182,7 @@ public class CoordinatorRuntimeMetricsImplTest {
 
             // Check that all gauges were registered.
             expectedMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            expectedExecutorMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
         }
 
         clearInvocations(metrics);
@@ -142,7 +190,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         // Create second CoordinatorRuntimeMetricsImpl instance and capture sensor and metric names.
         Set<String> otherSensorNames;
         Set<MetricName> otherMetricNames;
-        try (CoordinatorRuntimeMetricsImpl otherRuntimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, OTHER_METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl otherRuntimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, OTHER_METRICS_GROUP, true)) {
             otherRuntimeMetrics.registerEventQueueSizeGauge(() -> 0);
             otherRuntimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
 
@@ -176,7 +224,7 @@ public class CoordinatorRuntimeMetricsImplTest {
     public void testUpdateNumPartitionsMetrics() {
         Metrics metrics = new Metrics();
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             IntStream.range(0, 10)
                 .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.INITIAL, CoordinatorState.LOADING));
             IntStream.range(0, 8)
@@ -197,7 +245,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             long startTimeMs = time.milliseconds();
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 1000);
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 2000);
@@ -219,7 +267,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
         IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordThreadIdleTime((i + 1) * 1000.0));
 
         org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "thread-idle-ratio-avg");
@@ -229,11 +277,24 @@ public class CoordinatorRuntimeMetricsImplTest {
 
 
     @Test
+    public void testExecutorThreadIdleSensor() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
+        IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordExecutorThreadBusyTime((i + 1) * 1000.0));
+
+        org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "executor-thread-idle-ratio-avg");
+        KafkaMetric metric = metrics.metrics().get(metricName);
+        assertEquals(1 - 6 / 30.0, metric.metricValue()); // '1 - busy_ms / window_ms'
+    }
+
+    @Test
     public void testEventQueueSize() {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 5);
             assertMetricGauge(metrics, kafkaMetricName(metrics, "event-queue-size"), 5);
         }
@@ -243,7 +304,7 @@ public class CoordinatorRuntimeMetricsImplTest {
     public void testBatchBufferCacheSize() {
         Metrics metrics = new Metrics();
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 5L);
             assertMetricGauge(metrics, kafkaMetricName(metrics, BATCH_BUFFER_CACHE_SIZE_METRIC_NAME), 5);
         }
@@ -253,7 +314,7 @@ public class CoordinatorRuntimeMetricsImplTest {
     public void testBatchBufferCacheDiscardCount() {
         Metrics metrics = new Metrics();
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.recordBufferCacheDiscarded();
             assertMetricGauge(metrics, kafkaMetricName(metrics, BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME), 1);
         }
@@ -265,13 +326,15 @@ public class CoordinatorRuntimeMetricsImplTest {
         EVENT_PROCESSING_TIME_METRIC_NAME,
         EVENT_PURGATORY_TIME_METRIC_NAME,
         BATCH_LINGER_TIME_METRIC_NAME,
-        BATCH_FLUSH_TIME_METRIC_NAME
+        BATCH_FLUSH_TIME_METRIC_NAME,
+        EXECUTOR_QUEUE_TIME_METRIC_NAME,
+        EXECUTOR_PROCESSING_TIME_METRIC_NAME
     })
     public void testHistogramMetrics(String metricNamePrefix) {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
 
         IntStream.range(1, 1001).forEach(i -> {
             switch (metricNamePrefix) {
@@ -289,6 +352,13 @@ public class CoordinatorRuntimeMetricsImplTest {
                     break;
                 case BATCH_FLUSH_TIME_METRIC_NAME:
                     runtimeMetrics.recordFlushTime(i);
+                    break;
+                case EXECUTOR_QUEUE_TIME_METRIC_NAME:
+                    runtimeMetrics.recordExecutorQueueTime(i);
+                    break;
+                case EXECUTOR_PROCESSING_TIME_METRIC_NAME:
+                    runtimeMetrics.recordExecutorProcessingTime(i);
+                    break;
             }
         });
 
@@ -319,7 +389,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
 
         IntStream.range(1, 1001).forEach(__ -> runtimeMetrics.recordEventPurgatoryTime(MAX_LATENCY_MS + 1000L));
 
@@ -340,7 +410,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
         IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordFlushTime((i + 1) * 1000));
 
         org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "batch-flush-rate");

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -59,7 +59,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -126,7 +126,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -199,7 +199,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -252,7 +252,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -309,7 +309,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -383,7 +383,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -440,7 +440,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -497,7 +497,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -542,7 +542,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -593,7 +593,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(metrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -650,7 +650,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -738,7 +738,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -861,7 +861,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -887,7 +887,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -917,7 +917,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -979,7 +979,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1033,7 +1033,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1072,7 +1072,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1145,7 +1145,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1241,7 +1241,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1304,7 +1304,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1431,7 +1431,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1493,7 +1493,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1560,7 +1560,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1660,7 +1660,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1745,7 +1745,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1805,7 +1805,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1832,7 +1832,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1880,7 +1880,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -1922,7 +1922,7 @@ public class CoordinatorRuntimeTest {
     public void testClose() throws Exception {
         MockCoordinatorLoader loader = spy(new MockCoordinatorLoader());
         MockTimer timer = new MockTimer();
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
             new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
@@ -2001,7 +2001,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2029,7 +2029,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2057,7 +2057,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2092,7 +2092,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2127,7 +2127,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2155,7 +2155,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2191,7 +2191,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2257,7 +2257,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2315,7 +2315,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2392,7 +2392,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2466,7 +2466,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2528,7 +2528,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2604,7 +2604,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2649,7 +2649,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2702,7 +2702,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2761,7 +2761,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2842,7 +2842,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2901,7 +2901,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -2961,7 +2961,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3008,7 +3008,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3084,7 +3084,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3163,7 +3163,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3238,7 +3238,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3309,7 +3309,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3363,7 +3363,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3412,7 +3412,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> cachedBufferMaxBytes)
                 .build();
 
@@ -3466,7 +3466,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(maxBufferSizeSupplierMock)
                 .build();
 
@@ -3540,7 +3540,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3676,7 +3676,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3729,7 +3729,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3816,7 +3816,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -3915,7 +3915,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4049,7 +4049,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.empty())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4158,7 +4158,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.empty())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4348,7 +4348,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.empty())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4509,7 +4509,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4625,7 +4625,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4675,7 +4675,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4785,7 +4785,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4882,7 +4882,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -4970,7 +4970,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(serializer)
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5041,7 +5041,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5155,7 +5155,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5267,7 +5267,7 @@ public class CoordinatorRuntimeTest {
                 .withCompression(compression)
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5354,7 +5354,7 @@ public class CoordinatorRuntimeTest {
                 .withCompression(compression)
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5441,7 +5441,7 @@ public class CoordinatorRuntimeTest {
                 .withCompression(compression)
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5533,7 +5533,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5621,7 +5621,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(0))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5689,7 +5689,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorRuntimeMetrics(runtimeMetrics)
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 
@@ -5749,7 +5749,7 @@ public class CoordinatorRuntimeTest {
         MockPartitionWriter writer = new MockPartitionWriter();
         ManualEventProcessor processor = new ManualEventProcessor();
         CoordinatorRuntimeMetrics runtimeMetrics = mock(CoordinatorRuntimeMetrics.class);
-        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPoolExecutor executorService = mock(ThreadPoolExecutor.class);
 
         when(executorService.submit(any(Runnable.class))).thenAnswer(args -> {
             Runnable op = args.getArgument(0);
@@ -5853,7 +5853,7 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
                 .withSerializer(new StringSerializer())
                 .withAppendLingerMs(OptionalInt.of(10))
-                .withExecutorService(mock(ExecutorService.class))
+                .withExecutorService(mock(ThreadPoolExecutor.class))
                 .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
                 .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -140,7 +140,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
@@ -277,8 +279,12 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withSerializer(new GroupCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.offsetTopicCompressionType()).build())
                     .withAppendLingerMs(config.appendLingerMs())
-                    .withExecutorService(Executors.newFixedThreadPool(
+                    .withExecutorService(new ThreadPoolExecutor(
                         config.numBackgroundThreads(),
+                        config.numBackgroundThreads(),
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        new LinkedBlockingQueue<>(),
                         ThreadUtils.createThreadFactory("group-coordinator-background-%d", false)
                     ))
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -23,6 +23,6 @@ public class GroupCoordinatorRuntimeMetrics extends CoordinatorRuntimeMetricsImp
     public static final String METRICS_GROUP = "group-coordinator-metrics";
 
     public GroupCoordinatorRuntimeMetrics(Metrics metrics) {
-        super(metrics, METRICS_GROUP);
+        super(metrics, METRICS_GROUP, true);
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.requests.ReadShareGroupStateSummaryResponse;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorEventProcessor;
@@ -75,7 +76,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
@@ -205,7 +208,14 @@ public class ShareCoordinatorService implements ShareCoordinator {
                     .withSerializer(new ShareCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.shareCoordinatorStateTopicCompressionType()).build())
                     .withAppendLingerMs(config.shareCoordinatorAppendLingerMs())
-                    .withExecutorService(Executors.newSingleThreadExecutor())
+                    .withExecutorService(new ThreadPoolExecutor(
+                        1,
+                        1,
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        new LinkedBlockingQueue<>(),
+                        ThreadUtils.createThreadFactory("share-coordinator-background-%d", false)
+                    ))
                     .withCachedBufferMaxBytesSupplier(config::shareCoordinatorCachedBufferMaxBytes)
                     .build();
 

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorRuntimeMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorRuntimeMetrics.java
@@ -26,6 +26,6 @@ public class ShareCoordinatorRuntimeMetrics extends CoordinatorRuntimeMetricsImp
     public static final String METRICS_GROUP = "share-coordinator-metrics";
 
     public ShareCoordinatorRuntimeMetrics(Metrics metrics) {
-        super(metrics, METRICS_GROUP);
+        super(metrics, METRICS_GROUP, false);
     }
 }


### PR DESCRIPTION
Add the background-queue-time and background-processing-time histogram
metrics.

Add the background-thread-idle-ratio-avg metric. Unlike the event
processor, we cannot measure idle time when using an ExecutorService.
Instead, we measure busy time and invert it when reporting the metric.

All three background metrics are only reported by the group coordinator
and not the share coordinator.
