### PR TITLE
 KAFKA-13630: Reduce deque lock scope in RecordAccumulator.drainBatchesForOneNode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -874,6 +874,8 @@ public class RecordAccumulator {
             OptionalInt leaderEpoch = metadataSnapshot.leaderEpochFor(tp);
 
             final ProducerBatch batch;
+            final boolean isTransactional;
+            final boolean needsTxnStateUpdate;
             synchronized (deque) {
                 // invariant: !isMuted(tp,now) && deque != null
                 ProducerBatch first = deque.peekFirst();
@@ -896,33 +898,35 @@ public class RecordAccumulator {
                 }
 
                 batch = deque.pollFirst();
+                isTransactional = transactionManager != null && transactionManager.isTransactional();
+                needsTxnStateUpdate = transactionManager != null
+                    && transactionManager.producerIdAndEpoch() != null
+                    && !batch.hasSequence();
+            }
 
-                boolean isTransactional = transactionManager != null && transactionManager.isTransactional();
-                ProducerIdAndEpoch producerIdAndEpoch =
-                    transactionManager != null ? transactionManager.producerIdAndEpoch() : null;
-                if (producerIdAndEpoch != null && !batch.hasSequence()) {
-                    // If the producer id/epoch of the partition do not match the latest one
-                    // of the producer, we update it and reset the sequence. This should be
-                    // only done when all its in-flight batches have completed. This is guarantee
-                    // in `shouldStopDrainBatchesForPartition`.
-                    transactionManager.maybeUpdateProducerIdAndEpoch(batch.topicPartition);
+            if (transactionManager != null && needsTxnStateUpdate) {
+                // If the producer id/epoch of the partition do not match the latest one
+                // of the producer, we update it and reset the sequence. This should be
+                // only done when all its in-flight batches have completed. This is guarantee
+                // in `shouldStopDrainBatchesForPartition`.
+                transactionManager.maybeUpdateProducerIdAndEpoch(batch.topicPartition);
+                ProducerIdAndEpoch producerIdAndEpoch = transactionManager.producerIdAndEpoch();
 
-                    // If the batch already has an assigned sequence, then we should not change the producer id and
-                    // sequence number, since this may introduce duplicates. In particular, the previous attempt
-                    // may actually have been accepted, and if we change the producer id and sequence here, this
-                    // attempt will also be accepted, causing a duplicate.
-                    //
-                    // Additionally, we update the next sequence number bound for the partition, and also have
-                    // the transaction manager track the batch so as to ensure that sequence ordering is maintained
-                    // even if we receive out of order responses.
-                    batch.setProducerState(producerIdAndEpoch, transactionManager.sequenceNumber(batch.topicPartition), isTransactional);
-                    transactionManager.incrementSequenceNumber(batch.topicPartition, batch.recordCount);
-                    log.debug("Assigned producerId {} and producerEpoch {} to batch with base sequence " +
-                            "{} being sent to partition {}", producerIdAndEpoch.producerId,
-                        producerIdAndEpoch.epoch, batch.baseSequence(), tp);
+                // If the batch already has an assigned sequence, then we should not change the producer id and
+                // sequence number, since this may introduce duplicates. In particular, the previous attempt
+                // may actually have been accepted, and if we change the producer id and sequence here, this
+                // attempt will also be accepted, causing a duplicate.
+                //
+                // Additionally, we update the next sequence number bound for the partition, and also have
+                // the transaction manager track the batch so as to ensure that sequence ordering is maintained
+                // even if we receive out of order responses.
+                batch.setProducerState(producerIdAndEpoch, transactionManager.sequenceNumber(batch.topicPartition), isTransactional);
+                transactionManager.incrementSequenceNumber(batch.topicPartition, batch.recordCount);
+                log.debug("Assigned producerId {} and producerEpoch {} to batch with base sequence " +
+                        "{} being sent to partition {}", producerIdAndEpoch.producerId,
+                    producerIdAndEpoch.epoch, batch.baseSequence(), tp);
 
-                    transactionManager.addInFlightBatch(batch);
-                }
+                transactionManager.addInFlightBatch(batch);
             }
 
             // the rest of the work by processing outside the lock


### PR DESCRIPTION

This PR reduces lock hold time in RecordAccumulator.drainBatchesForOneNode by moving transactional producer state updates outside the synchronized deque block after the batch is removed.
The change keeps only deque-dependent checks and pollFirst() under the lock, which helps reduce producer-side contention without changing the existing drain logic.