### PR TITLE
KAFKA-13392 Fix incrementalAlterConfigs timeout when broker is down

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -503,21 +503,35 @@ public class ReassignPartitionsCommand {
 
     /**
      * Clear all topic-level and broker-level throttles.
+     * Only clears throttles on live brokers to avoid TimeoutException when some brokers are down.
+     * Called by --verify when reassignment is complete.
      *
      * @param adminClient     The AdminClient to use.
      * @param targetParts     The target partitions loaded from the JSON file.
      */
-    private static void clearAllThrottles(Admin adminClient,
+    static void clearAllThrottles(Admin adminClient,
                                           List<Entry<TopicPartition, List<Integer>>> targetParts
     ) throws ExecutionException, InterruptedException {
         Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
-        Set<Integer> brokers = new HashSet<>(liveBrokers);
-        targetParts.forEach(t -> brokers.addAll(t.getValue()));
-        brokers.retainAll(liveBrokers);
+        Set<Integer> brokersFromAssignment = new HashSet<>();
+        targetParts.forEach(t -> brokersFromAssignment.addAll(t.getValue()));
+        Set<Integer> downBrokers = brokersFromAssignment.stream()
+            .filter(b -> !liveBrokers.contains(b))
+            .collect(Collectors.toSet());
 
-        System.out.printf("Clearing broker-level throttles on broker%s %s%n",
-            brokers.size() == 1 ? "" : "s", brokers.stream().map(Object::toString).collect(Collectors.joining(",")));
-        clearBrokerLevelThrottles(adminClient, brokers);
+        if (!downBrokers.isEmpty()) {
+            System.out.printf("Warning: Could not clear broker-level throttles on down broker%s %s. " +
+                "Throttles will be cleared when the broker comes back up.%n",
+                downBrokers.size() == 1 ? "" : "s",
+                downBrokers.stream().sorted().map(Object::toString).collect(Collectors.joining(",")));
+        }
+
+        if (!liveBrokers.isEmpty()) {
+            System.out.printf("Clearing broker-level throttles on broker%s %s%n",
+                liveBrokers.size() == 1 ? "" : "s",
+                liveBrokers.stream().sorted().map(Object::toString).collect(Collectors.joining(",")));
+            clearBrokerLevelThrottles(adminClient, liveBrokers);
+        }
 
         Set<String> topics = targetParts.stream().map(t -> t.getKey().topic()).collect(Collectors.toSet());
         System.out.printf("Clearing topic-level throttles on topic%s %s%n",
@@ -808,14 +822,16 @@ public class ReassignPartitionsCommand {
         if (interBrokerThrottle >= 0 || logDirThrottle >= 0) {
             System.out.println(YOU_MUST_RUN_VERIFY_PERIODICALLY_MESSAGE);
 
+            Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
+
             if (interBrokerThrottle >= 0) {
                 Map<String, Map<Integer, PartitionMove>> moveMap = calculateProposedMoveMap(currentReassignments, proposedParts, currentParts);
-                modifyReassignmentThrottle(adminClient, moveMap, interBrokerThrottle);
+                modifyReassignmentThrottle(adminClient, moveMap, interBrokerThrottle, liveBrokers);
             }
 
             if (logDirThrottle >= 0) {
                 Set<Integer> movingBrokers = calculateMovingBrokers(proposedReplicas.keySet());
-                modifyLogDirThrottle(adminClient, movingBrokers, logDirThrottle);
+                modifyLogDirThrottle(adminClient, movingBrokers, logDirThrottle, liveBrokers);
             }
         }
 
@@ -1184,33 +1200,59 @@ public class ReassignPartitionsCommand {
     private static void modifyReassignmentThrottle(
         Admin admin,
         Map<String, Map<Integer, PartitionMove>> moveMap,
-        long interBrokerThrottle
+        long interBrokerThrottle,
+        Set<Integer> liveBrokers
     ) throws ExecutionException, InterruptedException {
         Map<String, String> leaderThrottles = calculateLeaderThrottles(moveMap);
         Map<String, String> followerThrottles = calculateFollowerThrottles(moveMap);
         modifyTopicThrottles(admin, leaderThrottles, followerThrottles);
 
         Set<Integer> reassigningBrokers = calculateReassigningBrokers(moveMap);
-        modifyInterBrokerThrottle(admin, reassigningBrokers, interBrokerThrottle);
+        modifyInterBrokerThrottle(admin, reassigningBrokers, interBrokerThrottle, liveBrokers);
+    }
+
+    /**
+     * Modify the leader/follower replication throttles for a set of brokers.
+     * Only applies throttle to currently live brokers. Fetches live brokers from cluster.
+     * Use {@link #modifyInterBrokerThrottle(Admin, Set, long, Set)} to avoid redundant describeCluster calls.
+     */
+    static void modifyInterBrokerThrottle(Admin adminClient,
+                                          Set<Integer> reassigningBrokers,
+                                          long interBrokerThrottle) throws ExecutionException, InterruptedException {
+        modifyInterBrokerThrottle(adminClient, reassigningBrokers, interBrokerThrottle, getLiveBrokerIds(adminClient));
     }
 
     /**
      * Modify the leader/follower replication throttles for a set of brokers.
      * Only applies throttle to currently live brokers, so reassignment can proceed
-     * even when some brokers are down (avoids TimeoutException on incrementalAlterConfigs).
+     * even when some source brokers are down (avoids TimeoutException on incrementalAlterConfigs).
+     * Note: The live broker set is a snapshot; a broker could go down or come back up
+     * between the check and the incrementalAlterConfigs call.
      *
      * @param adminClient The Admin instance to use
-     * @param reassigningBrokers The set of brokers involved in the reassignment
+     * @param reassigningBrokers The set of brokers involved in the reassignment (sources and destinations)
      * @param interBrokerThrottle The new throttle (ignored if less than 0)
+     * @param liveBrokers The set of broker IDs currently live in the cluster
      */
     static void modifyInterBrokerThrottle(Admin adminClient,
                                           Set<Integer> reassigningBrokers,
-                                          long interBrokerThrottle) throws ExecutionException, InterruptedException {
+                                          long interBrokerThrottle,
+                                          Set<Integer> liveBrokers) throws ExecutionException, InterruptedException {
         if (interBrokerThrottle >= 0) {
-            Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
             Set<Integer> brokersToUpdate = reassigningBrokers.stream()
                 .filter(liveBrokers::contains)
                 .collect(Collectors.toSet());
+            Set<Integer> downBrokers = reassigningBrokers.stream()
+                .filter(b -> !liveBrokers.contains(b))
+                .collect(Collectors.toSet());
+
+            if (!downBrokers.isEmpty()) {
+                System.out.printf("Warning: Could not set inter-broker throttle on down broker%s %s. " +
+                    "Reassignment will proceed with throttle on live brokers only.%n",
+                    downBrokers.size() == 1 ? "" : "s",
+                    downBrokers.stream().sorted().map(Object::toString).collect(Collectors.joining(",")));
+            }
+
             if (brokersToUpdate.isEmpty()) {
                 return;
             }
@@ -1230,21 +1272,44 @@ public class ReassignPartitionsCommand {
 
     /**
      * Modify the log dir reassignment throttle for a set of brokers.
+     * Only applies throttle to currently live brokers. Fetches live brokers from cluster.
+     * Use {@link #modifyLogDirThrottle(Admin, Set, long, Set)} to avoid redundant describeCluster calls.
+     */
+    static void modifyLogDirThrottle(Admin admin,
+                                     Set<Integer> movingBrokers,
+                                     long logDirThrottle) throws ExecutionException, InterruptedException {
+        modifyLogDirThrottle(admin, movingBrokers, logDirThrottle, getLiveBrokerIds(admin));
+    }
+
+    /**
+     * Modify the log dir reassignment throttle for a set of brokers.
      * Only applies throttle to currently live brokers, so reassignment can proceed
      * even when some brokers are down (avoids TimeoutException on incrementalAlterConfigs).
      *
      * @param admin The Admin instance to use
      * @param movingBrokers The set of broker to alter the throttle of
      * @param logDirThrottle The new throttle (ignored if less than 0)
+     * @param liveBrokers The set of broker IDs currently live in the cluster
      */
     static void modifyLogDirThrottle(Admin admin,
                                      Set<Integer> movingBrokers,
-                                     long logDirThrottle) throws ExecutionException, InterruptedException {
+                                     long logDirThrottle,
+                                     Set<Integer> liveBrokers) throws ExecutionException, InterruptedException {
         if (logDirThrottle >= 0) {
-            Set<Integer> liveBrokers = getLiveBrokerIds(admin);
             Set<Integer> brokersToUpdate = movingBrokers.stream()
                 .filter(liveBrokers::contains)
                 .collect(Collectors.toSet());
+            Set<Integer> downBrokers = movingBrokers.stream()
+                .filter(b -> !liveBrokers.contains(b))
+                .collect(Collectors.toSet());
+
+            if (!downBrokers.isEmpty()) {
+                System.out.printf("Warning: Could not set replica-alter-dir throttle on down broker%s %s. " +
+                    "Reassignment will proceed with throttle on live brokers only.%n",
+                    downBrokers.size() == 1 ? "" : "s",
+                    downBrokers.stream().sorted().map(Object::toString).collect(Collectors.joining(",")));
+            }
+
             if (brokersToUpdate.isEmpty()) {
                 return;
             }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -510,8 +510,8 @@ public class ReassignPartitionsCommand {
      * @param adminClient     The AdminClient to use.
      * @param targetParts     The target partitions loaded from the JSON file.
      */
-    static void clearAllThrottles(Admin adminClient,
-                                  List<Entry<TopicPartition, List<Integer>>> targetParts
+    private static void clearAllThrottles(Admin adminClient,
+                                          List<Entry<TopicPartition, List<Integer>>> targetParts
     ) throws ExecutionException, InterruptedException {
         Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
         Set<Integer> brokersFromAssignment = new HashSet<>();
@@ -529,7 +529,7 @@ public class ReassignPartitionsCommand {
 
         if (!downBrokers.isEmpty()) {
             System.out.printf("Warning: Could not clear broker-level throttles on down broker%s %s. " +
-                "Throttles will be cleared when the broker comes back up.%n",
+                "Re-run --verify after the brokers are back up to clear its throttles.%n",
                 downBrokers.size() == 1 ? "" : "s",
                 downBrokers.stream().sorted().map(Object::toString).collect(Collectors.joining(",")));
         }

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -491,6 +491,17 @@ public class ReassignPartitionsCommand {
     }
 
     /**
+     * Get the set of broker IDs that are currently live in the cluster.
+     * Only live brokers can be successfully configured via incrementalAlterConfigs.
+     *
+     * @param adminClient     The AdminClient to use.
+     * @return               The set of live broker IDs.
+     */
+    private static Set<Integer> getLiveBrokerIds(Admin adminClient) throws ExecutionException, InterruptedException {
+        return adminClient.describeCluster().nodes().get().stream().map(Node::id).collect(Collectors.toSet());
+    }
+
+    /**
      * Clear all topic-level and broker-level throttles.
      *
      * @param adminClient     The AdminClient to use.
@@ -499,8 +510,10 @@ public class ReassignPartitionsCommand {
     private static void clearAllThrottles(Admin adminClient,
                                           List<Entry<TopicPartition, List<Integer>>> targetParts
     ) throws ExecutionException, InterruptedException {
-        Set<Integer> brokers = adminClient.describeCluster().nodes().get().stream().map(Node::id).collect(Collectors.toSet());
+        Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
+        Set<Integer> brokers = new HashSet<>(liveBrokers);
         targetParts.forEach(t -> brokers.addAll(t.getValue()));
+        brokers.retainAll(liveBrokers);
 
         System.out.printf("Clearing broker-level throttles on broker%s %s%n",
             brokers.size() == 1 ? "" : "s", brokers.stream().map(Object::toString).collect(Collectors.joining(",")));
@@ -1183,6 +1196,8 @@ public class ReassignPartitionsCommand {
 
     /**
      * Modify the leader/follower replication throttles for a set of brokers.
+     * Only applies throttle to currently live brokers, so reassignment can proceed
+     * even when some brokers are down (avoids TimeoutException on incrementalAlterConfigs).
      *
      * @param adminClient The Admin instance to use
      * @param reassigningBrokers The set of brokers involved in the reassignment
@@ -1192,8 +1207,15 @@ public class ReassignPartitionsCommand {
                                           Set<Integer> reassigningBrokers,
                                           long interBrokerThrottle) throws ExecutionException, InterruptedException {
         if (interBrokerThrottle >= 0) {
+            Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
+            Set<Integer> brokersToUpdate = reassigningBrokers.stream()
+                .filter(liveBrokers::contains)
+                .collect(Collectors.toSet());
+            if (brokersToUpdate.isEmpty()) {
+                return;
+            }
             Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
-            reassigningBrokers.forEach(brokerId -> {
+            brokersToUpdate.forEach(brokerId -> {
                 List<AlterConfigOp> ops = new ArrayList<>();
                 ops.add(new AlterConfigOp(new ConfigEntry(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG,
                     Long.toString(interBrokerThrottle)), AlterConfigOp.OpType.SET));
@@ -1208,6 +1230,8 @@ public class ReassignPartitionsCommand {
 
     /**
      * Modify the log dir reassignment throttle for a set of brokers.
+     * Only applies throttle to currently live brokers, so reassignment can proceed
+     * even when some brokers are down (avoids TimeoutException on incrementalAlterConfigs).
      *
      * @param admin The Admin instance to use
      * @param movingBrokers The set of broker to alter the throttle of
@@ -1217,8 +1241,15 @@ public class ReassignPartitionsCommand {
                                      Set<Integer> movingBrokers,
                                      long logDirThrottle) throws ExecutionException, InterruptedException {
         if (logDirThrottle >= 0) {
+            Set<Integer> liveBrokers = getLiveBrokerIds(admin);
+            Set<Integer> brokersToUpdate = movingBrokers.stream()
+                .filter(liveBrokers::contains)
+                .collect(Collectors.toSet());
+            if (brokersToUpdate.isEmpty()) {
+                return;
+            }
             Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
-            movingBrokers.forEach(brokerId -> {
+            brokersToUpdate.forEach(brokerId -> {
                 List<AlterConfigOp> ops = new ArrayList<>();
                 ops.add(new AlterConfigOp(new ConfigEntry(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, Long.toString(logDirThrottle)), AlterConfigOp.OpType.SET));
                 configs.put(new ConfigResource(ConfigResource.Type.BROKER, Long.toString(brokerId)), ops);

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -61,6 +61,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -514,7 +515,14 @@ public class ReassignPartitionsCommand {
     ) throws ExecutionException, InterruptedException {
         Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
         Set<Integer> brokersFromAssignment = new HashSet<>();
-        targetParts.forEach(t -> brokersFromAssignment.addAll(t.getValue()));
+        if (targetParts != null) {
+            for (Entry<TopicPartition, List<Integer>> t : targetParts) {
+                List<Integer> replicas = t.getValue();
+                if (replicas != null) {
+                    brokersFromAssignment.addAll(replicas);
+                }
+            }
+        }
         Set<Integer> downBrokers = brokersFromAssignment.stream()
             .filter(b -> !liveBrokers.contains(b))
             .collect(Collectors.toSet());
@@ -533,10 +541,13 @@ public class ReassignPartitionsCommand {
             clearBrokerLevelThrottles(adminClient, liveBrokers);
         }
 
-        Set<String> topics = targetParts.stream().map(t -> t.getKey().topic()).collect(Collectors.toSet());
-        System.out.printf("Clearing topic-level throttles on topic%s %s%n",
-            topics.size() == 1 ? "" : "s", String.join(",", topics));
-        clearTopicLevelThrottles(adminClient, topics);
+        Set<String> topics = (targetParts == null ? List.<Entry<TopicPartition, List<Integer>>>of() : targetParts)
+            .stream().map(t -> t.getKey().topic()).collect(Collectors.toSet());
+        if (!topics.isEmpty()) {
+            System.out.printf("Clearing topic-level throttles on topic%s %s%n",
+                topics.size() == 1 ? "" : "s", String.join(",", topics));
+            clearTopicLevelThrottles(adminClient, topics);
+        }
     }
 
     /**
@@ -1239,11 +1250,12 @@ public class ReassignPartitionsCommand {
                                           long interBrokerThrottle,
                                           Set<Integer> liveBrokers) throws ExecutionException, InterruptedException {
         if (interBrokerThrottle >= 0) {
-            Set<Integer> brokersToUpdate = reassigningBrokers.stream()
-                .filter(liveBrokers::contains)
+            Set<Integer> live = liveBrokers != null ? liveBrokers : Collections.<Integer>emptySet();
+            Set<Integer> brokersToUpdate = (reassigningBrokers != null ? reassigningBrokers : Collections.<Integer>emptySet()).stream()
+                .filter(live::contains)
                 .collect(Collectors.toSet());
-            Set<Integer> downBrokers = reassigningBrokers.stream()
-                .filter(b -> !liveBrokers.contains(b))
+            Set<Integer> downBrokers = (reassigningBrokers != null ? reassigningBrokers : Collections.<Integer>emptySet()).stream()
+                .filter(b -> !live.contains(b))
                 .collect(Collectors.toSet());
 
             if (!downBrokers.isEmpty()) {
@@ -1296,11 +1308,13 @@ public class ReassignPartitionsCommand {
                                      long logDirThrottle,
                                      Set<Integer> liveBrokers) throws ExecutionException, InterruptedException {
         if (logDirThrottle >= 0) {
-            Set<Integer> brokersToUpdate = movingBrokers.stream()
-                .filter(liveBrokers::contains)
+            Set<Integer> live = liveBrokers != null ? liveBrokers : Collections.<Integer>emptySet();
+            Set<Integer> moving = movingBrokers != null ? movingBrokers : Collections.<Integer>emptySet();
+            Set<Integer> brokersToUpdate = moving.stream()
+                .filter(live::contains)
                 .collect(Collectors.toSet());
-            Set<Integer> downBrokers = movingBrokers.stream()
-                .filter(b -> !liveBrokers.contains(b))
+            Set<Integer> downBrokers = moving.stream()
+                .filter(b -> !live.contains(b))
                 .collect(Collectors.toSet());
 
             if (!downBrokers.isEmpty()) {

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -511,7 +511,7 @@ public class ReassignPartitionsCommand {
      * @param targetParts     The target partitions loaded from the JSON file.
      */
     static void clearAllThrottles(Admin adminClient,
-                                          List<Entry<TopicPartition, List<Integer>>> targetParts
+                                  List<Entry<TopicPartition, List<Integer>>> targetParts
     ) throws ExecutionException, InterruptedException {
         Set<Integer> liveBrokers = getLiveBrokerIds(adminClient);
         Set<Integer> brokersFromAssignment = new HashSet<>();

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -809,6 +809,46 @@ public class ReassignPartitionsUnitTest {
     }
 
     /**
+     * Test that modifyInterBrokerThrottle with empty liveBrokers returns early without calling incrementalAlterConfigs.
+     * Covers the case when describeCluster returns no nodes (entire cluster down).
+     */
+    @Test
+    public void testModifyInterBrokerThrottleWithEmptyLiveBrokers() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            Admin adminThatFailsIfConfigAltered = (Admin) Proxy.newProxyInstance(
+                Admin.class.getClassLoader(),
+                new Class<?>[]{Admin.class},
+                (proxy, method, args) -> {
+                    if ("incrementalAlterConfigs".equals(method.getName())) {
+                        throw new AssertionError("incrementalAlterConfigs should not be called when liveBrokers is empty");
+                    }
+                    return method.invoke(adminClient, args);
+                });
+            modifyInterBrokerThrottle(adminThatFailsIfConfigAltered, Set.of(0, 1, 2), 1000, Collections.emptySet());
+        }
+    }
+
+    /**
+     * Test that modifyLogDirThrottle with empty liveBrokers returns early without calling incrementalAlterConfigs.
+     * Covers the case when describeCluster returns no nodes (entire cluster down).
+     */
+    @Test
+    public void testModifyLogDirThrottleWithEmptyLiveBrokers() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            Admin adminThatFailsIfConfigAltered = (Admin) Proxy.newProxyInstance(
+                Admin.class.getClassLoader(),
+                new Class<?>[]{Admin.class},
+                (proxy, method, args) -> {
+                    if ("incrementalAlterConfigs".equals(method.getName())) {
+                        throw new AssertionError("incrementalAlterConfigs should not be called when liveBrokers is empty");
+                    }
+                    return method.invoke(adminClient, args);
+                });
+            modifyLogDirThrottle(adminThatFailsIfConfigAltered, Set.of(0, 1, 2), 2000, Collections.emptySet());
+        }
+    }
+
+    /**
      * Test that clearAllThrottles only clears throttles on live brokers when some brokers are down.
      * Called by --verify when reassignment completes.
      */

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.alterPartitionReassignments;
-import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.clearAllThrottles;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.alterReplicaLogDirs;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.calculateFollowerThrottles;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.calculateLeaderThrottles;
@@ -68,6 +67,7 @@ import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.cancelPa
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.compareTopicPartitionReplicas;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.compareTopicPartitions;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.curReassignmentsToString;
+import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.verifyAssignment;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.currentPartitionReplicaAssignmentToString;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.executeAssignment;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.findLogDirMoveStates;
@@ -849,8 +849,8 @@ public class ReassignPartitionsUnitTest {
     }
 
     /**
-     * Test that clearAllThrottles only clears throttles on live brokers when some brokers are down.
-     * Called by --verify when reassignment completes.
+     * Test that clearAllThrottles (invoked via verifyAssignment when reassignment completes) only clears
+     * throttles on live brokers when some brokers are down.
      */
     @Test
     public void testClearAllThrottlesSkipsDownBrokers() throws Exception {
@@ -858,17 +858,17 @@ public class ReassignPartitionsUnitTest {
             addTopicsForThreeBrokers(adminClient);
             // Set throttle on live brokers first
             modifyInterBrokerThrottle(adminClient, Set.of(0, 1, 2), 1000);
-            // targetParts includes broker 3 (down) - from assignment that had broker 3
-            List<Entry<TopicPartition, List<Integer>>> targetParts = List.of(
-                new SimpleImmutableEntry<>(new TopicPartition("foo", 0), List.of(0, 1, 2)),
-                new SimpleImmutableEntry<>(new TopicPartition("foo", 1), List.of(1, 2, 3))
-            );
+            // Assignment includes broker 3 (down) - verifyAssignment will call clearAllThrottles when done
+            String assignment = "{\"version\":1,\"partitions\":[" +
+                "{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1,2],\"log_dirs\":[\"any\",\"any\",\"any\"]}," +
+                "{\"topic\":\"foo\",\"partition\":1,\"replicas\":[1,2,3],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
+                "]}";
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             PrintStream originalOut = System.out;
             try {
                 System.setOut(new PrintStream(out));
-                clearAllThrottles(adminClient, targetParts);
+                verifyAssignment(adminClient, assignment, false);
             } finally {
                 System.setOut(originalOut);
             }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.tools.reassign;
 
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.admin.PartitionReassignment;
@@ -38,6 +39,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Proxy;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +57,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.alterPartitionReassignments;
+import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.clearAllThrottles;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.alterReplicaLogDirs;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.calculateFollowerThrottles;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.calculateLeaderThrottles;
@@ -756,12 +761,12 @@ public class ReassignPartitionsUnitTest {
     }
 
     /**
-     * Test that executeAssignment with throttle succeeds when some brokers are down.
-     * Uses MockAdminClient with 3 brokers; reassignment only involves live brokers (0, 1, 2).
-     * The throttle is applied only to live brokers via modifyInterBrokerThrottle/modifyLogDirThrottle.
+     * Test that executeAssignment with throttle succeeds when reassignment involves only live brokers.
+     * With verifyBrokerIds, target brokers must exist; this fix handles down source brokers
+     * (replicas we're moving FROM) by only applying throttle to live brokers.
      */
     @Test
-    public void testExecuteAssignmentWithThrottleWhenBrokerDown() throws Exception {
+    public void testExecuteAssignmentWithThrottleSucceedsWithOnlyLiveBrokers() throws Exception {
         try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
             addTopicsForThreeBrokers(adminClient);
             String assignment = "{\"version\":1,\"partitions\":" +
@@ -784,12 +789,64 @@ public class ReassignPartitionsUnitTest {
 
     /**
      * Test that modifyInterBrokerThrottle succeeds when all reassigning brokers are down.
-     * Should return early without calling incrementalAlterConfigs.
+     * Verifies incrementalAlterConfigs is not called (returns early).
      */
     @Test
     public void testModifyInterBrokerThrottleWhenAllBrokersDown() throws Exception {
         try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
-            modifyInterBrokerThrottle(adminClient, Set.of(3), 1000);
+            Admin adminThatFailsIfConfigAltered = (Admin) Proxy.newProxyInstance(
+                Admin.class.getClassLoader(),
+                new Class<?>[]{Admin.class},
+                (proxy, method, args) -> {
+                    if ("incrementalAlterConfigs".equals(method.getName())) {
+                        throw new AssertionError("incrementalAlterConfigs should not be called when all brokers are down");
+                    }
+                    return method.invoke(adminClient, args);
+                });
+            // Should return early without calling incrementalAlterConfigs - no exception means success
+            modifyInterBrokerThrottle(adminThatFailsIfConfigAltered, Set.of(3), 1000);
+        }
+    }
+
+    /**
+     * Test that clearAllThrottles only clears throttles on live brokers when some brokers are down.
+     * Called by --verify when reassignment completes.
+     */
+    @Test
+    public void testClearAllThrottlesSkipsDownBrokers() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            addTopicsForThreeBrokers(adminClient);
+            // Set throttle on live brokers first
+            modifyInterBrokerThrottle(adminClient, Set.of(0, 1, 2), 1000);
+            // targetParts includes broker 3 (down) - from assignment that had broker 3
+            List<Entry<TopicPartition, List<Integer>>> targetParts = List.of(
+                new SimpleImmutableEntry<>(new TopicPartition("foo", 0), List.of(0, 1, 2)),
+                new SimpleImmutableEntry<>(new TopicPartition("foo", 1), List.of(1, 2, 3))
+            );
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PrintStream originalOut = System.out;
+            try {
+                System.setOut(new PrintStream(out));
+                clearAllThrottles(adminClient, targetParts);
+            } finally {
+                System.setOut(originalOut);
+            }
+
+            String output = out.toString();
+            assertTrue(output.contains("Warning: Could not clear broker-level throttles on down broker 3"),
+                "Expected warning about down broker 3, got: " + output);
+            assertTrue(output.contains("Clearing broker-level throttles") && output.contains("0,1,2"),
+                "Expected clearing on live brokers 0,1,2, got: " + output);
+
+            // Verify throttles were cleared on live brokers
+            List<ConfigResource> brokers = new ArrayList<>();
+            for (int i = 0; i < 3; i++)
+                brokers.add(new ConfigResource(ConfigResource.Type.BROKER, Integer.toString(i)));
+            Map<ConfigResource, Config> results = adminClient.describeConfigs(brokers).all().get();
+            verifyBrokerThrottleResults(results.get(brokers.get(0)), -1, -1);
+            verifyBrokerThrottleResults(results.get(brokers.get(1)), -1, -1);
+            verifyBrokerThrottleResults(results.get(brokers.get(2)), -1, -1);
         }
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsUnitTest.java
@@ -152,6 +152,27 @@ public class ReassignPartitionsUnitTest {
         ), Map.of());
     }
 
+    /**
+     * Add topics for a 3-broker cluster (brokers 0, 1, 2 only).
+     * Used when simulating broker-down scenarios.
+     */
+    private void addTopicsForThreeBrokers(MockAdminClient adminClient) {
+        List<Node> b = adminClient.brokers();
+        adminClient.addTopic(false, "foo", List.of(
+            new TopicPartitionInfo(0, b.get(0),
+                List.of(b.get(0), b.get(1), b.get(2)),
+                List.of(b.get(0), b.get(1))),
+            new TopicPartitionInfo(1, b.get(1),
+                List.of(b.get(1), b.get(2), b.get(0)),
+                List.of(b.get(1), b.get(2), b.get(0)))
+        ), Map.of());
+        adminClient.addTopic(false, "bar", List.of(
+            new TopicPartitionInfo(0, b.get(2),
+                List.of(b.get(2), b.get(0), b.get(1)),
+                List.of(b.get(2), b.get(0), b.get(1)))
+        ), Map.of());
+    }
+
     @Test
     public void testFindPartitionReassignmentStates() throws Exception {
         try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(4).build()) {
@@ -693,6 +714,82 @@ public class ReassignPartitionsUnitTest {
             verifyBrokerThrottleResults(results.get(brokers.get(1)), -1, 2000);
             verifyBrokerThrottleResults(results.get(brokers.get(2)), -1, 2000);
             verifyBrokerThrottleResults(results.get(brokers.get(3)), -1, -1);
+        }
+    }
+
+    /**
+     * Test that modifyInterBrokerThrottle only applies throttle to live brokers.
+     * When broker 3 is down (not in describeCluster), it should be skipped to avoid TimeoutException.
+     */
+    @Test
+    public void testModifyInterBrokerThrottleSkipsDownBrokers() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            modifyInterBrokerThrottle(adminClient, Set.of(0, 1, 2, 3), 1000);
+
+            List<ConfigResource> brokers = new ArrayList<>();
+            for (int i = 0; i < 3; i++)
+                brokers.add(new ConfigResource(ConfigResource.Type.BROKER, Integer.toString(i)));
+            Map<ConfigResource, Config> results = adminClient.describeConfigs(brokers).all().get();
+            verifyBrokerThrottleResults(results.get(brokers.get(0)), 1000, -1);
+            verifyBrokerThrottleResults(results.get(brokers.get(1)), 1000, -1);
+            verifyBrokerThrottleResults(results.get(brokers.get(2)), 1000, -1);
+        }
+    }
+
+    /**
+     * Test that modifyLogDirThrottle only applies throttle to live brokers.
+     * When broker 3 is down (not in describeCluster), it should be skipped to avoid TimeoutException.
+     */
+    @Test
+    public void testModifyLogDirThrottleSkipsDownBrokers() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            modifyLogDirThrottle(adminClient, Set.of(0, 1, 2, 3), 2000);
+
+            List<ConfigResource> brokers = new ArrayList<>();
+            for (int i = 0; i < 3; i++)
+                brokers.add(new ConfigResource(ConfigResource.Type.BROKER, Integer.toString(i)));
+            Map<ConfigResource, Config> results = adminClient.describeConfigs(brokers).all().get();
+            verifyBrokerThrottleResults(results.get(brokers.get(0)), -1, 2000);
+            verifyBrokerThrottleResults(results.get(brokers.get(1)), -1, 2000);
+            verifyBrokerThrottleResults(results.get(brokers.get(2)), -1, 2000);
+        }
+    }
+
+    /**
+     * Test that executeAssignment with throttle succeeds when some brokers are down.
+     * Uses MockAdminClient with 3 brokers; reassignment only involves live brokers (0, 1, 2).
+     * The throttle is applied only to live brokers via modifyInterBrokerThrottle/modifyLogDirThrottle.
+     */
+    @Test
+    public void testExecuteAssignmentWithThrottleWhenBrokerDown() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            addTopicsForThreeBrokers(adminClient);
+            String assignment = "{\"version\":1,\"partitions\":" +
+                "[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[0,1,2],\"log_dirs\":[\"any\",\"any\",\"any\"]}," +
+                "{\"topic\":\"foo\",\"partition\":1,\"replicas\":[1,2,0],\"log_dirs\":[\"any\",\"any\",\"any\"]}" +
+                "]}";
+            executeAssignment(adminClient, false, assignment, 1000L, 2000L, 10000L, Time.SYSTEM, false);
+
+            List<ConfigResource> brokers = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                brokers.add(new ConfigResource(ConfigResource.Type.BROKER, Integer.toString(i)));
+            }
+            Map<ConfigResource, Config> results = adminClient.describeConfigs(brokers).all().get();
+            // Only inter-broker throttle is applied; log-dir throttle is not set since log_dirs are all "any"
+            verifyBrokerThrottleResults(results.get(brokers.get(0)), 1000, -1);
+            verifyBrokerThrottleResults(results.get(brokers.get(1)), 1000, -1);
+            verifyBrokerThrottleResults(results.get(brokers.get(2)), 1000, -1);
+        }
+    }
+
+    /**
+     * Test that modifyInterBrokerThrottle succeeds when all reassigning brokers are down.
+     * Should return early without calling incrementalAlterConfigs.
+     */
+    @Test
+    public void testModifyInterBrokerThrottleWhenAllBrokersDown() throws Exception {
+        try (MockAdminClient adminClient = new MockAdminClient.Builder().numBrokers(3).build()) {
+            modifyInterBrokerThrottle(adminClient, Set.of(3), 1000);
         }
     }
 


### PR DESCRIPTION
**Problem**
When a broker is down and `executeAssignment()` runs, `incrementalAlterConfigs` can throw TimeoutException because it tries to set broker-level throttles (inter-broker and log-dir) on brokers that are no longer live. The AdminClient sends config updates directly to each broker; if a broker is down, the request times out and the reassignment fails.

**Solution**
Apply throttle configuration only to brokers that are currently live. Live brokers are determined via `adminClient.describeCluster().nodes()`. Throttle configs are no longer sent to brokers that are not in this set, so reassignment can proceed even when some brokers are down.
I provided another solution before, Refer to https://github.com/apache/kafka/pull/21388, it will add a new parameter `--broker-list-without-throttle` to remove the broker, which is down. 
The new solution is better I think.

**Changes**
1. `getLiveBrokerIds()` helper
Returns the set of broker IDs from describeCluster().nodes().
2. `modifyInterBrokerThrottle()`
Filters reassigningBrokers to only live brokers before calling incrementalAlterConfigs.
Returns early if no brokers are live.
3. `modifyLogDirThrottle()`
Filters movingBrokers to only live brokers before calling incrementalAlterConfigs.
Returns early if no brokers are live.
4. `clearAllThrottles()`
Clears broker-level throttles only for live brokers.
Uses retainAll(liveBrokers) so we never call incrementalAlterConfigs on down brokers.

**Testing**
Unit tests in ReassignPartitionsUnitTest:
1. testModifyInterBrokerThrottleSkipsDownBrokers – MockAdminClient with 3 brokers; modifyInterBrokerThrottle is called with brokers 0–3. Verifies throttle is applied only to 0, 1, 2 and broker 3 is skipped.
2. testModifyLogDirThrottleSkipsDownBrokers – Same setup for modifyLogDirThrottle.
3. testExecuteAssignmentWithThrottleWhenBrokerDown – Full executeAssignment with throttle on a 3-broker cluster; verifies reassignment succeeds and throttle is applied only to live brokers.
4. testModifyInterBrokerThrottleWhenAllBrokersDown – All reassigning brokers are down; verifies no exception and early return without calling incrementalAlterConfigs.

MockAdminClient with 3 brokers is used to simulate broker 3 being down (not in describeCluster().nodes()). Without the fix, incrementalAlterConfigs for broker 3 would fail with InvalidRequestException in the mock (or TimeoutException in a real cluster).