### PR TITLE
KAFKA-20157 Document KIP-1257 partition size percentage metrics

### DIFF
--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -990,6 +990,19 @@ The size of a partition on disk, measured in bytes.
 <tr>  
 <td>
 
+Partition size as a percentage of retention limit
+</td>  
+<td>
+
+kafka.log:type=Log,name=RetentionSizeInPercent,topic=([-.\w]+),partition=([0-9]+)
+</td>  
+<td>
+
+The partition size expressed as a percentage of the configured retention.bytes limit. Returns 0 for topics with tiered storage enabled (where the metric is reported by RemoteLogManager) or when retention is unlimited. May exceed 100% if retention cleanup is delayed.
+</td> </tr>  
+<tr>  
+<td>
+
 Number of log segments in a partition
 </td>  
 <td>
@@ -1832,6 +1845,32 @@ The time to read data from remote storage by a broker
 <td>
 
 kafka.log.remote:type=RemoteLogManager,name=RemoteLogReaderFetchRateAndTimeMs
+</td> </tr>  
+<tr>  
+<td>
+
+Retention Size In Percent
+</td>  
+<td>
+
+Total partition size (local + remote) as a percentage of the configured retention.bytes limit. Available for tiered storage topics. May exceed 100% if retention cleanup is delayed. Returns 0 when retention is unlimited.
+</td>  
+<td>
+
+kafka.log.remote:type=RemoteLogManager,name=RetentionSizeInPercent,topic=([-.\w]+),partition=([0-9]+)
+</td> </tr>  
+<tr>  
+<td>
+
+Local Retention Size In Percent
+</td>  
+<td>
+
+Local log size as a percentage of the configured local.retention.bytes limit. Available for tiered storage topics. Helps operators monitor pressure on local disks independently of remote storage. May exceed 100% if retention cleanup is delayed. Returns 0 when local retention is unlimited.
+</td>  
+<td>
+
+kafka.log.remote:type=RemoteLogManager,name=LocalRetentionSizeInPercent,topic=([-.\w]+),partition=([0-9]+)
 </td> </tr>  
 <tr>  
 <td>

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -990,7 +990,7 @@ The size of a partition on disk, measured in bytes.
 <tr>  
 <td>
 
-Partition size as a percentage of retention limit
+Partition size as a percentage of retention bytes limit
 </td>  
 <td>
 
@@ -998,7 +998,7 @@ kafka.log:type=Log,name=RetentionSizeInPercent,topic=([-.\w]+),partition=([0-9]+
 </td>  
 <td>
 
-The partition size expressed as a percentage of the configured retention.bytes limit. Returns 0 for topics with tiered storage enabled (where the metric is reported by RemoteLogManager) or when retention is unlimited. May exceed 100% if retention cleanup is delayed.
+The partition size expressed as a percentage of the configured retention.bytes limit. Returns 0 for topics with tiered storage enabled (where the metric is reported by RemoteLogManager) or when retention bytes is unlimited. May exceed 100% if retention cleanup is delayed.
 </td> </tr>  
 <tr>  
 <td>
@@ -1853,7 +1853,7 @@ Retention Size In Percent
 </td>  
 <td>
 
-Total partition size (local + remote) as a percentage of the configured retention.bytes limit. Available for tiered storage topics. May exceed 100% if retention cleanup is delayed. Returns 0 when retention is unlimited.
+Total partition size (local + remote) as a percentage of the configured retention.bytes limit. Available for tiered storage topics. May exceed 100% if retention cleanup is delayed. Returns 0 when retention bytes is unlimited.
 </td>  
 <td>
 
@@ -1866,7 +1866,7 @@ Local Retention Size In Percent
 </td>  
 <td>
 
-Local log size as a percentage of the configured local.retention.bytes limit. Available for tiered storage topics. Helps operators monitor pressure on local disks independently of remote storage. May exceed 100% if retention cleanup is delayed. Returns 0 when local retention is unlimited.
+Local log size as a percentage of the configured local.retention.bytes limit. Available for tiered storage topics. Helps operators monitor pressure on local disks independently of remote storage. May exceed 100% if retention cleanup is delayed. Returns 0 when local retention bytes is unlimited.
 </td>  
 <td>
 


### PR DESCRIPTION
Adds documentation for the new RetentionSizeInPercent and
LocalRetentionSizeInPercent metrics introduced in
[KIP-1257](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1257%3A+Partition+Size+Percentage+Metrics+for+Storage+Monitoring).

This PR documents metrics added in:
- PR #21468 - Tiered storage metrics (RemoteLogManager)
- PR #21612 - Regular topic metrics (UnifiedLog)

Reviewers: Kamal Chandraprakash <kamal.chandraprakash@gmail.com>
