### PR TITLE
KAFKA-20077: Prevent infinite AddPartitionsToTxn retries causing producer.flush() to hang

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -135,6 +135,9 @@ public class TransactionManager {
     private static final long ADD_PARTITIONS_RETRY_BACKOFF_MS = 20L;
 
     private int inFlightRequestCorrelationId = NO_INFLIGHT_REQUEST_CORRELATION_ID;
+    // Set in TxnRequestHandler.onComplete() under the TransactionManager lock, and read in
+    // handleResponse() within the same synchronized block. Safe from interleaving because
+    // only one transactional request is in-flight at a time (enforced by inFlightRequestCorrelationId).
     private long currentRequestCompletionTimeMs = -1L;
     private Node transactionCoordinator;
     private Node consumerGroupCoordinator;
@@ -1599,7 +1602,7 @@ public class TransactionManager {
                     continue;
                 } else if (error == Errors.COORDINATOR_NOT_AVAILABLE || error == Errors.NOT_COORDINATOR) {
                     lookupCoordinator(FindCoordinatorRequest.CoordinatorType.TRANSACTION, transactionalId);
-                    reenqueue();
+                    maybeReenqueueOrTimeout(topicPartition, error);
                     return;
                 } else if (error == Errors.CONCURRENT_TRANSACTIONS) {
                     maybeOverrideRetryBackoffMs();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TransactionAbortableException;
 import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
@@ -134,6 +135,7 @@ public class TransactionManager {
     private static final long ADD_PARTITIONS_RETRY_BACKOFF_MS = 20L;
 
     private int inFlightRequestCorrelationId = NO_INFLIGHT_REQUEST_CORRELATION_ID;
+    private long currentRequestCompletionTimeMs = -1L;
     private Node transactionCoordinator;
     private Node consumerGroupCoordinator;
     private boolean coordinatorSupportsBumpingEpoch;
@@ -1439,6 +1441,7 @@ public class TransactionManager {
                     log.trace("Received transactional response {} for request {}", response.responseBody(),
                             requestBuilder());
                     synchronized (TransactionManager.this) {
+                        currentRequestCompletionTimeMs = response.receivedTimeMs();
                         handleResponse(response.responseBody());
                     }
                 } else {
@@ -1561,11 +1564,13 @@ public class TransactionManager {
     private class AddPartitionsToTxnHandler extends TxnRequestHandler {
         private final AddPartitionsToTxnRequest.Builder builder;
         private long retryBackoffMs;
+        private long firstRetriableErrorTimeMs;
 
         private AddPartitionsToTxnHandler(AddPartitionsToTxnRequest.Builder builder) {
             super("AddPartitionsToTxn");
             this.builder = builder;
             this.retryBackoffMs = TransactionManager.this.retryBackoffMs;
+            this.firstRetriableErrorTimeMs = -1L;
         }
 
         @Override
@@ -1598,10 +1603,10 @@ public class TransactionManager {
                     return;
                 } else if (error == Errors.CONCURRENT_TRANSACTIONS) {
                     maybeOverrideRetryBackoffMs();
-                    reenqueue();
+                    maybeReenqueueOrTimeout(topicPartition, error);
                     return;
                 } else if (error.exception() instanceof RetriableException) {
-                    reenqueue();
+                    maybeReenqueueOrTimeout(topicPartition, error);
                     return;
                 } else if (error == Errors.INVALID_PRODUCER_EPOCH || error == Errors.PRODUCER_FENCED) {
                     // We could still receive INVALID_PRODUCER_EPOCH from old versioned transaction coordinator,
@@ -1665,6 +1670,22 @@ public class TransactionManager {
             // https://issues.apache.org/jira/browse/KAFKA-5482
             if (partitionsInTransaction.isEmpty())
                 this.retryBackoffMs = ADD_PARTITIONS_RETRY_BACKOFF_MS;
+        }
+
+        private void maybeReenqueueOrTimeout(TopicPartition topicPartition, Errors error) {
+            if (firstRetriableErrorTimeMs < 0L) {
+                firstRetriableErrorTimeMs = currentRequestCompletionTimeMs;
+                reenqueue();
+                return;
+            }
+
+            if (currentRequestCompletionTimeMs - firstRetriableErrorTimeMs >= transactionTimeoutMs) {
+                abortableErrorIfPossible(new TimeoutException("Timed out after " + transactionTimeoutMs
+                    + "ms while adding partition " + topicPartition + " to transaction due to retriable error "
+                    + error + "."));
+            } else {
+                reenqueue();
+            }
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -2488,6 +2488,31 @@ public class TransactionManagerTest {
     }
 
     @Test
+    public void testRetriableAddPartitionsToTxnTimesOut() throws Exception {
+        doInitTransactions();
+
+        transactionManager.beginTransaction();
+        transactionManager.maybeAddPartition(tp0);
+
+        Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
+        assertFalse(responseFuture.isDone());
+
+        for (int i = 0; i < 20; i++) {
+            prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, epoch, producerId);
+        }
+
+        for (int i = 0; i < 20 && !transactionManager.hasError(); i++) {
+            sender.runOnce();
+        }
+
+        assertTrue(transactionManager.hasError());
+        assertInstanceOf(TimeoutException.class, transactionManager.lastError());
+
+        runUntil(responseFuture::isDone);
+        assertInstanceOf(TimeoutException.class, assertThrows(ExecutionException.class, responseFuture::get).getCause());
+    }
+
+    @Test
     public void testHandlingOfUnknownTopicPartitionErrorOnTxnOffsetCommit() {
         testRetriableErrorInTxnOffsetCommit(Errors.UNKNOWN_TOPIC_OR_PARTITION);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -2497,16 +2497,53 @@ public class TransactionManagerTest {
         Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
         assertFalse(responseFuture.isDone());
 
-        for (int i = 0; i < 20; i++) {
+        // Keep feeding retriable errors. The Sender sleeps retryBackoffMs (100 ms) on each
+        // retry, so after enough iterations MockTime will exceed transactionTimeoutMs (1121 ms)
+        // and maybeReenqueueOrTimeout will fire an abortable TimeoutException.
+        int maxRetries = (int) (transactionTimeoutMs / DEFAULT_RETRY_BACKOFF_MS) + 5;
+        for (int i = 0; i < maxRetries; i++) {
             prepareAddPartitionsToTxnResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, tp0, epoch, producerId);
         }
 
-        for (int i = 0; i < 20 && !transactionManager.hasError(); i++) {
+        long startMs = time.milliseconds();
+        for (int i = 0; i < maxRetries && !transactionManager.hasError(); i++) {
             sender.runOnce();
         }
 
         assertTrue(transactionManager.hasError());
         assertInstanceOf(TimeoutException.class, transactionManager.lastError());
+        assertTrue(time.milliseconds() - startMs >= transactionTimeoutMs,
+            "Expected MockTime to advance past transactionTimeoutMs (" + transactionTimeoutMs + " ms)");
+
+        runUntil(responseFuture::isDone);
+        assertInstanceOf(TimeoutException.class, assertThrows(ExecutionException.class, responseFuture::get).getCause());
+    }
+
+    @Test
+    public void testCoordinatorNotAvailableAddPartitionsToTxnTimesOut() throws Exception {
+        doInitTransactions();
+
+        transactionManager.beginTransaction();
+        transactionManager.maybeAddPartition(tp0);
+
+        Future<RecordMetadata> responseFuture = appendToAccumulator(tp0);
+        assertFalse(responseFuture.isDone());
+
+        int maxRetries = (int) (transactionTimeoutMs / DEFAULT_RETRY_BACKOFF_MS) + 5;
+        for (int i = 0; i < maxRetries; i++) {
+            prepareAddPartitionsToTxnResponse(Errors.COORDINATOR_NOT_AVAILABLE, tp0, epoch, producerId);
+            prepareFindCoordinatorResponse(Errors.NONE, false, FindCoordinatorRequest.CoordinatorType.TRANSACTION, transactionalId);
+        }
+
+        long startMs = time.milliseconds();
+        for (int i = 0; i < maxRetries * 2 && !transactionManager.hasError(); i++) {
+            sender.runOnce();
+        }
+
+        assertTrue(transactionManager.hasError());
+        assertInstanceOf(TimeoutException.class, transactionManager.lastError());
+        assertTrue(time.milliseconds() - startMs >= transactionTimeoutMs,
+            "Expected MockTime to advance past transactionTimeoutMs (" + transactionTimeoutMs + " ms)");
 
         runUntil(responseFuture::isDone);
         assertInstanceOf(TimeoutException.class, assertThrows(ExecutionException.class, responseFuture::get).getCause());


### PR DESCRIPTION
Root Cause
The AddPartitionsToTxn handler may repeatedly re-enqueue itself on
retriable errors without any client-side timeout bounding the retry loop.
If the topic is deleted during this phase, the client may never make
progress and producer.flush() may block indefinitely.

Fix
Track the first retriable error timestamp and fail the request if
retries exceed transaction.timeout.ms.