### PR TITLE
MINOR: Fix flaky test `CoordinatorBackgroundThreadPoolExecutorTest`

### DIFF
--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutorTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorBackgroundThreadPoolExecutorTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -79,6 +80,7 @@ public class CoordinatorBackgroundThreadPoolExecutorTest {
             mockTime.sleep(100);
             task1Unblocked.countDown();
             task1.get(5, TimeUnit.SECONDS);
+            verify(metrics, timeout(5000)).recordBackgroundProcessingTime(100);
 
             // Task 3 starts.
             task3Started.await();
@@ -87,16 +89,16 @@ public class CoordinatorBackgroundThreadPoolExecutorTest {
             mockTime.sleep(400);
             task2Unblocked.countDown();
             task2.get(5, TimeUnit.SECONDS);
+            verify(metrics, timeout(5000)).recordBackgroundProcessingTime(500);
 
             // Task 3 takes 500 ms.
             mockTime.sleep(100);
             task3Unblocked.countDown();
             task3.get(5, TimeUnit.SECONDS);
+            verify(metrics, timeout(5000).times(2)).recordBackgroundProcessingTime(500);
 
             verify(metrics, times(2)).recordBackgroundQueueTime(0);
             verify(metrics, times(1)).recordBackgroundQueueTime(100);
-            verify(metrics, times(1)).recordBackgroundProcessingTime(100);
-            verify(metrics, times(2)).recordBackgroundProcessingTime(500);
             verify(metrics, times(1)).recordBackgroundThreadBusyTime(50.0);
             verify(metrics, times(2)).recordBackgroundThreadBusyTime(250.0);
         } finally {


### PR DESCRIPTION
I ran the following command on my local machine, and all tests passed.
```
N=500; I=0; while [ $I -lt $N ] && ./gradlew coordinator-common:test
--tests CoordinatorBackgroundThreadPoolExecutorTest --rerun --fail-fast;
do (( I=$I+1 )); echo "Completed run: $I"; sleep 1; done
```
```
BUILD SUCCESSFUL in 1s
42 actionable tasks: 1 executed, 41 up-to-date
Consider enabling configuration cache to speed up this build:
https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html
Completed run: 500
```
