### PR TITLE
MINOR: perf optimization for header serialization and type conversion

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerializer.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.state.AggregationWithHeaders;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
@@ -75,23 +76,23 @@ class AggregationWithHeadersSerializer<AGG> implements WrappingNullableSerialize
 
         final byte[] rawAggregation = aggregationSerializer.serialize(topic, headers, plainAggregation);
 
+        // Since we can't control the result of the internal serializer, we make sure that the result
+        // is not null as well.
+        // Serializing non-null values to null can be useful when working with Optional-like values
+        // where the Optional.empty case is serialized to null.
+        // See the discussion here: https://github.com/apache/kafka/pull/7679
         if (rawAggregation == null) {
             return null;
         }
 
-        final byte[] rawHeaders = HeadersSerializer.serialize(headers);
+        // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
 
-        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             final DataOutputStream out = new DataOutputStream(baos)) {
-
-            ByteUtils.writeVarint(rawHeaders.length, out);
-            out.write(rawHeaders);
-            out.write(rawAggregation);
-
-            return baos.toByteArray();
-        } catch (final IOException e) {
-            throw new SerializationException("Failed to serialize AggregationWithHeaders on topic: " + topic, e);
-        }
+        // Format: [headersSize(varint)][headersBytes][value]
+        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + rawAggregation.length)
+            .put(rawHeaders)
+            .put(rawAggregation)
+            .array();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerializer.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.state.AggregationWithHeaders;
@@ -80,12 +81,16 @@ class AggregationWithHeadersSerializer<AGG> implements WrappingNullableSerialize
             return null;
         }
 
-        // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final int payloadSize = preSerializedHeaders.requiredBufferSizeForHeaders + rawAggregation.length;
 
         // Format: [headersSize(varint)][headersBytes][value]
-        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + rawAggregation.length)
-            .put(rawHeaders)
+        final ByteBuffer buffer = ByteBuffer.allocate(ByteUtils.sizeOfVarint(preSerializedHeaders.requiredBufferSizeForHeaders) + payloadSize);
+        ByteUtils.writeVarint(preSerializedHeaders.requiredBufferSizeForHeaders, buffer);
+
+        // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
+        return HeadersSerializer.serialize(preSerializedHeaders, buffer)
             .put(rawAggregation)
             .array();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AggregationWithHeadersSerializer.java
@@ -16,17 +16,12 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.state.AggregationWithHeaders;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
@@ -86,7 +81,7 @@ class AggregationWithHeadersSerializer<AGG> implements WrappingNullableSerialize
         }
 
         // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
 
         // Format: [headersSize(varint)][headersBytes][value]
         return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + rawAggregation.length)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -107,7 +107,7 @@ class HeadersSerializer {
      *
      * @param preSerializedHeaders the preSerializedHeaders
      * @param buffer the buffer to write the serialized header into (it's expected that the buffer position is set correctly)
-     * @return the modified {@code buffer} containing the serializer headers (empty array if headers are null or empty),\
+     * @return the modified {@code buffer} containing the serializer headers (empty array if headers are null or empty),
      * with corresponding advanced position
      */
     public static ByteBuffer serialize(final PreSerializedHeaders preSerializedHeaders, final ByteBuffer buffer) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -45,7 +45,7 @@ import java.nio.charset.StandardCharsets;
  */
 class HeadersSerializer {
 
-    final static class PreSerializedHeaders {
+    static final class PreSerializedHeaders {
         final int requiredBufferSizeForHeaders;
         final byte[][] rawHeaderKeys;
         final byte[][] rawHeaderValues;
@@ -53,11 +53,11 @@ class HeadersSerializer {
         PreSerializedHeaders(
             final int requiredBufferSizeForHeaders,
             final byte[][] rawHeaderKeys,
-            final byte[][] rawHeaderValued
+            final byte[][] rawHeaderValues
         ) {
             this.requiredBufferSizeForHeaders = requiredBufferSizeForHeaders;
             this.rawHeaderKeys = rawHeaderKeys;
-            this.rawHeaderValues = rawHeaderValued;
+            this.rawHeaderValues = rawHeaderValues;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.utils.ByteUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -82,7 +83,7 @@ class HeadersSerializer {
                 // Write value length and value bytes (varint + raw bytes)
                 // null is represented as -1, encoded as varint
                 if (valueBytes == null) {
-                    ByteUtils.writeVarint(-1, out);
+                    out.write(0x00);
                 } else {
                     ByteUtils.writeVarint(valueBytes.length, out);
                     out.write(valueBytes);
@@ -93,5 +94,87 @@ class HeadersSerializer {
         } catch (final IOException e) {
             throw new SerializationException("Failed to serialize headers", e);
         }
+    }
+
+    public static byte[] serialize2(final Headers headers) {
+        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
+
+        if (headersArray.length == 0) {
+            return new byte[0];
+        }
+
+        final ByteBuffer[][] rawHeaders = new ByteBuffer[headersArray.length][2];
+
+        int i = 0;
+        int size = 0;
+        for (final Header header : headersArray) {
+            final byte[] keyBytes = header.key().getBytes(StandardCharsets.UTF_8);
+            final byte[] valueBytes = header.value();
+
+            rawHeaders[i][0] = Utils.prepareByteBufferWithSizePrefix(keyBytes.length, keyBytes.length).put(keyBytes);
+            size += rawHeaders[i][0].position();
+
+            // Write value length and value bytes (varint + raw bytes)
+            // null is represented as -1, encoded as varint
+            byte[] value = header.value();
+            if (value == null) {
+                rawHeaders[i][1] = ByteBuffer.allocate(0).put((byte) 0x00);
+            } else {
+                rawHeaders[i][1] = Utils.prepareByteBufferWithSizePrefix(valueBytes.length, valueBytes.length).put(valueBytes);
+            }
+            size += rawHeaders[i][1].position();
+            ++i;
+        }
+
+        final ByteBuffer result = ByteBuffer.allocate(5 + size);
+        ByteUtils.writeVarint(headersArray.length, result);
+
+        for (final ByteBuffer[] rawHeader : rawHeaders) {
+            result.put(rawHeader[0].position(0));
+            result.put(rawHeader[1].position(0));
+        }
+
+        return result.array();
+    }
+
+    public static ByteBuffer serialize3(final Headers headers) {
+        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
+
+        if (headersArray.length == 0) {
+            return ByteBuffer.allocate(0);
+        }
+
+        int size = 0;
+        for (final Header header : headersArray) {
+            size += 5 + header.key().length();
+
+            byte[] value = header.value();
+            if (value == null) {
+                ++size;
+            } else {
+                size += 5 + value.length;
+            }
+        }
+
+        final ByteBuffer result = ByteBuffer.allocate(5 + size);
+        ByteUtils.writeVarint(headersArray.length, result);
+
+        for (final Header header : headersArray) {
+            String key = header.key();
+            byte[] value = header.value();
+            ByteUtils.writeVarint(key.length(), result);
+            result.put(key.getBytes(StandardCharsets.UTF_8));
+            if (value != null) {
+                ByteUtils.writeVarint(value.length, result);
+                result.put(value);
+            } else {
+                result.put((byte) 0x00);
+            }
+        }
+
+        result.limit(result.position());
+        result.position(0);
+
+        return result;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -47,9 +47,9 @@ class HeadersSerializer {
 
     final static class PreSerializedHeaders {
         final int requiredBufferSizeForHeaders;
-        final byte[][][] serializedHeaders;
+        final byte[][] serializedHeaders;
 
-        PreSerializedHeaders(final int requiredBufferSizeForHeaders, final byte[][][] serializedHeaders) {
+        PreSerializedHeaders(final int requiredBufferSizeForHeaders, final byte[][] serializedHeaders) {
             this.requiredBufferSizeForHeaders = requiredBufferSizeForHeaders;
             this.serializedHeaders = serializedHeaders;
         }
@@ -66,23 +66,25 @@ class HeadersSerializer {
         // so we can allocate the whole buffer at once later
 
         // cache to avoid translating String header-keys to byte[] twice
-        final byte[][][] serializedHeaders = new byte[headersArray.length][2][];
+        final byte[][] serializedHeaders = new byte[headersArray.length][];
 
         // start with varint encoding of header count
         int requiredBufferSizeForHeaders = ByteUtils.sizeOfVarint(headersArray.length);
         int i = 0;
 
         for (final Header header : headersArray) {
-            serializedHeaders[i][0] = header.key().getBytes(StandardCharsets.UTF_8);
-            requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(serializedHeaders[i][0].length) + serializedHeaders[i][0].length;
+            final byte[] rawHeaderKey = header.key().getBytes(StandardCharsets.UTF_8);
+            requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(rawHeaderKey.length) + rawHeaderKey.length;
 
-            serializedHeaders[i][1] = header.value();
-            if (serializedHeaders[i][1] == null) {
+            final byte[] rawHeaderValue = header.value();
+            if (rawHeaderValue == null) {
                 ++requiredBufferSizeForHeaders;
             } else {
-                requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(serializedHeaders[i][1].length) + serializedHeaders[i][1].length;
+                requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(rawHeaderValue.length) + rawHeaderValue.length;
             }
 
+            serializedHeaders[i] = rawHeaderKey;
+//            serializedHeaders[i][1] = rawHeaderValue;
             ++i;
         }
 
@@ -104,24 +106,45 @@ class HeadersSerializer {
      * with corresponding advanced position
      */
     public static ByteBuffer serialize(final PreSerializedHeaders preSerializedHeaders, final ByteBuffer buffer) {
+        return null;
+    }
+    public static ByteBuffer serialize(final PreSerializedHeaders preSerializedHeaders, final ByteBuffer buffer, final Headers headers) {
         if (preSerializedHeaders.requiredBufferSizeForHeaders == 0) {
             return buffer;
         }
 
-        ByteUtils.writeVarint(preSerializedHeaders.serializedHeaders.length, buffer);
+        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
 
-        for (final byte[][] serializedHeader : preSerializedHeaders.serializedHeaders) {
-            ByteUtils.writeVarint(serializedHeader[0].length, buffer);
-            buffer.put(serializedHeader[0]);
+//        ByteUtils.writeVarint(preSerializedHeaders.serializedHeaders.length, buffer);
+        ByteUtils.writeVarint(headersArray.length, buffer);
 
-            if (serializedHeader[1] != null) {
-                ByteUtils.writeVarint(serializedHeader[1].length, buffer);
-                buffer.put(serializedHeader[1]);
+//        for (final byte[][] serializedHeader : preSerializedHeaders.serializedHeaders) {
+//            ByteUtils.writeVarint(serializedHeader[0].length, buffer);
+//            buffer.put(serializedHeader[0]);
+//
+//            if (serializedHeader[1] != null) {
+//                ByteUtils.writeVarint(serializedHeader[1].length, buffer);
+//                buffer.put(serializedHeader[1]);
+//            } else {
+//                buffer.put((byte) 0x01); // hardcoded varint encoding for `-1`
+//            }
+//        }
+
+        int i = 0;
+        for (final Header header : headersArray) {
+//            final byte[] rawHeaderKey = header.key().getBytes(StandardCharsets.UTF_8);
+            final byte[] rawHeaderKey = preSerializedHeaders.serializedHeaders[i++];
+            ByteUtils.writeVarint(rawHeaderKey.length, buffer);
+            buffer.put(rawHeaderKey);
+
+            final byte[] rawHeaderValue = header.value();
+            if (rawHeaderValue != null) {
+                ByteUtils.writeVarint(rawHeaderValue.length, buffer);
+                buffer.put(rawHeaderValue);
             } else {
                 buffer.put((byte) 0x01); // hardcoded varint encoding for `-1`
             }
         }
-
         return buffer;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -47,11 +47,17 @@ class HeadersSerializer {
 
     final static class PreSerializedHeaders {
         final int requiredBufferSizeForHeaders;
-        final byte[][] serializedHeaders;
+        final byte[][] rawHeaderKeys;
+        final byte[][] rawHeaderValues;
 
-        PreSerializedHeaders(final int requiredBufferSizeForHeaders, final byte[][] serializedHeaders) {
+        PreSerializedHeaders(
+            final int requiredBufferSizeForHeaders,
+            final byte[][] rawHeaderKeys,
+            final byte[][] rawHeaderValued
+        ) {
             this.requiredBufferSizeForHeaders = requiredBufferSizeForHeaders;
-            this.serializedHeaders = serializedHeaders;
+            this.rawHeaderKeys = rawHeaderKeys;
+            this.rawHeaderValues = rawHeaderValued;
         }
     }
 
@@ -59,36 +65,35 @@ class HeadersSerializer {
         final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
 
         if (headersArray.length == 0) {
-            return new PreSerializedHeaders(0, null);
+            return new PreSerializedHeaders(0, null, null);
         }
 
         // we first compute the size for the buffer we need,
         // so we can allocate the whole buffer at once later
 
         // cache to avoid translating String header-keys to byte[] twice
-        final byte[][] serializedHeaders = new byte[headersArray.length][];
+        final byte[][] serializerHeaderKeys = new byte[headersArray.length][];
+        final byte[][] serializedHeaderValues = new byte[headersArray.length][];
 
         // start with varint encoding of header count
         int requiredBufferSizeForHeaders = ByteUtils.sizeOfVarint(headersArray.length);
+
         int i = 0;
-
         for (final Header header : headersArray) {
-            final byte[] rawHeaderKey = header.key().getBytes(StandardCharsets.UTF_8);
-            requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(rawHeaderKey.length) + rawHeaderKey.length;
+            serializerHeaderKeys[i] = header.key().getBytes(StandardCharsets.UTF_8);
+            requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(serializerHeaderKeys[i].length) + serializerHeaderKeys[i].length;
 
-            final byte[] rawHeaderValue = header.value();
-            if (rawHeaderValue == null) {
+            serializedHeaderValues[i] = header.value();
+            if (serializedHeaderValues[i] == null) {
                 ++requiredBufferSizeForHeaders;
             } else {
-                requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(rawHeaderValue.length) + rawHeaderValue.length;
+                requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(serializedHeaderValues[i].length) + serializedHeaderValues[i].length;
             }
 
-            serializedHeaders[i] = rawHeaderKey;
-//            serializedHeaders[i][1] = rawHeaderValue;
             ++i;
         }
 
-        return new PreSerializedHeaders(requiredBufferSizeForHeaders, serializedHeaders);
+        return new PreSerializedHeaders(requiredBufferSizeForHeaders, serializerHeaderKeys, serializedHeaderValues);
     }
 
     /**
@@ -106,45 +111,25 @@ class HeadersSerializer {
      * with corresponding advanced position
      */
     public static ByteBuffer serialize(final PreSerializedHeaders preSerializedHeaders, final ByteBuffer buffer) {
-        return null;
-    }
-    public static ByteBuffer serialize(final PreSerializedHeaders preSerializedHeaders, final ByteBuffer buffer, final Headers headers) {
         if (preSerializedHeaders.requiredBufferSizeForHeaders == 0) {
             return buffer;
         }
 
-        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
+        final int numberOfHeaders = preSerializedHeaders.rawHeaderKeys.length;
 
-//        ByteUtils.writeVarint(preSerializedHeaders.serializedHeaders.length, buffer);
-        ByteUtils.writeVarint(headersArray.length, buffer);
+        ByteUtils.writeVarint(numberOfHeaders, buffer);
+        for (int i = 0; i < numberOfHeaders; ++i) {
+            ByteUtils.writeVarint(preSerializedHeaders.rawHeaderKeys[i].length, buffer);
+            buffer.put(preSerializedHeaders.rawHeaderKeys[i]);
 
-//        for (final byte[][] serializedHeader : preSerializedHeaders.serializedHeaders) {
-//            ByteUtils.writeVarint(serializedHeader[0].length, buffer);
-//            buffer.put(serializedHeader[0]);
-//
-//            if (serializedHeader[1] != null) {
-//                ByteUtils.writeVarint(serializedHeader[1].length, buffer);
-//                buffer.put(serializedHeader[1]);
-//            } else {
-//                buffer.put((byte) 0x01); // hardcoded varint encoding for `-1`
-//            }
-//        }
-
-        int i = 0;
-        for (final Header header : headersArray) {
-//            final byte[] rawHeaderKey = header.key().getBytes(StandardCharsets.UTF_8);
-            final byte[] rawHeaderKey = preSerializedHeaders.serializedHeaders[i++];
-            ByteUtils.writeVarint(rawHeaderKey.length, buffer);
-            buffer.put(rawHeaderKey);
-
-            final byte[] rawHeaderValue = header.value();
-            if (rawHeaderValue != null) {
-                ByteUtils.writeVarint(rawHeaderValue.length, buffer);
-                buffer.put(rawHeaderValue);
+            if (preSerializedHeaders.rawHeaderValues[i] != null) {
+                ByteUtils.writeVarint(preSerializedHeaders.rawHeaderValues[i].length, buffer);
+                buffer.put(preSerializedHeaders.rawHeaderValues[i]);
             } else {
                 buffer.put((byte) 0x01); // hardcoded varint encoding for `-1`
             }
         }
+
         return buffer;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -55,7 +55,7 @@ class HeadersSerializer {
      * instead of encoding headerCount=0 (1 byte).
      * <p>
      * The returned ByteBuffer may have larger capacity than actual payload size.
-     * It's possition will be set to zero, and its limit marks the payload end.
+     * It's position will be set to zero, and its limit marks the payload end.
      *
      * @param headers the headers to serialize (can be null)
      * @return the serialized byte array (empty array if headers are null or empty)
@@ -67,31 +67,38 @@ class HeadersSerializer {
             return ByteBuffer.allocate(0);
         }
 
-        int size = 0;
+        // we first estimate an upper bound for the buffer we need,
+        // so we can allocate the whole buffer at once
+
+        // start with 5 bytes for varint encoding of header count
+        int estimatedBufferSize = 5;
         for (final Header header : headersArray) {
-            size += 5 + header.key().length();
+            // adding 5 bytes for varint encoding of header-key length
+            estimatedBufferSize += 5 + header.key().length();
 
             final byte[] value = header.value();
             if (value == null) {
-                ++size;
+                ++estimatedBufferSize;
             } else {
-                size += 5 + value.length;
+                // adding 5 bytes for varint encoding of header-value length
+                estimatedBufferSize += 5 + value.length;
             }
         }
 
-        final ByteBuffer result = ByteBuffer.allocate(5 + size);
+        final ByteBuffer result = ByteBuffer.allocate(estimatedBufferSize);
         ByteUtils.writeVarint(headersArray.length, result);
 
         for (final Header header : headersArray) {
-            final String key = header.key();
-            final byte[] value = header.value();
-            ByteUtils.writeVarint(key.length(), result);
-            result.put(key.getBytes(StandardCharsets.UTF_8));
-            if (value != null) {
-                ByteUtils.writeVarint(value.length, result);
-                result.put(value);
+            final String headerKey = header.key();
+            ByteUtils.writeVarint(headerKey.length(), result);
+            result.put(headerKey.getBytes(StandardCharsets.UTF_8));
+
+            final byte[] headerValue = header.value();
+            if (headerValue != null) {
+                ByteUtils.writeVarint(headerValue.length, result);
+                result.put(headerValue);
             } else {
-                result.put((byte) 0x01);
+                result.put((byte) 0x01); // hardcoded varint encoding for `-1`
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -16,14 +16,10 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.ByteUtils;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -50,94 +46,21 @@ import java.nio.charset.StandardCharsets;
 class HeadersSerializer {
 
     /**
-     * Serializes headers into a byte array using varint encoding per KIP-1271.
+     * Serializes headers into a ByteBuffer using varint encoding per KIP-1271.
      * <p>
      * The output format is [count][header1][header2]... without a size prefix.
      * The size prefix is added by the outer serializer that uses this.
      * <p>
      * For null or empty headers, returns an empty byte array (0 bytes)
      * instead of encoding headerCount=0 (1 byte).
+     * <p>
+     * The returned ByteBuffer may have larger capacity than actual payload size.
+     * It's possition will be set to zero, and its limit marks the payload end.
      *
      * @param headers the headers to serialize (can be null)
      * @return the serialized byte array (empty array if headers are null or empty)
      */
-    public static byte[] serialize(final Headers headers) {
-        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
-
-        if (headersArray.length == 0) {
-            return new byte[0];
-        }
-
-        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             final DataOutputStream out = new DataOutputStream(baos)) {
-
-            ByteUtils.writeVarint(headersArray.length, out);
-
-            for (final Header header : headersArray) {
-                final byte[] keyBytes = header.key().getBytes(StandardCharsets.UTF_8);
-                final byte[] valueBytes = header.value();
-
-                ByteUtils.writeVarint(keyBytes.length, out);
-                out.write(keyBytes);
-
-                // Write value length and value bytes (varint + raw bytes)
-                // null is represented as -1, encoded as varint
-                if (valueBytes == null) {
-                    out.write(0x00);
-                } else {
-                    ByteUtils.writeVarint(valueBytes.length, out);
-                    out.write(valueBytes);
-                }
-            }
-
-            return baos.toByteArray();
-        } catch (final IOException e) {
-            throw new SerializationException("Failed to serialize headers", e);
-        }
-    }
-
-    public static byte[] serialize2(final Headers headers) {
-        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
-
-        if (headersArray.length == 0) {
-            return new byte[0];
-        }
-
-        final ByteBuffer[][] rawHeaders = new ByteBuffer[headersArray.length][2];
-
-        int i = 0;
-        int size = 0;
-        for (final Header header : headersArray) {
-            final byte[] keyBytes = header.key().getBytes(StandardCharsets.UTF_8);
-            final byte[] valueBytes = header.value();
-
-            rawHeaders[i][0] = Utils.prepareByteBufferWithSizePrefix(keyBytes.length, keyBytes.length).put(keyBytes);
-            size += rawHeaders[i][0].position();
-
-            // Write value length and value bytes (varint + raw bytes)
-            // null is represented as -1, encoded as varint
-            byte[] value = header.value();
-            if (value == null) {
-                rawHeaders[i][1] = ByteBuffer.allocate(0).put((byte) 0x00);
-            } else {
-                rawHeaders[i][1] = Utils.prepareByteBufferWithSizePrefix(valueBytes.length, valueBytes.length).put(valueBytes);
-            }
-            size += rawHeaders[i][1].position();
-            ++i;
-        }
-
-        final ByteBuffer result = ByteBuffer.allocate(5 + size);
-        ByteUtils.writeVarint(headersArray.length, result);
-
-        for (final ByteBuffer[] rawHeader : rawHeaders) {
-            result.put(rawHeader[0].position(0));
-            result.put(rawHeader[1].position(0));
-        }
-
-        return result.array();
-    }
-
-    public static ByteBuffer serialize3(final Headers headers) {
+    public static ByteBuffer serialize(final Headers headers) {
         final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
 
         if (headersArray.length == 0) {
@@ -148,7 +71,7 @@ class HeadersSerializer {
         for (final Header header : headersArray) {
             size += 5 + header.key().length();
 
-            byte[] value = header.value();
+            final byte[] value = header.value();
             if (value == null) {
                 ++size;
             } else {
@@ -160,15 +83,15 @@ class HeadersSerializer {
         ByteUtils.writeVarint(headersArray.length, result);
 
         for (final Header header : headersArray) {
-            String key = header.key();
-            byte[] value = header.value();
+            final String key = header.key();
+            final byte[] value = header.value();
             ByteUtils.writeVarint(key.length(), result);
             result.put(key.getBytes(StandardCharsets.UTF_8));
             if (value != null) {
                 ByteUtils.writeVarint(value.length, result);
                 result.put(value);
             } else {
-                result.put((byte) 0x00);
+                result.put((byte) 0x01);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -70,11 +70,17 @@ class HeadersSerializer {
         // we first estimate an upper bound for the buffer we need,
         // so we can allocate the whole buffer at once
 
+        // cache to avoid translating String header-keys to byte[] twice
+        final byte[][] serializedHeaderKeys = new byte[headersArray.length][];
+
         // start with 5 bytes for varint encoding of header count
         int estimatedBufferSize = 5;
+        int i = 0;
         for (final Header header : headersArray) {
             // adding 5 bytes for varint encoding of header-key length
-            estimatedBufferSize += 5 + header.key().length();
+            serializedHeaderKeys[i] = header.key().getBytes(StandardCharsets.UTF_8);
+            estimatedBufferSize += 5 + serializedHeaderKeys[i].length;
+            ++i;
 
             final byte[] value = header.value();
             if (value == null) {
@@ -88,10 +94,11 @@ class HeadersSerializer {
         final ByteBuffer result = ByteBuffer.allocate(estimatedBufferSize);
         ByteUtils.writeVarint(headersArray.length, result);
 
+        i = 0;
         for (final Header header : headersArray) {
             final String headerKey = header.key();
             ByteUtils.writeVarint(headerKey.length(), result);
-            result.put(headerKey.getBytes(StandardCharsets.UTF_8));
+            result.put(serializedHeaderKeys[i++]);
 
             final byte[] headerValue = header.value();
             if (headerValue != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/HeadersSerializer.java
@@ -45,6 +45,50 @@ import java.nio.charset.StandardCharsets;
  */
 class HeadersSerializer {
 
+    final static class PreSerializedHeaders {
+        final int requiredBufferSizeForHeaders;
+        final byte[][][] serializedHeaders;
+
+        PreSerializedHeaders(final int requiredBufferSizeForHeaders, final byte[][][] serializedHeaders) {
+            this.requiredBufferSizeForHeaders = requiredBufferSizeForHeaders;
+            this.serializedHeaders = serializedHeaders;
+        }
+    }
+
+    public static PreSerializedHeaders prepareSerialization(final Headers headers) {
+        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
+
+        if (headersArray.length == 0) {
+            return new PreSerializedHeaders(0, null);
+        }
+
+        // we first compute the size for the buffer we need,
+        // so we can allocate the whole buffer at once later
+
+        // cache to avoid translating String header-keys to byte[] twice
+        final byte[][][] serializedHeaders = new byte[headersArray.length][2][];
+
+        // start with varint encoding of header count
+        int requiredBufferSizeForHeaders = ByteUtils.sizeOfVarint(headersArray.length);
+        int i = 0;
+
+        for (final Header header : headersArray) {
+            serializedHeaders[i][0] = header.key().getBytes(StandardCharsets.UTF_8);
+            requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(serializedHeaders[i][0].length) + serializedHeaders[i][0].length;
+
+            serializedHeaders[i][1] = header.value();
+            if (serializedHeaders[i][1] == null) {
+                ++requiredBufferSizeForHeaders;
+            } else {
+                requiredBufferSizeForHeaders += ByteUtils.sizeOfVarint(serializedHeaders[i][1].length) + serializedHeaders[i][1].length;
+            }
+
+            ++i;
+        }
+
+        return new PreSerializedHeaders(requiredBufferSizeForHeaders, serializedHeaders);
+    }
+
     /**
      * Serializes headers into a ByteBuffer using varint encoding per KIP-1271.
      * <p>
@@ -53,65 +97,31 @@ class HeadersSerializer {
      * <p>
      * For null or empty headers, returns an empty byte array (0 bytes)
      * instead of encoding headerCount=0 (1 byte).
-     * <p>
-     * The returned ByteBuffer may have larger capacity than actual payload size.
-     * It's position will be set to zero, and its limit marks the payload end.
      *
-     * @param headers the headers to serialize (can be null)
-     * @return the serialized byte array (empty array if headers are null or empty)
+     * @param preSerializedHeaders the preSerializedHeaders
+     * @param buffer the buffer to write the serialized header into (it's expected that the buffer position is set correctly)
+     * @return the modified {@code buffer} containing the serializer headers (empty array if headers are null or empty),\
+     * with corresponding advanced position
      */
-    public static ByteBuffer serialize(final Headers headers) {
-        final Header[] headersArray = (headers == null) ? new Header[0] : headers.toArray();
-
-        if (headersArray.length == 0) {
-            return ByteBuffer.allocate(0);
+    public static ByteBuffer serialize(final PreSerializedHeaders preSerializedHeaders, final ByteBuffer buffer) {
+        if (preSerializedHeaders.requiredBufferSizeForHeaders == 0) {
+            return buffer;
         }
 
-        // we first estimate an upper bound for the buffer we need,
-        // so we can allocate the whole buffer at once
+        ByteUtils.writeVarint(preSerializedHeaders.serializedHeaders.length, buffer);
 
-        // cache to avoid translating String header-keys to byte[] twice
-        final byte[][] serializedHeaderKeys = new byte[headersArray.length][];
+        for (final byte[][] serializedHeader : preSerializedHeaders.serializedHeaders) {
+            ByteUtils.writeVarint(serializedHeader[0].length, buffer);
+            buffer.put(serializedHeader[0]);
 
-        // start with 5 bytes for varint encoding of header count
-        int estimatedBufferSize = 5;
-        int i = 0;
-        for (final Header header : headersArray) {
-            // adding 5 bytes for varint encoding of header-key length
-            serializedHeaderKeys[i] = header.key().getBytes(StandardCharsets.UTF_8);
-            estimatedBufferSize += 5 + serializedHeaderKeys[i].length;
-            ++i;
-
-            final byte[] value = header.value();
-            if (value == null) {
-                ++estimatedBufferSize;
+            if (serializedHeader[1] != null) {
+                ByteUtils.writeVarint(serializedHeader[1].length, buffer);
+                buffer.put(serializedHeader[1]);
             } else {
-                // adding 5 bytes for varint encoding of header-value length
-                estimatedBufferSize += 5 + value.length;
+                buffer.put((byte) 0x01); // hardcoded varint encoding for `-1`
             }
         }
 
-        final ByteBuffer result = ByteBuffer.allocate(estimatedBufferSize);
-        ByteUtils.writeVarint(headersArray.length, result);
-
-        i = 0;
-        for (final Header header : headersArray) {
-            final String headerKey = header.key();
-            ByteUtils.writeVarint(headerKey.length(), result);
-            result.put(serializedHeaderKeys[i++]);
-
-            final byte[] headerValue = header.value();
-            if (headerValue != null) {
-                ByteUtils.writeVarint(headerValue.length, result);
-                result.put(headerValue);
-            } else {
-                result.put((byte) 0x01); // hardcoded varint encoding for `-1`
-            }
-        }
-
-        result.limit(result.position());
-        result.position(0);
-
-        return result;
+        return buffer;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -17,14 +17,8 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.serialization.LongSerializer;
-import org.apache.kafka.common.utils.ByteUtils;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public final class RecordConverters {
@@ -33,7 +27,7 @@ public final class RecordConverters {
     private static final RecordConverter RAW_TO_TIMESTAMED_INSTANCE = record -> {
         final byte[] rawValue = record.value();
         final long timestamp = record.timestamp();
-        final byte[] recordValue = rawValue == null ? null :
+        final byte[] recordValueWithTimestamp = rawValue == null ? null :
             ByteBuffer.allocate(8 + rawValue.length)
                 .putLong(timestamp)
                 .put(rawValue)
@@ -45,9 +39,9 @@ public final class RecordConverters {
             timestamp,
             record.timestampType(),
             record.serializedKeySize(),
-            record.serializedValueSize(),
+            recordValueWithTimestamp != null ? recordValueWithTimestamp.length : 0,
             record.key(),
-            recordValue,
+            recordValueWithTimestamp,
             record.headers(),
             record.leaderEpoch()
         );
@@ -57,7 +51,7 @@ public final class RecordConverters {
         final byte[] rawValue = record.value();
 
         // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
-        final byte[] recordValue = reconstructFromRaw(
+        final byte[] recordValueWithTimestampAndHeaders = reconstructFromRaw(
             rawValue,
             record.timestamp(),
             record.headers()
@@ -70,9 +64,9 @@ public final class RecordConverters {
             record.timestamp(),
             record.timestampType(),
             record.serializedKeySize(),
-            record.serializedValueSize(),
+            recordValueWithTimestampAndHeaders != null ? recordValueWithTimestampAndHeaders.length : 0,
             record.key(),
-            recordValue,
+            recordValueWithTimestampAndHeaders,
             record.headers(),
             record.leaderEpoch()
         );
@@ -86,7 +80,7 @@ public final class RecordConverters {
         final byte[] rawValue = record.value();
 
         // Format: [headersSize(varint)][headersBytes][aggregation] (no timestamp)
-        final byte[] recordValue = reconstructSessionFromRaw(
+        final byte[] recordValueWithHeaders = reconstructSessionFromRaw(
             rawValue,
             record.headers()
         );
@@ -98,9 +92,9 @@ public final class RecordConverters {
             record.timestamp(),
             record.timestampType(),
             record.serializedKeySize(),
-            record.serializedValueSize(),
+            recordValueWithHeaders != null ? recordValueWithHeaders.length : 0,
             record.key(),
-            recordValue,
+            recordValueWithHeaders,
             record.headers(),
             record.leaderEpoch()
         );
@@ -133,22 +127,8 @@ public final class RecordConverters {
         if (rawValue == null) {
             return null;
         }
-//        final byte[] rawHeaders = HeadersSerializer.serialize2(headers);
-//
-//        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-//             final DataOutputStream out = new DataOutputStream(baos)) {
-//
-//            ByteUtils.writeVarint(rawHeaders.length, out);
-//            out.write(rawHeaders);
-//            out.write(rawValue);
-//
-//            return baos.toByteArray();
-//        } catch (final IOException e) {
-//            throw new SerializationException("Failed to reconstruct AggregationWithHeaders", e);
-//        }
 
-
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
         return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + rawValue.length)
             .put(rawHeaders)
             .put(rawValue)
@@ -168,26 +148,8 @@ public final class RecordConverters {
         if (rawValue == null) {
             return null;
         }
-//        final byte[] rawTimestamp;
-//        try (LongSerializer timestampSerializer = new LongSerializer()) {
-//            rawTimestamp = timestampSerializer.serialize("", timestamp);
-//        }
-//        final byte[] rawHeaders = HeadersSerializer.serialize2(headers);
-//        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-//             final DataOutputStream out = new DataOutputStream(baos)) {
-//
-//            ByteUtils.writeVarint(rawHeaders.length, out);
-//            out.write(rawHeaders);
-//            out.write(rawTimestamp);
-//            out.write(rawValue);
-//
-//            return baos.toByteArray();
-//        } catch (final IOException e) {
-//            throw new SerializationException("Failed to reconstruct ValueTimestampHeaders", e);
-//        }
 
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
-
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
         return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + 8 + rawValue.length)
             .put(rawHeaders)
             .putLong(timestamp)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.ByteUtils;
 
 import java.nio.ByteBuffer;
 
@@ -128,9 +129,15 @@ public final class RecordConverters {
             return null;
         }
 
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
-        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + rawValue.length)
-            .put(rawHeaders)
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final int payloadSize = preSerializedHeaders.requiredBufferSizeForHeaders + rawValue.length;
+
+        // Format: [headersSize(varint)][headersBytes][value]
+        final ByteBuffer buffer = ByteBuffer.allocate(ByteUtils.sizeOfVarint(preSerializedHeaders.requiredBufferSizeForHeaders) + payloadSize);
+        ByteUtils.writeVarint(preSerializedHeaders.requiredBufferSizeForHeaders, buffer);
+
+        return HeadersSerializer.serialize(preSerializedHeaders, buffer)
             .put(rawValue)
             .array();
     }
@@ -149,9 +156,15 @@ public final class RecordConverters {
             return null;
         }
 
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
-        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + 8 + rawValue.length)
-            .put(rawHeaders)
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final int payloadSize = preSerializedHeaders.requiredBufferSizeForHeaders + 8 + rawValue.length;
+
+        // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
+        final ByteBuffer buffer = ByteBuffer.allocate(ByteUtils.sizeOfVarint(preSerializedHeaders.requiredBufferSizeForHeaders) + payloadSize);
+        ByteUtils.writeVarint(preSerializedHeaders.requiredBufferSizeForHeaders, buffer);
+
+        return HeadersSerializer.serialize(preSerializedHeaders, buffer)
             .putLong(timestamp)
             .put(rawValue)
             .array();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RecordConverters.java
@@ -133,19 +133,26 @@ public final class RecordConverters {
         if (rawValue == null) {
             return null;
         }
-        final byte[] rawHeaders = HeadersSerializer.serialize(headers);
+//        final byte[] rawHeaders = HeadersSerializer.serialize2(headers);
+//
+//        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+//             final DataOutputStream out = new DataOutputStream(baos)) {
+//
+//            ByteUtils.writeVarint(rawHeaders.length, out);
+//            out.write(rawHeaders);
+//            out.write(rawValue);
+//
+//            return baos.toByteArray();
+//        } catch (final IOException e) {
+//            throw new SerializationException("Failed to reconstruct AggregationWithHeaders", e);
+//        }
 
-        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             final DataOutputStream out = new DataOutputStream(baos)) {
 
-            ByteUtils.writeVarint(rawHeaders.length, out);
-            out.write(rawHeaders);
-            out.write(rawValue);
-
-            return baos.toByteArray();
-        } catch (final IOException e) {
-            throw new SerializationException("Failed to reconstruct AggregationWithHeaders", e);
-        }
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
+        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + rawValue.length)
+            .put(rawHeaders)
+            .put(rawValue)
+            .array();
     }
 
     /**
@@ -161,23 +168,30 @@ public final class RecordConverters {
         if (rawValue == null) {
             return null;
         }
-        final byte[] rawTimestamp;
-        try (LongSerializer timestampSerializer = new LongSerializer()) {
-            rawTimestamp = timestampSerializer.serialize("", timestamp);
-        }
-        final byte[] rawHeaders = HeadersSerializer.serialize(headers);
+//        final byte[] rawTimestamp;
+//        try (LongSerializer timestampSerializer = new LongSerializer()) {
+//            rawTimestamp = timestampSerializer.serialize("", timestamp);
+//        }
+//        final byte[] rawHeaders = HeadersSerializer.serialize2(headers);
+//        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+//             final DataOutputStream out = new DataOutputStream(baos)) {
+//
+//            ByteUtils.writeVarint(rawHeaders.length, out);
+//            out.write(rawHeaders);
+//            out.write(rawTimestamp);
+//            out.write(rawValue);
+//
+//            return baos.toByteArray();
+//        } catch (final IOException e) {
+//            throw new SerializationException("Failed to reconstruct ValueTimestampHeaders", e);
+//        }
 
-        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             final DataOutputStream out = new DataOutputStream(baos)) {
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
 
-            ByteUtils.writeVarint(rawHeaders.length, out);
-            out.write(rawHeaders);
-            out.write(rawTimestamp);
-            out.write(rawValue);
-
-            return baos.toByteArray();
-        } catch (final IOException e) {
-            throw new SerializationException("Failed to reconstruct ValueTimestampHeaders", e);
-        }
+        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + 8 + rawValue.length)
+            .put(rawHeaders)
+            .putLong(timestamp)
+            .put(rawValue)
+            .array();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Utils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Utils.java
@@ -28,6 +28,22 @@ import java.nio.ByteBuffer;
 
 public class Utils {
     /**
+     * Create a new ByteBuffer to store {@code bufferSize} bytes, after a var-length encoded prefix.
+     */
+    static ByteBuffer prepareByteBufferWithSizePrefix(final int prefix, final int bufferSize) {
+        final ByteBuffer varLengthBuffer = ByteBuffer.allocate(5);
+        ByteUtils.writeVarint(prefix, varLengthBuffer);
+
+        final ByteBuffer buffer = ByteBuffer.allocate(varLengthBuffer.position() + bufferSize);
+
+        varLengthBuffer.limit(varLengthBuffer.position());
+        varLengthBuffer.position(0);
+        buffer.put(varLengthBuffer);
+
+        return buffer;
+    }
+
+    /**
      * Extract raw plain value from serialized ValueTimestampHeaders.
      * This strips both the headers and timestamp portions.
      *

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Utils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Utils.java
@@ -31,9 +31,10 @@ public class Utils {
      * Create a new ByteBuffer to store {@code bufferSize} bytes, after a var-length encoded prefix.
      */
     static ByteBuffer prepareByteBufferWithSizePrefix(final int prefix, final int bufferSize) {
-        final ByteBuffer varLengthBuffer = ByteBuffer.allocate(5);
+        final ByteBuffer varLengthBuffer = ByteBuffer.allocate(5); // 5 bytes for max varint encoding
         ByteUtils.writeVarint(prefix, varLengthBuffer);
 
+        // allocate buffer with _exact_ size
         final ByteBuffer buffer = ByteBuffer.allocate(varLengthBuffer.position() + bufferSize);
 
         varLengthBuffer.limit(varLengthBuffer.position());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Utils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Utils.java
@@ -28,23 +28,6 @@ import java.nio.ByteBuffer;
 
 public class Utils {
     /**
-     * Create a new ByteBuffer to store {@code bufferSize} bytes, after a var-length encoded prefix.
-     */
-    static ByteBuffer prepareByteBufferWithSizePrefix(final int prefix, final int bufferSize) {
-        final ByteBuffer varLengthBuffer = ByteBuffer.allocate(5); // 5 bytes for max varint encoding
-        ByteUtils.writeVarint(prefix, varLengthBuffer);
-
-        // allocate buffer with _exact_ size
-        final ByteBuffer buffer = ByteBuffer.allocate(varLengthBuffer.position() + bufferSize);
-
-        varLengthBuffer.limit(varLengthBuffer.position());
-        varLengthBuffer.position(0);
-        buffer.put(varLengthBuffer);
-
-        return buffer;
-    }
-
-    /**
      * Extract raw plain value from serialized ValueTimestampHeaders.
      * This strips both the headers and timestamp portions.
      *

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
@@ -81,12 +82,16 @@ class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<V
             return null;
         }
 
-        // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final int payloadSize = preSerializedHeaders.requiredBufferSizeForHeaders + 8 + rawValue.length;
 
         // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
-        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + 8 + rawValue.length)
-            .put(rawHeaders)
+        final ByteBuffer buffer = ByteBuffer.allocate(ByteUtils.sizeOfVarint(preSerializedHeaders.requiredBufferSizeForHeaders) + payloadSize);
+        ByteUtils.writeVarint(preSerializedHeaders.requiredBufferSizeForHeaders, buffer);
+
+        // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
+        return HeadersSerializer.serialize(preSerializedHeaders, buffer)
             .putLong(timestamp)
             .put(rawValue)
             .array();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -16,18 +16,12 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
@@ -88,7 +82,7 @@ class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<V
         }
 
         // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
-        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize(headers);
 
         // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
         return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + 8 + rawValue.length)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueTimestampHeadersSerializer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
@@ -51,18 +52,15 @@ import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.i
  */
 class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<ValueTimestampHeaders<V>, Void, V> {
     public final Serializer<V> valueSerializer;
-    private final LongSerializer timestampSerializer;
 
     ValueTimestampHeadersSerializer(final Serializer<V> valueSerializer) {
         Objects.requireNonNull(valueSerializer);
         this.valueSerializer = valueSerializer;
-        this.timestampSerializer = new LongSerializer();
     }
 
     @Override
     public void configure(final Map<String, ?> configs, final boolean isKey) {
         valueSerializer.configure(configs, isKey);
-        timestampSerializer.configure(configs, isKey);
     }
 
     @Override
@@ -89,30 +87,20 @@ class ValueTimestampHeadersSerializer<V> implements WrappingNullableSerializer<V
             return null;
         }
 
-        final byte[] rawTimestamp = timestampSerializer.serialize(topic, timestamp);
-
         // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
-        final byte[] rawHeaders = HeadersSerializer.serialize(headers);
+        final ByteBuffer rawHeaders = HeadersSerializer.serialize3(headers);
 
         // Format: [headersSize(varint)][headersBytes][timestamp(8)][value]
-        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             final DataOutputStream out = new DataOutputStream(baos)) {
-
-            ByteUtils.writeVarint(rawHeaders.length, out);  // headersSize (it may be 0 due to null/empty headers)
-            out.write(rawHeaders);                          // empty (byte[0]) for null/empty headers, or [count][header1][header2]... for non-empty
-            out.write(rawTimestamp);                        // [timestamp(8)]
-            out.write(rawValue);                            // [value]
-
-            return baos.toByteArray();
-        } catch (final IOException e) {
-            throw new SerializationException("Failed to serialize ValueTimestampHeaders", e);
-        }
+        return Utils.prepareByteBufferWithSizePrefix(rawHeaders.limit(), rawHeaders.limit() + 8 + rawValue.length)
+            .put(rawHeaders)
+            .putLong(timestamp)
+            .put(rawValue)
+            .array();
     }
 
     @Override
     public void close() {
         valueSerializer.close();
-        timestampSerializer.close();
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
@@ -50,11 +50,10 @@ public class HeadersDeserializerTest {
 
     @Test
     public void shouldRoundTripEmptyHeaders() {
-        final Headers original = new RecordHeaders();
-        final ByteBuffer serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(
-            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
-        );
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(new RecordHeaders());
+        final byte[] serialized = HeadersSerializer.serialize(preSerializedHeaders, ByteBuffer.allocate(0)).array();
+
+        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
 
         assertNotNull(deserialized);
         assertEquals(0, deserialized.toArray().length);
@@ -64,10 +63,13 @@ public class HeadersDeserializerTest {
     public void shouldRoundTripSingleHeader() {
         final Headers original = new RecordHeaders()
             .add("key1", "value1".getBytes());
-        final ByteBuffer serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(
-            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
-        );
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(original);
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
+
+        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
 
         assertNotNull(deserialized);
         assertEquals(1, deserialized.toArray().length);
@@ -84,10 +86,14 @@ public class HeadersDeserializerTest {
             .add("key0", "value0".getBytes())
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes());
-        final ByteBuffer serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(
-            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
-        );
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(original);
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
+
+        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+
         assertNotNull(deserialized);
 
         final Header[] headerArray = deserialized.toArray();
@@ -103,10 +109,13 @@ public class HeadersDeserializerTest {
     public void shouldRoundTripHeaderWithNullValue() {
         final Headers original = new RecordHeaders()
             .add("key1", null);
-        final ByteBuffer serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(
-            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
-        );
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(original);
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
+
+        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
 
         assertNotNull(deserialized);
         assertEquals(1, deserialized.toArray().length);
@@ -121,10 +130,13 @@ public class HeadersDeserializerTest {
     public void shouldRoundTripHeaderWithEmptyValue() {
         final Headers original = new RecordHeaders()
             .add("key1", new byte[0]);
-        final ByteBuffer serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(
-            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
-        );
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(original);
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
+
+        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
 
         assertNotNull(deserialized);
         assertEquals(1, deserialized.toArray().length);
@@ -143,10 +155,14 @@ public class HeadersDeserializerTest {
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes())
             .add("key2", "value3".getBytes());
-        final ByteBuffer serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(
-            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
-        );
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(original);
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
+
+        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+
         assertNotNull(deserialized);
 
         final Header[] headerArray = deserialized.toArray();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersDeserializerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -50,8 +51,10 @@ public class HeadersDeserializerTest {
     @Test
     public void shouldRoundTripEmptyHeaders() {
         final Headers original = new RecordHeaders();
-        final byte[] serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+        final ByteBuffer serialized = HeadersSerializer.serialize(original);
+        final Headers deserialized = HeadersDeserializer.deserialize(
+            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
+        );
 
         assertNotNull(deserialized);
         assertEquals(0, deserialized.toArray().length);
@@ -61,8 +64,10 @@ public class HeadersDeserializerTest {
     public void shouldRoundTripSingleHeader() {
         final Headers original = new RecordHeaders()
             .add("key1", "value1".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+        final ByteBuffer serialized = HeadersSerializer.serialize(original);
+        final Headers deserialized = HeadersDeserializer.deserialize(
+            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
+        );
 
         assertNotNull(deserialized);
         assertEquals(1, deserialized.toArray().length);
@@ -79,8 +84,10 @@ public class HeadersDeserializerTest {
             .add("key0", "value0".getBytes())
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+        final ByteBuffer serialized = HeadersSerializer.serialize(original);
+        final Headers deserialized = HeadersDeserializer.deserialize(
+            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
+        );
         assertNotNull(deserialized);
 
         final Header[] headerArray = deserialized.toArray();
@@ -96,8 +103,10 @@ public class HeadersDeserializerTest {
     public void shouldRoundTripHeaderWithNullValue() {
         final Headers original = new RecordHeaders()
             .add("key1", null);
-        final byte[] serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+        final ByteBuffer serialized = HeadersSerializer.serialize(original);
+        final Headers deserialized = HeadersDeserializer.deserialize(
+            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
+        );
 
         assertNotNull(deserialized);
         assertEquals(1, deserialized.toArray().length);
@@ -112,8 +121,10 @@ public class HeadersDeserializerTest {
     public void shouldRoundTripHeaderWithEmptyValue() {
         final Headers original = new RecordHeaders()
             .add("key1", new byte[0]);
-        final byte[] serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+        final ByteBuffer serialized = HeadersSerializer.serialize(original);
+        final Headers deserialized = HeadersDeserializer.deserialize(
+            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
+        );
 
         assertNotNull(deserialized);
         assertEquals(1, deserialized.toArray().length);
@@ -132,8 +143,10 @@ public class HeadersDeserializerTest {
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes())
             .add("key2", "value3".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize(original);
-        final Headers deserialized = HeadersDeserializer.deserialize(serialized);
+        final ByteBuffer serialized = HeadersSerializer.serialize(original);
+        final Headers deserialized = HeadersDeserializer.deserialize(
+            ByteBuffer.allocate(serialized.limit()).put(serialized).array()
+        );
         assertNotNull(deserialized);
 
         final Header[] headerArray = deserialized.toArray();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
@@ -33,26 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HeadersSerializerTest {
 
     @Test
-    public void test() {
-        final Headers headers = new RecordHeaders()
-            .add("key0", "value0".getBytes())
-            .add("key1", "value1".getBytes())
-            .add("key2", "value2".getBytes());
-
-        long start = System.currentTimeMillis();
-        HeadersSerializer.PreSerializedHeaders preSerializedHeaders = null;
-        for (int i = 0; i < 500000000; i++) {
-            preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
-        }
-        System.out.println("runtime: " + (System.currentTimeMillis() - start));
-        long start2 = System.currentTimeMillis();
-        for (int i = 0; i < 500000000; i++) {
-            HeadersSerializer.serialize(preSerializedHeaders, ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders), headers);
-        }
-        System.out.println("runtime: " + (System.currentTimeMillis() - start2));
-    }
-
-    @Test
     public void shouldSerializeNullHeaders() {
         final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(null);
         assertEquals(0, preSerializedHeaders.requiredBufferSizeForHeaders);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
@@ -34,8 +34,10 @@ public class HeadersSerializerTest {
 
     @Test
     public void shouldSerializeNullHeaders() {
-        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(null);
-        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(null);
+        assertEquals(0, preSerializedHeaders.requiredBufferSizeForHeaders);
+
+        final byte[] serialized = HeadersSerializer.serialize(preSerializedHeaders, ByteBuffer.allocate(0)).array();
 
         assertNotNull(serialized);
         assertEquals(0, serialized.length, "Null headers should serialize to empty byte array (0 bytes)");
@@ -43,9 +45,10 @@ public class HeadersSerializerTest {
 
     @Test
     public void shouldSerializeEmptyHeaders() {
-        final Headers headers = new RecordHeaders();
-        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
-        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(new RecordHeaders());
+        assertEquals(0, preSerializedHeaders.requiredBufferSizeForHeaders);
+
+        final byte[] serialized = HeadersSerializer.serialize(preSerializedHeaders, ByteBuffer.allocate(0)).array();
 
         assertNotNull(serialized);
         assertEquals(0, serialized.length, "Empty headers should serialize to empty byte array (0 bytes)");
@@ -55,8 +58,12 @@ public class HeadersSerializerTest {
     public void shouldSerializeSingleHeader() {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());
-        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
-        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -77,8 +84,12 @@ public class HeadersSerializerTest {
             .add("key0", "value0".getBytes())
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes());
-        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
-        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -99,8 +110,12 @@ public class HeadersSerializerTest {
     public void shouldSerializeHeaderWithNullValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", null);
-        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
-        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -119,8 +134,12 @@ public class HeadersSerializerTest {
     public void shouldSerializeHeadersWithEmptyValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", new byte[0]);
-        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
-        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
+        final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+
+        final byte[] serialized = HeadersSerializer.serialize(
+            preSerializedHeaders,
+            ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders)
+        ).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
@@ -33,6 +33,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HeadersSerializerTest {
 
     @Test
+    public void test() {
+        final Headers headers = new RecordHeaders()
+            .add("key0", "value0".getBytes())
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes());
+
+        long start = System.currentTimeMillis();
+        HeadersSerializer.PreSerializedHeaders preSerializedHeaders = null;
+        for (int i = 0; i < 500000000; i++) {
+            preSerializedHeaders = HeadersSerializer.prepareSerialization(headers);
+        }
+        System.out.println("runtime: " + (System.currentTimeMillis() - start));
+        long start2 = System.currentTimeMillis();
+        for (int i = 0; i < 500000000; i++) {
+            HeadersSerializer.serialize(preSerializedHeaders, ByteBuffer.allocate(preSerializedHeaders.requiredBufferSizeForHeaders), headers);
+        }
+        System.out.println("runtime: " + (System.currentTimeMillis() - start2));
+    }
+
+    @Test
     public void shouldSerializeNullHeaders() {
         final HeadersSerializer.PreSerializedHeaders preSerializedHeaders = HeadersSerializer.prepareSerialization(null);
         assertEquals(0, preSerializedHeaders.requiredBufferSizeForHeaders);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,7 +34,8 @@ public class HeadersSerializerTest {
 
     @Test
     public void shouldSerializeNullHeaders() {
-        final byte[] serialized = HeadersSerializer.serialize(null);
+        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(null);
+        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
 
         assertNotNull(serialized);
         assertEquals(0, serialized.length, "Null headers should serialize to empty byte array (0 bytes)");
@@ -41,7 +44,8 @@ public class HeadersSerializerTest {
     @Test
     public void shouldSerializeEmptyHeaders() {
         final Headers headers = new RecordHeaders();
-        final byte[] serialized = HeadersSerializer.serialize(headers);
+        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
+        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
 
         assertNotNull(serialized);
         assertEquals(0, serialized.length, "Empty headers should serialize to empty byte array (0 bytes)");
@@ -51,7 +55,8 @@ public class HeadersSerializerTest {
     public void shouldSerializeSingleHeader() {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize2(headers);
+        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
+        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -72,7 +77,8 @@ public class HeadersSerializerTest {
             .add("key0", "value0".getBytes())
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize2(headers);
+        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
+        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -90,26 +96,11 @@ public class HeadersSerializerTest {
     }
 
     @Test
-    public void test() {
-        final Headers headers = new RecordHeaders()
-            .add("key0", "value0".getBytes())
-            .add("key1", "value1".getBytes())
-            .add("key2", "value2".getBytes());
-
-        long start = System.currentTimeMillis();
-        for (int i = 0; i < 500000000; i++) {
-//            HeadersSerializer.serialize(headers);
-//            HeadersSerializer.serialize2(headers);
-            HeadersSerializer.serialize3(headers);
-        }
-        System.out.println("runtime: " + (System.currentTimeMillis() - start));
-    }
-
-    @Test
     public void shouldSerializeHeaderWithNullValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", null);
-        final byte[] serialized = HeadersSerializer.serialize2(headers);
+        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
+        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -128,7 +119,8 @@ public class HeadersSerializerTest {
     public void shouldSerializeHeadersWithEmptyValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", new byte[0]);
-        final byte[] serialized = HeadersSerializer.serialize(headers);
+        final ByteBuffer serializedBuffer = HeadersSerializer.serialize(headers);
+        final byte[] serialized = ByteBuffer.allocate(serializedBuffer.limit()).put(serializedBuffer).array();
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/HeadersSerializerTest.java
@@ -51,7 +51,7 @@ public class HeadersSerializerTest {
     public void shouldSerializeSingleHeader() {
         final Headers headers = new RecordHeaders()
             .add("key1", "value1".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize(headers);
+        final byte[] serialized = HeadersSerializer.serialize2(headers);
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -72,7 +72,7 @@ public class HeadersSerializerTest {
             .add("key0", "value0".getBytes())
             .add("key1", "value1".getBytes())
             .add("key2", "value2".getBytes());
-        final byte[] serialized = HeadersSerializer.serialize(headers);
+        final byte[] serialized = HeadersSerializer.serialize2(headers);
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);
@@ -90,10 +90,26 @@ public class HeadersSerializerTest {
     }
 
     @Test
+    public void test() {
+        final Headers headers = new RecordHeaders()
+            .add("key0", "value0".getBytes())
+            .add("key1", "value1".getBytes())
+            .add("key2", "value2".getBytes());
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 500000000; i++) {
+//            HeadersSerializer.serialize(headers);
+//            HeadersSerializer.serialize2(headers);
+            HeadersSerializer.serialize3(headers);
+        }
+        System.out.println("runtime: " + (System.currentTimeMillis() - start));
+    }
+
+    @Test
     public void shouldSerializeHeaderWithNullValue() {
         final Headers headers = new RecordHeaders()
             .add("key1", null);
-        final byte[] serialized = HeadersSerializer.serialize(headers);
+        final byte[] serialized = HeadersSerializer.serialize2(headers);
 
         assertNotNull(serialized);
         assertTrue(serialized.length > 0);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 
 import static org.apache.kafka.streams.state.internals.RecordConverters.rawValueToHeadersValue;
+import static org.apache.kafka.streams.state.internals.RecordConverters.rawValueToSessionHeadersValue;
 import static org.apache.kafka.streams.state.internals.RecordConverters.rawValueToTimestampedValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -35,6 +36,7 @@ public class RecordConvertersTest {
 
     private final RecordConverter timestampedValueConverter = rawValueToTimestampedValue();
     private final RecordConverter headersValueConverter = rawValueToHeadersValue();
+    private final RecordConverter sessionValueConverter = rawValueToSessionHeadersValue();
 
 
     @Test
@@ -42,6 +44,7 @@ public class RecordConvertersTest {
         final ConsumerRecord<byte[], byte[]> nullValueRecord = new ConsumerRecord<>("", 0, 0L, new byte[0], null);
         assertNull(timestampedValueConverter.convert(nullValueRecord).value());
         assertNull(headersValueConverter.convert(nullValueRecord).value());
+        assertNull(sessionValueConverter.convert(nullValueRecord).value());
     }
 
     @Test
@@ -66,9 +69,56 @@ public class RecordConvertersTest {
             headers, Optional.empty());
         // Expected format: [headersSize(varint)][headersBytes][timestamp(8)][value]
         final byte[] expectedValue =
-            {50, 2, 20, 104, 101, 97, 100, 101, 114, 45, 107, 101, 121, 24, 104, 101, 97, 100, 101,
-                114, 45, 118, 97, 108, 117, 101, 0, 0, 0, 0, 0, 0, 0, 10, 0};
+            {50, 2, 20, 'h', 'e', 'a', 'd', 'e', 'r', '-', 'k', 'e', 'y', 24, 'h', 'e', 'a', 'd', 'e',
+                'r', '-', 'v', 'a', 'l', 'u', 'e', 0, 0, 0, 0, 0, 0, 0, 10, value[0]};
         final byte[] actualValue = headersValueConverter.convert(inputRecord).value();
         assertArrayEquals(expectedValue, actualValue);
     }
+
+    @Test
+    public void test1() {
+        final byte[] value = new byte[1];
+        final Headers headers = new RecordHeaders().add("header-key", "header-value".getBytes());
+        final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
+            "topic", 1, 0, 10, TimestampType.CREATE_TIME, 0, 0, new byte[0], value,
+            headers, Optional.empty());
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 500000000; i++) {
+            headersValueConverter.convert(inputRecord).value();
+        }
+        System.out.println("runtime: " + (System.currentTimeMillis() - start));
+    }
+
+    @Test
+    public void shouldAddHeadersToValueOnConversionWhenValueIsNotNull() {
+        final byte[] value = new byte[1];
+        final Headers headers = new RecordHeaders().add("header-key", "header-value".getBytes());
+        final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
+            "topic", 1, 0, 0, TimestampType.CREATE_TIME, 0, 0, new byte[0], value,
+            headers, Optional.empty());
+        // Expected format: [headersSize(varint)][headersBytes][value]
+        final byte[] expectedValue =
+            {50, 2, 20, 'h', 'e', 'a', 'd', 'e', 'r', '-', 'k', 'e', 'y', 24, 'h', 'e', 'a', 'd', 'e',
+                'r', '-', 'v', 'a', 'l', 'u', 'e', value[0]};
+        final byte[] actualValue = sessionValueConverter.convert(inputRecord).value();
+        assertArrayEquals(expectedValue, actualValue);
+    }
+
+
+    @Test
+    public void test2() {
+        final byte[] value = new byte[1];
+        final Headers headers = new RecordHeaders().add("header-key", "header-value".getBytes());
+        final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
+            "topic", 1, 0, 0, TimestampType.CREATE_TIME, 0, 0, new byte[0], value,
+            headers, Optional.empty());
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 500000000; i++) {
+            sessionValueConverter.convert(inputRecord).value();
+        }
+        System.out.println("runtime: " + (System.currentTimeMillis() - start));
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RecordConvertersTest.java
@@ -76,21 +76,6 @@ public class RecordConvertersTest {
     }
 
     @Test
-    public void test1() {
-        final byte[] value = new byte[1];
-        final Headers headers = new RecordHeaders().add("header-key", "header-value".getBytes());
-        final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
-            "topic", 1, 0, 10, TimestampType.CREATE_TIME, 0, 0, new byte[0], value,
-            headers, Optional.empty());
-
-        long start = System.currentTimeMillis();
-        for (int i = 0; i < 500000000; i++) {
-            headersValueConverter.convert(inputRecord).value();
-        }
-        System.out.println("runtime: " + (System.currentTimeMillis() - start));
-    }
-
-    @Test
     public void shouldAddHeadersToValueOnConversionWhenValueIsNotNull() {
         final byte[] value = new byte[1];
         final Headers headers = new RecordHeaders().add("header-key", "header-value".getBytes());
@@ -103,22 +88,6 @@ public class RecordConvertersTest {
                 'r', '-', 'v', 'a', 'l', 'u', 'e', value[0]};
         final byte[] actualValue = sessionValueConverter.convert(inputRecord).value();
         assertArrayEquals(expectedValue, actualValue);
-    }
-
-
-    @Test
-    public void test2() {
-        final byte[] value = new byte[1];
-        final Headers headers = new RecordHeaders().add("header-key", "header-value".getBytes());
-        final ConsumerRecord<byte[], byte[]> inputRecord = new ConsumerRecord<>(
-            "topic", 1, 0, 0, TimestampType.CREATE_TIME, 0, 0, new byte[0], value,
-            headers, Optional.empty());
-
-        long start = System.currentTimeMillis();
-        for (int i = 0; i < 500000000; i++) {
-            sessionValueConverter.convert(inputRecord).value();
-        }
-        System.out.println("runtime: " + (System.currentTimeMillis() - start));
     }
 
 }


### PR DESCRIPTION
This PR replaces the usage of ByteArrayOutputStreams with ByteBuffers.
Some manual benchmarks show a perf improvement for the value-ts-header
and session-header converters of 3x.

Reviewers: PoAn Yang <payang@apache.org>, Nilesh Kumar
 <nileshkumar3@gmail.com>, aliehsaeedii <asaeedi@confluent.io>,
 Chia-Ping Tsai <chia7712@gmail.com>
