### PR TITLE
KAFKA-20349: Upgrade to ZooKeeper 3.8.6 - fix CVE-2026-24308

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -270,8 +270,8 @@ scala-java8-compat_2.12-1.0.2
 scala-java8-compat_2.13-1.0.2
 snappy-java-1.1.10.5
 swagger-annotations-2.2.8
-zookeeper-3.8.4
-zookeeper-jute-3.8.4
+zookeeper-3.8.6
+zookeeper-jute-3.8.6
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -162,7 +162,7 @@ versions += [
   snappy: "1.1.10.5",
   spotbugs: "4.8.6",
   zinc: "1.9.2",
-  zookeeper: "3.8.4",
+  zookeeper: "3.8.6",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-4",


### PR DESCRIPTION
Update dependency ZooKeeper "org.apache.zookeeper:zookeeper" from `3.8.4` to `3.8.6` to fix CVE-2026-24308 in `kafka_2.13:3.9.2`.
https://www.cve.org/CVERecord?id=CVE-2026-24308
https://zookeeper.apache.org/security.html#CVE-2026-24308

Goal: new release of Kafka 3.9.x (e.g., 3.9.3) including this fix

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
