### PR TITLE
MINOR: fix protocol link in templates.py

### DIFF
--- a/release/templates.py
+++ b/release/templates.py
@@ -230,7 +230,7 @@ https://github.com/apache/kafka/releases/tag/{rc_tag}
 https://kafka.apache.org/{docs_version}/documentation.html
 
 * Protocol:
-https://kafka.apache.org/{docs_version}/protocol.html
+https://kafka.apache.org/{docs_version}/design/protocol
 
 * Successful CI builds for the {dev_branch} branch:
 Unit/integration tests: https://github.com/apache/kafka/actions/runs/<RUN_NUMBER>


### PR DESCRIPTION
The protocol link is changed to `/design/protocol`.

Reviewers: Andrew Schofield <aschofield@confluent.io>
