### PR TITLE
KAFKA-20211, KAFKA-20345: Fix group coordinator background metrics test flake

### DIFF
--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutorTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutorTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -80,7 +81,7 @@ public class CoordinatorBackgroundThreadPoolExecutorTest {
             task1Unblocked.countDown();
             task1.get(5, TimeUnit.SECONDS);
 
-            // Task 3 starts.
+            // Task 3 starts after task 1's metrics are recorded.
             task3Started.await();
 
             // Task 2 takes 500 ms.
@@ -88,20 +89,24 @@ public class CoordinatorBackgroundThreadPoolExecutorTest {
             task2Unblocked.countDown();
             task2.get(5, TimeUnit.SECONDS);
 
+            // Wait until the metrics are recorded before advancing the clock.
+            verify(metrics, timeout(5000).times(1)).recordBackgroundProcessingTime(500L);
+            verify(metrics, timeout(5000).times(1)).recordBackgroundThreadBusyTime(250.0);
+
             // Task 3 takes 500 ms.
             mockTime.sleep(100);
             task3Unblocked.countDown();
             task3.get(5, TimeUnit.SECONDS);
-
-            verify(metrics, times(2)).recordBackgroundQueueTime(0);
-            verify(metrics, times(1)).recordBackgroundQueueTime(100);
-            verify(metrics, times(1)).recordBackgroundProcessingTime(100);
-            verify(metrics, times(2)).recordBackgroundProcessingTime(500);
-            verify(metrics, times(1)).recordBackgroundThreadBusyTime(50.0);
-            verify(metrics, times(2)).recordBackgroundThreadBusyTime(250.0);
         } finally {
             threadPoolExecutor.shutdown();
             threadPoolExecutor.awaitTermination(5, TimeUnit.SECONDS);
         }
+
+        verify(metrics, times(2)).recordBackgroundQueueTime(0L);
+        verify(metrics, times(1)).recordBackgroundQueueTime(100L);
+        verify(metrics, times(1)).recordBackgroundProcessingTime(100L);
+        verify(metrics, times(2)).recordBackgroundProcessingTime(500L);
+        verify(metrics, times(1)).recordBackgroundThreadBusyTime(50.0);
+        verify(metrics, times(2)).recordBackgroundThreadBusyTime(250.0);
     }
 }


### PR DESCRIPTION
Executor task futures complete before metrics are recorded, so we have
to take care to not advance the clock until after metrics are recorded.

Reviewers: Zheguang Zhao <zheguang.zhao@gmail.com>, ChickenchickenLove
 <ojt90902@naver.com>, Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
