### PR TITLE
MINOR: Followup Deprecate group.coordinator.rebalance.protocols config

### DIFF
--- a/core/src/test/scala/unit/kafka/server/StreamsGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupDescribeRequestTest.scala
@@ -70,7 +70,6 @@ class StreamsGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCoo
 
   @ClusterTest(
     serverProperties = Array(
-      new ClusterConfigProperty(key = GroupCoordinatorConfig.GROUP_COORDINATOR_REBALANCE_PROTOCOLS_CONFIG, value = "classic,consumer,streams"),
       new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
       new ClusterConfigProperty(key = GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")
     )


### PR DESCRIPTION
Cleanup test which using `classic,consumer,streams`, see comment
https://github.com/apache/kafka/pull/21522#issuecomment-4029545287

Reviewers: TengYao Chi <frankvicky@apache.org>, Lan Ding
 <isDing_L@163.com>
