### PR TITLE
MINOR: version updates for build and test dependencies

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -252,7 +252,7 @@ License Version 2.0:
 - scala-reflect-2.13.18
 - snappy-java-1.1.10.7
 - snakeyaml-2.5
-- swagger-annotations-2.2.39
+- swagger-annotations-2.2.48
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/build.gradle
+++ b/build.gradle
@@ -29,17 +29,17 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.53.0'
+  id 'com.github.ben-manes.versions' version '0.54.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'
-  id 'org.owasp.dependencycheck' version '12.1.8'
+  id 'org.owasp.dependencycheck' version '12.2.1'
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
-  id "com.github.spotbugs" version '6.4.4' apply false
+  id "com.github.spotbugs" version '6.5.1' apply false
   id 'org.scoverage' version '8.1' apply false
-  id 'com.gradleup.shadow' version '9.3.1' apply false
+  id 'com.gradleup.shadow' version '9.4.1' apply false
   id 'com.diffplug.spotless' version "8.4.0"
 }
 

--- a/checkstyle/.scalafmt.conf
+++ b/checkstyle/.scalafmt.conf
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-version = 3.10.2
+version = 3.10.3
 runner.dialect = scala213
 docstrings.style = Asterisk
 docstrings.wrap = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ group=org.apache.kafka
 version=4.4.0-SNAPSHOT
 scalaVersion=2.13.18
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
-swaggerVersion=2.2.39
+swaggerVersion=2.2.48
 task=build
 org.gradle.jvmargs=-Xmx4g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -56,7 +56,7 @@ versions += [
   bcpkix: "1.83",
   caffeine: "3.2.0",
   bndlib: "7.1.0",
-  checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.2.0",
+  checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.3.1",
   commonsValidator: "1.10.1",
   classgraph: "4.8.179",
   gradle: "9.4.1",
@@ -70,7 +70,7 @@ versions += [
   // (e.g. Logger.atDebug()) in production code, as Kafka uses SLF4J 1.7.x.
   jetty: "12.0.34",
   jersey: "3.1.10",
-  jgit: "7.5.0.202512021534-r",
+  jgit: "7.6.0.202603022253-r",
   jline: "3.30.4",
   jmh: "1.37",
   hamcrest: "3.0",
@@ -82,7 +82,7 @@ versions += [
   jfreechart: "1.5.6",
   jopt: "5.0.4",
   jose4j: "0.9.6",
-  junit: "5.13.1",
+  junit: "5.14.3",
   jqwik: "1.9.2",
   kafka_0110: "0.11.0.3",
   kafka_10: "1.0.2",
@@ -125,19 +125,19 @@ versions += [
   // When updating the scalafmt version please also update the version field in checkstyle/.scalafmt.conf. scalafmt now
   // has the version field as mandatory in its configuration, see
   // https://github.com/scalameta/scalafmt/releases/tag/v3.1.0.
-  scalafmt: "3.10.2",
-  scoverage: "2.5.1",
+  scalafmt: "3.10.3",
+  scoverage: "2.5.2",
   slf4j: "1.7.36",
   snappy: "1.1.10.7",
   spotbugs: "4.9.8",
   testcontainers: "1.20.2",
   testcontainersKeycloak: "3.5.1",
-  mockOAuth2Server: "2.2.1",
-  zinc: "1.11.0",
+  mockOAuth2Server: "2.3.0",
+  zinc: "1.12.0",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-10",
-  junitPlatform: "1.13.1",
+  junitPlatform: "1.14.3",
   hdrHistogram: "2.2.2",
   hash4j: "0.22.0"
 ]


### PR DESCRIPTION
details:
- checkstyle: 12.2.0 -->> 12.3.1
- jgit: 7.5.0 -->> 7.6.0
- junit: 5.13.1 -->> 5.14.3
- junitPlatform: 1.13.1 -->> 1.14.3
- scalafmt: 3.10.2 -->> 3.10.3
- scoverage: 2.5.1 -->> 2.5.2
- mockOAuth2Server: 2.2.1 -->> 2.3.0
- swagger: 2.2.39 -->> 2.2.48
- zinc: 1.11.0 -->> 1.12.0
- gradle plugins:
  - gradle-versions-plugin: 0.53.0 -->> 0.54.0
  - dependencycheck: 12.1.8 -->> 12.2.1
  - spotbugs: 6.4.4 -->> 6.5.1
  - shadow: 9.3.1 -->> 9.4.1

Some notable release notes:
- JGit:
https://projects.eclipse.org/projects/technology.jgit/releases/7.6.0
- JUnit:
  - https://docs.junit.org/5.14.3/release-notes.html
  -
https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-5.14
- mockOAuth2Server:
  - https://github.com/navikt/mock-oauth2-server/releases/tag/2.3.0
  - https://github.com/navikt/mock-oauth2-server/compare/2.2.1...2.3.0
- Zinc: https://github.com/sbt/zinc/releases/tag/v1.12.0
- Gradle Shadow plugin:
https://gradleup.com/shadow/changes/#941-2026-03-27

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
