### PR TITLE
KAFKA-20239: Document Kafka ACLS required for Connect

### DIFF
--- a/docs/kafka-connect/user-guide.md
+++ b/docs/kafka-connect/user-guide.md
@@ -435,220 +435,6 @@ If a source connector supports exactly-once semantics, you must configure your C
 
 For new Connect clusters, set the `exactly.once.source.support` property to `enabled` in the worker config for each node in the cluster. For existing clusters, two rolling upgrades are necessary. During the first upgrade, the `exactly.once.source.support` property should be set to `preparing`, and during the second, it should be set to `enabled`.
 
-#### ACL requirements
-
-With exactly-once source support enabled, or with `exactly.once.source.support` set to `preparing`, the principal for each Connect worker will require the following ACLs:  
-  
-<table>  
-<tr>  
-<th>
-
-Operation
-</th>  
-<th>
-
-Resource Type
-</th>  
-<th>
-
-Resource Name
-</th>  
-<th>
-
-Note
-</th> </tr>  
-<tr>  
-<td>
-
-Write
-</td>  
-<td>
-
-TransactionalId
-</td>  
-<td>
-
-`connect-cluster-${groupId}`, where `${groupId}` is the `group.id` of the cluster
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-Describe
-</td>  
-<td>
-
-TransactionalId
-</td>  
-<td>
-
-`connect-cluster-${groupId}`, where `${groupId}` is the `group.id` of the cluster
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-IdempotentWrite
-</td>  
-<td>
-
-Cluster
-</td>  
-<td>
-
-ID of the Kafka cluster that hosts the worker's config topic
-</td>  
-<td>
-
-The IdempotentWrite ACL has been deprecated as of 2.8 and will only be necessary for Connect clusters running on pre-2.8 Kafka clusters
-</td> </tr> </table>
-
-And with exactly-once source enabled (but not if `exactly.once.source.support` is set to `preparing`), the principal for each individual connector will require the following ACLs:  
-  
-<table>  
-<tr>  
-<th>
-
-Operation
-</th>  
-<th>
-
-Resource Type
-</th>  
-<th>
-
-Resource Name
-</th>  
-<th>
-
-Note
-</th> </tr>  
-<tr>  
-<td>
-
-Write
-</td>  
-<td>
-
-TransactionalId
-</td>  
-<td>
-
-`${groupId}-${connector}-${taskId}`, for each task that the connector will create, where `${groupId}` is the `group.id` of the Connect cluster, `${connector}` is the name of the connector, and `${taskId}` is the ID of the task (starting from zero)
-</td>  
-<td>
-
-A wildcard prefix of `${groupId}-${connector}*` can be used for convenience if there is no risk of conflict with other transactional IDs or if conflicts are acceptable to the user.
-</td> </tr>  
-<tr>  
-<td>
-
-Describe
-</td>  
-<td>
-
-TransactionalId
-</td>  
-<td>
-
-`${groupId}-${connector}-${taskId}`, for each task that the connector will create, where `${groupId}` is the `group.id` of the Connect cluster, `${connector}` is the name of the connector, and `${taskId}` is the ID of the task (starting from zero)
-</td>  
-<td>
-
-A wildcard prefix of `${groupId}-${connector}*` can be used for convenience if there is no risk of conflict with other transactional IDs or if conflicts are acceptable to the user.
-</td> </tr>  
-<tr>  
-<td>
-
-Write
-</td>  
-<td>
-
-Topic
-</td>  
-<td>
-
-Offsets topic used by the connector, which is either the value of the `offsets.storage.topic` property in the connector’s configuration if provided, or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-Read
-</td>  
-<td>
-
-Topic
-</td>  
-<td>
-
-Offsets topic used by the connector, which is either the value of the `offsets.storage.topic` property in the connector’s configuration if provided, or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-Describe
-</td>  
-<td>
-
-Topic
-</td>  
-<td>
-
-Offsets topic used by the connector, which is either the value of the `offsets.storage.topic` property in the connector’s configuration if provided, or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
-</td>  
-<td>
-
-
-</td> </tr>  
-<tr>  
-<td>
-
-Create
-</td>  
-<td>
-
-Topic
-</td>  
-<td>
-
-Offsets topic used by the connector, which is either the value of the `offsets.storage.topic` property in the connector’s configuration if provided, or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
-</td>  
-<td>
-
-Only necessary if the offsets topic for the connector does not exist yet
-</td> </tr>  
-<tr>  
-<td>
-
-IdempotentWrite
-</td>  
-<td>
-
-Cluster
-</td>  
-<td>
-
-ID of the Kafka cluster that the source connector writes to
-</td>  
-<td>
-
-The IdempotentWrite ACL has been deprecated as of 2.8 and will only be necessary for Connect clusters running on pre-2.8 Kafka clusters
-</td> </tr> </table>
-
 ## Plugin Discovery
 
 Plugin discovery is the name for the strategy which the Connect worker uses to find plugin classes and make them accessible to configure and run in connectors. This is controlled by the plugin.discovery worker configuration, and has a significant impact on worker startup time. `service_load` is the fastest strategy, but care should be taken to verify that plugins are compatible before setting this configuration to `service_load`.
@@ -765,6 +551,22 @@ The principal for each Connect worker requires the following ACLs:
 
 `status.storage.topic` of the Connect cluster
 </td><td>Only necessary if the status topic for Connect does not exist yet</td></tr>
+<tr><td>Write</td><td>TransactionalId</td><td>
+
+`connect-cluster-${groupId}`, where `${groupId}` is the `group.id` of the cluster
+</td><td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled
+or if `exactly.once.source.support` is set to `preparing`.
+</td> </tr>
+<tr><td>Describe</td><td>TransactionalId</td><td>
+
+`connect-cluster-${groupId}`, where `${groupId}` is the `group.id` of the cluster
+</td><td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled
+or if `exactly.once.source.support` is set to `preparing`.
+</td> </tr>
 </table>
 
 To support Source connectors, the principal for each individual connector will require the following ACLs:
@@ -780,6 +582,33 @@ To support Source connectors, the principal for each individual connector will r
 <tr><td>Create</td><td>Topic</td><td>topic(s) used as the destination</td><td>
 
 Only necessary if `topic.creation.enable` is `true` and the topic(s) do not exist yet
+</td></tr>
+<tr><td>Describe</td><td>Topic</td>
+<td>
+
+Offsets topic used by the connector, which is either the value of the `offsets.storage.topic` property in the connector’s configuration if provided,
+or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
+</td>
+<td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled.
+</td> </tr>
+<tr><td>Write</td><td>TransactionalId</td><td>
+
+`${groupId}-${connector}-${taskId}`, for each task that the connector will create, where `${groupId}` is the `group.id` of the Connect cluster, `${connector}` is the name of the connector, and `${taskId}` is the ID of the task (starting from zero)
+</td><td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled.
+A wildcard prefix of `${groupId}-${connector}*` can be used for convenience if there is no risk of conflict with other transactional IDs or if conflicts are acceptable to the user.
+</td></tr>
+<tr><td>Describe</td><td>TransactionalId</td><td>
+
+`${groupId}-${connector}-${taskId}`, for each task that the connector will create, where `${groupId}` is the `group.id` of the Connect cluster, `${connector}` is the name of the connector, and `${taskId}` is the ID of the task (starting from zero)
+</td>
+<td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled.
+A wildcard prefix of `${groupId}-${connector}*` can be used for convenience if there is no risk of conflict with other transactional IDs or if conflicts are acceptable to the user.
 </td></tr>
 </table>
 
@@ -812,5 +641,3 @@ Only necessary if `errors.deadletterqueue.topic.name` is set to a non-empty valu
 </table>
 
 Some connectors make additional use of Kafka topics that is not managed by the Kafka Connect framework (for example, change data capture connectors may use additional topics to store schema history). Refer to Connector documentation for details of any additional ACLs that are required. These can be added to the principal for the individual connector.
-
-Additional ACLs are required if exactly-once support is enabled. These are detailed in [Exactly-once support](#exactly-once-support).

--- a/docs/kafka-connect/user-guide.md
+++ b/docs/kafka-connect/user-guide.md
@@ -713,3 +713,104 @@ You should then verify that your manifests are correct by using the verification
 ## Security
 
 It's important to understand the security concerns inherent to Connect. First, Connect allows running custom plugins. These plugins can run arbitrary code, so you must trust them before installing them in your Connect clusters. By default, the REST API is unsecured and allows anyone that can access it to start and stop connectors. You should only directly expose the REST API to trusted users, otherwise it's easy to gain arbitrary code execution on Connect workers. By default, connectors can also override the configurations of the Kafka clients that Connect uses internally. Since Kafka 4.2.0, it's recommended to set `connector.client.config.override.policy` to `Allowlist`, this will be the default from Kafka 5.0.0, and explicitly only allow configurations that you need to override. Keep in mind that configurations that can load classes such as `sasl.jaas.config` or `sasl.login.class` should only be allowed if only trusted users can access the REST API as they, by design, enable executing code on the Connect worker.
+
+### ACL requirements
+
+The principal for each Connect worker requires the following ACLs:
+
+<table>
+<tr>
+<th>Operation</th>
+<th>Resource Type</th>
+<th>Resource Name</th>
+<th>Note</th>
+</tr>
+<tr><td>Read</td><td>Group</td><td>
+
+`group.id` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Read</td><td>Topic</td><td>
+
+`config.storage.topic` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Write</td><td>Topic</td><td>
+
+`config.storage.topic` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Create</td><td>Topic</td><td>
+
+`config.storage.topic` of the Connect cluster
+</td><td>Only necessary if the config topic for Connect does not exist yet</td></tr>
+<tr><td>Read</td><td>Topic</td><td>
+
+`offset.storage.topic` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Write</td><td>Topic</td><td>
+
+`offset.storage.topic` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Create</td><td>Topic</td><td>
+
+`offset.storage.topic` of the Connect cluster
+</td><td>Only necessary if the offsets topic for Connect does not exist yet</td></tr>
+<tr><td>Read</td><td>Topic</td><td>
+
+`status.storage.topic` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Write</td><td>Topic</td><td>
+
+`status.storage.topic` of the Connect cluster
+</td><td> </td></tr>
+<tr><td>Create</td><td>Topic</td><td>
+
+`status.storage.topic` of the Connect cluster
+</td><td>Only necessary if the status topic for Connect does not exist yet</td></tr>
+</table>
+
+To support Source connectors, the principal for each individual connector will require the following ACLs:
+
+<table>
+<tr>
+<th>Operation</th>
+<th>Resource Type</th>
+<th>Resource Name</th>
+<th>Note</th>
+</tr>
+<tr><td>Write</td><td>Topic</td><td>topic(s) used as the destination</td><td> </td></tr>
+<tr><td>Create</td><td>Topic</td><td>topic(s) used as the destination</td><td>
+
+Only necessary if `topic.creation.enable` is `true` and the topic(s) do not exist yet
+</td></tr>
+</table>
+
+To support Sink connectors, the principal for each individual connector will require the following ACLs:
+
+<table>
+<tr>
+<th>Operation</th>
+<th>Resource Type</th>
+<th>Resource Name</th>
+<th>Note</th>
+</tr>
+<tr><td>Read</td><td>Group</td><td>
+
+`connect-${connector}` where `${connector}` is the name of the connector,
+or the value of `consumer.group.id` if present in the Connect configuration,
+or the value of `consumer.overrides.group.id` if present in the Connector configuration
+</td><td> </td></tr>
+<tr><td>Read</td><td>Topic</td><td>sink topic(s) that the connector will consume from</td><td>
+
+These will be identified by the `topics` or `topics.regex` option of the connector
+</td></tr>
+<tr><td>Write</td><td>Topic</td><td>
+
+`errors.deadletterqueue.topic.name` of the connector
+</td><td>
+
+Only necessary if `errors.deadletterqueue.topic.name` is set to a non-empty value
+</td></tr>
+</table>
+
+Some connectors make additional use of Kafka topics that is not managed by the Kafka Connect framework (for example, change data capture connectors may use additional topics to store schema history). Refer to Connector documentation for details of any additional ACLs that are required. These can be added to the principal for the individual connector.
+
+Additional ACLs are required if exactly-once support is enabled. These are detailed in [Exactly-once support](#exactly-once-support).

--- a/docs/kafka-connect/user-guide.md
+++ b/docs/kafka-connect/user-guide.md
@@ -425,7 +425,7 @@ Kafka Connect is capable of providing exactly-once semantics for sink connectors
 
 ### Sink connectors
 
-If a sink connector supports exactly-once semantics, to enable exactly-once at the Connect worker level, you must ensure its consumer group is configured to ignore records in aborted transactions. You can do this by setting the worker property `consumer.isolation.level` to `read_committed` or, if running a version of Kafka Connect that supports it, using a connector client config override policy that allows the `consumer.override.isolation.level` property to be set to `read_committed` in individual connector configs. There are no additional ACL requirements.
+If a sink connector supports exactly-once semantics, to enable exactly-once at the Connect worker level, you must ensure its consumer group is configured to ignore records in aborted transactions. You can do this by setting the worker property `consumer.isolation.level` to `read_committed` or, if running a version of Kafka Connect that supports it, using a connector client config override policy that allows the `consumer.override.isolation.level` property to be set to `read_committed` in individual connector configs.
 
 ### Source connectors
 
@@ -553,7 +553,9 @@ The principal for each Connect worker requires the following ACLs:
 </td><td>Only necessary if the status topic for Connect does not exist yet</td></tr>
 <tr><td>Write</td><td>TransactionalId</td><td>
 
-`connect-cluster-${groupId}`, where `${groupId}` is the `group.id` of the cluster
+`connect-cluster-${groupId}`
+
+where `${groupId}` is the `group.id` of the cluster
 </td><td>
 
 Only necessary if [exactly-once support](#exactly-once-support) is enabled
@@ -561,11 +563,20 @@ or if `exactly.once.source.support` is set to `preparing`.
 </td> </tr>
 <tr><td>Describe</td><td>TransactionalId</td><td>
 
-`connect-cluster-${groupId}`, where `${groupId}` is the `group.id` of the cluster
+`connect-cluster-${groupId}`
+
+where `${groupId}` is the `group.id` of the cluster
 </td><td>
 
 Only necessary if [exactly-once support](#exactly-once-support) is enabled
 or if `exactly.once.source.support` is set to `preparing`.
+</td> </tr>
+<tr><td>IdempotentWrite</td><td>Cluster</td><td>ID of the Kafka cluster that hosts the worker's config topic</td>  <td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled
+or if `exactly.once.source.support` is set to `preparing`.
+
+The IdempotentWrite ACL has been deprecated as of 2.8 and will only be necessary for Connect clusters running on pre-2.8 Kafka clusters
 </td> </tr>
 </table>
 
@@ -586,7 +597,10 @@ Only necessary if `topic.creation.enable` is `true` and the topic(s) do not exis
 <tr><td>Describe</td><td>Topic</td>
 <td>
 
-Offsets topic used by the connector, which is either the value of the `offsets.storage.topic` property in the connector’s configuration if provided,
+Offsets topic used by the connector
+
+This is the value of the `offsets.storage.topic` property in the connector’s configuration if provided,
+
 or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
 </td>
 <td>
@@ -595,21 +609,45 @@ Only necessary if [exactly-once support](#exactly-once-support) is enabled.
 </td> </tr>
 <tr><td>Write</td><td>TransactionalId</td><td>
 
-`${groupId}-${connector}-${taskId}`, for each task that the connector will create, where `${groupId}` is the `group.id` of the Connect cluster, `${connector}` is the name of the connector, and `${taskId}` is the ID of the task (starting from zero)
+`${groupId}-${connector}-${taskId}`
+
+for each task that the connector will create, where
+
+`${groupId}` is the `group.id` of the Connect cluster
+
+`${connector}` is the name of the connector
+
+`${taskId}` is the ID of the task (starting from zero)
 </td><td>
 
 Only necessary if [exactly-once support](#exactly-once-support) is enabled.
+
 A wildcard prefix of `${groupId}-${connector}*` can be used for convenience if there is no risk of conflict with other transactional IDs or if conflicts are acceptable to the user.
 </td></tr>
 <tr><td>Describe</td><td>TransactionalId</td><td>
 
-`${groupId}-${connector}-${taskId}`, for each task that the connector will create, where `${groupId}` is the `group.id` of the Connect cluster, `${connector}` is the name of the connector, and `${taskId}` is the ID of the task (starting from zero)
+`${groupId}-${connector}-${taskId}`
+
+for each task that the connector will create, where
+
+`${groupId}` is the `group.id` of the Connect cluster
+
+`${connector}` is the name of the connector
+
+`${taskId}` is the ID of the task (starting from zero)
 </td>
 <td>
 
 Only necessary if [exactly-once support](#exactly-once-support) is enabled.
+
 A wildcard prefix of `${groupId}-${connector}*` can be used for convenience if there is no risk of conflict with other transactional IDs or if conflicts are acceptable to the user.
 </td></tr>
+<tr><td>IdempotentWrite</td><td>Cluster</td><td>ID of the Kafka cluster that hosts the worker's config topic</td>  <td>
+
+Only necessary if [exactly-once support](#exactly-once-support) is enabled.
+
+The IdempotentWrite ACL has been deprecated as of 2.8 and will only be necessary for Connect clusters running on pre-2.8 Kafka clusters
+</td> </tr>
 </table>
 
 To support Sink connectors, the principal for each individual connector will require the following ACLs:
@@ -623,8 +661,14 @@ To support Sink connectors, the principal for each individual connector will req
 </tr>
 <tr><td>Read</td><td>Group</td><td>
 
-`connect-${connector}` where `${connector}` is the name of the connector,
+`connect-${connector}`
+
+where `${connector}` is
+
+the name of the connector
+
 or the value of `consumer.group.id` if present in the Connect configuration,
+
 or the value of `consumer.overrides.group.id` if present in the Connector configuration
 </td><td> </td></tr>
 <tr><td>Read</td><td>Topic</td><td>sink topic(s) that the connector will consume from</td><td>


### PR DESCRIPTION
Adding a list of permissions needed by Connect

I've tried to copy the style and wording in the ACL requirements table
already there for Exactly-once support.

https: //issues.apache.org/jira/browse/KAFKA-20239

Reviewers: Andrew Schofield <aschofield@confluent.io>
