### PR TITLE
KAFKA-14922: Fail fast if application.id does not exist as consumer group in StreamsResetter

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -207,7 +207,6 @@ public class StreamsResetter {
         }
     }
 
-
     // visible for testing
     void maybeDeleteActiveConsumers(final String groupId,
                                     final Admin adminClient,

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -562,7 +562,6 @@ public class StreamsResetter {
     }
 
     private int maybeDeleteInternalTopics(final Admin adminClient, final StreamsResetterOptions options) {
-
         final List<String> inferredInternalTopics = allTopics.stream()
                 .filter(options::isInferredInternalTopic)
                 .collect(Collectors.toList());

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -20,6 +20,8 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsOptions;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListGroupsOptions;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -39,9 +41,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.Exit;
 import org.apache.kafka.server.util.CommandDefaultOptions;
 import org.apache.kafka.server.util.CommandLineUtils;
-import org.apache.kafka.clients.admin.GroupListing;
-import org.apache.kafka.clients.admin.ListGroupsOptions;
-import java.util.concurrent.TimeoutException;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.time.Duration;
@@ -58,6 +58,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import joptsimple.OptionException;

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -17,11 +17,10 @@
 package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsOptions;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
-import org.apache.kafka.clients.admin.GroupListing;
-import org.apache.kafka.clients.admin.ListGroupsOptions;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -29,6 +28,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
@@ -156,7 +156,13 @@ public class StreamsResetter {
             properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServerValue);
 
             try (Admin adminClient = Admin.create(properties)) {
-                maybeDeleteActiveConsumers(groupId, adminClient, options.hasForce());
+                final boolean force = options.hasForce();
+
+                maybeDeleteActiveConsumers(groupId, adminClient, force);
+
+                if (!force) {
+                    validateApplicationIdExists(groupId, adminClient);
+                }
 
                 allTopics.clear();
                 allTopics.addAll(adminClient.listTopics().names().get(60, TimeUnit.SECONDS));
@@ -184,19 +190,29 @@ public class StreamsResetter {
         }
     }
 
+    // Note: this check confirms the application.id exists as a consumer group,
+    // but cannot prevent topic deletion for other applications whose IDs share
+    // this application.id as a prefix (e.g. resetting "foo" may affect "foo-v2"
+    // topics). This is a known limitation of prefix-based topic inference.
     void validateApplicationIdExists(final String applicationId,
                                              final Admin adminClient)
-            throws ExecutionException, InterruptedException, TimeoutException {
+            throws InterruptedException, TimeoutException {
+        ConsumerGroupDescription description = null;
+        try {
+            final Map<String, ConsumerGroupDescription> groups = adminClient
+                    .describeConsumerGroups(Set.of(applicationId))
+                    .all()
+                    .get(60, TimeUnit.SECONDS);
 
-        final Collection<GroupListing> groups = adminClient
-                .listGroups(new ListGroupsOptions())
-                .all()
-                .get(60, TimeUnit.SECONDS);
+            description = groups.get(applicationId);
+        } catch (final ExecutionException e) {
+            if (!(e.getCause() instanceof GroupIdNotFoundException)) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+        System.out.println("This method is invoked");
 
-        final boolean groupExists = groups.stream()
-                .anyMatch(group -> group.groupId().equals(applicationId));
-
-        if (!groupExists) {
+        if (description == null || GroupState.DEAD.equals(description.groupState())) {
             throw new IllegalArgumentException(
                     "No consumer group found with application.id '" + applicationId + "'. "
                             + "Refusing to delete internal topics to avoid accidentally removing topics "
@@ -547,9 +563,6 @@ public class StreamsResetter {
     }
 
     private int maybeDeleteInternalTopics(final Admin adminClient, final StreamsResetterOptions options) throws ExecutionException, InterruptedException, TimeoutException {
-        if (!options.hasForce()) {
-            validateApplicationIdExists(options.applicationId(), adminClient);
-        }
 
         final List<String> inferredInternalTopics = allTopics.stream()
                 .filter(options::isInferredInternalTopic)

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -39,7 +39,9 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.Exit;
 import org.apache.kafka.server.util.CommandDefaultOptions;
 import org.apache.kafka.server.util.CommandLineUtils;
-
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListGroupsOptions;
+import java.util.concurrent.TimeoutException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.time.Duration;
@@ -153,6 +155,9 @@ public class StreamsResetter {
             properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServerValue);
 
             try (Admin adminClient = Admin.create(properties)) {
+                if (!options.hasForce()) {
+                    validateApplicationIdExists(groupId, adminClient);
+                }
                 maybeDeleteActiveConsumers(groupId, adminClient, options.hasForce());
 
                 allTopics.clear();
@@ -180,6 +185,31 @@ public class StreamsResetter {
             return EXIT_CODE_ERROR;
         }
     }
+
+
+    void validateApplicationIdExists(final String applicationId,
+                                             final Admin adminClient)
+            throws ExecutionException, InterruptedException, TimeoutException {
+
+        final Collection<GroupListing> groups = adminClient
+                .listGroups(new ListGroupsOptions())
+                .all()
+                .get(60, TimeUnit.SECONDS);
+
+        final boolean groupExists = groups.stream()
+                .anyMatch(group -> group.groupId().equals(applicationId));
+
+        if (!groupExists) {
+            throw new IllegalArgumentException(
+                    "No consumer group found with application.id '" + applicationId + "'. "
+                            + "Refusing to delete internal topics to avoid accidentally removing topics "
+                            + "that belong to other applications sharing a similar name prefix. "
+                            + "Verify your --application-id value. "
+                            + "Re-run with --force to bypass this check."
+            );
+        }
+    }
+
 
     // visible for testing
     void maybeDeleteActiveConsumers(final String groupId,

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -210,7 +210,6 @@ public class StreamsResetter {
                 throw new RuntimeException(e.getCause());
             }
         }
-        System.out.println("This method is invoked");
 
         if (description == null || GroupState.DEAD.equals(description.groupState())) {
             throw new IllegalArgumentException(
@@ -562,7 +561,7 @@ public class StreamsResetter {
         return validatedTopicPartitionsOffsets;
     }
 
-    private int maybeDeleteInternalTopics(final Admin adminClient, final StreamsResetterOptions options) throws ExecutionException, InterruptedException, TimeoutException {
+    private int maybeDeleteInternalTopics(final Admin adminClient, final StreamsResetterOptions options) {
 
         final List<String> inferredInternalTopics = allTopics.stream()
                 .filter(options::isInferredInternalTopic)

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -156,9 +156,6 @@ public class StreamsResetter {
             properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServerValue);
 
             try (Admin adminClient = Admin.create(properties)) {
-                if (!options.hasForce()) {
-                    validateApplicationIdExists(groupId, adminClient);
-                }
                 maybeDeleteActiveConsumers(groupId, adminClient, options.hasForce());
 
                 allTopics.clear();
@@ -551,7 +548,11 @@ public class StreamsResetter {
         return validatedTopicPartitionsOffsets;
     }
 
-    private int maybeDeleteInternalTopics(final Admin adminClient, final StreamsResetterOptions options) {
+    private int maybeDeleteInternalTopics(final Admin adminClient, final StreamsResetterOptions options) throws ExecutionException, InterruptedException, TimeoutException {
+        if (!options.hasForce()) {
+            validateApplicationIdExists(options.applicationId(), adminClient);
+        }
+
         final List<String> inferredInternalTopics = allTopics.stream()
                 .filter(options::isInferredInternalTopic)
                 .collect(Collectors.toList());

--- a/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/StreamsResetter.java
@@ -184,7 +184,6 @@ public class StreamsResetter {
         }
     }
 
-
     void validateApplicationIdExists(final String applicationId,
                                              final Admin adminClient)
             throws ExecutionException, InterruptedException, TimeoutException {

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
@@ -232,6 +232,7 @@ public class ResetIntegrationTest {
         cluster.createTopic(INPUT_TOPIC, 1, (short) 1);
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--input-topics", INPUT_TOPIC
         };

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
@@ -379,12 +379,14 @@ public class ResetIntegrationTest {
     public void shouldNotAllowToResetWhenSpecifiedInternalTopicIsNotInternal(ClusterInstance cluster) throws Exception {
         final String appId = generateAppId();
         cluster.createTopic(INPUT_TOPIC, 1, (short) 1);
+
         final String[] parameters = new String[] {
             "--application-id", appId,
             "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--internal-topics", INPUT_TOPIC
         };
+
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
@@ -196,6 +196,7 @@ public class ResetIntegrationTest {
         final String appId = generateAppId();
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--input-topics", NON_EXISTING_TOPIC
         };

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
@@ -213,6 +213,7 @@ public class ResetIntegrationTest {
         cluster.createTopic(INPUT_TOPIC, 1, (short) 1);
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--input-topics", INPUT_TOPIC
         };
@@ -250,6 +251,7 @@ public class ResetIntegrationTest {
         cluster.createTopic(INPUT_TOPIC, 1, (short) 1);
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--input-topics", INPUT_TOPIC
         };
@@ -268,6 +270,7 @@ public class ResetIntegrationTest {
         final String appId = generateAppId();
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--intermediate-topics", NON_EXISTING_TOPIC
         };
@@ -284,6 +287,7 @@ public class ResetIntegrationTest {
         final String appId = generateAppId();
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--internal-topics", NON_EXISTING_TOPIC
         };
@@ -296,11 +300,88 @@ public class ResetIntegrationTest {
     }
 
     @ClusterTest
+    public void shouldSucceedWhenApplicationIdExistsAsConsumerGroup(ClusterInstance cluster) throws Exception {
+        try (Admin adminClient = cluster.admin()) {
+            final String appID = generateAppId();
+            prepare(cluster, null, appID);
+            streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+            final KafkaStreams streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+            startApplicationAndWaitUntilRunning(streams);
+            waitUntilMinKeyValueRecordsReceived(cluster, resultConsumerConfig, OUTPUT_TOPIC, 10);
+            streams.close();
+            waitForEmptyConsumerGroup(adminClient, appID);
+
+            final KafkaStreams cleanupInstance = new KafkaStreams(
+                    setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+            cleanupInstance.cleanUp();
+            cleanupInstance.close();
+
+            final String[] parameters = new String[] {
+                "--application-id", appID,
+                "--bootstrap-server", cluster.bootstrapServers()
+            };
+            final Properties cleanUpConfig = new Properties();
+            cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+            cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
+
+            final int exitCode = new StreamsResetter().execute(parameters, cleanUpConfig);
+            assertEquals(0, exitCode);
+        }
+    }
+
+    @ClusterTest
+    public void shouldFailWithErrorWhenApplicationIdDoesNotExist(ClusterInstance cluster) {
+        final String nonExistentAppID = generateAppId() + "-does-not-exist";
+
+        final String[] parameters = new String[] {
+            "--application-id", nonExistentAppID,
+            "--bootstrap-server", cluster.bootstrapServers()
+        };
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
+
+        final String errorOutput = ToolsTestUtils.captureStandardErr(() -> {
+            final int exitCode = new StreamsResetter().execute(parameters, cleanUpConfig);
+            assertEquals(1, exitCode);
+        });
+
+        assertTrue(errorOutput.contains(nonExistentAppID));
+        assertTrue(errorOutput.contains("Refusing to delete internal topics"));
+    }
+
+    @ClusterTest
+    public void shouldSucceedWhenApplicationIdDoesNotExistWithForce(ClusterInstance cluster) {
+
+        final String nonExistentAppID = generateAppId() + "-does-not-exist";
+
+        final String[] parameters = new String[] {
+            "--application-id", nonExistentAppID,
+            "--force",
+            "--bootstrap-server", cluster.bootstrapServers()
+        };
+
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "100");
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG,
+                Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
+
+        final String output = ToolsTestUtils.captureStandardOut(() -> {
+            final int exitCode = new StreamsResetter().execute(parameters, cleanUpConfig);
+            assertEquals(0, exitCode);
+        });
+
+        assertTrue(output.contains("Done."));
+    }
+
+    @ClusterTest
     public void shouldNotAllowToResetWhenSpecifiedInternalTopicIsNotInternal(ClusterInstance cluster) throws Exception {
         final String appId = generateAppId();
         cluster.createTopic(INPUT_TOPIC, 1, (short) 1);
         final String[] parameters = new String[] {
             "--application-id", appId,
+            "--force",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--internal-topics", INPUT_TOPIC
         };

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -446,8 +446,11 @@ public class StreamsResetterTest {
         when(describeResult.all()).thenReturn(future);
         when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
-        assertThrows(IllegalArgumentException.class,
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+
+        assertTrue(ex.getMessage().contains(groupId));
+        assertTrue(ex.getMessage().contains("--force"));
     }
 
     @Test
@@ -494,26 +497,6 @@ public class StreamsResetterTest {
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
 
         streamsResetter.validateApplicationIdExists(existingGroupId, adminClient);
-    }
-
-    @Test
-    public void shouldFailWithTypoInApplicationId() throws Exception {
-        final String groupId = "my-ap";
-
-        final Admin adminClient = mock(Admin.class);
-        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
-
-        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
-        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
-
-        when(describeResult.all()).thenReturn(future);
-        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
-
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
-
-        assertTrue(ex.getMessage().contains("my-ap"));
-        assertTrue(ex.getMessage().contains("--force"));
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -19,9 +19,6 @@ package org.apache.kafka.tools;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
-import org.apache.kafka.clients.admin.GroupListing;
-import org.apache.kafka.clients.admin.ListGroupsOptions;
-import org.apache.kafka.clients.admin.ListGroupsResult;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.MemberToRemove;
 import org.apache.kafka.clients.admin.MockAdminClient;
@@ -33,7 +30,6 @@ import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.GroupState;
-import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -54,7 +50,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -437,20 +432,19 @@ public class StreamsResetterTest {
             return topicPartitionToOffsetAndTimestamp;
         }
     }
+
     @Test
     public void shouldFailIfApplicationIdDoesNotExistAsConsumerGroup() throws Exception {
         final String groupId = "my-app";
 
         final Admin adminClient = mock(Admin.class);
-        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
 
-        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
-                List.of(
-                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
-                        new GroupListing("my-app-v2", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
-                )
-        ));
-        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
@@ -461,17 +455,17 @@ public class StreamsResetterTest {
         final String groupId = "my-app-v1";
 
         final Admin adminClient = mock(Admin.class);
-        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
+        final ConsumerGroupDescription stableDescription = mock(ConsumerGroupDescription.class);
 
-        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
-                List.of(
-                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
-                        new GroupListing("my-app-v2", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
-                )
-        ));
-        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+        when(stableDescription.groupState()).thenReturn(GroupState.STABLE);
 
-        // should not throw
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.complete(Map.of(groupId, stableDescription));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
+
         streamsResetter.validateApplicationIdExists(groupId, adminClient);
     }
 
@@ -480,10 +474,13 @@ public class StreamsResetterTest {
         final String groupId = "my-app";
 
         final Admin adminClient = mock(Admin.class);
-        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
 
-        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(List.of()));
-        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
@@ -491,18 +488,16 @@ public class StreamsResetterTest {
 
     @Test
     public void shouldFailIfApplicationIdIsAPrefixOfExistingGroup() throws Exception {
-        // "my-app" is a prefix of "my-app-v1" but NOT an exact match
         final String groupId = "my-app";
 
         final Admin adminClient = mock(Admin.class);
-        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
 
-        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
-                List.of(
-                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
-                )
-        ));
-        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
@@ -513,15 +508,13 @@ public class StreamsResetterTest {
         final String groupId = "my-ap";
 
         final Admin adminClient = mock(Admin.class);
-        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
 
-        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
-                List.of(
-                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
-                        new GroupListing("my-app-v2", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
-                )
-        ));
-        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
@@ -535,17 +528,39 @@ public class StreamsResetterTest {
         final String groupId = "foo";
 
         final Admin adminClient = mock(Admin.class);
-        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
 
-        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
-                List.of(
-                        new GroupListing("foobar", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
-                        new GroupListing("foo-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
-                )
-        ));
-        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+    }
+
+    @Test
+    public void shouldThrowWhenApplicationIdGroupIsDead() throws Exception {
+        final String groupId = "test-app-dead-group";
+
+        final Admin adminClient = mock(Admin.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
+        final ConsumerGroupDescription deadDescription = mock(ConsumerGroupDescription.class);
+
+        when(deadDescription.groupState()).thenReturn(GroupState.DEAD);
+
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.complete(Map.of(groupId, deadDescription));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+
+        assertTrue(exception.getMessage().contains(groupId));
+        assertTrue(exception.getMessage().contains("Refusing to delete internal topics"));
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -510,7 +510,6 @@ public class StreamsResetterTest {
 
     @Test
     public void shouldFailWithTypoInApplicationId() throws Exception {
-        // user types "my-ap" instead of "my-app-v1"
         final String groupId = "my-ap";
 
         final Admin adminClient = mock(Admin.class);
@@ -527,14 +526,12 @@ public class StreamsResetterTest {
         final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
 
-        // error message should mention the bad application-id and --force hint
         assertTrue(ex.getMessage().contains("my-ap"));
         assertTrue(ex.getMessage().contains("--force"));
     }
 
     @Test
     public void shouldMatchExactGroupIdNotSubstring() throws Exception {
-        // "foo" should NOT match "foobar" or "foo-v1"
         final String groupId = "foo";
 
         final Admin adminClient = mock(Admin.class);

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -490,11 +490,9 @@ public class StreamsResetterTest {
         when(existingResult.all()).thenReturn(existingFuture);
         when(adminClient.describeConsumerGroups(Set.of(existingGroupId))).thenReturn(existingResult);
 
-        // querying "my-app" still fails even though "my-app-v32" is a real, existing group
         assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
 
-        // querying "my-app-v2" directly succeeds — confirms it's a genuine, resolvable group
         streamsResetter.validateApplicationIdExists(existingGroupId, adminClient);
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -62,6 +62,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListGroupsOptions;
+import org.apache.kafka.clients.admin.ListGroupsResult;
+
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.GroupType;
+
+import java.util.Optional;
 
 @Timeout(value = 600)
 public class StreamsResetterTest {
@@ -430,5 +438,126 @@ public class StreamsResetterTest {
             timestampsToSearch.keySet().forEach(k -> topicPartitionToOffsetAndTimestamp.put(k, null));
             return topicPartitionToOffsetAndTimestamp;
         }
+    }
+    @Test
+    public void shouldFailIfApplicationIdDoesNotExistAsConsumerGroup() throws Exception {
+        final String groupId = "my-app";
+
+        final Admin adminClient = mock(Admin.class);
+        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+
+        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
+                List.of(
+                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
+                        new GroupListing("my-app-v2", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
+                )
+        ));
+        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+    }
+
+    @Test
+    public void shouldSucceedIfApplicationIdExistsAsConsumerGroup() throws Exception {
+        final String groupId = "my-app-v1";
+
+        final Admin adminClient = mock(Admin.class);
+        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+
+        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
+                List.of(
+                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
+                        new GroupListing("my-app-v2", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
+                )
+        ));
+        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+
+        // should not throw
+        streamsResetter.validateApplicationIdExists(groupId, adminClient);
+    }
+
+    @Test
+    public void shouldFailIfNoConsumerGroupsExistAtAll() throws Exception {
+        final String groupId = "my-app";
+
+        final Admin adminClient = mock(Admin.class);
+        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+
+        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(List.of()));
+        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+    }
+
+    @Test
+    public void shouldFailIfApplicationIdIsAPrefixOfExistingGroup() throws Exception {
+        // "my-app" is a prefix of "my-app-v1" but NOT an exact match
+        final String groupId = "my-app";
+
+        final Admin adminClient = mock(Admin.class);
+        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+
+        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
+                List.of(
+                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
+                )
+        ));
+        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+    }
+
+    @Test
+    public void shouldFailWithTypoInApplicationId() throws Exception {
+        // user types "my-ap" instead of "my-app-v1"
+        final String groupId = "my-ap";
+
+        final Admin adminClient = mock(Admin.class);
+        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+
+        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
+                List.of(
+                        new GroupListing("my-app-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
+                        new GroupListing("my-app-v2", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
+                )
+        ));
+        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+
+        // error message should mention the bad application-id and --force hint
+        assertTrue(ex.getMessage().contains("my-ap"));
+        assertTrue(ex.getMessage().contains("--force"));
+    }
+
+    @Test
+    public void shouldMatchExactGroupIdNotSubstring() throws Exception {
+        // "foo" should NOT match "foobar" or "foo-v1"
+        final String groupId = "foo";
+
+        final Admin adminClient = mock(Admin.class);
+        final ListGroupsResult listGroupsResult = mock(ListGroupsResult.class);
+
+        when(listGroupsResult.all()).thenReturn(KafkaFutureImpl.completedFuture(
+                List.of(
+                        new GroupListing("foobar", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE)),
+                        new GroupListing("foo-v1", Optional.of(GroupType.CLASSIC), "", Optional.of(GroupState.STABLE))
+                )
+        ));
+        when(adminClient.listGroups(any(ListGroupsOptions.class))).thenReturn(listGroupsResult);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+    }
+
+    @Test
+    public void shouldSkipValidationWhenForceOptionProvided() throws Exception {
+        final Admin adminClient = mock(Admin.class);
+
+        verify(adminClient, never()).listGroups(any(ListGroupsOptions.class));
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -452,27 +452,6 @@ public class StreamsResetterTest {
     }
 
     @Test
-    public void shouldMatchExactGroupIdNotSubstring() throws Exception {
-        final String groupId = "my-app";
-        final String existingGroupId = "my-app-v2";
-
-        final Admin adminClient = mock(Admin.class);
-        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
-
-
-        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
-        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
-
-        when(describeResult.all()).thenReturn(future);
-        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
-        assertNotEquals(groupId, existingGroupId);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
-    }
-
-
-    @Test
     public void shouldSucceedIfApplicationIdExistsAsConsumerGroup() throws Exception {
         final String groupId = "my-app-v1";
 
@@ -489,23 +468,6 @@ public class StreamsResetterTest {
         when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         streamsResetter.validateApplicationIdExists(groupId, adminClient);
-    }
-
-    @Test
-    public void shouldFailIfApplicationIdIsAPrefixOfExistingGroup() throws Exception {
-        final String groupId = "my-app";
-
-        final Admin adminClient = mock(Admin.class);
-        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
-
-        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
-        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
-
-        when(describeResult.all()).thenReturn(future);
-        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -551,11 +551,4 @@ public class StreamsResetterTest {
         assertThrows(IllegalArgumentException.class,
                 () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
     }
-
-    @Test
-    public void shouldSkipValidationWhenForceOptionProvided() throws Exception {
-        final Admin adminClient = mock(Admin.class);
-
-        verify(adminClient, never()).listGroups(any(ListGroupsOptions.class));
-    }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -54,7 +54,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -468,6 +467,35 @@ public class StreamsResetterTest {
         when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         streamsResetter.validateApplicationIdExists(groupId, adminClient);
+    }
+
+    @Test
+    public void shouldMatchExactGroupIdNotSubstring() throws Exception {
+        final String groupId = "my-app";
+        final String existingGroupId = "my-app-v2";
+
+        final Admin adminClient = mock(Admin.class);
+
+        final DescribeConsumerGroupsResult notFoundResult = mock(DescribeConsumerGroupsResult.class);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> notFoundFuture = new KafkaFutureImpl<>();
+        notFoundFuture.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+        when(notFoundResult.all()).thenReturn(notFoundFuture);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(notFoundResult);
+
+        final DescribeConsumerGroupsResult existingResult = mock(DescribeConsumerGroupsResult.class);
+        final ConsumerGroupDescription existingDescription = mock(ConsumerGroupDescription.class);
+        when(existingDescription.groupState()).thenReturn(GroupState.STABLE);
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> existingFuture = new KafkaFutureImpl<>();
+        existingFuture.complete(Map.of(existingGroupId, existingDescription));
+        when(existingResult.all()).thenReturn(existingFuture);
+        when(adminClient.describeConsumerGroups(Set.of(existingGroupId))).thenReturn(existingResult);
+
+        // querying "my-app" still fails even though "my-app-v32" is a real, existing group
+        assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+
+        // querying "my-app-v2" directly succeeds — confirms it's a genuine, resolvable group
+        streamsResetter.validateApplicationIdExists(existingGroupId, adminClient);
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -19,6 +19,9 @@ package org.apache.kafka.tools;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListGroupsOptions;
+import org.apache.kafka.clients.admin.ListGroupsResult;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.MemberToRemove;
 import org.apache.kafka.clients.admin.MockAdminClient;
@@ -29,6 +32,8 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -49,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -62,14 +68,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.apache.kafka.clients.admin.GroupListing;
-import org.apache.kafka.clients.admin.ListGroupsOptions;
-import org.apache.kafka.clients.admin.ListGroupsResult;
-
-import org.apache.kafka.common.GroupState;
-import org.apache.kafka.common.GroupType;
-
-import java.util.Optional;
 
 @Timeout(value = 600)
 public class StreamsResetterTest {

--- a/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/StreamsResetterTest.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -451,6 +452,27 @@ public class StreamsResetterTest {
     }
 
     @Test
+    public void shouldMatchExactGroupIdNotSubstring() throws Exception {
+        final String groupId = "my-app";
+        final String existingGroupId = "my-app-v2";
+
+        final Admin adminClient = mock(Admin.class);
+        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
+
+
+        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
+
+        when(describeResult.all()).thenReturn(future);
+        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
+        assertNotEquals(groupId, existingGroupId);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
+    }
+
+
+    @Test
     public void shouldSucceedIfApplicationIdExistsAsConsumerGroup() throws Exception {
         final String groupId = "my-app-v1";
 
@@ -467,23 +489,6 @@ public class StreamsResetterTest {
         when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
 
         streamsResetter.validateApplicationIdExists(groupId, adminClient);
-    }
-
-    @Test
-    public void shouldFailIfNoConsumerGroupsExistAtAll() throws Exception {
-        final String groupId = "my-app";
-
-        final Admin adminClient = mock(Admin.class);
-        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
-
-        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
-        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
-
-        when(describeResult.all()).thenReturn(future);
-        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
     }
 
     @Test
@@ -521,23 +526,6 @@ public class StreamsResetterTest {
 
         assertTrue(ex.getMessage().contains("my-ap"));
         assertTrue(ex.getMessage().contains("--force"));
-    }
-
-    @Test
-    public void shouldMatchExactGroupIdNotSubstring() throws Exception {
-        final String groupId = "foo";
-
-        final Admin adminClient = mock(Admin.class);
-        final DescribeConsumerGroupsResult describeResult = mock(DescribeConsumerGroupsResult.class);
-
-        final KafkaFutureImpl<Map<String, ConsumerGroupDescription>> future = new KafkaFutureImpl<>();
-        future.completeExceptionally(new GroupIdNotFoundException("Group " + groupId + " not found."));
-
-        when(describeResult.all()).thenReturn(future);
-        when(adminClient.describeConsumerGroups(Set.of(groupId))).thenReturn(describeResult);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> streamsResetter.validateApplicationIdExists(groupId, adminClient));
     }
 
     @Test


### PR DESCRIPTION
kafka-streams-application-reset uses a topic name prefix match to infer
internal topics to delete. This means that running the tool with
--application-id my-app would silently delete internal topics belonging
to my-app-v1 and my-app-v2 — any application whose application.id
shares the same prefix. This is especially dangerous with typos or when
multiple applications share a common naming convention.

**Solution**
Added a validateApplicationIdExists() method that calls listGroups()
to verify the provided application.id exists as a consumer group before
any topic deletion is attempted. Since Kafka Streams maps application.id
1:1 to consumer group.id, this is a reliable and cheap check.

If the group does not exist → fail fast with a clear error message  If
the group exists → proceed as normal  If --force is provided → skip the
check (existing behaviour preserved)

**Changes**

StreamsResetter.java — added validateApplicationIdExists() called

**Screenshot of output:**
<img width="1668" height="385" alt="Screenshot 2026-03-19 at 12 34
08 PM"
src="https://github.com/user-attachments/assets/9d64bb68-4797-4ab1-9d31-c07fffcad878"
/>

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
