### PR TITLE
KAFKA-20253: Fix high CPU loop after failed re-authentication

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1570,9 +1570,11 @@ public abstract class AbstractCoordinator implements Closeable {
                 }
             } catch (AuthenticationException e) {
                 log.error("An authentication error occurred in the heartbeat thread", e);
+                heartbeat.failHeartbeat();
                 setFailureCause(e);
             } catch (GroupAuthorizationException e) {
                 log.error("A group authorization error occurred in the heartbeat thread", e);
+                heartbeat.failHeartbeat();
                 setFailureCause(e);
             } catch (InterruptedException | InterruptException e) {
                 Thread.interrupted();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -256,8 +256,17 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
         if (membershipManager().state() == MemberState.UNSUBSCRIBED) {
             return Long.MAX_VALUE;
         }
-        if (pollTimer.isExpired() || (membershipManager().shouldHeartbeatNow() && !heartbeatRequestState.requestInFlight())) {
+        if (pollTimer.isExpired()) {
             return 0L;
+        }
+        if (membershipManager().shouldHeartbeatNow() && !heartbeatRequestState.requestInFlight()) {
+            // Only return 0 if the heartbeat can actually be sent now. If the request is
+            // in backoff (e.g., after re-authentication failure), return the remaining backoff
+            // time to avoid a busy-wait loop in the network thread.
+            if (heartbeatRequestState.canSendRequest(currentTimeMs)) {
+                return 0L;
+            }
+            return heartbeatRequestState.timeToNextHeartbeatMs(currentTimeMs);
         }
         return Math.min(pollTimer.remainingMs() / 2, heartbeatRequestState.timeToNextHeartbeatMs(currentTimeMs));
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -528,10 +528,14 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
     @Override
     public long maximumTimeToWait(long currentTimeMs) {
         pollTimer.update(currentTimeMs);
-        if (pollTimer.isExpired() ||
-            membershipManager.shouldNotWaitForHeartbeatInterval() && !heartbeatRequestState.requestInFlight()) {
-
+        if (pollTimer.isExpired()) {
             return 0L;
+        }
+        if (membershipManager.shouldNotWaitForHeartbeatInterval() && !heartbeatRequestState.requestInFlight()) {
+            if (heartbeatRequestState.canSendRequest(currentTimeMs)) {
+                return 0L;
+            }
+            return heartbeatRequestState.timeToNextHeartbeatMs(currentTimeMs);
         }
         return Math.min(pollTimer.remainingMs() / 2, heartbeatRequestState.timeToNextHeartbeatMs(currentTimeMs));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -336,6 +336,41 @@ public class ConsumerHeartbeatRequestManagerTest
     }
 
     @Test
+    public void testHeartbeatOutsideInterval() {
+        when(membershipManager.shouldSkipHeartbeat()).thenReturn(false);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+        NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+
+        // Heartbeat should be sent
+        assertEquals(1, result.unsentRequests.size());
+        // Interval timer reset
+        assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, result.timeUntilNextPollMs);
+        assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, heartbeatRequestManager.maximumTimeToWait(time.milliseconds()));
+        // Membership manager updated (to transition out of the heartbeating state)
+        verify(membershipManager).onHeartbeatRequestGenerated();
+    }
+
+    @Test
+    public void testMaximumTimeToWaitRespectsBackoffWhenHeartbeatNow() {
+        // Simulate a heartbeat failure that puts the request state into backoff
+        createHeartbeatRequestStateWithZeroHeartbeatInterval();
+        NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, result.unsentRequests.size());
+
+        // Fail the heartbeat request (simulates auth failure recovery scenario)
+        result.unsentRequests.get(0).handler().onFailure(time.milliseconds(), new TimeoutException("timeout"));
+
+        // shouldHeartbeatNow is true but the request is in backoff
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+
+        // maximumTimeToWait should respect the backoff and NOT return 0
+        long waitTime = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(waitTime > 0,
+            "maximumTimeToWait should return backoff time when heartbeat is requested " +
+            "but request is in backoff, got " + waitTime);
+    }
+
+    @Test
     public void testNetworkTimeout() {
         // The initial heartbeatInterval is set to 0
         createHeartbeatRequestStateWithZeroHeartbeatInterval();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
@@ -111,6 +111,22 @@ public class HeartbeatTest {
     }
 
     @Test
+    public void testFailHeartbeatResetsTimerWithBackoff() {
+        // Simulate: heartbeat was sent, then auth failure after interval elapsed
+        heartbeat.sentHeartbeat(time.milliseconds());
+        time.sleep(heartbeatIntervalMs + 50);
+
+        // Timer expired, timeToNextHeartbeat returns 0 (would cause busy loop)
+        assertEquals(0, heartbeat.timeToNextHeartbeat(time.milliseconds()));
+
+        // failHeartbeat should reset the timer with a backoff, preventing 0-timeout spin
+        heartbeat.failHeartbeat();
+        long nextHeartbeat = heartbeat.timeToNextHeartbeat(time.milliseconds());
+        assertTrue(nextHeartbeat > 0,
+            "After failHeartbeat(), timeToNextHeartbeat should return a positive backoff value, got " + nextHeartbeat);
+    }
+
+    @Test
     public void testPollTimeout() {
         assertFalse(heartbeat.pollTimeoutExpired(time.milliseconds()));
         time.sleep(maxPollIntervalMs / 2);


### PR DESCRIPTION
**JIRA:**
[KAFKA-20253](https://issues.apache.org/jira/browse/KAFKA-20253)

When re-authentication fails in the consumer (e.g., temporary OAuth
token server unavailability with SASL_OAUTHBEARER), the heartbeat timer
is left in an expired state. This causes `timeToNextHeartbeat()` to
return 0, leading the consumer poll loop to busy-wait with a 0ms timeout
- pinning a CPU core at 100% (ClassicKafkaConsumer) or 40-50%
(AsyncKafkaConsumer).

## Changes

### ClassicKafkaConsumer (AbstractCoordinator heartbeat thread)

The heartbeat thread's `catch (AuthenticationException)` and `catch
(GroupAuthorizationException)` blocks call `setFailureCause()` but never
call `heartbeat.failHeartbeat()`. This leaves the heartbeat timer
expired. After the user catches the exception and calls `poll()` again,
`timeToNextHeartbeat()` returns 0, causing the main thread to spin.

**Fix:** Call `heartbeat.failHeartbeat()` before `setFailureCause()` in
both exception handlers. This resets the heartbeat timer with
exponential backoff, preventing the 0-timeout spin.

### AsyncKafkaConsumer (AbstractHeartbeatRequestManager +
StreamsGroupHeartbeatRequestManager)

`maximumTimeToWait()` returns 0 when `shouldHeartbeatNow()` is true,
even if the heartbeat request is in backoff (can't actually be sent).
This causes the background network thread to spin.

**Fix:** Check `canSendRequest()` before returning 0. If the request is
in backoff, return the remaining backoff time instead.

## Testing

- Added `HeartbeatTest.testFailHeartbeatResetsTimerWithBackoff()` -
verifies that `failHeartbeat()` resets the timer to a positive backoff
value after expiry
- Added
`ConsumerHeartbeatRequestManagerTest.testMaximumTimeToWaitRespectsBackoffWhenHeartbeatNow()`
- verifies that `maximumTimeToWait()` returns a positive value when
`shouldHeartbeatNow()` is true but the request is in backoff

## Reproducer

See https://github.com/mstruk/kafka-consumer-reproducer for a standalone
reproducer demonstrating the CPU spin with SASL_OAUTHBEARER.

This contribution was developed with AI assistance (Claude Code).

Reviewers: Lianet Magrans <lmagrans@confluent.io>
