### PR TITLE
KAFKA-17895: Add num-keys metric for in-memory state stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -381,6 +381,13 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         open = false;
     }
 
+    long approximateNumEntries() {
+        return endTimeMap.values().stream()
+            .flatMap(keyMap -> keyMap.values().stream())
+            .mapToLong(Map::size)
+            .sum();
+    }
+
     private void removeExpiredSegments() {
         long minLiveTime = Math.max(0L, observedStreamTime - retentionPeriod + 1);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -381,7 +381,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         open = false;
     }
 
-    long approximateNumEntries() {
+    long numEntries() {
         return endTimeMap.values().stream()
             .flatMap(keyMap -> keyMap.values().stream())
             .mapToLong(Map::size)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -403,6 +403,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         open = false;
     }
 
+    long approximateNumEntries() {
+        return segmentMap.values().stream()
+            .mapToLong(Map::size)
+            .sum();
+    }
+
     private void removeExpiredSegments() {
         long minLiveTime = Math.max(0L, observedStreamTime - retentionPeriod + 1);
         for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -403,7 +403,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         open = false;
     }
 
-    long approximateNumEntries() {
+    long numEntries() {
         return segmentMap.values().stream()
             .mapToLong(Map::size)
             .sum();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -177,7 +177,6 @@ public class MeteredKeyValueStore<K, V>
                 }
             }
         );
-        // Only register this metric if it is an in-memory store
         if (!persistent()) {
             StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
                     (config, now) -> wrapped().approximateNumEntries());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -177,6 +177,11 @@ public class MeteredKeyValueStore<K, V>
                 }
             }
         );
+        // Only register this metric if it is an in-memory store
+        if (!persistent()) {
+            StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
+                    (config, now) -> wrapped().approximateNumEntries());
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -138,6 +138,25 @@ public class MeteredSessionStore<K, V>
                 }
             }
         );
+        // Only register this metric if it is an in-memory store
+        if (!persistent()) {
+            StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
+                    (config, now) -> {
+                        final InMemorySessionStore inMemoryStore = findInMemorySessionStore(wrapped());
+                        return inMemoryStore != null ? inMemoryStore.approximateNumEntries() : -1L;
+                    }
+            );
+        }
+    }
+
+    private static InMemorySessionStore findInMemorySessionStore(final StateStore store) {
+        if (store instanceof InMemorySessionStore) {
+            return (InMemorySessionStore) store;
+        } else if (store instanceof WrappedStateStore) {
+            return findInMemorySessionStore(((WrappedStateStore<?, ?, ?>) store).wrapped());
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -138,12 +138,11 @@ public class MeteredSessionStore<K, V>
                 }
             }
         );
-        // Only register this metric if it is an in-memory store
         if (!persistent()) {
             StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
                     (config, now) -> {
                         final InMemorySessionStore inMemoryStore = findInMemorySessionStore(wrapped());
-                        return inMemoryStore != null ? inMemoryStore.approximateNumEntries() : -1L;
+                        return inMemoryStore != null ? inMemoryStore.numEntries() : -1L;
                     }
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -158,12 +158,11 @@ public class MeteredWindowStore<K, V>
                 }
             }
         );
-        // Only register this metric if it is an in-memory store
         if (!persistent()) {
             StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
                     (config, now) -> {
                         final InMemoryWindowStore inMemoryStore = findInMemoryWindowStore(wrapped());
-                        return inMemoryStore != null ? inMemoryStore.approximateNumEntries() : -1L;
+                        return inMemoryStore != null ? inMemoryStore.numEntries() : -1L;
                     }
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -158,6 +158,25 @@ public class MeteredWindowStore<K, V>
                 }
             }
         );
+        // Only register this metric if it is an in-memory store
+        if (!persistent()) {
+            StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
+                    (config, now) -> {
+                        final InMemoryWindowStore inMemoryStore = findInMemoryWindowStore(wrapped());
+                        return inMemoryStore != null ? inMemoryStore.approximateNumEntries() : -1L;
+                    }
+            );
+        }
+    }
+
+    private static InMemoryWindowStore findInMemoryWindowStore(final StateStore store) {
+        if (store instanceof InMemoryWindowStore) {
+            return (InMemoryWindowStore) store;
+        } else if (store instanceof WrappedStateStore) {
+            return findInMemoryWindowStore(((WrappedStateStore<?, ?, ?>) store).wrapped());
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -158,6 +158,10 @@ public class StateStoreMetrics {
     private static final String ITERATOR_DURATION_MAX_DESCRIPTION =
             MAX_DESCRIPTION_PREFIX + ITERATOR_DURATION_DESCRIPTION;
 
+    private static final String NUM_KEYS = "num-keys";
+    private static final String NUM_KEYS_DESCRIPTION =
+            "The current number of keys in the in-memory state store";
+
     private static final String OLDEST_ITERATOR_OPEN_SINCE_MS = "oldest-iterator-open-since-ms";
     private static final String OLDEST_ITERATOR_OPEN_SINCE_MS_DESCRIPTION =
             "The UNIX timestamp the oldest still open iterator was created, in milliseconds";
@@ -514,5 +518,21 @@ public class StateStoreMetrics {
             descriptionOfMax
         );
         return sensor;
+    }
+
+    public static void addNumKeysGauge(final String taskId,
+                                          final String storeType,
+                                          final String storeName,
+                                          final StreamsMetricsImpl streamsMetrics,
+                                          final Gauge<Long> numKeysGauge) {
+        streamsMetrics.addStoreLevelMutableMetric(
+                taskId,
+                storeType,
+                storeName,
+                NUM_KEYS,
+                NUM_KEYS_DESCRIPTION,
+                RecordingLevel.INFO,
+                numKeysGauge
+        );
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -521,10 +521,10 @@ public class StateStoreMetrics {
     }
 
     public static void addNumKeysGauge(final String taskId,
-                                          final String storeType,
-                                          final String storeName,
-                                          final StreamsMetricsImpl streamsMetrics,
-                                          final Gauge<Long> numKeysGauge) {
+                                       final String storeType,
+                                       final String storeName,
+                                       final StreamsMetricsImpl streamsMetrics,
+                                       final Gauge<Long> numKeysGauge) {
         streamsMetrics.addStoreLevelMutableMetric(
                 taskId,
                 storeType,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -33,6 +34,29 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
     @Override
     StoreType storeType() {
         return StoreType.InMemoryStore;
+    }
+
+    @Test
+    public void shouldCountApproximateNumEntries() {
+        final InMemorySessionStore store = new InMemorySessionStore("test", RETENTION_PERIOD, "scope");
+        store.init(context, store);
+
+        assertEquals(0L, store.approximateNumEntries());
+
+        store.put(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(0, 0)), "1".getBytes());
+        assertEquals(1L, store.approximateNumEntries());
+
+        store.put(new Windowed<>(Bytes.wrap("b".getBytes()), new SessionWindow(0, 10)), "2".getBytes());
+        assertEquals(2L, store.approximateNumEntries());
+
+        store.put(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(5, 15)), "3".getBytes());
+        assertEquals(3L, store.approximateNumEntries());
+
+        // remove one entry
+        store.remove(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(0, 0)));
+        assertEquals(2L, store.approximateNumEntries());
+
+        store.close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -37,24 +37,24 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
     }
 
     @Test
-    public void shouldCountApproximateNumEntries() {
+    public void shouldCountNumEntries() {
         final InMemorySessionStore store = new InMemorySessionStore("test", RETENTION_PERIOD, "scope");
         store.init(context, store);
 
-        assertEquals(0L, store.approximateNumEntries());
+        assertEquals(0L, store.numEntries());
 
         store.put(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(0, 0)), "1".getBytes());
-        assertEquals(1L, store.approximateNumEntries());
+        assertEquals(1L, store.numEntries());
 
         store.put(new Windowed<>(Bytes.wrap("b".getBytes()), new SessionWindow(0, 10)), "2".getBytes());
-        assertEquals(2L, store.approximateNumEntries());
+        assertEquals(2L, store.numEntries());
 
         store.put(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(5, 15)), "3".getBytes());
-        assertEquals(3L, store.approximateNumEntries());
+        assertEquals(3L, store.numEntries());
 
         // remove one entry
         store.remove(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(0, 0)));
-        assertEquals(2L, store.approximateNumEntries());
+        assertEquals(2L, store.numEntries());
 
         store.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -43,17 +43,40 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
 
         assertEquals(0L, store.numEntries());
 
-        store.put(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(0, 0)), "1".getBytes());
+        store.put(
+                new Windowed<>(
+                        Bytes.wrap("a".getBytes()),
+                        new SessionWindow(0, 0)
+                ),
+                "1".getBytes()
+        );
         assertEquals(1L, store.numEntries());
 
-        store.put(new Windowed<>(Bytes.wrap("b".getBytes()), new SessionWindow(0, 10)), "2".getBytes());
+        store.put(
+                new Windowed<>(
+                        Bytes.wrap("b".getBytes()),
+                        new SessionWindow(0, 10)
+                ),
+                "2".getBytes()
+        );
         assertEquals(2L, store.numEntries());
 
-        store.put(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(5, 15)), "3".getBytes());
+        store.put(
+                new Windowed<>(
+                        Bytes.wrap("a".getBytes()),
+                        new SessionWindow(5, 15)
+                ),
+                "3".getBytes()
+        );
         assertEquals(3L, store.numEntries());
 
         // remove one entry
-        store.remove(new Windowed<>(Bytes.wrap("a".getBytes()), new SessionWindow(0, 0)));
+        store.remove(
+                new Windowed<>(
+                        Bytes.wrap("a".getBytes()),
+                        new SessionWindow(0, 0)
+                )
+        );
         assertEquals(2L, store.numEntries());
 
         store.close();
@@ -62,14 +85,29 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
     @Test
     public void shouldNotExpireFromOpenIterator() {
 
-        sessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 1L);
-        sessionStore.put(new Windowed<>("aa", new SessionWindow(0, 10)), 2L);
-        sessionStore.put(new Windowed<>("a", new SessionWindow(10, 20)), 3L);
+        sessionStore.put(
+                new Windowed<>("a", new SessionWindow(0, 0)),
+                1L
+        );
+        sessionStore.put(
+                new Windowed<>("aa", new SessionWindow(0, 10)),
+                2L
+        );
+        sessionStore.put(
+                new Windowed<>("a", new SessionWindow(10, 20)),
+                3L
+        );
 
         final KeyValueIterator<Windowed<String>, Long> iterator = sessionStore.findSessions("a", "b", 0L, RETENTION_PERIOD);
 
         // Advance stream time to expire the first three record
-        sessionStore.put(new Windowed<>("aa", new SessionWindow(100, 2 * RETENTION_PERIOD)), 4L);
+        sessionStore.put(
+                new Windowed<>(
+                        "aa",
+                        new SessionWindow(100, 2 * RETENTION_PERIOD)
+                ),
+                4L
+        );
 
         assertEquals(Set.of(1L, 2L, 3L, 4L), valuesToSet(iterator));
         assertFalse(iterator.hasNext());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -84,6 +84,33 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
             .build();
     }
 
+    @Test
+    public void shouldCountApproximateNumEntries() {
+        final InMemoryWindowStore store = new InMemoryWindowStore("test", RETENTION_PERIOD, WINDOW_SIZE, false, "scope");
+        store.init(context, store);
+
+        assertEquals(0L, store.approximateNumEntries());
+
+        store.put(Bytes.wrap("a".getBytes()), "1".getBytes(), 0L);
+        assertEquals(1L, store.approximateNumEntries());
+
+        store.put(Bytes.wrap("b".getBytes()), "2".getBytes(), 0L);
+        assertEquals(2L, store.approximateNumEntries());
+
+        store.put(Bytes.wrap("a".getBytes()), "3".getBytes(), 10L);
+        assertEquals(3L, store.approximateNumEntries());
+
+        // overwrite existing entry (same key, same timestamp)
+        store.put(Bytes.wrap("a".getBytes()), "4".getBytes(), 0L);
+        assertEquals(3L, store.approximateNumEntries());
+
+        // delete entry by putting null
+        store.put(Bytes.wrap("b".getBytes()), null, 0L);
+        assertEquals(2L, store.approximateNumEntries());
+
+        store.close();
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void shouldRestore() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -85,28 +85,28 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
     }
 
     @Test
-    public void shouldCountApproximateNumEntries() {
+    public void shouldCountNumEntries() {
         final InMemoryWindowStore store = new InMemoryWindowStore("test", RETENTION_PERIOD, WINDOW_SIZE, false, "scope");
         store.init(context, store);
 
-        assertEquals(0L, store.approximateNumEntries());
+        assertEquals(0L, store.numEntries());
 
         store.put(Bytes.wrap("a".getBytes()), "1".getBytes(), 0L);
-        assertEquals(1L, store.approximateNumEntries());
+        assertEquals(1L, store.numEntries());
 
         store.put(Bytes.wrap("b".getBytes()), "2".getBytes(), 0L);
-        assertEquals(2L, store.approximateNumEntries());
+        assertEquals(2L, store.numEntries());
 
         store.put(Bytes.wrap("a".getBytes()), "3".getBytes(), 10L);
-        assertEquals(3L, store.approximateNumEntries());
+        assertEquals(3L, store.numEntries());
 
         // overwrite existing entry (same key, same timestamp)
         store.put(Bytes.wrap("a".getBytes()), "4".getBytes(), 0L);
-        assertEquals(3L, store.approximateNumEntries());
+        assertEquals(3L, store.numEntries());
 
         // delete entry by putting null
         store.put(Bytes.wrap("b".getBytes()), null, 0L);
-        assertEquals(2L, store.approximateNumEntries());
+        assertEquals(2L, store.numEntries());
 
         store.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -91,21 +91,41 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
 
         assertEquals(0L, store.numEntries());
 
-        store.put(Bytes.wrap("a".getBytes()), "1".getBytes(), 0L);
+        store.put(
+                Bytes.wrap("a".getBytes()),
+                "1".getBytes(),
+                0L
+        );
         assertEquals(1L, store.numEntries());
 
-        store.put(Bytes.wrap("b".getBytes()), "2".getBytes(), 0L);
+        store.put(
+                Bytes.wrap("b".getBytes()),
+                "2".getBytes(),
+                0L
+        );
         assertEquals(2L, store.numEntries());
 
-        store.put(Bytes.wrap("a".getBytes()), "3".getBytes(), 10L);
+        store.put(
+                Bytes.wrap("a".getBytes()),
+                "3".getBytes(),
+                10L
+        );
         assertEquals(3L, store.numEntries());
 
         // overwrite existing entry (same key, same timestamp)
-        store.put(Bytes.wrap("a".getBytes()), "4".getBytes(), 0L);
+        store.put(
+                Bytes.wrap("a".getBytes()),
+                "4".getBytes(),
+                0L
+        );
         assertEquals(3L, store.numEntries());
 
         // delete entry by putting null
-        store.put(Bytes.wrap("b".getBytes()), null, 0L);
+        store.put(
+                Bytes.wrap("b".getBytes()),
+                null,
+                0L
+        );
         assertEquals(2L, store.numEntries());
 
         store.close();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -470,6 +470,17 @@ public class MeteredKeyValueStoreTest {
         assertTrue((Double) metric.metricValue() > 0);
     }
 
+    @Test
+    public void shouldTrackNumKeysMetric() {
+        setUp();
+        when(inner.approximateNumEntries()).thenReturn(42L);
+        init();
+
+        final KafkaMetric numKeysMetric = metric("num-keys");
+        assertThat(numKeysMetric, not(nullValue()));
+        assertThat((Long) numKeysMetric.metricValue(), equalTo(42L));
+    }
+
     @SuppressWarnings("unused")
     @Test
     public void shouldTrackOpenIteratorsMetric() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -655,6 +655,17 @@ public class MeteredSessionStoreTest {
         assertThat(storeMetrics(), empty());
     }
 
+    @Test
+    public void shouldTrackNumKeysMetric() {
+        setUp();
+        init();
+
+        final KafkaMetric numKeysMetric = metric("num-keys");
+        assertThat(numKeysMetric, not(nullValue()));
+        // inner store is a mock (not InMemorySessionStore), so returns -1
+        assertThat((Long) numKeysMetric.metricValue(), equalTo(-1L));
+    }
+
     @SuppressWarnings("unused")
     @Test
     public void shouldTrackOpenIteratorsMetric() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -442,6 +442,16 @@ public class MeteredWindowStoreTest {
         assertThrows(NullPointerException.class, () -> store.backwardFetch(null, 0L, 1L));
     }
 
+    @Test
+    public void shouldTrackNumKeysMetric() {
+        store.init(context, store);
+
+        final KafkaMetric numKeysMetric = metric("num-keys");
+        assertThat(numKeysMetric, not(nullValue()));
+        // inner store is a mock (not InMemoryWindowStore), so returns -1
+        assertThat((Long) numKeysMetric.metricValue(), equalTo(-1L));
+    }
+
     @SuppressWarnings("unused")
     @Test
     public void shouldTrackOpenIteratorsMetric() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
@@ -301,6 +301,24 @@ public class StateStoreMetricsTest {
     }
 
     @Test
+    public void shouldAddNumKeysGauge() {
+        @SuppressWarnings("unchecked")
+        final org.apache.kafka.common.metrics.Gauge<Long> gauge = mock(org.apache.kafka.common.metrics.Gauge.class);
+
+        StateStoreMetrics.addNumKeysGauge(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics, gauge);
+
+        org.mockito.Mockito.verify(streamsMetrics).addStoreLevelMutableMetric(
+            TASK_ID,
+            STORE_TYPE,
+            STORE_NAME,
+            "num-keys",
+            "The current number of keys in the in-memory state store",
+            RecordingLevel.INFO,
+            gauge
+        );
+    }
+
+    @Test
     public void shouldGetRecordE2ELatencySensor() {
         final String metricName = "record-e2e-latency";
         final String e2eLatencyDescription =


### PR DESCRIPTION
This PR implements KIP-1250: Add metric to track size of in-memory state
stores. Today in Kafka Streams, we have the `estimate-num-keys` metric
for RocksDB, which tracks the number of keys in the state store at any
given moment. An equivalent metric is missing for in-memory state
stores, which we aim to fill with this KIP/PR.

Reviewers: Bill Bejeck <bbejeck@apache.org>

Jira: https://issues.apache.org/jira/browse/KAFKA-17895  KIP:
https://cwiki.apache.org/confluence/x/noTMFw
