### PR TITLE
KAFKA-20329: Test headers dsl.store.format further (4/N)

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
@@ -49,8 +49,8 @@ import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Properties;
 
@@ -82,8 +82,10 @@ public class CogroupedKStreamImplTest {
     private static final Initializer<Integer> SUM_INITIALIZER = () -> 0;
 
 
-    @BeforeEach
-    public void setup() {
+    private void setup(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed.with(Serdes.String(), Serdes.String()));
 
@@ -91,73 +93,101 @@ public class CogroupedKStreamImplTest {
         cogroupedStream = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER);
     }
 
-    @Test
-    public void shouldThrowNPEInCogroupIfKGroupedStreamIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNPEInCogroupIfKGroupedStreamIsNull(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.cogroup(null, MockAggregator.TOSTRING_ADDER));
     }
 
-    @Test
-    public void shouldNotHaveNullAggregatorOnCogroup() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullAggregatorOnCogroup(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.cogroup(groupedStream, null));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(null));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerOnAggregateWitNamed() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerOnAggregateWitNamed(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(null, Named.as("name")));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerOnAggregateWitMaterialized() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerOnAggregateWitMaterialized(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(null, Materialized.as("store")));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerOnAggregateWitNamedAndMaterialized() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerOnAggregateWitNamedAndMaterialized(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(null, Named.as("name"), Materialized.as("store")));
     }
 
-    @Test
-    public void shouldNotHaveNullNamedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullNamedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(STRING_INITIALIZER, (Named) null));
     }
 
-    @Test
-    public void shouldNotHaveNullMaterializedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullMaterializedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(STRING_INITIALIZER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null));
     }
 
-    @Test
-    public void shouldNotHaveNullNamedOnAggregateWithMateriazlied() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullNamedOnAggregateWithMateriazlied(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(STRING_INITIALIZER,  null,  Materialized.as("store")));
     }
 
-    @Test
-    public void shouldNotHaveNullMaterializedOnAggregateWithNames() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullMaterializedOnAggregateWithNames(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(STRING_INITIALIZER, Named.as("name"), null));
     }
 
-    @Test
-    public void shouldNotHaveNullWindowOnWindowedByTime() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullWindowOnWindowedByTime(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.windowedBy((Windows<? extends Window>) null));
     }
 
-    @Test
-    public void shouldNotHaveNullWindowOnWindowedBySession() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullWindowOnWindowedBySession(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.windowedBy((SessionWindows) null));
     }
 
-    @Test
-    public void shouldNotHaveNullWindowOnWindowedBySliding() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullWindowOnWindowedBySliding(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.windowedBy((SlidingWindows) null));
     }
 
-    @Test
-    public void shouldNameProcessorsAndStoreBasedOnNamedParameter() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNameProcessorsAndStoreBasedOnNamedParameter(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -199,8 +229,10 @@ public class CogroupedKStreamImplTest {
                 "      <-- KTABLE-TOSTREAM-0000000005\n\n"));
     }
 
-    @Test
-    public void shouldNameRepartitionTopic() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNameRepartitionTopic(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -253,8 +285,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- KTABLE-TOSTREAM-0000000010\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModification() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModification(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
         final KStream<String, String> test2 = builder.stream("two", stringConsumed);
@@ -306,8 +340,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- KTABLE-TOSTREAM-0000000009\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInSameCogroups() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInSameCogroups(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -387,10 +423,11 @@ public class CogroupedKStreamImplTest {
                         "      <-- KTABLE-TOSTREAM-0000000019\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInSameCogroupsWithOptimization() {
-        final Properties properties = new Properties();
-        properties.setProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInSameCogroupsWithOptimization(final boolean withHeaders) {
+        setup(withHeaders);
+        props.setProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -412,7 +449,7 @@ public class CogroupedKStreamImplTest {
         cogroupedOne.toStream().to(OUTPUT);
         cogroupedTwo.toStream().to("OUTPUT2");
 
-        final String topologyDescription = builder.build(properties).describe().toString();
+        final String topologyDescription = builder.build(props).describe().toString();
 
         assertThat(
                 topologyDescription,
@@ -463,8 +500,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- KTABLE-TOSTREAM-0000000019\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInDifferentCogroups() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInDifferentCogroups(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -534,8 +573,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- COGROUPKSTREAM-AGGREGATE-0000000008, COGROUPKSTREAM-AGGREGATE-0000000009\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInDifferentCogroupsWithOptimization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedInDifferentCogroupsWithOptimization(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final Properties properties = new Properties();
@@ -600,8 +641,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- COGROUPKSTREAM-AGGREGATE-0000000015, COGROUPKSTREAM-AGGREGATE-0000000016\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReused() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReused(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -659,8 +702,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- KSTREAM-SOURCE-0000000014\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedWithOptimization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedReusedWithOptimization(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final Properties properties = new Properties();
@@ -713,8 +758,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- COGROUPKSTREAM-AGGREGATE-STATE-STORE-0000000003-repartition-source\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedRemadeWithOptimization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForUpstreamKeyModificationWithGroupedRemadeWithOptimization(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final Properties properties = new Properties();
@@ -793,8 +840,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- COGROUPKSTREAM-AGGREGATE-0000000016, COGROUPKSTREAM-AGGREGATE-0000000017\n\n"));
     }
 
-    @Test
-    public void shouldInsertRepartitionsTopicForCogroupsUsedTwice() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldInsertRepartitionsTopicForCogroupsUsedTwice(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final Properties properties = new Properties();
@@ -840,8 +889,10 @@ public class CogroupedKStreamImplTest {
                         "      <-- COGROUPKSTREAM-AGGREGATE-0000000012\n\n"));
     }
 
-    @Test
-    public void shouldCogroupAndAggregateSingleKStreams() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCogroupAndAggregateSingleKStreams(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
 
@@ -870,8 +921,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void testCogroupHandleNullValues() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testCogroupHandleNullValues(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
 
@@ -899,8 +952,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldCogroupAndAggregateTwoKStreamsWithDistinctKeys() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCogroupAndAggregateTwoKStreamsWithDistinctKeys(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
         final KStream<String, String> stream2 = builder.stream("two", stringConsumed);
@@ -947,8 +1002,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldCogroupAndAggregateTwoKStreamsWithSharedKeys() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCogroupAndAggregateTwoKStreamsWithSharedKeys(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
         final KStream<String, String> stream2 = builder.stream("two", stringConsumed);
@@ -997,8 +1054,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldAllowDifferentOutputTypeInCoGroup() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldAllowDifferentOutputTypeInCoGroup(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
         final KStream<String, String> stream2 = builder.stream("two", stringConsumed);
@@ -1050,8 +1109,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldCoGroupStreamsWithDifferentInputTypes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCoGroupStreamsWithDifferentInputTypes(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Consumed<String, Integer> integerConsumed = Consumed.with(Serdes.String(), Serdes.Integer());
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
@@ -1102,8 +1163,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void testCogroupKeyMixedAggregators() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testCogroupKeyMixedAggregators(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
         final KStream<String, String> stream2 = builder.stream("two", stringConsumed);
@@ -1149,8 +1212,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void testCogroupWithThreeGroupedStreams() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testCogroupWithThreeGroupedStreams(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream1 = builder.stream("one", stringConsumed);
         final KStream<String, String> stream2 = builder.stream("two", stringConsumed);
@@ -1206,8 +1271,10 @@ public class CogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void testCogroupWithKTableKTableInnerJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testCogroupWithKTableKTableInnerJoin(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KGroupedStream<String, String> grouped1 = builder.stream("one", stringConsumed).groupByKey();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -97,13 +97,6 @@ public class KStreamKStreamJoinTest {
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
     private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-
-    private void setupProps(final boolean withHeaders) {
-        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-    }
     private final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(50), Duration.ofMillis(50));
     private final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
     private final String errorMessagePrefix = "Window settings mismatch. WindowBytesStoreSupplier settings";
@@ -111,7 +104,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldLogAndMeterOnSkippedRecordsWithNullValueWithBuiltInMetricsVersionLatest(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
@@ -143,7 +136,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldReuseRepartitionTopicWithGeneratedName(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -159,7 +152,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldCreateRepartitionTopicsWithUserProvidedName(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -178,7 +171,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldDisableLoggingOnStreamJoined(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100), Duration.ofMillis(50));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined
             .with(Serdes.String(), Serdes.Integer(), Serdes.Integer())
@@ -206,7 +199,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldEnableLoggingWithCustomConfigOnStreamJoined(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100), Duration.ofMillis(50));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined
             .with(Serdes.String(), Serdes.Integer(), Serdes.Integer())
@@ -243,7 +236,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowExceptionThisStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         // Case where retention of thisJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 500L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
@@ -258,7 +251,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowExceptionThisStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         //Case where window size of thisJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 150L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
@@ -273,7 +266,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowExceptionWhenThisJoinStoreSetsRetainDuplicatesFalse(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         //Case where thisJoinStore retain duplicates false
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, false);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
@@ -288,7 +281,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowExceptionOtherStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         //Case where retention size of otherJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 500L, 100L, true);
@@ -303,7 +296,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowExceptionOtherStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         //Case where window size of otherJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 150L, true);
@@ -318,7 +311,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowExceptionWhenOtherJoinStoreSetsRetainDuplicatesFalse(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         //Case where otherJoinStore retain duplicates false
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, false);
@@ -333,7 +326,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldBuildJoinWithCustomStoresAndCorrectWindowSettings(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         //Case where everything matches up
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
@@ -351,7 +344,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldExceptionWhenJoinStoresDoNotHaveUniqueNames(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100L), Duration.ofMillis(50L));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
@@ -367,7 +360,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldJoinWithCustomStoreSuppliers(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore(
@@ -410,7 +403,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldJoinWithDslStoreSuppliersIfNoStoreSupplied(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         TrackingDslStoreSuppliers.NUM_CALLS.set(0);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
@@ -448,7 +441,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldJoinWithDslStoreSuppliersFromStreamsConfig(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         TrackingDslStoreSuppliers.NUM_CALLS.set(0);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
@@ -476,7 +469,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldCreateCorrectWindowStoreTypeBasedOnConfiguration(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
         final CapturingStoreSuppliers storeSuppliers = new CapturingStoreSuppliers();
@@ -497,7 +490,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrottleEmitNonJoinedOuterRecordsEvenWhenClockDrift(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         /*
          * This test is testing something internal to [[KStreamKStreamJoin]], so we had to setup low-level api manually.
          */
@@ -610,7 +603,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -734,7 +727,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testOuterJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -858,7 +851,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testWindowing(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -1423,7 +1416,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testAsymmetricWindowingAfter(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -1693,7 +1686,7 @@ public class KStreamKStreamJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testAsymmetricWindowingBefore(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -2109,4 +2102,19 @@ public class KStreamKStreamJoinTest {
             "      <-- KSTREAM-MERGE-0000000011\n" +
             "    Sink: KSTREAM-SINK-0000000021 (topic: out-to)\n" +
             "      <-- KSTREAM-MERGE-0000000020\n\n";
+
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
+        }
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -61,7 +61,8 @@ import org.apache.kafka.test.MockInternalProcessorContext;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.time.Duration;
@@ -95,13 +96,22 @@ public class KStreamKStreamJoinTest {
     private final String topic1 = "topic1";
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+
+    private void setupProps(final boolean withHeaders) {
+        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+    }
     private final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(50), Duration.ofMillis(50));
     private final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
     private final String errorMessagePrefix = "Window settings mismatch. WindowBytesStoreSupplier settings";
 
-    @Test
-    public void shouldLogAndMeterOnSkippedRecordsWithNullValueWithBuiltInMetricsVersionLatest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterOnSkippedRecordsWithNullValueWithBuiltInMetricsVersionLatest(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
@@ -130,8 +140,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void shouldReuseRepartitionTopicWithGeneratedName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldReuseRepartitionTopicWithGeneratedName(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -144,8 +156,10 @@ public class KStreamKStreamJoinTest {
         assertEquals(expectedTopologyWithGeneratedRepartitionTopic, builder.build(props).describe().toString());
     }
 
-    @Test
-    public void shouldCreateRepartitionTopicsWithUserProvidedName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCreateRepartitionTopicsWithUserProvidedName(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -161,8 +175,10 @@ public class KStreamKStreamJoinTest {
         assertEquals(expectedTopologyWithUserNamedRepartitionTopics, topology.describe().toString());
     }
 
-    @Test
-    public void shouldDisableLoggingOnStreamJoined() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldDisableLoggingOnStreamJoined(final boolean withHeaders) {
+        setupProps(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100), Duration.ofMillis(50));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined
             .with(Serdes.String(), Serdes.Integer(), Serdes.Integer())
@@ -187,8 +203,10 @@ public class KStreamKStreamJoinTest {
         assertThat(internalTopologyBuilder.stateStores().get("store-other-join-store").loggingEnabled(), equalTo(false));
     }
 
-    @Test
-    public void shouldEnableLoggingWithCustomConfigOnStreamJoined() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldEnableLoggingWithCustomConfigOnStreamJoined(final boolean withHeaders) {
+        setupProps(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100), Duration.ofMillis(50));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined
             .with(Serdes.String(), Serdes.Integer(), Serdes.Integer())
@@ -222,8 +240,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void shouldThrowExceptionThisStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowExceptionThisStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace(final boolean withHeaders) {
+        setupProps(withHeaders);
         // Case where retention of thisJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 500L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
@@ -235,8 +255,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldThrowExceptionThisStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowExceptionThisStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize(final boolean withHeaders) {
+        setupProps(withHeaders);
         //Case where window size of thisJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 150L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
@@ -248,8 +270,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldThrowExceptionWhenThisJoinStoreSetsRetainDuplicatesFalse() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowExceptionWhenThisJoinStoreSetsRetainDuplicatesFalse(final boolean withHeaders) {
+        setupProps(withHeaders);
         //Case where thisJoinStore retain duplicates false
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, false);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
@@ -261,8 +285,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldThrowExceptionOtherStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowExceptionOtherStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace(final boolean withHeaders) {
+        setupProps(withHeaders);
         //Case where retention size of otherJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 500L, 100L, true);
@@ -274,8 +300,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldThrowExceptionOtherStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowExceptionOtherStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize(final boolean withHeaders) {
+        setupProps(withHeaders);
         //Case where window size of otherJoinStore doesn't match JoinWindows
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 150L, true);
@@ -287,8 +315,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldThrowExceptionWhenOtherJoinStoreSetsRetainDuplicatesFalse() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowExceptionWhenOtherJoinStoreSetsRetainDuplicatesFalse(final boolean withHeaders) {
+        setupProps(withHeaders);
         //Case where otherJoinStore retain duplicates false
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
         final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, false);
@@ -300,8 +330,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldBuildJoinWithCustomStoresAndCorrectWindowSettings() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldBuildJoinWithCustomStoresAndCorrectWindowSettings(final boolean withHeaders) {
+        setupProps(withHeaders);
         //Case where everything matches up
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
@@ -316,8 +348,10 @@ public class KStreamKStreamJoinTest {
         builder.build();
     }
 
-    @Test
-    public void shouldExceptionWhenJoinStoresDoNotHaveUniqueNames() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldExceptionWhenJoinStoresDoNotHaveUniqueNames(final boolean withHeaders) {
+        setupProps(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100L), Duration.ofMillis(50L));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
         final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
@@ -330,8 +364,10 @@ public class KStreamKStreamJoinTest {
         );
     }
 
-    @Test
-    public void shouldJoinWithCustomStoreSuppliers() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldJoinWithCustomStoreSuppliers(final boolean withHeaders) {
+        setupProps(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore(
@@ -371,8 +407,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void shouldJoinWithDslStoreSuppliersIfNoStoreSupplied() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldJoinWithDslStoreSuppliersIfNoStoreSupplied(final boolean withHeaders) {
+        setupProps(withHeaders);
         TrackingDslStoreSuppliers.NUM_CALLS.set(0);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
@@ -407,8 +445,10 @@ public class KStreamKStreamJoinTest {
 
     }
 
-    @Test
-    public void shouldJoinWithDslStoreSuppliersFromStreamsConfig() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldJoinWithDslStoreSuppliersFromStreamsConfig(final boolean withHeaders) {
+        setupProps(withHeaders);
         TrackingDslStoreSuppliers.NUM_CALLS.set(0);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
@@ -433,8 +473,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void shouldJoinWithNonTimestampedStore() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCreateCorrectWindowStoreTypeBasedOnConfiguration(final boolean withHeaders) {
+        setupProps(withHeaders);
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
         final CapturingStoreSuppliers storeSuppliers = new CapturingStoreSuppliers();
@@ -443,12 +485,19 @@ public class KStreamKStreamJoinTest {
                         .withDslStoreSuppliers(storeSuppliers);
 
         runJoin(streamJoined, joinWindows);
-        assertThat("Expected stream joined to supply builders that create non-timestamped stores",
+        if (withHeaders) {
+            assertThat("Expected stream joined to supply builders that create headers stores",
+                WrappedStateStore.isHeadersAware(storeSuppliers.capture.get().get()));
+        } else {
+            assertThat("Expected stream joined to supply builders that create non-timestamped stores",
                 !WrappedStateStore.isTimestamped(storeSuppliers.capture.get().get()));
+        }
     }
 
-    @Test
-    public void shouldThrottleEmitNonJoinedOuterRecordsEvenWhenClockDrift() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrottleEmitNonJoinedOuterRecordsEvenWhenClockDrift(final boolean withHeaders) {
+        setupProps(withHeaders);
         /*
          * This test is testing something internal to [[KStreamKStreamJoin]], so we had to setup low-level api manually.
          */
@@ -558,8 +607,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void testJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -680,8 +731,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void testOuterJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOuterJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -802,8 +855,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void testWindowing() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWindowing(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -1365,8 +1420,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void testAsymmetricWindowingAfter() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testAsymmetricWindowingAfter(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -1633,8 +1690,10 @@ public class KStreamKStreamJoinTest {
         }
     }
 
-    @Test
-    public void testAsymmetricWindowingBefore() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testAsymmetricWindowingBefore(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
@@ -35,7 +36,8 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -53,11 +55,20 @@ public class KStreamKStreamLeftJoinTest {
     private final String topic1 = "topic1";
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-    private static final Properties PROPS = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+
+    private Properties getProps(final boolean withHeaders) {
+        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+        return props;
+    }
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed
-    @Test
-    public void testLeftJoinWithSpuriousResultFixDisabledOldApi() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftJoinWithSpuriousResultFixDisabledOldApi(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -77,7 +88,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -116,8 +127,10 @@ public class KStreamKStreamLeftJoinTest {
     }
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed
-    @Test
-    public void testLeftJoinDuplicatesWithSpuriousResultFixDisabledOldApi() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftJoinDuplicatesWithSpuriousResultFixDisabledOldApi(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -135,7 +148,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -158,8 +171,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testLeftJoinDuplicates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftJoinDuplicates(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -177,7 +192,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -214,8 +229,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -233,7 +250,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -269,8 +286,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheRightProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheRightProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -288,7 +307,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -324,8 +343,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testRightNonJoinedRecordsAreNeverEmittedByTheLeftProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testRightNonJoinedRecordsAreNeverEmittedByTheLeftProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -343,7 +364,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -376,8 +397,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testRightNonJoinedRecordsAreNeverEmittedByTheRightProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testRightNonJoinedRecordsAreNeverEmittedByTheRightProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -395,7 +418,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -428,8 +451,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testLeftJoinedRecordsWithZeroAfterAreEmitted() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftJoinedRecordsWithZeroAfterAreEmitted(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -457,7 +482,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -606,8 +631,9 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testLeftJoinWithInMemoryCustomSuppliers() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftJoinWithInMemoryCustomSuppliers(final boolean withHeaders) {
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100L), ofMillis(0L));
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store",
@@ -620,19 +646,22 @@ public class KStreamKStreamLeftJoinTest {
 
         final StreamJoined<Integer, String, String> streamJoined = StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String());
 
-        runLeftJoin(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier), joinWindows);
+        runLeftJoin(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier), joinWindows, withHeaders);
     }
 
-    @Test
-    public void testLeftJoinWithDefaultSuppliers() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftJoinWithDefaultSuppliers(final boolean withHeaders) {
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
         final StreamJoined<Integer, String, String> streamJoined = StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String());
 
-        runLeftJoin(streamJoined, joinWindows);
+        runLeftJoin(streamJoined, joinWindows, withHeaders);
     }
 
     public void runLeftJoin(final StreamJoined<Integer, String, String> streamJoined,
-                            final JoinWindows joinWindows) {
+                            final JoinWindows joinWindows,
+                            final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -658,7 +687,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -744,8 +773,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testOrdering() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOrdering(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -763,7 +794,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -795,8 +826,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testGracePeriod() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGracePeriod(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -821,7 +854,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -867,8 +900,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void testWindowing() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWindowing(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -893,7 +928,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -928,8 +963,10 @@ public class KStreamKStreamLeftJoinTest {
         }
     }
 
-    @Test
-    public void shouldNotEmitLeftJoinResultForAsymmetricWindow() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotEmitLeftJoinResultForAsymmetricWindow(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -948,7 +985,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -55,20 +55,13 @@ public class KStreamKStreamLeftJoinTest {
     private final String topic1 = "topic1";
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-
-    private Properties getProps(final boolean withHeaders) {
-        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-        return props;
-    }
+    private static final Properties PROPS = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftJoinWithSpuriousResultFixDisabledOldApi(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -88,7 +81,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -130,7 +123,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftJoinDuplicatesWithSpuriousResultFixDisabledOldApi(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -148,7 +141,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -174,7 +167,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftJoinDuplicates(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -192,7 +185,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -232,7 +225,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -250,7 +243,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -289,7 +282,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftExpiredNonJoinedRecordsAreEmittedByTheRightProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -307,7 +300,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -346,7 +339,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testRightNonJoinedRecordsAreNeverEmittedByTheLeftProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -364,7 +357,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -400,7 +393,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testRightNonJoinedRecordsAreNeverEmittedByTheRightProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -418,7 +411,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -454,7 +447,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftJoinedRecordsWithZeroAfterAreEmitted(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -482,7 +475,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -661,7 +654,7 @@ public class KStreamKStreamLeftJoinTest {
     public void runLeftJoin(final StreamJoined<Integer, String, String> streamJoined,
                             final JoinWindows joinWindows,
                             final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -687,7 +680,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -776,7 +769,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testOrdering(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -794,7 +787,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -829,7 +822,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testGracePeriod(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -854,7 +847,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -903,7 +896,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testWindowing(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -928,7 +921,7 @@ public class KStreamKStreamLeftJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -966,7 +959,7 @@ public class KStreamKStreamLeftJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotEmitLeftJoinResultForAsymmetricWindow(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -985,7 +978,7 @@ public class KStreamKStreamLeftJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -1347,5 +1340,20 @@ public class KStreamKStreamLeftJoinTest {
         // all previous late records were emitted immediately
         inputTopic1.pipeInput(0, "dummy", time + 300L);
         processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "dummy+null", 1203L));
+    }
+
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            PROPS.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            PROPS.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
@@ -45,7 +46,8 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -64,11 +66,20 @@ public class KStreamKStreamOuterJoinTest {
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
     private final Consumed<Integer, Long> consumed2 = Consumed.with(Serdes.Integer(), Serdes.Long());
-    private static final Properties PROPS = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+
+    private Properties getProps(final boolean withHeaders) {
+        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+        return props;
+    }
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed
-    @Test
-    public void testOuterJoinDuplicatesWithFixDisabledOldApi() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOuterJoinDuplicatesWithFixDisabledOldApi(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -86,7 +97,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -111,8 +122,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testOuterJoinDuplicates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOuterJoinDuplicates(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -130,7 +143,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -177,8 +190,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -196,7 +211,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -232,8 +247,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheRightProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLeftExpiredNonJoinedRecordsAreEmittedByTheRightProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -251,7 +268,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -287,8 +304,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testRightExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testRightExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -306,7 +325,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -342,8 +361,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testRightExpiredNonJoinedRecordsAreEmittedByTheRightProcessor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testRightExpiredNonJoinedRecordsAreEmittedByTheRightProcessor(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -361,7 +382,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -397,8 +418,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testOrdering() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOrdering(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -416,7 +439,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -447,8 +470,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testGracePeriod() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testGracePeriod(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -472,7 +497,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -513,8 +538,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testEmitAllNonJoinedResultsForAsymmetricWindow() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testEmitAllNonJoinedResultsForAsymmetricWindow(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -538,7 +565,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -608,8 +635,9 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
     
-    @Test
-    public void testOuterJoinWithInMemoryCustomSuppliers() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOuterJoinWithInMemoryCustomSuppliers(final boolean withHeaders) {
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore(
@@ -628,19 +656,22 @@ public class KStreamKStreamOuterJoinTest {
 
         final StreamJoined<Integer, String, Long> streamJoined = StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.Long());
 
-        runOuterJoin(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier), joinWindows);
+        runOuterJoin(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier), joinWindows, withHeaders);
     }
 
-    @Test
-    public void testOuterJoinWithDefaultSuppliers() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testOuterJoinWithDefaultSuppliers(final boolean withHeaders) {
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100L));
         final StreamJoined<Integer, String, Long> streamJoined = StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.Long());
 
-        runOuterJoin(streamJoined, joinWindows);
+        runOuterJoin(streamJoined, joinWindows, withHeaders);
     }
 
     public void runOuterJoin(final StreamJoined<Integer, String, Long> streamJoined,
-                             final JoinWindows joinWindows) {
+                             final JoinWindows joinWindows,
+                             final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -666,7 +697,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -753,8 +784,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testWindowing() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWindowing(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
 
@@ -779,7 +812,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -815,8 +848,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testShouldNotEmitLeftJoinResultForAsymmetricBeforeWindow() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testShouldNotEmitLeftJoinResultForAsymmetricBeforeWindow(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -835,7 +870,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -902,8 +937,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testShouldNotEmitLeftJoinResultForAsymmetricAfterWindow() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testShouldNotEmitLeftJoinResultForAsymmetricAfterWindow(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -922,7 +959,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -994,8 +1031,10 @@ public class KStreamKStreamOuterJoinTest {
      * NOTE: Header forwarding is undefined behavior, but we still want to understand the
      * behavior so that we can make decisions about defining it in the future.
      */
-    @Test
-    public void testShouldForwardCurrentHeaders() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testShouldForwardCurrentHeaders(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -1013,7 +1052,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -1419,8 +1458,10 @@ public class KStreamKStreamOuterJoinTest {
         }
     }
 
-    @Test
-    public void testShouldJoinWithNonTimestampedStore() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testShouldJoinWithNonTimestampedStore(final boolean withHeaders) {
+        final Properties props = getProps(withHeaders);
         final CapturingStoreSuppliers suppliers = new CapturingStoreSuppliers();
         final StreamJoined<Integer, String, String> streamJoined =
                 StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
@@ -1444,7 +1485,7 @@ public class KStreamKStreamOuterJoinTest {
         joined.process(supplier);
 
         // create a TTD so that the topology gets built
-        try (final TopologyTestDriver ignored = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
+        try (final TopologyTestDriver ignored = new TopologyTestDriver(builder.build(props), props)) {
             assertThat("Expected stream joined to supply builders that create non-timestamped stores",
                     !WrappedStateStore.isTimestamped(suppliers.capture.get().get()));
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -66,20 +66,14 @@ public class KStreamKStreamOuterJoinTest {
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
     private final Consumed<Integer, Long> consumed2 = Consumed.with(Serdes.Integer(), Serdes.Long());
+    private static final Properties PROPS = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
-    private Properties getProps(final boolean withHeaders) {
-        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-        return props;
-    }
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testOuterJoinDuplicatesWithFixDisabledOldApi(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -97,7 +91,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -125,7 +119,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testOuterJoinDuplicates(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -143,7 +137,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -193,7 +187,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -211,7 +205,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -250,7 +244,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testLeftExpiredNonJoinedRecordsAreEmittedByTheRightProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -268,7 +262,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -307,7 +301,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testRightExpiredNonJoinedRecordsAreEmittedByTheLeftProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -325,7 +319,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -364,7 +358,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testRightExpiredNonJoinedRecordsAreEmittedByTheRightProcessor(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -382,7 +376,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -421,7 +415,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testOrdering(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -439,7 +433,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -473,7 +467,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testGracePeriod(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -497,7 +491,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -541,7 +535,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testEmitAllNonJoinedResultsForAsymmetricWindow(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -565,7 +559,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -671,7 +665,7 @@ public class KStreamKStreamOuterJoinTest {
     public void runOuterJoin(final StreamJoined<Integer, String, Long> streamJoined,
                              final JoinWindows joinWindows,
                              final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -697,7 +691,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -787,7 +781,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testWindowing(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
 
@@ -812,7 +806,7 @@ public class KStreamKStreamOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -851,7 +845,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testShouldNotEmitLeftJoinResultForAsymmetricBeforeWindow(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -870,7 +864,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -940,7 +934,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testShouldNotEmitLeftJoinResultForAsymmetricAfterWindow(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -959,7 +953,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -1034,7 +1028,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testShouldForwardCurrentHeaders(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream1;
@@ -1052,7 +1046,7 @@ public class KStreamKStreamOuterJoinTest {
         );
         joined.process(supplier);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                 driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, Long> inputTopic2 =
@@ -1461,7 +1455,7 @@ public class KStreamKStreamOuterJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testShouldJoinWithNonTimestampedStore(final boolean withHeaders) {
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final CapturingStoreSuppliers suppliers = new CapturingStoreSuppliers();
         final StreamJoined<Integer, String, String> streamJoined =
                 StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
@@ -1485,9 +1479,24 @@ public class KStreamKStreamOuterJoinTest {
         joined.process(supplier);
 
         // create a TTD so that the topology gets built
-        try (final TopologyTestDriver ignored = new TopologyTestDriver(builder.build(props), props)) {
+        try (final TopologyTestDriver ignored = new TopologyTestDriver(builder.build(PROPS), PROPS)) {
             assertThat("Expected stream joined to supply builders that create non-timestamped stores",
                     !WrappedStateStore.isTimestamped(suppliers.capture.get().get()));
+        }
+    }
+
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            PROPS.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            PROPS.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoinTest.java
@@ -52,9 +52,7 @@ public class KStreamKStreamSelfJoinTest {
     public void shouldMatchInnerJoinWithSelfJoinWithSingleStream(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        setDslStoreFormat(withHeaders);
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -123,9 +121,7 @@ public class KStreamKStreamSelfJoinTest {
     public void shouldMatchInnerJoinWithSelfJoinWithTwoStreams(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        setDslStoreFormat(withHeaders);
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -197,9 +193,7 @@ public class KStreamKStreamSelfJoinTest {
     public void shouldMatchInnerJoinWithSelfJoinDifferentBeforeAfterWindows(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        setDslStoreFormat(withHeaders);
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -276,9 +270,7 @@ public class KStreamKStreamSelfJoinTest {
     public void shouldMatchInnerJoinWithSelfJoinOutOfOrderMessages(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        setDslStoreFormat(withHeaders);
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -351,6 +343,21 @@ public class KStreamKStreamSelfJoinTest {
 
             // Then:
             processor.checkAndClearProcessResult(expected.toArray(new KeyValueTimestamp[0]));
+        }
+    }
+
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoinTest.java
@@ -33,7 +33,8 @@ import org.apache.kafka.test.MockApiProcessor;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.Properties;
@@ -44,12 +45,16 @@ import static java.time.Duration.ofSeconds;
 public class KStreamKStreamSelfJoinTest {
     private final String topic1 = "topic1";
     private final String topic2 = "topic2";
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
-    @Test
-    public void shouldMatchInnerJoinWithSelfJoinWithSingleStream() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMatchInnerJoinWithSelfJoinWithSingleStream(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -113,10 +118,14 @@ public class KStreamKStreamSelfJoinTest {
     }
 
 
-    @Test
-    public void shouldMatchInnerJoinWithSelfJoinWithTwoStreams() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMatchInnerJoinWithSelfJoinWithTwoStreams(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -183,10 +192,14 @@ public class KStreamKStreamSelfJoinTest {
         }
     }
 
-    @Test
-    public void shouldMatchInnerJoinWithSelfJoinDifferentBeforeAfterWindows() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMatchInnerJoinWithSelfJoinDifferentBeforeAfterWindows(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();
@@ -258,10 +271,14 @@ public class KStreamKStreamSelfJoinTest {
         }
     }
 
-    @Test
-    public void shouldMatchInnerJoinWithSelfJoinOutOfOrderMessages() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMatchInnerJoinWithSelfJoinOutOfOrderMessages(final boolean withHeaders) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final ValueJoiner<String, String, String> valueJoiner = (v, v2) -> v + v2;
         final List<KeyValueTimestamp<String, String>> expected;
         final StreamsBuilder streamsBuilder = new StreamsBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -73,7 +73,7 @@ public class KStreamKTableJoinTest {
     private StreamsBuilder builder;
     private final MockApiProcessorSupplier<Integer, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
 
-    private void setUp(final boolean withHeaders) {
+    public void setUp(final boolean withHeaders) {
         builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream;
@@ -131,7 +131,7 @@ public class KStreamKTableJoinTest {
     }
 
 
-    private void makeJoin(final Duration grace, final boolean withHeaders) {
+    private void makeJoin(final Duration grace) {
         final KStream<Integer, String> stream;
         final KTable<Integer, String> table;
         final MockApiProcessorSupplier<Integer, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
@@ -146,9 +146,6 @@ public class KStreamKTableJoinTest {
             Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String(), "Grace", grace)
         ).process(supplier);
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
         driver = new TopologyTestDriver(builder.build(), props);
         inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
         inputTableTopic = driver.createInputTopic("tableTopic2", new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
@@ -161,6 +158,9 @@ public class KStreamKTableJoinTest {
     public void shouldFailIfTableIsNotVersioned(final boolean withHeaders) {
         setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
 
@@ -177,6 +177,9 @@ public class KStreamKTableJoinTest {
     public void shouldFailIfTableIsNotVersionedButMaterializationIsInherited(final boolean withHeaders) {
         setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> source = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.inMemoryKeyValueStore("tableB")));
@@ -199,9 +202,7 @@ public class KStreamKTableJoinTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> source = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.persistentVersionedKeyValueStore("tableB", Duration.ofMinutes(5))));
@@ -211,7 +212,7 @@ public class KStreamKTableJoinTest {
         streamA.join(tableB, (value1, value2) -> value1 + value2, Joined.with(Serdes.String(), Serdes.String(), Serdes.String(), "first-join", Duration.ofMillis(6))).to("out-one");
 
         //should not throw an error
-        builder.build(props);
+        builder.build();
     }
 
     @ParameterizedTest
@@ -221,9 +222,7 @@ public class KStreamKTableJoinTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.persistentVersionedKeyValueStore("tableB", Duration.ofMinutes(5))));
@@ -241,9 +240,7 @@ public class KStreamKTableJoinTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> source = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.persistentVersionedKeyValueStore("V-grace", Duration.ofMinutes(0))));
@@ -261,7 +258,7 @@ public class KStreamKTableJoinTest {
     @ValueSource(booleans = {false, true})
     public void shouldDelayJoinByGracePeriod(final boolean withHeaders) {
         setUp(withHeaders);
-        makeJoin(Duration.ofMillis(2), withHeaders);
+        makeJoin(Duration.ofMillis(2));
 
         // push four items to the table. this should not produce any item.
         pushToTableNonRandom(4, "Y");
@@ -301,7 +298,7 @@ public class KStreamKTableJoinTest {
     @ValueSource(booleans = {false, true})
     public void shouldHandleLateJoinsWithGracePeriod(final boolean withHeaders) {
         setUp(withHeaders);
-        makeJoin(Duration.ofMillis(2), withHeaders);
+        makeJoin(Duration.ofMillis(2));
 
         // push four items to the table. this should not produce any item.
         pushToTableNonRandom(4, "Y");
@@ -326,9 +323,7 @@ public class KStreamKTableJoinTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableC = builder.table("topic3", Consumed.with(Serdes.String(), Serdes.String()));
@@ -346,9 +341,7 @@ public class KStreamKTableJoinTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
+        maybeSetDslStoreFormatHeaders(props, withHeaders);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableC = builder.table("topic3", Consumed.with(Serdes.String(), Serdes.String()));
@@ -365,12 +358,8 @@ public class KStreamKTableJoinTest {
     @ValueSource(booleans = {false, true})
     public void shouldRequireCopartitionedStreams(final boolean withHeaders) {
         setUp(withHeaders);
-        final Properties props = new Properties();
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
         final Collection<Set<String>> copartitionGroups =
-            TopologyWrapper.getInternalTopologyBuilder(builder.build(props)).copartitionGroups();
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(streamTopic, tableTopic), copartitionGroups.iterator().next());
@@ -616,4 +605,10 @@ public class KStreamKTableJoinTest {
                     + "    Processor: KTABLE-SOURCE-0000000006 (stores: [topic3-STATE-STORE-0000000004])\n"
                     + "      --> none\n"
                     + "      <-- KSTREAM-SOURCE-0000000005\n\n";
+
+    private static void maybeSetDslStoreFormatHeaders(final Properties streamsConfig, final boolean withHeaders) {
+        if (withHeaders) {
+            streamsConfig.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -96,7 +96,9 @@ public class KStreamKTableJoinTest {
 
     @AfterEach
     public void cleanup() {
-        driver.close();
+        if (driver != null) {
+            driver.close();
+        }
     }
 
     private void pushToStream(final int messageCount, final String valuePrefix) {
@@ -156,7 +158,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldFailIfTableIsNotVersioned(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -175,7 +176,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldFailIfTableIsNotVersionedButMaterializationIsInherited(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -198,7 +198,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotFailIfTableIsVersionedButMaterializationIsInherited(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -218,7 +217,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldFailIfGracePeriodIsLongerThanHistoryRetention(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -236,7 +234,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldFailIfGracePeriodIsLongerThanHistoryRetentionAndInheritedStore(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -319,7 +316,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldReuseRepartitionTopicWithGeneratedName(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
@@ -337,7 +333,6 @@ public class KStreamKTableJoinTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldCreateRepartitionTopicsWithUserProvidedName(final boolean withHeaders) {
-        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -41,8 +41,8 @@ import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -73,8 +73,7 @@ public class KStreamKTableJoinTest {
     private StreamsBuilder builder;
     private final MockApiProcessorSupplier<Integer, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
 
-    @BeforeEach
-    public void setUp() {
+    private void setUp(final boolean withHeaders) {
         builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream;
@@ -85,6 +84,9 @@ public class KStreamKTableJoinTest {
         table = builder.table(tableTopic, consumed);
         stream.join(table, MockValueJoiner.TOSTRING_JOINER).process(supplier);
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         driver = new TopologyTestDriver(builder.build(), props);
         inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
         inputTableTopic = driver.createInputTopic(tableTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
@@ -129,7 +131,7 @@ public class KStreamKTableJoinTest {
     }
 
 
-    private void makeJoin(final Duration grace) {
+    private void makeJoin(final Duration grace, final boolean withHeaders) {
         final KStream<Integer, String> stream;
         final KTable<Integer, String> table;
         final MockApiProcessorSupplier<Integer, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
@@ -144,6 +146,9 @@ public class KStreamKTableJoinTest {
             Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String(), "Grace", grace)
         ).process(supplier);
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         driver = new TopologyTestDriver(builder.build(), props);
         inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
         inputTableTopic = driver.createInputTopic("tableTopic2", new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
@@ -151,11 +156,11 @@ public class KStreamKTableJoinTest {
         processor = supplier.theCapturedProcessor();
     }
 
-    @Test
-    public void shouldFailIfTableIsNotVersioned() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldFailIfTableIsNotVersioned(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
-        final Properties props = new Properties();
-        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
 
@@ -167,11 +172,11 @@ public class KStreamKTableJoinTest {
         );
     }
 
-    @Test
-    public void shouldFailIfTableIsNotVersionedButMaterializationIsInherited() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldFailIfTableIsNotVersionedButMaterializationIsInherited(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
-        final Properties props = new Properties();
-        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> source = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.inMemoryKeyValueStore("tableB")));
@@ -187,11 +192,16 @@ public class KStreamKTableJoinTest {
         );
     }
 
-    @Test
-    public void shouldNotFailIfTableIsVersionedButMaterializationIsInherited() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotFailIfTableIsVersionedButMaterializationIsInherited(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> source = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.persistentVersionedKeyValueStore("tableB", Duration.ofMinutes(5))));
@@ -201,14 +211,19 @@ public class KStreamKTableJoinTest {
         streamA.join(tableB, (value1, value2) -> value1 + value2, Joined.with(Serdes.String(), Serdes.String(), Serdes.String(), "first-join", Duration.ofMillis(6))).to("out-one");
 
         //should not throw an error
-        builder.build();
+        builder.build(props);
     }
 
-    @Test
-    public void shouldFailIfGracePeriodIsLongerThanHistoryRetention() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldFailIfGracePeriodIsLongerThanHistoryRetention(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.persistentVersionedKeyValueStore("tableB", Duration.ofMinutes(5))));
@@ -219,11 +234,16 @@ public class KStreamKTableJoinTest {
         assertThat(exception.getMessage(), is("History retention must be at least grace period."));
     }
 
-    @Test
-    public void shouldFailIfGracePeriodIsLongerThanHistoryRetentionAndInheritedStore() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldFailIfGracePeriodIsLongerThanHistoryRetentionAndInheritedStore(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> source = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.as(Stores.persistentVersionedKeyValueStore("V-grace", Duration.ofMinutes(0))));
@@ -237,9 +257,11 @@ public class KStreamKTableJoinTest {
     }
 
 
-    @Test
-    public void shouldDelayJoinByGracePeriod() {
-        makeJoin(Duration.ofMillis(2));
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldDelayJoinByGracePeriod(final boolean withHeaders) {
+        setUp(withHeaders);
+        makeJoin(Duration.ofMillis(2), withHeaders);
 
         // push four items to the table. this should not produce any item.
         pushToTableNonRandom(4, "Y");
@@ -275,9 +297,11 @@ public class KStreamKTableJoinTest {
         processor.checkAndClearProcessResult(EMPTY);
     }
 
-    @Test
-    public void shouldHandleLateJoinsWithGracePeriod() {
-        makeJoin(Duration.ofMillis(2));
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldHandleLateJoinsWithGracePeriod(final boolean withHeaders) {
+        setUp(withHeaders);
+        makeJoin(Duration.ofMillis(2), withHeaders);
 
         // push four items to the table. this should not produce any item.
         pushToTableNonRandom(4, "Y");
@@ -295,11 +319,16 @@ public class KStreamKTableJoinTest {
             new KeyValueTimestamp<>(0, "X0+Y0", 0));
     }
 
-    @Test
-    public void shouldReuseRepartitionTopicWithGeneratedName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldReuseRepartitionTopicWithGeneratedName(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableC = builder.table("topic3", Consumed.with(Serdes.String(), Serdes.String()));
@@ -310,11 +339,16 @@ public class KStreamKTableJoinTest {
         assertEquals(expectedTopologyWithGeneratedRepartitionTopicNames, topology.describe().toString());
     }
 
-    @Test
-    public void shouldCreateRepartitionTopicsWithUserProvidedName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCreateRepartitionTopicsWithUserProvidedName(final boolean withHeaders) {
+        setUp(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties props = new Properties();
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
         final KTable<String, String> tableC = builder.table("topic3", Consumed.with(Serdes.String(), Serdes.String()));
@@ -327,24 +361,34 @@ public class KStreamKTableJoinTest {
         assertEquals(expectedTopologyWithUserProvidedRepartitionTopicNames, topology.describe().toString());
     }
 
-    @Test
-    public void shouldRequireCopartitionedStreams() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldRequireCopartitionedStreams(final boolean withHeaders) {
+        setUp(withHeaders);
+        final Properties props = new Properties();
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final Collection<Set<String>> copartitionGroups =
-            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+            TopologyWrapper.getInternalTopologyBuilder(builder.build(props)).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(streamTopic, tableTopic), copartitionGroups.iterator().next());
     }
 
-    @Test
-    public void shouldNotJoinWithEmptyTableOnStreamUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotJoinWithEmptyTableOnStreamUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push two items to the primary stream. the table is empty
         pushToStream(2, "X");
         processor.checkAndClearProcessResult(EMPTY);
     }
 
-    @Test
-    public void shouldNotJoinOnTableUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotJoinOnTableUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push two items to the primary stream. the table is empty
         pushToStream(2, "X");
         processor.checkAndClearProcessResult(EMPTY);
@@ -378,8 +422,10 @@ public class KStreamKTableJoinTest {
         processor.checkAndClearProcessResult(EMPTY);
     }
 
-    @Test
-    public void shouldJoinOnlyIfMatchFoundOnStreamUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldJoinOnlyIfMatchFoundOnStreamUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push two items to the table. this should not produce any item.
         pushToTable(2, "Y");
         processor.checkAndClearProcessResult(EMPTY);
@@ -392,8 +438,10 @@ public class KStreamKTableJoinTest {
         );
     }
 
-    @Test
-    public void shouldClearTableEntryOnNullValueUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldClearTableEntryOnNullValueUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push all four items to the table. this should not produce any item.
         pushToTable(4, "Y");
         processor.checkAndClearProcessResult(EMPTY);
@@ -419,8 +467,10 @@ public class KStreamKTableJoinTest {
         );
     }
 
-    @Test
-    public void shouldLogAndMeterWhenSkippingNullLeftKey() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterWhenSkippingNullLeftKey(final boolean withHeaders) {
+        setUp(withHeaders);
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
@@ -448,8 +498,10 @@ public class KStreamKTableJoinTest {
         );
     }
 
-    @Test
-    public void shouldLogAndMeterWhenSkippingNullLeftValue() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterWhenSkippingNullLeftValue(final boolean withHeaders) {
+        setUp(withHeaders);
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
@@ -35,8 +36,8 @@ import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -63,8 +64,8 @@ public class KStreamKTableLeftJoinTest {
     private MockApiProcessor<Integer, String, Void, Void> processor;
     private StreamsBuilder builder;
 
-    @BeforeEach
-    public void setUp() {
+
+    public void setUp(final boolean withHeaders) {
         builder = new StreamsBuilder();
 
         final KStream<Integer, String> stream;
@@ -77,6 +78,9 @@ public class KStreamKTableLeftJoinTest {
         stream.leftJoin(table, MockValueJoiner.TOSTRING_JOINER).process(supplier);
 
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         driver = new TopologyTestDriver(builder.build(), props);
         inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
         inputTableTopic = driver.createInputTopic(tableTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
@@ -111,8 +115,10 @@ public class KStreamKTableLeftJoinTest {
         }
     }
 
-    @Test
-    public void shouldRequireCopartitionedStreams() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldRequireCopartitionedStreams(final boolean withHeaders) {
+        setUp(withHeaders);
         final Collection<Set<String>> copartitionGroups =
             TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
@@ -120,16 +126,20 @@ public class KStreamKTableLeftJoinTest {
         assertEquals(Set.of(streamTopic, tableTopic), copartitionGroups.iterator().next());
     }
 
-    @Test
-    public void shouldJoinWithEmptyTableOnStreamUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldJoinWithEmptyTableOnStreamUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push two items to the primary stream. the table is empty
         pushToStream(2, "X");
         processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+null", 0),
                 new KeyValueTimestamp<>(1, "X1+null", 1));
     }
 
-    @Test
-    public void shouldNotJoinOnTableUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotJoinOnTableUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push two items to the primary stream. the table is empty
         pushToStream(2, "X");
         processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+null", 0),
@@ -162,8 +172,10 @@ public class KStreamKTableLeftJoinTest {
         processor.checkAndClearProcessResult(EMPTY);
     }
 
-    @Test
-    public void shouldJoinRegardlessIfMatchFoundOnStreamUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldJoinRegardlessIfMatchFoundOnStreamUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push two items to the table. this should not produce any item.
         pushToTable(2, "Y");
         processor.checkAndClearProcessResult(EMPTY);
@@ -177,8 +189,10 @@ public class KStreamKTableLeftJoinTest {
 
     }
 
-    @Test
-    public void shouldClearTableEntryOnNullValueUpdates() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldClearTableEntryOnNullValueUpdates(final boolean withHeaders) {
+        setUp(withHeaders);
         // push all four items to the table. this should not produce any item.
         pushToTable(4, "Y");
         processor.checkAndClearProcessResult(EMPTY);
@@ -202,8 +216,10 @@ public class KStreamKTableLeftJoinTest {
                 new KeyValueTimestamp<>(3, "XX3+Y3", 3));
     }
 
-    @Test
-    public void shouldNotDropLeftNullKey() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotDropLeftNullKey(final boolean withHeaders) {
+        setUp(withHeaders);
         // push all four items to the table. this should not produce any item.
         pushToTable(1, "Y");
         processor.checkAndClearProcessResult(EMPTY);
@@ -234,8 +250,10 @@ public class KStreamKTableLeftJoinTest {
         );
     }
 
-    @Test
-    public void shouldLogAndMeterWhenSkippingNullLeftValue() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterWhenSkippingNullLeftValue(final boolean withHeaders) {
+        setUp(withHeaders);
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -101,7 +101,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private EmitStrategy emitStrategy;
     private boolean emitFinal;
 
-    public static Stream<Arguments> data() {
+    public static Stream<Arguments> emitStrategyAndHeadersMatrix() {
         return Stream.of(
             Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true),
             Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false),
@@ -189,7 +189,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldCreateSingleSessionWhenWithinGap(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         processor.process(new Record<>("john", "first", 0L));
@@ -203,7 +203,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldMergeSessions(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         final String sessionId = "mel";
@@ -234,7 +234,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldUpdateSessionIfTheSameTime(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         processor.process(new Record<>("mel", "first", 0L));
@@ -247,7 +247,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
 
@@ -300,7 +300,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldRemoveMergedSessionsFromStateStore(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         processor.process(new Record<>("a", "1", 0L));
@@ -327,7 +327,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldHandleMultipleSessionsAndMerging(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
 
@@ -401,7 +401,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldGetAggregatedValuesFromValueGetter(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         final KTableValueGetter<Windowed<String>, Long> getter = sessionAggregator.view().get();
@@ -416,7 +416,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldImmediatelyForwardNewSessionWhenNonCachedStore(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         if (emitFinal)
@@ -449,7 +449,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldImmediatelyForwardRemovedSessionsWhenMerging(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, true, withHeaders);
         if (emitFinal)
@@ -480,7 +480,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, false, withHeaders);
         mockContext.setRecordContext(
@@ -508,7 +508,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, false, withHeaders);
         final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
@@ -575,7 +575,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("emitStrategyAndHeadersMatrix")
     public void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
         setup(inputType, false, withHeaders);
         final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -103,14 +103,10 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     public static Stream<Arguments> data() {
         return Stream.of(
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true, false),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true, true),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false, false),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false, true),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, true, false),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, true, true),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, false, false),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, false, true)
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false)
         );
     }
 
@@ -194,8 +190,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldCreateSingleSessionWhenWithinGap(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldCreateSingleSessionWhenWithinGap(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         processor.process(new Record<>("john", "first", 0L));
         processor.process(new Record<>("john", "second", 500L));
 
@@ -208,8 +204,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldMergeSessions(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldMergeSessions(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         final String sessionId = "mel";
         processor.process(new Record<>(sessionId, "first", 0L));
         try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iterator = sessionStore.findSessions(sessionId, 0, 0)) {
@@ -239,8 +235,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldUpdateSessionIfTheSameTime(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldUpdateSessionIfTheSameTime(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         processor.process(new Record<>("mel", "first", 0L));
         processor.process(new Record<>("mel", "second", 0L));
         try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iterator =
@@ -252,12 +248,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
-        // This test expects caching behavior for accurate result counts
-        if (!enableCaching && !emitFinal) {
-            return;
-        }
+    public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
+
         final String sessionId = "mel";
         long now = 0;
         processor.process(new Record<>(sessionId, "first", now));
@@ -308,8 +301,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldRemoveMergedSessionsFromStateStore(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldRemoveMergedSessionsFromStateStore(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         processor.process(new Record<>("a", "1", 0L));
 
         // first ensure it is in the store
@@ -335,12 +328,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldHandleMultipleSessionsAndMerging(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
-        // This test expects caching behavior for accurate result counts
-        if (!enableCaching && !emitFinal) {
-            return;
-        }
+    public void shouldHandleMultipleSessionsAndMerging(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
+
         processor.process(new Record<>("a", "1", 0L));
         processor.process(new Record<>("b", "1", 0L));
         processor.process(new Record<>("c", "1", 0L));
@@ -412,8 +402,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldGetAggregatedValuesFromValueGetter(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldGetAggregatedValuesFromValueGetter(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         final KTableValueGetter<Windowed<String>, Long> getter = sessionAggregator.view().get();
         getter.init(mockContext);
         processor.process(new Record<>("a", "1", 0L));
@@ -427,8 +417,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldImmediatelyForwardNewSessionWhenNonCachedStore(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldImmediatelyForwardNewSessionWhenNonCachedStore(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         if (emitFinal)
             return;
 
@@ -460,8 +450,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldImmediatelyForwardRemovedSessionsWhenMerging(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldImmediatelyForwardRemovedSessionsWhenMerging(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, true, withHeaders);
         if (emitFinal)
             return;
 
@@ -491,8 +481,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, false, withHeaders);
         mockContext.setRecordContext(
             new ProcessorRecordContext(-1, -2, -3, "topic", new RecordHeaders())
         );
@@ -519,8 +509,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, false, withHeaders);
         final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.ofInactivityGapAndGrace(ofMillis(10L), ofMillis(0L)),
             mockStoreFactory(STORE_NAME),
@@ -586,8 +576,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
-        setup(inputType, enableCaching, withHeaders);
+    public void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final EmitStrategy.StrategyType inputType, final boolean withHeaders) {
+        setup(inputType, false, withHeaders);
         final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.ofInactivityGapAndGrace(ofMillis(10L), ofMillis(1L)),
             mockStoreFactory(STORE_NAME),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -254,10 +254,10 @@ public class KStreamSessionWindowAggregateProcessorTest {
     @MethodSource("data")
     public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
         setup(inputType, enableCaching, withHeaders);
-        // This test expects caching behavior for accurate result counts
-        if (!enableCaching && !emitFinal) {
-            return;
-        }
+//        // This test expects caching behavior for accurate result counts
+//        if (!enableCaching && !emitFinal) {
+//            return;
+//        }
         final String sessionId = "mel";
         long now = 0;
         processor.process(new Record<>(sessionId, "first", now));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -53,7 +53,8 @@ import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -93,17 +95,33 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private KStreamSessionWindowAggregate<String, String, Long> sessionAggregator;
     private Processor<String, String, Windowed<String>, Change<Long>> processor;
     private SessionStoreWithHeaders<String, Long> sessionStore;
-    
+
     public EmitStrategy.StrategyType type;
 
     private EmitStrategy emitStrategy;
     private boolean emitFinal;
 
-    private void setup(final EmitStrategy.StrategyType inputType, final boolean enableCaching) {
+    public static Stream<Arguments> data() {
+        return Stream.of(
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true, false),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true, true),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false, false),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false, true),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, true, false),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, true, true),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, false, false),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, false, true)
+        );
+    }
+
+    private void setup(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
         type = inputType;
         // Always process
         final Properties prop = StreamsTestUtils.getStreamsConfig();
         prop.put(StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
+        if (withHeaders) {
+            prop.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final StreamsConfig config = new StreamsConfig(prop);
 
         mockContext = new InternalMockProcessorContext<>(
@@ -175,9 +193,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldCreateSingleSessionWhenWithinGap(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldCreateSingleSessionWhenWithinGap(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         processor.process(new Record<>("john", "first", 0L));
         processor.process(new Record<>("john", "second", 500L));
 
@@ -189,9 +207,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldMergeSessions(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldMergeSessions(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         final String sessionId = "mel";
         processor.process(new Record<>(sessionId, "first", 0L));
         try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iterator = sessionStore.findSessions(sessionId, 0, 0)) {
@@ -220,9 +238,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldUpdateSessionIfTheSameTime(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldUpdateSessionIfTheSameTime(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         processor.process(new Record<>("mel", "first", 0L));
         processor.process(new Record<>("mel", "second", 0L));
         try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iterator =
@@ -233,9 +251,13 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
+        // This test expects caching behavior for accurate result counts
+        if (!enableCaching && !emitFinal) {
+            return;
+        }
         final String sessionId = "mel";
         long now = 0;
         processor.process(new Record<>(sessionId, "first", now));
@@ -285,9 +307,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldRemoveMergedSessionsFromStateStore(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldRemoveMergedSessionsFromStateStore(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         processor.process(new Record<>("a", "1", 0L));
 
         // first ensure it is in the store
@@ -312,9 +334,13 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldHandleMultipleSessionsAndMerging(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldHandleMultipleSessionsAndMerging(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
+        // This test expects caching behavior for accurate result counts
+        if (!enableCaching && !emitFinal) {
+            return;
+        }
         processor.process(new Record<>("a", "1", 0L));
         processor.process(new Record<>("b", "1", 0L));
         processor.process(new Record<>("c", "1", 0L));
@@ -385,9 +411,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldGetAggregatedValuesFromValueGetter(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldGetAggregatedValuesFromValueGetter(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         final KTableValueGetter<Windowed<String>, Long> getter = sessionAggregator.view().get();
         getter.init(mockContext);
         processor.process(new Record<>("a", "1", 0L));
@@ -400,9 +426,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldImmediatelyForwardNewSessionWhenNonCachedStore(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldImmediatelyForwardNewSessionWhenNonCachedStore(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         if (emitFinal)
             return;
 
@@ -433,9 +459,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldImmediatelyForwardRemovedSessionsWhenMerging(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, true);
+    @MethodSource("data")
+    public void shouldImmediatelyForwardRemovedSessionsWhenMerging(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         if (emitFinal)
             return;
 
@@ -464,9 +490,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, false);
+    @MethodSource("data")
+    public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         mockContext.setRecordContext(
             new ProcessorRecordContext(-1, -2, -3, "topic", new RecordHeaders())
         );
@@ -492,9 +518,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, false);
+    @MethodSource("data")
+    public void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.ofInactivityGapAndGrace(ofMillis(10L), ofMillis(0L)),
             mockStoreFactory(STORE_NAME),
@@ -559,9 +585,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     @ParameterizedTest
-    @EnumSource(EmitStrategy.StrategyType.class)
-    public void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final EmitStrategy.StrategyType inputType) {
-        setup(inputType, false);
+    @MethodSource("data")
+    public void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
+        setup(inputType, enableCaching, withHeaders);
         final Processor<String, String, Windowed<String>, Change<Long>> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.ofInactivityGapAndGrace(ofMillis(10L), ofMillis(1L)),
             mockStoreFactory(STORE_NAME),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -254,10 +254,10 @@ public class KStreamSessionWindowAggregateProcessorTest {
     @MethodSource("data")
     public void shouldHaveMultipleSessionsForSameIdWhenTimestampApartBySessionGap(final EmitStrategy.StrategyType inputType, final boolean enableCaching, final boolean withHeaders) {
         setup(inputType, enableCaching, withHeaders);
-//        // This test expects caching behavior for accurate result counts
-//        if (!enableCaching && !emitFinal) {
-//            return;
-//        }
+        // This test expects caching behavior for accurate result counts
+        if (!enableCaching && !emitFinal) {
+            return;
+        }
         final String sessionId = "mel";
         long now = 0;
         processor.process(new Record<>(sessionId, "first", now));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
@@ -92,14 +92,22 @@ public class KStreamSlidingWindowAggregateTest {
     
     public static Stream<Arguments> data() {
         return Stream.of(
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true),
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false),
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, true),
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, false),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, true), 
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, false),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, true),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, false)
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false, true),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, false, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, false, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, false, true)
         );
     }
     public StrategyType type;
@@ -112,18 +120,21 @@ public class KStreamSlidingWindowAggregateTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
     private final String threadId = Thread.currentThread().getName();
     
-    public void setup(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
+    public void setup(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         type = inputType;
         inOrderIterator = inputInOrderIterator;
         withCache = inputWithCache;
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
+        if (withHeaders) {
+            props.put(org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_CONFIG, org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAggregateSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testAggregateSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -220,8 +231,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReduceSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testReduceSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
         final WindowBytesStoreSupplier storeSupplier = setupWindowBytesStoreSupplier(1);
@@ -287,8 +298,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAggregateLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testAggregateLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final long grace = emitFinal ? 10L : 50L;
@@ -508,8 +519,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testJoin(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testJoin(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String topic2 = "topic2";
@@ -658,8 +669,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testEarlyRecordsSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testEarlyRecordsSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -782,8 +793,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testEarlyRecordsRepeatedInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testEarlyRecordsRepeatedInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -866,8 +877,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testEarlyRecordsLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testEarlyRecordsLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
         final WindowBytesStoreSupplier storeSupplier = setupWindowBytesStoreSupplier(1);
@@ -1021,8 +1032,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testEarlyNoGracePeriodSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testEarlyNoGracePeriodSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -1121,8 +1132,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testNoGracePeriodSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testNoGracePeriodSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -1213,8 +1224,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testEarlyNoGracePeriodLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testEarlyNoGracePeriodLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
         final WindowBytesStoreSupplier storeSupplier =
@@ -1334,8 +1345,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testNoGracePeriodLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testNoGracePeriodLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
         final WindowBytesStoreSupplier storeSupplier =
@@ -1459,8 +1470,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final String builtInMetricsVersion = StreamsConfig.METRICS_LATEST;
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
@@ -1492,8 +1503,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final String builtInMetricsVersion = StreamsConfig.METRICS_LATEST;
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
@@ -1571,8 +1582,8 @@ public class KStreamSlidingWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAggregateRandomInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache) {
-        setup(inputType, inputInOrderIterator, inputWithCache);
+    public void testAggregateRandomInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final WindowBytesStoreSupplier storeSupplier =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
@@ -90,7 +90,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KStreamSlidingWindowAggregateTest {
     
-    public static Stream<Arguments> data() {
+    public static Stream<Arguments> testParameters() {
         return Stream.of(
             Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true, false),
             Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true, true),
@@ -132,7 +132,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testAggregateSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -230,7 +230,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testReduceSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -297,7 +297,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testAggregateLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -518,7 +518,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testJoin(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -668,7 +668,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testEarlyRecordsSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -792,7 +792,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testEarlyRecordsRepeatedInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -876,7 +876,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testEarlyRecordsLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1031,7 +1031,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testEarlyNoGracePeriodSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1131,7 +1131,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testNoGracePeriodSmallInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1223,7 +1223,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testEarlyNoGracePeriodLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1344,7 +1344,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testNoGracePeriodLargeInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1469,7 +1469,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final String builtInMetricsVersion = StreamsConfig.METRICS_LATEST;
@@ -1502,7 +1502,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final String builtInMetricsVersion = StreamsConfig.METRICS_LATEST;
@@ -1581,7 +1581,7 @@ public class KStreamSlidingWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testAggregateRandomInput(final StrategyType inputType, final boolean inputInOrderIterator, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputInOrderIterator, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -103,7 +103,7 @@ public class KStreamWindowAggregateTest {
 
     private boolean emitFinal;
 
-    public static Stream<Arguments> data() {
+    public static Stream<Arguments> testParameters() {
         return Stream.of(
             Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false),
             Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true),
@@ -129,7 +129,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testAggBasic(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -225,7 +225,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void testJoin(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -475,7 +475,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -503,7 +503,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldLogAndMeterWhenSkippingExpiredWindow(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -589,7 +589,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -646,7 +646,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldNotEmitFinalIfNotProgressEnough(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -736,7 +736,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldEmitWithInterval0(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -805,7 +805,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldEmitWithLargeInterval(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -906,7 +906,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void shouldEmitFromLastEmitTime(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -988,7 +988,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @MethodSource("testParameters")
     public void showThrowIfEmitFinalUsedWithUnlimitedWindow(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         if (emitFinal) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
@@ -90,7 +91,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KStreamWindowAggregateTest {
     private static final String WINDOW_STORE_NAME = "dummy-store-name";
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private Properties props;
     private final String threadId = Thread.currentThread().getName();
     private final StoreFactory storeFactory = mockStoreFactory(WINDOW_STORE_NAME);
 
@@ -104,24 +105,32 @@ public class KStreamWindowAggregateTest {
 
     public static Stream<Arguments> getEmitStrategy() {
         return Stream.of(
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true),
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false)
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, true)
         );
     }
-    
-    public void setup(final StrategyType inputType, final boolean inputWithCache) {
+
+    public void setup(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         type = inputType;
         withCache = inputWithCache;
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
+        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
     }
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void testAggBasic(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void testAggBasic(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -216,8 +225,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void testJoin(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void testJoin(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String topic2 = "topic2";
@@ -466,8 +475,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -494,8 +503,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldLogAndMeterWhenSkippingExpiredWindow(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldLogAndMeterWhenSkippingExpiredWindow(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -580,8 +589,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -637,8 +646,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldNotEmitFinalIfNotProgressEnough(final StrategyType inputType, final boolean inputWithCache) throws IOException {
-        setup(inputType, inputWithCache);
+    public void shouldNotEmitFinalIfNotProgressEnough(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
+        setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
         final long windowSize = 10L;
         final Windows<TimeWindow> windows = TimeWindows.ofSizeAndGrace(ofMillis(windowSize), ofMillis(5)).advanceBy(ofMillis(5));
@@ -727,8 +736,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldEmitWithInterval0(final StrategyType inputType, final boolean inputWithCache) throws IOException {
-        setup(inputType, inputWithCache);
+    public void shouldEmitWithInterval0(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
+        setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
         final long windowSize = 10L;
         final Windows<TimeWindow> windows = TimeWindows.ofSizeAndGrace(ofMillis(windowSize), ofMillis(5)).advanceBy(ofMillis(5));
@@ -796,8 +805,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldEmitWithLargeInterval(final StrategyType inputType, final boolean inputWithCache) throws IOException {
-        setup(inputType, inputWithCache);
+    public void shouldEmitWithLargeInterval(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
+        setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
         final long windowSize = 10L;
         final Windows<TimeWindow> windows = TimeWindows.ofSizeAndGrace(ofMillis(windowSize), ofMillis(5)).advanceBy(ofMillis(5));
@@ -897,8 +906,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void shouldEmitFromLastEmitTime(final StrategyType inputType, final boolean inputWithCache) throws IOException {
-        setup(inputType, inputWithCache);
+    public void shouldEmitFromLastEmitTime(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
+        setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
         final long windowSize = 10L;
         final Windows<TimeWindow> windows = TimeWindows.ofSizeAndGrace(ofMillis(windowSize), ofMillis(5)).advanceBy(ofMillis(5));
@@ -979,8 +988,8 @@ public class KStreamWindowAggregateTest {
 
     @ParameterizedTest
     @MethodSource("getEmitStrategy")
-    public void showThrowIfEmitFinalUsedWithUnlimitedWindow(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void showThrowIfEmitFinalUsedWithUnlimitedWindow(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         if (emitFinal) {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class, () -> new KStreamWindowAggregate<>(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -91,7 +91,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KStreamWindowAggregateTest {
     private static final String WINDOW_STORE_NAME = "dummy-store-name";
-    private Properties props;
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
     private final String threadId = Thread.currentThread().getName();
     private final StoreFactory storeFactory = mockStoreFactory(WINDOW_STORE_NAME);
 
@@ -103,7 +103,7 @@ public class KStreamWindowAggregateTest {
 
     private boolean emitFinal;
 
-    public static Stream<Arguments> getEmitStrategy() {
+    public static Stream<Arguments> data() {
         return Stream.of(
             Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false),
             Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true),
@@ -121,14 +121,15 @@ public class KStreamWindowAggregateTest {
         withCache = inputWithCache;
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
-        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void testAggBasic(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -224,7 +225,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void testJoin(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -474,7 +475,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldLogAndMeterWhenSkippingNullKey(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -502,7 +503,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldLogAndMeterWhenSkippingExpiredWindow(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -588,7 +589,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -645,7 +646,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldNotEmitFinalIfNotProgressEnough(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -735,7 +736,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldEmitWithInterval0(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -804,7 +805,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldEmitWithLargeInterval(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -905,7 +906,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void shouldEmitFromLastEmitTime(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) throws IOException {
         setup(inputType, inputWithCache, withHeaders);
         final File stateDir = TestUtils.tempDirectory();
@@ -987,7 +988,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getEmitStrategy")
+    @MethodSource("data")
     public void showThrowIfEmitFinalUsedWithUnlimitedWindow(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         setup(inputType, inputWithCache, withHeaders);
         if (emitFinal) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -52,7 +52,9 @@ import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -60,6 +62,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -76,17 +79,28 @@ public class KTableAggregateTest {
     private final MockApiProcessorSupplier<String, Object, Void, Void> supplier = new MockApiProcessorSupplier<>();
     private static final Properties CONFIG = mkProperties(mkMap(
         mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory("kafka-test").getAbsolutePath())));
-    
-    private StreamsBuilder createStreamBuilderInMemory() {
+
+    public static Stream<Arguments> data() {
+        return Stream.of(
+            Arguments.of(false),
+            Arguments.of(true)
+        );
+    }
+
+    private StreamsBuilder createStreamBuilderInMemory(final boolean withHeaders) {
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
         props.put(StreamsConfig.DSL_STORE_SUPPLIERS_CLASS_CONFIG,
                     BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers.class.getName());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         return new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
     }
 
-    @Test
-    public void testAggBasic() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAggBasic(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String topic1 = "topic1";
 
         final KTable<String, String> table1 = builder.table(topic1, consumed);
@@ -134,9 +148,10 @@ public class KTableAggregateTest {
         }
     }
 
-    @Test
-    public void testAggRepartition() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAggRepartition(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String topic1 = "topic1";
 
         final KTable<String, String> table1 = builder.table(topic1, consumed);
@@ -191,9 +206,19 @@ public class KTableAggregateTest {
         }
     }
 
-    @Test
-    public void testAggOfVersionedStore() {
-        final StreamsBuilder builder = new StreamsBuilder();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAggOfVersionedStore(final boolean withHeaders) {
+        final StreamsBuilder builder;
+        if (withHeaders) {
+            final Properties props = new Properties();
+            props.putAll(CONFIG);
+            props.putAll(StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()));
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+            builder = new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
+        } else {
+            builder = new StreamsBuilder();
+        }
         final String topic1 = "topic1";
 
         final Materialized<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
@@ -275,9 +300,10 @@ public class KTableAggregateTest {
     }
 
 
-    @Test
-    public void testCount() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCount(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "count-test-input";
 
         builder
@@ -290,9 +316,10 @@ public class KTableAggregateTest {
         testCountHelper(builder, input, supplier);
     }
 
-    @Test
-    public void testCountWithInternalStore() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCountWithInternalStore(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "count-test-input";
 
         builder
@@ -305,9 +332,19 @@ public class KTableAggregateTest {
         testCountHelper(builder, input, supplier);
     }
 
-    @Test
-    public void testCountOfVersionedStore() {
-        final StreamsBuilder builder = new StreamsBuilder();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCountOfVersionedStore(final boolean withHeaders) {
+        final StreamsBuilder builder;
+        if (withHeaders) {
+            final Properties props = new Properties();
+            props.putAll(CONFIG);
+            props.putAll(StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()));
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+            builder = new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
+        } else {
+            builder = new StreamsBuilder();
+        }
         final String input = "count-test-input";
 
         final Materialized<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
@@ -344,9 +381,10 @@ public class KTableAggregateTest {
         }
     }
 
-    @Test
-    public void testRemoveOldBeforeAddNew() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testRemoveOldBeforeAddNew(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "count-test-input";
         final MockApiProcessorSupplier<String, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
 
@@ -391,8 +429,8 @@ public class KTableAggregateTest {
         }
     }
 
-    private void testUpgradeFromConfig(final Properties config, final List<KeyValueTimestamp<String, Long>> expected) {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    private void testUpgradeFromConfig(final Properties config, final List<KeyValueTimestamp<String, Long>> expected, final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "input-topic";
         final String output = "output-topic";
         final Serde<String> stringSerde = Serdes.String();
@@ -421,8 +459,9 @@ public class KTableAggregateTest {
         }
     }
 
-    @Test
-    public void testShouldSendTransientStateWhenUpgrading() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testShouldSendTransientStateWhenUpgrading(final boolean withHeaders) {
         final Properties upgradingConfig = new Properties();
         upgradingConfig.putAll(CONFIG);
         upgradingConfig.put(StreamsConfig.UPGRADE_FROM_CONFIG, StreamsConfig.UPGRADE_FROM_33);
@@ -430,15 +469,16 @@ public class KTableAggregateTest {
                 new KeyValueTimestamp<>("1", 1L, 8),
                 new KeyValueTimestamp<>("1", 0L, 9), // transient inconsistent state
                 new KeyValueTimestamp<>("1", 1L, 9)
-        ));
+        ), withHeaders);
     }
 
-    @Test
-    public void testShouldNotSendTransientStateIfNotUpgrading() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testShouldNotSendTransientStateIfNotUpgrading(final boolean withHeaders) {
         testUpgradeFromConfig(CONFIG, asList(
                 new KeyValueTimestamp<>("1", 1L, 8),
                 new KeyValueTimestamp<>("1", 1L, 9)
-        ));
+        ), withHeaders);
     }
 
     private static class NoEqualsImpl {
@@ -474,8 +514,9 @@ public class KTableAggregateTest {
 
     private void testKeyWithNoEquals(
             final KeyValueMapper<NoEqualsImpl, NoEqualsImpl, KeyValue<NoEqualsImpl, NoEqualsImpl>> keyValueMapper,
-            final List<TestRecord<NoEqualsImpl, Long>> expected) {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+            final List<TestRecord<NoEqualsImpl, Long>> expected,
+            final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "input-topic";
         final String output = "output-topic";
         final Serde<NoEqualsImpl> noEqualsImplSerde = new NoEqualsImplSerde();
@@ -507,8 +548,9 @@ public class KTableAggregateTest {
         }
     }
 
-    @Test
-    public void testNoEqualsAndNotSameObject() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNoEqualsAndNotSameObject(final boolean withHeaders) {
         testKeyWithNoEquals(
                 // key changes, different object reference (deserializer returns a new object reference)
                 (k, v) -> new KeyValue<>(v, v),
@@ -516,19 +558,22 @@ public class KTableAggregateTest {
                         new TestRecord<>(new NoEqualsImpl("1"), 1L, Instant.ofEpochMilli(8)),
                         new TestRecord<>(new NoEqualsImpl("1"), 0L, Instant.ofEpochMilli(9)), // transient inconsistent state
                         new TestRecord<>(new NoEqualsImpl("1"), 1L, Instant.ofEpochMilli(9))
-                )
+                ),
+                withHeaders
         );
     }
 
-    @Test
-    public void testNoEqualsAndSameObject() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNoEqualsAndSameObject(final boolean withHeaders) {
         testKeyWithNoEquals(
                 // key does not change, same object reference
                 KeyValue::new,
                 asList(
                         new TestRecord<>(new NoEqualsImpl("1"), 1L, Instant.ofEpochMilli(8)),
                         new TestRecord<>(new NoEqualsImpl("1"), 1L, Instant.ofEpochMilli(9))
-                )
+                ),
+                withHeaders
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -54,8 +54,7 @@ import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -63,7 +62,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -81,12 +79,6 @@ public class KTableAggregateTest {
     private static final Properties CONFIG = mkProperties(mkMap(
         mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory("kafka-test").getAbsolutePath())));
 
-    public static Stream<Arguments> data() {
-        return Stream.of(
-            Arguments.of(false),
-            Arguments.of(true)
-        );
-    }
 
     private StreamsBuilder createStreamBuilderInMemory(final boolean withHeaders) {
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
@@ -99,7 +91,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testAggBasic(final boolean withHeaders) {
         final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String topic1 = "topic1";
@@ -150,7 +142,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testAggRepartition(final boolean withHeaders) {
         final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String topic1 = "topic1";
@@ -292,7 +284,7 @@ public class KTableAggregateTest {
 
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testCount(final boolean withHeaders) {
         final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "count-test-input";
@@ -308,7 +300,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testCountWithInternalStore(final boolean withHeaders) {
         final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "count-test-input";
@@ -363,7 +355,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testRemoveOldBeforeAddNew(final boolean withHeaders) {
         final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final String input = "count-test-input";
@@ -441,7 +433,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testShouldSendTransientStateWhenUpgrading(final boolean withHeaders) {
         final Properties upgradingConfig = new Properties();
         upgradingConfig.putAll(CONFIG);
@@ -454,7 +446,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testShouldNotSendTransientStateIfNotUpgrading(final boolean withHeaders) {
         testUpgradeFromConfig(CONFIG, asList(
                 new KeyValueTimestamp<>("1", 1L, 8),
@@ -530,7 +522,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testNoEqualsAndNotSameObject(final boolean withHeaders) {
         testKeyWithNoEquals(
                 // key changes, different object reference (deserializer returns a new object reference)
@@ -545,7 +537,7 @@ public class KTableAggregateTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
+    @CsvSource({"true", "false"})
     public void testNoEqualsAndSameObject(final boolean withHeaders) {
         testKeyWithNoEquals(
                 // key does not change, same object reference

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -52,6 +52,7 @@ import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -206,19 +207,9 @@ public class KTableAggregateTest {
         }
     }
 
-    @ParameterizedTest
-    @MethodSource("data")
-    public void testAggOfVersionedStore(final boolean withHeaders) {
-        final StreamsBuilder builder;
-        if (withHeaders) {
-            final Properties props = new Properties();
-            props.putAll(CONFIG);
-            props.putAll(StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()));
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-            builder = new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
-        } else {
-            builder = new StreamsBuilder();
-        }
+    @Test
+    public void testAggOfVersionedStore() {
+        final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
         final Materialized<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
@@ -332,19 +323,9 @@ public class KTableAggregateTest {
         testCountHelper(builder, input, supplier);
     }
 
-    @ParameterizedTest
-    @MethodSource("data")
-    public void testCountOfVersionedStore(final boolean withHeaders) {
-        final StreamsBuilder builder;
-        if (withHeaders) {
-            final Properties props = new Properties();
-            props.putAll(CONFIG);
-            props.putAll(StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()));
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-            builder = new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
-        } else {
-            builder = new StreamsBuilder();
-        }
+    @Test
+    public void testCountOfVersionedStore() {
+        final StreamsBuilder builder = new StreamsBuilder();
         final String input = "count-test-input";
 
         final Materialized<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -79,7 +79,6 @@ public class KTableAggregateTest {
     private static final Properties CONFIG = mkProperties(mkMap(
         mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory("kafka-test").getAbsolutePath())));
 
-
     private StreamsBuilder createStreamBuilderInMemory(final boolean withHeaders) {
         final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
         props.put(StreamsConfig.DSL_STORE_SUPPLIERS_CLASS_CONFIG,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -43,8 +43,8 @@ import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -59,12 +59,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @SuppressWarnings("unchecked")
 public class KTableFilterTest {
     private final Consumed<String, Integer> consumed = Consumed.with(Serdes.String(), Serdes.Integer());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.Integer());
+    private Properties props;
 
-    @BeforeEach
-    public void setUp() {
+    private void setupProps(final boolean withHeaders) {
+        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.Integer());
         // disable caching at the config level
         props.setProperty(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, "0");
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
     }
 
     private final Predicate<String, Integer> predicate = (key, value) -> (value % 2) == 0;
@@ -104,8 +107,10 @@ public class KTableFilterTest {
             new KeyValueTimestamp<>("B", null, 15));
     }
 
-    @Test
-    public void shouldPassThroughWithoutMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldPassThroughWithoutMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -120,8 +125,10 @@ public class KTableFilterTest {
         doTestKTable(builder, table2, table3, topic1);
     }
 
-    @Test
-    public void shouldPassThroughOnMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldPassThroughOnMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -206,8 +213,10 @@ public class KTableFilterTest {
         }
     }
 
-    @Test
-    public void shouldGetValuesOnMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldGetValuesOnMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -277,8 +286,10 @@ public class KTableFilterTest {
     }
 
 
-    @Test
-    public void shouldNotSendOldValuesWithoutMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotSendOldValuesWithoutMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -289,8 +300,10 @@ public class KTableFilterTest {
         doTestNotSendingOldValue(builder, table1, table2, topic1);
     }
 
-    @Test
-    public void shouldNotSendOldValuesOnMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotSendOldValuesOnMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -302,8 +315,10 @@ public class KTableFilterTest {
         doTestNotSendingOldValue(builder, table1, table2, topic1);
     }
 
-    @Test
-    public void shouldNotEnableSendingOldValuesIfNotAlreadyMaterializedAndNotForcedToMaterialize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotEnableSendingOldValuesIfNotAlreadyMaterializedAndNotForcedToMaterialize(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -381,8 +396,10 @@ public class KTableFilterTest {
         }
     }
 
-    @Test
-    public void shouldEnableSendOldValuesWhenNotMaterializedAlreadyButForcedToMaterialize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldEnableSendOldValuesWhenNotMaterializedAlreadyButForcedToMaterialize(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -399,8 +416,10 @@ public class KTableFilterTest {
         doTestSendingOldValue(builder, table1, table2, topic1);
     }
 
-    @Test
-    public void shouldEnableSendOldValuesWhenMaterializedAlreadyAndForcedToMaterialize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldEnableSendOldValuesWhenMaterializedAlreadyAndForcedToMaterialize(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -417,8 +436,10 @@ public class KTableFilterTest {
         doTestSendingOldValue(builder, table1, table2, topic1);
     }
 
-    @Test
-    public void shouldSendOldValuesWhenEnabledOnUpStreamMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldSendOldValuesWhenEnabledOnUpStreamMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -468,8 +489,10 @@ public class KTableFilterTest {
         }
     }
 
-    @Test
-    public void shouldSkipNullToRepartitionWithoutMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldSkipNullToRepartitionWithoutMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         // Do not explicitly set enableSendingOldValues. Let a further downstream stateful operator trigger it instead.
         final StreamsBuilder builder = new StreamsBuilder();
 
@@ -486,8 +509,10 @@ public class KTableFilterTest {
         doTestSkipNullOnMaterialization(builder, table1, table2, topic1, true);
     }
 
-    @Test
-    public void shouldSkipNullToRepartitionOnMaterialization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldSkipNullToRepartitionOnMaterialization(final boolean withHeaders) {
+        setupProps(withHeaders);
         // Do not explicitly set enableSendingOldValues. Let a further downstream stateful operator trigger it instead.
         final StreamsBuilder builder = new StreamsBuilder();
 
@@ -504,8 +529,10 @@ public class KTableFilterTest {
         doTestSkipNullOnMaterialization(builder, table1, table2, topic1, true);
     }
 
-    @Test
-    public void shouldNotSkipNullIfVersionedUpstream() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotSkipNullIfVersionedUpstream(final boolean withHeaders) {
+        setupProps(withHeaders);
         // stateful downstream operation enables sendOldValues, but duplicate nulls will still
         // be sent because the source table is versioned
         final StreamsBuilder builder = new StreamsBuilder();
@@ -525,8 +552,10 @@ public class KTableFilterTest {
         doTestSkipNullOnMaterialization(builder, table1, table2, topic1, false);
     }
 
-    @Test
-    public void shouldSkipNullIfVersionedDownstream() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldSkipNullIfVersionedDownstream(final boolean withHeaders) {
+        setupProps(withHeaders);
         // materializing the result of the filter as a versioned store does not prevent duplicate
         // tombstones from being sent, as it's whether the input table is versioned or not that
         // determines whether the optimization is enabled
@@ -547,8 +576,10 @@ public class KTableFilterTest {
         doTestSkipNullOnMaterialization(builder, table1, table2, topic1, true);
     }
 
-    @Test
-    public void testTypeVariance() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testTypeVariance(final boolean withHeaders) {
+        setupProps(withHeaders);
         final Predicate<Number, Object> numberKeyPredicate = (key, value) -> false;
 
         new StreamsBuilder()

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -59,14 +59,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @SuppressWarnings("unchecked")
 public class KTableFilterTest {
     private final Consumed<String, Integer> consumed = Consumed.with(Serdes.String(), Serdes.Integer());
-    private Properties props;
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.Integer());
 
     private void setupProps(final boolean withHeaders) {
-        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.Integer());
         // disable caching at the config level
         props.setProperty(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, "0");
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -61,7 +61,7 @@ public class KTableFilterTest {
     private final Consumed<String, Integer> consumed = Consumed.with(Serdes.String(), Serdes.Integer());
     private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.Integer());
 
-    private void setupProps(final boolean withHeaders) {
+    private void setup(final boolean withHeaders) {
         // disable caching at the config level
         props.setProperty(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, "0");
         if (withHeaders) {
@@ -111,7 +111,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldPassThroughWithoutMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -129,7 +129,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldPassThroughOnMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -217,7 +217,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldGetValuesOnMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -290,7 +290,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotSendOldValuesWithoutMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -304,7 +304,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotSendOldValuesOnMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -319,7 +319,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotEnableSendingOldValuesIfNotAlreadyMaterializedAndNotForcedToMaterialize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -400,7 +400,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldEnableSendOldValuesWhenNotMaterializedAlreadyButForcedToMaterialize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -420,7 +420,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldEnableSendOldValuesWhenMaterializedAlreadyAndForcedToMaterialize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -440,7 +440,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldSendOldValuesWhenEnabledOnUpStreamMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -493,7 +493,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldSkipNullToRepartitionWithoutMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         // Do not explicitly set enableSendingOldValues. Let a further downstream stateful operator trigger it instead.
         final StreamsBuilder builder = new StreamsBuilder();
 
@@ -513,7 +513,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldSkipNullToRepartitionOnMaterialization(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         // Do not explicitly set enableSendingOldValues. Let a further downstream stateful operator trigger it instead.
         final StreamsBuilder builder = new StreamsBuilder();
 
@@ -533,7 +533,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotSkipNullIfVersionedUpstream(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         // stateful downstream operation enables sendOldValues, but duplicate nulls will still
         // be sent because the source table is versioned
         final StreamsBuilder builder = new StreamsBuilder();
@@ -556,7 +556,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldSkipNullIfVersionedDownstream(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         // materializing the result of the filter as a versioned store does not prevent duplicate
         // tombstones from being sent, as it's whether the input table is versioned or not that
         // determines whether the optimization is enabled
@@ -580,7 +580,7 @@ public class KTableFilterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testTypeVariance(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setup(withHeaders);
         final Predicate<Number, Object> numberKeyPredicate = (key, value) -> false;
 
         new StreamsBuilder()

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -87,7 +87,7 @@ public class KTableImplTest {
 
     private KTable<String, String> table;
 
-    private void setupProps(final boolean withHeaders) {
+    private void setDslStoreFormat(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
         } else {
@@ -103,7 +103,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testKTable(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final String topic1 = "topic1";
@@ -173,7 +173,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testMaterializedKTable(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final String topic1 = "topic1";
@@ -240,7 +240,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldPreserveSerdesForOperators(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<String, String> table1 = builder.table("topic-2", stringConsumed);
         final ConsumedInternal<String, String> consumedInternal = new ConsumedInternal<>(stringConsumed);
@@ -366,7 +366,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testStateStoreLazyEval(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String topic2 = "topic2";
@@ -385,7 +385,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testStateStore(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String topic2 = "topic2";
@@ -405,7 +405,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotEnableSendingOldValuesIfNotMaterializedAlreadyAndNotForcedToMaterialize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final var table = assertInstanceOf(KTableImpl.class, builder.table("topic1", consumed));
@@ -417,7 +417,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldEnableSendingOldValuesIfNotMaterializedAlreadyButForcedToMaterialize(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final var table = assertInstanceOf(KTableImpl.class, builder.table("topic1", consumed));
@@ -441,7 +441,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldCreateSourceAndSinkNodesForRepartitioningTopic(final boolean withHeaders) throws Exception {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String storeName1 = "storeName1";
@@ -496,98 +496,98 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullSelectorOnToStream(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.toStream((KeyValueMapper<String, String, ?>) null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullPredicateOnFilter(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.filter(null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullPredicateOnFilterNot(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.filterNot(null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullMapperOnMapValues(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.mapValues((ValueMapper<String, ?>) null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullMapperOnMapValueWithKey(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.mapValues((ValueMapperWithKey<String, String, ?>) null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullSelectorOnGroupBy(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.groupBy(null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullOtherTableOnJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.join(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldAllowNullStoreInJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         table.join(table, MockValueJoiner.TOSTRING_JOINER);
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullJoinerJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.join(table, null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullOtherTableOnOuterJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.outerJoin(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullJoinerOnOuterJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.outerJoin(table, null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullJoinerOnLeftJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.leftJoin(table, null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotAllowNullOtherTableOnLeftJoin(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.leftJoin(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnFilterWhenMaterializedIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.filter((key, value) -> false, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
@@ -597,7 +597,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnFilterNotWhenMaterializedIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.filterNot((key, value) -> false, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
@@ -607,7 +607,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnJoinWhenMaterializedIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.join(table, MockValueJoiner.TOSTRING_JOINER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
@@ -617,7 +617,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnLeftJoinWhenMaterializedIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.leftJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
@@ -627,7 +627,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnOuterJoinWhenMaterializedIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.outerJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
@@ -637,14 +637,14 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnTransformValuesWithKeyWhenTransformerSupplierIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.transformValues(null));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnTransformValuesWithKeyWhenMaterializedIsNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.transformValues(mock(), (Materialized<String, Object, KeyValueStore<Bytes, byte[]>>) null));
     }
 
@@ -652,7 +652,7 @@ public class KTableImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldThrowNullPointerOnTransformValuesWithKeyWhenStoreNamesNull(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         assertThrows(NullPointerException.class, () -> table.transformValues(mock(), (String[]) null));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -82,15 +82,16 @@ public class KTableImplTest {
     private final Consumed<String, String> stringConsumed = Consumed.with(Serdes.String(), Serdes.String());
     private final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
     private final Produced<String, String> produced = Produced.with(Serdes.String(), Serdes.String());
-    private Properties props;
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
     private final Serde<String> mySerde = new Serdes.StringSerde();
 
     private KTable<String, String> table;
 
     private void setupProps(final boolean withHeaders) {
-        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
@@ -54,8 +55,9 @@ import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -80,18 +82,27 @@ public class KTableImplTest {
     private final Consumed<String, String> stringConsumed = Consumed.with(Serdes.String(), Serdes.String());
     private final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
     private final Produced<String, String> produced = Produced.with(Serdes.String(), Serdes.String());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private Properties props;
     private final Serde<String> mySerde = new Serdes.StringSerde();
 
     private KTable<String, String> table;
+
+    private void setupProps(final boolean withHeaders) {
+        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+    }
 
     @BeforeEach
     public void setUp() {
         table = new StreamsBuilder().table("test");
     }
 
-    @Test
-    public void testKTable() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testKTable(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final String topic1 = "topic1";
@@ -158,8 +169,10 @@ public class KTableImplTest {
             processors.get(3).processed());
     }
 
-    @Test
-    public void testMaterializedKTable() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testMaterializedKTable(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final String topic1 = "topic1";
@@ -223,8 +236,10 @@ public class KTableImplTest {
             processors.get(3).processed());
     }
 
-    @Test
-    public void shouldPreserveSerdesForOperators() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldPreserveSerdesForOperators(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<String, String> table1 = builder.table("topic-2", stringConsumed);
         final ConsumedInternal<String, String> consumedInternal = new ConsumedInternal<>(stringConsumed);
@@ -347,8 +362,10 @@ public class KTableImplTest {
             mySerde);
     }
 
-    @Test
-    public void testStateStoreLazyEval() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testStateStoreLazyEval(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String topic2 = "topic2";
@@ -364,8 +381,10 @@ public class KTableImplTest {
         }
     }
 
-    @Test
-    public void testStateStore() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testStateStore(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String topic2 = "topic2";
@@ -382,8 +401,10 @@ public class KTableImplTest {
         }
     }
 
-    @Test
-    public void shouldNotEnableSendingOldValuesIfNotMaterializedAlreadyAndNotForcedToMaterialize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotEnableSendingOldValuesIfNotMaterializedAlreadyAndNotForcedToMaterialize(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final var table = assertInstanceOf(KTableImpl.class, builder.table("topic1", consumed));
@@ -392,8 +413,10 @@ public class KTableImplTest {
         assertThat(table.sendingOldValueEnabled(), is(false));
     }
 
-    @Test
-    public void shouldEnableSendingOldValuesIfNotMaterializedAlreadyButForcedToMaterialize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldEnableSendingOldValuesIfNotMaterializedAlreadyButForcedToMaterialize(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
 
         final var table = assertInstanceOf(KTableImpl.class, builder.table("topic1", consumed));
@@ -414,8 +437,10 @@ public class KTableImplTest {
             + "found in the provided Topology:\n" + topology.describe());
     }
 
-    @Test
-    public void shouldCreateSourceAndSinkNodesForRepartitioningTopic() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCreateSourceAndSinkNodesForRepartitioningTopic(final boolean withHeaders) throws Exception {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String storeName1 = "storeName1";
@@ -467,124 +492,166 @@ public class KTableImplTest {
         }
     }
 
-    @Test
-    public void shouldNotAllowNullSelectorOnToStream() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullSelectorOnToStream(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.toStream((KeyValueMapper<String, String, ?>) null));
     }
 
-    @Test
-    public void shouldNotAllowNullPredicateOnFilter() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullPredicateOnFilter(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.filter(null));
     }
 
-    @Test
-    public void shouldNotAllowNullPredicateOnFilterNot() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullPredicateOnFilterNot(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.filterNot(null));
     }
 
-    @Test
-    public void shouldNotAllowNullMapperOnMapValues() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullMapperOnMapValues(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.mapValues((ValueMapper<String, ?>) null));
     }
 
-    @Test
-    public void shouldNotAllowNullMapperOnMapValueWithKey() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullMapperOnMapValueWithKey(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.mapValues((ValueMapperWithKey<String, String, ?>) null));
     }
 
-    @Test
-    public void shouldNotAllowNullSelectorOnGroupBy() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullSelectorOnGroupBy(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.groupBy(null));
     }
 
-    @Test
-    public void shouldNotAllowNullOtherTableOnJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullOtherTableOnJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.join(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
-    @Test
-    public void shouldAllowNullStoreInJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldAllowNullStoreInJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         table.join(table, MockValueJoiner.TOSTRING_JOINER);
     }
 
-    @Test
-    public void shouldNotAllowNullJoinerJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullJoinerJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.join(table, null));
     }
 
-    @Test
-    public void shouldNotAllowNullOtherTableOnOuterJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullOtherTableOnOuterJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.outerJoin(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
-    @Test
-    public void shouldNotAllowNullJoinerOnOuterJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullJoinerOnOuterJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.outerJoin(table, null));
     }
 
-    @Test
-    public void shouldNotAllowNullJoinerOnLeftJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullJoinerOnLeftJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.leftJoin(table, null));
     }
 
-    @Test
-    public void shouldNotAllowNullOtherTableOnLeftJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotAllowNullOtherTableOnLeftJoin(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.leftJoin(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnFilterWhenMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnFilterWhenMaterializedIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.filter((key, value) -> false, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
         );
     }
 
-    @Test
-    public void shouldThrowNullPointerOnFilterNotWhenMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnFilterNotWhenMaterializedIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.filterNot((key, value) -> false, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
         );
     }
 
-    @Test
-    public void shouldThrowNullPointerOnJoinWhenMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnJoinWhenMaterializedIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.join(table, MockValueJoiner.TOSTRING_JOINER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
         );
     }
 
-    @Test
-    public void shouldThrowNullPointerOnLeftJoinWhenMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnLeftJoinWhenMaterializedIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.leftJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
         );
     }
 
-    @Test
-    public void shouldThrowNullPointerOnOuterJoinWhenMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnOuterJoinWhenMaterializedIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(
             NullPointerException.class,
             () -> table.outerJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null)
         );
     }
 
-    @Test
-    public void shouldThrowNullPointerOnTransformValuesWithKeyWhenTransformerSupplierIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnTransformValuesWithKeyWhenTransformerSupplierIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.transformValues(null));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnTransformValuesWithKeyWhenMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnTransformValuesWithKeyWhenMaterializedIsNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.transformValues(mock(), (Materialized<String, Object, KeyValueStore<Bytes, byte[]>>) null));
     }
 
 
-    @Test
-    public void shouldThrowNullPointerOnTransformValuesWithKeyWhenStoreNamesNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnTransformValuesWithKeyWhenStoreNamesNull(final boolean withHeaders) {
+        setupProps(withHeaders);
         assertThrows(NullPointerException.class, () -> table.transformValues(mock(), (String[]) null));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableForeignKeyJoinScenarioTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableForeignKeyJoinScenarioTest.java
@@ -36,7 +36,8 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.utils.UniqueTopicSerdeScope;
 import org.apache.kafka.test.TestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,8 +57,9 @@ public class KTableKTableForeignKeyJoinScenarioTest {
     private static final String RIGHT_TABLE = "right_table";
     private static final String OUTPUT = "output-topic";
 
-    @Test
-    public void shouldWorkWithDefaultSerdes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithDefaultSerdes(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Integer, String> aTable = builder.table("A");
         final KTable<Integer, String> bTable = builder.table("B");
@@ -76,11 +78,12 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         finalJoinResult.toStream().to("output");
 
-        validateTopologyCanProcessData(builder);
+        validateTopologyCanProcessData(builder, withHeaders);
     }
 
-    @Test
-    public void shouldWorkWithDefaultAndConsumedSerdes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithDefaultAndConsumedSerdes(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Integer, String> aTable = builder.table("A", Consumed.with(Serdes.Integer(), Serdes.String()));
         final KTable<Integer, String> bTable = builder.table("B");
@@ -99,11 +102,12 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         finalJoinResult.toStream().to("output");
 
-        validateTopologyCanProcessData(builder);
+        validateTopologyCanProcessData(builder, withHeaders);
     }
 
-    @Test
-    public void shouldWorkWithDefaultAndJoinResultSerdes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithDefaultAndJoinResultSerdes(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Integer, String> aTable = builder.table("A");
         final KTable<Integer, String> bTable = builder.table("B");
@@ -124,11 +128,12 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         finalJoinResult.toStream().to("output");
 
-        validateTopologyCanProcessData(builder);
+        validateTopologyCanProcessData(builder, withHeaders);
     }
 
-    @Test
-    public void shouldWorkWithDefaultAndEquiJoinResultSerdes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithDefaultAndEquiJoinResultSerdes(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Integer, String> aTable = builder.table("A");
         final KTable<Integer, String> bTable = builder.table("B");
@@ -148,11 +153,12 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         finalJoinResult.toStream().to("output");
 
-        validateTopologyCanProcessData(builder);
+        validateTopologyCanProcessData(builder, withHeaders);
     }
 
-    @Test
-    public void shouldWorkWithDefaultAndProducedSerdes() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithDefaultAndProducedSerdes(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Integer, String> aTable = builder.table("A");
         final KTable<Integer, String> bTable = builder.table("B");
@@ -171,16 +177,20 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         finalJoinResult.toStream().to("output", Produced.with(Serdes.Integer(), Serdes.String()));
 
-        validateTopologyCanProcessData(builder);
+        validateTopologyCanProcessData(builder, withHeaders);
     }
 
-    @Test
-    public void shouldUseExpectedTopicsWithSerde() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldUseExpectedTopicsWithSerde(final boolean withHeaders) {
         final String applicationId = "ktable-ktable-joinOnForeignKey";
         final Properties streamsConfig = mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         ));
+        if (withHeaders) {
+            streamsConfig.setProperty(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
 
         final UniqueTopicSerdeScope serdeScope = new UniqueTopicSerdeScope();
         final StreamsBuilder builder = new StreamsBuilder();
@@ -234,8 +244,9 @@ public class KTableKTableForeignKeyJoinScenarioTest {
         )));
     }
 
-    @Test
-    public void shouldWorkWithCompositeKeyAndProducerIdInValue() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithCompositeKeyAndProducerIdInValue(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         // Left table keyed by <producer_id, product_id>
@@ -260,7 +271,7 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         joined.toStream().to("output");
 
-        try (final TopologyTestDriver driver = createTopologyTestDriver(builder)) {
+        try (final TopologyTestDriver driver = createTopologyTestDriver(builder, withHeaders)) {
             final TestInputTopic<String, String> leftInput = driver.createInputTopic(
                 "left_table",
                 new StringSerializer(),
@@ -295,8 +306,9 @@ public class KTableKTableForeignKeyJoinScenarioTest {
         }
     }
 
-    @Test
-    public void shouldWorkWithCompositeKeyAndBiFunctionExtractor() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldWorkWithCompositeKeyAndBiFunctionExtractor(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         // Left table keyed by <producer_id, product_id>
@@ -321,7 +333,7 @@ public class KTableKTableForeignKeyJoinScenarioTest {
 
         joined.toStream().to("output");
 
-        try (final TopologyTestDriver driver = createTopologyTestDriver(builder)) {
+        try (final TopologyTestDriver driver = createTopologyTestDriver(builder, withHeaders)) {
             final TestInputTopic<String, String> leftInput = driver.createInputTopic(
                 "left_table",
                 new StringSerializer(),
@@ -355,21 +367,27 @@ public class KTableKTableForeignKeyJoinScenarioTest {
         }
     }
 
-    private TopologyTestDriver createTopologyTestDriver(final StreamsBuilder builder) {
+    private TopologyTestDriver createTopologyTestDriver(final StreamsBuilder builder, final boolean withHeaders) {
         final Properties config = new Properties();
         config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "test-app");
         config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
         config.setProperty(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        if (withHeaders) {
+            config.setProperty(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         return new TopologyTestDriver(builder.build(), config);
     }
 
-    private void validateTopologyCanProcessData(final StreamsBuilder builder) {
+    private void validateTopologyCanProcessData(final StreamsBuilder builder, final boolean withHeaders) {
         final Properties config = new Properties();
         config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class.getName());
         config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
         config.setProperty(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+        if (withHeaders) {
+            config.setProperty(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         try (final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), config)) {
             final TestInputTopic<Integer, String> aTopic = topologyTestDriver.createInputTopic("A", new IntegerSerializer(), new StringSerializer());
             final TestInputTopic<Integer, String> bTopic = topologyTestDriver.createInputTopic("B", new IntegerSerializer(), new StringSerializer());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
@@ -63,16 +64,8 @@ public class KTableKTableInnerJoinTest {
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
     private final Materialized<Integer, String, KeyValueStore<Bytes, byte[]>> materialized =
         Materialized.with(Serdes.Integer(), Serdes.String());
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
-
-    private Properties getProps(final boolean withHeaders) {
-        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
-        if (withHeaders) {
-            props.put(org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_CONFIG,
-                     org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-        return props;
-    }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -170,7 +163,8 @@ public class KTableKTableInnerJoinTest {
 
         builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
+        setDslStoreFormat(withHeaders);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -272,7 +266,8 @@ public class KTableKTableInnerJoinTest {
             null
         ).get();
 
-        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(getProps(withHeaders));
+        setDslStoreFormat(withHeaders);
+        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(props);
         context.setRecordMetadata("left", -1, -2);
         join.init(context);
 
@@ -294,7 +289,8 @@ public class KTableKTableInnerJoinTest {
                                            final KTable<Integer, String> joined,
                                            final boolean withHeaders) {
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
+        setDslStoreFormat(withHeaders);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -391,7 +387,8 @@ public class KTableKTableInnerJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
+        setDslStoreFormat(withHeaders);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -492,6 +489,14 @@ public class KTableKTableInnerJoinTest {
                                                final String expectedValue,
                                                final long expectedTimestamp) {
         assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp)));
+    }
+
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
@@ -38,7 +38,8 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -62,10 +63,20 @@ public class KTableKTableInnerJoinTest {
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
     private final Materialized<Integer, String, KeyValueStore<Bytes, byte[]>> materialized =
         Materialized.with(Serdes.Integer(), Serdes.String());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
-    @Test
-    public void testJoin() {
+
+    private Properties getProps(final boolean withHeaders) {
+        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        if (withHeaders) {
+            props.put(org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_CONFIG,
+                     org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+        return props;
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testJoin(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -78,11 +89,12 @@ public class KTableKTableInnerJoinTest {
         joined = table1.join(table2, MockValueJoiner.TOSTRING_JOINER);
         joined.toStream().to(output);
 
-        doTestJoin(builder, expectedKeys);
+        doTestJoin(builder, expectedKeys, withHeaders);
     }
 
-    @Test
-    public void testQueryableJoin() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testQueryableJoin(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -95,11 +107,12 @@ public class KTableKTableInnerJoinTest {
         table3 = table1.join(table2, MockValueJoiner.TOSTRING_JOINER, materialized);
         table3.toStream().to(output);
 
-        doTestJoin(builder, expectedKeys);
+        doTestJoin(builder, expectedKeys, withHeaders);
     }
 
-    @Test
-    public void testQueryableNotSendingOldValues() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testQueryableNotSendingOldValues(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -114,11 +127,12 @@ public class KTableKTableInnerJoinTest {
         joined = table1.join(table2, MockValueJoiner.TOSTRING_JOINER, materialized);
         builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        doTestNotSendingOldValues(builder, expectedKeys, table1, table2, supplier, joined);
+        doTestNotSendingOldValues(builder, expectedKeys, table1, table2, supplier, joined, withHeaders);
     }
 
-    @Test
-    public void testNotSendingOldValues() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testNotSendingOldValues(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -133,11 +147,12 @@ public class KTableKTableInnerJoinTest {
         joined = table1.join(table2, MockValueJoiner.TOSTRING_JOINER);
         builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        doTestNotSendingOldValues(builder, expectedKeys, table1, table2, supplier, joined);
+        doTestNotSendingOldValues(builder, expectedKeys, table1, table2, supplier, joined, withHeaders);
     }
 
-    @Test
-    public void testSendingOldValues() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSendingOldValues(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
@@ -155,7 +170,7 @@ public class KTableKTableInnerJoinTest {
 
         builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -245,8 +260,9 @@ public class KTableKTableInnerJoinTest {
         }
     }
 
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -256,7 +272,7 @@ public class KTableKTableInnerJoinTest {
             null
         ).get();
 
-        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(props);
+        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(getProps(withHeaders));
         context.setRecordMetadata("left", -1, -2);
         join.init(context);
 
@@ -275,9 +291,10 @@ public class KTableKTableInnerJoinTest {
                                            final KTable<Integer, String> table1,
                                            final KTable<Integer, String> table2,
                                            final MockApiProcessorSupplier<Integer, String, Void, Void> supplier,
-                                           final KTable<Integer, String> joined) {
+                                           final KTable<Integer, String> joined,
+                                           final boolean withHeaders) {
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -367,14 +384,14 @@ public class KTableKTableInnerJoinTest {
         }
     }
 
-    private void doTestJoin(final StreamsBuilder builder, final int[] expectedKeys) {
+    private void doTestJoin(final StreamsBuilder builder, final int[] expectedKeys, final boolean withHeaders) {
         final Collection<Set<String>> copartitionGroups =
             TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
@@ -491,6 +491,13 @@ public class KTableKTableInnerJoinTest {
         assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp)));
     }
 
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
     private void setDslStoreFormat(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -46,7 +46,8 @@ import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -69,16 +70,20 @@ public class KTableKTableLeftJoinTest {
     private final String topic2 = "topic2";
     private final String output = "output";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+    private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
-    private StreamsBuilder createStreamBuilderInMemory() {
+    private StreamsBuilder createStreamBuilderInMemory(final boolean withHeaders) {
         props.put(StreamsConfig.DSL_STORE_SUPPLIERS_CLASS_CONFIG, BuiltInDslStoreSuppliers.InMemoryDslStoreSuppliers.class.getName());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         return new StreamsBuilder(new TopologyConfig(new StreamsConfig(props)));
     }
 
-    @Test
-    public void testJoin() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testJoin(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -197,9 +202,10 @@ public class KTableKTableLeftJoinTest {
         }
     }
 
-    @Test
-    public void testNotSendingOldValue() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testNotSendingOldValue(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -313,9 +319,10 @@ public class KTableKTableLeftJoinTest {
         }
     }
 
-    @Test
-    public void testSendingOldValue() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSendingOldValue(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
 
         final int[] expectedKeys = new int[] {0, 1, 2, 3};
 
@@ -438,8 +445,9 @@ public class KTableKTableLeftJoinTest {
      * It is based on a fairly complicated join used by the developer that reported the bug.
      * Before the fix this would trigger an IllegalStateException.
      */
-    @Test
-    public void shouldNotThrowIllegalStateExceptionWhenMultiCacheEvictions() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotThrowIllegalStateExceptionWhenMultiCacheEvictions(final boolean withHeaders) {
         final String agg = "agg";
         final String tableOne = "tableOne";
         final String tableTwo = "tableTwo";
@@ -449,7 +457,7 @@ public class KTableKTableLeftJoinTest {
         final String tableSix = "tableSix";
         final String[] inputs = {agg, tableOne, tableTwo, tableThree, tableFour, tableFive, tableSix};
 
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
         final Consumed<Long, String> consumed = Consumed.with(Serdes.Long(), Serdes.String());
         final KTable<Long, String> aggTable = builder
             .table(agg, consumed, Materialized.as(Stores.inMemoryKeyValueStore("agg-base-store")))
@@ -501,9 +509,10 @@ public class KTableKTableLeftJoinTest {
         }
     }
 
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey() {
-        final StreamsBuilder builder = createStreamBuilderInMemory();
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final boolean withHeaders) {
+        final StreamsBuilder builder = createStreamBuilderInMemory(withHeaders);
 
         @SuppressWarnings("unchecked")
         final Processor<String, Change<String>, String, Change<Object>> join = new KTableKTableLeftJoin<>(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
@@ -445,6 +445,13 @@ public class KTableKTableOuterJoinTest {
         assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp)));
     }
 
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
     private void setDslStoreFormat(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
@@ -57,15 +58,8 @@ public class KTableKTableOuterJoinTest {
     private final String topic2 = "topic2";
     private final String output = "output";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
+    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
-    private Properties getProps(final boolean withHeaders) {
-        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
-        if (withHeaders) {
-            props.put(org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_CONFIG,
-                     org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-        return props;
-    }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -89,7 +83,8 @@ public class KTableKTableOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
+        setDslStoreFormat(withHeaders);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -210,7 +205,8 @@ public class KTableKTableOuterJoinTest {
 
         final Topology topology = builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, getProps(withHeaders))) {
+        setDslStoreFormat(withHeaders);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -322,7 +318,8 @@ public class KTableKTableOuterJoinTest {
 
         final Topology topology = builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, getProps(withHeaders))) {
+        setDslStoreFormat(withHeaders);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -426,7 +423,8 @@ public class KTableKTableOuterJoinTest {
                 null
         ).get();
 
-        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(getProps(withHeaders));
+        setDslStoreFormat(withHeaders);
+        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(props);
         context.setRecordMetadata("left", -1, -2);
         join.init(context);
 
@@ -445,6 +443,14 @@ public class KTableKTableOuterJoinTest {
                                                final String expectedValue,
                                                final long expectedTimestamp) {
         assertThat(outputTopic.readRecord(), equalTo(new TestRecord<>(expectedKey, expectedValue, null, expectedTimestamp)));
+    }
+
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
@@ -36,7 +36,8 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -56,10 +57,19 @@ public class KTableKTableOuterJoinTest {
     private final String topic2 = "topic2";
     private final String output = "output";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
-    @Test
-    public void testJoin() {
+    private Properties getProps(final boolean withHeaders) {
+        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        if (withHeaders) {
+            props.put(org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_CONFIG,
+                     org.apache.kafka.streams.StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+        return props;
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testJoin(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
@@ -79,7 +89,7 @@ public class KTableKTableOuterJoinTest {
         assertEquals(1, copartitionGroups.size());
         assertEquals(Set.of(topic1, topic2), copartitionGroups.iterator().next());
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), getProps(withHeaders))) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -182,8 +192,9 @@ public class KTableKTableOuterJoinTest {
         }
     }
 
-    @Test
-    public void testNotSendingOldValue() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testNotSendingOldValue(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
@@ -199,7 +210,7 @@ public class KTableKTableOuterJoinTest {
 
         final Topology topology = builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, getProps(withHeaders))) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -291,8 +302,9 @@ public class KTableKTableOuterJoinTest {
         }
     }
 
-    @Test
-    public void testSendingOldValue() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSendingOldValue(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
@@ -310,7 +322,7 @@ public class KTableKTableOuterJoinTest {
 
         final Topology topology = builder.build().addProcessor("proc", supplier, ((KTableImpl<?, ?, ?>) joined).name);
 
-        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, getProps(withHeaders))) {
             final TestInputTopic<Integer, String> inputTopic1 =
                     driver.createInputTopic(topic1, Serdes.Integer().serializer(), Serdes.String().serializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
             final TestInputTopic<Integer, String> inputTopic2 =
@@ -402,8 +414,9 @@ public class KTableKTableOuterJoinTest {
         }
     }
 
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -413,7 +426,7 @@ public class KTableKTableOuterJoinTest {
                 null
         ).get();
 
-        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(props);
+        final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(getProps(withHeaders));
         context.setRecordMetadata("left", -1, -2);
         join.init(context);
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
@@ -71,6 +71,13 @@ public class KTableKTableRightJoinTest {
         }
     }
 
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
     private void setDslStoreFormat(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
@@ -27,7 +27,8 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -37,10 +38,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KTableKTableRightJoinTest {
 
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private Properties getProps(final boolean withHeaders) {
+        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+        return props;
+    }
 
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersionLatest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersionLatest(final boolean withHeaders) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -50,6 +58,7 @@ public class KTableKTableRightJoinTest {
             null
         ).get();
 
+        final Properties props = getProps(withHeaders);
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(props);
         context.setRecordMetadata("left", -1, -2);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
@@ -38,13 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KTableKTableRightJoinTest {
 
-    private Properties getProps(final boolean withHeaders) {
-        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-        return props;
-    }
+    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -58,7 +52,7 @@ public class KTableKTableRightJoinTest {
             null
         ).get();
 
-        final Properties props = getProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         final MockProcessorContext<String, Change<Object>> context = new MockProcessorContext<>(props);
         context.setRecordMetadata("left", -1, -2);
@@ -74,6 +68,14 @@ public class KTableKTableRightJoinTest {
                     .collect(Collectors.toList()),
                 hasItem("Skipping record due to null key. topic=[left] partition=[-1] offset=[-2]")
             );
+        }
+    }
+
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
@@ -40,19 +40,12 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class KTableMapKeysTest {
-    private Properties props;
-
-    private void setupProps(final boolean withHeaders) {
-        props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-    }
+    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testMapKeysConvertingToStream(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic_map_keys";
 
@@ -85,6 +78,14 @@ public class KTableMapKeysTest {
         assertEquals(3, supplier.theCapturedProcessor().processed().size());
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], supplier.theCapturedProcessor().processed().get(i));
+        }
+    }
+
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -29,7 +30,8 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,10 +40,19 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class KTableMapKeysTest {
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+    private Properties props;
 
-    @Test
-    public void testMapKeysConvertingToStream() {
+    private void setupProps(final boolean withHeaders) {
+        props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testMapKeysConvertingToStream(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic_map_keys";
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapKeysTest.java
@@ -81,6 +81,13 @@ public class KTableMapKeysTest {
         }
     }
 
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
     private void setDslStoreFormat(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
@@ -55,14 +55,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @SuppressWarnings("unchecked")
 public class KTableMapValuesTest {
     private final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
-    private Properties props;
+    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
-    private void setupProps(final boolean withHeaders) {
-        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-        if (withHeaders) {
-            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
-        }
-    }
 
     private void doTestKTable(final StreamsBuilder builder,
                               final String topic1,
@@ -84,7 +78,7 @@ public class KTableMapValuesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testKTable(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -100,7 +94,7 @@ public class KTableMapValuesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testQueryableKTable(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -188,7 +182,7 @@ public class KTableMapValuesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testQueryableValueGetter(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String storeName2 = "store2";
@@ -219,7 +213,7 @@ public class KTableMapValuesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testNotSendingOldValue(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -262,7 +256,7 @@ public class KTableMapValuesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldEnableSendingOldValuesOnParentIfMapValuesNotMaterialized(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -282,7 +276,7 @@ public class KTableMapValuesTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldNotEnableSendingOldValuesOnParentIfMapValuesMaterialized(final boolean withHeaders) {
-        setupProps(withHeaders);
+        setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -340,6 +334,14 @@ public class KTableMapValuesTest {
             proc.checkAndClearProcessResult(
                 new KeyValueTimestamp<>("A", new Change<>(null, 3), 30)
             );
+        }
+    }
+
+    private void setDslStoreFormat(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
@@ -37,7 +38,8 @@ import org.apache.kafka.test.MockApiProcessor;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -53,7 +55,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @SuppressWarnings("unchecked")
 public class KTableMapValuesTest {
     private final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
-    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private Properties props;
+
+    private void setupProps(final boolean withHeaders) {
+        props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
+    }
 
     private void doTestKTable(final StreamsBuilder builder,
                               final String topic1,
@@ -72,8 +81,10 @@ public class KTableMapValuesTest {
         }
     }
 
-    @Test
-    public void testKTable() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testKTable(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -86,8 +97,10 @@ public class KTableMapValuesTest {
         doTestKTable(builder, topic1, supplier);
     }
 
-    @Test
-    public void testQueryableKTable() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testQueryableKTable(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -172,8 +185,10 @@ public class KTableMapValuesTest {
         }
     }
 
-    @Test
-    public void testQueryableValueGetter() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testQueryableValueGetter(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
         final String storeName2 = "store2";
@@ -201,8 +216,10 @@ public class KTableMapValuesTest {
         doTestValueGetter(builder, topic1, table2, table3);
     }
 
-    @Test
-    public void testNotSendingOldValue() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testNotSendingOldValue(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -242,8 +259,10 @@ public class KTableMapValuesTest {
         }
     }
 
-    @Test
-    public void shouldEnableSendingOldValuesOnParentIfMapValuesNotMaterialized() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldEnableSendingOldValuesOnParentIfMapValuesNotMaterialized(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
@@ -260,8 +279,10 @@ public class KTableMapValuesTest {
         testSendingOldValues(builder, topic1, table2);
     }
 
-    @Test
-    public void shouldNotEnableSendingOldValuesOnParentIfMapValuesMaterialized() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotEnableSendingOldValuesOnParentIfMapValuesMaterialized(final boolean withHeaders) {
+        setupProps(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
@@ -337,6 +337,13 @@ public class KTableMapValuesTest {
         }
     }
 
+    /**
+     * Configures the DSL store format to use headers if enabled.
+     * This is a helper method to reduce boilerplate in parameterized tests that test both
+     * with and without headers mode.
+     *
+     * @param withHeaders Whether to enable headers mode
+     */
     private void setDslStoreFormat(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -54,6 +54,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -353,8 +355,9 @@ public class KTableTransformValuesTest {
         getter.close();
     }
 
-    @Test
-    public void shouldTransformValuesWithKey() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldTransformValuesWithKey(final boolean withHeaders) {
         builder
             .addStateStore(storeBuilder(STORE_NAME))
             .addStateStore(storeBuilder(OTHER_STORE_NAME))
@@ -365,7 +368,7 @@ public class KTableTransformValuesTest {
             .toStream()
             .process(capture);
 
-        driver = new TopologyTestDriver(builder.build(), props());
+        driver = new TopologyTestDriver(builder.build(), props(withHeaders));
         final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
 
@@ -381,8 +384,9 @@ public class KTableTransformValuesTest {
         assertNull(driver.getKeyValueStore(QUERYABLE_NAME), "Store should not be materialized");
     }
 
-    @Test
-    public void shouldTransformValuesWithKeyAndMaterialize() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldTransformValuesWithKeyAndMaterialize(final boolean withHeaders) {
         builder
             .addStateStore(storeBuilder(STORE_NAME))
             .table(INPUT_TOPIC, CONSUMED)
@@ -395,7 +399,7 @@ public class KTableTransformValuesTest {
             .toStream()
             .process(capture);
 
-        driver = new TopologyTestDriver(builder.build(), props());
+        driver = new TopologyTestDriver(builder.build(), props(withHeaders));
         final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
         inputTopic.pipeInput("A", "a", 5L);
@@ -420,8 +424,9 @@ public class KTableTransformValuesTest {
         }
     }
 
-    @Test
-    public void shouldCalculateCorrectOldValuesIfMaterializedEvenIfStateful() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCalculateCorrectOldValuesIfMaterializedEvenIfStateful(final boolean withHeaders) {
         builder
             .table(INPUT_TOPIC, CONSUMED)
             .transformValues(
@@ -435,7 +440,7 @@ public class KTableTransformValuesTest {
             .toStream()
             .process(capture);
 
-        driver = new TopologyTestDriver(builder.build(), props());
+        driver = new TopologyTestDriver(builder.build(), props(withHeaders));
         final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
 
@@ -453,8 +458,9 @@ public class KTableTransformValuesTest {
             equalTo(Set.of(QUERYABLE_NAME, "KTABLE-AGGREGATE-STATE-STORE-0000000005")));
     }
 
-    @Test
-    public void shouldCalculateCorrectOldValuesIfNotStatefulEvenIfNotMaterialized() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCalculateCorrectOldValuesIfNotStatefulEvenIfNotMaterialized(final boolean withHeaders) {
         builder
             .table(INPUT_TOPIC, CONSUMED)
             .transformValues(new StatelessTransformerSupplier())
@@ -464,7 +470,7 @@ public class KTableTransformValuesTest {
             .toStream()
             .process(capture);
 
-        driver = new TopologyTestDriver(builder.build(), props());
+        driver = new TopologyTestDriver(builder.build(), props(withHeaders));
         final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
 
@@ -479,8 +485,9 @@ public class KTableTransformValuesTest {
             equalTo(Set.of("inputTopic-STATE-STORE-0000000000", "KTABLE-AGGREGATE-STATE-STORE-0000000005")));
     }
 
-    @Test
-    public void shouldCalculateCorrectOldValuesIfNotStatefulEvenNotMaterializedNoQueryableName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCalculateCorrectOldValuesIfNotStatefulEvenNotMaterializedNoQueryableName(final boolean withHeaders) {
         builder
             .table(INPUT_TOPIC, CONSUMED)
             .transformValues(new StatelessTransformerSupplier(),
@@ -492,7 +499,7 @@ public class KTableTransformValuesTest {
             .toStream()
             .process(capture);
 
-        driver = new TopologyTestDriver(builder.build(), props());
+        driver = new TopologyTestDriver(builder.build(), props(withHeaders));
         final TestInputTopic<String, String> inputTopic =
             driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
 
@@ -523,11 +530,14 @@ public class KTableTransformValuesTest {
         return Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore(storeName), Serdes.Long(), Serdes.Long());
     }
 
-    public static Properties props() {
+    public static Properties props(final boolean withHeaders) {
         final Properties props = new Properties();
         props.setProperty(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
         props.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
         props.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         return props;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImplTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
@@ -43,8 +44,8 @@ import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -70,8 +71,10 @@ public class SlidingWindowedCogroupedKStreamImplTest {
 
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
-    @BeforeEach
-    public void setup() {
+    public void setup(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed
                 .with(Serdes.String(), Serdes.String()));
         final KStream<String, String> stream2 = builder.stream(TOPIC2, Consumed
@@ -85,48 +88,66 @@ public class SlidingWindowedCogroupedKStreamImplTest {
             WINDOW_SIZE_MS), ofMillis(2000L)));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(null));
     }
 
-    @Test
-    public void shouldNotHaveNullMaterializedOnTwoOptionAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullMaterializedOnTwoOptionAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Materialized<String, String, WindowStore<Bytes, byte[]>>) null));
     }
 
-    @Test
-    public void shouldNotHaveNullNamedTwoOptionOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullNamedTwoOptionOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Named) null));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerTwoOptionNamedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerTwoOptionNamedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(null, Named.as("test")));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerTwoOptionMaterializedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerTwoOptionMaterializedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(null, Materialized.as("test")));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerThreeOptionOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerThreeOptionOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(null, Named.as("test"), Materialized.as("test")));
     }
 
-    @Test
-    public void shouldNotHaveNullMaterializedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullMaterializedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, Named.as("Test"), null));
     }
 
-    @Test
-    public void shouldNotHaveNullNamedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullNamedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () ->  windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, Materialized.as("test")));
     }
 
-    @Test
-    public void namedParamShouldSetName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void namedParamShouldSetName(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed
                 .with(Serdes.String(), Serdes.String()));
@@ -148,8 +169,10 @@ public class SlidingWindowedCogroupedKStreamImplTest {
                         "      <-- foo-cogroup-agg-0\n\n"));
     }
 
-    @Test
-    public void slidingWindowAggregateStreamsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void slidingWindowAggregateStreamsTest(final boolean withHeaders) {
+        setup(withHeaders);
         final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(
                 MockInitializer.STRING_INIT, Materialized.with(Serdes.String(), Serdes.String()));
         customers.toStream().to(OUTPUT);
@@ -205,8 +228,10 @@ public class SlidingWindowedCogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void slidingWindowAggregateOverlappingWindowsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void slidingWindowAggregateOverlappingWindowsTest(final boolean withHeaders) {
+        setup(withHeaders);
 
         final KTable<Windowed<String>, String> customers = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER)
                 .windowedBy(SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(WINDOW_SIZE_MS), ofMillis(2000L))).aggregate(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImplTest.java
@@ -74,6 +74,8 @@ public class SlidingWindowedCogroupedKStreamImplTest {
     public void setup(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed
                 .with(Serdes.String(), Serdes.String()));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImplTest.java
@@ -66,6 +66,8 @@ public class SlidingWindowedKStreamImplTest {
     public void before(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed.with(Serdes.String(), Serdes.String()));
         windowedStream = stream.

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImplTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -42,8 +43,8 @@ import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -62,16 +63,20 @@ public class SlidingWindowedKStreamImplTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
     private TimeWindowedKStream<String, String> windowedStream;
 
-    @BeforeEach
-    public void before() {
+    public void before(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed.with(Serdes.String(), Serdes.String()));
         windowedStream = stream.
             groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
             .windowedBy(SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(100L), ofMillis(1000L)));
     }
 
-    @Test
-    public void shouldCountSlidingWindows() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldCountSlidingWindows(final boolean withHeaders) {
+        before(withHeaders);
         final MockApiProcessorSupplier<Windowed<String>, Long, Void, Void> supplier = new MockApiProcessorSupplier<>();
         windowedStream
             .count()
@@ -111,8 +116,10 @@ public class SlidingWindowedKStreamImplTest {
             equalTo(ValueAndTimestamp.make(1L, 200L)));
     }
 
-    @Test
-    public void shouldReduceSlidingWindows() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldReduceSlidingWindows(final boolean withHeaders) {
+        before(withHeaders);
         final MockApiProcessorSupplier<Windowed<String>, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
         windowedStream
             .reduce(MockReducer.STRING_ADDER)
@@ -152,8 +159,10 @@ public class SlidingWindowedKStreamImplTest {
             equalTo(ValueAndTimestamp.make("10", 200L)));
     }
 
-    @Test
-    public void shouldAggregateSlidingWindows() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldAggregateSlidingWindows(final boolean withHeaders) {
+        before(withHeaders);
         final MockApiProcessorSupplier<Windowed<String>, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
         windowedStream
             .aggregate(
@@ -196,8 +205,10 @@ public class SlidingWindowedKStreamImplTest {
             equalTo(ValueAndTimestamp.make("0+10", 200L)));
     }
 
-    @Test
-    public void shouldMaterializeCount() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMaterializeCount(final boolean withHeaders) {
+        before(withHeaders);
         windowedStream.count(
             Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("count-store")
                 .withKeySerde(Serdes.String())
@@ -235,8 +246,10 @@ public class SlidingWindowedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldMaterializeReduced() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMaterializeReduced(final boolean withHeaders) {
+        before(withHeaders);
         windowedStream.reduce(
             MockReducer.STRING_ADDER,
             Materialized.<String, String, WindowStore<Bytes, byte[]>>as("reduced")
@@ -275,8 +288,10 @@ public class SlidingWindowedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldMaterializeAggregated() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMaterializeAggregated(final boolean withHeaders) {
+        before(withHeaders);
         windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
@@ -316,28 +331,38 @@ public class SlidingWindowedKStreamImplTest {
         }
     }
 
-    @Test
-    public void shouldThrowNullPointerOnAggregateIfInitializerIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnAggregateIfInitializerIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(null, MockAggregator.TOSTRING_ADDER));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnAggregateIfAggregatorIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnAggregateIfAggregatorIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(MockInitializer.STRING_INIT, null));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnReduceIfReducerIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnReduceIfReducerIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(null));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(null, MockAggregator.TOSTRING_ADDER, Materialized.as("store")));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             null,
@@ -345,34 +370,46 @@ public class SlidingWindowedKStreamImplTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Test
-    public void shouldThrowNullPointerOnMaterializedAggregateIfMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnMaterializedAggregateIfMaterializedIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(MockInitializer.STRING_INIT, MockAggregator.TOSTRING_ADDER, (Materialized) null));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(null, Materialized.as("store")));
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
     @SuppressWarnings("unchecked")
-    public void shouldThrowNullPointerOnMaterializedReduceIfMaterializedIsNull() {
+    public void shouldThrowNullPointerOnMaterializedReduceIfMaterializedIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(MockReducer.STRING_ADDER, (Materialized) null));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnMaterializedReduceIfNamedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnMaterializedReduceIfNamedIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(MockReducer.STRING_ADDER, (Named) null));
     }
 
-    @Test
-    public void shouldThrowNullPointerOnCountIfMaterializedIsNull() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowNullPointerOnCountIfMaterializedIsNull(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.count((Materialized<String, Long, WindowStore<Bytes, byte[]>>) null));
     }
 
-    @Test
-    public void shouldThrowIllegalArgumentWhenRetentionIsTooSmall() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldThrowIllegalArgumentWhenRetentionIsTooSmall(final boolean withHeaders) {
+        before(withHeaders);
         assertThrows(IllegalArgumentException.class, () -> windowedStream
             .aggregate(
                 MockInitializer.STRING_INIT,
@@ -386,8 +423,10 @@ public class SlidingWindowedKStreamImplTest {
         );
     }
 
-    @Test
-    public void shouldDropWindowsOutsideOfRetention() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldDropWindowsOutsideOfRetention(final boolean withHeaders) {
+        before(withHeaders);
         final WindowBytesStoreSupplier storeSupplier = Stores.inMemoryWindowStore("aggregated", ofMillis(1200L), ofMillis(100L), false);
         windowedStream.aggregate(
             MockInitializer.STRING_INIT,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
@@ -43,8 +44,8 @@ import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Properties;
 
@@ -69,8 +70,10 @@ public class TimeWindowedCogroupedKStreamImplTest {
 
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
-    @BeforeEach
-    public void setup() {
+    public void setup(final boolean withHeaders) {
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed
             .with(Serdes.String(), Serdes.String()));
         final KStream<String, String> stream2 = builder.stream(TOPIC2, Consumed
@@ -83,49 +86,67 @@ public class TimeWindowedCogroupedKStreamImplTest {
         windowedCogroupedStream = cogroupedStream.windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(WINDOW_SIZE)));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null));
     }
 
-    @Test
-    public void shouldNotHaveNullMaterializedOnTwoOptionAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullMaterializedOnTwoOptionAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
             (Materialized<String, String, WindowStore<Bytes, byte[]>>) null));
     }
 
-    @Test
-    public void shouldNotHaveNullNamedTwoOptionOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullNamedTwoOptionOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Named) null));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerTwoOptionNamedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerTwoOptionNamedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, Named.as("test")));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerTwoOptionMaterializedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerTwoOptionMaterializedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, Materialized.as("test")));
     }
 
-    @Test
-    public void shouldNotHaveNullInitializerThreeOptionOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullInitializerThreeOptionOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, Named.as("test"), Materialized.as("test")));
     }
 
-    @Test
-    public void shouldNotHaveNullMaterializedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullMaterializedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, Named.as("Test"), null));
     }
 
-    @Test
-    public void shouldNotHaveNullNamedOnAggregate() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldNotHaveNullNamedOnAggregate(final boolean withHeaders) {
+        setup(withHeaders);
         assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, Materialized.as("test")));
     }
 
-    @Test
-    public void namedParamShouldSetName() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void namedParamShouldSetName(final boolean withHeaders) {
+        setup(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed
                 .with(Serdes.String(), Serdes.String()));
@@ -147,8 +168,10 @@ public class TimeWindowedCogroupedKStreamImplTest {
                 "      <-- foo-cogroup-agg-0\n\n"));
     }
 
-    @Test
-    public void timeWindowAggregateTestStreamsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void timeWindowAggregateTestStreamsTest(final boolean withHeaders) {
+        setup(withHeaders);
 
         final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(
                 MockInitializer.STRING_INIT, Materialized.with(Serdes.String(), Serdes.String()));
@@ -181,8 +204,10 @@ public class TimeWindowedCogroupedKStreamImplTest {
 
     }
 
-    @Test
-    public void timeWindowMixAggregatorsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void timeWindowMixAggregatorsTest(final boolean withHeaders) {
+        setup(withHeaders);
 
         final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(
                 MockInitializer.STRING_INIT, Materialized.with(Serdes.String(), Serdes.String()));
@@ -217,8 +242,10 @@ public class TimeWindowedCogroupedKStreamImplTest {
 
     }
 
-    @Test
-    public void timeWindowAggregateManyWindowsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void timeWindowAggregateManyWindowsTest(final boolean withHeaders) {
+        setup(withHeaders);
 
         final KTable<Windowed<String>, String> customers = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER)
                 .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(500L))).aggregate(
@@ -243,8 +270,10 @@ public class TimeWindowedCogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void timeWindowAggregateOverlappingWindowsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void timeWindowAggregateOverlappingWindowsTest(final boolean withHeaders) {
+        setup(withHeaders);
 
         final KTable<Windowed<String>, String> customers = groupedStream.cogroup(MockAggregator.TOSTRING_ADDER)
                 .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(500L)).advanceBy(ofMillis(200L))).aggregate(
@@ -277,8 +306,10 @@ public class TimeWindowedCogroupedKStreamImplTest {
         }
     }
 
-    @Test
-    public void timeWindowMixAggregatorsManyWindowsTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void timeWindowMixAggregatorsManyWindowsTest(final boolean withHeaders) {
+        setup(withHeaders);
 
         final KTable<Windowed<String>, String> customers = windowedCogroupedStream.aggregate(
                 MockInitializer.STRING_INIT, Materialized.with(Serdes.String(), Serdes.String()));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
@@ -73,6 +73,8 @@ public class TimeWindowedCogroupedKStreamImplTest {
     public void setup(final boolean withHeaders) {
         if (withHeaders) {
             props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        } else {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_DEFAULT);
         }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed
             .with(Serdes.String(), Serdes.String()));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -82,18 +83,25 @@ public class TimeWindowedKStreamImplTest {
 
     public static Stream<Arguments> data() {
         return Stream.of(
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true),
-            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true),
-            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false)
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_UPDATE, false, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, true, true),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, false),
+            Arguments.of(StrategyType.ON_WINDOW_CLOSE, false, true)
         );
     }
 
-    public void setup(final StrategyType inputType, final boolean inputWithCache) {
+    public void setup(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
         type = inputType;
         withCache = inputWithCache;
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
+        if (withHeaders) {
+            props.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, StreamsConfig.DSL_STORE_FORMAT_HEADERS);
+        }
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed.with(Serdes.String(), Serdes.String()));
         windowedStream = stream.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
             .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(500L)));
@@ -101,8 +109,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldCountWindowed(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldCountWindowed(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final MockApiProcessorSupplier<Windowed<String>, Long, Void, Void> supplier = new MockApiProcessorSupplier<>();
         windowedStream
             .emitStrategy(emitStrategy)
@@ -141,8 +149,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldReduceWindowed(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldReduceWindowed(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final MockApiProcessorSupplier<Windowed<String>, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
         windowedStream
             .emitStrategy(emitStrategy)
@@ -181,8 +189,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldAggregateWindowed(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldAggregateWindowed(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         final MockApiProcessorSupplier<Windowed<String>, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
         windowedStream
             .emitStrategy(emitStrategy)
@@ -225,8 +233,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldMaterializeCount(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldMaterializeCount(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         windowedStream
             .emitStrategy(emitStrategy)
             .count(
@@ -292,8 +300,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldMaterializeReduced(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldMaterializeReduced(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         windowedStream.reduce(
             MockReducer.STRING_ADDER,
             setMaterializedCache(Materialized.<String, String, WindowStore<Bytes, byte[]>>as("reduced")
@@ -344,8 +352,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldMaterializeAggregated(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldMaterializeAggregated(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
@@ -396,29 +404,29 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnAggregateIfInitializerIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnAggregateIfInitializerIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(null, MockAggregator.TOSTRING_ADDER));
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnAggregateIfAggregatorIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnAggregateIfAggregatorIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(MockInitializer.STRING_INIT, null));
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnReduceIfReducerIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnReduceIfReducerIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(null));
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             null,
             MockAggregator.TOSTRING_ADDER,
@@ -427,8 +435,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             null,
@@ -438,8 +446,8 @@ public class TimeWindowedKStreamImplTest {
     @SuppressWarnings("unchecked")
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnMaterializedAggregateIfMaterializedIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnMaterializedAggregateIfMaterializedIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
@@ -448,8 +456,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(
             null,
             setMaterializedCache(Materialized.as("store"))));
@@ -458,8 +466,8 @@ public class TimeWindowedKStreamImplTest {
     @ParameterizedTest
     @MethodSource("data")
     @SuppressWarnings("unchecked")
-    public void shouldThrowNullPointerOnMaterializedReduceIfMaterializedIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnMaterializedReduceIfMaterializedIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(
             MockReducer.STRING_ADDER,
             (Materialized) null));
@@ -467,8 +475,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnMaterializedReduceIfNamedIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnMaterializedReduceIfNamedIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.reduce(
             MockReducer.STRING_ADDER,
             (Named) null));
@@ -476,8 +484,8 @@ public class TimeWindowedKStreamImplTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldThrowNullPointerOnCountIfMaterializedIsNull(final StrategyType inputType, final boolean inputWithCache) {
-        setup(inputType, inputWithCache);
+    public void shouldThrowNullPointerOnCountIfMaterializedIsNull(final StrategyType inputType, final boolean inputWithCache, final boolean withHeaders) {
+        setup(inputType, inputWithCache, withHeaders);
         assertThrows(NullPointerException.class, () -> windowedStream.count((Materialized<String, Long, WindowStore<Bytes, byte[]>>) null));
     }
 


### PR DESCRIPTION
Parametrized 28 DSL and processor test classes to validate functionality
with both `headers` and `default` store configurations. This ensures
backward compatibility and correctness as Kafka Streams transitions to
supporting record headers in state stores.

  Modified Tests:    - Materializer Tests    - Windowed KStream Tests
- Aggregation Tests    -  Cogroup Tests    -   Join Tests    -   KTable
Tests

Reviewers: Matthias J. Sax <matthias@confluent.io>, TengYao Chi <frankvicky@apache.org>
