### PR TITLE
MINOR: Fix bug where dslStoreFormat is non-null and always set to HEADERS

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionStoreMaterializer.java
@@ -60,7 +60,7 @@ public class SessionStoreMaterializer<K, V> extends MaterializedStoreFactory<K, 
 
     @Override
     public  StoreBuilder<SessionStoreWithHeaders<K, V>> builder() {
-        final DslStoreFormat storeFormat = dslStoreFormat() == null ? DslStoreFormat.PLAIN : DslStoreFormat.HEADERS;
+        final DslStoreFormat storeFormat = dslStoreFormat() == null ? DslStoreFormat.PLAIN : dslStoreFormat();
         final SessionBytesStoreSupplier supplier = materialized.storeSupplier() == null
                 ? dslStoreSuppliers().sessionStore(new DslSessionParams(
                         materialized.storeName(),


### PR DESCRIPTION
This PR fixes a bug identified during reviews but was missed addressing
comments

  Bug: always returns HEADERS when dslStoreFormat() is non-null `final
DslStoreFormat storeFormat = dslStoreFormat() == null ?
DslStoreFormat.PLAIN : DslStoreFormat.HEADERS;`

  Fix:    `final DslStoreFormat storeFormat = dslStoreFormat() == null ?
DslStoreFormat.PLAIN : dslStoreFormat();`

Reviewers: TengYao Chi <frankvicky@apache.org>
