### PR TITLE
fix: architecture detection for Kafka heap options

### DIFF
--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -25,8 +25,7 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
     rem detect OS architecture
-    wmic os get osarchitecture | find /i "32-bit" >nul 2>&1
-    IF NOT ERRORLEVEL 1 (
+    IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
         rem 32-bit OS
         set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
     ) ELSE (


### PR DESCRIPTION
Starting with Windows 11 version 25H2, Microsoft has completely removed the legacy WMIC (Windows Management Instrumentation Command-line) utility from the operating system.
Many legacy batch scripts used WMIC to determine whether the operating system is 32-bit or 64-bit, for example:
```wmic os get osarchitecture```
or similar commands to query system properties.
Since WMIC is no longer available, these commands will fail.
