### PR TITLE
KAFKA-20323: Refactor deleteRecords stub to use partition-based matching for Mockito upgrade

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -118,7 +118,7 @@ versions += [
   lz4: "1.10.2",
   mavenArtifact: "3.9.11",
   metrics: "2.2.0",
-  mockito: "5.20.0",
+  mockito: "5.23.0",
   opentelemetryProto: "1.3.2-alpha",
   protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.2",

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -1510,15 +1510,15 @@ class ShareCoordinatorServiceTest {
             .thenReturn(List.of(tp1, tp2));
 
         when(writer.deleteRecords(
-            any(),
-            eq(10L)
+            eq(tp1),
+            anyLong()
         )).thenReturn(
             CompletableFuture.completedFuture(null)
         );
 
         when(writer.deleteRecords(
-            any(),
-            eq(20L)
+            eq(tp2),
+            anyLong()
         )).thenReturn(
             CompletableFuture.failedFuture(new Exception("bad stuff"))
         );


### PR DESCRIPTION
`testRecordPruningTaskPeriodicityWithSomeFailures` fails with Mockito
5.21+ because  unstubbed `CompletableFuture` methods now
return`completedFuture(null)` instead of `null`, so unstubbed
`deleteRecords` calls succeed instead of being no-ops.

Changed `deleteRecords` stubs from offset-based matching to
partition-based matching, which better reflects the test intent (tp1
succeeds, tp2 fails) and removes dependency on Mockito's default return
behavior.

Upgraded Mockito from 5.20.0 to 5.23.0 as the issue description allows
5.21.0 or more recent versions.  Verified locally that both 5.21.0 and
5.23.0 pass all `ShareCoordinatorServiceTest` tests.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Sushant Mahajan
 <smahajan@confluent.io>, nileshkumar3 <nileshkumar3@gmail.com>
