### PR TITLE
KAFKA-20168: Add comment to explain why we don't upgrade jetty version (4.0)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,6 +69,10 @@ versions += [
   jackson: "2.18.6",
   jacoco: "0.8.10",
   javassist: "3.29.2-GA",
+  // Jetty 12.0.30+ introduced SLF4J 2.x fluent API usage (e.g. Logger.atDebug()) in production
+  // code, which causes NoSuchMethodError at runtime since Kafka uses SLF4J 1.7.x.
+  // 12.0.25 is the version that includes the CVE-2025-5115 fix while only using the
+  // SLF4J 2.x fluent API in test code, avoiding the runtime incompatibility.
   jetty: "12.0.25",
   jersey: "3.1.10",
   jline: "3.25.1",


### PR DESCRIPTION
Follow-up to https://github.com/apache/kafka/pull/21561#issuecomment-4068484146.
Add a comment explaining why Jetty is pinned to 12.0.25 on the 4.1 and 4.0 branches, matching the comment already present on trunk and 4.2.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
