### PR TITLE
KAFKA-20292 [1/N]: Handle membership changes during offloaded assignments

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -86,6 +86,7 @@ import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorResult;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorTimer;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
+import org.apache.kafka.coordinator.group.api.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.MemberAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.PartitionAssignorException;
 import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssignor;
@@ -3815,7 +3816,7 @@ public class GroupMetadataManager {
         ).orElse(defaultConsumerGroupAssignor.name());
         try {
             TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder assignmentResultBuilder =
-                new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(group.groupId(), groupEpoch, consumerGroupAssignors.get(preferredServerAssignor))
+                new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(logContext, group.groupId(), groupEpoch, consumerGroupAssignors.get(preferredServerAssignor))
                     .withTime(time)
                     .withMembers(group.members())
                     .withStaticMembers(group.staticMembers())
@@ -3834,8 +3835,9 @@ public class GroupMetadataManager {
             }
 
             long startTimeMs = time.milliseconds();
+            GroupAssignment groupAssignment = assignmentResultBuilder.buildTargetAssignment();
             TargetAssignmentBuilder.TargetAssignmentResult assignmentResult =
-                assignmentResultBuilder.build();
+                assignmentResultBuilder.buildRecords(groupAssignment);
             long assignorTimeMs = time.milliseconds() - startTimeMs;
 
             if (log.isDebugEnabled()) {
@@ -3890,7 +3892,7 @@ public class GroupMetadataManager {
                 Map.of();
 
             TargetAssignmentBuilder.ShareTargetAssignmentBuilder assignmentResultBuilder =
-                new TargetAssignmentBuilder.ShareTargetAssignmentBuilder(group.groupId(), groupEpoch, shareGroupAssignor)
+                new TargetAssignmentBuilder.ShareTargetAssignmentBuilder(logContext, group.groupId(), groupEpoch, shareGroupAssignor)
                     .withTime(time)
                     .withMembers(group.members())
                     .withSubscriptionType(subscriptionType)
@@ -3901,8 +3903,9 @@ public class GroupMetadataManager {
                     .addOrUpdateMember(updatedMember.memberId(), updatedMember);
 
             long startTimeMs = time.milliseconds();
+            GroupAssignment groupAssignment = assignmentResultBuilder.buildTargetAssignment();
             TargetAssignmentBuilder.TargetAssignmentResult assignmentResult =
-                assignmentResultBuilder.build();
+                assignmentResultBuilder.buildRecords(groupAssignment);
             long assignorTimeMs = time.milliseconds() - startTimeMs;
 
             if (log.isDebugEnabled()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/TargetAssignmentBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.modern;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -30,9 +31,12 @@ import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.modern.consumer.ResolvedRegularExpression;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 
+import org.slf4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -101,11 +105,12 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
         private Map<String, ResolvedRegularExpression> resolvedRegularExpressions = Map.of();
 
         public ConsumerTargetAssignmentBuilder(
+            LogContext logContext,
             String groupId,
             int groupEpoch,
             PartitionAssignor assignor
         ) {
-            super(groupId, groupEpoch, assignor);
+            super(logContext, groupId, groupEpoch, assignor);
         }
 
         /**
@@ -188,11 +193,12 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
 
     public static class ShareTargetAssignmentBuilder extends TargetAssignmentBuilder<ShareGroupMember, ShareTargetAssignmentBuilder> {
         public ShareTargetAssignmentBuilder(
+            LogContext logContext,
             String groupId,
             int groupEpoch,
             PartitionAssignor assignor
         ) {
-            super(groupId, groupEpoch, assignor);
+            super(logContext, groupId, groupEpoch, assignor);
         }
 
         @Override
@@ -240,6 +246,11 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
             );
         }
     }
+
+    /**
+     * The logger.
+     */
+    private final Logger log;
 
     /**
      * The time.
@@ -306,15 +317,18 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
     /**
      * Constructs the object.
      *
+     * @param logContext    The log context.
      * @param groupId       The group id.
      * @param groupEpoch    The group epoch to compute a target assignment for.
      * @param assignor      The assignor to use to compute the target assignment.
      */
     public TargetAssignmentBuilder(
+        LogContext logContext,
         String groupId,
         int groupEpoch,
         PartitionAssignor assignor
     ) {
+        this.log = logContext.logger(this.getClass());
         this.groupId = Objects.requireNonNull(groupId);
         this.groupEpoch = groupEpoch;
         this.assignor = Objects.requireNonNull(assignor);
@@ -448,11 +462,10 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
     /**
      * Builds the new target assignment.
      *
-     * @return A TargetAssignmentResult which contains the records to update
-     *         the existing target assignment.
+     * @return The new target assignment.
      * @throws PartitionAssignorException if the target assignment cannot be computed.
      */
-    public TargetAssignmentResult build() throws PartitionAssignorException {
+    public GroupAssignment buildTargetAssignment() throws PartitionAssignorException {
         Map<String, MemberSubscriptionAndAssignmentImpl> memberSpecs = new HashMap<>();
         TopicIds.TopicResolver topicResolver = new TopicIds.CachedTopicResolver(metadataImage);
 
@@ -499,19 +512,126 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
             new SubscribedTopicDescriberImpl(metadataImage)
         );
 
+        return newGroupAssignment;
+    }
+
+    /**
+     * Builds the records for the new target assignment, when the set of members and static members
+     * have not changed since the assignment was built.
+     *
+     * @param newGroupAssignment    The new target assignment.
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the existing target assignment.
+     */
+    public TargetAssignmentResult buildRecords(GroupAssignment newGroupAssignment) {
+        return buildRecords(newGroupAssignment, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * Builds the records for the new target assignment, when the set of members and static members
+     * may have changed since the assignment was built.
+     *
+     * @param newGroupAssignment    The new target assignment.
+     * @param currentMemberIds      The current set of member ids.
+     * @param currentStaticMembers  The current static members.
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the existing target assignment.
+     */
+    public TargetAssignmentResult buildRecords(
+        GroupAssignment newGroupAssignment,
+        Set<String> currentMemberIds,
+        Map<String, String> currentStaticMembers
+    ) {
+        return buildRecords(newGroupAssignment, Optional.of(currentMemberIds), Optional.of(currentStaticMembers));
+    }
+
+    /**
+     * Builds the records for the new target assignment.
+     *
+     * @param newGroupAssignment    The new target assignment.
+     * @param currentMemberIds      The current set of member ids, if they may have changed since the assignment was built.
+     * @param currentStaticMembers  The current static members, if they may have changed since the assignment was built.
+     * @return A TargetAssignmentResult which contains the records to update
+     *         the existing target assignment.
+     */
+    @SuppressWarnings({"CyclomaticComplexity", "NPathComplexity"})
+    public TargetAssignmentResult buildRecords(
+        GroupAssignment newGroupAssignment,
+        Optional<Set<String>> currentMemberIds,
+        Optional<Map<String, String>> currentStaticMembers
+    ) {
+        Set<String> memberIds = new HashSet<>(members.keySet());
+
+        // Update the member ids for updated or deleted members.
+        updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+            if (updatedMemberOrNull == null) {
+                memberIds.remove(memberId);
+            } else {
+                memberIds.add(memberId);
+            }
+        });
+
+        // Build map of replacement member ids for static members that have churned.
+        Map<String, String> staticMemberIdRemapping = new HashMap<>();
+        if (currentStaticMembers.isPresent()) {
+            for (Map.Entry<String, String> entry : staticMembers.entrySet()) {
+                String instanceId = entry.getKey();
+                String oldMemberId = entry.getValue();
+                String newMemberId = currentStaticMembers.get().get(instanceId);
+                staticMemberIdRemapping.put(oldMemberId, newMemberId);
+
+                if (log.isDebugEnabled()) {
+                    if (newMemberId == null) {
+                        log.debug("[GroupId {}] Skipping target assignment record for removed static member {} with instance id {}.",
+                            groupId, oldMemberId, instanceId);
+                    } else if (!oldMemberId.equals(newMemberId)) {
+                        log.debug("[GroupId {}] Replacing static member id {} with {} for instance id {} in target assignment.",
+                            groupId, oldMemberId, newMemberId, instanceId);
+                    }
+                }
+            }
+        }
+
         // Compute delta from previous to new target assignment and create the relevant records.
         List<CoordinatorRecord> records = new ArrayList<>();
+        Map<String, MemberAssignment> newTargetAssignment = null;
 
-        for (String memberId : memberSpecs.keySet()) {
+        // Construct newTargetAssignment when the current set of members may have changed.
+        if (currentMemberIds.isPresent() || currentStaticMembers.isPresent()) {
+            newTargetAssignment = new HashMap<>();
+        }
+
+        for (String memberId : memberIds) {
+            String newMemberId = memberId;
+
+            // Run the member id through the static member remapping.
+            if (staticMemberIdRemapping.containsKey(memberId)) {
+                newMemberId = staticMemberIdRemapping.get(memberId);
+                if (newMemberId == null) {
+                    // The static member has been removed.
+                    continue;
+                }
+            }
+
+            // Don't emit records for members that have been removed.
+            if (currentMemberIds.isPresent() && !currentMemberIds.get().contains(newMemberId)) {
+                log.debug("[GroupId {}] Skipping target assignment record for removed member {}.", groupId, newMemberId);
+                continue;
+            }
+
             Assignment oldMemberAssignment = targetAssignment.get(memberId);
             Assignment newMemberAssignment = newMemberAssignment(newGroupAssignment, memberId);
+
+            if (newTargetAssignment != null) {
+                newTargetAssignment.put(newMemberId, newGroupAssignment.members().get(memberId));
+            }
 
             if (!newMemberAssignment.equals(oldMemberAssignment)) {
                 // If the member had no assignment or had a different assignment, we
                 // create a record for the new assignment.
                 records.add(newTargetAssignmentRecord(
                     groupId,
-                    memberId,
+                    newMemberId,
                     newMemberAssignment.partitions()
                 ));
             }
@@ -520,7 +640,10 @@ public abstract class TargetAssignmentBuilder<T extends ModernGroupMember, U ext
         // Bump the target assignment epoch.
         records.add(newTargetAssignmentMetadataRecord(groupId, groupEpoch, time.milliseconds()));
 
-        return new TargetAssignmentResult(records, newGroupAssignment.members());
+        return new TargetAssignmentResult(
+            records,
+            newTargetAssignment != null ? newTargetAssignment : newGroupAssignment.members()
+        );
     }
 
     protected abstract U self();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/TargetAssignmentBuilderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.modern;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
@@ -30,6 +31,8 @@ import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.modern.consumer.ResolvedRegularExpression;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -217,6 +220,20 @@ public class TargetAssignmentBuilderTest {
         }
 
         public TargetAssignmentBuilder.TargetAssignmentResult build() {
+            return build(Optional.empty(), Optional.empty());
+        }
+
+        public TargetAssignmentBuilder.TargetAssignmentResult build(
+            Set<String> currentMemberIds,
+            Map<String, String> currentStaticMembers
+        ) {
+            return build(Optional.of(currentMemberIds), Optional.of(currentStaticMembers));
+        }
+
+        private TargetAssignmentBuilder.TargetAssignmentResult build(
+            Optional<Set<String>> currentMemberIds,
+            Optional<Map<String, String>> currentStaticMembers
+        ) {
             CoordinatorMetadataImage cooridnatorMetadataImage = new KRaftCoordinatorMetadataImage(metadataImageBuilder.build());
             TopicIds.TopicResolver topicResolver = new TopicIds.CachedTopicResolver(cooridnatorMetadataImage);
             // Prepare expected member specs.
@@ -276,8 +293,9 @@ public class TargetAssignmentBuilderTest {
                 .thenReturn(new GroupAssignment(memberAssignments));
 
             // Create and populate the assignment builder.
+            LogContext logContext = new LogContext();
             TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder builder =
-                new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(groupId, groupEpoch, assignor)
+                new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(logContext, groupId, groupEpoch, assignor)
                     .withTime(new MockTime(0, assignmentTimestamp, assignmentTimestamp))
                     .withMembers(members)
                     .withStaticMembers(staticMembers)
@@ -297,7 +315,12 @@ public class TargetAssignmentBuilderTest {
             });
 
             // Execute the builder.
-            TargetAssignmentBuilder.TargetAssignmentResult result = builder.build();
+            GroupAssignment groupAssignment = builder.buildTargetAssignment();
+            TargetAssignmentBuilder.TargetAssignmentResult result = builder.buildRecords(
+                groupAssignment,
+                currentMemberIds,
+                currentStaticMembers
+            );
 
             // Verify that the assignor was called once with the expected
             // assignment spec.
@@ -783,6 +806,95 @@ public class TargetAssignmentBuilderTest {
         assertEquals(expectedAssignment, result.targetAssignment());
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testDeleteMemberDuringAssignmentOffload(boolean isStatic) {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20,
+            12345L
+        );
+
+        Uuid fooTopicId = context.addTopicMetadata("foo", 6);
+        Uuid barTopicId = context.addTopicMetadata("bar", 6);
+
+        context.addGroupMember("member-1", isStatic ? "instance-member-1" : null, Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", isStatic ? "instance-member-2" : null, Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", isStatic ? "instance-member-3" : null, Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build(
+            // member-3 leaves during the offloaded assignment.
+            Set.of("member-1", "member-2"),
+            isStatic ?
+                Map.of(
+                    "instance-member-1", "member-1",
+                    "instance-member-2", "member-2"
+                ) :
+                Map.of()
+        );
+
+        assertUnorderedRecordsEquals(
+            List.of(
+                List.of(
+                    newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4),
+                        mkTopicAssignment(barTopicId, 3, 4)
+                    )),
+                    newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                        mkTopicAssignment(fooTopicId, 5, 6),
+                        mkTopicAssignment(barTopicId, 5, 6)
+                    ))
+                ),
+                List.of(
+                    newConsumerGroupTargetAssignmentMetadataRecord(
+                        "my-group",
+                        20,
+                        12345L
+                    )
+                )
+            ),
+            result.records()
+        );
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignmentImpl(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignmentImpl(mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
     @Test
     public void testReplaceStaticMember() {
         TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
@@ -860,6 +972,102 @@ public class TargetAssignmentBuilderTest {
         expectedAssignment.put("member-3-a", new MemberAssignmentImpl(mkAssignment(
             mkTopicAssignment(fooTopicId, 5, 6),
             mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.targetAssignment());
+    }
+
+    @Test
+    public void testReplaceStaticMemberDuringAssignmentOffload() {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20,
+            12345L
+        );
+
+        Uuid fooTopicId = context.addTopicMetadata("foo", 6);
+        Uuid barTopicId = context.addTopicMetadata("bar", 6);
+
+        context.addGroupMember("member-1", "instance-member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", "instance-member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", "instance-member-3", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build(
+            // member-3 is replaced during the offloaded assignment.
+            Set.of("member-1", "member-2", "member-3-a"),
+            Map.of(
+                "instance-member-1", "member-1",
+                "instance-member-2", "member-2",
+                "instance-member-3", "member-3-a"
+            )
+        );
+
+        assertUnorderedRecordsEquals(
+            List.of(
+                List.of(
+                    newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4),
+                        mkTopicAssignment(barTopicId, 3, 4)
+                    )),
+                    newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                        mkTopicAssignment(fooTopicId, 5, 6),
+                        mkTopicAssignment(barTopicId, 5, 6)
+                    )),
+                    newConsumerGroupTargetAssignmentRecord("my-group", "member-3-a", mkAssignment(
+                        mkTopicAssignment(fooTopicId, 1, 2),
+                        mkTopicAssignment(barTopicId, 1, 2)
+                    ))
+                ),
+                List.of(
+                    newConsumerGroupTargetAssignmentMetadataRecord(
+                        "my-group",
+                        20,
+                        12345L
+                    )
+                )
+            ),
+            result.records()
+        );
+
+        Map<String, MemberAssignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new MemberAssignmentImpl(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        )));
+        expectedAssignment.put("member-2", new MemberAssignmentImpl(mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        expectedAssignment.put("member-3-a", new MemberAssignmentImpl(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
         )));
 
         assertEquals(expectedAssignment, result.targetAssignment());

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.jmh.assignor;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.group.api.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.GroupSpec;
@@ -112,7 +113,8 @@ public class TargetAssignmentBuilderBenchmark {
             .setSubscribedTopicNames(allTopicNames)
             .build();
 
-        targetAssignmentBuilder = new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(GROUP_ID, GROUP_EPOCH, partitionAssignor)
+        LogContext logContext = new LogContext();
+        targetAssignmentBuilder = new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(logContext, GROUP_ID, GROUP_EPOCH, partitionAssignor)
             .withMembers(members)
             .withSubscriptionType(subscriptionType)
             .withTargetAssignment(existingTargetAssignment)
@@ -189,6 +191,7 @@ public class TargetAssignmentBuilderBenchmark {
     @Threads(1)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public void build() {
-        targetAssignmentBuilder.build();
+        GroupAssignment groupAssignment = targetAssignmentBuilder.buildTargetAssignment();
+        targetAssignmentBuilder.buildRecords(groupAssignment);
     }
 }


### PR DESCRIPTION
When a member leaves a group, its target assignment is directly removed.
When a static member is replaced, its target assignment is moved to the
new member. These target assignment updates can happen while an
offloaded assignment is being computed.

When an offloaded assignment has finished, we must not emit records for
members that have left the group and we must apply any static member
replacements that occurred to the emitted records, to match the
behavior when assignments are not offloaded. That is, we act as if the
member removals and static member replacements are reordered after the
assignment.

We break up the assignment process into two parts: computing the target
assignment map and generating the records. Only the former can run on
the executor. To generate the records without removed members and with
static member replacements applied we need to use the current state of
the group.