### PR TITLE
MINOR: Update supported image in docker_scan.yml

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # This is an array of supported tags. Make sure this array only contains the supported tags
-        supported_image_tag: ['latest', '3.9.2', '4.0.1', '4.1.2', '4.2.0']
+        supported_image_tag: ['latest', '3.9.2', '4.0.2', '4.1.2', '4.2.0']
     steps:
       - name: Run CVE scan
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1


### PR DESCRIPTION
Updates the docker_scan.yml to contain 4.0.2 instead of 4.0.1 for CVE
scans.

Reviewers: Andrew Schofield <aschofield@confluent.io>
