### PR TITLE
MINOR: Fix typo 'curent' to 'current' in LeaderState

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -507,7 +507,7 @@ public class LeaderState<T> implements EpochState {
      * This methods upgrades the kraft version to {@code newVersion}. If the version is already
      * {@code newVersion}, this is a noop operation.
      *
-     * KRaft only supports upgrades, so {@code newVersion} must be greater than or equal to curent
+     * KRaft only supports upgrades, so {@code newVersion} must be greater than or equal to current
      * kraft version {@code persistedVersion}.
      *
      * For the upgrade to succeed all of the voters in the voter set must support the new kraft


### PR DESCRIPTION
Fix typo `curent` -> `current` in LeaderState Javadoc.

Reviewers: Ken Huang <s7133700@gmail.com>, Nilesh Kumar
 <nileshkumar3@gmail.com>, PoAn Yang <payang@apache.org>
