### PR TITLE
KAFKA-20157 Add RetentionSizeInPercent metrics for regular topics

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogMetricNames.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogMetricNames.java
@@ -24,6 +24,7 @@ public class LogMetricNames {
     public static final String LOG_START_OFFSET = "LogStartOffset";
     public static final String LOG_END_OFFSET = "LogEndOffset";
     public static final String SIZE = "Size";
+    public static final String RETENTION_SIZE_IN_PERCENT = "RetentionSizeInPercent";
 
-    public static final List<String> ALL_METRIC_NAMES = List.of(NUM_LOG_SEGMENTS, LOG_START_OFFSET, LOG_END_OFFSET, SIZE);
+    public static final List<String> ALL_METRIC_NAMES = List.of(NUM_LOG_SEGMENTS, LOG_START_OFFSET, LOG_END_OFFSET, SIZE, RETENTION_SIZE_IN_PERCENT);
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogMetricNames.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogMetricNames.java
@@ -26,5 +26,9 @@ public class LogMetricNames {
     public static final String SIZE = "Size";
     public static final String RETENTION_SIZE_IN_PERCENT = "RetentionSizeInPercent";
 
-    public static final List<String> ALL_METRIC_NAMES = List.of(NUM_LOG_SEGMENTS, LOG_START_OFFSET, LOG_END_OFFSET, SIZE, RETENTION_SIZE_IN_PERCENT);
+    public static final List<String> ALL_METRIC_NAMES = List.of(
+                                                            NUM_LOG_SEGMENTS, 
+                                                            LOG_START_OFFSET, 
+                                                            LOG_END_OFFSET, SIZE, 
+                                                            RETENTION_SIZE_IN_PERCENT);
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -82,6 +82,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -121,6 +122,7 @@ public class UnifiedLog implements AutoCloseable {
     /* A lock that guards all modifications to the log */
     private final Object lock = new Object();
     private final Map<String, Map<String, String>> metricNames = new HashMap<>();
+    private final AtomicInteger retentionSizeInPercentValue = new AtomicInteger(0);
 
     // localLog The LocalLog instance containing non-empty log segments recovered from disk
     private final LocalLog localLog;
@@ -714,10 +716,29 @@ public class UnifiedLog implements AutoCloseable {
         metricsGroup.newGauge(LogMetricNames.LOG_START_OFFSET, this::logStartOffset, tags);
         metricsGroup.newGauge(LogMetricNames.LOG_END_OFFSET, this::logEndOffset, tags);
         metricsGroup.newGauge(LogMetricNames.SIZE, this::size, tags);
+        metricsGroup.newGauge(LogMetricNames.RETENTION_SIZE_IN_PERCENT, retentionSizeInPercentValue::get, tags);
         metricNames.put(LogMetricNames.NUM_LOG_SEGMENTS, tags);
         metricNames.put(LogMetricNames.LOG_START_OFFSET, tags);
         metricNames.put(LogMetricNames.LOG_END_OFFSET, tags);
         metricNames.put(LogMetricNames.SIZE, tags);
+        metricNames.put(LogMetricNames.RETENTION_SIZE_IN_PERCENT, tags);
+    }
+
+    /**
+     * Calculates the partition size as a percentage of the configured retention size.
+     * This metric is only meaningful for non-tiered topics with size-based retention configured.
+     *
+     * @return The partition size as a percentage of retention.bytes, or 0 if:
+     *         - Remote storage is enabled with remote copy enabled (metric handled by RemoteLogManager)
+     *         - Retention size is not configured (0 or negative)
+     */
+    // Visible for testing
+    int calculateRetentionSizeInPercent() {
+        long retentionSize = localRetentionSize(config(), remoteLogEnabledAndRemoteCopyEnabled());
+        if (!remoteLogEnabledAndRemoteCopyEnabled() && retentionSize > 0) {
+            return (int) ((size() * 100) / retentionSize);
+        }
+        return 0;
     }
 
     public void removeExpiredProducers(long currentTimeMs) {
@@ -1944,25 +1965,29 @@ public class UnifiedLog implements AutoCloseable {
      * not deletion is enabled, delete any local log segments that are before the log start offset
      */
     public int deleteOldSegments() throws IOException {
+        int deletedSegments;
         if (config().delete) {
-            return deleteLogStartOffsetBreachedSegments() +
+            deletedSegments = deleteLogStartOffsetBreachedSegments() +
                     deleteRetentionSizeBreachedSegments() +
                     deleteRetentionMsBreachedSegments();
         } else if (config().compact) {
-            return deleteLogStartOffsetBreachedSegments();
+            deletedSegments = deleteLogStartOffsetBreachedSegments();
         } else {
             // If cleanup.policy is empty and remote storage is enabled, the local log segments will 
             // be cleaned based on the values of log.local.retention.bytes and log.local.retention.ms
             if (remoteLogEnabledAndRemoteCopyEnabled()) {
-                return deleteLogStartOffsetBreachedSegments() +
+                deletedSegments = deleteLogStartOffsetBreachedSegments() +
                         deleteRetentionSizeBreachedSegments() +
                         deleteRetentionMsBreachedSegments();
             } else {
                 // If cleanup.policy is empty and remote storage is disabled, we should not delete any local log segments 
                 // unless the log start offset advances through deleteRecords
-                return deleteLogStartOffsetBreachedSegments();
+                deletedSegments = deleteLogStartOffsetBreachedSegments();
             }
         }
+        // To save CPU cycles, calculate retentionSizeInPercent only when the log-cleaner thread runs
+        retentionSizeInPercentValue.set(calculateRetentionSizeInPercent());
+        return deletedSegments;
     }
 
     public interface DeletionCondition {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1965,7 +1965,7 @@ public class UnifiedLog implements AutoCloseable {
      * not deletion is enabled, delete any local log segments that are before the log start offset
      */
     public int deleteOldSegments() throws IOException {
-        int deletedSegments = 0;
+        int deletedSegments;
         try {
             if (config().delete) {
                 deletedSegments = deleteLogStartOffsetBreachedSegments() +
@@ -1986,13 +1986,13 @@ public class UnifiedLog implements AutoCloseable {
                     deletedSegments = deleteLogStartOffsetBreachedSegments();
                 }
             }
-            return deletedSegments;
         } finally {
             // Calculate retentionSizeInPercent in finally block to ensure the metric is updated
             // even when log deletion encounters errors. This also saves CPU cycles by only
             // calculating when the log-cleaner thread runs.
             retentionSizeInPercentValue.set(calculateRetentionSizeInPercent());
         }
+        return deletedSegments;
     }
 
     public interface DeletionCondition {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -1965,29 +1965,34 @@ public class UnifiedLog implements AutoCloseable {
      * not deletion is enabled, delete any local log segments that are before the log start offset
      */
     public int deleteOldSegments() throws IOException {
-        int deletedSegments;
-        if (config().delete) {
-            deletedSegments = deleteLogStartOffsetBreachedSegments() +
-                    deleteRetentionSizeBreachedSegments() +
-                    deleteRetentionMsBreachedSegments();
-        } else if (config().compact) {
-            deletedSegments = deleteLogStartOffsetBreachedSegments();
-        } else {
-            // If cleanup.policy is empty and remote storage is enabled, the local log segments will 
-            // be cleaned based on the values of log.local.retention.bytes and log.local.retention.ms
-            if (remoteLogEnabledAndRemoteCopyEnabled()) {
+        int deletedSegments = 0;
+        try {
+            if (config().delete) {
                 deletedSegments = deleteLogStartOffsetBreachedSegments() +
                         deleteRetentionSizeBreachedSegments() +
                         deleteRetentionMsBreachedSegments();
-            } else {
-                // If cleanup.policy is empty and remote storage is disabled, we should not delete any local log segments 
-                // unless the log start offset advances through deleteRecords
+            } else if (config().compact) {
                 deletedSegments = deleteLogStartOffsetBreachedSegments();
+            } else {
+                // If cleanup.policy is empty and remote storage is enabled, the local log segments will 
+                // be cleaned based on the values of log.local.retention.bytes and log.local.retention.ms
+                if (remoteLogEnabledAndRemoteCopyEnabled()) {
+                    deletedSegments = deleteLogStartOffsetBreachedSegments() +
+                            deleteRetentionSizeBreachedSegments() +
+                            deleteRetentionMsBreachedSegments();
+                } else {
+                    // If cleanup.policy is empty and remote storage is disabled, we should not delete any local log segments 
+                    // unless the log start offset advances through deleteRecords
+                    deletedSegments = deleteLogStartOffsetBreachedSegments();
+                }
             }
+            return deletedSegments;
+        } finally {
+            // Calculate retentionSizeInPercent in finally block to ensure the metric is updated
+            // even when log deletion encounters errors. This also saves CPU cycles by only
+            // calculating when the log-cleaner thread runs.
+            retentionSizeInPercentValue.set(calculateRetentionSizeInPercent());
         }
-        // To save CPU cycles, calculate retentionSizeInPercent only when the log-cleaner thread runs
-        retentionSizeInPercentValue.set(calculateRetentionSizeInPercent());
-        return deletedSegments;
     }
 
     public interface DeletionCondition {

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -28,12 +28,15 @@ import org.apache.kafka.common.record.internal.SimpleRecord;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig;
 import org.apache.kafka.server.common.TransactionVersion;
+import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.server.storage.log.FetchIsolation;
 import org.apache.kafka.server.util.MockTime;
 import org.apache.kafka.server.util.Scheduler;
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 import org.apache.kafka.test.TestUtils;
+
+import com.yammer.metrics.core.Gauge;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +52,9 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -746,5 +752,102 @@ public class UnifiedLogTest {
             builder.append(record);
         }
         return builder.build();
+    }
+
+    /**
+     * Test RetentionSizeInPercent metric for regular (non-tiered) topics.
+     * The metric should only be reported for non-tiered topics with size-based retention configured.
+     *
+     * @param remoteLogStorageEnable whether remote log storage is enabled
+     * @param remoteLogCopyDisable whether remote log copy is disabled (only relevant when remote storage is enabled)
+     * @param expectedSizeInPercent expected percentage value after retention cleanup
+     */
+    @ParameterizedTest
+    @CsvSource({
+        // Remote storage enabled with copy enabled: metric handled by RemoteLogManager, returns 0 here
+        "true, false, 0",
+        // Remote storage enabled but copy disabled: metric should be calculated (100%)
+        "true, true, 100",
+        // Remote storage disabled: metric should be calculated (100%)
+        "false, false, 100",
+        // Remote storage disabled (remoteLogCopyDisable is ignored): metric should be calculated (100%)
+        "false, true, 100"
+    })
+    public void testRetentionSizeInPercentMetric(boolean remoteLogStorageEnable, boolean remoteLogCopyDisable, int expectedSizeInPercent) throws IOException {
+        Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
+        int recordSize = records.get().sizeInBytes();
+        LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
+                .segmentBytes(recordSize * 5)
+                .retentionBytes(recordSize * 10L)
+                .remoteLogStorageEnable(remoteLogStorageEnable)
+                .remoteLogCopyDisable(remoteLogCopyDisable)
+                .build();
+        log = createLog(logDir, logConfig, true);
+
+        String metricName = "name=RetentionSizeInPercent,topic=" + log.topicPartition().topic() + 
+                ",partition=" + log.topicPartition().partition();
+
+        // Append some messages to create 3 segments (15 records / 5 records per segment = 3 segments)
+        for (int i = 0; i < 15; i++) {
+            log.appendAsLeader(records.get(), 0);
+        }
+
+        // Before deletion, calculate what the percentage should be
+        // Total size = 15 * recordSize, retention = 10 * recordSize
+        // Percentage = (15 * 100) / 10 = 150% (for non-tiered topics)
+        if (!remoteLogStorageEnable || remoteLogCopyDisable) {
+            assertEquals(150, log.calculateRetentionSizeInPercent());
+        }
+
+        log.updateHighWatermark(log.logEndOffset());
+        // For tiered storage tests, simulate remote storage having the data
+        if (remoteLogStorageEnable) {
+            log.updateHighestOffsetInRemoteStorage(9);
+        }
+        log.deleteOldSegments();
+
+        // After deletion: log size should be ~10 * recordSize (2 segments), retention = 10 * recordSize
+        // Percentage = (10 * 100) / 10 = 100% (for non-tiered topics)
+        // Verify via Yammer metric (JMX)
+        assertEquals(expectedSizeInPercent, yammerMetricValue(metricName));
+        assertEquals(2, log.numberOfSegments(), "should have 2 segments after deletion");
+    }
+
+    @Test
+    public void testRetentionSizeInPercentWithZeroRetention() throws IOException {
+        Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
+        // Create log with no retention configured (retentionBytes = -1 means unlimited)
+        LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
+                .segmentBytes(records.get().sizeInBytes() * 5)
+                .retentionBytes(-1L)
+                .build();
+        log = createLog(logDir, logConfig, false);
+
+        String metricName = "name=RetentionSizeInPercent,topic=" + log.topicPartition().topic() + 
+                ",partition=" + log.topicPartition().partition();
+
+        for (int i = 0; i < 10; i++) {
+            log.appendAsLeader(records.get(), 0);
+        }
+
+        // With unlimited retention, the metric should be 0
+        assertEquals(0, log.calculateRetentionSizeInPercent());
+
+        log.updateHighWatermark(log.logEndOffset());
+        log.deleteOldSegments();
+
+        // After deleteOldSegments, metric should still be 0
+        // Verify via Yammer metric (JMX)
+        assertEquals(0, yammerMetricValue(metricName));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object yammerMetricValue(String name) {
+        Gauge<Object> gauge = (Gauge<Object>) KafkaYammerMetrics.defaultRegistry().allMetrics().entrySet().stream()
+                .filter(e -> e.getKey().getMBeanName().endsWith(name))
+                .findFirst()
+                .get()
+                .getValue();
+        return gauge.value();
     }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -40,6 +40,8 @@ import com.yammer.metrics.core.Gauge;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import·org.junit.jupiter.params.ParameterizedTest;
+import·org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,9 +54,6 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -56,7 +56,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
@@ -776,8 +775,11 @@ public class UnifiedLogTest {
         // Remote storage disabled (remoteLogCopyDisable is ignored): metric should be calculated (100%)
         "false, true, 100"
     })
-    public void testRetentionSizeInPercentMetric(boolean remoteLogStorageEnable, 
-        boolean remoteLogCopyDisable, int expectedSizeInPercent) throws IOException {
+    public void testRetentionSizeInPercentMetric(
+            boolean remoteLogStorageEnable,
+            boolean remoteLogCopyDisable,
+            int expectedSizeInPercent
+    ) throws IOException {
         Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
         int recordSize = records.get().sizeInBytes();
         LogConfig logConfig = new LogTestUtils.LogConfigBuilder()

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -40,8 +40,8 @@ import com.yammer.metrics.core.Gauge;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import·org.junit.jupiter.params.ParameterizedTest;
-import·org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,6 +57,8 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 public class UnifiedLogTest {
 
@@ -772,7 +774,8 @@ public class UnifiedLogTest {
         // Remote storage disabled (remoteLogCopyDisable is ignored): metric should be calculated (100%)
         "false, true, 100"
     })
-    public void testRetentionSizeInPercentMetric(boolean remoteLogStorageEnable, boolean remoteLogCopyDisable, int expectedSizeInPercent) throws IOException {
+    public void testRetentionSizeInPercentMetric(boolean remoteLogStorageEnable, 
+        boolean remoteLogCopyDisable, int expectedSizeInPercent) throws IOException {
         Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
         int recordSize = records.get().sizeInBytes();
         LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
@@ -813,7 +816,7 @@ public class UnifiedLogTest {
     }
 
     @Test
-    public void testRetentionSizeInPercentWithZeroRetention() throws IOException {
+    public void testRetentionSizeInPercentWithInfiniteRetention() throws IOException {
         Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
         // Create log with no retention configured (retentionBytes = -1 means unlimited)
         LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
@@ -838,6 +841,70 @@ public class UnifiedLogTest {
         // After deleteOldSegments, metric should still be 0
         // Verify via Yammer metric (JMX)
         assertEquals(0, yammerMetricValue(metricName));
+    }
+
+    /**
+     * Test that verifies the RetentionSizeInPercent metric is always updated in the finally block
+     * of deleteOldSegments(). This ensures the metric is calculated even when log deletion
+     * encounters errors. The finally block guarantees metric updates regardless of success or failure.
+     */
+    @Test
+    public void testRetentionSizeInPercentMetricAlwaysUpdatedInFinallyBlock() throws IOException {
+        Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
+        int recordSize = records.get().sizeInBytes();
+
+        // Create log with retention smaller than data to force deletion
+        LogConfig logConfig = new LogTestUtils.LogConfigBuilder()
+                .segmentBytes(recordSize * 5)
+                .retentionBytes(recordSize * 10L)
+                .build();
+        log = createLog(logDir, logConfig, false);
+
+        String metricName = "name=RetentionSizeInPercent,topic=" + log.topicPartition().topic() +
+                ",partition=" + log.topicPartition().partition();
+
+        // Append messages to create multiple segments (15 records / 5 per segment = 3 segments)
+        for (int i = 0; i < 15; i++) {
+            log.appendAsLeader(records.get(), 0);
+        }
+        assertEquals(3, log.numberOfSegments(), "Should have 3 segments before deletion");
+
+        log.updateHighWatermark(log.logEndOffset());
+
+        // Before deleteOldSegments: Total size = 15 * recordSize, retention = 10 * recordSize
+        // Percentage = (15 * 100) / 10 = 150%
+        assertEquals(150, log.calculateRetentionSizeInPercent());
+
+        // Metric should not be exposed via JMX until deleteOldSegments() runs
+        // (since calculateRetentionSizeInPercent is only called internally via deleteOldSegments)
+
+        // Call deleteOldSegments - the finally block should always update the metric
+        log.deleteOldSegments();
+
+        // After deletion: 1 segment deleted, remaining = 2 segments = 10 records
+        // Percentage = (10 * 100) / 10 = 100%
+        assertEquals(100, yammerMetricValue(metricName),
+                "Metric must be updated via finally block after deleteOldSegments");
+        assertEquals(2, log.numberOfSegments(), "Should have 2 segments after deletion");
+
+        // Append more data to increase the percentage again
+        for (int i = 0; i < 10; i++) {
+            log.appendAsLeader(records.get(), 0);
+        }
+        log.updateHighWatermark(log.logEndOffset());
+
+        // Before second deleteOldSegments call, metric should still show old value (100)
+        // because we haven't called deleteOldSegments yet
+        assertEquals(100, yammerMetricValue(metricName));
+
+        // Call deleteOldSegments again - finally block should update metric with new value
+        log.deleteOldSegments();
+
+        // After second deletion, verify metric is updated
+        // The metric value depends on how many segments were deleted
+        int updatedMetricValue = (Integer) yammerMetricValue(metricName);
+        assertTrue(updatedMetricValue > 0,
+                "Metric should be recalculated in finally block on every deleteOldSegments call");
     }
 
     @SuppressWarnings("unchecked")

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -56,6 +56,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -845,11 +847,11 @@ public class UnifiedLogTest {
 
     /**
      * Test that verifies the RetentionSizeInPercent metric is always updated in the finally block
-     * of deleteOldSegments(). This ensures the metric is calculated even when log deletion
-     * encounters errors. The finally block guarantees metric updates regardless of success or failure.
+     * of deleteOldSegments(), even when an exception is thrown during deletion.
+     * This ensures the metric is calculated even when log deletion encounters errors.
      */
     @Test
-    public void testRetentionSizeInPercentMetricAlwaysUpdatedInFinallyBlock() throws IOException {
+    public void testRetentionSizeInPercentMetricUpdatedOnDeletionError() throws IOException {
         Supplier<MemoryRecords> records = () -> singletonRecords("test".getBytes());
         int recordSize = records.get().sizeInBytes();
 
@@ -867,44 +869,37 @@ public class UnifiedLogTest {
         for (int i = 0; i < 15; i++) {
             log.appendAsLeader(records.get(), 0);
         }
-        assertEquals(3, log.numberOfSegments(), "Should have 3 segments before deletion");
+        assertEquals(3, log.numberOfSegments(), "Should have 3 segments");
 
         log.updateHighWatermark(log.logEndOffset());
 
-        // Before deleteOldSegments: Total size = 15 * recordSize, retention = 10 * recordSize
-        // Percentage = (15 * 100) / 10 = 150%
-        assertEquals(150, log.calculateRetentionSizeInPercent());
-
-        // Metric should not be exposed via JMX until deleteOldSegments() runs
-        // (since calculateRetentionSizeInPercent is only called internally via deleteOldSegments)
-
-        // Call deleteOldSegments - the finally block should always update the metric
+        // First call to initialize the metric normally
         log.deleteOldSegments();
+        assertEquals(100, yammerMetricValue(metricName), "Metric should be 100% after initial deletion");
 
-        // After deletion: 1 segment deleted, remaining = 2 segments = 10 records
-        // Percentage = (10 * 100) / 10 = 100%
-        assertEquals(100, yammerMetricValue(metricName),
-                "Metric must be updated via finally block after deleteOldSegments");
-        assertEquals(2, log.numberOfSegments(), "Should have 2 segments after deletion");
-
-        // Append more data to increase the percentage again
+        // Add more data to change the metric value
         for (int i = 0; i < 10; i++) {
             log.appendAsLeader(records.get(), 0);
         }
         log.updateHighWatermark(log.logEndOffset());
 
-        // Before second deleteOldSegments call, metric should still show old value (100)
-        // because we haven't called deleteOldSegments yet
-        assertEquals(100, yammerMetricValue(metricName));
+        // Create a spy and make config() throw on first call, but work normally on subsequent calls
+        // This simulates an error in the try block while allowing the finally block to succeed
+        // The config() method is called in both the try block and calculateRetentionSizeInPercent()
+        UnifiedLog spyLog = spy(log);
+        doThrow(new RuntimeException("Simulated error during deletion"))
+                .doCallRealMethod()  // Allow subsequent calls to work (for finally block)
+                .when(spyLog).config();
 
-        // Call deleteOldSegments again - finally block should update metric with new value
-        log.deleteOldSegments();
+        // Call deleteOldSegments on the spy - it should throw due to config() error
+        // But the finally block should still execute and update the metric
+        assertThrows(RuntimeException.class, spyLog::deleteOldSegments);
 
-        // After second deletion, verify metric is updated
-        // The metric value depends on how many segments were deleted
-        int updatedMetricValue = (Integer) yammerMetricValue(metricName);
-        assertTrue(updatedMetricValue > 0,
-                "Metric should be recalculated in finally block on every deleteOldSegments call");
+        // Verify the metric was still updated in the finally block despite the exception
+        // After adding 10 more records (2 more segments), total = 4 segments = 20 records
+        // Percentage = (20 * 100) / 10 = 200%
+        assertEquals(200, yammerMetricValue(metricName),
+                "Metric should be updated in finally block even when exception occurs");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Introduces `RetentionSizeInPercent` JMX metric for regular (non-tiered)
topics to express partition storage as a percentage of configured
retention limits. No existing metrics or behavior are changed.  This PR
is a follow-up to the tiered storage metrics implementation and
completes [KIP-1257: Partition Size Percentage Metrics for Storage
Monitoring](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1257%3A+Partition+Size+Percentage+Metrics+for+Storage+Monitoring).

JMX Metric
```
kafka.log:type=Log,name=RetentionSizeInPercent,topic=<topic>,partition=<partition>
```

Testing
- Parameterized tests covering tiered/non-tiered topic scenarios
- Tests for unlimited retention bytes configuration
- Tests verify metric values via Yammer/JMX gauges

Reviewers: Kamal Chandraprakash <kamal.chandraprakash@gmail.com>
