### PR TITLE
MINOR: Share consumer config heading

### DIFF
--- a/docs/configuration/consumer-configs.md
+++ b/docs/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
-title: Consumer Configs
-description: Consumer Configs
+title: Consumer and Share Consumer Configs
+description: Consumer and Share Consumer Configs
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 


### PR DESCRIPTION
Share consumer configurations are a subset of the consumer
configurations. When trying to use the share consumer API, we have
learnt that users find it hard to find the share consumer configurations
in the docs. This PR changes the heading for the consumer configs so it
is clear that share consumer configs can be found in there too.

Before:  <img width="1537" height="384" alt="Screenshot 2026-03-10 at 19
56 07"
src="https://github.com/user-attachments/assets/ecf6c9be-8dd8-468c-980e-bb1533f40283"
/>

After:  <img width="1537" height="384" alt="Screenshot 2026-03-10 at 19
55 40"
src="https://github.com/user-attachments/assets/3f4c2dcc-23e1-4d59-9cfc-a7180f76f596"
/>

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
