### PR TITLE
MINOR: fix share poll event to call the share membership manager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -228,12 +228,12 @@ public class ApplicationEventProcessor implements EventProcessor<ApplicationEven
     }
 
     private void process(final SharePollEvent event) {
-        requestManagers.consumerMembershipManager.ifPresent(consumerMembershipManager ->
-            consumerMembershipManager.maybeReconcile(true));
-        requestManagers.shareHeartbeatRequestManager.ifPresent(hrm -> {
-            hrm.membershipManager().onConsumerPoll();
-            hrm.resetPollTimer(event.pollTimeMs());
+        requestManagers.shareMembershipManager.ifPresent(shareMembershipManager -> {
+            shareMembershipManager.maybeReconcile(true);
+            shareMembershipManager.onConsumerPoll();
         });
+        requestManagers.shareHeartbeatRequestManager.ifPresent(hrm ->
+            hrm.resetPollTimer(event.pollTimeMs()));
     }
 
     private void process(final CreateFetchRequestsEvent event) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessorTest.java
@@ -31,6 +31,9 @@ import org.apache.kafka.clients.consumer.internals.MockRebalanceListener;
 import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate;
 import org.apache.kafka.clients.consumer.internals.OffsetsRequestManager;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
+import org.apache.kafka.clients.consumer.internals.ShareConsumeRequestManager;
+import org.apache.kafka.clients.consumer.internals.ShareHeartbeatRequestManager;
+import org.apache.kafka.clients.consumer.internals.ShareMembershipManager;
 import org.apache.kafka.clients.consumer.internals.StreamsGroupHeartbeatRequestManager;
 import org.apache.kafka.clients.consumer.internals.StreamsMembershipManager;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
@@ -95,6 +98,8 @@ public class ApplicationEventProcessorTest {
     private final ConsumerMetadata metadata = mock(ConsumerMetadata.class);
     private final StreamsGroupHeartbeatRequestManager streamsGroupHeartbeatRequestManager = mock(StreamsGroupHeartbeatRequestManager.class);
     private final StreamsMembershipManager streamsMembershipManager = mock(StreamsMembershipManager.class);
+    private final ShareHeartbeatRequestManager shareHeartbeatRequestManager = mock(ShareHeartbeatRequestManager.class);
+    private final ShareMembershipManager shareMembershipManager = mock(ShareMembershipManager.class);
     private ApplicationEventProcessor processor;
 
     private void setupProcessor(boolean withGroupId) {
@@ -130,6 +135,22 @@ public class ApplicationEventProcessorTest {
             Optional.empty(),
             withGroupId ? Optional.of(streamsGroupHeartbeatRequestManager) : Optional.empty(),
             withGroupId ? Optional.of(streamsMembershipManager) : Optional.empty()
+        );
+        processor = new ApplicationEventProcessor(
+            new LogContext(),
+            requestManagers,
+            metadata,
+            subscriptionState
+        );
+    }
+
+    private void setupShareProcessor() {
+        RequestManagers requestManagers = new RequestManagers(
+            new LogContext(),
+            mock(ShareConsumeRequestManager.class),
+            Optional.of(mock(CoordinatorRequestManager.class)),
+            Optional.of(shareHeartbeatRequestManager),
+            Optional.of(shareMembershipManager)
         );
         processor = new ApplicationEventProcessor(
             new LogContext(),
@@ -281,6 +302,19 @@ public class ApplicationEventProcessorTest {
         verify(heartbeatRequestManager).resetPollTimer(event.pollTimeMs());
         verify(offsetsRequestManager).updateFetchPositions(event.deadlineMs());
         verify(fetchRequestManager).createFetchRequests();
+    }
+
+    @Test
+    public void testSharePollEventCallsShareManagers() {
+        SharePollEvent event = new SharePollEvent(12345);
+
+        setupShareProcessor();
+        processor.process(event);
+
+        verify(shareMembershipManager).maybeReconcile(true);
+        verify(shareMembershipManager).onConsumerPoll();
+
+        verify(shareHeartbeatRequestManager).resetPollTimer(event.pollTimeMs());
     }
 
     @Test


### PR DESCRIPTION
Fix to call the shareMembershipMgr reconcile when processing a share
poll event (not the consumerMembershipManager)

No changes in logic because maybeReconcile is implemented in the parent
class AbstractMembershipMgr, but it's confusing and could lead to errors
if ever we override the maybeReconcile.

Reviewers: Andrew Schofield <aschofield@confluent.io>
