### PR TITLE
fix: insecure default behavior in SslClientAuth.forConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslClientAuth.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslClientAuth.java
@@ -32,7 +32,7 @@ public enum SslClientAuth {
 
     public static SslClientAuth forConfig(String key) {
         if (key == null) {
-            return SslClientAuth.NONE;
+            return null;
         }
         String upperCaseKey = key.toUpperCase(Locale.ROOT);
         for (SslClientAuth auth : VALUES) {
@@ -40,7 +40,7 @@ public enum SslClientAuth {
                 return auth;
             }
         }
-        return null;
+        return SslClientAuth.NONE;
     }
 
     @Override


### PR DESCRIPTION
Delete this text and replace it with a detailed description of your change. The 
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including 
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.

fix: insecure default behavior in SslClientAuth.forConfig

The `forConfig` method returns `null` when an invalid configuration key is provided, instead of throwing an exception or using a default value. This could lead to unexpected behavior or misconfiguration in SSL client authentication settings, where a null value might be silently ignored or cause downstream failures. It's a security risk because misconfigured SSL settings could weaken the security posture.

Suggestion: Throw an `IllegalArgumentException` or return a default value (e.g., `SslClientAuth.NONE`) when the input key is invalid, ensuring that misconfigurations are caught early and explicitly handled.

Files changed:
- `clients/src/main/java/org/apache/kafka/common/config/SslClientAuth.java` (modified)
Commit message: fix(security): insecure default behavior in sslclientauth.forconfig