### PR TITLE
KAFKA-20354: Add missing Control Batch types in documentation

### DIFF
--- a/docs/implementation/message-format.md
+++ b/docs/implementation/message-format.md
@@ -81,7 +81,7 @@ version: int16 (current version is 0)
 type: int16 (the control record types are in the table below)
 ```
 
-The following control record types are currently defined:
+The following control record types are currently defined for regular topics:
 
 <table>
 <tr>
@@ -126,79 +126,9 @@ COMMIT
 Marks a transaction as committed.
 </td>
 </tr>
-<tr>
-<td>
-
-2
-</td>
-<td>
-
-LEADER_CHANGE
-</td>
-<td>
-
-Records a KRaft leader change.
-</td>
-</tr>
-<tr>
-<td>
-
-3
-</td>
-<td>
-
-SNAPSHOT_HEADER
-</td>
-<td>
-
-Marks the beginning of a KRaft snapshot.
-</td>
-</tr>
-<tr>
-<td>
-
-4
-</td>
-<td>
-
-SNAPSHOT_FOOTER
-</td>
-<td>
-
-Marks the end of a KRaft snapshot.
-</td>
-</tr>
-<tr>
-<td>
-
-5
-</td>
-<td>
-
-KRAFT_VERSION
-</td>
-<td>
-
-Records the finalized kraft.version supported by all replicas.
-</td>
-</tr>
-<tr>
-<td>
-
-6
-</td>
-<td>
-
-KRAFT_VOTERS
-</td>
-<td>
-
-Records the set of voters at a specific offset.
-</td>
-</tr>
 </table>
 
-Types 0 and 1 are used as end-of-transaction markers for the transactional messaging protocol. Types 2 through 6 are used internally by the KRaft consensus protocol. The schema of the value in the control record is dependent on the type. The value is opaque to clients.
+Types 0 and 1 are used as end-of-transaction markers for the transactional messaging protocol. Types 2 through 6 are used internally by the KRaft consensus protocol.
 
 ## Record
 

--- a/docs/implementation/message-format.md
+++ b/docs/implementation/message-format.md
@@ -75,9 +75,10 @@ Compaction may also modify the baseTimestamp if the record batch contains record
 A control batch contains a single record called the control record. Control records should not be returned to applications. Instead, they are used by consumers to filter out aborted transactional messages, and by the KRaft implementation for its protocol metadata.
 
 The key of a control record conforms to the following schema:
+
 ```text
-    version: int16 (current version is 0)
-    type: int16 (0 indicates an abort marker, 1 indicates a commit)
+version: int16 (current version is 0)
+type: int16 (the control record types are in the table below)
 ```
 
 The following control record types are currently defined:

--- a/docs/implementation/message-format.md
+++ b/docs/implementation/message-format.md
@@ -128,7 +128,7 @@ Marks a transaction as committed.
 </tr>
 </table>
 
-Types 0 and 1 are used as end-of-transaction markers for the transactional messaging protocol. Types 2 through 6 are used internally by the KRaft consensus protocol.
+Types 0 and 1 are used as end-of-transaction markers for the transactional messaging protocol. Types 2 through 6 are used internally by the KRaft consensus protocol. The schema of the value in the control record is dependent on the type. The value is opaque to clients.
 
 ## Record
 

--- a/docs/implementation/message-format.md
+++ b/docs/implementation/message-format.md
@@ -72,16 +72,132 @@ Compaction may also modify the baseTimestamp if the record batch contains record
 
 ### Control Batches
 
-A control batch contains a single record called the control record. Control records should not be passed on to applications. Instead, they are used by consumers to filter out aborted transactional messages.
+A control batch contains a single record called the control record. Control records should not be returned to applications. Instead, they are used by consumers to filter out aborted transactional messages, and by the KRaft implementation for its protocol metadata.
 
-The key of a control record conforms to the following schema: 
-
+The key of a control record conforms to the following schema:
 ```text
-version: int16 (current version is 0)
-type: int16 (0 indicates an abort marker, 1 indicates a commit)
+    version: int16 (current version is 0)
+    type: int16 (0 indicates an abort marker, 1 indicates a commit)
 ```
 
-The schema for the value of a control record is dependent on the type. The value is opaque to clients.
+The following control record types are currently defined:
+
+<table>
+<tr>
+<th>
+
+Type
+</th>
+<th>
+
+Name
+</th>
+<th>
+
+Description
+</th>
+</tr>
+<tr>
+<td>
+
+0
+</td>
+<td>
+
+ABORT
+</td>
+<td>
+
+Marks a transaction as aborted.
+</td>
+</tr>
+<tr>
+<td>
+
+1
+</td>
+<td>
+
+COMMIT
+</td>
+<td>
+
+Marks a transaction as committed.
+</td>
+</tr>
+<tr>
+<td>
+
+2
+</td>
+<td>
+
+LEADER_CHANGE
+</td>
+<td>
+
+Records a KRaft leader change.
+</td>
+</tr>
+<tr>
+<td>
+
+3
+</td>
+<td>
+
+SNAPSHOT_HEADER
+</td>
+<td>
+
+Marks the beginning of a KRaft snapshot.
+</td>
+</tr>
+<tr>
+<td>
+
+4
+</td>
+<td>
+
+SNAPSHOT_FOOTER
+</td>
+<td>
+
+Marks the end of a KRaft snapshot.
+</td>
+</tr>
+<tr>
+<td>
+
+5
+</td>
+<td>
+
+KRAFT_VERSION
+</td>
+<td>
+
+Records the finalized kraft.version supported by all replicas.
+</td>
+</tr>
+<tr>
+<td>
+
+6
+</td>
+<td>
+
+KRAFT_VOTERS
+</td>
+<td>
+
+Records the set of voters at a specific offset.
+</td>
+</tr>
+</table>
+
+Types 0 and 1 are used as end-of-transaction markers for the transactional messaging protocol. Types 2 through 6 are used internally by the KRaft consensus protocol. The schema of the value in the control record is dependent on the type. The value is opaque to clients.
 
 ## Record
 


### PR DESCRIPTION
This patch adds missing Control Batch types in the documentation.

<img width="1344" height="848" alt="Screenshot From 2026-03-25 09-28-38"
src="https://github.com/user-attachments/assets/f233eb3f-e1cd-4cb5-8646-5cf870d9717a"
/>

Reviewers: Luke Chen <showuon@gmail.com>, Ken Huang <s7133700@gmail.com>
