### PR TITLE
KAFKA-20253: Fix high CPU spin loop after failed SASL re-authentication

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1515,6 +1515,11 @@ public abstract class AbstractCoordinator implements Closeable {
                             // probably make sure the coordinator is still healthy.
                             markCoordinatorUnknown("session timed out without receiving a "
                                     + "heartbeat response");
+                            // KAFKA-20253: Reset the session timer to prevent a tight loop where the
+                            // coordinator is rediscovered but immediately marked unknown again because
+                            // the session timer remains expired. This can happen after a transient
+                            // authentication failure where heartbeats could not be sent.
+                            heartbeat.resetSessionTimeout();
                         } else if (heartbeat.pollTimeoutExpired(now)) {
                             // the poll timeout has expired, which means that the foreground thread has stalled
                             // in between calls to poll().

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -251,7 +251,15 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
     @Override
     public long maximumTimeToWait(long currentTimeMs) {
         pollTimer.update(currentTimeMs);
-        if (pollTimer.isExpired() || (membershipManager().shouldHeartbeatNow() && !heartbeatRequestState.requestInFlight())) {
+        if (pollTimer.isExpired()) {
+            return 0L;
+        }
+        // KAFKA-20253: Only return 0 when we need an immediate heartbeat AND the coordinator
+        // is available to receive it. Without this check, the consumer spins with 0 timeout
+        // when the coordinator is unavailable (e.g., after a re-authentication failure), because
+        // poll() returns EMPTY but maximumTimeToWait() keeps returning 0.
+        if (membershipManager().shouldHeartbeatNow() && !heartbeatRequestState.requestInFlight()
+                && coordinatorRequestManager.coordinator().isPresent()) {
             return 0L;
         }
         return Math.min(pollTimer.remainingMs() / 2, heartbeatRequestState.timeToNextHeartbeatMs(currentTimeMs));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -375,6 +375,67 @@ public class ConsumerHeartbeatRequestManagerTest {
     }
 
     @Test
+    public void testMaximumTimeToWaitDoesNotSpinWhenCoordinatorUnavailable() {
+        // KAFKA-20253: When shouldHeartbeatNow() is true but the coordinator is not available
+        // (e.g., after re-authentication failure), maximumTimeToWait() should NOT return 0
+        // to avoid a CPU spin loop.
+        when(membershipManager.shouldSkipHeartbeat()).thenReturn(false);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
+
+        long waitTime = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(waitTime > 0,
+            "maximumTimeToWait() should not return 0 when coordinator is unavailable, " +
+            "to avoid a CPU spin loop. Got: " + waitTime);
+
+        // poll() should return EMPTY since coordinator is unavailable
+        NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(0, result.unsentRequests.size(),
+            "No heartbeat should be sent when coordinator is unavailable");
+    }
+
+    @Test
+    public void testMaximumTimeToWaitReturnsZeroWhenCoordinatorAvailable() {
+        // Complementary test: when coordinator IS available and shouldHeartbeatNow() is true,
+        // maximumTimeToWait() SHOULD return 0 (original behavior preserved).
+        when(membershipManager.shouldSkipHeartbeat()).thenReturn(false);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mock(Node.class)));
+
+        assertEquals(0, heartbeatRequestManager.maximumTimeToWait(time.milliseconds()),
+            "maximumTimeToWait() should return 0 when coordinator is available and heartbeat needed now");
+    }
+
+    @Test
+    public void testNoSpinLoopAfterAuthenticationFailureAndRecovery() {
+        // KAFKA-20253: Simulate the full scenario - heartbeat sent, auth failure, then coordinator
+        // becomes unavailable. The consumer should not spin.
+        createHeartbeatRequestStateWithZeroHeartbeatInterval();
+
+        // Send initial heartbeat
+        NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, result.unsentRequests.size());
+
+        // Simulate authentication failure on the heartbeat response
+        result.unsentRequests.get(0).handler().onFailure(time.milliseconds(),
+            new AuthenticationException("SASL re-authentication failed"));
+
+        // Coordinator becomes unavailable after auth failure
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+
+        // maximumTimeToWait should NOT return 0 (would cause spin loop)
+        long waitTime = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(waitTime > 0,
+            "After auth failure with coordinator unavailable, maximumTimeToWait() should not " +
+            "return 0. Got: " + waitTime);
+
+        // poll should return empty (no coordinator to send to)
+        result = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(0, result.unsentRequests.size());
+    }
+
+    @Test
     public void testNetworkTimeout() {
         // The initial heartbeatInterval is set to 0
         createHeartbeatRequestStateWithZeroHeartbeatInterval();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
@@ -111,6 +111,31 @@ public class HeartbeatTest {
     }
 
     @Test
+    public void testSessionTimeoutResetPreventsSpinLoop() {
+        // KAFKA-20253: After session timeout expires, resetSessionTimeout() should be called
+        // to prevent a tight loop where the coordinator is rediscovered but immediately marked
+        // unknown again because the session timer remains expired.
+        heartbeat.sentHeartbeat(time.milliseconds());
+        time.sleep(sessionTimeoutMs + 5);
+        assertTrue(heartbeat.sessionTimeoutExpired(time.milliseconds()),
+            "Session should have timed out");
+
+        // Simulating what HeartbeatThread does: after detecting session timeout,
+        // it marks coordinator unknown and resets the session timer.
+        heartbeat.resetSessionTimeout();
+
+        // After reset, session timeout should no longer be expired,
+        // allowing the coordinator to be used once it's rediscovered.
+        assertFalse(heartbeat.sessionTimeoutExpired(time.milliseconds()),
+            "Session timeout should not be expired after reset");
+
+        // The heartbeat timer should still be expired (we don't reset that),
+        // so the next heartbeat can be sent when the coordinator is found.
+        assertTrue(heartbeat.shouldHeartbeat(time.milliseconds()),
+            "Heartbeat should be due after session timeout reset");
+    }
+
+    @Test
     public void testPollTimeout() {
         assertFalse(heartbeat.pollTimeoutExpired(time.milliseconds()));
         time.sleep(maxPollIntervalMs / 2);


### PR DESCRIPTION
## Summary

Fixes [KAFKA-20253](https://issues.apache.org/jira/browse/KAFKA-20253): After a SASL_OAUTHBEARER re-authentication failure followed by successful recovery, consumers could enter a high CPU spin loop (100% for ClassicKafkaConsumer, ~40-50% for AsyncKafkaConsumer).

### Root Cause

**AsyncKafkaConsumer (`AbstractHeartbeatRequestManager`):**
- `maximumTimeToWait()` returned 0 when `shouldHeartbeatNow()` was true but the coordinator was unavailable (e.g., disconnected after auth failure)
- `poll()` correctly returned `EMPTY` (no coordinator to send to), but the 0 wait time caused the background thread to immediately poll again in a tight loop
- This resulted in continuous `SelectorImpl.selectNow()` calls consuming ~40-50% CPU

**ClassicKafkaConsumer (`AbstractCoordinator.HeartbeatThread`):**
- When `heartbeat.sessionTimeoutExpired()` was true, `markCoordinatorUnknown()` was called without resetting the session timer
- After coordinator rediscovery, the expired session timer immediately triggered another `markCoordinatorUnknown()`, creating a find-coordinator → mark-unknown → find-coordinator cycle
- This resulted in 100% CPU consumption

### Fix

1. **`AbstractHeartbeatRequestManager.maximumTimeToWait()`**: Added coordinator availability check before returning 0. When `shouldHeartbeatNow()` is true but coordinator is unavailable, falls through to the normal wait time calculation instead of returning 0.

2. **`AbstractCoordinator.HeartbeatThread`**: Added `heartbeat.resetSessionTimeout()` after handling session timeout expiry, preventing the session timer from remaining stuck in an expired state after coordinator rediscovery.

### Testing

- Added `testMaximumTimeToWaitDoesNotSpinWhenCoordinatorUnavailable` — verifies `maximumTimeToWait()` returns non-zero when coordinator is unavailable
- Added `testMaximumTimeToWaitReturnsZeroWhenCoordinatorAvailable` — verifies original behavior is preserved when coordinator IS available
- Added `testNoSpinLoopAfterAuthenticationFailureAndRecovery` — end-to-end scenario: heartbeat sent → auth failure → coordinator unavailable → no spin
- Added `testSessionTimeoutResetPreventsSpinLoop` — verifies session timer reset after expiry

All existing tests in `ConsumerHeartbeatRequestManagerTest`, `ShareHeartbeatRequestManagerTest`, `AbstractCoordinatorTest`, and `HeartbeatTest` continue to pass.

### Committer Checklist (Conditions for Approval)

- [x] Has associated JIRA: [KAFKA-20253](https://issues.apache.org/jira/browse/KAFKA-20253)
- [x] PR title starts with JIRA reference
- [x] Tests included
- [x] No breaking API changes