### PR TITLE
KAFKA-20333: Fix flaky consumer test

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerPollTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/PlaintextConsumerPollTest.java
@@ -418,7 +418,7 @@ public class PlaintextConsumerPollTest {
         Map<String, Object> config = Map.of(
             GROUP_PROTOCOL_CONFIG, groupProtocol.name().toLowerCase(Locale.ROOT),
             GROUP_ID_CONFIG, "test-group",
-            MAX_POLL_INTERVAL_MS_CONFIG, 100
+            MAX_POLL_INTERVAL_MS_CONFIG, 1000
         );
         // use consumers defined in this class plus one additional consumer
         // Use topic defined in this class + one additional topic


### PR DESCRIPTION
Flaky on trunk, log showed poll timer expired, so increasing it to 1000
(aligned with other tests in the file) to ensure that it's still low
enough so that when a consumer poll is stopped it eventually hits the
poll timer and leaves, but not too low that the other stable consumers
may get an expired poll-timer across rebalances.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
