### PR TITLE
KAFKA-19651: Restore thread interrupted status in consumer close()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1637,6 +1637,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         Throwable exception = firstException.get();
         if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
+                Thread.currentThread().interrupt();
                 throw (InterruptException) exception;
             }
             throw new KafkaException("Failed to close kafka consumer", exception);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
@@ -1171,6 +1171,7 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
         Throwable exception = firstException.get();
         if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
+                Thread.currentThread().interrupt();
                 throw (InterruptException) exception;
             }
             throw new KafkaException("Failed to close kafka consumer", exception);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -1055,6 +1055,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
         Throwable exception = firstException.get();
         if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
+                Thread.currentThread().interrupt();
                 throw (InterruptException) exception;
             }
             throw new KafkaException("Failed to close Kafka share consumer", exception);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1573,6 +1573,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         Throwable exception = firstException.get();
         if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
+                Thread.currentThread().interrupt();
                 throw (InterruptException) exception;
             }
             throw new KafkaException("Failed to close kafka producer", exception);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -756,6 +756,29 @@ public class AsyncKafkaConsumerTest {
     }
 
     @Test
+    public void testCloseRestoresThreadInterruptedStatus() {
+        // KAFKA-19651: Verify that Thread.interrupted() returns true after close() throws InterruptException
+        Set<TopicPartition> partitions = singleton(new TopicPartition("topic1", 0));
+        SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.assignedPartitions()).thenReturn(partitions);
+        when(applicationEventHandler.addAndGet(any(CompletableApplicationEvent.class))).thenThrow(InterruptException.class);
+        consumer = spy(newConsumer(
+            mock(FetchBuffer.class),
+            mock(ConsumerInterceptors.class),
+            mock(ConsumerRebalanceListenerInvoker.class),
+            subscriptions));
+
+        try {
+            assertThrows(InterruptException.class, () -> consumer.close(CloseOptions.timeout(Duration.ZERO)));
+            assertTrue(Thread.interrupted(),
+                "Thread interrupted status should be restored when close() throws InterruptException");
+        } finally {
+            // Clear interrupted status in case assertion failed
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     public void testCommitSyncAllConsumed() {
         SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
         consumer = newConsumer(


### PR DESCRIPTION
## Problem

When `AsyncKafkaConsumer.close()` encounters an `InterruptException`
during cleanup, the thread's interrupted status may be cleared by
subsequent cleanup operations (`metrics.close()`,
`interceptors.close()`, etc.) before the exception is re-thrown.

This causes `Thread.interrupted()` to return `false` after catching the
`InterruptException`, which is inconsistent with the contract of
`InterruptException` (whose constructor sets the interrupted flag via
`Thread.currentThread().interrupt()`).

## Root Cause

In the `close()` method, when an `InterruptException` is caught by
`swallow()` and stored in `firstException`, the thread's interrupted
flag is set by the `InterruptException` constructor. However, subsequent
cleanup calls (`closeQuietly` for metrics, interceptors, deserializers,
etc.) may internally clear this flag before the exception is re-thrown
at the end of the method.

## Fix

Explicitly call `Thread.currentThread().interrupt()` before re-throwing
the `InterruptException`. This ensures the interrupted status is always
restored regardless of what cleanup code executed between the initial
interrupt and the re-throw.

The same vulnerable pattern exists in four close() implementations, all
fixed in this PR:

- AsyncKafkaConsumer.close() - primary fix per KAFKA-19651
- ClassicKafkaConsumer.close() - same pattern
- ShareConsumerImpl.close() - same pattern
- KafkaProducer.close() - same pattern

## Tests Added

- testCloseRestoresThreadInterruptedStatus in AsyncKafkaConsumerTest:
Verifies that Thread.interrupted() returns true after close() throws
InterruptException.

## Impact

- Minimal change: one line added per close() implementation
- No behavioral change for non-interrupt code paths
- Restores consistency with InterruptException contract

Fixes KAFKA-19651

Reviewers: Matthias J. Sax <matthias@confluent.io>, Kirk True
 <kirk@kirktrue.pro>
