### PR TITLE
KAFKA-20287 : Fix CF handle leaks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingSessionStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingSessionStoreWithHeaders.java
@@ -67,24 +67,34 @@ public class RocksDBMigratingSessionStoreWithHeaders extends RocksDBStore implem
         final ColumnFamilyHandle withHeadersColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily);
-        noHeadersIter.seekToFirst();
-        if (noHeadersIter.isValid()) {
-            log.info("Opening store {} in upgrade mode", name);
-            cfAccessor = new DualColumnFamilyAccessor(
-                offsetsCf,
-                noHeadersColumnFamily,
-                withHeadersColumnFamily,
-                HeadersBytesStore::convertToHeaderFormat,
-                this,
-                    open
-            );
-        } else {
-            log.info("Opening store {} in regular mode", name);
-            cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
-            noHeadersColumnFamily.close();
+        boolean success = false;
+        try {
+            try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
+                noHeadersIter.seekToFirst();
+                if (noHeadersIter.isValid()) {
+                    log.info("Opening store {} in upgrade mode", name);
+                    cfAccessor = new DualColumnFamilyAccessor(
+                        offsetsCf,
+                        noHeadersColumnFamily,
+                        withHeadersColumnFamily,
+                        HeadersBytesStore::convertToHeaderFormat,
+                        this,
+                            open
+                    );
+                } else {
+                    log.info("Opening store {} in regular mode", name);
+                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
+                    noHeadersColumnFamily.close();
+                }
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                for (final ColumnFamilyHandle handle : columnFamilies) {
+                    handle.close();
+                }
+            }
         }
-        noHeadersIter.close();
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingSessionStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingSessionStoreWithHeaders.java
@@ -67,7 +67,6 @@ public class RocksDBMigratingSessionStoreWithHeaders extends RocksDBStore implem
         final ColumnFamilyHandle withHeadersColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        boolean success = false;
         try {
             try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
                 noHeadersIter.seekToFirst();
@@ -87,13 +86,11 @@ public class RocksDBMigratingSessionStoreWithHeaders extends RocksDBStore implem
                     noHeadersColumnFamily.close();
                 }
             }
-            success = true;
-        } finally {
-            if (!success) {
-                for (final ColumnFamilyHandle handle : columnFamilies) {
-                    handle.close();
-                }
+        } catch (final RuntimeException e) {
+            for (final ColumnFamilyHandle handle : columnFamilies) {
+                handle.close();
             }
+            throw e;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingSessionStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingSessionStoreWithHeaders.java
@@ -67,24 +67,22 @@ public class RocksDBMigratingSessionStoreWithHeaders extends RocksDBStore implem
         final ColumnFamilyHandle withHeadersColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        try {
-            try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
-                noHeadersIter.seekToFirst();
-                if (noHeadersIter.isValid()) {
-                    log.info("Opening store {} in upgrade mode", name);
-                    cfAccessor = new DualColumnFamilyAccessor(
-                        offsetsCf,
-                        noHeadersColumnFamily,
-                        withHeadersColumnFamily,
-                        HeadersBytesStore::convertToHeaderFormat,
-                        this,
-                            open
-                    );
-                } else {
-                    log.info("Opening store {} in regular mode", name);
-                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
-                    noHeadersColumnFamily.close();
-                }
+        try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
+            noHeadersIter.seekToFirst();
+            if (noHeadersIter.isValid()) {
+                log.info("Opening store {} in upgrade mode", name);
+                cfAccessor = new DualColumnFamilyAccessor(
+                    offsetsCf,
+                    noHeadersColumnFamily,
+                    withHeadersColumnFamily,
+                    HeadersBytesStore::convertToHeaderFormat,
+                    this,
+                    open
+                );
+            } else {
+                log.info("Opening store {} in regular mode", name);
+                cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
+                noHeadersColumnFamily.close();
             }
         } catch (final RuntimeException e) {
             for (final ColumnFamilyHandle handle : columnFamilies) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingWindowStoreWithHeaders.java
@@ -72,25 +72,23 @@ public class RocksDBMigratingWindowStoreWithHeaders extends RocksDBStore impleme
         final ColumnFamilyHandle withHeadersColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        try {
-            // Check if DEFAULT CF has data (upgrade from old format without headers)
-            try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
-                noHeadersIter.seekToFirst();
-                if (noHeadersIter.isValid()) {
-                    log.info("Opening window store {} in upgrade mode from plain value format", name);
-                    cfAccessor = new DualColumnFamilyAccessor(
-                        offsetsCf,
-                        noHeadersColumnFamily,
-                        withHeadersColumnFamily,
-                        HeadersBytesStore::convertToHeaderFormat,
-                        this,
-                        open
-                    );
-                } else {
-                    log.info("Opening window store {} in regular headers-aware mode", name);
-                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
-                    noHeadersColumnFamily.close();
-                }
+        // Check if DEFAULT CF has data (upgrade from old format without headers)
+        try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
+            noHeadersIter.seekToFirst();
+            if (noHeadersIter.isValid()) {
+                log.info("Opening window store {} in upgrade mode from plain value format", name);
+                cfAccessor = new DualColumnFamilyAccessor(
+                    offsetsCf,
+                    noHeadersColumnFamily,
+                    withHeadersColumnFamily,
+                    HeadersBytesStore::convertToHeaderFormat,
+                    this,
+                    open
+                );
+            } else {
+                log.info("Opening window store {} in regular headers-aware mode", name);
+                cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
+                noHeadersColumnFamily.close();
             }
         } catch (final RuntimeException e) {
             for (final ColumnFamilyHandle handle : columnFamilies) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingWindowStoreWithHeaders.java
@@ -72,26 +72,31 @@ public class RocksDBMigratingWindowStoreWithHeaders extends RocksDBStore impleme
         final ColumnFamilyHandle withHeadersColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        // Check if DEFAULT CF has data (upgrade from old format without headers)
-        try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
-            noHeadersIter.seekToFirst();
-            if (noHeadersIter.isValid()) {
-                log.info("Opening window store {} in upgrade mode from plain value format", name);
-                // Migrate from [value] to [headers][value]
-                // Add empty headers prefix [0x00] to plain value
-                cfAccessor = new DualColumnFamilyAccessor(
-                    offsetsCf,
-                    noHeadersColumnFamily,
-                    withHeadersColumnFamily,
-                    HeadersBytesStore::convertToHeaderFormat,
-                    this,
-                    open
-                );
-            } else {
-                log.info("Opening window store {} in regular headers-aware mode", name);
-                cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
-                noHeadersColumnFamily.close();
+        try {
+            // Check if DEFAULT CF has data (upgrade from old format without headers)
+            try (final RocksIterator noHeadersIter = db.newIterator(noHeadersColumnFamily)) {
+                noHeadersIter.seekToFirst();
+                if (noHeadersIter.isValid()) {
+                    log.info("Opening window store {} in upgrade mode from plain value format", name);
+                    cfAccessor = new DualColumnFamilyAccessor(
+                        offsetsCf,
+                        noHeadersColumnFamily,
+                        withHeadersColumnFamily,
+                        HeadersBytesStore::convertToHeaderFormat,
+                        this,
+                        open
+                    );
+                } else {
+                    log.info("Opening window store {} in regular headers-aware mode", name);
+                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, withHeadersColumnFamily);
+                    noHeadersColumnFamily.close();
+                }
             }
+        } catch (final RuntimeException e) {
+            for (final ColumnFamilyHandle handle : columnFamilies) {
+                handle.close();
+            }
+            throw e;
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -245,7 +245,6 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         // Setup statistics before the database is opened, otherwise the statistics are not updated
         // with the measurements from Rocks DB
         setupStatistics(configs, dbOptions);
-        boolean success = false;
         try {
             openRocksDB(dbOptions, columnFamilyOptions);
             dbAccessor = new DirectDBAccessor(db, fOptions, wOptions);
@@ -263,11 +262,9 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             } catch (final RocksDBException e) {
                 throw new ProcessorStateException("Error opening store " + name, e);
             }
-            success = true;
-        } finally {
-            if (!success) {
-                closeNativeResources();
-            }
+        } catch (final RuntimeException e) {
+            closeNativeResources();
+            throw e;
         }
 
         addValueProvidersToMetricsRecorder();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -370,25 +370,18 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
                     .collect(Collectors.toList());
             final List<ColumnFamilyHandle> existingColumnFamilies = new ArrayList<>(existingDescriptors.size());
             final List<ColumnFamilyHandle> createdColumnFamilies = new ArrayList<>();
-            db = RocksDB.open(dbOptions, absolutePath, existingDescriptors, existingColumnFamilies);
-            boolean openSuccess = false;
             try {
+                db = RocksDB.open(dbOptions, absolutePath, existingDescriptors, existingColumnFamilies);
                 createdColumnFamilies.addAll(db.createColumnFamilies(toCreate));
-                final List<ColumnFamilyHandle> result =
-                    mergeColumnFamilyHandleLists(existingColumnFamilies, createdColumnFamilies, allDescriptors);
-                openSuccess = true;
-                return result;
-            } finally {
-                if (!openSuccess) {
-                    for (final ColumnFamilyHandle handle : existingColumnFamilies) {
-                        handle.close();
-                    }
-                    for (final ColumnFamilyHandle handle : createdColumnFamilies) {
-                        handle.close();
-                    }
-                    db.close();
-                    db = null;
+                return mergeColumnFamilyHandleLists(existingColumnFamilies, createdColumnFamilies, allDescriptors);
+            } catch (final Exception e) {
+                for (final ColumnFamilyHandle handle : existingColumnFamilies) {
+                    handle.close();
                 }
+                for (final ColumnFamilyHandle handle : createdColumnFamilies) {
+                    handle.close();
+                }
+                throw e;
             }
 
         } catch (final RocksDBException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -245,21 +245,29 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         // Setup statistics before the database is opened, otherwise the statistics are not updated
         // with the measurements from Rocks DB
         setupStatistics(configs, dbOptions);
-        openRocksDB(dbOptions, columnFamilyOptions);
-        dbAccessor = new DirectDBAccessor(db, fOptions, wOptions);
+        boolean success = false;
         try {
-            final Position existingPositionOrEmpty = cfAccessor.open(dbAccessor, !eosEnabled);
-            if (position == null) {
-                position = existingPositionOrEmpty;
-            } else {
-                // For segmented stores, the overall position is composed of multiple underlying stores, so merge this store's position into it.
-                position.merge(existingPositionOrEmpty);
+            openRocksDB(dbOptions, columnFamilyOptions);
+            dbAccessor = new DirectDBAccessor(db, fOptions, wOptions);
+            try {
+                final Position existingPositionOrEmpty = cfAccessor.open(dbAccessor, !eosEnabled);
+                if (position == null) {
+                    position = existingPositionOrEmpty;
+                } else {
+                    // For segmented stores, the overall position is composed of multiple underlying stores, so merge this store's position into it.
+                    position.merge(existingPositionOrEmpty);
+                }
+            } catch (final StreamsException fatal) {
+                final String fatalMessage = "State store " + name + " didn't find a valid state, since under EOS it has the risk of getting uncommitted data in stores";
+                throw new ProcessorStateException(fatalMessage, fatal);
+            } catch (final RocksDBException e) {
+                throw new ProcessorStateException("Error opening store " + name, e);
             }
-        } catch (final StreamsException fatal) {
-            final String fatalMessage = "State store " + name + " didn't find a valid state, since under EOS it has the risk of getting uncommitted data in stores";
-            throw new ProcessorStateException(fatalMessage, fatal);
-        } catch (final RocksDBException e) {
-            throw new ProcessorStateException("Error opening store " + name, e);
+            success = true;
+        } finally {
+            if (!success) {
+                closeNativeResources();
+            }
         }
 
         addValueProvidersToMetricsRecorder();
@@ -361,10 +369,27 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
                     .filter(descriptor -> allExisting.stream().noneMatch(existing -> Arrays.equals(existing, descriptor.getName())))
                     .collect(Collectors.toList());
             final List<ColumnFamilyHandle> existingColumnFamilies = new ArrayList<>(existingDescriptors.size());
+            final List<ColumnFamilyHandle> createdColumnFamilies = new ArrayList<>();
             db = RocksDB.open(dbOptions, absolutePath, existingDescriptors, existingColumnFamilies);
-            final List<ColumnFamilyHandle> createdColumnFamilies = db.createColumnFamilies(toCreate);
-
-            return mergeColumnFamilyHandleLists(existingColumnFamilies, createdColumnFamilies, allDescriptors);
+            boolean openSuccess = false;
+            try {
+                createdColumnFamilies.addAll(db.createColumnFamilies(toCreate));
+                final List<ColumnFamilyHandle> result =
+                    mergeColumnFamilyHandleLists(existingColumnFamilies, createdColumnFamilies, allDescriptors);
+                openSuccess = true;
+                return result;
+            } finally {
+                if (!openSuccess) {
+                    for (final ColumnFamilyHandle handle : existingColumnFamilies) {
+                        handle.close();
+                    }
+                    for (final ColumnFamilyHandle handle : createdColumnFamilies) {
+                        handle.close();
+                    }
+                    db.close();
+                    db = null;
+                }
+            }
 
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error opening store " + name + " at location " + dbDir.toString(), e);
@@ -785,6 +810,64 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         filter = null;
         cache = null;
         statistics = null;
+    }
+
+    /**
+     * Close all native RocksDB resources with null-safety.
+     * Used only by the error cleanup path in {@link #openDB} where some resources
+     * may not have been initialized yet.
+     */
+    private void closeNativeResources() {
+        closeDbAndAccessors();
+        closeOptionsAndFilters();
+    }
+
+    private void closeDbAndAccessors() {
+        if (cfAccessor != null) {
+            try {
+                if (dbAccessor != null) {
+                    cfAccessor.close(dbAccessor);
+                }
+            } catch (final Exception e) {
+                log.error("Error while closing column family handles for store " + name, e);
+            }
+            cfAccessor = null;
+        }
+        if (dbAccessor != null) {
+            dbAccessor.close();
+            dbAccessor = null;
+        }
+        if (db != null) {
+            db.close();
+            db = null;
+        }
+    }
+
+    private void closeOptionsAndFilters() {
+        if (userSpecifiedOptions != null) {
+            userSpecifiedOptions.close();
+            userSpecifiedOptions = null;
+        }
+        if (wOptions != null) {
+            wOptions.close();
+            wOptions = null;
+        }
+        if (fOptions != null) {
+            fOptions.close();
+            fOptions = null;
+        }
+        if (filter != null) {
+            filter.close();
+            filter = null;
+        }
+        if (cache != null) {
+            cache.close();
+            cache = null;
+        }
+        if (statistics != null) {
+            statistics.close();
+            statistics = null;
+        }
     }
 
     private void closeOpenIterators() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -63,23 +63,22 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         final ColumnFamilyHandle withTimestampColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsColumnFamily = columnFamilies.get(2);
 
-        try {
-            try (final RocksIterator noTimestampsIter = db.newIterator(noTimestampColumnFamily)) {
-                noTimestampsIter.seekToFirst();
-                if (noTimestampsIter.isValid()) {
-                    log.info("Opening store {} in upgrade mode", name);
-                    cfAccessor = new DualColumnFamilyAccessor(
-                        offsetsColumnFamily,
-                        noTimestampColumnFamily,
-                        withTimestampColumnFamily,
-                        TimestampedBytesStore::convertToTimestampedFormat,
-                        this, open
-                    );
-                } else {
-                    log.info("Opening store {} in regular mode", name);
-                    cfAccessor = new SingleColumnFamilyAccessor(offsetsColumnFamily, withTimestampColumnFamily);
-                    noTimestampColumnFamily.close();
-                }
+        try (final RocksIterator noTimestampsIter = db.newIterator(noTimestampColumnFamily)) {
+            noTimestampsIter.seekToFirst();
+            if (noTimestampsIter.isValid()) {
+                log.info("Opening store {} in upgrade mode", name);
+                cfAccessor = new DualColumnFamilyAccessor(
+                    offsetsColumnFamily,
+                    noTimestampColumnFamily,
+                    withTimestampColumnFamily,
+                    TimestampedBytesStore::convertToTimestampedFormat,
+                    this,
+                    open
+                );
+            } else {
+                log.info("Opening store {} in regular mode", name);
+                cfAccessor = new SingleColumnFamilyAccessor(offsetsColumnFamily, withTimestampColumnFamily);
+                noTimestampColumnFamily.close();
             }
         } catch (final RuntimeException e) {
             for (final ColumnFamilyHandle handle : columnFamilies) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -63,7 +63,6 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         final ColumnFamilyHandle withTimestampColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsColumnFamily = columnFamilies.get(2);
 
-        boolean success = false;
         try {
             try (final RocksIterator noTimestampsIter = db.newIterator(noTimestampColumnFamily)) {
                 noTimestampsIter.seekToFirst();
@@ -82,13 +81,11 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
                     noTimestampColumnFamily.close();
                 }
             }
-            success = true;
-        } finally {
-            if (!success) {
-                for (final ColumnFamilyHandle handle : columnFamilies) {
-                    handle.close();
-                }
+        } catch (final RuntimeException e) {
+            for (final ColumnFamilyHandle handle : columnFamilies) {
+                handle.close();
             }
+            throw e;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -63,23 +63,33 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
         final ColumnFamilyHandle withTimestampColumnFamily = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsColumnFamily = columnFamilies.get(2);
 
-        final RocksIterator noTimestampsIter = db.newIterator(noTimestampColumnFamily);
-        noTimestampsIter.seekToFirst();
-        if (noTimestampsIter.isValid()) {
-            log.info("Opening store {} in upgrade mode", name);
-            cfAccessor = new DualColumnFamilyAccessor(
-                offsetsColumnFamily,
-                noTimestampColumnFamily,
-                withTimestampColumnFamily,
-                TimestampedBytesStore::convertToTimestampedFormat,
-                this, open
-            );
-        } else {
-            log.info("Opening store {} in regular mode", name);
-            cfAccessor = new SingleColumnFamilyAccessor(offsetsColumnFamily, withTimestampColumnFamily);
-            noTimestampColumnFamily.close();
+        boolean success = false;
+        try {
+            try (final RocksIterator noTimestampsIter = db.newIterator(noTimestampColumnFamily)) {
+                noTimestampsIter.seekToFirst();
+                if (noTimestampsIter.isValid()) {
+                    log.info("Opening store {} in upgrade mode", name);
+                    cfAccessor = new DualColumnFamilyAccessor(
+                        offsetsColumnFamily,
+                        noTimestampColumnFamily,
+                        withTimestampColumnFamily,
+                        TimestampedBytesStore::convertToTimestampedFormat,
+                        this, open
+                    );
+                } else {
+                    log.info("Opening store {} in regular mode", name);
+                    cfAccessor = new SingleColumnFamilyAccessor(offsetsColumnFamily, withTimestampColumnFamily);
+                    noTimestampColumnFamily.close();
+                }
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                for (final ColumnFamilyHandle handle : columnFamilies) {
+                    handle.close();
+                }
+            }
         }
-        noTimestampsIter.close();
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -105,23 +105,33 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
         final ColumnFamilyHandle headersCf = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        // Check if default CF has data (plain store upgrade)
-        try (final RocksIterator defaultIter = db.newIterator(defaultCf)) {
-            defaultIter.seekToFirst();
-            if (defaultIter.isValid()) {
-                log.info("Opening store {} in upgrade mode from plain key value store", name);
-                cfAccessor = new DualColumnFamilyAccessor(
-                    offsetsCf,
-                    defaultCf,
-                    headersCf,
-                    HeadersBytesStore::convertFromPlainToHeaderFormat,
-                    this,
-                        open
-                );
-            } else {
-                log.info("Opening store {} in regular headers-aware mode", name);
-                cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, headersCf);
-                defaultCf.close();
+        boolean success = false;
+        try {
+            // Check if default CF has data (plain store upgrade)
+            try (final RocksIterator defaultIter = db.newIterator(defaultCf)) {
+                defaultIter.seekToFirst();
+                if (defaultIter.isValid()) {
+                    log.info("Opening store {} in upgrade mode from plain key value store", name);
+                    cfAccessor = new DualColumnFamilyAccessor(
+                        offsetsCf,
+                        defaultCf,
+                        headersCf,
+                        HeadersBytesStore::convertFromPlainToHeaderFormat,
+                        this,
+                            open
+                    );
+                } else {
+                    log.info("Opening store {} in regular headers-aware mode", name);
+                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, headersCf);
+                    defaultCf.close();
+                }
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                for (final ColumnFamilyHandle handle : columnFamilies) {
+                    handle.close();
+                }
             }
         }
     }
@@ -137,51 +147,56 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
             new ColumnFamilyDescriptor(OFFSETS_COLUMN_FAMILY_NAME, columnFamilyOptions)
         );
 
-        // verify and close empty Default ColumnFamily
-        try (final RocksIterator defaultIter = db.newIterator(columnFamilies.get(0))) {
-            defaultIter.seekToFirst();
-            if (defaultIter.isValid()) {
-                // Close all column family handles before throwing
-                columnFamilies.get(0).close();
-                columnFamilies.get(1).close();
-                columnFamilies.get(2).close();
-                throw new ProcessorStateException(
-                    "Inconsistent store state for " + name + ". " +
-                        "Cannot have both plain (DEFAULT) and timestamped data simultaneously. " +
-                        "Headers store can upgrade from either plain or timestamped format, but not both."
-                );
+        boolean success = false;
+        try {
+            // verify and close empty Default ColumnFamily
+            try (final RocksIterator defaultIter = db.newIterator(columnFamilies.get(0))) {
+                defaultIter.seekToFirst();
+                if (defaultIter.isValid()) {
+                    throw new ProcessorStateException(
+                        "Inconsistent store state for " + name + ". " +
+                            "Cannot have both plain (DEFAULT) and timestamped data simultaneously. " +
+                            "Headers store can upgrade from either plain or timestamped format, but not both."
+                    );
+                }
             }
             // close default column family handle
             columnFamilies.get(0).close();
-        }
 
-        final ColumnFamilyHandle legacyTimestampedCf = columnFamilies.get(1);
-        final ColumnFamilyHandle headersCf = columnFamilies.get(2);
-        final ColumnFamilyHandle offsetsCf = columnFamilies.get(3);
+            final ColumnFamilyHandle legacyTimestampedCf = columnFamilies.get(1);
+            final ColumnFamilyHandle headersCf = columnFamilies.get(2);
+            final ColumnFamilyHandle offsetsCf = columnFamilies.get(3);
 
-
-        // Check if legacy timestamped CF has data
-        try (final RocksIterator legacyIter = db.newIterator(legacyTimestampedCf)) {
-            legacyIter.seekToFirst();
-            if (legacyIter.isValid()) {
-                log.info("Opening store {} in upgrade mode from timestamped store", name);
-                cfAccessor = new DualColumnFamilyAccessor(
-                    offsetsCf,
-                    legacyTimestampedCf,
-                    headersCf,
-                    HeadersBytesStore::convertToHeaderFormat,
-                    this,
-                        open
-                );
-            } else {
-                log.info("Opening store {} in regular headers-aware mode", name);
-                cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, headersCf);
-                try {
-                    db.dropColumnFamily(legacyTimestampedCf);
-                } catch (final RocksDBException e) {
-                    throw new RuntimeException(e);
-                } finally {
-                    legacyTimestampedCf.close();
+            // Check if legacy timestamped CF has data
+            try (final RocksIterator legacyIter = db.newIterator(legacyTimestampedCf)) {
+                legacyIter.seekToFirst();
+                if (legacyIter.isValid()) {
+                    log.info("Opening store {} in upgrade mode from timestamped store", name);
+                    cfAccessor = new DualColumnFamilyAccessor(
+                        offsetsCf,
+                        legacyTimestampedCf,
+                        headersCf,
+                        HeadersBytesStore::convertToHeaderFormat,
+                        this,
+                            open
+                    );
+                } else {
+                    log.info("Opening store {} in regular headers-aware mode", name);
+                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, headersCf);
+                    try {
+                        db.dropColumnFamily(legacyTimestampedCf);
+                    } catch (final RocksDBException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        legacyTimestampedCf.close();
+                    }
+                }
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                for (final ColumnFamilyHandle handle : columnFamilies) {
+                    handle.close();
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -105,25 +105,23 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
         final ColumnFamilyHandle headersCf = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        try {
-            // Check if default CF has data (plain store upgrade)
-            try (final RocksIterator defaultIter = db.newIterator(defaultCf)) {
-                defaultIter.seekToFirst();
-                if (defaultIter.isValid()) {
-                    log.info("Opening store {} in upgrade mode from plain key value store", name);
-                    cfAccessor = new DualColumnFamilyAccessor(
-                        offsetsCf,
-                        defaultCf,
-                        headersCf,
-                        HeadersBytesStore::convertFromPlainToHeaderFormat,
-                        this,
-                            open
-                    );
-                } else {
-                    log.info("Opening store {} in regular headers-aware mode", name);
-                    cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, headersCf);
-                    defaultCf.close();
-                }
+        // Check if default CF has data (plain store upgrade)
+        try (final RocksIterator defaultIter = db.newIterator(defaultCf)) {
+            defaultIter.seekToFirst();
+            if (defaultIter.isValid()) {
+                log.info("Opening store {} in upgrade mode from plain key value store", name);
+                cfAccessor = new DualColumnFamilyAccessor(
+                    offsetsCf,
+                    defaultCf,
+                    headersCf,
+                    HeadersBytesStore::convertFromPlainToHeaderFormat,
+                    this,
+                    open
+                );
+            } else {
+                log.info("Opening store {} in regular headers-aware mode", name);
+                cfAccessor = new SingleColumnFamilyAccessor(offsetsCf, headersCf);
+                defaultCf.close();
             }
         } catch (final RuntimeException e) {
             for (final ColumnFamilyHandle handle : columnFamilies) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -105,7 +105,6 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
         final ColumnFamilyHandle headersCf = columnFamilies.get(1);
         final ColumnFamilyHandle offsetsCf = columnFamilies.get(2);
 
-        boolean success = false;
         try {
             // Check if default CF has data (plain store upgrade)
             try (final RocksIterator defaultIter = db.newIterator(defaultCf)) {
@@ -126,13 +125,11 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
                     defaultCf.close();
                 }
             }
-            success = true;
-        } finally {
-            if (!success) {
-                for (final ColumnFamilyHandle handle : columnFamilies) {
-                    handle.close();
-                }
+        } catch (final RuntimeException e) {
+            for (final ColumnFamilyHandle handle : columnFamilies) {
+                handle.close();
             }
+            throw e;
         }
     }
 
@@ -147,7 +144,6 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
             new ColumnFamilyDescriptor(OFFSETS_COLUMN_FAMILY_NAME, columnFamilyOptions)
         );
 
-        boolean success = false;
         try {
             // verify and close empty Default ColumnFamily
             try (final RocksIterator defaultIter = db.newIterator(columnFamilies.get(0))) {
@@ -192,13 +188,11 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
                     }
                 }
             }
-            success = true;
-        } finally {
-            if (!success) {
-                for (final ColumnFamilyHandle handle : columnFamilies) {
-                    handle.close();
-                }
+        } catch (final RuntimeException e) {
+            for (final ColumnFamilyHandle handle : columnFamilies) {
+                handle.close();
             }
+            throw e;
         }
     }
 


### PR DESCRIPTION
- RocksDBStore.java — openRocksDB() base method: Added finally block
after RocksDB.open() to close all CF handles and db if
createColumnFamilies() or mergeColumnFamilyHandleLists() fails.

- RocksDBStore.java — openDB(): Added finally block with
closeNativeResources() to close all partially-initialized native
resources  if openRocksDB() or cfAccessor.open() fails.

- RocksDBTimestampedStore.java: Changed RocksIterator from manual
close() to try-with-resources, and added finally block to close all CF
handles if an exception occurs before the accessor takes ownership.

- RocksDBMigratingSessionStoreWithHeaders.java: Same as above —
try-with-resources for RocksIterator and finally block for CF handle
cleanup on failure.

- RocksDBTimestampedStoreWithHeaders.java — openFromDefaultStore():
Added finally block to close all CF handles if an exception occurs
before the accessor takes ownership.

- RocksDBTimestampedStoreWithHeaders.java — openFromTimestampedStore():
Replaced manual per-handle close() calls (which missed
columnFamilies.get(3)) with a single finally block that loops over all
handles on failure.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Alieh Saeedi
 <asaeedi@confluent.io>
