### PR TITLE
KAFKA-20237: Re-enqueue InitProducerId request after authentication failure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -687,13 +687,25 @@ public class TransactionManager {
             }
             if (currentState != State.INITIALIZING && !hasProducerId()) {
                 transitionTo(State.INITIALIZING);
-                InitProducerIdRequestData requestData = new InitProducerIdRequestData()
-                        .setTransactionalId(null)
-                        .setTransactionTimeoutMs(Integer.MAX_VALUE);
-                InitProducerIdHandler handler = new InitProducerIdHandler(new InitProducerIdRequest.Builder(requestData), false);
-                enqueueRequest(handler);
+                enqueueInitProducerIdRequest();
+            } else if (currentState == State.INITIALIZING && !hasProducerId()
+                    && pendingRequests.isEmpty() && !hasInFlightRequest()) {
+                // The previous InitProducerId request was dequeued but lost before it could
+                // be sent (e.g., due to an authentication error during connection). Re-enqueue
+                // to allow recovery without requiring a producer restart.
+                log.info("Re-enqueuing InitProducerId request after previous attempt was lost");
+                enqueueInitProducerIdRequest();
             }
         }
+    }
+
+    private void enqueueInitProducerIdRequest() {
+        InitProducerIdRequestData requestData = new InitProducerIdRequestData()
+                .setTransactionalId(null)
+                .setTransactionTimeoutMs(Integer.MAX_VALUE);
+        InitProducerIdHandler handler = new InitProducerIdHandler(
+                new InitProducerIdRequest.Builder(requestData), false);
+        enqueueRequest(handler);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -4613,6 +4613,37 @@ public class TransactionManagerTest {
         }
     }
 
+    @Test
+    public void testIdempotentProducerRecoversFromLostInitProducerIdRequest() {
+        // Simulate the scenario from KAFKA-20237: InitProducerId request is dequeued
+        // but lost due to authentication failure, leaving state stuck at INITIALIZING.
+        initializeTransactionManager(Optional.empty(), false);
+
+        // First call transitions to INITIALIZING and enqueues request
+        transactionManager.bumpIdempotentEpochAndResetIdIfNeeded();
+        assertTrue(transactionManager.isInitializing());
+
+        // Simulate the request being dequeued (as nextRequest() would do in Sender)
+        TransactionManager.TxnRequestHandler handler = transactionManager.nextRequest(false);
+        assertNotNull(handler, "InitProducerIdHandler should have been enqueued");
+
+        // Simulate authentication failure: the request was dequeued but never sent.
+        // authenticationFailed() iterates pendingRequests (now empty) so it does nothing.
+        transactionManager.authenticationFailed(new org.apache.kafka.common.errors.AuthenticationException("SSL handshake failed"));
+
+        // State should still be INITIALIZING (the handler was already dequeued)
+        assertTrue(transactionManager.isInitializing());
+
+        // On the next Sender iteration, bumpIdempotentEpochAndResetIdIfNeeded should
+        // detect the lost request and re-enqueue
+        transactionManager.bumpIdempotentEpochAndResetIdIfNeeded();
+        assertTrue(transactionManager.isInitializing());
+
+        // Verify a new request was enqueued
+        TransactionManager.TxnRequestHandler retryHandler = transactionManager.nextRequest(false);
+        assertNotNull(retryHandler, "A new InitProducerIdHandler should have been re-enqueued");
+    }
+
     private void runUntil(Supplier<Boolean> condition) {
         ProducerTestUtils.runUntil(sender, condition);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -4617,13 +4617,14 @@ public class TransactionManagerTest {
     public void testIdempotentProducerRecoversFromLostInitProducerIdRequest() {
         // Simulate the scenario from KAFKA-20237: InitProducerId request is dequeued
         // but lost due to authentication failure, leaving state stuck at INITIALIZING.
+        // Note: isInitializing() checks isTransactional(), so we verify state via
+        // behavioral assertions (request enqueue/dequeue) rather than state checks.
         initializeTransactionManager(Optional.empty(), false);
 
         // First call transitions to INITIALIZING and enqueues request
         transactionManager.bumpIdempotentEpochAndResetIdIfNeeded();
-        assertTrue(transactionManager.isInitializing());
 
-        // Simulate the request being dequeued (as nextRequest() would do in Sender)
+        // Verify a request was enqueued by dequeuing it (as nextRequest() would in Sender)
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequest(false);
         assertNotNull(handler, "InitProducerIdHandler should have been enqueued");
 
@@ -4631,15 +4632,11 @@ public class TransactionManagerTest {
         // authenticationFailed() iterates pendingRequests (now empty) so it does nothing.
         transactionManager.authenticationFailed(new org.apache.kafka.common.errors.AuthenticationException("SSL handshake failed"));
 
-        // State should still be INITIALIZING (the handler was already dequeued)
-        assertTrue(transactionManager.isInitializing());
-
         // On the next Sender iteration, bumpIdempotentEpochAndResetIdIfNeeded should
         // detect the lost request and re-enqueue
         transactionManager.bumpIdempotentEpochAndResetIdIfNeeded();
-        assertTrue(transactionManager.isInitializing());
 
-        // Verify a new request was enqueued
+        // Verify a new request was re-enqueued
         TransactionManager.TxnRequestHandler retryHandler = transactionManager.nextRequest(false);
         assertNotNull(retryHandler, "A new InitProducerIdHandler should have been re-enqueued");
     }


### PR DESCRIPTION
**JIRA:**
[KAFKA-20237](https://issues.apache.org/jira/browse/KAFKA-20237)

When an idempotent (non-transactional) KafkaProducer encounters an SSL
handshake failure during the initial connection, the `InitProducerId`
request is dequeued from the pending requests queue but never sent. The
`AuthenticationException` is caught in `Sender.runOnce()`, which calls
`transactionManager.authenticationFailed()`. However, since the request
was already dequeued, `authenticationFailed()` iterates over an empty
queue and does nothing.

The `TransactionManager` remains stuck in `INITIALIZING` state:
- `bumpIdempotentEpochAndResetIdIfNeeded()` skips re-enqueueing because
`currentState == INITIALIZING`
- `nextRequest()` returns null because the queue is empty
- The producer becomes permanently unable to send messages, even after
the SSL configuration is corrected

## Changes

Added a recovery path in `bumpIdempotentEpochAndResetIdIfNeeded()` that
detects when the state is `INITIALIZING` but the pending queue is empty
and no request is in-flight. In this case, the `InitProducerId` request
is re-enqueued, allowing the producer to recover without requiring a
restart.

Also extracted the `InitProducerId` request creation into a helper
method (`enqueueInitProducerIdRequest()`) to avoid duplication.

## Testing

Added `testIdempotentProducerRecoversFromLostInitProducerIdRequest()`
that simulates:
1. Transitioning to INITIALIZING and enqueuing the request
2. Dequeuing the request (as
`Sender.maybeSendAndPollTransactionalRequest()` would)
3. Triggering `authenticationFailed()` (which does nothing since queue
is empty)
4. Verifying that the next call to
`bumpIdempotentEpochAndResetIdIfNeeded()` re-enqueues the request

## Impact

This enables self-recovery for idempotent producers in cloud-native
environments where certificate rotation or temporary auth server
unavailability can cause transient SSL failures. Previously, the only
workaround was to close and recreate the KafkaProducer.

This contribution was developed with AI assistance (Claude Code).
