### PR TITLE
KAFKA-20158: Adding SessionStore with headers adapters and iterator facade

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.state.internals.RocksDbSessionBytesStoreSupplier
 import org.apache.kafka.streams.state.internals.RocksDbVersionedKeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.RocksDbWindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
+import org.apache.kafka.streams.state.internals.SessionStoreBuilderWithHeaders;
 import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilderWithHeaders;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
@@ -664,6 +665,23 @@ public final class Stores {
                                                                               final Serde<V> valueSerde) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
         return new SessionStoreBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+    }
+
+    /**
+     * Creates a {@link StoreBuilder} that can be used to build a {@link SessionStoreWithHeaders}.
+     *
+     * @param supplier      a {@link SessionBytesStoreSupplier} (cannot be {@code null})
+     * @param keySerde      the key serde to use
+     * @param valueSerde    the value serde to use
+     * @param <K>           key type
+     * @param <V>           value type
+     * @return an instance of {@link StoreBuilder} than can build a {@link SessionStoreWithHeaders}
+     */
+    public static <K, V> StoreBuilder<SessionStoreWithHeaders<K, V>> sessionStoreBuilderWithHeaders(final SessionBytesStoreSupplier supplier,
+                                                                                                     final Serde<K> keySerde,
+                                                                                                     final Serde<V> valueSerde) {
+        Objects.requireNonNull(supplier, "supplier cannot be null");
+        return new SessionStoreBuilderWithHeaders<>(supplier, keySerde, valueSerde, Time.SYSTEM);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerde.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerde;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Serde for AggregationWithHeaders.
+ *
+ * This serde wraps a value serde and handles serialization/deserialization of
+ * aggregated values along with their headers.
+ *
+ * This is used by KIP-1271 to support headers in session state stores.
+ */
+public class AggregationWithHeadersSerde<AGG> extends WrappingNullableSerde<AggregationWithHeaders<AGG>, Void, AGG> {
+    public AggregationWithHeadersSerde(final Serde<AGG> aggSerde) {
+        super(
+            new AggregationWithHeadersSerializer<>(requireNonNull(aggSerde, "aggSerde was null").serializer()),
+            new AggregationWithHeadersDeserializer<>(requireNonNull(aggSerde, "aggSerde was null").deserializer())
+        );
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderWithHeaders.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
+import org.apache.kafka.streams.state.HeadersBytesStore;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.SessionStoreWithHeaders;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Builder for {@link SessionStoreWithHeaders} instances.
+ *
+ * This is analogous to {@link SessionStoreBuilder}, but uses
+ * {@link AggregationWithHeaders} as the value wrapper and wires up the
+ * header-aware store stack (change-logging, caching, metering).
+ */
+public class SessionStoreBuilderWithHeaders<K, V>
+    extends AbstractStoreBuilder<K, AggregationWithHeaders<V>, SessionStoreWithHeaders<K, V>> {
+
+    private final SessionBytesStoreSupplier storeSupplier;
+
+    public SessionStoreBuilderWithHeaders(final SessionBytesStoreSupplier storeSupplier,
+                                          final Serde<K> keySerde,
+                                          final Serde<V> valueSerde,
+                                          final Time time) {
+        super(
+            Objects.requireNonNull(storeSupplier, "storeSupplier cannot be null").name(),
+            keySerde,
+            valueSerde == null ? null : new AggregationWithHeadersSerde<>(valueSerde),
+            time
+        );
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
+        this.storeSupplier = storeSupplier;
+    }
+
+    @Override
+    public SessionStoreWithHeaders<K, V> build() {
+        SessionStore<Bytes, byte[]> sessionStore = storeSupplier.get();
+
+        if (!(sessionStore instanceof HeadersBytesStore)) {
+            if (sessionStore.persistent()) {
+                sessionStore = new SessionToHeadersStoreAdapter(sessionStore);
+            } else {
+                sessionStore = new InMemorySessionStoreWithHeadersMarker(sessionStore);
+            }
+        }
+        return new MeteredSessionStoreWithHeaders<>(
+            maybeWrapCaching(maybeWrapLogging(sessionStore)),
+            storeSupplier.metricsScope(),
+            keySerde,
+            valueSerde,
+            time
+        );
+    }
+
+    private SessionStore<Bytes, byte[]> maybeWrapCaching(final SessionStore<Bytes, byte[]> inner) {
+        if (!enableCaching) {
+            return inner;
+        }
+        return new CachingSessionStore(inner, storeSupplier.segmentIntervalMs());
+    }
+
+    private SessionStore<Bytes, byte[]> maybeWrapLogging(final SessionStore<Bytes, byte[]> inner) {
+        if (!enableLogging) {
+            return inner;
+        }
+        return new ChangeLoggingSessionBytesStoreWithHeaders(inner);
+    }
+
+    public long retentionPeriod() {
+        return storeSupplier.retentionPeriod();
+    }
+
+    private static final class InMemorySessionStoreWithHeadersMarker
+        extends WrappedStateStore<SessionStore<Bytes, byte[]>, Bytes, byte[]>
+        implements SessionStore<Bytes, byte[]>, HeadersBytesStore {
+        private InMemorySessionStoreWithHeadersMarker(final SessionStore<Bytes, byte[]> wrapped) {
+            super(wrapped);
+            if (wrapped.persistent()) {
+                throw new IllegalArgumentException("Provided store must not be a persistent store, but it is.");
+            }
+        }
+
+        @Override
+        public void remove(final Windowed<Bytes> sessionKey) {
+            wrapped().remove(sessionKey);
+        }
+
+        @Override
+        public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
+            wrapped().put(sessionKey, aggregate);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes key) {
+            return wrapped().fetch(key);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
+            return wrapped().fetch(keyFrom, keyTo);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes key,
+                                                                      final long earliestSessionEndTime,
+                                                                      final long latestSessionStartTime) {
+            return wrapped().findSessions(key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes key,
+                                                                              final long earliestSessionEndTime,
+                                                                              final long latestSessionStartTime) {
+            return wrapped().backwardFindSessions(key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes keyFrom,
+                                                                      final Bytes keyTo,
+                                                                      final long earliestSessionEndTime,
+                                                                      final long latestSessionStartTime) {
+            return wrapped().findSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes keyFrom,
+                                                                              final Bytes keyTo,
+                                                                              final long earliestSessionEndTime,
+                                                                              final long latestSessionStartTime) {
+            return wrapped().backwardFindSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public byte[] fetchSession(final Bytes key,
+                                   final long earliestSessionEndTime,
+                                   final long latestSessionStartTime) {
+            return wrapped().fetchSession(key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final long earliestSessionEndTime, final long latestSessionEndTime) {
+            return wrapped().findSessions(earliestSessionEndTime, latestSessionEndTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes key,
+                                                                      final Instant earliestSessionEndTime,
+                                                                      final Instant latestSessionStartTime) {
+            return wrapped().findSessions(key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes key,
+                                                                              final Instant earliestSessionEndTime,
+                                                                              final Instant latestSessionStartTime) {
+            return wrapped().backwardFindSessions(key, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes keyFrom,
+                                                                      final Bytes keyTo,
+                                                                      final Instant earliestSessionEndTime,
+                                                                      final Instant latestSessionStartTime) {
+            return wrapped().findSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes keyFrom,
+                                                                              final Bytes keyTo,
+                                                                              final Instant earliestSessionEndTime,
+                                                                              final Instant latestSessionStartTime) {
+            return wrapped().backwardFindSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+        }
+
+        @Override
+        public byte[] fetchSession(final Bytes key,
+                                   final Instant sessionStartTime,
+                                   final Instant sessionEndTime) {
+            return wrapped().fetchSession(key, sessionStartTime, sessionEndTime);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes key) {
+            return wrapped().backwardFetch(key);
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo) {
+            return wrapped().backwardFetch(keyFrom, keyTo);
+        }
+
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreIteratorFacade.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionStoreIteratorFacade.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+/**
+ * Wraps a {@code KeyValueIterator<K, AggregationWithHeaders<V>>} to present a
+ * {@code KeyValueIterator<K, V>} by stripping the {@link AggregationWithHeaders} wrapper.
+ * <p>
+ * This is analogous to {@link KeyValueIteratorFacade} which strips {@code ValueAndTimestamp}.
+ *
+ * @param <K> the key type
+ * @param <V> the aggregated value type
+ */
+public class SessionStoreIteratorFacade<K, V> implements KeyValueIterator<K, V> {
+    private final KeyValueIterator<K, AggregationWithHeaders<V>> innerIterator;
+
+    public SessionStoreIteratorFacade(final KeyValueIterator<K, AggregationWithHeaders<V>> iterator) {
+        innerIterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return innerIterator.hasNext();
+    }
+
+    @Override
+    public K peekNextKey() {
+        return innerIterator.peekNextKey();
+    }
+
+    @Override
+    public KeyValue<K, V> next() {
+        final KeyValue<K, AggregationWithHeaders<V>> innerKeyValue = innerIterator.next();
+        if (innerKeyValue == null) {
+            return null;
+        }
+        return KeyValue.pair(innerKeyValue.key, AggregationWithHeaders.getAggregationOrNull(innerKeyValue.value));
+    }
+
+    @Override
+    public void close() {
+        innerIterator.close();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapter.java
@@ -21,14 +21,16 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+
 /**
  * This class is used to ensure backward compatibility at DSL level between
  * {@link org.apache.kafka.streams.state.SessionStoreWithHeaders} and
  * {@link org.apache.kafka.streams.state.SessionStore}.
  * <p>
- * When iterating over session entries from a store that stores values with headers,
- * this adapter strips the headers prefix so the caller receives raw aggregation bytes
- * without headers.
+ * When iterating over session entries from a store that contains only values,
+ * this adapter adds the headers prefix so the caller receives aggregation bytes
+ * with headers.
  *
  * @see SessionToHeadersStoreAdapter
  */
@@ -57,6 +59,9 @@ class SessionToHeadersIteratorAdapter implements KeyValueIterator<Windowed<Bytes
     @Override
     public KeyValue<Windowed<Bytes>, byte[]> next() {
         final KeyValue<Windowed<Bytes>, byte[]> keyValue = innerIterator.next();
-        return KeyValue.pair(keyValue.key, AggregationWithHeadersDeserializer.rawAggregation(keyValue.value));
+        if (keyValue == null) {
+            return null;
+        }
+        return KeyValue.pair(keyValue.key, convertToHeaderFormat(keyValue.value));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+/**
+ * This class is used to ensure backward compatibility at DSL level between
+ * {@link org.apache.kafka.streams.state.SessionStoreWithHeaders} and
+ * {@link org.apache.kafka.streams.state.SessionStore}.
+ * <p>
+ * When iterating over session entries from a store that stores values with headers,
+ * this adapter strips the headers prefix so the caller receives raw aggregation bytes
+ * without headers.
+ *
+ * @see SessionToHeadersStoreAdapter
+ */
+class SessionToHeadersIteratorAdapter implements KeyValueIterator<Windowed<Bytes>, byte[]> {
+    private final KeyValueIterator<Windowed<Bytes>, byte[]> innerIterator;
+
+    SessionToHeadersIteratorAdapter(final KeyValueIterator<Windowed<Bytes>, byte[]> innerIterator) {
+        this.innerIterator = innerIterator;
+    }
+
+    @Override
+    public void close() {
+        innerIterator.close();
+    }
+
+    @Override
+    public Windowed<Bytes> peekNextKey() {
+        return innerIterator.peekNextKey();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return innerIterator.hasNext();
+    }
+
+    @Override
+    public KeyValue<Windowed<Bytes>, byte[]> next() {
+        final KeyValue<Windowed<Bytes>, byte[]> keyValue = innerIterator.next();
+        return KeyValue.pair(keyValue.key, AggregationWithHeadersDeserializer.rawAggregation(keyValue.value));
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
@@ -43,10 +43,10 @@ import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFo
  * a {@code SessionStoreWithHeaders}, this adapter is used to translate between
  * the raw aggregation {@code byte[]} format and the aggregation-with-headers {@code byte[]} format.
  * <p>
- * On writes (put), empty headers are prepended to the raw aggregation value before
- * delegating to the inner store.
- * On reads (get, fetch, findSessions), the headers prefix is stripped from the stored value
- * so the caller receives raw aggregation bytes without headers.
+ * On writes (put), the headers prefix is stripped from the aggregation-with-headers value
+ * before delegating to the inner plain store, which stores raw aggregation bytes only.
+ * On reads (get, fetch, findSessions), empty headers are prepended to the raw aggregation
+ * value read from the inner store so the caller receives aggregation-with-headers bytes.
  *
  * @see SessionToHeadersIteratorAdapter
  */
@@ -106,7 +106,7 @@ public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]>
     public byte[] fetchSession(final Bytes key,
                                final long sessionStartTime,
                                final long sessionEndTime) {
-        return AggregationWithHeadersDeserializer.rawAggregation(store.fetchSession(key, sessionStartTime, sessionEndTime));
+        return convertToHeaderFormat(store.fetchSession(key, sessionStartTime, sessionEndTime));
     }
 
     @Override
@@ -135,8 +135,8 @@ public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]>
     }
 
     @Override
-    public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
-        store.put(sessionKey, convertToHeaderFormat(aggregate));
+    public void put(final Windowed<Bytes> sessionKey, final byte[] aggregateWithHeader) {
+        store.put(sessionKey, AggregationWithHeadersDeserializer.rawAggregation(aggregateWithHeader));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.WindowRangeQuery;
+import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
 
@@ -174,7 +176,19 @@ public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]>
                                     final PositionBound positionBound,
                                     final QueryConfig config) {
         final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
-        final QueryResult<R> result = store.query(query, positionBound, config);
+        final QueryResult<R> result;
+        if (query instanceof WindowRangeQuery) {
+            final WindowRangeQuery<Bytes, byte[]> windowRangeQuery = (WindowRangeQuery<Bytes, byte[]>) query;
+            final QueryResult<KeyValueIterator<Windowed<Bytes>, byte[]>> rawResult = store.query(windowRangeQuery, positionBound, config);
+            if (rawResult.isSuccess()) {
+                final KeyValueIterator<Windowed<Bytes>, byte[]> wrappedIterator = new SessionToHeadersIteratorAdapter(rawResult.getResult());
+                result = (QueryResult<R>) InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, wrappedIterator);
+            } else {
+                result = (QueryResult<R>) rawResult;
+            }
+        } else {
+            result = store.query(query, positionBound, config);
+        }
         if (config.isCollectExecutionInfo()) {
             result.addExecutionInfo(
                 "Handled in " + getClass() + " in " + (System.nanoTime() - start) + "ns");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.SessionStore;
+
+import java.util.Map;
+
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+
+/**
+ * This class is used to ensure backward compatibility at DSL level between
+ * {@link org.apache.kafka.streams.state.SessionStoreWithHeaders} and
+ * {@link org.apache.kafka.streams.state.SessionStore}.
+ * <p>
+ * If a user provides a supplier for {@code SessionStore} (without headers) via
+ * {@link org.apache.kafka.streams.kstream.Materialized} when building
+ * a {@code SessionStoreWithHeaders}, this adapter is used to translate between
+ * the raw aggregation {@code byte[]} format and the aggregation-with-headers {@code byte[]} format.
+ * <p>
+ * On writes (put), empty headers are prepended to the raw aggregation value before
+ * delegating to the inner store.
+ * On reads (get, fetch, findSessions), the headers prefix is stripped from the stored value
+ * so the caller receives raw aggregation bytes without headers.
+ *
+ * @see SessionToHeadersIteratorAdapter
+ */
+@SuppressWarnings("unchecked")
+public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]> {
+    final SessionStore<Bytes, byte[]> store;
+
+    SessionToHeadersStoreAdapter(final SessionStore<Bytes, byte[]> store) {
+        if (!store.persistent()) {
+            throw new IllegalArgumentException("Provided store must be a persistent store, but it is not.");
+        }
+        this.store = store;
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes key,
+                                                                  final long earliestSessionEndTime,
+                                                                  final long latestSessionStartTime) {
+        return new SessionToHeadersIteratorAdapter(
+            store.findSessions(key, earliestSessionEndTime, latestSessionStartTime));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final long earliestSessionEndTime,
+                                                                  final long latestSessionEndTime) {
+        return new SessionToHeadersIteratorAdapter(
+            store.findSessions(earliestSessionEndTime, latestSessionEndTime));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes key,
+                                                                          final long earliestSessionEndTime,
+                                                                          final long latestSessionStartTime) {
+        return new SessionToHeadersIteratorAdapter(
+            store.backwardFindSessions(key, earliestSessionEndTime, latestSessionStartTime));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes keyFrom,
+                                                                  final Bytes keyTo,
+                                                                  final long earliestSessionEndTime,
+                                                                  final long latestSessionStartTime) {
+        return new SessionToHeadersIteratorAdapter(
+            store.findSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFindSessions(final Bytes keyFrom,
+                                                                          final Bytes keyTo,
+                                                                          final long earliestSessionEndTime,
+                                                                          final long latestSessionStartTime) {
+        return new SessionToHeadersIteratorAdapter(
+            store.backwardFindSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime));
+    }
+
+    @Override
+    public byte[] fetchSession(final Bytes key,
+                               final long sessionStartTime,
+                               final long sessionEndTime) {
+        return AggregationWithHeadersDeserializer.rawAggregation(store.fetchSession(key, sessionStartTime, sessionEndTime));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes key) {
+        return new SessionToHeadersIteratorAdapter(store.fetch(key));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes key) {
+        return new SessionToHeadersIteratorAdapter(store.backwardFetch(key));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
+        return new SessionToHeadersIteratorAdapter(store.fetch(keyFrom, keyTo));
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo) {
+        return new SessionToHeadersIteratorAdapter(store.backwardFetch(keyFrom, keyTo));
+    }
+
+    @Override
+    public void remove(final Windowed<Bytes> sessionKey) {
+        store.remove(sessionKey);
+    }
+
+    @Override
+    public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
+        store.put(sessionKey, convertToHeaderFormat(aggregate));
+    }
+
+    @Override
+    public String name() {
+        return store.name();
+    }
+
+    @Override
+    public void init(final StateStoreContext stateStoreContext, final StateStore root) {
+        store.init(stateStoreContext, root);
+    }
+
+    @Override
+    public void commit(final Map<TopicPartition, Long> changelogOffsets) {
+        store.commit(changelogOffsets);
+    }
+
+    @Override
+    public void close() {
+        store.close();
+    }
+
+    @Override
+    public boolean persistent() {
+        return store.persistent();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return store.isOpen();
+    }
+
+    @Override
+    public <R> QueryResult<R> query(final Query<R> query,
+                                    final PositionBound positionBound,
+                                    final QueryConfig config) {
+        final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
+        final QueryResult<R> result = store.query(query, positionBound, config);
+        if (config.isCollectExecutionInfo()) {
+            result.addExecutionInfo(
+                "Handled in " + getClass() + " in " + (System.nanoTime() - start) + "ns");
+        }
+        return result;
+    }
+
+    @Override
+    public Position getPosition() {
+        return store.getPosition();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class SessionToHeadersIteratorAdapterTest {
+
+    private static final Bytes KEY = Bytes.wrap("key".getBytes());
+    private static final byte[] RAW_VALUE = "value".getBytes();
+    private static final byte[] VALUE_WITH_EMPTY_HEADERS = convertToHeaderFormat(RAW_VALUE);
+    private static final Windowed<Bytes> SESSION_KEY =
+        new Windowed<>(KEY, new SessionWindow(10L, 20L));
+
+    @Mock
+    private KeyValueIterator<Windowed<Bytes>, byte[]> innerIterator;
+
+    @Test
+    public void shouldStripHeadersOnNext() {
+        when(innerIterator.hasNext()).thenReturn(true);
+        when(innerIterator.next())
+            .thenReturn(KeyValue.pair(SESSION_KEY, VALUE_WITH_EMPTY_HEADERS));
+
+        final SessionToHeadersIteratorAdapter adapter =
+            new SessionToHeadersIteratorAdapter(innerIterator);
+
+        assertTrue(adapter.hasNext());
+        final KeyValue<Windowed<Bytes>, byte[]> result = adapter.next();
+        assertEquals(SESSION_KEY, result.key);
+        assertArrayEquals(RAW_VALUE, result.value);
+    }
+
+    @Test
+    public void shouldHandleNullValueOnNext() {
+        when(innerIterator.next())
+            .thenReturn(KeyValue.pair(SESSION_KEY, null));
+
+        final SessionToHeadersIteratorAdapter adapter =
+            new SessionToHeadersIteratorAdapter(innerIterator);
+
+        final KeyValue<Windowed<Bytes>, byte[]> result = adapter.next();
+        assertEquals(SESSION_KEY, result.key);
+        assertNull(result.value);
+    }
+
+    @Test
+    public void shouldDelegateHasNext() {
+        when(innerIterator.hasNext()).thenReturn(false);
+
+        final SessionToHeadersIteratorAdapter adapter =
+            new SessionToHeadersIteratorAdapter(innerIterator);
+
+        assertFalse(adapter.hasNext());
+    }
+
+    @Test
+    public void shouldDelegatePeekNextKey() {
+        when(innerIterator.peekNextKey()).thenReturn(SESSION_KEY);
+
+        final SessionToHeadersIteratorAdapter adapter =
+            new SessionToHeadersIteratorAdapter(innerIterator);
+
+        assertEquals(SESSION_KEY, adapter.peekNextKey());
+    }
+
+    @Test
+    public void shouldDelegateClose() {
+        final SessionToHeadersIteratorAdapter adapter =
+            new SessionToHeadersIteratorAdapter(innerIterator);
+
+        adapter.close();
+        verify(innerIterator).close();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersIteratorAdapterTest.java
@@ -52,10 +52,10 @@ public class SessionToHeadersIteratorAdapterTest {
     private KeyValueIterator<Windowed<Bytes>, byte[]> innerIterator;
 
     @Test
-    public void shouldStripHeadersOnNext() {
+    public void shouldAddHeadersOnNext() {
         when(innerIterator.hasNext()).thenReturn(true);
         when(innerIterator.next())
-            .thenReturn(KeyValue.pair(SESSION_KEY, VALUE_WITH_EMPTY_HEADERS));
+            .thenReturn(KeyValue.pair(SESSION_KEY, RAW_VALUE));
 
         final SessionToHeadersIteratorAdapter adapter =
             new SessionToHeadersIteratorAdapter(innerIterator);
@@ -63,7 +63,7 @@ public class SessionToHeadersIteratorAdapterTest {
         assertTrue(adapter.hasNext());
         final KeyValue<Windowed<Bytes>, byte[]> result = adapter.next();
         assertEquals(SESSION_KEY, result.key);
-        assertArrayEquals(RAW_VALUE, result.value);
+        assertArrayEquals(VALUE_WITH_EMPTY_HEADERS, result.value);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterTest.java
@@ -81,8 +81,8 @@ public class SessionToHeadersStoreAdapterTest {
 
     @Test
     public void shouldPutWithEmptyHeaders() {
-        adapter.put(SESSION_KEY, RAW_VALUE);
-        verify(innerStore).put(SESSION_KEY, VALUE_WITH_EMPTY_HEADERS);
+        adapter.put(SESSION_KEY, VALUE_WITH_EMPTY_HEADERS);
+        verify(innerStore).put(SESSION_KEY, RAW_VALUE);
     }
 
     @Test
@@ -93,9 +93,9 @@ public class SessionToHeadersStoreAdapterTest {
 
     @Test
     public void shouldFetchSessionAndStripHeaders() {
-        when(innerStore.fetchSession(KEY, 10L, 20L)).thenReturn(VALUE_WITH_EMPTY_HEADERS);
+        when(innerStore.fetchSession(KEY, 10L, 20L)).thenReturn(RAW_VALUE);
         final byte[] result = adapter.fetchSession(KEY, 10L, 20L);
-        assertArrayEquals(RAW_VALUE, result);
+        assertArrayEquals(VALUE_WITH_EMPTY_HEADERS, result);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.SessionStore;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class SessionToHeadersStoreAdapterTest {
+
+    private static final Bytes KEY = Bytes.wrap("key".getBytes());
+    private static final Bytes KEY_FROM = Bytes.wrap("a".getBytes());
+    private static final Bytes KEY_TO = Bytes.wrap("z".getBytes());
+    private static final byte[] RAW_VALUE = "value".getBytes();
+    private static final byte[] VALUE_WITH_EMPTY_HEADERS = convertToHeaderFormat(RAW_VALUE);
+    private static final Windowed<Bytes> SESSION_KEY = new Windowed<>(KEY, new SessionWindow(10L, 20L));
+
+    @Mock
+    private SessionStore<Bytes, byte[]> innerStore;
+
+    private SessionToHeadersStoreAdapter adapter;
+
+    @BeforeEach
+    public void setUp() {
+        when(innerStore.persistent()).thenReturn(true);
+        adapter = new SessionToHeadersStoreAdapter(innerStore);
+    }
+
+    @Test
+    public void shouldThrowIfStoreIsNotPersistent() {
+        final SessionStore<Bytes, byte[]> nonPersistentStore = mock(SessionStore.class);
+        when(nonPersistentStore.persistent()).thenReturn(false);
+        assertThrows(IllegalArgumentException.class,
+            () -> new SessionToHeadersStoreAdapter(nonPersistentStore));
+    }
+
+    @Test
+    public void shouldPutWithEmptyHeaders() {
+        adapter.put(SESSION_KEY, RAW_VALUE);
+        verify(innerStore).put(SESSION_KEY, VALUE_WITH_EMPTY_HEADERS);
+    }
+
+    @Test
+    public void shouldPutNullValue() {
+        adapter.put(SESSION_KEY, null);
+        verify(innerStore).put(SESSION_KEY, null);
+    }
+
+    @Test
+    public void shouldFetchSessionAndStripHeaders() {
+        when(innerStore.fetchSession(KEY, 10L, 20L)).thenReturn(VALUE_WITH_EMPTY_HEADERS);
+        final byte[] result = adapter.fetchSession(KEY, 10L, 20L);
+        assertArrayEquals(RAW_VALUE, result);
+    }
+
+    @Test
+    public void shouldReturnNullForNullFetchSession() {
+        when(innerStore.fetchSession(KEY, 10L, 20L)).thenReturn(null);
+        assertNull(adapter.fetchSession(KEY, 10L, 20L));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapFindSessionsIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.findSessions(KEY, 10L, 20L)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.findSessions(KEY, 10L, 20L);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapBackwardFindSessionsIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.backwardFindSessions(KEY, 10L, 20L)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.backwardFindSessions(KEY, 10L, 20L);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapFindSessionsWithKeyRangeIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.findSessions(KEY_FROM, KEY_TO, 10L, 20L)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result =
+            adapter.findSessions(KEY_FROM, KEY_TO, 10L, 20L);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapBackwardFindSessionsWithKeyRangeIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.backwardFindSessions(KEY_FROM, KEY_TO, 10L, 20L)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result =
+            adapter.backwardFindSessions(KEY_FROM, KEY_TO, 10L, 20L);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapFetchIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.fetch(KEY)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.fetch(KEY);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapBackwardFetchIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.backwardFetch(KEY)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.backwardFetch(KEY);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapFetchWithKeyRangeIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.fetch(KEY_FROM, KEY_TO)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.fetch(KEY_FROM, KEY_TO);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapBackwardFetchWithKeyRangeIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.backwardFetch(KEY_FROM, KEY_TO)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.backwardFetch(KEY_FROM, KEY_TO);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    @Test
+    public void shouldDelegateRemove() {
+        adapter.remove(SESSION_KEY);
+        verify(innerStore).remove(SESSION_KEY);
+    }
+
+    @Test
+    public void shouldDelegateInit() {
+        final StateStoreContext context = mock(StateStoreContext.class);
+        final StateStore root = mock(StateStore.class);
+        adapter.init(context, root);
+        verify(innerStore).init(context, root);
+    }
+
+    @Test
+    public void shouldDelegateClose() {
+        adapter.close();
+        verify(innerStore).close();
+    }
+
+    @Test
+    public void shouldReturnPersistentTrue() {
+        assertTrue(adapter.persistent());
+    }
+
+    @Test
+    public void shouldDelegateIsOpen() {
+        when(innerStore.isOpen()).thenReturn(true);
+        assertTrue(adapter.isOpen());
+    }
+
+    @Test
+    public void shouldDelegateName() {
+        when(innerStore.name()).thenReturn("test-store");
+        assertEquals("test-store", adapter.name());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldDelegateQueryToInnerStore() {
+        final QueryResult<Void> expectedResult = QueryResult.forFailure(
+            FailureReason.UNKNOWN_QUERY_TYPE, "unknown");
+        when(innerStore.query(any(Query.class), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn(expectedResult);
+
+        final Query<Void> query = new Query<Void>() { };
+        final QueryResult<Void> result = adapter.query(query, PositionBound.unbounded(), new QueryConfig(false));
+        assertTrue(result.isFailure());
+        assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, result.getFailureReason());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldAddExecutionInfoOnQuery() {
+        final QueryResult<Void> expectedResult = QueryResult.forFailure(
+            FailureReason.UNKNOWN_QUERY_TYPE, "unknown");
+        when(innerStore.query(any(Query.class), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn(expectedResult);
+
+        final Query<Void> query = new Query<Void>() { };
+        final QueryResult<Void> result = adapter.query(query, PositionBound.unbounded(), new QueryConfig(true));
+        assertTrue(result.getExecutionInfo().stream()
+            .anyMatch(info -> info.contains("SessionToHeadersStoreAdapter")));
+    }
+
+    @Test
+    public void shouldStripHeadersFromRawAggregationValue() {
+        final byte[] result = AggregationWithHeadersDeserializer.rawAggregation(VALUE_WITH_EMPTY_HEADERS);
+        assertArrayEquals(RAW_VALUE, result);
+    }
+
+    @Test
+    public void shouldReturnNullFromRawAggregationValueForNull() {
+        assertNull(AggregationWithHeadersDeserializer.rawAggregation(null));
+    }
+}


### PR DESCRIPTION
This is a follow-up PR for RocksDBSessionStore with headers for
KIP-1271, adding session store with headers infrastructure classes
required for IQv2 support including SessionToHeadersStoreAdapter,
SessionStoreBuilderWithHeaders, and related iterators. These classes
enable the query delegation chain needed for Interactive Queries v2 to
work through session stores with headers, returning plain values without
exposing headers.

Reviewers: Matthias Sax <matthias@confluent.io>
