### PR TITLE
KAFKA-20369 - Upgrade log4j2 to 2.25.4

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -237,10 +237,10 @@ License Version 2.0:
 - jetty-util-12.0.25
 - jose4j-0.9.6
 - jspecify-1.0.0
-- log4j-api-2.25.3
-- log4j-core-2.25.3
-- log4j-slf4j-impl-2.25.3
-- log4j-1.2-api-2.25.3
+- log4j-api-2.25.4
+- log4j-core-2.25.4
+- log4j-slf4j-impl-2.25.4
+- log4j-1.2-api-2.25.4
 - lz4-java-1.10.2
 - maven-artifact-3.9.11
 - metrics-core-2.2.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -111,7 +111,7 @@ versions += [
   kafka_40: "4.0.1",
   kafka_41: "4.1.2",
   kafka_42: "4.2.0",
-  log4j2: "2.25.3",
+  log4j2: "2.25.4",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.internal.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/internal/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24


### PR DESCRIPTION
Upgrade log4j2 from 2.25.3 to 2.25.4 This change updates  all four
artifacts (log4j-api, log4j-core, log4j-1.2-api, log4j-slf4j-impl)

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
