### PR TITLE
MINOR: Replace Collections factory methods with Java 11+ equivalents in group-coordinator and part of clients

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -133,7 +133,7 @@ public class AbstractConfig {
      * @param originals  the configuration properties plus any optional config provider properties; may not be null
      */
     public AbstractConfig(ConfigDef definition, Map<?, ?> originals) {
-        this(definition, originals, Collections.emptyMap(), true);
+        this(definition, originals, Map.of(), true);
     }
 
     /**
@@ -146,7 +146,7 @@ public class AbstractConfig {
      * @param doLog      whether the configurations should be logged
      */
     public AbstractConfig(ConfigDef definition, Map<?, ?> originals, boolean doLog) {
-        this(definition, originals, Collections.emptyMap(), doLog);
+        this(definition, originals, Map.of(), doLog);
     }
 
     /**
@@ -168,7 +168,7 @@ public class AbstractConfig {
      * @return a map of updates that should be applied to the configuration (will be validated to prevent bad updates)
      */
     protected Map<String, Object> postProcessParsedConfig(Map<String, Object> parsedValues) {
-        return Collections.emptyMap();
+        return Map.of();
     }
 
     protected Object get(String key) {
@@ -430,7 +430,7 @@ public class AbstractConfig {
      * @return A configured instance of the class
      */
     public <T> T getConfiguredInstance(String key, Class<T> t) {
-        return getConfiguredInstance(key, t, Collections.emptyMap());
+        return getConfiguredInstance(key, t, Map.of());
     }
 
     /**
@@ -458,7 +458,7 @@ public class AbstractConfig {
      * @return The list of configured instances
      */
     public <T> List<T> getConfiguredInstances(String key, Class<T> t) {
-        return getConfiguredInstances(key, t, Collections.emptyMap());
+        return getConfiguredInstances(key, t, Map.of());
     }
 
     /**
@@ -606,7 +606,7 @@ public class AbstractConfig {
         final String configProviders = indirectConfigs.get(CONFIG_PROVIDERS_CONFIG);
 
         if (configProviders == null || configProviders.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         Map<String, String> providerMap = new HashMap<>();

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -218,7 +218,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Validator validator, Importance importance, String documentation,
                             String group, int orderInGroup, Width width, String displayName, Recommender recommender) {
-        return define(name, type, defaultValue, validator, importance, documentation, group, orderInGroup, width, displayName, Collections.emptyList(), recommender);
+        return define(name, type, defaultValue, validator, importance, documentation, group, orderInGroup, width, displayName, List.of(), recommender);
     }
 
     /**
@@ -237,7 +237,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Validator validator, Importance importance, String documentation,
                             String group, int orderInGroup, Width width, String displayName) {
-        return define(name, type, defaultValue, validator, importance, documentation, group, orderInGroup, width, displayName, Collections.emptyList());
+        return define(name, type, defaultValue, validator, importance, documentation, group, orderInGroup, width, displayName, List.of());
     }
 
     /**
@@ -295,7 +295,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Importance importance, String documentation,
                             String group, int orderInGroup, Width width, String displayName, Recommender recommender) {
-        return define(name, type, defaultValue, null, importance, documentation, group, orderInGroup, width, displayName, Collections.emptyList(), recommender);
+        return define(name, type, defaultValue, null, importance, documentation, group, orderInGroup, width, displayName, List.of(), recommender);
     }
 
     /**
@@ -313,7 +313,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Importance importance, String documentation,
                             String group, int orderInGroup, Width width, String displayName) {
-        return define(name, type, defaultValue, null, importance, documentation, group, orderInGroup, width, displayName, Collections.emptyList());
+        return define(name, type, defaultValue, null, importance, documentation, group, orderInGroup, width, displayName, List.of());
     }
 
     /**
@@ -368,7 +368,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Importance importance, String documentation, String group, int orderInGroup,
                             Width width, String displayName, Recommender recommender) {
-        return define(name, type, NO_DEFAULT_VALUE, null, importance, documentation, group, orderInGroup, width, displayName, Collections.emptyList(), recommender);
+        return define(name, type, NO_DEFAULT_VALUE, null, importance, documentation, group, orderInGroup, width, displayName, List.of(), recommender);
     }
 
     /**
@@ -385,7 +385,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Importance importance, String documentation, String group, int orderInGroup,
                             Width width, String displayName) {
-        return define(name, type, NO_DEFAULT_VALUE, null, importance, documentation, group, orderInGroup, width, displayName, Collections.emptyList());
+        return define(name, type, NO_DEFAULT_VALUE, null, importance, documentation, group, orderInGroup, width, displayName, List.of());
     }
 
     /**
@@ -427,7 +427,7 @@ public class ConfigDef {
      */
     public ConfigDef define(String name, Type type, Object defaultValue, Importance importance, String documentation, String alternativeString) {
         return define(name, type, defaultValue, null, importance, documentation, null, -1, Width.NONE,
-                name, Collections.emptyList(), null, alternativeString);
+                name, List.of(), null, alternativeString);
     }
 
     /**
@@ -452,7 +452,7 @@ public class ConfigDef {
      * @return This ConfigDef so you can chain calls
      */
     public ConfigDef defineInternal(final String name, final Type type, final Object defaultValue, final Importance importance) {
-        return define(new ConfigKey(name, type, defaultValue, null, importance, "", "", -1, Width.NONE, name, Collections.emptyList(), null, true, null));
+        return define(new ConfigKey(name, type, defaultValue, null, importance, "", "", -1, Width.NONE, name, List.of(), null, true, null));
     }
 
     /**
@@ -467,7 +467,7 @@ public class ConfigDef {
      * @return This ConfigDef so you can chain calls
      */
     public ConfigDef defineInternal(final String name, final Type type, final Object defaultValue, final Validator validator, final Importance importance, final String documentation) {
-        return define(new ConfigKey(name, type, defaultValue, validator, importance, documentation, "", -1, Width.NONE, name, Collections.emptyList(), null, true, null));
+        return define(new ConfigKey(name, type, defaultValue, validator, importance, documentation, "", -1, Width.NONE, name, List.of(), null, true, null));
     }
 
     /**
@@ -768,7 +768,7 @@ public class ConfigDef {
                         return value;
                     else if (value instanceof String)
                         if (trimmed.isEmpty())
-                            return Collections.emptyList();
+                            return List.of();
                         else
                             return Arrays.asList(COMMA_WITH_WHITESPACE.split(trimmed, -1));
                     else
@@ -1445,7 +1445,7 @@ public class ConfigDef {
     }
 
     public String toHtmlTable() {
-        return toHtmlTable(Collections.emptyMap());
+        return toHtmlTable(Map.of());
     }
 
     private void addHeader(StringBuilder builder, String headerName) {
@@ -1700,7 +1700,7 @@ public class ConfigDef {
     }
 
     public String toHtml() {
-        return toHtml(Collections.emptyMap());
+        return toHtml(Map.of());
     }
 
     /**
@@ -1709,7 +1709,7 @@ public class ConfigDef {
      * @param idGenerator A function for computing the HTML id attribute in the generated HTML from a given config name.
      */
     public String toHtml(int headerDepth, Function<String, String> idGenerator) {
-        return toHtml(headerDepth, idGenerator, Collections.emptyMap());
+        return toHtml(headerDepth, idGenerator, Map.of());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/config/internals/BrokerSecurityConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/internals/BrokerSecurityConfigs.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
 import org.apache.kafka.common.utils.Utils;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
@@ -61,7 +60,7 @@ public class BrokerSecurityConfigs {
             " configuration.";
 
     public static final String SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_CONFIG = "sasl.kerberos.principal.to.local.rules";
-    public static final List<String> DEFAULT_SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES = Collections.singletonList(DEFAULT_SSL_PRINCIPAL_MAPPING_RULES);
+    public static final List<String> DEFAULT_SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES = List.of(DEFAULT_SSL_PRINCIPAL_MAPPING_RULES);
     public static final String SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_DOC = "A list of rules for mapping from principal " +
             "names to short names (typically operating system usernames). The rules are evaluated in order and the " +
             "first rule that matches a principal name is used to map it to a short name. Any later rules in the list are " +
@@ -95,7 +94,7 @@ public class BrokerSecurityConfigs {
             + "</ul>";
 
     public static final String SASL_ENABLED_MECHANISMS_CONFIG = "sasl.enabled.mechanisms";
-    public static final List<String> DEFAULT_SASL_ENABLED_MECHANISMS = Collections.singletonList(SaslConfigs.GSSAPI_MECHANISM);
+    public static final List<String> DEFAULT_SASL_ENABLED_MECHANISMS = List.of(SaslConfigs.GSSAPI_MECHANISM);
     public static final String SASL_ENABLED_MECHANISMS_DOC = "The list of SASL mechanisms enabled in the Kafka server. "
             + "The list may contain any mechanism for which a security provider is available. "
             + "Only GSSAPI is enabled by default.";

--- a/clients/src/main/java/org/apache/kafka/common/config/provider/DirectoryConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/DirectoryConfigProvider.java
@@ -32,7 +32,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyMap;
 
 /**
  * An implementation of {@link ConfigProvider} based on a directory of files.
@@ -87,7 +86,7 @@ public class DirectoryConfigProvider implements ConfigProvider {
             throw new IllegalStateException("The provider has not been configured yet.");
         }
 
-        Map<String, String> map = emptyMap();
+        Map<String, String> map = Map.of();
 
         if (path != null && !path.isEmpty()) {
             Path dir = allowedPaths.parseUntrustedPath(path);

--- a/clients/src/main/java/org/apache/kafka/common/errors/TopicAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TopicAuthorizationException.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.errors;
 
-import java.util.Collections;
 import java.util.Set;
 
 public class TopicAuthorizationException extends AuthorizationException {
@@ -32,7 +31,7 @@ public class TopicAuthorizationException extends AuthorizationException {
     }
 
     public TopicAuthorizationException(String message) {
-        this(message, Collections.emptySet());
+        this(message, Set.of());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.protocol.SendBuilder;
 
 import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -65,7 +64,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
     public abstract Map<Errors, Integer> errorCounts();
 
     protected static Map<Errors, Integer> errorCounts(Errors error) {
-        return Collections.singletonMap(error, 1);
+        return Map.of(error, 1);
     }
 
     protected static Map<Errors, Integer> errorCounts(Stream<Errors> errors) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class AddRaftVoterResponse extends AbstractResponse {
@@ -51,9 +50,9 @@ public class AddRaftVoterResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         if (data.errorCode() != Errors.NONE.code()) {
-            return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+            return Map.of(Errors.forCode(data.errorCode()), 1);
         } else {
-            return Collections.emptyMap();
+            return Map.of();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class AllocateProducerIdsResponse extends AbstractResponse {
@@ -47,7 +46,7 @@ public class AllocateProducerIdsResponse extends AbstractResponse {
      */
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return Map.of(Errors.forCode(data.errorCode()), 1);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -90,7 +89,7 @@ public class AlterPartitionRequest extends AbstractRequest {
                                 newIsr.add(brokerState.brokerId())
                             );
                             partitionData.setNewIsr(newIsr);
-                            partitionData.setNewIsrWithEpochs(Collections.emptyList());
+                            partitionData.setNewIsrWithEpochs(List.of());
                         }
                     })
                 );

--- a/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class AssignReplicasToDirsResponse extends AbstractResponse {
@@ -40,7 +39,7 @@ public class AssignReplicasToDirsResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return Map.of(Errors.forCode(data.errorCode()), 1);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
@@ -22,8 +22,8 @@ import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+import java.util.List;
 
-import java.util.Collections;
 
 public class BeginQuorumEpochRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<BeginQuorumEpochRequest> {
@@ -75,10 +75,10 @@ public class BeginQuorumEpochRequest extends AbstractRequest {
     ) {
         return new BeginQuorumEpochRequestData()
                    .setClusterId(clusterId)
-                   .setTopics(Collections.singletonList(
+                   .setTopics(List.of(
                        new BeginQuorumEpochRequestData.TopicData()
                            .setTopicName(topicPartition.topic())
-                           .setPartitions(Collections.singletonList(
+                           .setPartitions(List.of(
                                new BeginQuorumEpochRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
                                    .setLeaderEpoch(leaderEpoch)

--- a/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BeginQuorumEpochRequest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+
 import java.util.List;
 
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -59,7 +58,7 @@ public class ConsumerGroupHeartbeatResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return Map.of(Errors.forCode(data.errorCode()), 1);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class ControllerRegistrationResponse extends AbstractResponse {
@@ -50,7 +49,7 @@ public class ControllerRegistrationResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return Map.of(Errors.forCode(data.errorCode()), 1);
     }
 
     public static ControllerRegistrationResponse parse(Readable readable, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -104,7 +103,7 @@ public class DeleteTopicsRequest extends AbstractRequest {
     public List<Uuid> topicIds() {
         if (version() >= 6)
             return data.topics().stream().map(DeleteTopicState::topicId).collect(Collectors.toList());
-        return Collections.emptyList();
+        return List.of();
     }
     
     public List<DeleteTopicState> topics() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.utils.Utils;
 
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +105,7 @@ public class DescribeGroupsResponse extends AbstractResponse {
 
     public static DescribedGroup groupError(String groupId, Errors error) {
         return groupMetadata(groupId, error, DescribeGroupsResponse.UNKNOWN_STATE, DescribeGroupsResponse.UNKNOWN_PROTOCOL_TYPE,
-            DescribeGroupsResponse.UNKNOWN_PROTOCOL, Collections.emptyList(), AUTHORIZED_OPERATIONS_OMITTED);
+            DescribeGroupsResponse.UNKNOWN_PROTOCOL, List.of(), AUTHORIZED_OPERATIONS_OMITTED);
     }
 
     public static DescribedGroup groupError(String groupId, Errors error, String errorMessage) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumRequest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -61,10 +60,10 @@ public class DescribeQuorumRequest extends AbstractRequest {
 
     public static DescribeQuorumRequestData singletonRequest(TopicPartition topicPartition) {
         return new DescribeQuorumRequestData()
-            .setTopics(Collections.singletonList(
+            .setTopics(List.of(
                 new DescribeQuorumRequestData.TopicData()
                     .setTopicName(topicPartition.topic())
-                    .setPartitions(Collections.singletonList(
+                    .setPartitions(List.of(
                         new DescribeQuorumRequestData.PartitionData()
                             .setPartitionIndex(topicPartition.partition()))
             )));

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuorumResponse.java
@@ -22,8 +22,8 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -79,9 +79,9 @@ public class DescribeQuorumResponse extends AbstractResponse {
         Errors error
     ) {
         return new DescribeQuorumResponseData()
-            .setTopics(Collections.singletonList(new DescribeQuorumResponseData.TopicData()
+            .setTopics(List.of(new DescribeQuorumResponseData.TopicData()
                 .setTopicName(topicPartition.topic())
-                .setPartitions(Collections.singletonList(new DescribeQuorumResponseData.PartitionData()
+                .setPartitions(List.of(new DescribeQuorumResponseData.PartitionData()
                     .setPartitionIndex(topicPartition.partition())
                     .setErrorCode(error.code())
                     .setErrorMessage(error.message())))));
@@ -94,9 +94,9 @@ public class DescribeQuorumResponse extends AbstractResponse {
         DescribeQuorumResponseData.NodeCollection nodes
     ) {
         DescribeQuorumResponseData res = new DescribeQuorumResponseData()
-            .setTopics(Collections.singletonList(new DescribeQuorumResponseData.TopicData()
+            .setTopics(List.of(new DescribeQuorumResponseData.TopicData()
                 .setTopicName(topicPartition.topic())
-                .setPartitions(Collections.singletonList(partitionData
+                .setPartitions(List.of(partitionData
                     .setPartitionIndex(topicPartition.partition())))));
 
         if (nodes != null)

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsRequest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.List;
 
 public class DescribeTopicPartitionsRequest extends AbstractRequest {
@@ -83,7 +82,7 @@ public class DescribeTopicPartitionsRequest extends AbstractRequest {
                 .setName(topic.name())
                 .setErrorCode(error.code())
                 .setIsInternal(false)
-                .setPartitions(Collections.emptyList())
+                .setPartitions(List.of())
             );
         }
         responseData.setThrottleTimeMs(throttleTimeMs);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -92,7 +91,7 @@ public class ElectLeadersRequest extends AbstractRequest {
 
     public Set<TopicPartition> topicPartitions() {
         if (this.data.topicPartitions() == null) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return this.data.topicPartitions().stream()
             .flatMap(topicPartition -> topicPartition.partitions().stream()

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -84,10 +83,10 @@ public class EndQuorumEpochRequest extends AbstractRequest {
                                                              List<Integer> preferredSuccessors) {
         return new EndQuorumEpochRequestData()
                    .setClusterId(clusterId)
-                   .setTopics(Collections.singletonList(
+                   .setTopics(List.of(
                        new EndQuorumEpochRequestData.TopicData()
                            .setTopicName(topicPartition.topic())
-                           .setPartitions(Collections.singletonList(
+                           .setPartitions(List.of(
                                new EndQuorumEpochRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
                                    .setLeaderEpoch(leaderEpoch)

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.internal.RecordBatch;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -159,8 +158,8 @@ public class FetchRequest extends AbstractRequest {
         private IsolationLevel isolationLevel = IsolationLevel.READ_UNCOMMITTED;
         private int maxBytes = DEFAULT_RESPONSE_MAX_BYTES;
         private FetchMetadata metadata = FetchMetadata.LEGACY;
-        private List<TopicIdPartition> removed = Collections.emptyList();
-        private List<TopicIdPartition> replaced = Collections.emptyList();
+        private List<TopicIdPartition> removed = List.of();
+        private List<TopicIdPartition> replaced = List.of();
         private String rackId = "";
 
         public static Builder forConsumer(short maxVersion, int maxWait, int minBytes, Map<TopicPartition, PartitionData> fetchData) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.record.internal.MemoryRecords;
 import org.apache.kafka.common.record.internal.Records;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -166,7 +165,7 @@ public class FetchResponse extends AbstractResponse {
                              FetchResponseData.PartitionData>> partIterator) {
         // Since the throttleTimeMs and metadata field sizes are constant and fixed, we can
         // use arbitrary values here without affecting the result.
-        FetchResponseData data = toMessage(Errors.NONE, 0, INVALID_SESSION_ID, partIterator, Collections.emptyList());
+        FetchResponseData data = toMessage(Errors.NONE, 0, INVALID_SESSION_ID, partIterator, List.of());
         ObjectSerializationCache cache = new ObjectSerializationCache();
         return 4 + data.size(cache, version);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+
 import java.util.List;
 
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorRequest.java
@@ -24,8 +24,8 @@ import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+import java.util.List;
 
-import java.util.Collections;
 
 public class FindCoordinatorRequest extends AbstractRequest {
 
@@ -52,10 +52,10 @@ public class FindCoordinatorRequest extends AbstractRequest {
                         "because we require features supported only in " + MIN_BATCHED_VERSION + " or later.");
                 if (batchedKeys == 1) {
                     data.setKey(data.coordinatorKeys().get(0));
-                    data.setCoordinatorKeys(Collections.emptyList());
+                    data.setCoordinatorKeys(List.of());
                 }
             } else if (batchedKeys == 0 && data.key() != null) {
-                data.setCoordinatorKeys(Collections.singletonList(data.key()));
+                data.setCoordinatorKeys(List.of(data.key()));
                 data.setKey(""); // default value
             }
             return new FindCoordinatorRequest(data, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +131,7 @@ public class FindCoordinatorResponse extends AbstractResponse {
                     .setNodeId(data.nodeId())
                     .setHost(data.host())
                     .setPort(data.port());
-            return Collections.singletonList(coordinator);
+            return List.of(coordinator);
         }
     }
 
@@ -148,7 +147,7 @@ public class FindCoordinatorResponse extends AbstractResponse {
 
     public static FindCoordinatorResponse prepareResponse(Errors error, String key, Node node) {
         FindCoordinatorResponseData data = new FindCoordinatorResponseData();
-        data.setCoordinators(Collections.singletonList(
+        data.setCoordinators(List.of(
             prepareCoordinatorResponse(error, key, node)
         ));
         return new FindCoordinatorResponse(data);

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -24,8 +24,8 @@ import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+import java.util.List;
 
-import java.util.Collections;
 
 public class JoinGroupRequest extends AbstractRequest {
 
@@ -197,7 +197,7 @@ public class JoinGroupRequest extends AbstractRequest {
             .setProtocolName(UNKNOWN_PROTOCOL_NAME)
             .setLeader(UNKNOWN_MEMBER_ID)
             .setMemberId(UNKNOWN_MEMBER_ID)
-            .setMembers(Collections.emptyList());
+            .setMembers(List.of());
 
         if (version() >= 7)
             data.setProtocolName(null);

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+
 import java.util.List;
 
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupRequest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.List;
 
 public class LeaveGroupRequest extends AbstractRequest {
@@ -97,14 +96,14 @@ public class LeaveGroupRequest extends AbstractRequest {
         } else {
             return new LeaveGroupRequestData()
                 .setGroupId(data.groupId())
-                .setMembers(Collections.singletonList(
+                .setMembers(List.of(
                     new MemberIdentity().setMemberId(data.memberId())));
         }
     }
 
     public List<MemberIdentity> members() {
         // Before version 3, leave group request is still in single mode
-        return version() <= 2 ? Collections.singletonList(
+        return version() <= 2 ? List.of(
             new MemberIdentity()
                 .setMemberId(data.memberId())) : data.members();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -86,7 +85,7 @@ public class ListGroupsRequest extends AbstractRequest {
     @Override
     public ListGroupsResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ListGroupsResponseData listGroupsResponseData = new ListGroupsResponseData().
-            setGroups(Collections.emptyList()).
+            setGroups(List.of()).
             setErrorCode(Errors.forException(e).code());
         if (version() >= 1) {
             listGroupsResponseData.setThrottleTimeMs(throttleTimeMs);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsResponse.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.internal.RecordBatch;
 
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +104,7 @@ public class ListOffsetsResponse extends AbstractResponse {
     public static ListOffsetsTopicResponse singletonListOffsetsTopicResponse(TopicPartition tp, Errors error, long timestamp, long offset, int epoch) {
         return new ListOffsetsTopicResponse()
                  .setName(tp.topic())
-                 .setPartitions(Collections.singletonList(new ListOffsetsPartitionResponse()
+                 .setPartitions(List.of(new ListOffsetsPartitionResponse()
                          .setPartitionIndex(tp.partition())
                          .setErrorCode(error.code())
                          .setTimestamp(timestamp)

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -173,7 +172,7 @@ public class MetadataRequest extends AbstractRequest {
                     .setTopicId(topic.topicId())
                     .setErrorCode(error.code())
                     .setIsInternal(false)
-                    .setPartitions(Collections.emptyList()));
+                    .setPartitions(List.of()));
             }
         }
 
@@ -200,9 +199,9 @@ public class MetadataRequest extends AbstractRequest {
 
     public List<Uuid> topicIds() {
         if (isAllTopics())
-            return Collections.emptyList();
+            return List.of();
         else if (version() < 10)
-            return Collections.emptyList();
+            return List.of();
         else
             return data.topics()
                     .stream()

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -228,7 +227,7 @@ public class OffsetFetchRequest extends AbstractRequest {
                 );
             }
 
-            return Collections.singletonList(group);
+            return List.of(group);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -30,9 +30,9 @@ import org.apache.kafka.common.record.internal.RecordBatch;
 import org.apache.kafka.common.record.internal.Records;
 import org.apache.kafka.common.utils.Utils;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -174,7 +174,7 @@ public class ProduceRequest extends AbstractRequest {
             }
             tpr.partitionResponses().add(new ProduceResponseData.PartitionProduceResponse()
                     .setIndex(tpId.partition())
-                    .setRecordErrors(Collections.emptyList())
+                    .setRecordErrors(List.of())
                     .setBaseOffset(INVALID_OFFSET)
                     .setLogAppendTimeMs(RecordBatch.NO_TIMESTAMP)
                     .setLogStartOffset(INVALID_OFFSET)
@@ -187,7 +187,7 @@ public class ProduceRequest extends AbstractRequest {
     @Override
     public Map<Errors, Integer> errorCounts(Throwable e) {
         Errors error = Errors.forException(e);
-        return Collections.singletonMap(error, partitionSizes().size());
+        return Map.of(error, partitionSizes().size());
     }
 
     public short acks() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.record.internal.RecordBatch;
 
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +73,7 @@ public class ProduceResponse extends AbstractResponse {
      */
     @Deprecated
     public ProduceResponse(Map<TopicIdPartition, PartitionResponse> responses) {
-        this(responses, DEFAULT_THROTTLE_TIME, Collections.emptyList());
+        this(responses, DEFAULT_THROTTLE_TIME, List.of());
     }
 
     /**
@@ -85,7 +84,7 @@ public class ProduceResponse extends AbstractResponse {
      */
     @Deprecated
     public ProduceResponse(Map<TopicIdPartition, PartitionResponse> responses, int throttleTimeMs) {
-        this(toData(responses, throttleTimeMs, Collections.emptyList()));
+        this(toData(responses, throttleTimeMs, List.of()));
     }
 
     /**
@@ -170,11 +169,11 @@ public class ProduceResponse extends AbstractResponse {
         }
 
         public PartitionResponse(Errors error, String errorMessage) {
-            this(error, INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, INVALID_OFFSET, Collections.emptyList(), errorMessage);
+            this(error, INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, INVALID_OFFSET, List.of(), errorMessage);
         }
 
         public PartitionResponse(Errors error, long baseOffset, long logAppendTime, long logStartOffset) {
-            this(error, baseOffset, logAppendTime, logStartOffset, Collections.emptyList(), null);
+            this(error, baseOffset, logAppendTime, logStartOffset, List.of(), null);
         }
 
         public PartitionResponse(Errors error, long baseOffset, long logAppendTime, long logStartOffset, List<RecordError> recordErrors) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class RemoveRaftVoterResponse extends AbstractResponse {
@@ -51,9 +50,9 @@ public class RemoveRaftVoterResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         if (data.errorCode() != Errors.NONE.code()) {
-            return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+            return Map.of(Errors.forCode(data.errorCode()), 1);
         } else {
-            return Collections.emptyMap();
+            return Map.of();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.record.internal.MemoryRecords;
 import org.apache.kafka.common.record.internal.Records;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -139,7 +138,7 @@ public class ShareFetchResponse extends AbstractResponse {
                              Iterator<Map.Entry<TopicIdPartition, ShareFetchResponseData.PartitionData>> partIterator) {
         // Since the throttleTimeMs and metadata field sizes are constant and fixed, we can
         // use arbitrary values here without affecting the result.
-        ShareFetchResponseData data = toMessage(Errors.NONE, 0, partIterator, Collections.emptyList(), 0);
+        ShareFetchResponseData data = toMessage(Errors.NONE, 0, partIterator, List.of(), 0);
         ObjectSerializationCache cache = new ObjectSerializationCache();
         return 4 + data.size(cache, version);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -56,7 +55,7 @@ public class ShareGroupHeartbeatResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return Map.of(Errors.forCode(data.errorCode()), 1);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
@@ -59,7 +59,7 @@ public class StreamsGroupHeartbeatResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+        return Map.of(Errors.forCode(data.errorCode()), 1);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesRequest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Readable;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class UpdateFeaturesRequest extends AbstractRequest {
@@ -105,7 +105,7 @@ public class UpdateFeaturesRequest extends AbstractRequest {
     public UpdateFeaturesResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         return UpdateFeaturesResponse.createWithErrors(
             ApiError.fromThrowable(e),
-            Collections.emptySet(),
+            Set.of(),
             throttleTimeMs
         );
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class UpdateRaftVoterResponse extends AbstractResponse {
@@ -51,9 +50,9 @@ public class UpdateRaftVoterResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         if (data.errorCode() != Errors.NONE.code()) {
-            return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+            return Map.of(Errors.forCode(data.errorCode()), 1);
         } else {
-            return Collections.emptyMap();
+            return Map.of();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+
 import java.util.List;
 
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
@@ -22,8 +22,8 @@ import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
+import java.util.List;
 
-import java.util.Collections;
 
 public class VoteRequest extends AbstractRequest {
 
@@ -77,10 +77,10 @@ public class VoteRequest extends AbstractRequest {
                                                    boolean preVote) {
         return new VoteRequestData()
                    .setClusterId(clusterId)
-                   .setTopics(Collections.singletonList(
+                   .setTopics(List.of(
                        new VoteRequestData.TopicData()
                            .setTopicName(topicPartition.topic())
-                           .setPartitions(Collections.singletonList(
+                           .setPartitions(List.of(
                                new VoteRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
                                    .setReplicaEpoch(replicaEpoch)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -766,7 +766,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                         Map<Integer, PartitionErrorData> partitionErrors =
                             Optional.ofNullable(topicPartitionErrorsMap)
                                 .map(map -> map.get(topic.topicId()))
-                                .orElse(Collections.emptyMap());
+                                .orElse(Map.of());
                         PartitionErrorData error = partitionErrors.get(partition.partitionIndex());
                         if (error == null) {
                             partitionData = partition.duplicate();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2166,7 +2166,7 @@ public class GroupMetadataManager {
             response.setEndpointInformationEpoch(group.endpointInformationEpoch());
         }
 
-        Map<String, CreatableTopic> internalTopicsToBeCreated = Collections.emptyMap();
+        Map<String, CreatableTopic> internalTopicsToBeCreated = Map.of();
         if (updatedConfiguredTopology.topicConfigurationException().isPresent()) {
             TopicConfigurationException exception = updatedConfiguredTopology.topicConfigurationException().get();
             internalTopicsToBeCreated = updatedConfiguredTopology.internalTopicsToBeCreated();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -1275,11 +1275,11 @@ public class StreamsGroup implements Group {
 
             // Search for the partition in assigned tasks, then in tasks pending revocation
             Integer assignmentEpoch = assignedTasks.activeTasksWithEpochs()
-                .getOrDefault(subtopologyId, Collections.emptyMap())
+                .getOrDefault(subtopologyId, Map.of())
                 .get(partitionId);
             if (assignmentEpoch == null) {
                 assignmentEpoch = tasksPendingRevocation.activeTasksWithEpochs()
-                    .getOrDefault(subtopologyId, Collections.emptyMap())
+                    .getOrDefault(subtopologyId, Map.of())
                     .get(partitionId);
             }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -287,7 +287,7 @@ public record StreamsGroupMember(String memberId,
                 .setClientId("")
                 .setClientHost("")
                 .setProcessId("")
-                .setClientTags(Collections.emptyMap())
+                .setClientTags(Map.of())
                 .setState(MemberState.STABLE)
                 .setMemberEpoch(0)
                 .setPreviousMemberEpoch(0)


### PR DESCRIPTION
This PR is another one with changing old JDK 8 API to JDK 11. It's
changing in the whole `group-coordinator` module and part of clients
(i.e., common/requests, common/errors, common/config). I didn't want to
do the whole... because it would be more bigger change ...

Also I have faced the issue where in  `GroupCoordinatorService we use
`Collections.singletonList(null)` so I skipped that as `List.of(...)`
would break the code. Moreover in `AssignorHelpers` there is
`Collections.emptyMap().getClass()` which is using reflection and that I
would also use different class  ...

Reviewers: Ken Huang <s7133700@gmail.com>, PoAn Yang
 <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>
