### PR TITLE
KAFKA-20361 : Fix LazyDownConversionRecordsTest in using zlib-ng

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
@@ -154,7 +154,8 @@ public class LazyDownConversionRecordsTest {
             ByteBuffer convertedRecordsBuffer;
             try (TransferableChannel channel = toTransferableChannel(FileChannel.open(outputFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE))) {
                 int written = 0;
-                while (written < bytesToConvert) written += lazySend.writeTo(channel, written, bytesToConvert - written);
+                // Use bytesToConvert as remaining to avoid truncating batches when V1 is larger than V2 (e.g. zlib-ng)
+                while (written < bytesToConvert) written += lazySend.writeTo(channel, written, bytesToConvert);
                 try (FileRecords convertedRecords = FileRecords.open(outputFile, true, written, false)) {
                     convertedRecordsBuffer = ByteBuffer.allocate(convertedRecords.sizeInBytes());
                     convertedRecords.readInto(convertedRecordsBuffer, 0);


### PR DESCRIPTION
The test's write loop passed bytesToConvert - written as the remaining parameter to LazyDownConversionRecordsSend.writeTo(). This shrinks with each batch written, and the last batch gets truncated via Math.min(batchSize, remaining) when total V1 size exceeds V2 size — which happens with zlib-ng due to its longer match sizes compressing V1 format less efficiently.

Fix: pass bytesToConvert (constant) as remaining so no individual batch is ever truncated, regardless of the compression library used.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
