### PR TITLE
KAFKA-20291 [2/3]: Implement assignment batching for share groups

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerRackAwareTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerRackAwareTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.test.TestUtils;
@@ -41,7 +42,21 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+@ClusterTestDefaults(
+    serverProperties = {
+        @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+    }
+)
 public class ShareConsumerRackAwareTest {
+
+    @ClusterTestDefaults(
+        serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        }
+    )
+    public static class WithAssignmentBatchingTest extends ShareConsumerRackAwareTest {
+    }
+
     @ClusterTest(
         types = {Type.KRAFT},
         brokers = 3,

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerRackAwareTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerRackAwareTest.java
@@ -42,19 +42,14 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@ClusterTestDefaults(
-    serverProperties = {
-        @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
-    }
-)
 public class ShareConsumerRackAwareTest {
 
     @ClusterTestDefaults(
         serverProperties = {
-            @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
         }
     )
-    public static class WithAssignmentBatchingTest extends ShareConsumerRackAwareTest {
+    public static class WithAssignmentBatchingDisabledTest extends ShareConsumerRackAwareTest {
     }
 
     @ClusterTest(

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -66,6 +66,7 @@ import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.ClusterTests;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.GroupConfig;
@@ -138,7 +139,6 @@ import static org.junit.jupiter.api.Assertions.fail;
         @ClusterConfigProperty(key = "group.share.max.partition.max.record.locks", value = "10000"),
         @ClusterConfigProperty(key = "group.share.partition.max.record.locks", value = "10000"),
         @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "15000"),
-        @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
         @ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
         @ClusterConfigProperty(key = "share.coordinator.state.topic.min.isr", value = "1"),
         @ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "3"),
@@ -148,29 +148,6 @@ import static org.junit.jupiter.api.Assertions.fail;
     }
 )
 public class ShareConsumerTest {
-
-    @ClusterTestDefaults(
-        types = {Type.KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = "auto.create.topics.enable", value = "false"),
-            @ClusterConfigProperty(key = "group.share.max.partition.max.record.locks", value = "10000"),
-            @ClusterConfigProperty(key = "group.share.partition.max.record.locks", value = "10000"),
-            @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "15000"),
-            @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
-            @ClusterConfigProperty(key = "share.coordinator.state.topic.min.isr", value = "1"),
-            @ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "3"),
-            @ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
-            @ClusterConfigProperty(key = "transaction.state.log.min.isr", value = "1"),
-            @ClusterConfigProperty(key = "transaction.state.log.replication.factor", value = "1")
-        }
-    )
-    public static class WithAssignmentBatchingTest extends ShareConsumerTest {
-        public WithAssignmentBatchingTest(ClusterInstance cluster) {
-            super(cluster);
-        }
-    }
-
     private final ClusterInstance cluster;
     private final TopicPartition tp = new TopicPartition("topic", 0);
     private Uuid tpId;
@@ -296,7 +273,14 @@ public class ShareConsumerTest {
         }
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testSubscriptionAndPoll() {
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -314,7 +298,14 @@ public class ShareConsumerTest {
         }
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testSubscriptionAndPollMultiple() {
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -1310,7 +1301,14 @@ public class ShareConsumerTest {
             "Consumer close should not wait for full timeout when broker is already shut down");
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testMultipleConsumersInGroupSequentialConsumption() {
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -1346,7 +1344,14 @@ public class ShareConsumerTest {
         }
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testMultipleConsumersInGroupConcurrentConsumption()
         throws InterruptedException, ExecutionException, TimeoutException {
         AtomicInteger totalMessagesConsumed = new AtomicInteger(0);
@@ -1380,7 +1385,14 @@ public class ShareConsumerTest {
         assertEquals(producerCount * messagesPerProducer, totalResult);
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testMultipleConsumersInMultipleGroupsConcurrentConsumption()
         throws ExecutionException, InterruptedException, TimeoutException {
         AtomicInteger totalMessagesConsumedGroup1 = new AtomicInteger(0);
@@ -1493,7 +1505,14 @@ public class ShareConsumerTest {
         }
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testMultipleConsumersInGroupFailureConcurrentConsumption()
         throws InterruptedException, ExecutionException, TimeoutException {
         AtomicInteger totalMessagesConsumed = new AtomicInteger(0);
@@ -1806,7 +1825,14 @@ public class ShareConsumerTest {
         }
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testSubscriptionFollowedByTopicCreation() throws InterruptedException {
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -1835,7 +1861,14 @@ public class ShareConsumerTest {
         }
     }
 
-    @ClusterTest
+    @ClusterTests({
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+        }),
+        @ClusterTest(serverProperties = {
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000")
+        })
+    })
     public void testSubscriptionAndPollFollowedByTopicDeletion() throws InterruptedException, ExecutionException {
         String topic1 = "bar";
         String topic2 = "baz";

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -69,6 +69,7 @@ import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.GroupConfig;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.server.share.SharePartitionKey;
@@ -137,6 +138,7 @@ import static org.junit.jupiter.api.Assertions.fail;
         @ClusterConfigProperty(key = "group.share.max.partition.max.record.locks", value = "10000"),
         @ClusterConfigProperty(key = "group.share.partition.max.record.locks", value = "10000"),
         @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "15000"),
+        @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
         @ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
         @ClusterConfigProperty(key = "share.coordinator.state.topic.min.isr", value = "1"),
         @ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "3"),
@@ -146,6 +148,29 @@ import static org.junit.jupiter.api.Assertions.fail;
     }
 )
 public class ShareConsumerTest {
+
+    @ClusterTestDefaults(
+        types = {Type.KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = "auto.create.topics.enable", value = "false"),
+            @ClusterConfigProperty(key = "group.share.max.partition.max.record.locks", value = "10000"),
+            @ClusterConfigProperty(key = "group.share.partition.max.record.locks", value = "10000"),
+            @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "15000"),
+            @ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
+            @ClusterConfigProperty(key = "share.coordinator.state.topic.min.isr", value = "1"),
+            @ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "3"),
+            @ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
+            @ClusterConfigProperty(key = "transaction.state.log.min.isr", value = "1"),
+            @ClusterConfigProperty(key = "transaction.state.log.replication.factor", value = "1")
+        }
+    )
+    public static class WithAssignmentBatchingTest extends ShareConsumerTest {
+        public WithAssignmentBatchingTest(ClusterInstance cluster) {
+            super(cluster);
+        }
+    }
+
     private final ClusterInstance cluster;
     private final TopicPartition tp = new TopicPartition("topic", 0);
     private Uuid tpId;

--- a/core/src/test/scala/integration/kafka/api/AbstractAuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractAuthorizerIntegrationTest.scala
@@ -117,6 +117,7 @@ class AbstractAuthorizerIntegrationTest extends BaseRequestTest {
     properties.put(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
     properties.put(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, "0")
     properties.put(GroupCoordinatorConfig.CONSUMER_GROUP_REGEX_REFRESH_INTERVAL_MS_CONFIG, "10000")
+    properties.put(GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, "0")
     properties.put(TransactionLogConfig.TRANSACTIONS_TOPIC_PARTITIONS_CONFIG, "1")
     properties.put(TransactionLogConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
     properties.put(TransactionLogConfig.TRANSACTIONS_TOPIC_MIN_ISR_CONFIG, "1")

--- a/core/src/test/scala/unit/kafka/server/ShareGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupDescribeRequestTest.scala
@@ -38,6 +38,7 @@ import scala.jdk.CollectionConverters._
 
 @Timeout(120)
 @ClusterTestDefaults(types = Array(Type.KRAFT), brokers = 1, serverProperties = Array(
+  new ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
   new ClusterConfigProperty(key = ShareGroupConfig.SHARE_GROUP_PERSISTER_CLASS_NAME_CONFIG, value = "")
 ))
 class ShareGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCoordinatorBaseRequestTest(cluster) {

--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.{ShareGroupHeartbeatRequestData, ShareGro
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ShareGroupHeartbeatRequest, ShareGroupHeartbeatResponse}
 import org.apache.kafka.common.test.ClusterInstance
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.server.common.Feature
 import org.apache.kafka.server.IntegrationTestUtils;
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertNotNull, assertNull, assertTrue}
@@ -33,11 +34,25 @@ import org.junit.jupiter.api.Timeout
 import java.util
 import scala.jdk.CollectionConverters._
 
+object ShareGroupHeartbeatRequestTest {
+  @ClusterTestDefaults(types = Array(Type.KRAFT), brokers = 1, serverProperties = Array(
+    new ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000"),
+    new ClusterConfigProperty(key = "group.share.persister.class.name", value = "")
+  ))
+  class WithAssignmentBatchingTest(cluster: ClusterInstance) extends ShareGroupHeartbeatRequestTest(cluster) {
+  }
+}
+
 @Timeout(120)
 @ClusterTestDefaults(types = Array(Type.KRAFT), brokers = 1, serverProperties = Array(
+  new ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
   new ClusterConfigProperty(key = "group.share.persister.class.name", value = "")
 ))
 class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
+
+  protected def isShareAssignmentBatchingEnabled: Boolean = {
+    cluster.brokers.values.stream.allMatch(b => b.config.groupCoordinatorConfig.shareGroupAssignmentIntervalMs > 0)
+  }
 
   @ClusterTest(
     features = Array(
@@ -88,10 +103,11 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      var expectedMemberEpoch = 2
 
       // Verify the response.
       assertNotNull(shareGroupHeartbeatResponse.data.memberId)
-      assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, shareGroupHeartbeatResponse.data.memberEpoch)
       assertEquals(new ShareGroupHeartbeatResponseData.Assignment(), shareGroupHeartbeatResponse.data.assignment)
 
       // Create the topic.
@@ -122,9 +138,18 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
 
       // Verify the response.
-      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, shareGroupHeartbeatResponse.data.memberEpoch)
       assertEquals(expectedAssignment, shareGroupHeartbeatResponse.data.assignment)
 
       // Leave the group.
@@ -178,11 +203,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      var expectedMemberEpoch = 2
 
       // Verify the response for member 1.
       val memberId1 = shareGroupHeartbeatResponse.data.memberId
+      var memberEpoch1 = shareGroupHeartbeatResponse.data.memberEpoch
       assertNotNull(memberId1)
-      assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, memberEpoch1)
       assertEquals(new ShareGroupHeartbeatResponseData.Assignment(), shareGroupHeartbeatResponse.data.assignment)
 
       // The second member request to join the group.
@@ -198,13 +225,15 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       TestUtils.waitUntilTrue(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
-          shareGroupHeartbeatResponse.data.memberEpoch > 2
+          (!isShareAssignmentBatchingEnabled || shareGroupHeartbeatResponse.data.memberEpoch > expectedMemberEpoch)
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      expectedMemberEpoch += 1
 
       // Verify the response for member 2.
       val memberId2 = shareGroupHeartbeatResponse.data.memberId
+      val memberEpoch2 = shareGroupHeartbeatResponse.data.memberEpoch
       assertNotNull(memberId2)
-      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, memberEpoch2)
       assertEquals(new ShareGroupHeartbeatResponseData.Assignment(), shareGroupHeartbeatResponse.data.assignment)
       // Verify the member id is different.
       assertNotEquals(memberId1, memberId2)
@@ -221,7 +250,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId1)
-          .setMemberEpoch(2)
+          .setMemberEpoch(memberEpoch1)
       ).build()
 
       // Heartbeats until the partitions are assigned for member 1.
@@ -241,17 +270,27 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           false
         }
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      // Verify the response.
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
 
       val topicPartitionsAssignedToMember1 = shareGroupHeartbeatResponse.data.assignment.topicPartitions()
-      // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch1 = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch1)
 
       // Prepare the next heartbeat for member 2.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId2)
-          .setMemberEpoch(3)
+          .setMemberEpoch(memberEpoch2)
       ).build()
 
       // Heartbeats until the partitions are assigned for member 2.
@@ -263,7 +302,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       val topicPartitionsAssignedToMember2 = shareGroupHeartbeatResponse.data.assignment.topicPartitions()
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, shareGroupHeartbeatResponse.data.memberEpoch)
 
       val partitionsAssigned: util.Set[Integer] = new util.HashSet[Integer]()
       topicPartitionsAssignedToMember1.forEach(topicPartition => {
@@ -276,12 +315,12 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       assertEquals(util.Set.of(0, 1, 2), partitionsAssigned)
 
       // Verify the assignments are not changed for member 1.
-      // Prepare another heartbeat for member 1 with latest received epoch 4 for member 1.
+      // Prepare another heartbeat for member 1 with latest received epoch for member 1.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId1)
-          .setMemberEpoch(4)
+          .setMemberEpoch(memberEpoch1)
       ).build()
 
       // Heartbeats until the response for no change of assignment occurs for member 1 with same epoch.
@@ -293,7 +332,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, shareGroupHeartbeatResponse.data.memberEpoch)
     } finally {
       admin.close()
     }
@@ -333,11 +372,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      var expectedMemberEpoch = 2
 
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
+      var memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
       assertNotNull(memberId)
-      assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, memberEpoch)
       assertEquals(new ShareGroupHeartbeatResponseData.Assignment(), shareGroupHeartbeatResponse.data.assignment)
 
       // Create the topic.
@@ -358,7 +399,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(2)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -366,9 +407,18 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
 
       // Verify the response.
-      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, shareGroupHeartbeatResponse.data.memberEpoch)
 
       // Member leaves the group.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
@@ -383,6 +433,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
       }, msg = s"Could not leave the group successfully. Last response $shareGroupHeartbeatResponse.")
+      expectedMemberEpoch += 1
 
       // Verify the response for member.
       assertEquals(-1, shareGroupHeartbeatResponse.data.memberEpoch)
@@ -398,11 +449,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       TestUtils.waitUntilTrue(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
-        shareGroupHeartbeatResponse.data.memberEpoch >= 4
+        (!isShareAssignmentBatchingEnabled || shareGroupHeartbeatResponse.data.memberEpoch > expectedMemberEpoch)
       }, msg = s"Could not rejoin the group successfully. Last response $shareGroupHeartbeatResponse.")
+      expectedMemberEpoch += 1
 
       // Verify the response for member 1.
-      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch)
       assertEquals(memberId, shareGroupHeartbeatResponse.data.memberId)
       // Partition assignment remains intact on rejoining.
       assertEquals(expectedAssignment, shareGroupHeartbeatResponse.data.assignment)
@@ -442,10 +495,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      var expectedMemberEpoch = 2
+
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
+      var memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
       assertNotNull(memberId)
-      assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, memberEpoch)
       assertEquals(new ShareGroupHeartbeatResponseData.Assignment(), shareGroupHeartbeatResponse.data.assignment)
       // Create the topic foo.
       val fooTopicId = TestUtils.createTopicWithAdminRaw(
@@ -473,7 +529,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(2)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       cluster.waitTopicCreation("foo", 2)
@@ -486,8 +542,19 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not get partitions for topic foo and bar assigned. Last response $shareGroupHeartbeatResponse.")
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
+
       // Verify the response.
-      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch)
       // Create the topic baz.
       val bazTopicId = TestUtils.createTopicWithAdminRaw(
         admin = admin,
@@ -511,7 +578,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(3)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -521,8 +588,19 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not get partitions for topic baz assigned. Last response $shareGroupHeartbeatResponse.")
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
+
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch)
       // Increasing the partitions of topic bar which is already being consumed in the share group.
       increasePartitions(admin, "bar", 6)
 
@@ -542,7 +620,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(4)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -552,8 +630,19 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not update partitions assignment for topic bar. Last response $shareGroupHeartbeatResponse.")
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
+
       // Verify the response.
-      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch)
       // Delete the topic foo.
       TestUtils.deleteTopicWithAdmin(
         admin = admin,
@@ -575,7 +664,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(5)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -585,15 +674,29 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
-      // Verify the response. Reconciliation filters out the assignment for deleted topic foo before the next assignment.
-      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
 
-      TestUtils.waitUntilTrue(() => {
-        shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
-        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
-          shareGroupHeartbeatResponse.data.memberEpoch > shareGroupHeartbeatRequest.data.memberEpoch
-      }, msg = s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
-      assertEquals(6, shareGroupHeartbeatResponse.data.memberEpoch)
+      if (isShareAssignmentBatchingEnabled) {
+        // Verify the response. Reconciliation filters out the assignment for deleted topic foo before the next assignment.
+        memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+        assertEquals(expectedMemberEpoch, memberEpoch)
+
+        TestUtils.waitUntilTrue(() => {
+          shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
+          shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
+            shareGroupHeartbeatResponse.data.memberEpoch > shareGroupHeartbeatRequest.data.memberEpoch
+        }, msg = s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
+        expectedMemberEpoch += 1
+
+        // Verify the response.
+        memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+        assertEquals(expectedMemberEpoch, memberEpoch)
+      } else {
+        expectedMemberEpoch += 1
+
+        // Verify the response.
+        memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+        assertEquals(expectedMemberEpoch, memberEpoch)
+      }
     } finally {
       admin.close()
     }
@@ -883,10 +986,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
+      var expectedMemberEpoch = 2
+
       // Verify the response for member.
       val memberId = shareGroupHeartbeatResponse.data.memberId
+      var memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
       assertNotNull(memberId)
-      assertEquals(2, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(expectedMemberEpoch, memberEpoch)
       assertEquals(new ShareGroupHeartbeatResponseData.Assignment(), shareGroupHeartbeatResponse.data.assignment)
       // Create the topic.
       val fooId = TestUtils.createTopicWithAdminRaw(
@@ -904,7 +1010,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(2)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -912,8 +1018,19 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
+      if (isShareAssignmentBatchingEnabled) {
+        // The group epoch is bumped by the metadata update, but not share partition initialization
+        // due to the pending delayed assignment.
+        expectedMemberEpoch += 1
+      } else {
+        // The group epoch is bumped by the metadata update and share partition initialization.
+        // Assignments are computed for both epoch bumps.
+        expectedMemberEpoch += 2
+      }
+
       // Verify the response.
-      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch)
 
       // Restart the only running broker.
       val broker = cluster.brokers().values().iterator().next()
@@ -925,7 +1042,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(3)
+          .setMemberEpoch(memberEpoch)
       ).build()
 
       // Should receive no error and no assignment changes.
@@ -936,7 +1053,8 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Verify the response. Epoch should not have changed and null assignments determines that no
       // change in old assignment.
-      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
+      memberEpoch = shareGroupHeartbeatResponse.data.memberEpoch
+      assertEquals(expectedMemberEpoch, memberEpoch)
       assertNull(shareGroupHeartbeatResponse.data.assignment)
     } finally {
       admin.close()

--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -36,16 +36,15 @@ import scala.jdk.CollectionConverters._
 
 object ShareGroupHeartbeatRequestTest {
   @ClusterTestDefaults(types = Array(Type.KRAFT), brokers = 1, serverProperties = Array(
-    new ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "1000"),
+    new ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
     new ClusterConfigProperty(key = "group.share.persister.class.name", value = "")
   ))
-  class WithAssignmentBatchingTest(cluster: ClusterInstance) extends ShareGroupHeartbeatRequestTest(cluster) {
+  class WithAssignmentBatchingDisabledTest(cluster: ClusterInstance) extends ShareGroupHeartbeatRequestTest(cluster) {
   }
 }
 
 @Timeout(120)
 @ClusterTestDefaults(types = Array(Type.KRAFT), brokers = 1, serverProperties = Array(
-  new ClusterConfigProperty(key = GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
   new ClusterConfigProperty(key = "group.share.persister.class.name", value = "")
 ))
 class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {

--- a/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ShareGroupHeartbeatRequestTest.scala
@@ -124,7 +124,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
       assertEquals(expectedAssignment, shareGroupHeartbeatResponse.data.assignment)
 
       // Leave the group.
@@ -197,7 +197,8 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       // Send the second member request until receiving a successful response.
       TestUtils.waitUntilTrue(() => {
         shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
-        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code
+        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
+          shareGroupHeartbeatResponse.data.memberEpoch > 2
       }, msg = s"Could not join the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member 2.
@@ -243,7 +244,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       val topicPartitionsAssignedToMember1 = shareGroupHeartbeatResponse.data.assignment.topicPartitions()
       // Verify the response.
-      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
 
       // Prepare the next heartbeat for member 2.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
@@ -262,7 +263,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       val topicPartitionsAssignedToMember2 = shareGroupHeartbeatResponse.data.assignment.topicPartitions()
       // Verify the response.
-      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
 
       val partitionsAssigned: util.Set[Integer] = new util.HashSet[Integer]()
       topicPartitionsAssignedToMember1.forEach(topicPartition => {
@@ -275,7 +276,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       assertEquals(util.Set.of(0, 1, 2), partitionsAssigned)
 
       // Verify the assignments are not changed for member 1.
-      // Prepare another heartbeat for member 1 with latest received epoch 3 for member 1.
+      // Prepare another heartbeat for member 1 with latest received epoch 4 for member 1.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
@@ -292,7 +293,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
-      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
     } finally {
       admin.close()
     }
@@ -367,7 +368,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
 
       // Member leaves the group.
       shareGroupHeartbeatRequest = new ShareGroupHeartbeatRequest.Builder(
@@ -395,10 +396,13 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           .setSubscribedTopicNames(List("foo").asJava)
       ).build()
 
-      shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
+      TestUtils.waitUntilTrue(() => {
+        shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
+        shareGroupHeartbeatResponse.data.memberEpoch >= 4
+      }, msg = s"Could not rejoin the group successfully. Last response $shareGroupHeartbeatResponse.")
 
       // Verify the response for member 1.
-      assertEquals(6, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
       assertEquals(memberId, shareGroupHeartbeatResponse.data.memberId)
       // Partition assignment remains intact on rejoining.
       assertEquals(expectedAssignment, shareGroupHeartbeatResponse.data.assignment)
@@ -483,7 +487,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not get partitions for topic foo and bar assigned. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
       // Create the topic baz.
       val bazTopicId = TestUtils.createTopicWithAdminRaw(
         admin = admin,
@@ -507,7 +511,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(4)
+          .setMemberEpoch(3)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -518,7 +522,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not get partitions for topic baz assigned. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
-      assertEquals(6, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
       // Increasing the partitions of topic bar which is already being consumed in the share group.
       increasePartitions(admin, "bar", 6)
 
@@ -538,7 +542,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(6)
+          .setMemberEpoch(4)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -549,7 +553,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not update partitions assignment for topic bar. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
-      assertEquals(8, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
       // Delete the topic foo.
       TestUtils.deleteTopicWithAdmin(
         admin = admin,
@@ -571,7 +575,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         new ShareGroupHeartbeatRequestData()
           .setGroupId("grp")
           .setMemberId(memberId)
-          .setMemberEpoch(8)
+          .setMemberEpoch(5)
       ).build()
 
       TestUtils.waitUntilTrue(() => {
@@ -581,8 +585,15 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           expectedAssignment.topicPartitions.containsAll(shareGroupHeartbeatResponse.data.assignment.topicPartitions) &&
           shareGroupHeartbeatResponse.data.assignment.topicPartitions.containsAll(expectedAssignment.topicPartitions)
       }, msg = s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
-      // Verify the response.
-      assertEquals(9, shareGroupHeartbeatResponse.data.memberEpoch)
+      // Verify the response. Reconciliation filters out the assignment for deleted topic foo before the next assignment.
+      assertEquals(5, shareGroupHeartbeatResponse.data.memberEpoch)
+
+      TestUtils.waitUntilTrue(() => {
+        shareGroupHeartbeatResponse = connectAndReceive(shareGroupHeartbeatRequest)
+        shareGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
+          shareGroupHeartbeatResponse.data.memberEpoch > shareGroupHeartbeatRequest.data.memberEpoch
+      }, msg = s"Could not update partitions assignment for topic foo. Last response $shareGroupHeartbeatResponse.")
+      assertEquals(6, shareGroupHeartbeatResponse.data.memberEpoch)
     } finally {
       admin.close()
     }
@@ -902,7 +913,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
           shareGroupHeartbeatResponse.data.assignment == expectedAssignment
       }, msg = s"Could not get partitions assigned. Last response $shareGroupHeartbeatResponse.")
       // Verify the response.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
 
       // Restart the only running broker.
       val broker = cluster.brokers().values().iterator().next()
@@ -925,7 +936,7 @@ class ShareGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
       // Verify the response. Epoch should not have changed and null assignments determines that no
       // change in old assignment.
-      assertEquals(4, shareGroupHeartbeatResponse.data.memberEpoch)
+      assertEquals(3, shareGroupHeartbeatResponse.data.memberEpoch)
       assertNull(shareGroupHeartbeatResponse.data.assignment)
     } finally {
       admin.close()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3928,6 +3928,15 @@ public class GroupMetadataManager {
             return UpdateTargetAssignmentResult.fromLastTargetAssignment(group, updatedMember);
         }
 
+        boolean canComputeNextTargetAssignment = canComputeNextTargetAssignment(
+            group.assignmentTimestamp(),
+            shareGroupAssignmentIntervalMs(group.groupId()),
+            time.milliseconds()
+        );
+        if (!canComputeNextTargetAssignment) {
+            return UpdateTargetAssignmentResult.fromLastTargetAssignment(group, updatedMember);
+        }
+
         try {
             Map<Uuid, Set<Integer>> initializedTopicPartitions = shareGroupStatePartitionMetadata.containsKey(group.groupId()) ?
                 stripInitValue(shareGroupStatePartitionMetadata.get(group.groupId()).initializedTopics()) :

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2729,9 +2729,15 @@ public class GroupMetadataManager {
             member,
             updatedMember,
             records
-        ) || initializedAssignmentPending(group);
+        );
 
         int groupEpoch = group.groupEpoch();
+        if (group.assignmentEpoch() >= groupEpoch) {
+            // A new assignment is needed if no assignment is pending and there are unassigned
+            // initialized partitions.
+            bumpGroupEpoch |= initializedAssignmentPending(group);
+        }
+
         Map<String, SubscriptionCount> subscribedTopicNamesMap = group.subscribedTopicNames();
         SubscriptionType subscriptionType = group.subscriptionType();
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -25641,6 +25641,84 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testShareGroupHeartbeatDoesNotBumpGroupEpochDuringAssignmentDelay() {
+        Uuid t1Uuid = Uuid.randomUuid();
+        String t1Name = "t1";
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(t1Uuid, t1Name, 2)
+            .buildCoordinatorMetadataImage();
+
+        String groupId = "share-group";
+        String memberId = Uuid.randomUuid().toString();
+
+        ShareGroupMember member = new ShareGroupMember.Builder(memberId)
+            .setState(MemberState.STABLE)
+            .setMemberEpoch(2)
+            .setPreviousMemberEpoch(0)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(List.of(t1Name))
+            .setAssignedPartitions(Map.of())
+            .build();
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withMetadataImage(metadataImage)
+            .withShareGroup(new ShareGroupBuilder(groupId, 2)
+                .withMember(member)
+                .withAssignment(memberId, mkAssignment())
+                .withAssignmentEpoch(2)
+                // Suppress assignments.
+                .withAssignmentTimestamp(Integer.MAX_VALUE)
+                .withMetadataHash(computeGroupHash(Map.of(
+                    t1Name, computeTopicHash(t1Name, metadataImage)
+                ))))
+            .build();
+
+        // t1-0 and t1-1 are initialized and not yet assigned.
+        context.groupMetadataManager.replay(
+            new ShareGroupStatePartitionMetadataKey()
+                .setGroupId(groupId),
+            new ShareGroupStatePartitionMetadataValue()
+                .setInitializingTopics(List.of())
+                .setInitializedTopics(List.of(
+                    new ShareGroupStatePartitionMetadataValue.TopicPartitionsInfo()
+                        .setTopicId(t1Uuid)
+                        .setTopicName(t1Name)
+                        .setPartitions(List.of(0, 1))
+                ))
+                .setDeletingTopics(List.of())
+        );
+
+        // Group epoch is bumped on the next heartbeat.
+        CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result1 = context.shareGroupHeartbeat(
+            new ShareGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(2));
+
+        assertEquals(
+            List.of(
+                GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 3, computeGroupHash(Map.of(
+                    t1Name, computeTopicHash(t1Name, metadataImage)
+                )))
+            ),
+            result1.records()
+        );
+
+        // Group epoch is not bumped again.
+        CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result2 = context.shareGroupHeartbeat(
+            new ShareGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(2));
+
+        assertEquals(
+            List.of(),
+            result2.records()
+        );
+    }
+
+    @Test
     public void testShareGroupHeartbeatPersisterRequestWithInitializing() {
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         assignor.prepareGroupAssignment(new GroupAssignment(Map.of()));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -26986,6 +26986,180 @@ public class GroupMetadataManagerTest {
         );
     }
 
+    @Test
+    public void testShareGroupAssignmentInterval() {
+        String groupId = "fooup";
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(fooTopicId, fooTopicName, 6)
+            .buildCoordinatorMetadataImage();
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.SHARE_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, 5000)
+            .withShareGroupAssignor(assignor)
+            .withMetadataImage(metadataImage)
+            .build();
+
+        // Member 1 joins the group and gets an assignment immediately.
+        assignor.prepareGroupAssignment(new GroupAssignment(Map.of(
+            memberId1, new MemberAssignmentImpl(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
+            ))
+        )));
+        CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result1 = context.shareGroupHeartbeat(
+            new ShareGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId1)
+                .setMemberEpoch(0)
+                .setSubscribedTopicNames(List.of(fooTopicName)));
+
+        assertResponseEquals(
+            new ShareGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(2)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ShareGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(List.of(
+                        new ShareGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(List.of(0, 1, 2, 3, 4, 5))
+                    ))),
+            result1.response().getKey()
+        );
+
+        ShareGroupMember expectedMember1 = new ShareGroupMember.Builder(memberId1)
+            .setMemberEpoch(2)
+            .setPreviousMemberEpoch(0)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(List.of(fooTopicName))
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)))
+            .build();
+
+        assertRecordsEquals(
+            List.of(
+                GroupCoordinatorRecordHelpers.newShareGroupMemberSubscriptionRecord(groupId, expectedMember1),
+                GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
+                    fooTopicName, computeTopicHash(fooTopicName, metadataImage)
+                ))),
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
+                )),
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentMetadataRecord(groupId, 2, context.time.milliseconds()),
+                GroupCoordinatorRecordHelpers.newShareGroupCurrentAssignmentRecord(groupId, expectedMember1),
+                GroupCoordinatorRecordHelpers.newShareGroupStatePartitionMetadataRecord(groupId, mkShareGroupStateMap(List.of(
+                        mkShareGroupStateMetadataEntry(fooTopicId, fooTopicName, List.of(0, 1, 2, 3, 4, 5))
+                    )),
+                    Map.of(),
+                    Map.of()
+                )
+            ),
+            result1.records()
+        );
+
+        // Wait until just before the expected delay.
+        context.time.sleep(4995);
+
+        // Member 2 joins the group and gets no assignment.
+        assignor.prepareGroupAssignment(new GroupAssignment(Map.of(
+            memberId1, new MemberAssignmentImpl(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
+            )),
+            memberId2, new MemberAssignmentImpl(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
+            ))
+        )));
+        CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result2 = context.shareGroupHeartbeat(
+            new ShareGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setMemberEpoch(0)
+                .setSubscribedTopicNames(List.of(fooTopicName)));
+
+        assertResponseEquals(
+            new ShareGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(2)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ShareGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(List.of())),
+            result2.response().getKey()
+        );
+
+        ShareGroupMember expectedMember2 = new ShareGroupMember.Builder(memberId2)
+            .setMemberEpoch(2)
+            .setPreviousMemberEpoch(0)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(List.of(fooTopicName))
+            .setAssignedPartitions(mkAssignment())
+            .build();
+
+        assertRecordsEquals(
+            List.of(
+                GroupCoordinatorRecordHelpers.newShareGroupMemberSubscriptionRecord(groupId, expectedMember2),
+                GroupCoordinatorRecordHelpers.newShareGroupEpochRecord(groupId, 3, computeGroupHash(Map.of(
+                    fooTopicName, computeTopicHash(fooTopicName, metadataImage)
+                ))),
+                GroupCoordinatorRecordHelpers.newShareGroupCurrentAssignmentRecord(groupId, expectedMember2)
+            ),
+            result2.records()
+        );
+
+        // Wait a little more. The next target assignment can be computed now.
+        context.time.sleep(10);
+
+        // The next target assignment is computed.
+        CoordinatorResult<Map.Entry<ShareGroupHeartbeatResponseData, Optional<InitializeShareGroupStateParameters>>, CoordinatorRecord> result3 = context.shareGroupHeartbeat(
+            new ShareGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setMemberEpoch(2));
+
+        assertResponseEquals(
+            new ShareGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(3)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ShareGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(List.of(
+                        new ShareGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(List.of(0, 1, 2, 3, 4, 5))
+                    ))),
+            result3.response().getKey()
+        );
+
+        ShareGroupMember expectedMember3 = new ShareGroupMember.Builder(memberId2)
+            .setMemberEpoch(3)
+            .setPreviousMemberEpoch(2)
+            .setClientId(DEFAULT_CLIENT_ID)
+            .setClientHost(DEFAULT_CLIENT_ADDRESS.toString())
+            .setSubscribedTopicNames(List.of(fooTopicName))
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)))
+            .build();
+
+        assertRecordsEquals(
+            List.of(
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentRecord(groupId, memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
+                )),
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentMetadataRecord(groupId, 3, context.time.milliseconds()),
+                GroupCoordinatorRecordHelpers.newShareGroupCurrentAssignmentRecord(groupId, expectedMember3)
+            ),
+            result3.records()
+        );
+    }
+
     private static void checkJoinGroupResponse(
         JoinGroupResponseData expectedResponse,
         JoinGroupResponseData actualResponse,

--- a/tests/kafkatest/tests/client/share_consumer_test.py
+++ b/tests/kafkatest/tests/client/share_consumer_test.py
@@ -119,8 +119,9 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_share_single_topic_partition(self, metadata_quorum=quorum.isolated_kraft):
+    def test_share_single_topic_partition(self, metadata_quorum=quorum.isolated_kraft, enable_assignment_batching=True):
 
         total_messages = 100000
         producer = self.setup_producer(self.TOPIC1["name"], max_messages=total_messages)
@@ -150,8 +151,9 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_share_multiple_partitions(self, metadata_quorum=quorum.isolated_kraft):
+    def test_share_multiple_partitions(self, metadata_quorum=quorum.isolated_kraft, enable_assignment_batching=True):
 
         total_messages = 1000000
         producer = self.setup_producer(self.TOPIC2["name"], max_messages=total_messages, throughput=5000)
@@ -182,8 +184,9 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
     @matrix(
         clean_shutdown=[True, False],
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_broker_rolling_bounce(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft):
+    def test_broker_rolling_bounce(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, enable_assignment_batching=True):
 
         producer = self.setup_producer(self.TOPIC2["name"])
         consumer = self.setup_share_group(self.TOPIC2["name"])
@@ -216,8 +219,9 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         clean_shutdown=[True, False],
         metadata_quorum=[quorum.isolated_kraft],
         num_failed_brokers=[1, 2],
+        enable_assignment_batching=[False, True]
     )
-    def test_broker_failure(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, num_failed_brokers=1):
+    def test_broker_failure(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, num_failed_brokers=1, enable_assignment_batching=True):
 
         producer = self.setup_producer(self.TOPIC2["name"])
         consumer = self.setup_share_group(self.TOPIC2["name"])
@@ -250,8 +254,9 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         clean_shutdown=[True, False],
         bounce_mode=["all", "rolling"],
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_share_consumer_bounce(self, clean_shutdown, bounce_mode, metadata_quorum=quorum.isolated_kraft):
+    def test_share_consumer_bounce(self, clean_shutdown, bounce_mode, metadata_quorum=quorum.isolated_kraft, enable_assignment_batching=True):
         """
         Verify correct share consumer behavior when the share consumers in the group are consecutively restarted.
 
@@ -294,8 +299,9 @@ class ShareConsumerTest(VerifiableShareConsumerTest):
         clean_shutdown=[True, False],
         num_failed_consumers=[1, 2],
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_share_consumer_failure(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, num_failed_consumers=1):
+    def test_share_consumer_failure(self, clean_shutdown, metadata_quorum=quorum.isolated_kraft, num_failed_consumers=1, enable_assignment_batching=True):
 
         producer = self.setup_producer(self.TOPIC2["name"])
         consumer = self.setup_share_group(self.TOPIC2["name"])

--- a/tests/kafkatest/tests/core/share_consume_bench_test.py
+++ b/tests/kafkatest/tests/core/share_consume_bench_test.py
@@ -65,9 +65,8 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
-        enable_assignment_batching=[False, True]
     )
-    def test_share_consume_bench(self, metadata_quorum, enable_assignment_batching=True):
+    def test_share_consume_bench(self, metadata_quorum):
         """
         Runs a ShareConsumeBench workload to consume messages
         """
@@ -93,9 +92,8 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
-        enable_assignment_batching=[False, True]
     )
-    def test_two_share_consumers_in_a_group_topics(self, metadata_quorum, enable_assignment_batching=True):
+    def test_two_share_consumers_in_a_group_topics(self, metadata_quorum):
         """
         Runs two share consumers in the same share group to read messages from topics.
         """
@@ -122,9 +120,8 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
-        enable_assignment_batching=[False, True]
     )
-    def test_one_share_consumer_subscribed_to_single_topic(self, metadata_quorum, enable_assignment_batching=True):
+    def test_one_share_consumer_subscribed_to_single_topic(self, metadata_quorum):
         """
         Runs one share consumers in a share group to read messages from topic with single partition.
         """
@@ -150,9 +147,8 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
-        enable_assignment_batching=[False, True]
     )
-    def test_multiple_share_consumers_subscribed_to_single_topic(self, metadata_quorum, enable_assignment_batching=True):
+    def test_multiple_share_consumers_subscribed_to_single_topic(self, metadata_quorum):
         """
         Runs multiple share consumers in a share group to read messages from topic with single partition.
         """

--- a/tests/kafkatest/tests/core/share_consume_bench_test.py
+++ b/tests/kafkatest/tests/core/share_consume_bench_test.py
@@ -65,8 +65,9 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_share_consume_bench(self, metadata_quorum):
+    def test_share_consume_bench(self, metadata_quorum, enable_assignment_batching=True):
         """
         Runs a ShareConsumeBench workload to consume messages
         """
@@ -92,8 +93,9 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_two_share_consumers_in_a_group_topics(self, metadata_quorum):
+    def test_two_share_consumers_in_a_group_topics(self, metadata_quorum, enable_assignment_batching=True):
         """
         Runs two share consumers in the same share group to read messages from topics.
         """
@@ -120,8 +122,9 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_one_share_consumer_subscribed_to_single_topic(self, metadata_quorum):
+    def test_one_share_consumer_subscribed_to_single_topic(self, metadata_quorum, enable_assignment_batching=True):
         """
         Runs one share consumers in a share group to read messages from topic with single partition.
         """
@@ -147,8 +150,9 @@ class ShareConsumeBenchTest(Test):
     @cluster(num_nodes=10)
     @matrix(
         metadata_quorum=[quorum.isolated_kraft],
+        enable_assignment_batching=[False, True]
     )
-    def test_multiple_share_consumers_subscribed_to_single_topic(self, metadata_quorum):
+    def test_multiple_share_consumers_subscribed_to_single_topic(self, metadata_quorum, enable_assignment_batching=True):
         """
         Runs multiple share consumers in a share group to read messages from topic with single partition.
         """


### PR DESCRIPTION
Implement target assignment batching for share groups.

Delay computing the next assignment for share groups until their
assignment interval has elapsed since their last assignment computation
finished.

Also fix a bug where we would bump the group epoch on every heartbeat
when the target assignment is delayed and there are unassigned
initialized share partitions. As a side effect, we bump the epoch fewer
times in tests when assignment batching is enabled. After the epoch is
bumped by a metadata update, it is not bumped again by share partition
initialization if the next assignment has not been computed yet.

We run request tests with assignment batching disabled, except for
heartbeat tests, which we run with and without assignment batching.

We run a selection of integration and system tests with and without
assignment batching.

Reviewers: Sushant Mahajan <smahajan@confluent.io>, David Jacot
 <djacot@confluent.io>
