### PR TITLE
KAFKA-20173: Propagate headers into serde 4/N

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/serialization/ListSerializerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/ListSerializerTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -167,15 +166,16 @@ public class ListSerializerTest {
         when(mockSerializer.serialize(anyString(), any(Headers.class), anyString())).thenReturn("test-value".getBytes());
 
         final String topic = "topic";
-        final List<String> data = List.of("test-key");
+        final String key = "test-key";
+        final List<String> data = List.of(key);
         final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
 
         final ListSerializer<String> testSerializer = new ListSerializer<>(mockSerializer);
 
         testSerializer.serialize(topic, headers, data);
 
-        verify(mockSerializer).serialize(eq(topic), eq(headers), eq("test-key"));
-        verify(mockSerializer, never()).serialize(anyString(), anyString());
+        verify(mockSerializer).serialize(topic, headers, key);
+        verify(mockSerializer, never()).serialize(topic, key);
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
@@ -111,10 +111,10 @@ public class SessionWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
-    public byte[] serializeBaseKey(final String topic, final Windowed<T> data) {
+    public byte[] serializeBaseKey(final String topic, final Headers headers, final Windowed<T> data) {
         WindowedSerdes.verifyInnerSerializerNotNull(inner, this);
 
-        return inner.serialize(topic, data.key());
+        return inner.serialize(topic, headers, data.key());
     }
 
     // Only for testing

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
@@ -111,6 +111,11 @@ public class SessionWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
+    public byte[] serializeBaseKey(String topic, Windowed<T> data) {
+        return serializeBaseKey(topic, new RecordHeaders(), data);
+    }
+
+    @Override
     public byte[] serializeBaseKey(final String topic, final Headers headers, final Windowed<T> data) {
         WindowedSerdes.verifyInnerSerializerNotNull(inner, this);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
@@ -111,7 +111,7 @@ public class SessionWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
-    public byte[] serializeBaseKey(String topic, Windowed<T> data) {
+    public byte[] serializeBaseKey(final String topic, final Windowed<T> data) {
         return serializeBaseKey(topic, new RecordHeaders(), data);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
@@ -112,10 +112,10 @@ public class TimeWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
-    public byte[] serializeBaseKey(final String topic, final Windowed<T> data) {
+    public byte[] serializeBaseKey(final String topic, final Headers headers, final Windowed<T> data) {
         WindowedSerdes.verifyInnerSerializerNotNull(inner, this);
 
-        return inner.serialize(topic, data.key());
+        return inner.serialize(topic, headers, data.key());
     }
 
     // Only for testing

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
@@ -112,6 +112,11 @@ public class TimeWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
+    public byte[] serializeBaseKey(String topic, Windowed<T> data) {
+        return serializeBaseKey(topic, new RecordHeaders(), data);
+    }
+
+    @Override
     public byte[] serializeBaseKey(final String topic, final Headers headers, final Windowed<T> data) {
         WindowedSerdes.verifyInnerSerializerNotNull(inner, this);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedSerializer.java
@@ -112,7 +112,7 @@ public class TimeWindowedSerializer<T> implements WindowedSerializer<T> {
     }
 
     @Override
-    public byte[] serializeBaseKey(String topic, Windowed<T> data) {
+    public byte[] serializeBaseKey(final String topic, final Windowed<T> data) {
         return serializeBaseKey(topic, new RecordHeaders(), data);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
@@ -22,5 +22,9 @@ import org.apache.kafka.streams.kstream.Windowed;
 
 public interface WindowedSerializer<T> extends Serializer<Windowed<T>> {
 
-    byte[] serializeBaseKey(String topic, Headers headers, Windowed<T> data);
+    byte[] serializeBaseKey(String topic, Windowed<T> data);
+
+    default byte[] serializeBaseKey(String topic, Headers headers, Windowed<T> data) {
+        return serializeBaseKey(topic, data);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
@@ -24,7 +24,7 @@ public interface WindowedSerializer<T> extends Serializer<Windowed<T>> {
 
     byte[] serializeBaseKey(String topic, Windowed<T> data);
 
-    default byte[] serializeBaseKey(String topic, Headers headers, Windowed<T> data) {
+    default byte[] serializeBaseKey(final String topic, final  Headers headers, final  Windowed<T> data) {
         return serializeBaseKey(topic, data);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedSerializer.java
@@ -16,10 +16,11 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.kstream.Windowed;
 
 public interface WindowedSerializer<T> extends Serializer<Windowed<T>> {
 
-    byte[] serializeBaseKey(String topic, Windowed<T> data);
+    byte[] serializeBaseKey(String topic, Headers headers, Windowed<T> data);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
@@ -46,7 +47,7 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
     @Override
     public Optional<Set<Integer>> partitions(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
         // for windowed key, the key bytes should never be null
-        final byte[] keyBytes = serializer.serializeBaseKey(topic, windowedKey);
+        final byte[] keyBytes = serializer.serializeBaseKey(topic, new RecordHeaders(), windowedKey);
 
         // stick with the same built-in partitioner util functions that producer used
         // to make sure its behavior is consistent with the producer

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedDeserializerTest.java
@@ -122,15 +122,16 @@ public class SessionWindowedDeserializerTest {
         final Deserializer<String> mockDeserializer = mock(StringDeserializer.class);
         when(mockDeserializer.deserialize(anyString(), any(Headers.class), any(byte[].class))).thenReturn("test-value");
 
+        final String topic = "dummy";
         final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
         final Windowed<String> windowed = new Windowed<>("test-key", new SessionWindow(0, 1));
-        final byte[] data = new SessionWindowedSerializer<>(Serdes.String().serializer()).serialize("dummy", headers, windowed);
+        final byte[] data = new SessionWindowedSerializer<>(Serdes.String().serializer()).serialize(topic, headers, windowed);
 
         final SessionWindowedDeserializer<String> testDeserializer = new SessionWindowedDeserializer<>(mockDeserializer);
 
-        testDeserializer.deserialize("dummy", headers, data);
+        testDeserializer.deserialize(topic, headers, data);
 
-        verify(mockDeserializer).deserialize(anyString(), eq(headers), any(byte[].class));
+        verify(mockDeserializer).deserialize(eq(topic), eq(headers), any(byte[].class));
         verify(mockDeserializer, never()).deserialize(anyString(), any(byte[].class));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -132,12 +131,12 @@ public class SessionWindowedSerializerTest {
 
         testSerializer.serialize(topic, headers, data);
 
-        verify(mockSerializer, times(1)).serialize(eq(topic), eq(headers), eq(key));
-        verify(mockSerializer, never()).serialize(anyString(), eq(key));
+        verify(mockSerializer, times(1)).serialize(topic, headers, key);
+        verify(mockSerializer, never()).serialize(topic, key);
 
         testSerializer.serializeBaseKey(topic, headers, data);
 
-        verify(mockSerializer, times(2)).serialize(eq(topic), eq(headers), eq(key));
-        verify(mockSerializer, never()).serialize(anyString(), eq(key));
+        verify(mockSerializer, times(2)).serialize(topic, headers, key);
+        verify(mockSerializer, never()).serialize(topic, key);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
@@ -123,20 +123,21 @@ public class SessionWindowedSerializerTest {
         final Serializer<String> mockSerializer = mock(StringSerializer.class);
         when(mockSerializer.serialize(anyString(), any(Headers.class), anyString())).thenReturn("test-value".getBytes());
 
+        final String topic = "dummy";
         final String key = "test-key";
         final Windowed<String> data = new Windowed<>(key, new SessionWindow(0, 1));
         final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
 
         final SessionWindowedSerializer<String> testSerializer = new SessionWindowedSerializer<>(mockSerializer);
 
-        testSerializer.serialize("dummy", headers, data);
+        testSerializer.serialize(topic, headers, data);
 
-        verify(mockSerializer, times(1)).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(1)).serialize(eq(topic), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
 
-        testSerializer.serializeBaseKey("dummy", headers, data);
+        testSerializer.serializeBaseKey(topic, headers, data);
 
-        verify(mockSerializer, times(2)).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(2)).serialize(eq(topic), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -130,12 +131,12 @@ public class SessionWindowedSerializerTest {
 
         testSerializer.serialize("dummy", headers, data);
 
-        verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(1)).serialize(anyString(), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
 
         testSerializer.serializeBaseKey("dummy", headers, data);
 
-        verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(2)).serialize(anyString(), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
@@ -132,5 +132,10 @@ public class SessionWindowedSerializerTest {
 
         verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
+
+        testSerializer.serializeBaseKey("dummy", headers, data);
+
+        verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, never()).serialize(anyString(), eq(key));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializerTest.java
@@ -179,15 +179,16 @@ public class TimeWindowedDeserializerTest {
         final Deserializer<String> mockDeserializer = mock(StringDeserializer.class);
         when(mockDeserializer.deserialize(anyString(), any(Headers.class), any(byte[].class))).thenReturn("test-value");
 
+        final String topic = "dummy";
         final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
         final Windowed<String> windowed = new Windowed<>("test-key", new TimeWindow(0, 1));
-        final byte[] data = new TimeWindowedSerializer<>(Serdes.String().serializer()).serialize("dummy", headers, windowed);
+        final byte[] data = new TimeWindowedSerializer<>(Serdes.String().serializer()).serialize(topic, headers, windowed);
 
         final TimeWindowedDeserializer<String> testDeserializer = new TimeWindowedDeserializer<>(mockDeserializer, 1L);
 
-        testDeserializer.deserialize("dummy", headers, data);
+        testDeserializer.deserialize(topic, headers, data);
 
-        verify(mockDeserializer).deserialize(anyString(), eq(headers), any(byte[].class));
+        verify(mockDeserializer).deserialize(eq(topic), eq(headers), any(byte[].class));
         verify(mockDeserializer, never()).deserialize(anyString(), any(byte[].class));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -130,12 +131,12 @@ public class TimeWindowedSerializerTest {
 
         testSerializer.serialize("dummy", headers, data);
 
-        verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(1)).serialize(anyString(), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
 
         testSerializer.serializeBaseKey("dummy", headers, data);
 
-        verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(2)).serialize(anyString(), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
@@ -132,5 +132,10 @@ public class TimeWindowedSerializerTest {
 
         verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
+
+        testSerializer.serializeBaseKey("dummy", headers, data);
+
+        verify(mockSerializer).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, never()).serialize(anyString(), eq(key));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -132,12 +131,12 @@ public class TimeWindowedSerializerTest {
 
         testSerializer.serialize(topic, headers, data);
 
-        verify(mockSerializer, times(1)).serialize(eq(topic), eq(headers), eq(key));
-        verify(mockSerializer, never()).serialize(anyString(), eq(key));
+        verify(mockSerializer, times(1)).serialize(topic, headers, key);
+        verify(mockSerializer, never()).serialize(topic, key);
 
         testSerializer.serializeBaseKey(topic, headers, data);
 
-        verify(mockSerializer, times(2)).serialize(eq(topic), eq(headers), eq(key));
-        verify(mockSerializer, never()).serialize(anyString(), eq(key));
+        verify(mockSerializer, times(2)).serialize(topic, headers, key);
+        verify(mockSerializer, never()).serialize(topic, key);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedSerializerTest.java
@@ -123,20 +123,21 @@ public class TimeWindowedSerializerTest {
         final Serializer<String> mockSerializer = mock(StringSerializer.class);
         when(mockSerializer.serialize(anyString(), any(Headers.class), anyString())).thenReturn("test-value".getBytes());
 
+        final String topic = "dummy";
         final String key = "test-key";
         final Windowed<String> data = new Windowed<>(key, new TimeWindow(0, 1));
         final Headers headers = new RecordHeaders().add("key1", "value1".getBytes());
 
         final TimeWindowedSerializer<String> testSerializer = new TimeWindowedSerializer<>(mockSerializer);
 
-        testSerializer.serialize("dummy", headers, data);
+        testSerializer.serialize(topic, headers, data);
 
-        verify(mockSerializer, times(1)).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(1)).serialize(eq(topic), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
 
-        testSerializer.serializeBaseKey("dummy", headers, data);
+        testSerializer.serializeBaseKey(topic, headers, data);
 
-        verify(mockSerializer, times(2)).serialize(anyString(), eq(headers), eq(key));
+        verify(mockSerializer, times(2)).serialize(eq(topic), eq(headers), eq(key));
         verify(mockSerializer, never()).serialize(anyString(), eq(key));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowedSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowedSerdesTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.kstream;
 
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -87,7 +88,7 @@ public class WindowedSerdesTest {
         final TimeWindowedSerializer<byte[]> serializer = new TimeWindowedSerializer<>();
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> serializer.serializeBaseKey("topic", new Windowed<>(new byte[0], new TimeWindow(0, 1))));
+            () -> serializer.serializeBaseKey("topic", new RecordHeaders(), new Windowed<>(new byte[0], new TimeWindow(0, 1))));
         assertThat(
             exception.getMessage(),
             equalTo("Inner serializer is `null`. User code must use constructor " +
@@ -123,7 +124,7 @@ public class WindowedSerdesTest {
         final SessionWindowedSerializer<byte[]> serializer = new SessionWindowedSerializer<>();
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> serializer.serializeBaseKey("topic", new Windowed<>(new byte[0], new SessionWindow(0, 0))));
+            () -> serializer.serializeBaseKey("topic", new RecordHeaders(), new Windowed<>(new byte[0], new SessionWindow(0, 0))));
         assertThat(
             exception.getMessage(),
             equalTo("Inner serializer is `null`. User code must use constructor " +


### PR DESCRIPTION
This PR fixes headers propagation in `SessionWindowedSerializer` and
`TimeWindowedSerializer` so they works as expected (from headers
propagation perspective).

Reviewers: Matthias J. Sax <matthias@confluent.io>
