### PR TITLE
KAFKA-20199: Use NodeId selector metric tag on controller-only KRaft nodes

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
+++ b/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
@@ -44,6 +44,7 @@ import org.apache.kafka.server.config.ServerConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -108,7 +109,7 @@ public class NodeToControllerChannelManagerImpl implements NodeToControllerChann
                 metrics,
                 time,
                 channelName,
-                Map.of("BrokerId", String.valueOf(config.brokerId())),
+                selectorMetricTags(config),
                 false,
                 channelBuilder,
                 logContext
@@ -131,6 +132,17 @@ public class NodeToControllerChannelManagerImpl implements NodeToControllerChann
                 logContext,
                 MetadataRecoveryStrategy.NONE
         );
+    }
+
+    static Map<String, String> selectorMetricTags(AbstractKafkaConfig config) {
+        List<String> processRoles = config.getList(KRaftConfigs.PROCESS_ROLES_CONFIG);
+        boolean isController = processRoles.contains(ProcessRole.ControllerRole.toString());
+        boolean isBroker = processRoles.contains(ProcessRole.BrokerRole.toString());
+
+        if (isController && !isBroker) {
+            return Map.of("NodeId", String.valueOf(config.nodeId()));
+        }
+        return Map.of("BrokerId", String.valueOf(config.brokerId()));
     }
 
     @Override

--- a/server/src/test/java/org/apache/kafka/server/NodeToControllerChannelManagerImplTest.java
+++ b/server/src/test/java/org/apache/kafka/server/NodeToControllerChannelManagerImplTest.java
@@ -1,0 +1,48 @@
+
+
+package org.apache.kafka.server;
+
+import org.apache.kafka.raft.KRaftConfigs;
+import org.apache.kafka.server.config.AbstractKafkaConfig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NodeToControllerChannelManagerImplTest {
+
+    @Test
+    void testSelectorMetricsTagsForControllerOnlyNode() {
+        AbstractKafkaConfig config = mock(AbstractKafkaConfig.class);
+        when(config.getList(KRaftConfigs.PROCESS_ROLES_CONFIG)).thenReturn(List.of("controller"));
+        when(config.nodeId()).thenReturn(123);
+
+        assertEquals(Map.of("NodeId", "123"), NodeToControllerChannelManagerImpl.selectorMetricTags(config));
+        verify(config, never()).brokerId();
+    }
+
+    @Test
+    void testSelectorMetricsTagsForBrokerOnlyNode() {
+        AbstractKafkaConfig config = mock(AbstractKafkaConfig.class);
+        when(config.getList(KRaftConfigs.PROCESS_ROLES_CONFIG)).thenReturn(List.of("broker"));
+        when(config.brokerId()).thenReturn(12);
+
+        assertEquals(Map.of("BrokerId", "12"), NodeToControllerChannelManagerImpl.selectorMetricTags(config));
+    }
+
+    @Test
+    void testSelectorMetricsTagsForCombinedRoleNode() {
+        AbstractKafkaConfig config = mock(AbstractKafkaConfig.class);
+        when(config.getList(KRaftConfigs.PROCESS_ROLES_CONFIG)).thenReturn(List.of("broker", "controller"));
+        when(config.brokerId()).thenReturn(98);
+
+        assertEquals(Map.of("BrokerId", "98"), NodeToControllerChannelManagerImpl.selectorMetricTags(config));
+    }
+}


### PR DESCRIPTION
This PR fixes KAFKA-20199.

In KRaft mode, controller-only nodes create a Selector via
NodeToControllerChannelManagerImpl with the metric tag "BrokerId".
This is misleading because the process is not acting as a broker.

This change makes the selector metric tag role-aware:
- Controller-only nodes use "NodeId"
- Broker and combined-role nodes continue to use "BrokerId"

This preserves existing broker metrics while avoiding broker-specific
tags on controller-only nodes.