### PR TITLE
KAFKA-20296: Fix flaky consumer metrics test

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerTest.java
@@ -962,11 +962,14 @@ public class PlaintextConsumerTest {
 
             // Remove topic from subscription
             consumer.subscribe(List.of(topic2), listener);
-            awaitRebalance(consumer, listener);
-
-            // Verify the metric has gone
-            assertNull(consumer.metrics().get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1)));
-            assertNull(consumer.metrics().get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags2)));
+            // Check the metrics are cleaned up.
+            // The cleanup is done when a new fetch request is generated, so poll until it happens.
+            var lagMetricName1 = new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1);
+            var lagMetricName2 = new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags2);
+            TestUtils.waitForCondition(() -> {
+                consumer.poll(Duration.ofMillis(100));
+                return consumer.metrics().get(lagMetricName1) == null && consumer.metrics().get(lagMetricName2) == null;
+            }, "Metrics for removed partitions should be cleaned up");
         }
     }
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerTest.java
@@ -891,11 +891,14 @@ public class PlaintextConsumerTest {
 
             // Remove topic from subscription
             consumer.subscribe(List.of(topic2), listener);
-            awaitRebalance(consumer, listener);
-
-            // Verify the metric has gone
-            assertNull(consumer.metrics().get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1)));
-            assertNull(consumer.metrics().get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags2)));
+            // Check the metrics are cleaned up.
+            // The cleanup is done when a new fetch request is generated, so poll until it happens.
+            var metricName1 = new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1);
+            var metricName2 = new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags2);
+            TestUtils.waitForCondition(() -> {
+                consumer.poll(Duration.ofMillis(100));
+                return consumer.metrics().get(metricName1) == null && consumer.metrics().get(metricName2) == null;
+            }, "Metrics for removed partitions should be cleaned up");
         }
     }
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerTest.java
@@ -889,16 +889,9 @@ public class PlaintextConsumerTest {
             assertNotNull(fetchLead0);
             assertEquals((double) records.count(), fetchLead0.metricValue(), "The lead should be " + records.count());
 
-            // Remove topic from subscription
+            // Remove topic from subscription and wait for metrics cleanup.
             consumer.subscribe(List.of(topic2), listener);
-            // Check the metrics are cleaned up.
-            // The cleanup is done when a new fetch request is generated, so poll until it happens.
-            var metricName1 = new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1);
-            var metricName2 = new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags2);
-            TestUtils.waitForCondition(() -> {
-                consumer.poll(Duration.ofMillis(100));
-                return consumer.metrics().get(metricName1) == null && consumer.metrics().get(metricName2) == null;
-            }, "Metrics for removed partitions should be cleaned up");
+            awaitMetricsCleanup(consumer, "records-lead", tags1, tags2);
         }
     }
 
@@ -960,16 +953,9 @@ public class PlaintextConsumerTest {
             var expectedLag = numMessages - records.count();
             assertEquals(expectedLag, (double) fetchLag0.metricValue(), EPSILON, "The lag should be " + expectedLag);
 
-            // Remove topic from subscription
+            // Remove topic from subscription and wait for metrics cleanup.
             consumer.subscribe(List.of(topic2), listener);
-            // Check the metrics are cleaned up.
-            // The cleanup is done when a new fetch request is generated, so poll until it happens.
-            var lagMetricName1 = new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1);
-            var lagMetricName2 = new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags2);
-            TestUtils.waitForCondition(() -> {
-                consumer.poll(Duration.ofMillis(100));
-                return consumer.metrics().get(lagMetricName1) == null && consumer.metrics().get(lagMetricName2) == null;
-            }, "Metrics for removed partitions should be cleaned up");
+            awaitMetricsCleanup(consumer, "records-lag", tags1, tags2);
         }
     }
 
@@ -1755,6 +1741,20 @@ public class PlaintextConsumerTest {
         }, "Timed out waiting for non-empty records from topic " + tp.topic() + " partition " + tp.partition());
 
         return result.get();
+    }
+
+    private void awaitMetricsCleanup(
+        Consumer<?, ?> consumer,
+        String metricName,
+        Map<String, String> tags1,
+        Map<String, String> tags2
+    ) throws InterruptedException {
+        var metric1 = new MetricName(metricName, "consumer-fetch-manager-metrics", "", tags1);
+        var metric2 = new MetricName(metricName, "consumer-fetch-manager-metrics", "", tags2);
+        TestUtils.waitForCondition(() -> {
+            consumer.poll(Duration.ofMillis(100));
+            return consumer.metrics().get(metric1) == null && consumer.metrics().get(metric2) == null;
+        }, "Metrics for removed partitions should be cleaned up");
     }
 
     public static class SerializerImpl implements Serializer<byte[]> {


### PR DESCRIPTION
It has been flaky on trunk and PRs, failing when it continues to find a
metric that is supposed to the removed when preparing fetch requests.

The metric is only removed when sending new fetch requests (on
prepareFetchRequests), but the test was just waiting for a rebalance
(callbacks triggered) , which really does not guarantee that we prepared
a new fetch request.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Nilesh Kumar
 <nileshkumar3@gmail.com>
