### PR TITLE
KAFKA-20256: Add ShareGroupDLQ interface and some infra classes.

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/NoOpShareGroupDLQManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/NoOpShareGroupDLQManager.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public class NoOpShareGroupDLQManager implements ShareGroupDLQ {
     @Override
-    public CompletableFuture<Void> enqueue(ShareGroupDLQRecord record) {
+    public CompletableFuture<Void> enqueue(ShareGroupDLQRecordParameter param) {
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/NoOpShareGroupDLQManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/NoOpShareGroupDLQManager.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.share.dlq;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A no op implementation of {@link ShareGroupDLQ}. This will be useful
+ * in development cycle and testing. All methods return immediately with
+ * a successfully completed future.
+ */
+public class NoOpShareGroupDLQManager implements ShareGroupDLQ {
+    @Override
+    public CompletableFuture<Void> enqueue(ShareGroupDLQRecord record) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.share.dlq;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The main interface to identify implementations of dead letter queues for share groups.
+ */
+@InterfaceStability.Evolving
+public interface ShareGroupDLQ {
+    /**
+     * Main method exposed to the world to enqueuing a record to the share groups dead letter queue.
+     *
+     * @param record A java record encapsulating required and optional information about the kafka record
+     *               being dead letter queued.
+     * @return A completable future of Void type, mainly to signal exceptions.
+     */
+    CompletableFuture<Void> enqueue(ShareGroupDLQRecord record);
+}
+

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
@@ -29,9 +29,9 @@ public interface ShareGroupDLQ {
     /**
      * Main method exposed to the world to enqueuing a record to the share groups dead letter queue.
      *
-     * @param record A java record encapsulating required and optional information about the kafka record
-     *               being dead letter queued.
+     * @param param A java record encapsulating required and optional information about the kafka record
+     *              being dead letter queued.
      * @return A completable future of Void type, mainly to signal exceptions.
      */
-    CompletableFuture<Void> enqueue(ShareGroupDLQRecord record);
+    CompletableFuture<Void> enqueue(ShareGroupDLQRecordParameter param);
 }

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
@@ -17,14 +17,11 @@
 
 package org.apache.kafka.server.share.dlq;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-
 import java.util.concurrent.CompletableFuture;
 
 /**
  * The main interface to identify implementations of dead letter queues for share groups.
  */
-@InterfaceStability.Evolving
 public interface ShareGroupDLQ {
     /**
      * Main method exposed to the world to enqueuing a record to the share groups dead letter queue.

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
@@ -35,4 +35,3 @@ public interface ShareGroupDLQ {
      */
     CompletableFuture<Void> enqueue(ShareGroupDLQRecord record);
 }
-

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQRecord.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQRecord.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.server.share.dlq;
 
 import org.apache.kafka.common.TopicIdPartition;
-import org.apache.kafka.common.header.Headers;
 
 import java.util.Optional;
 
@@ -30,7 +29,7 @@ import java.util.Optional;
  * @param offset             The offset of the record in the kafka topic partition.
  * @param deliveryCount      If known, the number of times the message was delivered to the share consumer.
  * @param cause              If known, throwable representing the reason for queueing the message.
- * @param originalRecordData If desired, header data and the key/value information in the original message.
+ * @param preserveRecordData If true, store original record headers, key and value in the dlq record as well.
  */
 public record ShareGroupDLQRecord(
     String groupId,
@@ -38,20 +37,6 @@ public record ShareGroupDLQRecord(
     long offset,
     Optional<Integer> deliveryCount,
     Optional<Throwable> cause,
-    Optional<OriginalRecordData> originalRecordData
+    boolean preserveRecordData
 ) {
-    /**
-     * Record representing header, key and value information about the original message.
-     * If known, this information will be written to the DLQ topic as well.
-     *
-     * @param headers   The headers of the original record.
-     * @param key       A byte array representing the key of the original record.
-     * @param value     A byte array representing the value of the original record.
-     */
-    public record OriginalRecordData(
-        Headers headers,
-        byte[] key,
-        byte[] value
-    ) {
-    }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQRecord.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQRecord.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.share.dlq;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Optional;
+
+/**
+ * Record representing information needed from callers of {@link ShareGroupDLQ#enqueue}
+ *
+ * @param groupId            The share group id of the message being recorded.
+ * @param topicIdPartition   The topic and partition information of the message.
+ * @param offset             The offset of the record in the kafka topic partition.
+ * @param deliveryCount      If known, the number of times the message was delivered to the share consumer.
+ * @param cause              If known, throwable representing the reason for queueing the message.
+ * @param originalRecordData If desired, header data and the key/value information in the original message.
+ */
+public record ShareGroupDLQRecord(
+    String groupId,
+    TopicIdPartition topicIdPartition,
+    long offset,
+    Optional<Integer> deliveryCount,
+    Optional<Throwable> cause,
+    Optional<OriginalRecordData> originalRecordData
+) {
+    /**
+     * Record representing header, key and value information about the original message.
+     * If known, this information will be written to the DLQ topic as well.
+     *
+     * @param headers   The headers of the original record.
+     * @param key       A byte array representing the key of the original record.
+     * @param value     A byte array representing the value of the original record.
+     */
+    public record OriginalRecordData(
+        Headers headers,
+        byte[] key,
+        byte[] value
+    ) {
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQRecordParameter.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQRecordParameter.java
@@ -22,19 +22,22 @@ import org.apache.kafka.common.TopicIdPartition;
 import java.util.Optional;
 
 /**
- * Record representing information needed from callers of {@link ShareGroupDLQ#enqueue}
+ * Record representing information needed from callers of {@link ShareGroupDLQ#enqueue}. Inclusion
+ * of first and last offset allows passing batch information as well.
  *
  * @param groupId            The share group id of the message being recorded.
  * @param topicIdPartition   The topic and partition information of the message.
- * @param offset             The offset of the record in the kafka topic partition.
+ * @param firstOffset        The first offset of the records in the kafka topic partition.
+ * @param lastOffset         The last offset of the records in the kafka topic partition.
  * @param deliveryCount      If known, the number of times the message was delivered to the share consumer.
  * @param cause              If known, throwable representing the reason for queueing the message.
  * @param preserveRecordData If true, store original record headers, key and value in the dlq record as well.
  */
-public record ShareGroupDLQRecord(
+public record ShareGroupDLQRecordParameter(
     String groupId,
     TopicIdPartition topicIdPartition,
-    long offset,
+    long firstOffset,
+    long lastOffset,
     Optional<Integer> deliveryCount,
     Optional<Throwable> cause,
     boolean preserveRecordData


### PR DESCRIPTION
* Add `DLQManager` interface (evolving).
* Add a NoOp impl for above.
* Add java record classes to server as arguments for
`ShareGroupDLQ.enqueue`

Reviewers: Andrew Schofield <aschofield@confluent.io>
