### PR TITLE
MINOR: Add test to enforce LATEST_STABLE_METADATA_VERSION sync with LATEST_PRODUCTION

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4141,11 +4141,10 @@ def verifyLatestStableMetadataVersionTask = tasks.register('verifyLatestStableMe
   description = "Verifies that LATEST_STABLE_METADATA_VERSION in version.py matches LATEST_PRODUCTION in MetadataVersion.java"
 
   doLast {
-    def mvJavaFile = file("${project.rootDir}/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java")
-    def versionPyFile = file("${project.rootDir}/tests/kafkatest/version.py")
-
     // Extract enum constant name that LATEST_PRODUCTION points to, e.g. LATEST_PRODUCTION = IBP_4_3_IV0 -> IBP_4_3_IV0
-    def mvContent = mvJavaFile.text
+    def mvContent = file("${project.rootDir}/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java").text
+    def pyContent = file("${project.rootDir}/tests/kafkatest/version.py").text
+
     def latestProductionEnumName = mvContent =~ /LATEST_PRODUCTION\s*=\s*(IBP_\w+)/
     if (!latestProductionEnumName) throw new GradleException("Could not find LATEST_PRODUCTION in MetadataVersion.java")
     def latestProductionEnumConstant = latestProductionEnumName[0][1] // e.g. "IBP_4_3_IV0"
@@ -4155,10 +4154,9 @@ def verifyLatestStableMetadataVersionTask = tasks.register('verifyLatestStableMe
     if (!enumMatch) throw new GradleException("Could not find enum definition for ${latestProductionEnumConstant} in MetadataVersion.java")
     def javaVersion = "${enumMatch[0][1]}-${enumMatch[0][2]}" // e.g. "4.3-IV0"
 
-    // Extract LATEST_STABLE_METADATA_VERSION from version.py
-    def pyLine = versionPyFile.readLines().find { it.startsWith("LATEST_STABLE_METADATA_VERSION") }
-    if (!pyLine) throw new GradleException("LATEST_STABLE_METADATA_VERSION not found in version.py")
-    def pyVersion = pyLine.replaceAll(/.*=\s*"([^"]+)".*/, '$1') // e.g. "4.3-IV0"
+    def pyMatch = pyContent =~ /LATEST_STABLE_METADATA_VERSION\s*=\s*"([^"]+)"/
+    if (!pyMatch) throw new GradleException("LATEST_STABLE_METADATA_VERSION not found in version.py")
+    def pyVersion = pyMatch[0][1] // e.g. "4.3-IV0"
 
     if (javaVersion != pyVersion) {
       throw new GradleException(

--- a/build.gradle
+++ b/build.gradle
@@ -4148,11 +4148,11 @@ def verifyLatestStableMetadataVersionTask = tasks.register('verifyLatestStableMe
     def mvContent = mvJavaFile.text
     def latestProductionEnumName = mvContent =~ /LATEST_PRODUCTION\s*=\s*(IBP_\w+)/
     if (!latestProductionEnumName) throw new GradleException("Could not find LATEST_PRODUCTION in MetadataVersion.java")
-    def alias = latestProductionEnumName[0][1] // e.g. "IBP_4_3_IV0"
+    def latestProductionEnumConstant = latestProductionEnumName[0][1] // e.g. "IBP_4_3_IV0"
 
     // Extract version from enum constant, e.g. IBP_4_3_IV0(30, "4.3", "IV0", true) -> 4.3-IV0
-    def enumMatch = mvContent =~ /${alias}\(\d+,\s*"(\d+\.\d+)",\s*"(IV\d+)"/
-    if (!enumMatch) throw new GradleException("Could not find enum definition for ${alias} in MetadataVersion.java")
+    def enumMatch = mvContent =~ /${latestProductionEnumConstant}\(\d+,\s*"(\d+\.\d+)",\s*"(IV\d+)"/
+    if (!enumMatch) throw new GradleException("Could not find enum definition for ${latestProductionEnumConstant} in MetadataVersion.java")
     def javaVersion = "${enumMatch[0][1]}-${enumMatch[0][2]}" // e.g. "4.3-IV0"
 
     // Extract LATEST_STABLE_METADATA_VERSION from version.py
@@ -4167,7 +4167,7 @@ def verifyLatestStableMetadataVersionTask = tasks.register('verifyLatestStableMe
         "Make sure LATEST_PRODUCTION in MetadataVersion.java and LATEST_STABLE_METADATA_VERSION in tests/kafkatest/version.py are in sync."
       )
     }
-    println "LATEST_STABLE_METADATA_VERSION is consistent: ${javaVersion}"
+    println "MetadataVersion.java LATEST_PRODUCTION=${latestProductionEnumConstant} (${javaVersion}) matches version.py LATEST_STABLE_METADATA_VERSION=${pyVersion}"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -305,10 +305,6 @@ println("Build properties: ignoreFailures=$userIgnoreFailures, maxParallelForks=
 
 subprojects {
 
-  tasks.withType(JavaForkOptions).configureEach {
-    systemProperty 'project.root.dir', project.rootDir.absolutePath
-  }
-
   // enable running :dependencies task recursively on all subprojects
   // eg: ./gradlew allDeps
   task allDeps(type: DependencyReportTask) {}
@@ -4139,3 +4135,40 @@ def verifyVersionConsistencyTask = tasks.register('verifyVersionConsistency') {
 }
 
 check.dependsOn verifyVersionConsistencyTask
+
+def verifyLatestStableMetadataVersionTask = tasks.register('verifyLatestStableMetadataVersion') {
+  group = "Verification"
+  description = "Verifies that LATEST_STABLE_METADATA_VERSION in version.py matches LATEST_PRODUCTION in MetadataVersion.java"
+
+  doLast {
+    def mvJavaFile = file("${project.rootDir}/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java")
+    def versionPyFile = file("${project.rootDir}/tests/kafkatest/version.py")
+
+    // Extract enum constant name that LATEST_PRODUCTION points to, e.g. LATEST_PRODUCTION = IBP_4_3_IV0 -> IBP_4_3_IV0
+    def mvContent = mvJavaFile.text
+    def latestProductionEnumName = mvContent =~ /LATEST_PRODUCTION\s*=\s*(IBP_\w+)/
+    if (!latestProductionEnumName) throw new GradleException("Could not find LATEST_PRODUCTION in MetadataVersion.java")
+    def alias = latestProductionEnumName[0][1] // e.g. "IBP_4_3_IV0"
+
+    // Extract version from enum constant, e.g. IBP_4_3_IV0(30, "4.3", "IV0", true) -> 4.3-IV0
+    def enumMatch = mvContent =~ /${alias}\(\d+,\s*"(\d+\.\d+)",\s*"(IV\d+)"/
+    if (!enumMatch) throw new GradleException("Could not find enum definition for ${alias} in MetadataVersion.java")
+    def javaVersion = "${enumMatch[0][1]}-${enumMatch[0][2]}" // e.g. "4.3-IV0"
+
+    // Extract LATEST_STABLE_METADATA_VERSION from version.py
+    def pyLine = versionPyFile.readLines().find { it.startsWith("LATEST_STABLE_METADATA_VERSION") }
+    if (!pyLine) throw new GradleException("LATEST_STABLE_METADATA_VERSION not found in version.py")
+    def pyVersion = pyLine.replaceAll(/.*=\s*"([^"]+)".*/, '$1') // e.g. "4.3-IV0"
+
+    if (javaVersion != pyVersion) {
+      throw new GradleException(
+        "LATEST_STABLE_METADATA_VERSION mismatch: MetadataVersion.java LATEST_PRODUCTION=${javaVersion}, " +
+        "tests/kafkatest/version.py LATEST_STABLE_METADATA_VERSION=${pyVersion}. " +
+        "Make sure LATEST_PRODUCTION in MetadataVersion.java and LATEST_STABLE_METADATA_VERSION in tests/kafkatest/version.py are in sync."
+      )
+    }
+    println "LATEST_STABLE_METADATA_VERSION is consistent: ${javaVersion}"
+  }
+}
+
+check.dependsOn verifyLatestStableMetadataVersionTask

--- a/build.gradle
+++ b/build.gradle
@@ -2244,6 +2244,10 @@ project(':server-common') {
     delete "${layout.buildDirectory.get().asFile.path}/kafka/"
   }
 
+  test {
+    systemProperty 'project.root.dir', project.rootDir.absolutePath
+  }
+
   checkstyle {
     configProperties = checkstyleConfigProperties("import-control-server-common.xml")
   }

--- a/build.gradle
+++ b/build.gradle
@@ -305,6 +305,10 @@ println("Build properties: ignoreFailures=$userIgnoreFailures, maxParallelForks=
 
 subprojects {
 
+  tasks.withType(JavaForkOptions).configureEach {
+    systemProperty 'project.root.dir', project.rootDir.absolutePath
+  }
+
   // enable running :dependencies task recursively on all subprojects
   // eg: ./gradlew allDeps
   task allDeps(type: DependencyReportTask) {}
@@ -2242,10 +2246,6 @@ project(':server-common') {
 
   clean.doFirst {
     delete "${layout.buildDirectory.get().asFile.path}/kafka/"
-  }
-
-  test {
-    systemProperty 'project.root.dir', project.rootDir.absolutePath
   }
 
   checkstyle {

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -56,7 +56,6 @@ import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -317,18 +316,8 @@ class MetadataVersionTest {
 
     @Test
     public void assertPythonLatestStableMetadataVersionMatchesLatestProduction() throws IOException {
-        // Walk up from cwd to find repo root (contains tests/kafkatest/version.py)
-        Path repoRoot = Paths.get("").toAbsolutePath();
-        Path versionPy = null;
-        while (repoRoot != null) {
-            Path candidate = repoRoot.resolve("tests/kafkatest/version.py");
-            if (Files.exists(candidate)) {
-                versionPy = candidate;
-                break;
-            }
-            repoRoot = repoRoot.getParent();
-        }
-        assertNotNull(versionPy, "Could not find tests/kafkatest/version.py");
+        Path versionPy = Paths.get("../tests/kafkatest/version.py").toAbsolutePath();
+        assertTrue(Files.exists(versionPy), "Could not find tests/kafkatest/version.py at: " + versionPy);
 
         String pythonVersion = Files.readAllLines(versionPy).stream()
             .filter(line -> line.startsWith("LATEST_STABLE_METADATA_VERSION"))

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -20,6 +20,11 @@ package org.apache.kafka.server.common;
 import org.apache.kafka.common.protocol.ApiKeys;
 
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -51,6 +56,7 @@ import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -307,6 +313,32 @@ class MetadataVersionTest {
     @Test
     public void assertLatestIsNotProduction() {
         assertFalse(MetadataVersion.latestTesting().isProduction());
+    }
+
+    @Test
+    public void assertPythonLatestStableMetadataVersionMatchesLatestProduction() throws IOException {
+        // Walk up from cwd to find repo root (contains tests/kafkatest/version.py)
+        Path repoRoot = Paths.get("").toAbsolutePath();
+        Path versionPy = null;
+        while (repoRoot != null) {
+            Path candidate = repoRoot.resolve("tests/kafkatest/version.py");
+            if (Files.exists(candidate)) {
+                versionPy = candidate;
+                break;
+            }
+            repoRoot = repoRoot.getParent();
+        }
+        assertNotNull(versionPy, "Could not find tests/kafkatest/version.py");
+
+        String pythonVersion = Files.readAllLines(versionPy).stream()
+            .filter(line -> line.startsWith("LATEST_STABLE_METADATA_VERSION"))
+            .map(line -> line.replaceAll(".*=\\s*\"([^\"]+)\".*", "$1"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("LATEST_STABLE_METADATA_VERSION not found in version.py"));
+
+        assertEquals(LATEST_PRODUCTION.version(), pythonVersion,
+            "tests/kafkatest/version.py LATEST_STABLE_METADATA_VERSION must match LATEST_PRODUCTION. " +
+            "Update the Python file when bumping LATEST_PRODUCTION in MetadataVersion.java");
     }
 
     @ParameterizedTest

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -316,7 +316,7 @@ class MetadataVersionTest {
 
     @Test
     public void assertPythonLatestStableMetadataVersionMatchesLatestProduction() throws IOException {
-        Path versionPy = Paths.get("../tests/kafkatest/version.py").toAbsolutePath();
+        Path versionPy = Paths.get(System.getProperty("user.dir") + "/../tests/kafkatest/version.py");
         assertTrue(Files.exists(versionPy), "Could not find tests/kafkatest/version.py at: " + versionPy);
 
         String pythonVersion = Files.readAllLines(versionPy).stream()

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -23,11 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_3_IV3;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_4_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV0;
@@ -312,22 +307,6 @@ class MetadataVersionTest {
     @Test
     public void assertLatestIsNotProduction() {
         assertFalse(MetadataVersion.latestTesting().isProduction());
-    }
-
-    @Test
-    public void assertPythonLatestStableMetadataVersionMatchesLatestProduction() throws IOException {
-        Path versionPy = Paths.get(System.getProperty("project.root.dir"), "tests/kafkatest/version.py");
-        assertTrue(Files.exists(versionPy), "Could not find tests/kafkatest/version.py at: " + versionPy);
-
-        String pythonVersion = Files.readAllLines(versionPy).stream()
-            .filter(line -> line.startsWith("LATEST_STABLE_METADATA_VERSION"))
-            .map(line -> line.replaceAll(".*=\\s*\"([^\"]+)\".*", "$1"))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("LATEST_STABLE_METADATA_VERSION not found in version.py"));
-
-        assertEquals(LATEST_PRODUCTION.version(), pythonVersion,
-            "tests/kafkatest/version.py LATEST_STABLE_METADATA_VERSION must match LATEST_PRODUCTION. " +
-            "Update the Python file when bumping LATEST_PRODUCTION in MetadataVersion.java");
     }
 
     @ParameterizedTest

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -316,7 +316,7 @@ class MetadataVersionTest {
 
     @Test
     public void assertPythonLatestStableMetadataVersionMatchesLatestProduction() throws IOException {
-        Path versionPy = Paths.get(System.getProperty("user.dir") + "/../tests/kafkatest/version.py");
+        Path versionPy = Paths.get(System.getProperty("project.root.dir"), "tests/kafkatest/version.py");
         assertTrue(Files.exists(versionPy), "Could not find tests/kafkatest/version.py at: " + versionPy);
 
         String pythonVersion = Files.readAllLines(versionPy).stream()

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -20,13 +20,13 @@ package org.apache.kafka.server.common;
 import org.apache.kafka.common.protocol.ApiKeys;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_3_IV3;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_4_IV0;


### PR DESCRIPTION
This PR is a follow-up of this comment:
https://github.com/apache/kafka/pull/21629#discussion_r2884634551

A Gradle task is added to check if `LATEST_STABLE_METADATA_VERSION`
matches  `LATEST_PRODUCTION`.

```
./gradlew verifyLatestStableMetadataVersion
```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
