### PR TITLE
fix: replace printStackTrace() with proper logging in KafkaStreamsNamedTopologyWrapper

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -306,7 +306,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                 log.info("Successfully completed resetting offsets.");
                 break;
             } catch (final InterruptedException ex) {
-                ex.printStackTrace();
+                log.warn("Interrupted while resetting offsets", ex);
                 log.error("Offset reset failed.", ex);
                 throw new StreamsException(ex);
             } catch (final ExecutionException ex) {
@@ -331,7 +331,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
             try {
                 Thread.sleep(100);
             } catch (final InterruptedException ex) {
-                ex.printStackTrace();
+                log.warn("Interrupted while resetting offsets", ex);
             }
         }
     }


### PR DESCRIPTION
## Description
Replace `printStackTrace()` calls with proper logging using SLF4J `log.warn()` in `KafkaStreamsNamedTopologyWrapper.java`.

## Changes
- Line 309: Replace `ex.printStackTrace()` with `log.warn("Interrupted while resetting offsets", ex)`
- Line 334: Replace `ex.printStackTrace()` with `log.warn("Interrupted while resetting offsets", ex)`

## Why
Using `printStackTrace()` is not recommended in production code as it:
1. Does not respect logging configuration
2. Writes directly to stderr
3. Cannot be easily filtered or controlled

Using proper logging ensures consistent log management and better production monitoring.