### PR TITLE
KAFKA-19939: StreamsConfig should log WARN by default

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1536,6 +1536,12 @@ public class StreamsConfig extends AbstractConfig {
         verifyTopologyOptimizationConfigs(getString(TOPOLOGY_OPTIMIZATION_CONFIG));
         verifyClientTelemetryConfigs();
         verifyStreamsProtocolCompatibility(doLog);
+        if (!getBoolean(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG)) {
+            log.warn("Processing exception handler is not enabled for the GlobalThread. " +
+                "It's recommended to set " + StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG + " to true to enable it. " +
+                "Enabling the processing exception handler for global state/KTable processing now, ensure future backward compatibility. " +
+                "The processing exception handler will get enabled by default with Kafka Streams 5.0 release.");
+        }
     }
 
     private void verifyStreamsProtocolCompatibility(final boolean doLog) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1540,7 +1540,7 @@ public class StreamsConfig extends AbstractConfig {
             log.warn("Processing exception handler is not enabled for the GlobalThread. " +
                 "It's recommended to set `" + StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG + "` to true to enable it. " +
                 "Enabling the processing exception handler for global state/KTable processing now, ensures future backward compatibility. " +
-                "The processing exception handler will get enabled by default with Kafka Streams 5.0 release.");
+                "The processing exception handler will get enabled by default with Apache Kafka 5.0 release.");
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1538,8 +1538,8 @@ public class StreamsConfig extends AbstractConfig {
         verifyStreamsProtocolCompatibility(doLog);
         if (!getBoolean(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG)) {
             log.warn("Processing exception handler is not enabled for the GlobalThread. " +
-                "It's recommended to set " + StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG + " to true to enable it. " +
-                "Enabling the processing exception handler for global state/KTable processing now, ensure future backward compatibility. " +
+                "It's recommended to set `" + StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG + "` to true to enable it. " +
+                "Enabling the processing exception handler for global state/KTable processing now, ensures future backward compatibility. " +
                 "The processing exception handler will get enabled by default with Kafka Streams 5.0 release.");
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -1786,9 +1786,37 @@ public class StreamsConfigTest {
             "Please set group.protocol=classic or remove group.instance.id from the configuration."));
     }
 
+    @Test
     public void shouldSetDefaultDeadLetterQueue() {
         final StreamsConfig config = new StreamsConfig(props);
         assertNull(config.getString(StreamsConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG));
+    }
+
+    @Test
+    public void shouldLogWarningWhenProcessingExceptionHandlerIsNotEnabledOnGlobalThread() {
+        try (LogCaptureAppender streamsConfigLogs = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            streamsConfigLogs.setClassLogger(StreamsConfig.class, Level.WARN);
+            streamsConfig = new StreamsConfig(props);
+
+            assertEquals(1, streamsConfigLogs.getMessages().size());
+            assertTrue(streamsConfigLogs
+                .getMessages(Level.WARN.name())
+                .get(0)
+                .startsWith("Processing exception handler is not enabled for the GlobalThread.")
+            );
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldNotLogWarningWhenProcessingExceptionHandlerIsEnabledOnGlobalThread() {
+        props.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_GLOBAL_ENABLED_CONFIG, true);
+        try (LogCaptureAppender streamsConfigLogs = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            streamsConfigLogs.setClassLogger(StreamsConfig.class, Level.WARN);
+            streamsConfig = new StreamsConfig(props);
+
+            assertEquals(0, streamsConfigLogs.getMessages().size());
+        }
     }
 
     static class MisconfiguredSerde implements Serde<Object> {


### PR DESCRIPTION
For backward compatibility, we keep the processing exception handler
disabled on the global thread by default. StreamsConfig should WARN
about it, to encourage users to enable it.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Arpit goyal
 <goyal.arpit.91@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
