### PR TITLE
MINOR: Fix typo 'boostrap' to 'bootstrap' in KafkaRaftClientTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
@@ -158,7 +158,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
 
   @Test
   def testListNodesFromControllersIncludingFencedBrokers(): Unit = {
-    useBoostrapControllers()
+    useBootstrapControllers()
     client = createAdminClient
     val result = client.describeCluster(new DescribeClusterOptions().includeFencedBrokers(true))
     val exception = assertThrows(classOf[Exception], () => { result.nodes().get()})
@@ -167,7 +167,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
 
   @Test
   def testListNodesFromControllers(): Unit = {
-    useBoostrapControllers()
+    useBootstrapControllers()
     client = createAdminClient
     val result = client.describeCluster(new DescribeClusterOptions())
     assertTrue(result.nodes().get().size().equals(controllerServers.size))
@@ -194,7 +194,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
     SslAdminIntegrationTest.semaphore = Some(testSemaphore)
     waitForNoBlockedRequestThreads()
 
-    useBoostrapControllers()
+    useBootstrapControllers()
     // Queue requests until all threads are blocked. ACL create requests are sent to least loaded
     // node, so we may need more than `numRequestThreads` requests to block all threads.
     val aclFutures = mutable.Buffer[CreateAclsResult]()
@@ -247,7 +247,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
 
     waitForNoBlockedRequestThreads()
 
-    useBoostrapControllers()
+    useBootstrapControllers()
     // In KRaft mode, ACL creation is handled exclusively by controller servers, not brokers.
     // Therefore, only the number of controller I/O threads is relevant in this context.
     val numReqThreads = controllerServers.head.config.numIoThreads * controllerServers.size
@@ -285,7 +285,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
     val testSemaphore = new Semaphore(0)
     SslAdminIntegrationTest.semaphore = Some(testSemaphore)
 
-    useBoostrapControllers()
+    useBootstrapControllers()
     client = createAdminClient
     val results = client.createAcls(java.util.List.of(acl2, acl3)).values
     assertEquals(Set(acl2, acl3), results.keySet().asScala)
@@ -349,7 +349,7 @@ class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
     props
   }
 
-  private def useBoostrapControllers(): Unit = {
+  private def useBootstrapControllers(): Unit = {
     val controllerListenerName = ListenerName.forSecurityProtocol(extraControllerSecurityProtocol)
     val config = controllerServers.map { s =>
       val listener = s.config.effectiveAdvertisedControllerListeners

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -2237,7 +2237,7 @@ class KafkaRaftClientTest {
     @ValueSource(booleans = { true, false })
     public void testObserverHandleRetryFetchToBootstrapServer(boolean withKip853Rpc) throws Exception {
         // This test tries to check that KRaft is able to handle a retrying Fetch request to
-        // a boostrap server after a Fetch request to the leader.
+        // a bootstrap server after a Fetch request to the leader.
         int localId = randomReplicaId();
         int leaderId = localId + 1;
         int otherNodeId = localId + 2;


### PR DESCRIPTION
Fix typo `boostrap` -> `bootstrap` in KafkaRaftClientTest.

Reviewers: Ken Huang <s7133700@gmail.com>, Nilesh Kumar
 <nileshkumar3@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
