### PR TITLE
MINOR: Revise Topic Resolving Logic in OffsetCommit Request to Prevent Race Condition

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -312,16 +312,12 @@ class KafkaApis(val requestChannel: RequestChannel,
         } else {
           // For lower API versions, the topic id may not be included in the request.
           // In this case, we resolve the topic id from metadata cache to ensure that the topic exists.
-          // If the topic doesn't exist, the currentTopicId will fallback to ZERO_UUID.
-          val currentTopicId = if (topic.topicId != Uuid.ZERO_UUID) {
-            topic.topicId
-          } else {
-            val resolvedTopicId = metadataCache.getTopicId(topic.name)
-            if (resolvedTopicId != Uuid.ZERO_UUID) topic.setTopicId(resolvedTopicId)
-            resolvedTopicId
+          // If the topic doesn't exist, the topicId will fallback to ZERO_UUID.
+          if (!useTopicIds) {
+            topic.setTopicId(metadataCache.getTopicId(topic.name))
           }
 
-          if (currentTopicId == Uuid.ZERO_UUID) {
+          if (topic.topicId == Uuid.ZERO_UUID) {
             // If the topic is unknown, we add the topic and all its partitions
             // to the response with UNKNOWN_TOPIC_OR_PARTITION.
             responseBuilder.addPartitions[OffsetCommitRequestData.OffsetCommitRequestPartition](

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -313,8 +313,13 @@ class KafkaApis(val requestChannel: RequestChannel,
           // For lower API versions, the topic id may not be included in the request.
           // In this case, we resolve the topic id from metadata cache to ensure that the topic exists.
           // If the topic doesn't exist, the currentTopicId will fallback to ZERO_UUID.
-          val currentTopicId = metadataCache.getTopicId(topic.name)
-          topic.setTopicId(currentTopicId)
+          val currentTopicId = if (topic.topicId != Uuid.ZERO_UUID) {
+            topic.topicId
+          } else {
+            val resolvedTopicId = metadataCache.getTopicId(topic.name)
+            if (resolvedTopicId != Uuid.ZERO_UUID) topic.setTopicId(resolvedTopicId)
+            resolvedTopicId
+          }
 
           if (currentTopicId == Uuid.ZERO_UUID) {
             // If the topic is unknown, we add the topic and all its partitions
@@ -324,7 +329,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           } else {
             // Otherwise, we check all partitions to ensure that they all exist.
             val topicWithValidPartitions = new OffsetCommitRequestData.OffsetCommitRequestTopic()
-              .setTopicId(topic.topicId())
+              .setTopicId(topic.topicId)
               .setName(topic.name)
 
             topic.partitions.forEach { partition =>
@@ -332,7 +337,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                 topicWithValidPartitions.partitions.add(partition)
               } else {
                 responseBuilder.addPartition(
-                  topic.topicId(),
+                  topic.topicId,
                   topic.name,
                   partition.partitionIndex,
                   Errors.UNKNOWN_TOPIC_OR_PARTITION


### PR DESCRIPTION
## Summary

This PR slightly revises the logic to resolve topicId in an offset
commit request. It avoids setting topicId twice if `topic.topicId`
already exists, avoiding race condition in between. This is a follow-up
of https://github.com/apache/kafka/pull/21692

Reviewers: David Jacot <djacot@confluent.io>
