### PR TITLE
MINOR: make processMessages task outputs relocatable for build cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1397,8 +1397,9 @@ project(':metadata') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.common.metadata",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/common/metadata",
+             "-o", "build/generated/main/java/org/apache/kafka/common/metadata",
              "-i", "src/main/resources/common/metadata",
              "-m", "MessageDataGenerator", "JsonConverterGenerator",
              "-t", "MetadataRecordTypeGenerator", "MetadataJsonConvertersGenerator"
@@ -1544,8 +1545,9 @@ project(':group-coordinator') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.coordinator.group.generated",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/coordinator/group/generated",
+             "-o", "build/generated/main/java/org/apache/kafka/coordinator/group/generated",
              "-i", "src/main/resources/common/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator",
              "-t", "CoordinatorRecordTypeGenerator", "CoordinatorRecordJsonConvertersGenerator"
@@ -1699,8 +1701,9 @@ project(':transaction-coordinator') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.coordinator.transaction.generated",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/coordinator/transaction/generated",
+             "-o", "build/generated/main/java/org/apache/kafka/coordinator/transaction/generated",
              "-i", "src/main/resources/common/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator",
              "-t", "CoordinatorRecordTypeGenerator", "CoordinatorRecordJsonConvertersGenerator"
@@ -1802,8 +1805,9 @@ project(':share-coordinator') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.coordinator.share.generated",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/coordinator/share/generated",
+             "-o", "build/generated/main/java/org/apache/kafka/coordinator/share/generated",
              "-i", "src/main/resources/common/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator",
              "-t", "CoordinatorRecordTypeGenerator", "CoordinatorRecordJsonConvertersGenerator"
@@ -1978,8 +1982,9 @@ project(':clients') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.common.message",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/common/message",
+             "-o", "build/generated/main/java/org/apache/kafka/common/message",
              "-i", "src/main/resources/common/message",
              "-t", "ApiMessageTypeGenerator",
              "-m", "MessageDataGenerator", "JsonConverterGenerator"
@@ -1994,8 +1999,9 @@ project(':clients') {
   task processTestMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.common.message",
-             "-o", "${projectDir}/build/generated/test/java/org/apache/kafka/common/message",
+             "-o", "build/generated/test/java/org/apache/kafka/common/message",
              "-i", "src/test/resources/common/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator"
            ]
@@ -2142,8 +2148,9 @@ project(':raft') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.raft.generated",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/raft/generated",
+             "-o", "build/generated/main/java/org/apache/kafka/raft/generated",
              "-i", "src/main/resources/common/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator"]
     inputs.dir("src/main/resources/common/message")
@@ -2379,8 +2386,9 @@ project(':storage') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.server.log.remote.metadata.storage.generated",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/server/log/remote/metadata/storage/generated",
+             "-o", "build/generated/main/java/org/apache/kafka/server/log/remote/metadata/storage/generated",
              "-i", "src/main/resources/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator",
              "-t", "MetadataRecordTypeGenerator", "MetadataJsonConvertersGenerator" ]
@@ -2731,8 +2739,9 @@ project(':streams') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
+    workingDir = projectDir
     args = [ "-p", "org.apache.kafka.streams.internals.generated",
-             "-o", "${projectDir}/build/generated/main/java/org/apache/kafka/streams/internals/generated",
+             "-o", "build/generated/main/java/org/apache/kafka/streams/internals/generated",
              "-i", "src/main/resources/common/message",
              "-m", "MessageDataGenerator"
            ]


### PR DESCRIPTION
### Motivation

Several `processMessages` / `processTestMessages` tasks were missing the build cache in CI even when the source inputs were unchanged.

The [task inputs comparison](https://ge.solutions-team.gradle.com/c/ljfa6m2wls2uq/6f4ed23e42nao/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) showed that the differing input was `args`. These `JavaExec` tasks were passing an absolute output path via `${projectDir}/build/...`, which makes the cache key depend on the checkout location and prevents relocatable cache hits across workspaces/agents.

### Changes

This change updates the message generator tasks to:

- set `workingDir = projectDir`
- pass `build/generated/...` as a relative `-o` argument instead of `${projectDir}/build/generated/...`

This keeps the generated output location unchanged while removing the checkout-root-dependent absolute path from the task input fingerprint.

Affected tasks include the message generators in:

- `:metadata`
- `:group-coordinator`
- `:transaction-coordinator`
- `:share-coordinator`
- `:clients`
- `:raft`
- `:storage`
- `:streams`

### Testing

You can observe all cacheable tasks getting cache hits in [this set of experiments](https://github.com/gradle/develocity-oss-projects/actions/runs/22668656054).

The expected validation is:
- `processMessages` / `processTestMessages` still generate sources in the same locations
- subsequent CI builds can reuse cached outputs for these tasks across different checkout paths

Reviewers: Clay Johnson <cjohnson@gradle.com>
