### PR TITLE
KAFKA-20211: Add group coordinator background metrics

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutor.java
@@ -51,7 +51,7 @@ public class CoordinatorBackgroundThreadPoolExecutor extends ThreadPoolExecutor 
             0L,
             TimeUnit.MILLISECONDS,
             new LinkedBlockingQueue<>(),
-            ThreadUtils.createThreadFactory(threadPrefix + "%d", false)
+            ThreadUtils.createThreadFactory(Objects.requireNonNull(threadPrefix) + "%d", false)
         );
         this.time = Objects.requireNonNull(time);
         this.metrics = Objects.requireNonNull(metrics);

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutor.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutor.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.common.runtime;
+
+import org.apache.kafka.common.utils.ThreadUtils;
+import org.apache.kafka.common.utils.Time;
+
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link ThreadPoolExecutor} that reports metrics.
+ */
+public class CoordinatorBackgroundThreadPoolExecutor extends ThreadPoolExecutor {
+
+    /**
+     * The time.
+     */
+    private final Time time;
+
+    /**
+     * The coordinator runtime metrics.
+     */
+    private final CoordinatorRuntimeMetrics metrics;
+
+    public CoordinatorBackgroundThreadPoolExecutor(
+        String threadPrefix,
+        int numThreads,
+        Time time,
+        CoordinatorRuntimeMetrics metrics
+    ) {
+        super(
+            numThreads,
+            numThreads,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(),
+            ThreadUtils.createThreadFactory(threadPrefix + "%d", false)
+        );
+        this.time = Objects.requireNonNull(time);
+        this.metrics = Objects.requireNonNull(metrics);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        var queuedTimeMs = time.milliseconds();
+
+        super.execute(() -> {
+            var dequeuedTimeMs = time.milliseconds();
+            metrics.recordBackgroundQueueTime(dequeuedTimeMs - queuedTimeMs);
+
+            try {
+                command.run();
+            } finally {
+                long processingTimeMs = time.milliseconds() - dequeuedTimeMs;
+                metrics.recordBackgroundProcessingTime(processingTimeMs);
+                metrics.recordBackgroundThreadBusyTime((double) processingTimeMs / getCorePoolSize());
+            }
+        });
+    }
+}

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetrics.java
@@ -81,6 +81,26 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void recordThreadIdleTime(double idleTimeMs);
 
     /**
+     * Update the background queue time.
+     *
+     * @param durationMs The queue time.
+     */
+    void recordBackgroundQueueTime(long durationMs);
+
+    /**
+     * Update the background processing time.
+     *
+     * @param durationMs The background processing time.
+     */
+    void recordBackgroundProcessingTime(long durationMs);
+
+    /**
+     * Record the background thread busy time.
+     * @param busyTimeMs The busy time in milliseconds.
+     */
+    void recordBackgroundThreadBusyTime(double busyTimeMs);
+
+    /**
      * Register the event queue size gauge.
      *
      * @param sizeSupplier The size supplier.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.common.runtime;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
@@ -78,6 +79,16 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
      * The buffer cache discard count metric name.
      */
     public static final String BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME = "batch-buffer-cache-discard-count";
+
+    /**
+     * The background queue time metric name.
+     */
+    public static final String BACKGROUND_QUEUE_TIME_METRIC_NAME = "background-queue-time-ms";
+
+    /**
+     * The background processing time metric name.
+     */
+    public static final String BACKGROUND_PROCESSING_TIME_METRIC_NAME = "background-processing-time-ms";
 
     /**
      * Metric to count the number of partitions in Loading state.
@@ -153,7 +164,22 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
      */
     private final Sensor flushSensor;
 
-    public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup) {
+    /**
+     * The background thread busy sensor. Null when background metrics are not enabled.
+     */
+    private final Sensor backgroundThreadBusySensor;
+
+    /**
+     * The background queue time sensor. Null when background metrics are not enabled.
+     */
+    private final Sensor backgroundQueueTimeSensor;
+
+    /**
+     * The background processing time sensor. Null when background metrics are not enabled.
+     */
+    private final Sensor backgroundProcessingTimeSensor;
+
+    public CoordinatorRuntimeMetricsImpl(Metrics metrics, String metricsGroup, boolean enableBackgroundMetrics) {
         this.metrics = Objects.requireNonNull(metrics);
         this.metricsGroup = Objects.requireNonNull(metricsGroup);
 
@@ -265,6 +291,44 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
                 this.metricsGroup,
                 "The flushes per second."),
             new Rate(TimeUnit.SECONDS, new WindowedCount()));
+
+        if (enableBackgroundMetrics) {
+            this.backgroundThreadBusySensor = metrics.sensor(this.metricsGroup + "-BackgroundThreadBusyRatio");
+            this.backgroundThreadBusySensor.add(
+                metrics.metricName(
+                    "background-thread-idle-ratio-avg",
+                    this.metricsGroup,
+                    "The fraction of time the background threads are idle. This is an average across " +
+                        "all coordinator background threads."),
+                new Rate(TimeUnit.MILLISECONDS) {
+                    @Override
+                    public double measure(MetricConfig config, long now) {
+                        return 1.0 - super.measure(config, now);
+                    }
+                });
+
+            KafkaMetricHistogram backgroundQueueTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
+                suffix -> kafkaMetricName(
+                    BACKGROUND_QUEUE_TIME_METRIC_NAME + "-" + suffix,
+                    "The " + suffix + " background queue time in milliseconds"
+                )
+            );
+            this.backgroundQueueTimeSensor = metrics.sensor(this.metricsGroup + "-BackgroundQueueTime");
+            this.backgroundQueueTimeSensor.add(backgroundQueueTimeHistogram);
+
+            KafkaMetricHistogram backgroundProcessingTimeHistogram = KafkaMetricHistogram.newLatencyHistogram(
+                suffix -> kafkaMetricName(
+                    BACKGROUND_PROCESSING_TIME_METRIC_NAME + "-" + suffix,
+                    "The " + suffix + " background processing time in milliseconds"
+                )
+            );
+            this.backgroundProcessingTimeSensor = metrics.sensor(this.metricsGroup + "-BackgroundProcessingTime");
+            this.backgroundProcessingTimeSensor.add(backgroundProcessingTimeHistogram);
+        } else {
+            this.backgroundThreadBusySensor = null;
+            this.backgroundQueueTimeSensor = null;
+            this.backgroundProcessingTimeSensor = null;
+        }
     }
 
     /**
@@ -298,6 +362,15 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
         metrics.removeSensor(eventPurgatoryTimeSensor.name());
         metrics.removeSensor(lingerTimeSensor.name());
         metrics.removeSensor(flushSensor.name());
+        if (backgroundThreadBusySensor != null) {
+            metrics.removeSensor(backgroundThreadBusySensor.name());
+        }
+        if (backgroundQueueTimeSensor != null) {
+            metrics.removeSensor(backgroundQueueTimeSensor.name());
+        }
+        if (backgroundProcessingTimeSensor != null) {
+            metrics.removeSensor(backgroundProcessingTimeSensor.name());
+        }
     }
 
     /**
@@ -370,6 +443,27 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
     @Override
     public void recordThreadIdleTime(double idleTimeMs) {
         threadIdleSensor.record(idleTimeMs);
+    }
+
+    @Override
+    public void recordBackgroundThreadBusyTime(double busyTimeMs) {
+        if (backgroundThreadBusySensor != null) {
+            backgroundThreadBusySensor.record(busyTimeMs);
+        }
+    }
+
+    @Override
+    public void recordBackgroundQueueTime(long durationMs) {
+        if (backgroundQueueTimeSensor != null) {
+            backgroundQueueTimeSensor.record(durationMs);
+        }
+    }
+
+    @Override
+    public void recordBackgroundProcessingTime(long durationMs) {
+        if (backgroundProcessingTimeSensor != null) {
+            backgroundProcessingTimeSensor.record(durationMs);
+        }
     }
 
     @Override

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutorTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.common.runtime;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CoordinatorBackgroundThreadPoolExecutorTest {
+
+    @Test
+    public void testMetrics() throws ExecutionException, InterruptedException, TimeoutException {
+        CoordinatorRuntimeMetrics metrics = mock(CoordinatorRuntimeMetrics.class);
+        Time mockTime = new MockTime();
+        CoordinatorBackgroundThreadPoolExecutor threadPoolExecutor = new CoordinatorBackgroundThreadPoolExecutor(
+            "threaad-pool-",
+            2,
+            mockTime,
+            metrics
+        );
+
+        try {
+            CountDownLatch task1Started = new CountDownLatch(1);
+            CountDownLatch task2Started = new CountDownLatch(1);
+            CountDownLatch task3Started = new CountDownLatch(1);
+            CountDownLatch task1Unblocked = new CountDownLatch(1);
+            CountDownLatch task2Unblocked = new CountDownLatch(1);
+            CountDownLatch task3Unblocked = new CountDownLatch(1);
+
+            Future<?> task1 = threadPoolExecutor.submit(() -> {
+                task1Started.countDown();
+                try {
+                    task1Unblocked.await();
+                } catch (InterruptedException e) { }
+            });
+            Future<?> task2 = threadPoolExecutor.submit(() -> {
+                task2Started.countDown();
+                try {
+                    task2Unblocked.await();
+                } catch (InterruptedException e) { }
+            });
+            Future<?> task3 = threadPoolExecutor.submit(() -> {
+                task3Started.countDown();
+                try {
+                    task3Unblocked.await();
+                } catch (InterruptedException e) { }
+            });
+
+            // Task 1 and task 2 start.
+            task1Started.await();
+            task2Started.await();
+
+            // Task 1 takes 100 ms.
+            mockTime.sleep(100);
+            task1Unblocked.countDown();
+            task1.get(5, TimeUnit.SECONDS);
+
+            // Task 3 starts.
+            task3Started.await();
+
+            // Task 2 takes 500 ms.
+            mockTime.sleep(400);
+            task2Unblocked.countDown();
+            task2.get(5, TimeUnit.SECONDS);
+
+            // Task 3 takes 500 ms.
+            mockTime.sleep(100);
+            task3Unblocked.countDown();
+            task3.get(5, TimeUnit.SECONDS);
+
+            verify(metrics, times(2)).recordBackgroundQueueTime(0);
+            verify(metrics, times(1)).recordBackgroundQueueTime(100);
+            verify(metrics, times(1)).recordBackgroundProcessingTime(100);
+            verify(metrics, times(2)).recordBackgroundProcessingTime(500);
+            verify(metrics, times(1)).recordBackgroundThreadBusyTime(50.0);
+            verify(metrics, times(2)).recordBackgroundThreadBusyTime(250.0);
+        } finally {
+            threadPoolExecutor.shutdown();
+            threadPoolExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImplTest.java
@@ -33,6 +33,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BACKGROUND_PROCESSING_TIME_METRIC_NAME;
+import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BACKGROUND_QUEUE_TIME_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_BUFFER_CACHE_SIZE_METRIC_NAME;
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorRuntimeMetricsImpl.BATCH_FLUSH_TIME_METRIC_NAME;
@@ -96,21 +98,66 @@ public class CoordinatorRuntimeMetricsImplTest {
         );
     }
 
+    private static Set<MetricName> expectedBackgroundMetricNames(Metrics metrics) {
+        return Set.of(
+            kafkaMetricName(metrics, "background-thread-idle-ratio-avg"),
+            kafkaMetricName(metrics, "background-queue-time-ms-max"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p50"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p95"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p99"),
+            kafkaMetricName(metrics, "background-queue-time-ms-p999"),
+            kafkaMetricName(metrics, "background-processing-time-ms-max"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p50"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p95"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p99"),
+            kafkaMetricName(metrics, "background-processing-time-ms-p999")
+        );
+    }
+
     @Test
-    public void testMetricNames() {
+    public void testMetricNamesWithoutBackgroundMetrics() {
         Metrics metrics = new Metrics();
 
         Set<MetricName> expectedMetrics = expectedMetricNames(metrics);
+        Set<MetricName> backgroundMetrics = expectedBackgroundMetricNames(metrics);
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, false)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
             expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            backgroundMetrics.forEach(metricName -> assertFalse(
+                metrics.metrics().containsKey(metricName),
+                "metrics should not contain background metricName: " + metricName + " when background metrics are disabled."
+            ));
         }
 
         expectedMetrics.forEach(metricName -> assertFalse(
             metrics.metrics().containsKey(metricName),
             "metrics did not expect to contain metricName: " + metricName + " after closing."
+        ));
+    }
+
+    @Test
+    public void testMetricNamesWithBackgroundMetrics() {
+        Metrics metrics = new Metrics();
+
+        Set<MetricName> expectedMetrics = expectedMetricNames(metrics);
+        Set<MetricName> backgroundMetrics = expectedBackgroundMetricNames(metrics);
+
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
+            runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
+            runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
+            expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            backgroundMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+        }
+
+        expectedMetrics.forEach(metricName -> assertFalse(
+            metrics.metrics().containsKey(metricName),
+            "metrics did not expect to contain metricName: " + metricName + " after closing."
+        ));
+        backgroundMetrics.forEach(metricName -> assertFalse(
+            metrics.metrics().containsKey(metricName),
+            "metrics did not expect to contain background metricName: " + metricName + " after closing."
         ));
     }
 
@@ -121,7 +168,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         // Create first CoordinatorRuntimeMetricsImpl instance and capture sensor and metric names.
         Set<String> sensorNames;
         Set<MetricName> metricNames;
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
 
@@ -135,6 +182,7 @@ public class CoordinatorRuntimeMetricsImplTest {
 
             // Check that all gauges were registered.
             expectedMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+            expectedBackgroundMetricNames(metrics).forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
         }
 
         clearInvocations(metrics);
@@ -142,7 +190,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         // Create second CoordinatorRuntimeMetricsImpl instance and capture sensor and metric names.
         Set<String> otherSensorNames;
         Set<MetricName> otherMetricNames;
-        try (CoordinatorRuntimeMetricsImpl otherRuntimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, OTHER_METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl otherRuntimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, OTHER_METRICS_GROUP, true)) {
             otherRuntimeMetrics.registerEventQueueSizeGauge(() -> 0);
             otherRuntimeMetrics.registerBufferCacheSizeGauge(() -> 0L);
 
@@ -176,7 +224,7 @@ public class CoordinatorRuntimeMetricsImplTest {
     public void testUpdateNumPartitionsMetrics() {
         Metrics metrics = new Metrics();
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             IntStream.range(0, 10)
                 .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.INITIAL, CoordinatorState.LOADING));
             IntStream.range(0, 8)
@@ -197,7 +245,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             long startTimeMs = time.milliseconds();
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 1000);
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 2000);
@@ -219,7 +267,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
         IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordThreadIdleTime((i + 1) * 1000.0));
 
         org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "thread-idle-ratio-avg");
@@ -229,11 +277,24 @@ public class CoordinatorRuntimeMetricsImplTest {
 
 
     @Test
+    public void testBackgroundThreadIdleSensor() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
+        IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordBackgroundThreadBusyTime((i + 1) * 1000.0));
+
+        org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "background-thread-idle-ratio-avg");
+        KafkaMetric metric = metrics.metrics().get(metricName);
+        assertEquals(1 - 6 / 30.0, metric.metricValue()); // '1 - busy_ms / window_ms'
+    }
+
+    @Test
     public void testEventQueueSize() {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 5);
             assertMetricGauge(metrics, kafkaMetricName(metrics, "event-queue-size"), 5);
         }
@@ -243,7 +304,7 @@ public class CoordinatorRuntimeMetricsImplTest {
     public void testBatchBufferCacheSize() {
         Metrics metrics = new Metrics();
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.registerBufferCacheSizeGauge(() -> 5L);
             assertMetricGauge(metrics, kafkaMetricName(metrics, BATCH_BUFFER_CACHE_SIZE_METRIC_NAME), 5);
         }
@@ -253,7 +314,7 @@ public class CoordinatorRuntimeMetricsImplTest {
     public void testBatchBufferCacheDiscardCount() {
         Metrics metrics = new Metrics();
 
-        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP)) {
+        try (CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true)) {
             runtimeMetrics.recordBufferCacheDiscarded();
             assertMetricGauge(metrics, kafkaMetricName(metrics, BATCH_BUFFER_CACHE_DISCARD_COUNT_METRIC_NAME), 1);
         }
@@ -265,13 +326,15 @@ public class CoordinatorRuntimeMetricsImplTest {
         EVENT_PROCESSING_TIME_METRIC_NAME,
         EVENT_PURGATORY_TIME_METRIC_NAME,
         BATCH_LINGER_TIME_METRIC_NAME,
-        BATCH_FLUSH_TIME_METRIC_NAME
+        BATCH_FLUSH_TIME_METRIC_NAME,
+        BACKGROUND_QUEUE_TIME_METRIC_NAME,
+        BACKGROUND_PROCESSING_TIME_METRIC_NAME
     })
     public void testHistogramMetrics(String metricNamePrefix) {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
 
         IntStream.range(1, 1001).forEach(i -> {
             switch (metricNamePrefix) {
@@ -289,6 +352,13 @@ public class CoordinatorRuntimeMetricsImplTest {
                     break;
                 case BATCH_FLUSH_TIME_METRIC_NAME:
                     runtimeMetrics.recordFlushTime(i);
+                    break;
+                case BACKGROUND_QUEUE_TIME_METRIC_NAME:
+                    runtimeMetrics.recordBackgroundQueueTime(i);
+                    break;
+                case BACKGROUND_PROCESSING_TIME_METRIC_NAME:
+                    runtimeMetrics.recordBackgroundProcessingTime(i);
+                    break;
             }
         });
 
@@ -319,7 +389,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
 
         IntStream.range(1, 1001).forEach(__ -> runtimeMetrics.recordEventPurgatoryTime(MAX_LATENCY_MS + 1000L));
 
@@ -340,7 +410,7 @@ public class CoordinatorRuntimeMetricsImplTest {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
 
-        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP);
+        CoordinatorRuntimeMetricsImpl runtimeMetrics = new CoordinatorRuntimeMetricsImpl(metrics, METRICS_GROUP, true);
         IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordFlushTime((i + 1) * 1000));
 
         org.apache.kafka.common.MetricName metricName = kafkaMetricName(metrics, "batch-flush-rate");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -140,6 +140,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
@@ -260,6 +261,13 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 coordinatorRuntimeMetrics
             );
 
+            ExecutorService executorService = new CoordinatorBackgroundThreadPoolExecutor(
+                "group-coordinator-background-",
+                config.numBackgroundThreads(),
+                time,
+                coordinatorRuntimeMetrics
+            );
+
             CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime =
                 new CoordinatorRuntime.Builder<GroupCoordinatorShard, CoordinatorRecord>()
                     .withTime(time)
@@ -276,14 +284,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withSerializer(new GroupCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.offsetTopicCompressionType()).build())
                     .withAppendLingerMs(config.appendLingerMs())
-                    .withExecutorService(
-                        new CoordinatorBackgroundThreadPoolExecutor(
-                            "group-coordinator-background-",
-                            config.numBackgroundThreads(),
-                            time,
-                            coordinatorRuntimeMetrics
-                        )
-                    )
+                    .withExecutorService(executorService)
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -81,9 +81,9 @@ import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorBackgroundThreadPoolExecutor;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorLoader;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
@@ -140,7 +140,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
@@ -277,10 +276,14 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withSerializer(new GroupCoordinatorRecordSerde())
                     .withCompression(Compression.of(config.offsetTopicCompressionType()).build())
                     .withAppendLingerMs(config.appendLingerMs())
-                    .withExecutorService(Executors.newFixedThreadPool(
-                        config.numBackgroundThreads(),
-                        ThreadUtils.createThreadFactory("group-coordinator-background-%d", false)
-                    ))
+                    .withExecutorService(
+                        new CoordinatorBackgroundThreadPoolExecutor(
+                            "group-coordinator-background-",
+                            config.numBackgroundThreads(),
+                            time,
+                            coordinatorRuntimeMetrics
+                        )
+                    )
                     .withCachedBufferMaxBytesSupplier(config::cachedBufferMaxBytes)
                     .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -23,6 +23,6 @@ public class GroupCoordinatorRuntimeMetrics extends CoordinatorRuntimeMetricsImp
     public static final String METRICS_GROUP = "group-coordinator-metrics";
 
     public GroupCoordinatorRuntimeMetrics(Metrics metrics) {
-        super(metrics, METRICS_GROUP);
+        super(metrics, METRICS_GROUP, true);
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorRuntimeMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorRuntimeMetrics.java
@@ -26,6 +26,6 @@ public class ShareCoordinatorRuntimeMetrics extends CoordinatorRuntimeMetricsImp
     public static final String METRICS_GROUP = "share-coordinator-metrics";
 
     public ShareCoordinatorRuntimeMetrics(Metrics metrics) {
-        super(metrics, METRICS_GROUP);
+        super(metrics, METRICS_GROUP, false);
     }
 }


### PR DESCRIPTION
Add the background-queue-time and background-processing-time histogram
metrics.

Add the background-thread-idle-ratio-avg metric. Unlike the event
processor, we cannot measure idle time when using an ExecutorService.
Instead, we measure busy time and invert it when reporting the metric.

All three background metrics are only reported by the group coordinator
and not the share coordinator.

Reviewers: David Jacot <djacot@confluent.io>
