### PR TITLE
MINOR: Upgrade LATEST_STABLE_METADATA_VERSION to match LATEST_PRODUCTION version

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -132,7 +132,7 @@ DEV_VERSION = KafkaVersion("4.3.0-SNAPSHOT")
 
 LATEST_STABLE_TRANSACTION_VERSION = 2
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
-LATEST_STABLE_METADATA_VERSION = "4.2-IV1"
+LATEST_STABLE_METADATA_VERSION = "4.3-IV0"
 
 # 2.1.x versions
 V_2_1_0 = KafkaVersion("2.1.0")


### PR DESCRIPTION
This PR upgraded `LATEST_STABLE_METADATA_VERSION` to match
`LATEST_PRODUCTION` version defined in `MetadataVersion.java`.

Related PR comment:
https://github.com/apache/kafka/pull/21273#discussion_r2883715284

To validate, run:

```
TC_PATHS="tests/kafkatest/tests/core/upgrade_test.py::TestUpgrade.test_combined_mode_upgrade"
\
/bin/bash tests/docker/run_tests.sh
```

Result:
```
...

================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.13.0
session_id:       2026-03-04--002
run time:         24 minutes 49.146 seconds
tests run:        9
passed:           9
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=3.4.1.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 38.050 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=3.5.2.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 54.445 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=3.6.2.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 43.253 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=3.7.2.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 34.646 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=3.8.1.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 50.826 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=3.9.2.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 49.461 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=4.0.1.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 48.707 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=4.1.1.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 43.649 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.core.upgrade_test.TestUpgrade.test_combined_mode_upgrade.from_kafka_version=dev.metadata_quorum=COMBINED_KRAFT
status:     PASS
run time:   2 minutes 44.996 seconds
--------------------------------------------------------------------------------
```

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
