### PR TITLE
MINOR: Replace Collections factory methods with Java 11+ equivalents in storage and metadata

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/MetadataCache.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/MetadataCache.java
@@ -36,7 +36,7 @@ import org.apache.kafka.server.common.MetadataVersion;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -188,7 +188,7 @@ public interface MetadataCache extends ConfigRepository {
             clusterId,
             brokerToNodes.values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
             partitionInfos,
-            Collections.emptySet(),
+            Set.of(),
             internalTopics,
             controllerNode
         );

--- a/metadata/src/main/java/org/apache/kafka/metadata/MetadataCache.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/MetadataCache.java
@@ -36,7 +36,6 @@ import org.apache.kafka.server.common.MetadataVersion;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleanerManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleanerManager.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleanerManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogCleanerManager.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -521,7 +521,7 @@ public class LogCleanerManager {
                 LOG.error("Failed to access checkpoint file in dir {}", sourceLogDir.getAbsolutePath(), e);
             }
 
-            Set<TopicPartition> logUncleanablePartitions = uncleanablePartitions.getOrDefault(sourceLogDir.toString(), Collections.emptySet());
+            Set<TopicPartition> logUncleanablePartitions = uncleanablePartitions.getOrDefault(sourceLogDir.toString(), Set.of());
             if (logUncleanablePartitions.contains(topicPartition)) {
                 logUncleanablePartitions.remove(topicPartition);
                 markPartitionUncleanable(destLogDir.toString(), topicPartition);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -70,7 +70,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -1588,7 +1588,7 @@ public class UnifiedLog implements AutoCloseable {
 
         return new LogAppendInfo(firstOffset, lastOffset, lastLeaderEpochOpt, maxTimestamp,
                 RecordBatch.NO_TIMESTAMP, logStartOffset, RecordValidationStats.EMPTY, sourceCompression,
-                validBytesCount, lastOffsetOfFirstBatch, Collections.emptyList(), LeaderHwChange.NONE);
+                validBytesCount, lastOffsetOfFirstBatch, List.of(), LeaderHwChange.NONE);
     }
 
     /**

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/UnifiedLog.java
@@ -70,7 +70,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;


### PR DESCRIPTION
This PR is another one with changing old JDK 8 API to JDK 11.

Question: I wonder if we should add also parts in test code or simply
divide it? I didn't cover tests in my previous PR so maybe to stay
consistent just make changes to production code and then we can simply
add into tests multiple modules?  Reviewers: Christo Lolov
<lolovc@amazon.com>, Ken Huang <s7133700@gmail.com>, Nilesh Kumar
<nileshkumar3@gmail.com>
