### PR TITLE
MINOR: Enable dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # 'daily' only runs on weekdays
+      interval: "cron"
+      cronjob: "00 20 * * *"
+    open-pull-requests-limit: 10
+    cooldown:
+      default: 4


### PR DESCRIPTION
As per https://infra.apache.org/github-actions-policy.html, we have
automatic dependency management for our GitHub Actions.

For the schedule, instead of using `daily` which only runs weekday, I
use the same pattern as in
https://github.com/apache/infrastructure-actions/blob/main/.github/dependabot.yml#L27-L30.
I kept the time as 20:00UTC as we have in kafka-site.

For the cooldown period, I followed the ASF recommendation from
https://github.com/apache/infrastructure-actions/tree/main?tab=readme-ov-file#dependabot-cooldown-period

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
