### PR TITLE
KAFKA-20292 [2/N]: Handle membership changes during offloaded streams assignments

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3973,6 +3973,7 @@ public class GroupMetadataManager {
         try {
             org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder assignmentResultBuilder =
                 new org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder(
+                    logContext,
                     group.groupId(),
                     groupEpoch,
                     assignor,
@@ -3990,8 +3991,10 @@ public class GroupMetadataManager {
             );
 
             long startTimeMs = time.milliseconds();
+            org.apache.kafka.coordinator.group.streams.assignor.GroupAssignment groupAssignment =
+                assignmentResultBuilder.buildTargetAssignment();
             org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult assignmentResult =
-                assignmentResultBuilder.build();
+                assignmentResultBuilder.buildRecords(groupAssignment);
             long assignorTimeMs = time.milliseconds() - startTimeMs;
 
             if (log.isDebugEnabled()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -27,12 +28,17 @@ import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 
+import org.slf4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +52,11 @@ import java.util.stream.Collectors;
  * words, this class does not yield a tombstone for removed members.
  */
 public class TargetAssignmentBuilder {
+
+    /**
+     * The logger.
+     */
+    private final Logger log;
 
     /**
      * The time.
@@ -109,11 +120,13 @@ public class TargetAssignmentBuilder {
      * @param assignor   The assignor to use to compute the target assignment.
      */
     public TargetAssignmentBuilder(
+        LogContext logContext,
         String groupId,
         int groupEpoch,
         TaskAssignor assignor,
         Map<String, String> assignmentConfigs
     ) {
+        this.log = logContext.logger(TargetAssignmentBuilder.class);
         this.groupId = Objects.requireNonNull(groupId);
         this.groupEpoch = groupEpoch;
         this.assignor = Objects.requireNonNull(assignor);
@@ -243,10 +256,10 @@ public class TargetAssignmentBuilder {
     /**
      * Builds the new target assignment.
      *
-     * @return A TargetAssignmentResult which contains the records to update the existing target assignment.
+     * @return The new target assignment.
      * @throws TaskAssignorException if the target assignment cannot be computed.
      */
-    public TargetAssignmentResult build() throws TaskAssignorException {
+    public GroupAssignment buildTargetAssignment() throws TaskAssignorException {
         Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
 
         // Prepare the member spec for all members.
@@ -297,22 +310,118 @@ public class TargetAssignmentBuilder {
                 memberSpecs.keySet().stream().collect(Collectors.toMap(x -> x, x -> MemberAssignment.empty())));
         }
 
+        return newGroupAssignment;
+    }
+
+    /**
+     * Builds the records for the new target assignment, when the set of members and static members
+     * have not changed since the assignment was built.
+     *
+     * @param newGroupAssignment    The new target assignment.
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the existing target assignment.
+     */
+    public TargetAssignmentResult buildRecords(GroupAssignment newGroupAssignment) {
+        return buildRecords(newGroupAssignment, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * Builds the records for the new target assignment, when the set of members and static members
+     * may have changed since the assignment was built.
+     *
+     * @param newGroupAssignment    The new target assignment.
+     * @param currentMemberIds      The current set of member ids.
+     * @param currentStaticMembers  The current static members.
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the existing target assignment.
+     */
+    public TargetAssignmentResult buildRecords(
+        GroupAssignment newGroupAssignment,
+        Set<String> currentMemberIds,
+        Map<String, String> currentStaticMembers
+    ) {
+        return buildRecords(newGroupAssignment, Optional.of(currentMemberIds), Optional.of(currentStaticMembers));
+    }
+
+    /**
+     * Builds the records for the new target assignment.
+     *
+     * @param newGroupAssignment    The new target assignment.
+     * @param currentMemberIds      The current set of member ids, if they may have changed since the assignment was built.
+     * @param currentStaticMembers  The current static members, if they may have changed since the assignment was built.
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the existing target assignment.
+     */
+    public TargetAssignmentResult buildRecords(
+        GroupAssignment newGroupAssignment,
+        Optional<Set<String>> currentMemberIds,
+        Optional<Map<String, String>> currentStaticMembers
+    ) {
+        Set<String> memberIds = new HashSet<>(members.keySet());
+
+        // Update the member ids for updated or deleted members.
+        updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+            if (updatedMemberOrNull == null) {
+                memberIds.remove(memberId);
+            } else {
+                memberIds.add(memberId);
+            }
+        });
+
+        // Build map of replacement member ids for static members that have churned.
+        Map<String, String> staticMemberIdRemapping = new HashMap<>();
+        if (currentStaticMembers.isPresent()) {
+            for (Map.Entry<String, String> entry : staticMembers.entrySet()) {
+                String instanceId = entry.getKey();
+                String oldMemberId = entry.getValue();
+                String newMemberId = currentStaticMembers.get().get(instanceId);
+                staticMemberIdRemapping.put(oldMemberId, newMemberId);
+
+                if (log.isDebugEnabled()) {
+                    if (newMemberId == null) {
+                        log.debug("[GroupId {}] Skipping target assignment record for removed static member {} with instance id {}.",
+                            groupId, oldMemberId, instanceId);
+                    } else if (!oldMemberId.equals(newMemberId)) {
+                        log.debug("[GroupId {}] Replacing static member id {} with {} for instance id {} in target assignment.",
+                            groupId, oldMemberId, newMemberId, instanceId);
+                    }
+                }
+            }
+        }
+
         // Compute delta from previous to new target assignment and create the
         // relevant records.
         List<CoordinatorRecord> records = new ArrayList<>();
         Map<String, org.apache.kafka.coordinator.group.streams.TasksTuple> newTargetAssignment = new HashMap<>();
 
-        memberSpecs.keySet().forEach(memberId -> {
+        memberIds.forEach(memberId -> {
+            String newMemberId = memberId;
+
+            // Run the member id through the static member remapping.
+            if (staticMemberIdRemapping.containsKey(memberId)) {
+                newMemberId = staticMemberIdRemapping.get(memberId);
+                if (newMemberId == null) {
+                    // The static member has been removed.
+                    return;
+                }
+            }
+
+            // Don't emit records for members that have been removed.
+            if (currentMemberIds.isPresent() && !currentMemberIds.get().contains(newMemberId)) {
+                log.debug("[GroupId {}] Skipping target assignment record for removed member {}.", groupId, newMemberId);
+                return;
+            }
+
             org.apache.kafka.coordinator.group.streams.TasksTuple oldMemberAssignment = targetAssignment.get(memberId);
             org.apache.kafka.coordinator.group.streams.TasksTuple newMemberAssignment = newMemberAssignment(newGroupAssignment, memberId);
 
-            newTargetAssignment.put(memberId, newMemberAssignment);
+            newTargetAssignment.put(newMemberId, newMemberAssignment);
 
             if (oldMemberAssignment == null) {
                 // If the member had no assignment, we always create a record for it.
                 records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(
                     groupId,
-                    memberId,
+                    newMemberId,
                     newMemberAssignment
                 ));
             } else {
@@ -321,7 +430,7 @@ public class TargetAssignmentBuilder {
                 if (!newMemberAssignment.equals(oldMemberAssignment)) {
                     records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(
                         groupId,
-                        memberId,
+                        newMemberId,
                         newMemberAssignment
                     ));
                 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -34,8 +35,11 @@ import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -71,11 +76,14 @@ public class TargetAssignmentBuilderTest {
 
         when(topology.isReady()).thenReturn(false);
 
-        TargetAssignmentBuilder builder = new TargetAssignmentBuilder(groupId, groupEpoch, assignor, assignmentConfigs)
+        LogContext logContext = new LogContext();
+
+        TargetAssignmentBuilder builder = new TargetAssignmentBuilder(logContext, groupId, groupEpoch, assignor, assignmentConfigs)
             .withTime(new MockTime(0, 12345L, 12345L))
             .withTopology(topology);
 
-        TargetAssignmentBuilder.TargetAssignmentResult result = builder.build();
+        GroupAssignment groupAssignment = builder.buildTargetAssignment();
+        TargetAssignmentBuilder.TargetAssignmentResult result = builder.buildRecords(groupAssignment);
 
         List<CoordinatorRecord> expectedRecords = List.of(
             StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord(groupId, groupEpoch, 12345L)
@@ -589,6 +597,100 @@ public class TargetAssignmentBuilderTest {
     }
 
     
+    private static Stream<Arguments> taskRolesAndBooleans() {
+        return Arrays.stream(TaskRole.values())
+            .flatMap(taskRole -> Stream.of(
+                Arguments.of(taskRole, false),
+                Arguments.of(taskRole, true)
+            ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("taskRolesAndBooleans")
+    public void testDeleteMemberDuringAssignmentOffload(TaskRole taskRole, boolean isStatic) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20,
+            12345L
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6);
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6);
+
+        context.addGroupMember("member-1", isStatic ? "instance-member-1" : null, mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", isStatic ? "instance-member-2" : null, mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", isStatic ? "instance-member-3" : null, mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = context.build(
+            // member-3 leaves during the offloaded assignment.
+            Set.of("member-1", "member-2"),
+            isStatic ?
+                Map.of(
+                    "instance-member-1", "member-1",
+                    "instance-member-2", "member-2"
+                ) :
+                Map.of()
+        );
+
+        assertEquals(3, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 3, 4),
+                mkTasks(barSubtopologyId, 3, 4)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 5, 6),
+                mkTasks(barSubtopologyId, 5, 6)
+            ))
+        )), result.records().subList(0, 2));
+
+        assertEquals(newStreamsGroupTargetAssignmentMetadataRecord(
+            "my-group",
+            20,
+            12345L
+        ), result.records().get(2));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
     @ParameterizedTest
     @EnumSource(TaskRole.class)
     public void testReplaceStaticMember(TaskRole taskRole) {
@@ -668,6 +770,99 @@ public class TargetAssignmentBuilderTest {
         expectedAssignment.put("member-3-a", mkTasksTuple(taskRole, 
             mkTasks(fooSubtopologyId, 5, 6),
             mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    
+    @ParameterizedTest
+    @EnumSource(TaskRole.class)
+    public void testReplaceStaticMemberDuringAssignmentOffload(TaskRole taskRole) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20,
+            12345L
+        );
+
+        String fooSubtopologyId = context.addSubtopologyWithSingleSourceTopic("foo", 6);
+        String barSubtopologyId = context.addSubtopologyWithSingleSourceTopic("bar", 6);
+
+        context.addGroupMember("member-1", "instance-member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", "instance-member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", "instance-member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build(
+            Set.of("member-1", "member-2", "member-3-a"),
+            Map.of(
+                "instance-member-1", "member-1",
+                "instance-member-2", "member-2",
+                "instance-member-3", "member-3-a"
+            )
+        );
+
+        assertEquals(4, result.records().size());
+
+        assertUnorderedRecordsEquals(List.of(List.of(
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 3, 4),
+                mkTasks(barSubtopologyId, 3, 4)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-2", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 5, 6),
+                mkTasks(barSubtopologyId, 5, 6)
+            )),
+            newStreamsGroupTargetAssignmentRecord("my-group", "member-3-a", mkTasksTuple(taskRole,
+                mkTasks(fooSubtopologyId, 1, 2),
+                mkTasks(barSubtopologyId, 1, 2)
+            ))
+        )), result.records().subList(0, 3));
+
+        assertEquals(newStreamsGroupTargetAssignmentMetadataRecord(
+            "my-group",
+            20,
+            12345L
+        ), result.records().get(3));
+
+        Map<String, TasksTuple> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 3, 4),
+            mkTasks(barSubtopologyId, 3, 4)
+        ));
+        expectedAssignment.put("member-2", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 5, 6),
+            mkTasks(barSubtopologyId, 5, 6)
+        ));
+
+        expectedAssignment.put("member-3-a", mkTasksTuple(taskRole,
+            mkTasks(fooSubtopologyId, 1, 2),
+            mkTasks(barSubtopologyId, 1, 2)
         ));
 
         assertEquals(expectedAssignment, result.targetAssignment());
@@ -787,6 +982,20 @@ public class TargetAssignmentBuilderTest {
         }
 
         public org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult build() {
+            return build(Optional.empty(), Optional.empty());
+        }
+
+        public org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult build(
+            Set<String> currentMemberIds,
+            Map<String, String> currentStaticMembers
+        ) {
+            return build(Optional.of(currentMemberIds), Optional.of(currentStaticMembers));
+        }
+
+        public org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult build(
+            Optional<Set<String>> currentMemberIds,
+            Optional<Map<String, String>> currentStaticMembers
+        ) {
             // Prepare expected member specs.
             Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
 
@@ -837,8 +1046,10 @@ public class TargetAssignmentBuilderTest {
                 .thenReturn(new GroupAssignment(memberAssignments));
 
             // Create and populate the assignment builder.
+            LogContext logContext = new LogContext();
             org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder builder = new org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder(
-                groupId, groupEpoch, assignor, Map.of())
+                logContext, groupId, groupEpoch, assignor, Map.of())
+                .withTime(new MockTime(0, assignmentTimestamp, assignmentTimestamp))
                 .withMembers(members)
                 .withTopology(topology)
                 .withStaticMembers(staticMembers)
@@ -855,9 +1066,12 @@ public class TargetAssignmentBuilderTest {
             });
 
             // Execute the builder.
-            org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = builder
-                .withTime(new MockTime(0, assignmentTimestamp, assignmentTimestamp))
-                .build();
+            GroupAssignment groupAssignment = builder.buildTargetAssignment();
+            org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder.TargetAssignmentResult result = builder.buildRecords(
+                groupAssignment,
+                currentMemberIds,
+                currentStaticMembers
+            );
 
             // Verify that the assignor was called once with the expected
             // assignment spec.


### PR DESCRIPTION
When a member leaves a group, its target assignment is directly removed.
When a static member is replaced, its target assignment is moved to the
new member. These target assignment updates can happen while an
offloaded assignment is being computed.

When an offloaded assignment has finished, we must not emit records for
members that have left the group and we must apply any static member
replacements that occurred to the emitted records, to match the behavior
when assignments are not offloaded. That is, we act as if the member
removals and static member replacements are reordered after the
assignment.

We break up the assignment process into two parts: computing the target
assignment map and generating the records. Only the former can run on
the executor. To generate the records without removed members and with
static member replacements applied we need to use the current state of
the group.

Reviewers: ChickenchickenLove <ojt90902@naver.com>
