### PR TITLE
KAFKA-20281: Enhance helper message for producer-props and command-property

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -319,7 +319,7 @@ public class ProducerPerformance {
                 .dest("producerConfig")
                 .help("(DEPRECATED) Kafka producer related configuration properties like client.id. " +
                         "These configs take precedence over those passed via --command-config or --producer.config. " +
-                        "This option will be removed in a future version. Use --command-property instead.");
+                        "This option will be removed in a future version. Use --command-property instead. Example: --command-property linger.ms=10 batch.size=32768");
 
         parser.addArgument("--command-property")
                 .nargs("+")
@@ -328,7 +328,7 @@ public class ProducerPerformance {
                 .type(String.class)
                 .dest("commandProperties")
                 .help("Kafka producer related configuration properties like client.id. " +
-                        "These configs take precedence over those passed via --command-config or --producer.config.");
+                        "These configs take precedence over those passed via --command-config or --producer.config. Example: --command-property linger.ms=10 batch.size=32768");
 
         parser.addArgument("--producer.config")
                 .action(store())

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -27,6 +27,8 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -773,5 +775,21 @@ public class ProducerPerformanceTest {
         verify(producerMock, times(10)).send(any(), any());
         assertEquals(10, producerPerformanceSpy.stats.totalCount());
         verify(producerMock, times(1)).close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"--command-property", "--producer-props"})
+    public void testMultipleProducerProperty(String configKey) throws IOException, ArgumentParserException {
+        ArgumentParser parser = ProducerPerformance.argParser();
+        String[] args = new String[]{
+            "--topic", "Hello-Kafka",
+            "--num-records", "5",
+            "--throughput", "100",
+            "--record-size", "100",
+            "--bootstrap-server", "localhost:9000",
+            configKey, "linger.ms=10", "batch.size=32768"};
+        ProducerPerformance.ConfigPostProcessor configs = new ProducerPerformance.ConfigPostProcessor(parser, args);
+        assertEquals("10", configs.producerProps.get(ProducerConfig.LINGER_MS_CONFIG));
+        assertEquals("32768", configs.producerProps.get(ProducerConfig.BATCH_SIZE_CONFIG));
     }
 }


### PR DESCRIPTION
* Add helper message for `--producer-props` and `--command-property`.
* Add related test cases.

Reviewers: Ken Huang <s7133700@gmail.com>, Nilesh Kumar
 <nileshkumar3@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
