### PR TITLE
KAFKA-20359 : Update docker image with fully qualified name

### DIFF
--- a/docker/docker_official_images/3.7.0/jvm/Dockerfile
+++ b/docker/docker_official_images/3.7.0/jvm/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM eclipse-temurin:21-jre-alpine AS build-jsa
+FROM docker.io/library/eclipse-temurin:21-jre-alpine AS build-jsa
 
 USER root
 
@@ -41,7 +41,7 @@ RUN set -eux ; \
 RUN /etc/kafka/docker/jsa_launch
 
 
-FROM eclipse-temurin:21-jre-alpine
+FROM docker.io/library/eclipse-temurin:21-jre-alpine
 
 # exposed ports
 EXPOSE 9092

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM eclipse-temurin:21-jre-alpine AS build-jsa
+FROM docker.io/library/eclipse-temurin:21-jre-alpine AS build-jsa
 
 USER root
 
@@ -49,7 +49,7 @@ RUN set -eux ; \
 RUN /etc/kafka/docker/jsa_launch
 
 
-FROM eclipse-temurin:21-jre-alpine
+FROM docker.io/library/eclipse-temurin:21-jre-alpine
 
 # exposed ports
 EXPOSE 9092

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -46,7 +46,7 @@ default_num_nodes=14
 
 # The default JDK base image with apt-get support.
 # The openjdk image has been officially deprecated. For more information, see: https://hub.docker.com/_/openjdk
-default_jdk="eclipse-temurin:17-jdk-jammy"
+default_jdk="docker.io/library/eclipse-temurin:17-jdk-jammy"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -91,8 +91,8 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     or a combination of port/port-range separated by comma (like 2181,9092 or 2181,5005-5008).
     By default no port is exposed. See README.md for more detail on this option.
 
-    If -j|--jdk is specified, you can customize the OpenJDK base image used for building
-    the ducker container. Defaults to ${default_jdk}. Example: -j openjdk:17-bullseye
+    If -j|--jdk is specified, you can customize the JDK base image used for building
+    the ducker container. Defaults to ${default_jdk}. Example: -j docker.io/library/eclipse-temurin:17-jdk-jammy
 
     If --ipv6 is specified, we will create a Docker network with IPv6 enabled.
 


### PR DESCRIPTION
Updating docker image with fully qualified name
`docker.io/library/eclipse-temurin:21-jdk-jammy`

Reviewers: TaiJuWu <tjwu1217@gmail.com>, PoAn Yang <payang@apache.org>,
 Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
