### PR TITLE
KAFKA-20245: Add throwables and new record state for share group DLQ. [1/N]

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
@@ -23,6 +23,13 @@ import java.util.concurrent.CompletableFuture;
  * The main interface to identify implementations of dead letter queues for share groups.
  */
 public interface ShareGroupDLQ {
+    Throwable STALE_BATCH = new Exception("Offset part of stale batch.");
+    Throwable BEHIND_LSO = new Exception("Offset before LSO.");
+    Throwable ABORTED_TRANSACTION = new Exception("Offset part of aborted transaction.");
+    Throwable CLIENT_REJECT = new Exception("Offset rejected by client.");
+    Throwable DELIVERY_COUNT_EXCEEDED = new Exception("Offset delivery count exceeded the threshold.");
+    Throwable ACQUISITION_LOCK_TIMEOUT = new Exception("Acquisition lock timed out.");
+
     /**
      * Main method exposed to the world to enqueuing a record to the share groups dead letter queue.
      *

--- a/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQ.java
@@ -23,12 +23,19 @@ import java.util.concurrent.CompletableFuture;
  * The main interface to identify implementations of dead letter queues for share groups.
  */
 public interface ShareGroupDLQ {
-    Throwable STALE_BATCH = new Exception("Offset part of stale batch.");
-    Throwable BEHIND_LSO = new Exception("Offset before LSO.");
-    Throwable ABORTED_TRANSACTION = new Exception("Offset part of aborted transaction.");
-    Throwable CLIENT_REJECT = new Exception("Offset rejected by client.");
-    Throwable DELIVERY_COUNT_EXCEEDED = new Exception("Offset delivery count exceeded the threshold.");
-    Throwable ACQUISITION_LOCK_TIMEOUT = new Exception("Acquisition lock timed out.");
+    class ShareGroupDLQThrowable extends Throwable {
+        ShareGroupDLQThrowable(String message) {
+            // We don't want the stack trace to be filled.
+            super(message, null, false, false);
+        }
+    }
+
+    Throwable STALE_BATCH = new ShareGroupDLQThrowable("Offset part of stale batch.");
+    Throwable BEHIND_LSO = new ShareGroupDLQThrowable("Offset before LSO.");
+    Throwable ABORTED_TRANSACTION = new ShareGroupDLQThrowable("Offset part of aborted transaction.");
+    Throwable CLIENT_REJECT = new ShareGroupDLQThrowable("Offset rejected by client.");
+    Throwable DELIVERY_COUNT_EXCEEDED = new ShareGroupDLQThrowable("Offset delivery count exceeded the threshold.");
+    Throwable ACQUISITION_LOCK_TIMEOUT = new ShareGroupDLQThrowable("Acquisition lock timed out.");
 
     /**
      * Main method exposed to the world to enqueuing a record to the share groups dead letter queue.

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
@@ -27,6 +27,7 @@ public enum RecordState {
     AVAILABLE((byte) 0),
     ACQUIRED((byte) 1),
     ACKNOWLEDGED((byte) 2),
+    ARCHIVING((byte) 3),
     ARCHIVED((byte) 4);
 
     public final byte id;
@@ -71,6 +72,7 @@ public enum RecordState {
             case 0 -> AVAILABLE;
             case 1 -> ACQUIRED;
             case 2 -> ACKNOWLEDGED;
+            case 3 -> ARCHIVING;
             case 4 -> ARCHIVED;
             default -> throw new IllegalArgumentException("Unknown record state id: " + id);
         };

--- a/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
+++ b/server/src/main/java/org/apache/kafka/server/share/fetch/RecordState.java
@@ -27,7 +27,7 @@ public enum RecordState {
     AVAILABLE((byte) 0),
     ACQUIRED((byte) 1),
     ACKNOWLEDGED((byte) 2),
-    ARCHIVING((byte) 3),
+    ARCHIVING((byte) 3),    // Per KIP-1191
     ARCHIVED((byte) 4);
 
     public final byte id;


### PR DESCRIPTION
* Introduce the ARCHIVING record state and possible throwables in
ShareGroupDLQ interface.
* The ARCHIVING state will precede ARCHIVED and the transition will
happen on successful DLQ or failure after max retries.

Reviewers: Andrew Schofield <aschofield@confluent.io>
