### PR TITLE
KAFKA-20347: Fix metric leak and JMX tag order in ShareCoordinatorMetrics

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetrics.java
@@ -20,6 +20,7 @@ package org.apache.kafka.coordinator.share.metrics;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.internals.MetricsUtils;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Meter;
@@ -115,6 +116,10 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             throw new IllegalArgumentException("ShareCoordinatorMetrics can only deactivate ShareCoordinatorMetricShard");
         }
         shards.remove(shard.topicPartition());
+        ShareGroupPruneMetrics removed = pruneMetrics.remove(shard.topicPartition());
+        if (removed != null) {
+            metrics.removeSensor(removed.pruneSensor.name());
+        }
     }
 
     @Override
@@ -159,7 +164,7 @@ public class ShareCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
         ShareGroupPruneMetrics(TopicPartition tp) {
             String sensorNameSuffix = tp.toString();
-            Map<String, String> tags = Map.of(
+            Map<String, String> tags = MetricsUtils.getTags(
                 "topic", tp.topic(),
                 "partition", Integer.toString(tp.partition())
             );

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetricsTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/metrics/ShareCoordinatorMetricsTest.java
@@ -20,13 +20,13 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.internals.MetricsUtils;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.coordinator.share.metrics.ShareCoordinatorMetrics.SHARE_COORDINATOR_WRITE_LATENCY_SENSOR_NAME;
@@ -113,10 +113,30 @@ public class ShareCoordinatorMetricsTest {
             "last-pruned-offset",
             ShareCoordinatorMetrics.METRICS_GROUP,
             "The offset at which the share-group state topic was last pruned.",
-            Map.of(
+            MetricsUtils.getTags(
                 "topic", topic,
                 "partition", Integer.toString(partition)
             )
         );
+    }
+
+    @Test
+    public void testDeactivateMetricsShardCleansUpPruneMetrics() {
+        Metrics metrics = new Metrics();
+        ShareCoordinatorMetrics coordinatorMetrics = new ShareCoordinatorMetrics(metrics);
+        TopicPartition tp = new TopicPartition(Topic.SHARE_GROUP_STATE_TOPIC_NAME, 0);
+        ShareCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(
+            new SnapshotRegistry(new LogContext()), tp
+        );
+
+        coordinatorMetrics.activateMetricsShard(shard);
+
+        // Record prune to create the per-partition sensor and metric.
+        coordinatorMetrics.recordPrune(10.0, tp);
+        assertTrue(metrics.metrics().containsKey(pruneMetricName(metrics, tp.topic(), tp.partition())));
+
+        // Deactivate the shard, should clean up the prune metric.
+        coordinatorMetrics.deactivateMetricsShard(shard);
+        assertFalse(metrics.metrics().containsKey(pruneMetricName(metrics, tp.topic(), tp.partition())));
     }
 }


### PR DESCRIPTION
Fix unpredictable JMX metric name tag order and per-partition prune
sensor leak on partition leader changes in `ShareCoordinatorMetrics`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
