### PR TITLE
KAFKA-19983: Fix MockProcessorContext doesn't work with WindowStores.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -56,6 +56,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
     protected final Optional<KeySchema> indexKeySchema;
     private final long retentionPeriod;
 
+    protected StateStoreContext stateStoreContext;
     protected InternalProcessorContext<?, ?> internalProcessorContext;
     private Sensor expiredRecordSensor;
     protected long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
@@ -145,7 +146,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
         final long timestamp = indexKeySchema.get().segmentTimestamp(indexKey);
         final long segmentId = segments.segmentId(timestamp);
-        final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+        final S segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
 
         if (segment != null) {
             segment.put(indexKey, value);
@@ -159,7 +160,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
         final long timestamp = indexKeySchema.get().segmentTimestamp(indexKey);
         final long segmentId = segments.segmentId(timestamp);
-        final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+        final S segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
 
         if (segment != null) {
             return segment.get(indexKey);
@@ -174,7 +175,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
         final long timestamp = indexKeySchema.get().segmentTimestamp(indexKey);
         final long segmentId = segments.segmentId(timestamp);
-        final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+        final S segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
 
         if (segment != null) {
             segment.delete(indexKey);
@@ -187,14 +188,16 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
         final long timestamp = baseKeySchema.segmentTimestamp(rawBaseKey);
         observedStreamTime = Math.max(observedStreamTime, timestamp);
         final long segmentId = segments.segmentId(timestamp);
-        final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+        final S segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
 
         if (segment == null) {
-            expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+            if (internalProcessorContext != null) {
+                expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());    
+            }
             LOG.warn("Skipping record for expired segment.");
         } else {
             synchronized (position) {
-                StoreQueryUtils.updatePosition(position, internalProcessorContext);
+                StoreQueryUtils.updatePosition(position, stateStoreContext);
 
                 // Put to index first so that if put to base failed, when we iterate index, we will
                 // find no base value. If put to base first but putting to index fails, when we iterate
@@ -242,7 +245,13 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
     @Override
     public void init(final StateStoreContext stateStoreContext, final StateStore root) {
-        this.internalProcessorContext = asInternalProcessorContext(stateStoreContext);
+        if (stateStoreContext instanceof InternalProcessorContext) {
+            this.internalProcessorContext = asInternalProcessorContext(stateStoreContext);
+            this.stateStoreContext = stateStoreContext;
+        } else {
+            this.internalProcessorContext = null;
+            this.stateStoreContext = stateStoreContext;
+        }
 
         final StreamsMetricsImpl metrics = ProcessorContextUtils.metricsImpl(stateStoreContext);
         final String threadId = Thread.currentThread().getName();
@@ -259,7 +268,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
         this.position = StoreQueryUtils.readPositionFromCheckpoint(positionCheckpoint);
         segments.setPosition(this.position);
 
-        segments.openExisting(internalProcessorContext, observedStreamTime);
+        segments.openExisting(stateStoreContext, observedStreamTime);
 
         // register and possibly restore the state from the logs
         stateStoreContext.register(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -57,6 +57,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
     private final long retentionPeriod;
     private final KeySchema keySchema;
 
+    private StateStoreContext stateStoreContext;
     private InternalProcessorContext<?, ?> internalProcessorContext;
     private Sensor expiredRecordSensor;
     private long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
@@ -250,12 +251,14 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         final long timestamp = keySchema.segmentTimestamp(key);
         observedStreamTime = Math.max(observedStreamTime, timestamp);
         final long segmentId = segments.segmentId(timestamp);
-        final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+        final S segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
         if (segment == null) {
-            expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+            if (internalProcessorContext != null) {
+                expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());    
+            }
         } else {
             synchronized (position) {
-                StoreQueryUtils.updatePosition(position, internalProcessorContext);
+                StoreQueryUtils.updatePosition(position, stateStoreContext);
                 segment.put(key, value);
             }
         }
@@ -284,7 +287,13 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
 
     @Override
     public void init(final StateStoreContext stateStoreContext, final StateStore root) {
-        this.internalProcessorContext = asInternalProcessorContext(stateStoreContext);
+        if (stateStoreContext instanceof InternalProcessorContext) {
+            this.internalProcessorContext = asInternalProcessorContext(stateStoreContext);
+            this.stateStoreContext = stateStoreContext;
+        } else {
+            this.internalProcessorContext = null;
+            this.stateStoreContext = stateStoreContext;
+        }
 
         final StreamsMetricsImpl metrics = ProcessorContextUtils.metricsImpl(stateStoreContext);
         final String threadId = Thread.currentThread().getName();
@@ -300,7 +309,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         this.positionCheckpoint = new OffsetCheckpoint(positionCheckpointFile);
         this.position = StoreQueryUtils.readPositionFromCheckpoint(positionCheckpoint);
         segments.setPosition(position);
-        segments.openExisting(internalProcessorContext, observedStreamTime);
+        segments.openExisting(stateStoreContext, observedStreamTime);
 
         // register and possibly restore the state from the logs
         stateStoreContext.register(
@@ -372,7 +381,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         for (final ConsumerRecord<byte[], byte[]> record : records) {
             final long timestamp = keySchema.segmentTimestamp(Bytes.wrap(record.key()));
             final long segmentId = segments.segmentId(timestamp);
-            final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+            final S segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
             if (segment != null) {
                 ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
                     record,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -73,6 +73,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap = new ConcurrentSkipListMap<>();
     private final Set<InMemoryWindowStoreIteratorWrapper> openIterators = ConcurrentHashMap.newKeySet();
 
+    private StateStoreContext stateStoreContext;
     private InternalProcessorContext<?, ?> internalProcessorContext;
     private Sensor expiredRecordSensor;
     private int seqnum = 0;
@@ -103,8 +104,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     @Override
     public void init(final StateStoreContext stateStoreContext,
                      final StateStore root) {
-        this.internalProcessorContext = ProcessorContextUtils.asInternalProcessorContext(stateStoreContext);
-
+        if (stateStoreContext instanceof InternalProcessorContext) {
+            this.internalProcessorContext = ProcessorContextUtils.asInternalProcessorContext(stateStoreContext);
+            this.stateStoreContext = stateStoreContext;
+        } else {
+            this.internalProcessorContext = null;
+            this.stateStoreContext = stateStoreContext;
+        }
+        
         final StreamsMetricsImpl metrics = ProcessorContextUtils.metricsImpl(stateStoreContext);
         final String threadId = Thread.currentThread().getName();
         final String taskName = stateStoreContext.taskId().toString();
@@ -155,7 +162,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         synchronized (position) {
             if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
-                expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+                if (internalProcessorContext != null) {
+                    expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+                }
                 LOG.warn("Skipping record for expired segment.");
             } else {
                 if (value != null) {
@@ -175,7 +184,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
                 }
             }
 
-            StoreQueryUtils.updatePosition(position, internalProcessorContext);
+            StoreQueryUtils.updatePosition(position, stateStoreContext);
         }
     }
 
@@ -381,7 +390,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
             config,
             this,
             position,
-            internalProcessorContext
+            stateStoreContext
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBytesStore.java
@@ -57,7 +57,7 @@ public class RocksDBTimeOrderedKeyValueBytesStore extends AbstractRocksDBTimeOrd
             observedStreamTime = Math.max(observedStreamTime, timestamp);
             minTimestamp = Math.min(minTimestamp, timestamp);
             final long segmentId = segments.segmentId(timestamp);
-            final KeyValueSegment segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+            final KeyValueSegment segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
             if (segment != null) {
                 //null segment is if it has expired, so  we don't want those records
                 ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSessionSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSessionSegmentedBytesStore.java
@@ -132,7 +132,7 @@ public class RocksDBTimeOrderedSessionSegmentedBytesStore extends AbstractRocksD
         for (final ConsumerRecord<byte[], byte[]> record : records) {
             final long timestamp = SessionKeySchema.extractEndTimestamp(record.key());
             final long segmentId = segments.segmentId(timestamp);
-            final KeyValueSegment segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+            final KeyValueSegment segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
             if (segment != null) {
                 ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
                     record,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowSegmentedBytesStore.java
@@ -92,7 +92,7 @@ public class RocksDBTimeOrderedWindowSegmentedBytesStore extends AbstractRocksDB
         for (final ConsumerRecord<byte[], byte[]> record : records) {
             final long timestamp = WindowKeySchema.extractStoreTimestamp(record.key());
             final long segmentId = segments.segmentId(timestamp);
-            final KeyValueSegment segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
+            final KeyValueSegment segment = segments.getOrCreateSegmentIfLive(segmentId, stateStoreContext, observedStreamTime);
             if (segment != null) {
                 ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
                     record,

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.test;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
@@ -30,10 +31,14 @@ import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.internals.RocksDbIndexedTimeOrderedWindowBytesStoreSupplier;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,12 +49,16 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -96,11 +105,31 @@ public class MockProcessorContextStateStoreTest {
         for (final Boolean timestamped : booleans) {
             for (final Boolean caching : booleans) {
                 for (final Boolean logging : booleans) {
-                    final List<WindowBytesStoreSupplier> windowBytesStoreSuppliers = asList(
+                    final List<WindowBytesStoreSupplier> windowBytesStoreSuppliers = new ArrayList<>(asList(
                         Stores.inMemoryWindowStore("w" + timestamped + caching + logging, Duration.ofSeconds(1), Duration.ofSeconds(1), false),
                         Stores.persistentWindowStore("w" + timestamped + caching + logging, Duration.ofSeconds(1), Duration.ofSeconds(1), false),
                         Stores.persistentTimestampedWindowStore("w" + timestamped + caching + logging, Duration.ofSeconds(1), Duration.ofSeconds(1), false)
-                    );
+                    ));
+                    if (!timestamped) {
+                        windowBytesStoreSuppliers.add(
+                            RocksDbIndexedTimeOrderedWindowBytesStoreSupplier.create(
+                                "w-time-ordered-index" + caching + logging,
+                                Duration.ofSeconds(1),
+                                Duration.ofSeconds(1),
+                                false,
+                                true
+                            )
+                        );
+                        windowBytesStoreSuppliers.add(
+                            RocksDbIndexedTimeOrderedWindowBytesStoreSupplier.create(
+                                "w-time-ordered-no-index" + caching + logging,
+                                Duration.ofSeconds(1),
+                                Duration.ofSeconds(1),
+                                false,
+                                false
+                            )
+                        );
+                    }
 
                     for (final WindowBytesStoreSupplier supplier : windowBytesStoreSuppliers) {
                         final StoreBuilder<? extends WindowStore<String, ?>> builder;
@@ -177,6 +206,9 @@ public class MockProcessorContextStateStoreTest {
                     IllegalArgumentException.class,
                     () -> store.init(context.getStateStoreContext(), store)
                 );
+            } else if (store instanceof WindowStore) {
+                assertDoesNotThrow(() -> store.init(context.getStateStoreContext(), store));
+                store.close();
             } else {
                 final InternalProcessorContext<?, ?> internalProcessorContext = mock(InternalProcessorContext.class);
                 when(internalProcessorContext.taskId()).thenReturn(context.taskId());
@@ -193,5 +225,190 @@ public class MockProcessorContextStateStoreTest {
                 // Failed to clean up the state dir. The JVM hooks will try again later.
             }
         }
+    }
+
+    @Test
+    public void shouldReadAndWriteInMemoryWindowStoreWithMockProcessorContextStateStoreContext() throws IOException {
+        shouldReadAndWriteWindowStore(
+            Stores.windowStoreBuilder(
+                Stores.inMemoryWindowStore("store-name", Duration.ofDays(1), Duration.ofDays(1), false),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    @Test
+    public void shouldReadAndWriteInMemoryTimestampedWindowStoreWithMockProcessorContextStateStoreContext()
+        throws IOException {
+        shouldReadAndWriteTimestampedWindowStore(
+            Stores.timestampedWindowStoreBuilder(
+                Stores.inMemoryWindowStore("timestamped-store-name", Duration.ofDays(1), Duration.ofDays(1), false),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    @Test
+    public void shouldReadAndWritePersistentWindowStoreWithMockProcessorContextStateStoreContext() throws IOException {
+        shouldReadAndWriteWindowStore(
+            Stores.windowStoreBuilder(
+                Stores.persistentWindowStore("persistent-store-name", Duration.ofDays(1), Duration.ofDays(1), false),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    @Test
+    public void shouldReadAndWritePersistentWindowStoreUsingTimestampedWindowStoreBuilderWithMockProcessorContextStateStoreContext()
+        throws IOException {
+        shouldReadAndWriteTimestampedWindowStore(
+            Stores.timestampedWindowStoreBuilder(
+                Stores.persistentWindowStore("persistent-window-store-for-timestamped-builder", Duration.ofDays(1), Duration.ofDays(1), false),
+                Serdes.String(),
+                Serdes.String()
+            ),
+            ConsumerRecord.NO_TIMESTAMP
+        );
+    }
+
+    @Test
+    public void shouldReadAndWritePersistentTimestampedWindowStoreUsingWindowStoreBuilderWithMockProcessorContextStateStoreContext()
+        throws IOException {
+        shouldReadAndWriteWindowStore(
+            Stores.windowStoreBuilder(
+                Stores.persistentTimestampedWindowStore("persistent-timestamped-store-for-window-builder", Duration.ofDays(1), Duration.ofDays(1), false),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    @Test
+    public void shouldReadAndWritePersistentTimestampedWindowStoreWithMockProcessorContextStateStoreContext() throws IOException {
+        shouldReadAndWriteTimestampedWindowStore(
+            Stores.timestampedWindowStoreBuilder(
+                Stores.persistentTimestampedWindowStore("persistent-timestamped-store-name", Duration.ofDays(1), Duration.ofDays(1), false),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    @Test
+    public void shouldReadAndWriteTimeOrderedWindowStoreWithIndexWithMockProcessorContextStateStoreContext() throws IOException {
+        shouldReadAndWriteWindowStore(
+            Stores.windowStoreBuilder(
+                RocksDbIndexedTimeOrderedWindowBytesStoreSupplier.create(
+                    "time-ordered-window-store-with-index",
+                    Duration.ofDays(1),
+                    Duration.ofDays(1),
+                    false,
+                    true
+                ),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    @Test
+    public void shouldReadAndWriteTimeOrderedWindowStoreWithoutIndexWithMockProcessorContextStateStoreContext() throws IOException {
+        shouldReadAndWriteWindowStore(
+            Stores.windowStoreBuilder(
+                RocksDbIndexedTimeOrderedWindowBytesStoreSupplier.create(
+                    "time-ordered-window-store-without-index",
+                    Duration.ofDays(1),
+                    Duration.ofDays(1),
+                    false,
+                    false
+                ),
+                Serdes.String(),
+                Serdes.String()
+            )
+        );
+    }
+
+    private void shouldReadAndWriteWindowStore(final StoreBuilder<? extends WindowStore<String, String>> builder)
+        throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final WindowStore<String, String> store = builder
+            .withCachingDisabled()
+            .withLoggingDisabled()
+            .build();
+
+        try {
+            final MockProcessorContext<Void, Void> context = new MockProcessorContext<>(
+                testProperties(),
+                new TaskId(0, 0),
+                stateDir
+            );
+
+            store.init(context.getStateStoreContext(), store);
+
+            store.put("fresh", "fresh-value", 1_000L);
+            assertEquals("fresh-value", store.fetch("fresh", 1_000L));
+
+            store.put("advance-stream-time", "advance-value", Duration.ofDays(3).toMillis());
+            assertDoesNotThrow(() -> store.put("expired", "expired-value", 1_000L));
+            assertNull(store.fetch("expired", 1_000L));
+        } finally {
+            if (store.isOpen()) {
+                store.close();
+            }
+            Utils.delete(stateDir);
+        }
+    }
+
+    private void shouldReadAndWriteTimestampedWindowStore(
+        final StoreBuilder<? extends TimestampedWindowStore<String, String>> builder
+    ) throws IOException {
+        shouldReadAndWriteTimestampedWindowStore(builder, 1_000L);
+    }
+
+    private void shouldReadAndWriteTimestampedWindowStore(
+        final StoreBuilder<? extends TimestampedWindowStore<String, String>> builder,
+        final long expectedFetchTimestamp
+    ) throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final TimestampedWindowStore<String, String> store = builder
+            .withCachingDisabled()
+            .withLoggingDisabled()
+            .build();
+
+        try {
+            final MockProcessorContext<Void, Void> context = new MockProcessorContext<>(
+                testProperties(),
+                new TaskId(0, 0),
+                stateDir
+            );
+
+            store.init(context.getStateStoreContext(), store);
+
+            store.put("fresh", ValueAndTimestamp.make("fresh-value", 1_000L), 1_000L);
+            assertEquals(ValueAndTimestamp.make("fresh-value", expectedFetchTimestamp), store.fetch("fresh", 1_000L));
+
+            store.put(
+                "advance-stream-time",
+                ValueAndTimestamp.make("advance-value", Duration.ofDays(3).toMillis()),
+                Duration.ofDays(3).toMillis()
+            );
+            assertDoesNotThrow(() -> store.put("expired", ValueAndTimestamp.make("expired-value", 1_000L), 1_000L));
+            assertNull(store.fetch("expired", 1_000L));
+        } finally {
+            if (store.isOpen()) {
+                store.close();
+            }
+            Utils.delete(stateDir);
+        }
+    }
+
+    private Properties testProperties() {
+        return mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "mock-processor-context-test"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock-localhost:9092")
+        ));
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
@@ -98,6 +98,36 @@ public class WindowedWordCountProcessorTest {
     }
 
     @Test
+    public void shouldWorkWithInMemoryStoreUsingStateStoreContext() {
+        final MockProcessorContext<String, String> context = new MockProcessorContext<>();
+
+        final WindowStore<String, Integer> store =
+            Stores.windowStoreBuilder(Stores.inMemoryWindowStore("WindowedCounts",
+                                                                 Duration.ofDays(24),
+                                                                 Duration.ofMillis(100),
+                                                                 false),
+                                      Serdes.String(),
+                                      Serdes.Integer())
+                  .withLoggingDisabled()
+                  .withCachingDisabled()
+                  .build();
+        store.init(context.getStateStoreContext(), store);
+
+        verifyWordCountProcessorOutput(
+            context,
+            asList(
+                new CapturedForward<>(new Record<>("[alpha@100/200]", "2", 1_000L)),
+                new CapturedForward<>(new Record<>("[beta@100/200]", "1", 1_000L)),
+                new CapturedForward<>(new Record<>("[gamma@100/200]", "1", 1_000L)),
+                new CapturedForward<>(new Record<>("[delta@200/300]", "1", 1_000L)),
+                new CapturedForward<>(new Record<>("[gamma@200/300]", "1", 1_000L))
+            )
+        );
+
+        store.close();
+    }
+
+    @Test
     public void shouldWorkWithPersistentStore() throws IOException {
         final File stateDir = TestUtils.tempDirectory();
 
@@ -157,6 +187,46 @@ public class WindowedWordCountProcessorTest {
         }
     }
 
+    @Test
+    public void shouldWorkWithPersistentStoreUsingStateStoreContext() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+
+        try {
+            final MockProcessorContext<String, String> context = new MockProcessorContext<>(
+                new Properties(),
+                new TaskId(0, 0),
+                stateDir
+            );
+
+            final WindowStore<String, Integer> store =
+                Stores.windowStoreBuilder(Stores.persistentWindowStore("WindowedCounts",
+                                                                       Duration.ofDays(24),
+                                                                       Duration.ofMillis(100),
+                                                                       false),
+                                          Serdes.String(),
+                                          Serdes.Integer())
+                      .withLoggingDisabled()
+                      .withCachingDisabled()
+                      .build();
+            store.init(context.getStateStoreContext(), store);
+
+            verifyWordCountProcessorOutput(
+                context,
+                asList(
+                    new CapturedForward<>(new Record<>("[alpha@100/200]", "2", 1_000L)),
+                    new CapturedForward<>(new Record<>("[beta@100/200]", "1", 1_000L)),
+                    new CapturedForward<>(new Record<>("[delta@200/300]", "1", 1_000L)),
+                    new CapturedForward<>(new Record<>("[gamma@100/200]", "1", 1_000L)),
+                    new CapturedForward<>(new Record<>("[gamma@200/300]", "1", 1_000L))
+                )
+            );
+
+            store.close();
+        } finally {
+            Utils.delete(stateDir);
+        }
+    }
+
     private InternalProcessorContext<?, ?> mockInternalProcessorContext(final MockProcessorContext<String, String> context) {
         return mockInternalProcessorContext(context, null);
     }
@@ -175,5 +245,20 @@ public class WindowedWordCountProcessorTest {
         }).when(internalProcessorContext).register(any(), any());
 
         return internalProcessorContext;
+    }
+
+    private void verifyWordCountProcessorOutput(final MockProcessorContext<String, String> context,
+                                                final List<CapturedForward<? extends String, ? extends String>> expected) {
+        final Processor<String, String, String, String> processor = new WindowedWordCountProcessorSupplier().get();
+        processor.init(context);
+
+        processor.process(new Record<>("key", "alpha beta gamma alpha", 101L));
+        processor.process(new Record<>("key", "gamma delta", 221L));
+
+        assertThat(context.forwarded().isEmpty(), is(true));
+
+        context.scheduledPunctuators().get(0).getPunctuator().punctuate(1_000L);
+
+        assertThat(context.forwarded(), is(expected));
     }
 }


### PR DESCRIPTION
### Description
After Kafka 4.0.0, `MockProcessorContext` doesn't work with WindowStores.
This is a regression caused by #16906. 

Some `StateStore`s accept a `StateStoreContext`, but internally require an `InternalProcessorContext`. 
Because of this, tests using `MockProcessorContext` no longer work with non-logging, non-caching `WindowStore`s.

This PR is draft based on my current understanding of the problem and one possible direction for fixing it.
I would like to use this PR as a starting point for discussion and align on the right approach with the community. 