### PR TITLE
MM2: Add offset gap detection and basic topic reset handling in MirrorSourceTask

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +60,7 @@ public class MirrorSourceTask extends SourceTask {
     private boolean stopping = false;
     private Semaphore consumerAccess;
     private OffsetSyncWriter offsetSyncWriter;
+    private HashMap<TopicPartition, Long> lastEmittedOffsets = new HashMap<>();
 
     public MirrorSourceTask() {}
 
@@ -144,6 +146,7 @@ public class MirrorSourceTask extends SourceTask {
                 SourceRecord converted = convertRecord(record);
                 sourceRecords.add(converted);
                 TopicPartition topicPartition = new TopicPartition(converted.topic(), converted.kafkaPartition());
+                validate(topicPartition, record.offset());
                 long age = System.currentTimeMillis() - record.timestamp();
                 long size = byteSize(record.value());
                 if (legacyMetrics != null) {
@@ -176,6 +179,50 @@ public class MirrorSourceTask extends SourceTask {
         }
     }
  
+    public Boolean isInternalTopic(TopicPartition topicPartition) {
+        return replicationPolicy.isInternalTopic(topicPartition.topic())
+        || replicationPolicy.isCheckpointsTopic(topicPartition.topic())
+        || replicationPolicy.isHeartbeatsTopic(topicPartition.topic())
+        || replicationPolicy.isMM2InternalTopic(topicPartition.topic());
+    }
+
+    public void validate(TopicPartition topicPartition, Long offset) {
+        /*
+            This function validates the offsets of partition per topic for a given record.
+            It validates if the offset is previously seen is monotonically increasing by 1 for a given partition and topic.
+            If We see any gaps, we throw an exception and stop the task to ensure data consistency.
+            If we observe that offset is rested to 0 while previous seen offset is >=0,
+            Then we expect that topic was recreated and reset the offset tracking.
+        */
+        if (isInternalTopic(topicPartition)) {
+            // Not verfying consecutive offsets for internal topics
+            return;
+        }
+        if (lastEmittedOffsets.containsKey(topicPartition)) {
+            long previousOffset = lastEmittedOffsets.get(topicPartition);
+            if (offset == 0) {
+                String timestamp = String.valueOf(System.currentTimeMillis());
+                log.warn("Offset for topic-partition {} reset to 0 at {}. This likely indicates that the topic was recreated. Previous offset was {}.",
+                    topicPartition, timestamp, previousOffset);
+                lastEmittedOffsets.put(topicPartition, offset);
+                consumer.seek(topicPartition, offset);
+                return;
+            }
+            if (offset != previousOffset + 1) {
+                log.error("Non-consecutive offsets for topic-partition {}: previous offset was {}, current offset is {}.",
+                        topicPartition, previousOffset, offset);
+                throw new RuntimeException("Non-consecutive offsets for topic-partition " + topicPartition + ": previous offset was " + previousOffset + ", current offset is " + offset);
+            }
+            lastEmittedOffsets.put(topicPartition, offset);
+        } else {
+            if (offset != 0) {
+                log.error("First offset for topic-partition {} is {}, not 0.", topicPartition, offset);
+                throw new RuntimeException("Non-consecutive offsets for topic-partition " + topicPartition + ": first offset is " + offset + ", not 0.");
+            }
+            lastEmittedOffsets.put(topicPartition, offset);    
+        }
+    }
+
     @Override
     public void commitRecord(SourceRecord record, RecordMetadata metadata) {
         if (stopping) {


### PR DESCRIPTION
## Summary

This PR solves enhancements that tries to handle data inconsistencies for MM2 Cluster topic replication-

- Fail-fast detection for offset gaps (log truncation)
- Basic handling for topic reset scenarios (delete + recreate)

## Problem

MM2 Currently does not handle following scenarios:

1. Silent data loss (fail fast) - If source data is deleted due to retention, mm2 continues to replicate without detecting the missing offsets
2. Topic reset (delete + recreate) - If topic in primary cluster is deleted and recreated, mm2 does not automatically reset the offset from beginning and continues to the previous chain which makes the replication offset tracking invalid

## Solution

For both of the above challenges, MirrorSourceTask is modified. Following are modifications:

1. Offset gap detection:

   - Added validation for each topic+partition combination while ignoring internal topics where newoffset should be previousoffset+1
   - Throwing exception when the above condition is not satisfied and can make replication invalid
   - Added appropriate error logs

2. Topic reset handling:
   - Added validation where if previous offset was >= 0 and now received offset 0 again, it detects it as a topic reset and the consumer updates it current offset
   - Added appropriate warning log