### PR TITLE
KAFKA-20272, KAFKA-20273: Fix merge conflict with KAFKA-20066

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -13609,9 +13609,9 @@ public class GroupMetadataManagerTest {
                     .setSessionTimeoutMs(5000)
                     .setSupportedProtocols(protocols1)
             )
-            .setAssignedPartitions(mkAssignment(
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2),
-                mkTopicAssignment(barTopicId, 0, 1)))
+                mkTopicAssignment(barTopicId, 0, 1)), 10))
             .build();
         ConsumerGroupMember oldMember2 = new ConsumerGroupMember.Builder(oldMemberId2)
             .setInstanceId(instanceId)
@@ -13623,8 +13623,8 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(List.of(fooTopicName, barTopicName))
             .setServerAssignorName(NoOpPartitionAssignor.NAME)
             .setRebalanceTimeoutMs(45000)
-            .setAssignedPartitions(mkAssignment(
-                mkTopicAssignment(fooTopicId, 3, 4, 5)))
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5)), 10))
             .build();
 
         CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
@@ -15319,8 +15319,8 @@ public class GroupMetadataManagerTest {
                     .setSessionTimeoutMs(5000)
                     .setSupportedProtocols(protocols)
             )
-            .setAssignedPartitions(mkAssignment(
-                mkTopicAssignment(fooTopicId, 0, 1, 2)))
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2)), 10))
             .build();
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
             .setState(MemberState.STABLE)
@@ -15331,7 +15331,7 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(List.of(barTopicName))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
-            .setAssignedPartitions(mkAssignment())
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(), 10))
             .build();
 
         CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
@@ -15686,8 +15686,8 @@ public class GroupMetadataManagerTest {
                     .setSessionTimeoutMs(5000)
                     .setSupportedProtocols(protocols)
             )
-            .setAssignedPartitions(mkAssignment(
-                mkTopicAssignment(fooTopicId, 0, 1, 2)))
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2)), 10))
             .build();
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
             .setState(MemberState.STABLE)
@@ -15698,7 +15698,7 @@ public class GroupMetadataManagerTest {
             .setSubscribedTopicNames(List.of(barTopicName))
             .setServerAssignorName("range")
             .setRebalanceTimeoutMs(45000)
-            .setAssignedPartitions(mkAssignment())
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(), 10))
             .build();
 
         CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()


### PR DESCRIPTION
KAFKA-20066 adds assignment epochs to member assignments. Update the new
tests from KAFKA-20272 and KAFKA-20273 to include assignment epochs.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, TengYao Chi
 <frankvicky@apache.org>, Ken Huang <s7133700@gmail.com>, David Jacot
 <djacot@confluent.io>
