### PR TITLE
KAFKA-20050: Add syntax highlighting for code blocks and commands

### DIFF
--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -31,19 +31,22 @@ type: docs
 [Docker](https://www.docker.com/) is a popular container runtime. Docker images for the JVM based Apache Kafka can be found on [Docker Hub](https://hub.docker.com/r/apache/kafka) and are available from version 3.7.0. 
 
 Docker image can be pulled from Docker Hub using the following command: 
-    
-    
-    $ docker pull apache/kafka:4.3.0
+
+```bash
+$ docker pull apache/kafka:4.3.0
+```
 
 If you want to fetch the latest version of the Docker image use following command: 
-    
-    
-    $ docker pull apache/kafka:latest
+
+```bash
+$ docker pull apache/kafka:latest
+```
 
 To start the Kafka container using this Docker image with default configs and on default port 9092: 
-    
-    
-    $ docker run -p 9092:9092 apache/kafka:4.3.0
+
+```bash
+$ docker run -p 9092:9092 apache/kafka:4.3.0
+```
 
 ## GraalVM Based Native Apache Kafka Docker Image
 
@@ -51,19 +54,22 @@ Docker images for the GraalVM Based Native Apache Kafka can be found on [Docker 
 NOTE: This image is experimental and intended for local development and testing purposes only; it is not recommended for production use. 
 
 Docker image can be pulled from Docker Hub using the following command: 
-    
-    
-    $ docker pull apache/kafka-native:4.3.0
+
+```bash
+$ docker pull apache/kafka-native:4.3.0
+```
 
 If you want to fetch the latest version of the Docker image use following command: 
-    
-    
-    $ docker pull apache/kafka-native:latest
+
+```bash
+$ docker pull apache/kafka-native:latest
+```
 
 To start the Kafka container using this Docker image with default configs and on default port 9092: 
-    
-    
-    $ docker run -p 9092:9092 apache/kafka-native:4.3.0
+
+```bash
+$ docker run -p 9092:9092 apache/kafka-native:4.3.0
+```
 
 ## Usage guide
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -29,10 +29,11 @@ type: docs
 ## Step 1: Get Kafka
 
 [Download](https://www.apache.org/dyn/closer.cgi?path=/kafka/4.3.0/kafka_2.13-4.3.0.tgz) the latest Kafka release and extract it: 
-    
-    
-    $ tar -xzf kafka_2.13-4.3.0.tgz
-    $ cd kafka_2.13-4.3.0
+
+```bash
+$ tar -xzf kafka_2.13-4.3.0.tgz
+$ cd kafka_2.13-4.3.0
+```
 
 ## Step 2: Start the Kafka environment
 
@@ -43,45 +44,52 @@ Kafka can be run using local scripts and downloaded files or the docker image.
 ### Using downloaded files
 
 Generate a Cluster UUID
-    
-    
-    $ KAFKA_CLUSTER_ID="$(bin/kafka-storage.sh random-uuid)"
+
+```bash
+$ KAFKA_CLUSTER_ID="$(bin/kafka-storage.sh random-uuid)"
+```
 
 Format Log Directories
-    
-    
-    $ bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/server.properties
+
+```bash
+$ bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/server.properties
+```
 
 Start the Kafka Server
-    
-    
-    $ bin/kafka-server-start.sh config/server.properties
+
+```bash
+$ bin/kafka-server-start.sh config/server.properties
+```
 
 Once the Kafka server has successfully launched, you will have a basic Kafka environment running and ready to use.
 
 ### Using JVM Based Apache Kafka Docker Image
 
 Get the Docker image:
-    
-    
-    $ docker pull apache/kafka:4.3.0
+
+```bash
+$ docker pull apache/kafka:4.3.0
+```
 
 Start the Kafka Docker container: 
-    
-    
-    $ docker run -p 9092:9092 apache/kafka:4.3.0
+
+```bash
+$ docker run -p 9092:9092 apache/kafka:4.3.0
+```
 
 ### Using GraalVM Based Native Apache Kafka Docker Image
 
 Get the Docker image:
-    
-    
-    $ docker pull apache/kafka-native:4.3.0
+
+```bash
+$ docker pull apache/kafka-native:4.3.0
+```
 
 Start the Kafka Docker container:
-    
-    
-    $ docker run -p 9092:9092 apache/kafka-native:4.3.0
+
+```bash
+$ docker run -p 9092:9092 apache/kafka-native:4.3.0
+```
 
 ## Step 3: Create a topic to store your events
 
@@ -90,38 +98,42 @@ Kafka is a distributed _event streaming platform_ that lets you read, write, sto
 Example events are payment transactions, geolocation updates from mobile phones, shipping orders, sensor measurements from IoT devices or medical equipment, and much more. These events are organized and stored in [_topics_](/{version}/getting-started/introduction/#main-concepts-and-terminology). Very simplified, a topic is similar to a folder in a filesystem, and the events are the files in that folder. 
 
 So before you can write your first events, you must create a topic. Open another terminal session and run: 
-    
-    
-    $ bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092
+
+```bash
+$ bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9092
+```
 
 All of Kafka's command line tools have additional options: run the `kafka-topics.sh` command without any arguments to display usage information. For example, it can also show you [details such as the partition count](/{version}/getting-started/introduction/#main-concepts-and-terminology) of the new topic: 
-    
-    
-    $ bin/kafka-topics.sh --describe --topic quickstart-events --bootstrap-server localhost:9092
-    Topic: quickstart-events        TopicId: NPmZHyhbR9y00wMglMH2sg PartitionCount: 1       ReplicationFactor: 1	Configs:
-    Topic: quickstart-events Partition: 0    Leader: 0   Replicas: 0 Isr: 0
+
+```bash
+$ bin/kafka-topics.sh --describe --topic quickstart-events --bootstrap-server localhost:9092
+Topic: quickstart-events        TopicId: NPmZHyhbR9y00wMglMH2sg PartitionCount: 1       ReplicationFactor: 1	Configs:
+Topic: quickstart-events Partition: 0    Leader: 0   Replicas: 0 Isr: 0
+```
 
 ## Step 4: Write some events into the topic
 
 A Kafka client communicates with the Kafka brokers via the network for writing (or reading) events. Once received, the brokers will store the events in a durable and fault-tolerant manner for as long as you need-even forever. 
 
 Run the console producer client to write a few events into your topic. By default, each line you enter will result in a separate event being written to the topic. 
-    
-    
-    $ bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092
-    >This is my first event
-    >This is my second event
+
+```bash
+$ bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092
+>This is my first event
+>This is my second event
+```
 
 You can stop the producer client with `Ctrl-C` at any time.
 
 ## Step 5: Read the events
 
 Open another terminal session and run the console consumer client to read the events you just created:
-    
-    
-    $ bin/kafka-console-consumer.sh --topic quickstart-events --from-beginning --bootstrap-server localhost:9092
-    This is my first event
-    This is my second event
+
+```bash
+$ bin/kafka-console-consumer.sh --topic quickstart-events --from-beginning --bootstrap-server localhost:9092
+This is my first event
+This is my second event
+```
 
 You can stop the consumer client with `Ctrl-C` at any time.
 
@@ -138,48 +150,55 @@ In this quickstart we'll see how to run Kafka Connect with simple connectors tha
 First, make sure to add `connect-file-4.3.0.jar` to the `plugin.path` property in the Connect worker's configuration. For the purpose of this quickstart we'll use a relative path and consider the connectors' package as an uber jar, which works when the quickstart commands are run from the installation directory. However, it's worth noting that for production deployments using absolute paths is always preferable. See [plugin.path](../../configuration/kafka-connect-configs/#connectconfigs_plugin.path) for a detailed description of how to set this config. 
 
 Edit the `config/connect-standalone.properties` file, add or change the `plugin.path` configuration property match the following, and save the file: 
-    
-    
-    $ echo "plugin.path=libs/connect-file-4.3.0.jar" >> config/connect-standalone.properties
+
+```bash
+$ echo "plugin.path=libs/connect-file-4.3.0.jar" >> config/connect-standalone.properties
+```
 
 Then, start by creating some seed data to test with: 
-    
-    
-    $ echo -e "foo
-    bar" > test.txt
+
+```bash
+$ echo -e "foo
+bar" > test.txt
+```
 
 Or on Windows: 
-    
-    
-    $ echo foo > test.txt
-    $ echo bar >> test.txt
+
+```bash
+$ echo foo > test.txt
+$ echo bar >> test.txt
+```
 
 Next, we'll start two connectors running in _standalone_ mode, which means they run in a single, local, dedicated process. We provide three configuration files as parameters. The first is always the configuration for the Kafka Connect process, containing common configuration such as the Kafka brokers to connect to and the serialization format for data. The remaining configuration files each specify a connector to create. These files include a unique connector name, the connector class to instantiate, and any other configuration required by the connector. 
-    
-    
-    $ bin/connect-standalone.sh config/connect-standalone.properties config/connect-file-source.properties config/connect-file-sink.properties
+
+```bash
+$ bin/connect-standalone.sh config/connect-standalone.properties config/connect-file-source.properties config/connect-file-sink.properties
+```
 
 These sample configuration files, included with Kafka, use the default local cluster configuration you started earlier and create two connectors: the first is a source connector that reads lines from an input file and produces each to a Kafka topic and the second is a sink connector that reads messages from a Kafka topic and produces each as a line in an output file. 
 
 During startup you'll see a number of log messages, including some indicating that the connectors are being instantiated. Once the Kafka Connect process has started, the source connector should start reading lines from `test.txt` and producing them to the topic `connect-test`, and the sink connector should start reading messages from the topic `connect-test` and write them to the file `test.sink.txt`. We can verify the data has been delivered through the entire pipeline by examining the contents of the output file: 
-    
-    
-    $ more test.sink.txt
-    foo
-    bar
+
+```bash
+$ more test.sink.txt
+foo
+bar
+```
 
 Note that the data is being stored in the Kafka topic `connect-test`, so we can also run a console consumer to see the data in the topic (or use custom consumer code to process it): 
-    
-    
-    $ bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic connect-test --from-beginning
-    {"schema":{"type":"string","optional":false},"payload":"foo"}
-    {"schema":{"type":"string","optional":false},"payload":"bar"}
-    …
+
+```bash
+$ bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic connect-test --from-beginning
+{"schema":{"type":"string","optional":false},"payload":"foo"}
+{"schema":{"type":"string","optional":false},"payload":"bar"}
+…
+```
 
 The connectors continue to process data, so we can add data to the file and see it move through the pipeline:
-    
-    
-    $ echo "Another line" >> test.txt
+
+```bash
+$ echo "Another line" >> test.txt
+```
 
 You should see the line appear in the console consumer output and in the sink file.
 
@@ -188,16 +207,17 @@ You should see the line appear in the console consumer output and in the sink fi
 Once your data is stored in Kafka as events, you can process the data with the [Kafka Streams](/documentation/streams) client library for Java/Scala. It allows you to implement mission-critical real-time applications and microservices, where the input and/or output data is stored in Kafka topics. Kafka Streams combines the simplicity of writing and deploying standard Java and Scala applications on the client side with the benefits of Kafka's server-side cluster technology to make these applications highly scalable, elastic, fault-tolerant, and distributed. The library supports exactly-once processing, stateful operations and aggregations, windowing, joins, processing based on event-time, and much more. 
 
 To give you a first taste, here's how one would implement the popular `WordCount` algorithm:
-    
-    
-    KStream<String, String> textLines = builder.stream("quickstart-events");
-    
-    KTable<String, Long> wordCounts = textLines
-                .flatMapValues(line -> Arrays.asList(line.toLowerCase().split(" ")))
-                .groupBy((keyIgnored, word) -> word)
-                .count();
-    
-    wordCounts.toStream().to("output-topic", Produced.with(Serdes.String(), Serdes.Long()));
+
+```java
+KStream<String, String> textLines = builder.stream("quickstart-events");
+
+KTable<String, Long> wordCounts = textLines
+            .flatMapValues(line -> Arrays.asList(line.toLowerCase().split(" ")))
+            .groupBy((keyIgnored, word) -> word)
+            .count();
+
+wordCounts.toStream().to("output-topic", Produced.with(Serdes.String(), Serdes.Long()));
+```
 
 The [Kafka Streams demo](/documentation/streams/quickstart) and the [app development tutorial](/43/documentation/streams/tutorial) demonstrate how to code and run such a streaming application from start to finish. 
 
@@ -211,9 +231,10 @@ Now that you reached the end of the quickstart, feel free to tear down the Kafka
 
 
 If you also want to delete any data of your local Kafka environment including any events you have created along the way, run the command: 
-    
-    
-    $ rm -rf /tmp/kafka-logs /tmp/kraft-combined-logs
+
+```bash
+$ rm -rf /tmp/kafka-logs /tmp/kraft-combined-logs
+```
 
 ## Congratulations!
 

--- a/docs/getting-started/zk2kraft.md
+++ b/docs/getting-started/zk2kraft.md
@@ -104,23 +104,27 @@ This section documents differences in behavior between KRaft mode and ZooKeeper 
 
 * The dynamic log levels feature allows you to change the log4j settings of a running broker or controller process without restarting it. The command-line syntax for setting dynamic log levels on brokers has not changed in KRaft mode. Here is an example of setting the log level on a broker:  
 
-        
-        ./bin/kafka-configs.sh --bootstrap-server localhost:9092 \
-            --entity-type broker-loggers \
-            --entity-name 1 \
-            --alter \
-            --add-config org.apache.kafka.raft.KafkaNetworkChannel=TRACE
-                        
+
+  ```bash
+  ./bin/kafka-configs.sh --bootstrap-server localhost:9092 \
+      --entity-type broker-loggers \
+      --entity-name 1 \
+      --alter \
+      --add-config org.apache.kafka.raft.KafkaNetworkChannel=TRACE
+  ```
+
 
 * When setting dynamic log levels on the controllers, the `--bootstrap-controller` flag must be used. Here is an example of setting the log level ona controller:  
 
-        
-        ./bin/kafka-configs.sh --bootstrap-controller localhost:9093 \
-            --entity-type broker-loggers \
-            --entity-name 1 \
-            --alter \
-            --add-config org.apache.kafka.raft.KafkaNetworkChannel=TRACE
-                        
+
+  ```bash
+  ./bin/kafka-configs.sh --bootstrap-controller localhost:9093 \
+      --entity-type broker-loggers \
+      --entity-name 1 \
+      --alter \
+      --add-config org.apache.kafka.raft.KafkaNetworkChannel=TRACE
+  ```
+
 
   
   Note that the entity-type must be specified as `broker-loggers`, even though we are changing a controller's log level rather than a broker's log level. 
@@ -134,23 +138,27 @@ This section documents differences in behavior between KRaft mode and ZooKeeper 
 
 * Some Kafka configurations can be changed dynamically, without restarting the process. The command-line syntax for setting dynamic log levels on brokers has not changed in KRaft mode. Here is an example of setting the number of IO threads on a broker:  
 
-        
-        ./bin/kafka-configs.sh --bootstrap-server localhost:9092 \
-            --entity-type brokers \
-            --entity-name 1 \
-            --alter \
-            --add-config num.io.threads=5
-                        
+
+  ```bash
+  ./bin/kafka-configs.sh --bootstrap-server localhost:9092 \
+      --entity-type brokers \
+      --entity-name 1 \
+      --alter \
+      --add-config num.io.threads=5
+  ```
+
 
 * Controllers will apply all applicable cluster-level dynamic configurations. For example, the following command-line will change the `max.connections` setting on all of the brokers and all of the controllers in the cluster:  
 
-        
-        ./bin/kafka-configs.sh --bootstrap-server localhost:9092 \
-            --entity-type brokers \
-            --entity-default \
-            --alter \
-            --add-config max.connections=10000
-                        
+
+  ```bash
+  ./bin/kafka-configs.sh --bootstrap-server localhost:9092 \
+      --entity-type brokers \
+      --entity-default \
+      --alter \
+      --add-config max.connections=10000
+  ```
+
 
   
 Prior to version 4.3, dynamic configuration updates were not supported unless a static quorum was used. 


### PR DESCRIPTION
Added language tags (e.g.,bash, java) to fenced code blocks in the
getting-started directory under docs/.  I verified the syntax
highlighting locally by building and running the kafka-site project.

**[ sample image 1 ]**

<img width="984" height="276" alt="syntax highlight1"
src="https://github.com/user-attachments/assets/9f7edfdb-dfb2-4d6b-92b3-bcfcc63293b0"
/>

**[ sample image 2 ]**

<img width="990" height="456" alt="syntax highlight2"
src="https://github.com/user-attachments/assets/47774200-1712-4193-a543-9d1cd1de0188"
/>

**A few questions:**

1. I understand that the kafka repo's docs/ is the source of truth, so I
submitted this PR here rather than to kafka-site. Is this the right
approach?

2. This PR targets trunk, so I assume it will be synced to kafka-site
when 4.3 is released. Should I also open a separate PR for the 4.2
branch to apply this to the currently released version?

3. To keep this PR small and focused, I've only applied syntax
highlighting to the getting-started directory for now. If this approach
looks good, would it be okay for me to handle the remaining directories
in follow-up PRs? Or would you prefer a single PR covering all docs?

Any feedback is welcome. Thanks for reviewing!

cc @mimaison
