### PR TITLE
MINOR: Set unequal assignment epochs fallback to default epoch for streams group

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -5710,7 +5710,7 @@ public class GroupMetadataManager {
             StreamsGroup streamsGroup = getOrMaybeCreatePersistedStreamsGroup(groupId, true);
             StreamsGroupMember oldMember = streamsGroup.getOrCreateUninitializedMember(memberId);
             StreamsGroupMember newMember = new StreamsGroupMember.Builder(oldMember)
-                .updateWith(value)
+                .updateWith(log, groupId, value)
                 .build();
             streamsGroup.updateMember(newMember);
         } else {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.streams;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
+
 import org.slf4j.Logger;
 
 import java.util.ArrayList;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.streams;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -249,12 +250,14 @@ public record StreamsGroupMember(String memberId,
             return this;
         }
 
-        public Builder updateWith(StreamsGroupCurrentMemberAssignmentValue record) {
+        public Builder updateWith(Logger log, String groupId, StreamsGroupCurrentMemberAssignmentValue record) {
             setMemberEpoch(record.memberEpoch());
             setPreviousMemberEpoch(record.previousMemberEpoch());
             setState(MemberState.fromValue(record.state()));
             setAssignedTasks(
                 TasksTupleWithEpochs.fromCurrentAssignmentRecord(
+                    log,
+                    groupId,
                     record.activeTasks(),
                     record.standbyTasks(),
                     record.warmupTasks(),
@@ -263,6 +266,8 @@ public record StreamsGroupMember(String memberId,
             );
             setTasksPendingRevocation(
                 TasksTupleWithEpochs.fromCurrentAssignmentRecord(
+                    log,
+                    groupId,
                     record.activeTasksPendingRevocation(),
                     record.standbyTasksPendingRevocation(),
                     record.warmupTasksPendingRevocation(),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
+
 import org.slf4j.Logger;
 
 import java.util.Collections;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -18,7 +18,6 @@ package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,8 +44,6 @@ import java.util.Set;
 public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTasksWithEpochs,
                                    Map<String, Set<Integer>> standbyTasks,
                                    Map<String, Set<Integer>> warmupTasks) {
-
-    private static final Logger log = LoggerFactory.getLogger(TasksTupleWithEpochs.class);
 
     public TasksTupleWithEpochs {
         activeTasksWithEpochs = Collections.unmodifiableMap(Objects.requireNonNull(activeTasksWithEpochs));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,6 +45,8 @@ import java.util.Set;
 public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTasksWithEpochs,
                                    Map<String, Set<Integer>> standbyTasks,
                                    Map<String, Set<Integer>> warmupTasks) {
+
+    private static final Logger log = LoggerFactory.getLogger(TasksTupleWithEpochs.class);
 
     public TasksTupleWithEpochs {
         activeTasksWithEpochs = Collections.unmodifiableMap(Objects.requireNonNull(activeTasksWithEpochs));
@@ -137,19 +141,16 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
 
             Map<Integer, Integer> partitionsWithEpochs = new HashMap<>();
 
-            if (epochs != null && !epochs.isEmpty()) {
-                if (epochs.size() != partitions.size()) {
-                    throw new IllegalStateException(
-                        "Assignment epochs must be provided for all partitions. " +
-                        "Subtopology " + subtopologyId + " has " + partitions.size() +
-                        " partitions but " + epochs.size() + " epochs"
-                    );
-                }
-
+            if (epochs != null && epochs.size() == partitions.size()) {
                 for (int i = 0; i < partitions.size(); i++) {
                     partitionsWithEpochs.put(partitions.get(i), epochs.get(i));
                 }
             } else {
+                if (epochs != null) {
+                    log.error("Size of assignment epochs {} is not equal to partitions {} for subtopology {}. " +
+                            "Using default epoch {} for all partitions.",
+                        epochs.size(), partitions.size(), subtopologyId, memberEpoch);
+                }
                 // Legacy record without epochs: use member epoch as default
                 for (Integer partition : partitions) {
                     partitionsWithEpochs.put(partition, memberEpoch);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochs.java
@@ -106,13 +106,15 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
      * @return The TasksTupleWithEpochs
      */
     public static TasksTupleWithEpochs fromCurrentAssignmentRecord(
+        Logger log,
+        String groupId,
         List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> activeTasks,
         List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> standbyTasks,
         List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> warmupTasks,
         int memberEpoch
     ) {
         return new TasksTupleWithEpochs(
-            parseActiveTasksWithEpochs(activeTasks, memberEpoch),
+            parseActiveTasksWithEpochs(log, groupId, activeTasks, memberEpoch),
             parseSimpleTasks(standbyTasks),
             parseSimpleTasks(warmupTasks)
         );
@@ -129,6 +131,8 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
     }
 
     private static Map<String, Map<Integer, Integer>> parseActiveTasksWithEpochs(
+        Logger log,
+        String groupId,
         List<StreamsGroupCurrentMemberAssignmentValue.TaskIds> taskIdsList,
         int memberEpoch
     ) {
@@ -147,9 +151,9 @@ public record TasksTupleWithEpochs(Map<String, Map<Integer, Integer>> activeTask
                 }
             } else {
                 if (epochs != null) {
-                    log.error("Size of assignment epochs {} is not equal to partitions {} for subtopology {}. " +
+                    log.error("[GroupId {}] Size of assignment epochs {} is not equal to partitions {} for subtopology {}. " +
                             "Using default epoch {} for all partitions.",
-                        epochs.size(), partitions.size(), subtopologyId, memberEpoch);
+                        groupId, epochs.size(), partitions.size(), subtopologyId, memberEpoch);
                 }
                 // Legacy record without epochs: use member epoch as default
                 for (Integer partition : partitions) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataVa
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue.KeyValue;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +48,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamsGroupMemberTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(StreamsGroupMemberTest.class);
+    private static final String GROUP_ID = "test-group";
     private static final String MEMBER_ID = "member-id";
     private static final int MEMBER_EPOCH = 10;
     private static final int PREVIOUS_MEMBER_EPOCH = 9;
@@ -226,7 +230,7 @@ public class StreamsGroupMemberTest {
             .setWarmupTasksPendingRevocation(List.of(new TaskIds().setSubtopologyId(SUBTOPOLOGY2).setPartitions(TASKS6)));
 
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID)
-            .updateWith(record)
+            .updateWith(LOG, GROUP_ID, record)
             .build();
 
         assertEquals(MEMBER_ID, member.memberId());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 
 import org.junit.jupiter.api.Test;
@@ -152,9 +153,16 @@ public class TasksTupleWithEpochsTest {
             .setPartitions(Arrays.asList(1, 2, 3))
             .setAssignmentEpochs(Arrays.asList(10, 11))); // Only 2 epochs for 3 partitions
 
-        assertThrows(IllegalStateException.class, () ->
-            TasksTupleWithEpochs.fromCurrentAssignmentRecord(activeTasks, List.of(), List.of(), 100)
-        );
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(TasksTupleWithEpochs.class)) {
+            TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(activeTasks, List.of(), List.of(), 100);
+            assertEquals(
+                Map.of(SUBTOPOLOGY_1, Map.of(1, 100, 2, 100, 3, 100)),
+                tuple.activeTasksWithEpochs()
+            );
+            assertEquals(1, appender.getMessages("ERROR").stream()
+                .filter(msg -> msg.contains("Size of assignment epochs 2 is not equal to partitions 3 for subtopology 1."))
+                .count());
+        }
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TasksTupleWithEpochsTest.java
@@ -20,6 +20,8 @@ import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TasksTupleWithEpochsTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TasksTupleWithEpochs.class);
+    private static final String GROUP_ID = "test-group";
     private static final String SUBTOPOLOGY_1 = "1";
     private static final String SUBTOPOLOGY_2 = "2";
     private static final String SUBTOPOLOGY_3 = "3";
@@ -98,7 +102,7 @@ public class TasksTupleWithEpochsTest {
             .setPartitions(Arrays.asList(7, 8, 9)));
 
         TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(
-            activeTasks, standbyTasks, warmupTasks, 100
+            LOG, GROUP_ID, activeTasks, standbyTasks, warmupTasks, 100
         );
 
         assertEquals(
@@ -134,7 +138,7 @@ public class TasksTupleWithEpochsTest {
 
         int memberEpoch = 100;
         TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(
-            activeTasks, List.of(), List.of(), memberEpoch
+            LOG, GROUP_ID, activeTasks, List.of(), List.of(), memberEpoch
         );
 
         // Should use member epoch as default
@@ -154,13 +158,13 @@ public class TasksTupleWithEpochsTest {
             .setAssignmentEpochs(Arrays.asList(10, 11))); // Only 2 epochs for 3 partitions
 
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(TasksTupleWithEpochs.class)) {
-            TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(activeTasks, List.of(), List.of(), 100);
+            TasksTupleWithEpochs tuple = TasksTupleWithEpochs.fromCurrentAssignmentRecord(LOG, GROUP_ID, activeTasks, List.of(), List.of(), 100);
             assertEquals(
                 Map.of(SUBTOPOLOGY_1, Map.of(1, 100, 2, 100, 3, 100)),
                 tuple.activeTasksWithEpochs()
             );
             assertEquals(1, appender.getMessages("ERROR").stream()
-                .filter(msg -> msg.contains("Size of assignment epochs 2 is not equal to partitions 3 for subtopology 1."))
+                .filter(msg -> msg.contains("[GroupId " + GROUP_ID + "] Size of assignment epochs 2 is not equal to partitions 3 for subtopology 1."))
                 .count());
         }
     }


### PR DESCRIPTION
## Summary

This PR modifies the way of handling unequal assignmentEpoch and
partition array length, from throwing an `IllegalStateException` to
logging an error and then fallback to default member epoch.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
