### PR TITLE
KAFKA-13499: Avoid restoring outdated records

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -356,7 +356,7 @@ public class ProcessorStateManager implements StateManager {
             stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
         } catch (final RuntimeException e) {
             throw new ProcessorStateException(format("%sError updating state directory offsets when creating the state manager",
-                    logPrefix), e);
+                logPrefix), e);
         }
     }
 
@@ -376,7 +376,7 @@ public class ProcessorStateManager implements StateManager {
         if (LegacyCheckpointingStateStore.CHECKPOINT_FILE_NAME.startsWith(storeName)) {
             store.close();
             throw new IllegalArgumentException(format("%sIllegal store name: %s, which collides with the pre-defined " +
-                    "checkpoint file name", logPrefix, storeName));
+                "checkpoint file name", logPrefix, storeName));
         }
 
         if (stores.containsKey(storeName)) {
@@ -390,13 +390,13 @@ public class ProcessorStateManager implements StateManager {
         }
 
         final StateStoreMetadata storeMetadata = isLoggingEnabled(storeName) ?
-                new StateStoreMetadata(
-                        store,
-                        getStorePartition(storeName),
-                        stateRestoreCallback,
-                        commitCallback,
-                        converterForStore(store)) :
-                new StateStoreMetadata(store, commitCallback);
+            new StateStoreMetadata(
+                store,
+                getStorePartition(storeName),
+                stateRestoreCallback,
+                commitCallback,
+                converterForStore(store)) :
+            new StateStoreMetadata(store, commitCallback);
 
         // register the store first, so that if later an exception is thrown then eventually while we call `close`
         // on the state manager this state store would be closed as well
@@ -429,7 +429,7 @@ public class ProcessorStateManager implements StateManager {
 
         if (!partitionsToMarkAsCorrupted.isEmpty()) {
             throw new IllegalStateException("Some partitions " + partitionsToMarkAsCorrupted + " are not contained in " +
-                    "the store list of task " + taskId + " marking as corrupted, this is not expected");
+                "the store list of task " + taskId + " marking as corrupted, this is not expected");
         }
     }
 
@@ -442,8 +442,8 @@ public class ProcessorStateManager implements StateManager {
                 // for changelog whose offset is unknown, use 0L indicating earliest offset
                 // otherwise return the current offset + 1 as the next offset to fetch
                 changelogOffsets.put(
-                        storeMetadata.changelogPartition,
-                        storeMetadata.offset == null ? 0L : storeMetadata.offset + 1L);
+                    storeMetadata.changelogPartition,
+                    storeMetadata.offset == null ? 0L : storeMetadata.offset + 1L);
             }
         }
         return changelogOffsets;
@@ -485,7 +485,7 @@ public class ProcessorStateManager implements StateManager {
     void restore(final StateStoreMetadata storeMetadata, final List<ConsumerRecord<byte[], byte[]>> restoreRecords, final OptionalLong optionalLag) {
         if (!stores.containsValue(storeMetadata)) {
             throw new IllegalStateException("Restoring " + storeMetadata + " which is not registered in this state manager, " +
-                    "this should not happen.");
+                "this should not happen.");
         }
 
         if (!restoreRecords.isEmpty()) {
@@ -493,15 +493,15 @@ public class ProcessorStateManager implements StateManager {
             final Long batchEndOffset = restoreRecords.get(restoreRecords.size() - 1).offset();
             final RecordBatchingStateRestoreCallback restoreCallback = adapt(storeMetadata.restoreCallback);
             final List<ConsumerRecord<byte[], byte[]>> convertedRecords = restoreRecords.stream()
-                    .map(storeMetadata.recordConverter::convert)
-                    .collect(Collectors.toList());
+                .map(storeMetadata.recordConverter::convert)
+                .collect(Collectors.toList());
 
             try {
                 restoreCallback.restoreBatch(convertedRecords);
             } catch (final RuntimeException e) {
                 throw new ProcessorStateException(
-                        format("%sException caught while trying to restore state from %s", logPrefix, storeMetadata.changelogPartition),
-                        e
+                    format("%sException caught while trying to restore state from %s", logPrefix, storeMetadata.changelogPartition),
+                    e
                 );
             }
 
@@ -596,14 +596,14 @@ public class ProcessorStateManager implements StateManager {
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException) {
                             firstException = new ProcessorStateException(
-                                    format("%sFailed to flush cache of store %s", logPrefix, store.name()),
-                                    exception.getCause());
+                                format("%sFailed to flush cache of store %s", logPrefix, store.name()),
+                                exception.getCause());
                         } else if (exception instanceof StreamsException) {
                             firstException = exception;
                         } else {
                             firstException = new ProcessorStateException(
-                                    format("%sFailed to flush cache of store %s", logPrefix, store.name()),
-                                    exception
+                                format("%sFailed to flush cache of store %s", logPrefix, store.name()),
+                                exception
                             );
                         }
                         log.error("Failed to flush cache of store {}: ", store.name(), firstException);
@@ -646,13 +646,13 @@ public class ProcessorStateManager implements StateManager {
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
                             firstException = new ProcessorStateException(
-                                    format("%sFailed to close state store %s", logPrefix, store.name()),
-                                    exception.getCause());
+                                format("%sFailed to close state store %s", logPrefix, store.name()),
+                                exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else
                             firstException = new ProcessorStateException(
-                                    format("%sFailed to close state store %s", logPrefix, store.name()), exception);
+                                format("%sFailed to close state store %s", logPrefix, store.name()), exception);
                         log.error("Failed to close state store {}: ", store.name(), firstException);
                     } else {
                         log.error("Failed to close state store {}: ", store.name(), exception);
@@ -738,12 +738,12 @@ public class ProcessorStateManager implements StateManager {
 
     private StateStoreMetadata findStore(final TopicPartition changelogPartition) {
         final List<StateStoreMetadata> found = stores.values().stream()
-                .filter(metadata -> changelogPartition.equals(metadata.changelogPartition))
-                .collect(Collectors.toList());
+            .filter(metadata -> changelogPartition.equals(metadata.changelogPartition))
+            .collect(Collectors.toList());
 
         if (found.size() > 1) {
             throw new IllegalStateException("Multiple state stores are found for changelog partition " + changelogPartition +
-                    ", this should never happen: " + found);
+                ", this should never happen: " + found);
         }
 
         return found.isEmpty() ? null : found.get(0);
@@ -753,14 +753,14 @@ public class ProcessorStateManager implements StateManager {
         final StateStoreMetadata storeMetadata = stores.get(storeName);
         if (storeMetadata == null) {
             throw new IllegalStateException("State store " + storeName
-                    + " for which the registered changelog partition should be"
-                    + " retrieved has not been registered"
+                + " for which the registered changelog partition should be"
+                + " retrieved has not been registered"
             );
         }
         if (storeMetadata.changelogPartition == null) {
             throw new IllegalStateException("Registered state store " + storeName
-                    + " does not have a registered changelog partition."
-                    + " This may happen if logging is disabled for the state store."
+                + " does not have a registered changelog partition."
+                + " This may happen if logging is disabled for the state store."
             );
         }
         return storeMetadata.changelogPartition;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -36,6 +36,8 @@ import org.apache.kafka.streams.state.internals.CachedStateStore;
 import org.apache.kafka.streams.state.internals.LegacyCheckpointingStateStore;
 import org.apache.kafka.streams.state.internals.RecordConverter;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+import org.apache.kafka.streams.state.internals.WithRetentionPeriod;
+import org.apache.kafka.streams.state.internals.WrappedStateStore;
 
 import org.slf4j.Logger;
 
@@ -102,6 +104,8 @@ public class ProcessorStateManager implements StateManager {
         // corrupted state store should not be included in checkpointing
         private boolean corrupted;
 
+        private final long retentionPeriod;
+
 
         private StateStoreMetadata(final StateStore stateStore,
                                    final CommitCallback commitCallback) {
@@ -112,6 +116,7 @@ public class ProcessorStateManager implements StateManager {
             this.changelogPartition = null;
             this.corrupted = false;
             this.offset = null;
+            this.retentionPeriod = -1L;
         }
 
         private StateStoreMetadata(final StateStore stateStore,
@@ -129,10 +134,22 @@ public class ProcessorStateManager implements StateManager {
             this.commitCallback = commitCallback;
             this.recordConverter = recordConverter;
             this.offset = null;
+            this.retentionPeriod = extractRetentionPeriod(stateStore);
         }
 
         private void setOffset(final Long offset) {
             this.offset = offset;
+        }
+
+        private static long extractRetentionPeriod(final StateStore stateStore) {
+            StateStore current = stateStore;
+            while (current instanceof WrappedStateStore) {
+                current = ((WrappedStateStore<?, ?, ?>) current).wrapped();
+            }
+            if (current instanceof WithRetentionPeriod) {
+                return ((WithRetentionPeriod) current).retentionPeriod();
+            }
+            return -1L;
         }
 
         // the offset is exposed to the changelog reader to determine if restoration is completed
@@ -142,6 +159,11 @@ public class ProcessorStateManager implements StateManager {
 
         Long endOffset() {
             return this.endOffset;
+        }
+
+        // the retentionPeriod is exposed to the changelog reader for window restoration
+        long retentionPeriod() {
+            return retentionPeriod;
         }
 
         public void setEndOffset(final Long endOffset) {
@@ -334,7 +356,7 @@ public class ProcessorStateManager implements StateManager {
             stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
         } catch (final RuntimeException e) {
             throw new ProcessorStateException(format("%sError updating state directory offsets when creating the state manager",
-                logPrefix), e);
+                    logPrefix), e);
         }
     }
 
@@ -354,7 +376,7 @@ public class ProcessorStateManager implements StateManager {
         if (LegacyCheckpointingStateStore.CHECKPOINT_FILE_NAME.startsWith(storeName)) {
             store.close();
             throw new IllegalArgumentException(format("%sIllegal store name: %s, which collides with the pre-defined " +
-                "checkpoint file name", logPrefix, storeName));
+                    "checkpoint file name", logPrefix, storeName));
         }
 
         if (stores.containsKey(storeName)) {
@@ -368,13 +390,13 @@ public class ProcessorStateManager implements StateManager {
         }
 
         final StateStoreMetadata storeMetadata = isLoggingEnabled(storeName) ?
-            new StateStoreMetadata(
-                store,
-                getStorePartition(storeName),
-                stateRestoreCallback,
-                commitCallback,
-                converterForStore(store)) :
-            new StateStoreMetadata(store, commitCallback);
+                new StateStoreMetadata(
+                        store,
+                        getStorePartition(storeName),
+                        stateRestoreCallback,
+                        commitCallback,
+                        converterForStore(store)) :
+                new StateStoreMetadata(store, commitCallback);
 
         // register the store first, so that if later an exception is thrown then eventually while we call `close`
         // on the state manager this state store would be closed as well
@@ -407,7 +429,7 @@ public class ProcessorStateManager implements StateManager {
 
         if (!partitionsToMarkAsCorrupted.isEmpty()) {
             throw new IllegalStateException("Some partitions " + partitionsToMarkAsCorrupted + " are not contained in " +
-                "the store list of task " + taskId + " marking as corrupted, this is not expected");
+                    "the store list of task " + taskId + " marking as corrupted, this is not expected");
         }
     }
 
@@ -420,8 +442,8 @@ public class ProcessorStateManager implements StateManager {
                 // for changelog whose offset is unknown, use 0L indicating earliest offset
                 // otherwise return the current offset + 1 as the next offset to fetch
                 changelogOffsets.put(
-                    storeMetadata.changelogPartition,
-                    storeMetadata.offset == null ? 0L : storeMetadata.offset + 1L);
+                        storeMetadata.changelogPartition,
+                        storeMetadata.offset == null ? 0L : storeMetadata.offset + 1L);
             }
         }
         return changelogOffsets;
@@ -463,7 +485,7 @@ public class ProcessorStateManager implements StateManager {
     void restore(final StateStoreMetadata storeMetadata, final List<ConsumerRecord<byte[], byte[]>> restoreRecords, final OptionalLong optionalLag) {
         if (!stores.containsValue(storeMetadata)) {
             throw new IllegalStateException("Restoring " + storeMetadata + " which is not registered in this state manager, " +
-                "this should not happen.");
+                    "this should not happen.");
         }
 
         if (!restoreRecords.isEmpty()) {
@@ -471,15 +493,15 @@ public class ProcessorStateManager implements StateManager {
             final Long batchEndOffset = restoreRecords.get(restoreRecords.size() - 1).offset();
             final RecordBatchingStateRestoreCallback restoreCallback = adapt(storeMetadata.restoreCallback);
             final List<ConsumerRecord<byte[], byte[]>> convertedRecords = restoreRecords.stream()
-                .map(storeMetadata.recordConverter::convert)
-                .collect(Collectors.toList());
+                    .map(storeMetadata.recordConverter::convert)
+                    .collect(Collectors.toList());
 
             try {
                 restoreCallback.restoreBatch(convertedRecords);
             } catch (final RuntimeException e) {
                 throw new ProcessorStateException(
-                    format("%sException caught while trying to restore state from %s", logPrefix, storeMetadata.changelogPartition),
-                    e
+                        format("%sException caught while trying to restore state from %s", logPrefix, storeMetadata.changelogPartition),
+                        e
                 );
             }
 
@@ -574,14 +596,14 @@ public class ProcessorStateManager implements StateManager {
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException) {
                             firstException = new ProcessorStateException(
-                                format("%sFailed to flush cache of store %s", logPrefix, store.name()),
-                                exception.getCause());
+                                    format("%sFailed to flush cache of store %s", logPrefix, store.name()),
+                                    exception.getCause());
                         } else if (exception instanceof StreamsException) {
                             firstException = exception;
                         } else {
                             firstException = new ProcessorStateException(
-                                format("%sFailed to flush cache of store %s", logPrefix, store.name()),
-                                exception
+                                    format("%sFailed to flush cache of store %s", logPrefix, store.name()),
+                                    exception
                             );
                         }
                         log.error("Failed to flush cache of store {}: ", store.name(), firstException);
@@ -624,13 +646,13 @@ public class ProcessorStateManager implements StateManager {
                         // In case of FailedProcessingException Do not keep the failed processing exception in the stack trace
                         if (exception instanceof FailedProcessingException)
                             firstException = new ProcessorStateException(
-                                format("%sFailed to close state store %s", logPrefix, store.name()),
-                                exception.getCause());
+                                    format("%sFailed to close state store %s", logPrefix, store.name()),
+                                    exception.getCause());
                         else if (exception instanceof StreamsException)
                             firstException = exception;
                         else
                             firstException = new ProcessorStateException(
-                                format("%sFailed to close state store %s", logPrefix, store.name()), exception);
+                                    format("%sFailed to close state store %s", logPrefix, store.name()), exception);
                         log.error("Failed to close state store {}: ", store.name(), firstException);
                     } else {
                         log.error("Failed to close state store {}: ", store.name(), exception);
@@ -716,12 +738,12 @@ public class ProcessorStateManager implements StateManager {
 
     private StateStoreMetadata findStore(final TopicPartition changelogPartition) {
         final List<StateStoreMetadata> found = stores.values().stream()
-            .filter(metadata -> changelogPartition.equals(metadata.changelogPartition))
-            .collect(Collectors.toList());
+                .filter(metadata -> changelogPartition.equals(metadata.changelogPartition))
+                .collect(Collectors.toList());
 
         if (found.size() > 1) {
             throw new IllegalStateException("Multiple state stores are found for changelog partition " + changelogPartition +
-                ", this should never happen: " + found);
+                    ", this should never happen: " + found);
         }
 
         return found.isEmpty() ? null : found.get(0);
@@ -731,14 +753,14 @@ public class ProcessorStateManager implements StateManager {
         final StateStoreMetadata storeMetadata = stores.get(storeName);
         if (storeMetadata == null) {
             throw new IllegalStateException("State store " + storeName
-                + " for which the registered changelog partition should be"
-                + " retrieved has not been registered"
+                    + " for which the registered changelog partition should be"
+                    + " retrieved has not been registered"
             );
         }
         if (storeMetadata.changelogPartition == null) {
             throw new IllegalStateException("Registered state store " + storeName
-                + " does not have a registered changelog partition."
-                + " This may happen if logging is disabled for the state store."
+                    + " does not have a registered changelog partition."
+                    + " This may happen if logging is disabled for the state store."
             );
         }
         return storeMetadata.changelogPartition;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -167,7 +168,7 @@ public class StoreChangelogReader implements ChangelogReader {
         public String toString() {
             final Long currentOffset = storeMetadata.offset();
             return changelogState + " " + stateManager.taskType() +
-                " (currentOffset " + currentOffset + ", endOffset " + restoreEndOffset + ")";
+                    " (currentOffset " + currentOffset + ", endOffset " + restoreEndOffset + ")";
         }
 
         // for testing only below
@@ -243,7 +244,7 @@ public class StoreChangelogReader implements ChangelogReader {
         this.groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
         this.pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
         this.updateOffsetIntervalMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) == Long.MAX_VALUE ?
-            DEFAULT_OFFSET_UPDATE_MS : config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
+                DEFAULT_OFFSET_UPDATE_MS : config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
         this.lastUpdateOffsetTime = 0L;
 
         this.changelogs = new HashMap<>();
@@ -259,7 +260,7 @@ public class StoreChangelogReader implements ChangelogReader {
             // end offset is not initialized meaning that it is from a standby task,
             // this should never happen since we only call this function for active task in restoring phase
             throw new IllegalStateException("End offset for changelog " + metadata + " is unknown when deciding " +
-                "if it has completed restoration, this should never happen.");
+                    "if it has completed restoration, this should never happen.");
         } else if (endOffset == 0) {
             // this is a special case, meaning there's nothing to be restored since the changelog has no data
             // OR the changelog is a source topic and there's no committed offset
@@ -287,7 +288,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 // this also includes InvalidOffsetException, which should not happen under normal
                 // execution, hence it is also okay to wrap it as fatal StreamsException
                 throw new StreamsException("Restore consumer get unexpected error trying to get the position " +
-                    " of " + partition, e);
+                        " of " + partition, e);
             }
         } else {
             return metadata.bufferedRecords.get(0).offset() >= endOffset;
@@ -324,8 +325,8 @@ public class StoreChangelogReader implements ChangelogReader {
     public void transitToUpdateStandby() {
         if (state != ChangelogReaderState.ACTIVE_RESTORING) {
             throw new IllegalStateException(
-                "The changelog reader is not restoring active tasks (is " + state + ") while trying to " +
-                    "transit to update standby tasks: " + changelogs
+                    "The changelog reader is not restoring active tasks (is " + state + ") while trying to " +
+                            "transit to update standby tasks: " + changelogs
             );
         }
 
@@ -351,7 +352,7 @@ public class StoreChangelogReader implements ChangelogReader {
         final StateStoreMetadata storeMetadata = stateManager.storeMetadata(partition);
         if (storeMetadata == null) {
             throw new IllegalStateException("Cannot find the corresponding state store metadata for changelog " +
-                partition);
+                    partition);
         }
 
         final ChangelogMetadata changelogMetadata = new ChangelogMetadata(storeMetadata, stateManager);
@@ -363,7 +364,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
         if (changelogs.putIfAbsent(partition, changelogMetadata) != null) {
             throw new IllegalStateException("There is already a changelog registered for " + partition +
-                ", this should not happen: " + changelogs);
+                    ", this should not happen: " + changelogs);
         }
     }
 
@@ -378,11 +379,11 @@ public class StoreChangelogReader implements ChangelogReader {
         final ChangelogMetadata changelogMetadata = changelogs.get(partition);
         if (changelogMetadata == null) {
             throw new IllegalStateException("The corresponding changelog restorer for " + partition +
-                " does not exist, this should not happen.");
+                    " does not exist, this should not happen.");
         }
         if (changelogMetadata.changelogState != ChangelogState.RESTORING) {
             throw new IllegalStateException("The corresponding changelog restorer for " + partition +
-                " has already transited to completed state, this should not happen.");
+                    " has already transited to completed state, this should not happen.");
         }
 
         return changelogMetadata;
@@ -390,45 +391,45 @@ public class StoreChangelogReader implements ChangelogReader {
 
     private Set<ChangelogMetadata> registeredChangelogs() {
         return changelogs.values().stream()
-            .filter(metadata -> metadata.changelogState == ChangelogState.REGISTERED)
-            .collect(Collectors.toSet());
+                .filter(metadata -> metadata.changelogState == ChangelogState.REGISTERED)
+                .collect(Collectors.toSet());
     }
 
     private Set<TopicPartition> restoringChangelogs() {
         return changelogs.values().stream()
-            .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING)
-            .map(metadata -> metadata.storeMetadata.changelogPartition())
-            .collect(Collectors.toSet());
+                .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING)
+                .map(metadata -> metadata.storeMetadata.changelogPartition())
+                .collect(Collectors.toSet());
     }
 
     private Set<TopicPartition> activeRestoringChangelogs() {
         return changelogs.values().stream()
-            .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
-                metadata.stateManager.taskType() == Task.TaskType.ACTIVE)
-            .map(metadata -> metadata.storeMetadata.changelogPartition())
-            .collect(Collectors.toSet());
+                .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
+                        metadata.stateManager.taskType() == Task.TaskType.ACTIVE)
+                .map(metadata -> metadata.storeMetadata.changelogPartition())
+                .collect(Collectors.toSet());
     }
 
     private Set<TopicPartition> standbyRestoringChangelogs() {
         return changelogs.values().stream()
-            .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
-                metadata.stateManager.taskType() == Task.TaskType.STANDBY)
-            .map(metadata -> metadata.storeMetadata.changelogPartition())
-            .collect(Collectors.toSet());
+                .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
+                        metadata.stateManager.taskType() == Task.TaskType.STANDBY)
+                .map(metadata -> metadata.storeMetadata.changelogPartition())
+                .collect(Collectors.toSet());
     }
 
     @Override
     public boolean allChangelogsCompleted() {
         return changelogs.values().stream()
-            .allMatch(metadata -> metadata.changelogState == ChangelogState.COMPLETED);
+                .allMatch(metadata -> metadata.changelogState == ChangelogState.COMPLETED);
     }
 
     @Override
     public Set<TopicPartition> completedChangelogs() {
         return changelogs.values().stream()
-            .filter(metadata -> metadata.changelogState == ChangelogState.COMPLETED)
-            .map(metadata -> metadata.storeMetadata.changelogPartition())
-            .collect(Collectors.toSet());
+                .filter(metadata -> metadata.changelogState == ChangelogState.COMPLETED)
+                .map(metadata -> metadata.storeMetadata.changelogPartition())
+                .collect(Collectors.toSet());
     }
 
     // 1. if there are any registered changelogs that needs initialization, try to initialize them first;
@@ -470,8 +471,8 @@ public class StoreChangelogReader implements ChangelogReader {
                     totalRestored += restoreChangelog(task, changelogMetadata);
                 } catch (final TimeoutException timeoutException) {
                     tasks.get(taskId).maybeInitTaskTimeoutOrThrow(
-                        time.milliseconds(),
-                        timeoutException
+                            time.milliseconds(),
+                            timeoutException
                     );
                 }
             }
@@ -497,10 +498,10 @@ public class StoreChangelogReader implements ChangelogReader {
             // TODO (?) If we cannot fetch records for standby task, should we trigger `task.timeout.ms` ?
         } catch (final InvalidOffsetException e) {
             log.warn("Encountered " + e.getClass().getName() +
-                " fetching records from restore consumer for partitions " + e.partitions() + ", it is likely that " +
-                "the consumer's position has fallen out of the topic partition offset range because the topic was " +
-                "truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing " +
-                "it later.", e);
+                    " fetching records from restore consumer for partitions " + e.partitions() + ", it is likely that " +
+                    "the consumer's position has fallen out of the topic partition offset range because the topic was " +
+                    "truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing " +
+                    "it later.", e);
 
             final Set<TaskId> corruptedTasks = new HashSet<>();
             e.partitions().forEach(partition -> corruptedTasks.add(changelogs.get(partition).stateManager.taskId()));
@@ -528,9 +529,9 @@ public class StoreChangelogReader implements ChangelogReader {
                                         final Set<TopicPartition> restoringChangelogs,
                                         final TaskType taskType) {
         final Collection<TopicPartition> toResume =
-            restoringChangelogs.stream().filter(t -> shouldResume(tasks, t, taskType)).collect(Collectors.toList());
+                restoringChangelogs.stream().filter(t -> shouldResume(tasks, t, taskType)).collect(Collectors.toList());
         final Collection<TopicPartition> toPause =
-            restoringChangelogs.stream().filter(t -> shouldPause(tasks, t, taskType)).collect(Collectors.toList());
+                restoringChangelogs.stream().filter(t -> shouldPause(tasks, t, taskType)).collect(Collectors.toList());
         restoreConsumer.resume(toResume);
         restoreConsumer.pause(toPause);
     }
@@ -561,20 +562,20 @@ public class StoreChangelogReader implements ChangelogReader {
                 final Set<TopicPartition> topicPartitions = activeRestoringChangelogs();
                 if (!topicPartitions.isEmpty()) {
                     final StringBuilder builder = new StringBuilder().append("Restoration in progress for ")
-                                                                     .append(topicPartitions.size())
-                                                                     .append(" partitions.");
+                            .append(topicPartitions.size())
+                            .append(" partitions.");
                     for (final TopicPartition partition : topicPartitions) {
                         final ChangelogMetadata changelogMetadata = restoringChangelogByPartition(partition);
                         builder.append(" {")
-                               .append(partition)
-                               .append(": ")
-                               .append("position=")
-                               .append(getPositionString(partition, changelogMetadata))
-                               .append(", end=")
-                               .append(changelogMetadata.restoreEndOffset)
-                               .append(", totalRestored=")
-                               .append(changelogMetadata.totalRestored)
-                               .append("}");
+                                .append(partition)
+                                .append(": ")
+                                .append("position=")
+                                .append(getPositionString(partition, changelogMetadata))
+                                .append(", end=")
+                                .append(changelogMetadata.restoreEndOffset)
+                                .append(", totalRestored=")
+                                .append(changelogMetadata.totalRestored)
+                                .append("}");
                     }
                     log.info(builder.toString());
                     lastRestoreLogTime = time.milliseconds();
@@ -595,18 +596,18 @@ public class StoreChangelogReader implements ChangelogReader {
     private void maybeUpdateLimitOffsetsForStandbyChangelogs(final Map<TaskId, Task> tasks) {
         // we only consider updating the limit offset for standbys if we are not restoring active tasks
         if (state == ChangelogReaderState.STANDBY_UPDATING &&
-            updateOffsetIntervalMs < time.milliseconds() - lastUpdateOffsetTime) {
+                updateOffsetIntervalMs < time.milliseconds() - lastUpdateOffsetTime) {
 
             // when the interval has elapsed we should try to update the limit offset for standbys reading from
-            // a source changelog with the new committed offset, unless there are no buffered records since 
+            // a source changelog with the new committed offset, unless there are no buffered records since
             // we only need the limit when processing new records
             // for other changelog partitions we do not need to update limit offset at all since we never need to
             // check when it completes based on limit offset anyways: the end offset would keep increasing and the
             // standby never need to stop
             final Set<TopicPartition> changelogsWithLimitOffsets = changelogs.entrySet().stream()
-                .filter(entry -> entry.getValue().stateManager.taskType() == Task.TaskType.STANDBY &&
-                    entry.getValue().stateManager.changelogAsSource(entry.getKey()))
-                .map(Map.Entry::getKey).collect(Collectors.toSet());
+                    .filter(entry -> entry.getValue().stateManager.taskType() == Task.TaskType.STANDBY &&
+                            entry.getValue().stateManager.changelogAsSource(entry.getKey()))
+                    .map(Map.Entry::getKey).collect(Collectors.toSet());
 
             for (final TopicPartition partition : changelogsWithLimitOffsets) {
                 if (!changelogs.get(partition).bufferedRecords().isEmpty()) {
@@ -624,7 +625,7 @@ public class StoreChangelogReader implements ChangelogReader {
             // filter polled records for null-keys and also possibly update buffer limit index
             if (record.key() == null) {
                 log.warn("Read changelog record with null key from changelog {} at offset {}, " +
-                    "skipping it for restoration", changelogMetadata.storeMetadata.changelogPartition(), record.offset());
+                        "skipping it for restoration", changelogMetadata.storeMetadata.changelogPartition(), record.offset());
             } else {
                 changelogMetadata.bufferedRecords.add(record);
                 final long offset = record.offset();
@@ -666,7 +667,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
             final Long currentOffset = storeMetadata.offset();
             log.trace("Restored {} records from changelog {} to store {}, end offset is {}, current offset is {}",
-                numRecords, partition, storeName, recordEndOffset(changelogMetadata.restoreEndOffset), currentOffset);
+                    numRecords, partition, storeName, recordEndOffset(changelogMetadata.restoreEndOffset), currentOffset);
 
             changelogMetadata.bufferedLimitIndex = 0;
             changelogMetadata.totalRestored += numRecords;
@@ -690,7 +691,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // we should check even if there's nothing restored, but do not check completed if we are processing standby tasks
         if (changelogMetadata.stateManager.taskType() == Task.TaskType.ACTIVE && hasRestoredToEnd(changelogMetadata)) {
             log.info("Finished restoring changelog {} to store {} with a total number of {} records",
-                partition, storeName, changelogMetadata.totalRestored);
+                    partition, storeName, changelogMetadata.totalRestored);
 
             changelogMetadata.transitTo(ChangelogState.COMPLETED);
             pauseChangelogsFromRestoreConsumer(Collections.singleton(partition));
@@ -743,23 +744,23 @@ public class StoreChangelogReader implements ChangelogReader {
         try {
             // those which do not have a committed offset would default to 0
             final ListConsumerGroupOffsetsOptions options = new ListConsumerGroupOffsetsOptions()
-                .requireStable(true);
+                    .requireStable(true);
             final ListConsumerGroupOffsetsSpec spec = new ListConsumerGroupOffsetsSpec()
-                .topicPartitions(new ArrayList<>(partitions));
+                    .topicPartitions(new ArrayList<>(partitions));
             final Map<TopicPartition, Long> committedOffsets =
-                adminClient.listConsumerGroupOffsets(
-                        Collections.singletonMap(groupId, spec),
-                        options
-                    )
-                    .partitionsToOffsetAndMetadata(groupId).get().entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() == null ? 0L : e.getValue().offset()));
+                    adminClient.listConsumerGroupOffsets(
+                                    Collections.singletonMap(groupId, spec),
+                                    options
+                            )
+                            .partitionsToOffsetAndMetadata(groupId).get().entrySet()
+                            .stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() == null ? 0L : e.getValue().offset()));
 
             clearTaskTimeout(getTasksFromPartitions(tasks, partitions));
             return committedOffsets;
         } catch (final TimeoutException | InterruptedException | ExecutionException retriableException) {
             log.debug("Could not retrieve the committed offsets for partitions {} due to {}, will retry in the next run loop",
-                partitions, retriableException.toString());
+                    partitions, retriableException.toString());
             maybeInitTaskTimeoutOrThrow(getTasksFromPartitions(tasks, partitions), retriableException);
             return Collections.emptyMap();
         } catch (final KafkaException e) {
@@ -769,7 +770,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
     private void filterNewPartitionsToRestore(final Map<TaskId, Task> tasks, final Set<ChangelogMetadata> newPartitionsToRestore) {
         newPartitionsToRestore.removeIf(changelogMetadata ->
-            !tasks.containsKey(changelogs.get(changelogMetadata.storeMetadata.changelogPartition()).stateManager.taskId()));
+                !tasks.containsKey(changelogs.get(changelogMetadata.storeMetadata.changelogPartition()).stateManager.taskId()));
     }
 
     private Map<TopicPartition, Long> endOffsetForChangelogs(final Map<TaskId, Task> tasks, final Set<TopicPartition> partitions) {
@@ -782,16 +783,16 @@ public class StoreChangelogReader implements ChangelogReader {
             // see KAFKA-10167 for more details
             final ListOffsetsOptions options = new ListOffsetsOptions(IsolationLevel.READ_UNCOMMITTED);
             final Map<TopicPartition, OffsetSpec> offsetSpecs =
-                partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
+                    partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
             final Map<TopicPartition, Long> logEndOffsets = adminClient.listOffsets(offsetSpecs, options)
-                .all().get().entrySet()
-                .stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().offset()));
+                    .all().get().entrySet()
+                    .stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().offset()));
 
             clearTaskTimeout(getTasksFromPartitions(tasks, partitions));
             return logEndOffsets;
         } catch (final TimeoutException | InterruptedException | ExecutionException retriableException) {
             log.debug("Could not fetch all end offsets for {} due to {}, will retry in the next run loop",
-                partitions, retriableException.toString());
+                    partitions, retriableException.toString());
             maybeInitTaskTimeoutOrThrow(getTasksFromPartitions(tasks, partitions), retriableException);
             return Collections.emptyMap();
         } catch (final KafkaException e) {
@@ -803,22 +804,22 @@ public class StoreChangelogReader implements ChangelogReader {
         for (final ChangelogMetadata metadata : changelogs.values()) {
             final TopicPartition partition = metadata.storeMetadata.changelogPartition();
             if (metadata.stateManager.taskType() == Task.TaskType.STANDBY &&
-                metadata.stateManager.changelogAsSource(partition) &&
-                committedOffsets.containsKey(partition)) {
+                    metadata.stateManager.changelogAsSource(partition) &&
+                    committedOffsets.containsKey(partition)) {
 
                 final Long newLimit = committedOffsets.get(partition);
                 final Long previousLimit = metadata.restoreEndOffset;
 
                 if (previousLimit != null && previousLimit > newLimit) {
                     throw new IllegalStateException("Offset limit should monotonically increase, but was reduced for partition " +
-                        partition + ". New limit: " + newLimit + ". Previous limit: " + previousLimit);
+                            partition + ". New limit: " + newLimit + ". Previous limit: " + previousLimit);
                 }
 
                 metadata.restoreEndOffset = newLimit;
 
                 // update the limit index for buffered records
                 while (metadata.bufferedLimitIndex < metadata.bufferedRecords.size() &&
-                    metadata.bufferedRecords.get(metadata.bufferedLimitIndex).offset() < metadata.restoreEndOffset)
+                        metadata.bufferedRecords.get(metadata.bufferedLimitIndex).offset() < metadata.restoreEndOffset)
                     metadata.bufferedLimitIndex++;
             }
         }
@@ -864,13 +865,13 @@ public class StoreChangelogReader implements ChangelogReader {
             final ChangelogMetadata changelogMetadata = changelogs.get(partition);
             final Long endOffset = endOffsets.get(partition);
             final Long committedOffset = newPartitionsToFindCommittedOffset.contains(partition) ?
-                committedOffsets.get(partition) : Long.valueOf(Long.MAX_VALUE);
+                    committedOffsets.get(partition) : Long.valueOf(Long.MAX_VALUE);
 
             if (endOffset != null && committedOffset != null) {
                 if (changelogMetadata.restoreEndOffset != null) {
                     throw new IllegalStateException("End offset for " + partition +
-                        " should only be initialized once. Existing value: " + changelogMetadata.restoreEndOffset +
-                        ", new value: (" + endOffset + ", " + committedOffset + ")");
+                            " should only be initialized once. Existing value: " + changelogMetadata.restoreEndOffset +
+                            ", new value: (" + endOffset + ", " + committedOffset + ")");
                 }
 
                 changelogMetadata.restoreEndOffset = Math.min(endOffset, committedOffset);
@@ -879,7 +880,7 @@ public class StoreChangelogReader implements ChangelogReader {
             } else {
                 if (!newPartitionsToRestore.remove(changelogMetadata)) {
                     throw new IllegalStateException("New changelogs to restore " + newPartitionsToRestore +
-                        " does not contain the one looking for end offset: " + partition + ", this should not happen.");
+                            " does not contain the one looking for end offset: " + partition + ", this should not happen.");
                 }
 
                 log.info("End offset for changelog {} cannot be found; will retry in the next time.", partition);
@@ -893,7 +894,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
         // add new partitions to the restore consumer and transit them to restoring state
         addChangelogsToRestoreConsumer(newPartitionsToRestore.stream().map(metadata -> metadata.storeMetadata.changelogPartition())
-            .collect(Collectors.toSet()));
+                .collect(Collectors.toSet()));
 
         newPartitionsToRestore.forEach(metadata -> metadata.transitTo(ChangelogState.RESTORING));
 
@@ -916,7 +917,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should not contain any of the new partitions
         if (assignment.removeAll(partitions)) {
             throw new IllegalStateException("The current assignment " + restoreConsumer.assignment() + " " +
-                "already contains some of the new partitions " + partitions);
+                    "already contains some of the new partitions " + partitions);
         }
         assignment.addAll(partitions);
         restoreConsumer.assign(assignment);
@@ -930,7 +931,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should contain all the partitions to pause
         if (!assignment.containsAll(partitions)) {
             throw new IllegalStateException("The current assignment " + assignment + " " +
-                "does not contain some of the partitions " + partitions + " for pausing.");
+                    "does not contain some of the partitions " + partitions + " for pausing.");
         }
         restoreConsumer.pause(partitions);
 
@@ -947,7 +948,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should contain all the partitions to remove
         if (!assignment.containsAll(partitions)) {
             throw new IllegalStateException("The current assignment " + assignment + " " +
-                "does not contain some of the partitions " + partitions + " for removing.");
+                    "does not contain some of the partitions " + partitions + " for removing.");
         }
         assignment.removeAll(partitions);
         restoreConsumer.assign(assignment);
@@ -959,7 +960,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should contain all the partitions to resume
         if (!assignment.containsAll(partitions)) {
             throw new IllegalStateException("The current assignment " + assignment + " " +
-                "does not contain some of the partitions " + partitions + " for resuming.");
+                    "does not contain some of the partitions " + partitions + " for resuming.");
         }
         restoreConsumer.resume(partitions);
 
@@ -970,6 +971,7 @@ public class StoreChangelogReader implements ChangelogReader {
                                    final Set<ChangelogMetadata> newPartitionsToRestore) {
         // separate those who do not have the current offset loaded from checkpoint
         final Set<TopicPartition> newPartitionsWithoutStartOffset = new HashSet<>();
+        final Map<TopicPartition, Long> newPartitionsWithTimestampSeek = new HashMap<>();
 
         for (final ChangelogMetadata changelogMetadata : newPartitionsToRestore) {
             final StateStoreMetadata storeMetadata = changelogMetadata.storeMetadata;
@@ -984,20 +986,24 @@ public class StoreChangelogReader implements ChangelogReader {
                 restoreConsumer.seek(partition, currentOffset + 1);
 
                 log.debug("Start restoring changelog partition {} from current offset {} to end offset {}.",
-                    partition, currentOffset, recordEndOffset(endOffset));
+                        partition, currentOffset, recordEndOffset(endOffset));
             } else {
-                log.debug("Start restoring changelog partition {} from the beginning offset to end offset {} " +
-                    "since we cannot find current offset.", partition, recordEndOffset(endOffset));
-
-                newPartitionsWithoutStartOffset.add(partition);
+                final long retentionPeriod = storeMetadata.retentionPeriod();
+                final long seekTimestamp = retentionPeriod > 0 && retentionPeriod != Long.MAX_VALUE
+                        ? time.milliseconds() - retentionPeriod : -1L;
+                if (seekTimestamp > 0) {
+                    newPartitionsWithTimestampSeek.put(partition, seekTimestamp);
+                    log.debug("Start restoring windowed changelog partition {} from timestamp {} to end offset {}.",
+                            partition, seekTimestamp, recordEndOffset(endOffset));
+                } else {
+                    log.debug("Start restoring changelog partition {} from the beginning offset to end offset {} " +
+                            "since we cannot find current offset.", partition, recordEndOffset(endOffset));
+                    newPartitionsWithoutStartOffset.add(partition);
+                }
             }
         }
 
-        // optimization: batch all seek-to-beginning offsets in a single request
-        //               seek is not a blocking call so there's nothing to capture
-        if (!newPartitionsWithoutStartOffset.isEmpty()) {
-            restoreConsumer.seekToBeginning(newPartitionsWithoutStartOffset);
-        }
+        seekToTimestampOrBeginning(newPartitionsWithTimestampSeek, newPartitionsWithoutStartOffset);
 
         for (final ChangelogMetadata changelogMetadata : newPartitionsToRestore) {
             final StateStoreMetadata storeMetadata = changelogMetadata.storeMetadata;
@@ -1036,6 +1042,29 @@ public class StoreChangelogReader implements ChangelogReader {
                     throw new StreamsException("Standby updater listener failed on update start");
                 }
             }
+        }
+    }
+
+    private void seekToTimestampOrBeginning(final Map<TopicPartition, Long> partitionsWithTimestampSeek,
+                                            final Set<TopicPartition> partitionsWithoutStartOffset) {
+        // optimization: seek windowed stores by timestamp to skip expired data
+        if (!partitionsWithTimestampSeek.isEmpty()) {
+            final Map<TopicPartition, OffsetAndTimestamp> offsetsByTimestamp =
+                    restoreConsumer.offsetsForTimes(partitionsWithTimestampSeek);
+            offsetsByTimestamp.forEach((key, value) -> {
+                if (value != null) {
+                    restoreConsumer.seek(key, value.offset());
+                } else {
+                    // no offset found for the timestamp, fall back to seeking to the beginning
+                    partitionsWithoutStartOffset.add(key);
+                }
+            });
+        }
+
+        // optimization: batch all seek-to-beginning offsets in a single request
+        //               seek is not a blocking call so there's nothing to capture
+        if (!partitionsWithoutStartOffset.isEmpty()) {
+            restoreConsumer.seekToBeginning(partitionsWithoutStartOffset);
         }
     }
 
@@ -1086,8 +1115,8 @@ public class StoreChangelogReader implements ChangelogReader {
                 changelogMetadata.clear();
             } else {
                 log.debug("Changelog partition {} could not be found," +
-                    " it could be already cleaned up during the handling" +
-                    " of task corruption and never restore again", partition);
+                        " it could be already cleaned up during the handling" +
+                        " of task corruption and never restore again", partition);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -168,7 +168,7 @@ public class StoreChangelogReader implements ChangelogReader {
         public String toString() {
             final Long currentOffset = storeMetadata.offset();
             return changelogState + " " + stateManager.taskType() +
-                    " (currentOffset " + currentOffset + ", endOffset " + restoreEndOffset + ")";
+                " (currentOffset " + currentOffset + ", endOffset " + restoreEndOffset + ")";
         }
 
         // for testing only below
@@ -244,7 +244,7 @@ public class StoreChangelogReader implements ChangelogReader {
         this.groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
         this.pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
         this.updateOffsetIntervalMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) == Long.MAX_VALUE ?
-                DEFAULT_OFFSET_UPDATE_MS : config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
+            DEFAULT_OFFSET_UPDATE_MS : config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
         this.lastUpdateOffsetTime = 0L;
 
         this.changelogs = new HashMap<>();
@@ -260,7 +260,7 @@ public class StoreChangelogReader implements ChangelogReader {
             // end offset is not initialized meaning that it is from a standby task,
             // this should never happen since we only call this function for active task in restoring phase
             throw new IllegalStateException("End offset for changelog " + metadata + " is unknown when deciding " +
-                    "if it has completed restoration, this should never happen.");
+                "if it has completed restoration, this should never happen.");
         } else if (endOffset == 0) {
             // this is a special case, meaning there's nothing to be restored since the changelog has no data
             // OR the changelog is a source topic and there's no committed offset
@@ -288,7 +288,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 // this also includes InvalidOffsetException, which should not happen under normal
                 // execution, hence it is also okay to wrap it as fatal StreamsException
                 throw new StreamsException("Restore consumer get unexpected error trying to get the position " +
-                        " of " + partition, e);
+                    " of " + partition, e);
             }
         } else {
             return metadata.bufferedRecords.get(0).offset() >= endOffset;
@@ -325,8 +325,8 @@ public class StoreChangelogReader implements ChangelogReader {
     public void transitToUpdateStandby() {
         if (state != ChangelogReaderState.ACTIVE_RESTORING) {
             throw new IllegalStateException(
-                    "The changelog reader is not restoring active tasks (is " + state + ") while trying to " +
-                            "transit to update standby tasks: " + changelogs
+                "The changelog reader is not restoring active tasks (is " + state + ") while trying to " +
+                    "transit to update standby tasks: " + changelogs
             );
         }
 
@@ -352,7 +352,7 @@ public class StoreChangelogReader implements ChangelogReader {
         final StateStoreMetadata storeMetadata = stateManager.storeMetadata(partition);
         if (storeMetadata == null) {
             throw new IllegalStateException("Cannot find the corresponding state store metadata for changelog " +
-                    partition);
+                partition);
         }
 
         final ChangelogMetadata changelogMetadata = new ChangelogMetadata(storeMetadata, stateManager);
@@ -364,7 +364,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
         if (changelogs.putIfAbsent(partition, changelogMetadata) != null) {
             throw new IllegalStateException("There is already a changelog registered for " + partition +
-                    ", this should not happen: " + changelogs);
+                ", this should not happen: " + changelogs);
         }
     }
 
@@ -379,11 +379,11 @@ public class StoreChangelogReader implements ChangelogReader {
         final ChangelogMetadata changelogMetadata = changelogs.get(partition);
         if (changelogMetadata == null) {
             throw new IllegalStateException("The corresponding changelog restorer for " + partition +
-                    " does not exist, this should not happen.");
+                " does not exist, this should not happen.");
         }
         if (changelogMetadata.changelogState != ChangelogState.RESTORING) {
             throw new IllegalStateException("The corresponding changelog restorer for " + partition +
-                    " has already transited to completed state, this should not happen.");
+                " has already transited to completed state, this should not happen.");
         }
 
         return changelogMetadata;
@@ -391,45 +391,45 @@ public class StoreChangelogReader implements ChangelogReader {
 
     private Set<ChangelogMetadata> registeredChangelogs() {
         return changelogs.values().stream()
-                .filter(metadata -> metadata.changelogState == ChangelogState.REGISTERED)
-                .collect(Collectors.toSet());
+            .filter(metadata -> metadata.changelogState == ChangelogState.REGISTERED)
+            .collect(Collectors.toSet());
     }
 
     private Set<TopicPartition> restoringChangelogs() {
         return changelogs.values().stream()
-                .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING)
-                .map(metadata -> metadata.storeMetadata.changelogPartition())
-                .collect(Collectors.toSet());
+            .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING)
+            .map(metadata -> metadata.storeMetadata.changelogPartition())
+            .collect(Collectors.toSet());
     }
 
     private Set<TopicPartition> activeRestoringChangelogs() {
         return changelogs.values().stream()
-                .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
-                        metadata.stateManager.taskType() == Task.TaskType.ACTIVE)
-                .map(metadata -> metadata.storeMetadata.changelogPartition())
-                .collect(Collectors.toSet());
+            .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
+                metadata.stateManager.taskType() == Task.TaskType.ACTIVE)
+            .map(metadata -> metadata.storeMetadata.changelogPartition())
+            .collect(Collectors.toSet());
     }
 
     private Set<TopicPartition> standbyRestoringChangelogs() {
         return changelogs.values().stream()
-                .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
-                        metadata.stateManager.taskType() == Task.TaskType.STANDBY)
-                .map(metadata -> metadata.storeMetadata.changelogPartition())
-                .collect(Collectors.toSet());
+            .filter(metadata -> metadata.changelogState == ChangelogState.RESTORING &&
+                metadata.stateManager.taskType() == Task.TaskType.STANDBY)
+            .map(metadata -> metadata.storeMetadata.changelogPartition())
+            .collect(Collectors.toSet());
     }
 
     @Override
     public boolean allChangelogsCompleted() {
         return changelogs.values().stream()
-                .allMatch(metadata -> metadata.changelogState == ChangelogState.COMPLETED);
+            .allMatch(metadata -> metadata.changelogState == ChangelogState.COMPLETED);
     }
 
     @Override
     public Set<TopicPartition> completedChangelogs() {
         return changelogs.values().stream()
-                .filter(metadata -> metadata.changelogState == ChangelogState.COMPLETED)
-                .map(metadata -> metadata.storeMetadata.changelogPartition())
-                .collect(Collectors.toSet());
+            .filter(metadata -> metadata.changelogState == ChangelogState.COMPLETED)
+            .map(metadata -> metadata.storeMetadata.changelogPartition())
+            .collect(Collectors.toSet());
     }
 
     // 1. if there are any registered changelogs that needs initialization, try to initialize them first;
@@ -471,8 +471,8 @@ public class StoreChangelogReader implements ChangelogReader {
                     totalRestored += restoreChangelog(task, changelogMetadata);
                 } catch (final TimeoutException timeoutException) {
                     tasks.get(taskId).maybeInitTaskTimeoutOrThrow(
-                            time.milliseconds(),
-                            timeoutException
+                        time.milliseconds(),
+                        timeoutException
                     );
                 }
             }
@@ -498,10 +498,10 @@ public class StoreChangelogReader implements ChangelogReader {
             // TODO (?) If we cannot fetch records for standby task, should we trigger `task.timeout.ms` ?
         } catch (final InvalidOffsetException e) {
             log.warn("Encountered " + e.getClass().getName() +
-                    " fetching records from restore consumer for partitions " + e.partitions() + ", it is likely that " +
-                    "the consumer's position has fallen out of the topic partition offset range because the topic was " +
-                    "truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing " +
-                    "it later.", e);
+                " fetching records from restore consumer for partitions " + e.partitions() + ", it is likely that " +
+                "the consumer's position has fallen out of the topic partition offset range because the topic was " +
+                "truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing " +
+                "it later.", e);
 
             final Set<TaskId> corruptedTasks = new HashSet<>();
             e.partitions().forEach(partition -> corruptedTasks.add(changelogs.get(partition).stateManager.taskId()));
@@ -529,9 +529,9 @@ public class StoreChangelogReader implements ChangelogReader {
                                         final Set<TopicPartition> restoringChangelogs,
                                         final TaskType taskType) {
         final Collection<TopicPartition> toResume =
-                restoringChangelogs.stream().filter(t -> shouldResume(tasks, t, taskType)).collect(Collectors.toList());
+            restoringChangelogs.stream().filter(t -> shouldResume(tasks, t, taskType)).collect(Collectors.toList());
         final Collection<TopicPartition> toPause =
-                restoringChangelogs.stream().filter(t -> shouldPause(tasks, t, taskType)).collect(Collectors.toList());
+            restoringChangelogs.stream().filter(t -> shouldPause(tasks, t, taskType)).collect(Collectors.toList());
         restoreConsumer.resume(toResume);
         restoreConsumer.pause(toPause);
     }
@@ -562,20 +562,20 @@ public class StoreChangelogReader implements ChangelogReader {
                 final Set<TopicPartition> topicPartitions = activeRestoringChangelogs();
                 if (!topicPartitions.isEmpty()) {
                     final StringBuilder builder = new StringBuilder().append("Restoration in progress for ")
-                            .append(topicPartitions.size())
-                            .append(" partitions.");
+                                                                     .append(topicPartitions.size())
+                                                                     .append(" partitions.");
                     for (final TopicPartition partition : topicPartitions) {
                         final ChangelogMetadata changelogMetadata = restoringChangelogByPartition(partition);
                         builder.append(" {")
-                                .append(partition)
-                                .append(": ")
-                                .append("position=")
-                                .append(getPositionString(partition, changelogMetadata))
-                                .append(", end=")
-                                .append(changelogMetadata.restoreEndOffset)
-                                .append(", totalRestored=")
-                                .append(changelogMetadata.totalRestored)
-                                .append("}");
+                               .append(partition)
+                               .append(": ")
+                               .append("position=")
+                               .append(getPositionString(partition, changelogMetadata))
+                               .append(", end=")
+                               .append(changelogMetadata.restoreEndOffset)
+                               .append(", totalRestored=")
+                               .append(changelogMetadata.totalRestored)
+                               .append("}");
                     }
                     log.info(builder.toString());
                     lastRestoreLogTime = time.milliseconds();
@@ -596,18 +596,18 @@ public class StoreChangelogReader implements ChangelogReader {
     private void maybeUpdateLimitOffsetsForStandbyChangelogs(final Map<TaskId, Task> tasks) {
         // we only consider updating the limit offset for standbys if we are not restoring active tasks
         if (state == ChangelogReaderState.STANDBY_UPDATING &&
-                updateOffsetIntervalMs < time.milliseconds() - lastUpdateOffsetTime) {
+            updateOffsetIntervalMs < time.milliseconds() - lastUpdateOffsetTime) {
 
             // when the interval has elapsed we should try to update the limit offset for standbys reading from
-            // a source changelog with the new committed offset, unless there are no buffered records since
+            // a source changelog with the new committed offset, unless there are no buffered records since 
             // we only need the limit when processing new records
             // for other changelog partitions we do not need to update limit offset at all since we never need to
             // check when it completes based on limit offset anyways: the end offset would keep increasing and the
             // standby never need to stop
             final Set<TopicPartition> changelogsWithLimitOffsets = changelogs.entrySet().stream()
-                    .filter(entry -> entry.getValue().stateManager.taskType() == Task.TaskType.STANDBY &&
-                            entry.getValue().stateManager.changelogAsSource(entry.getKey()))
-                    .map(Map.Entry::getKey).collect(Collectors.toSet());
+                .filter(entry -> entry.getValue().stateManager.taskType() == Task.TaskType.STANDBY &&
+                    entry.getValue().stateManager.changelogAsSource(entry.getKey()))
+                .map(Map.Entry::getKey).collect(Collectors.toSet());
 
             for (final TopicPartition partition : changelogsWithLimitOffsets) {
                 if (!changelogs.get(partition).bufferedRecords().isEmpty()) {
@@ -625,7 +625,7 @@ public class StoreChangelogReader implements ChangelogReader {
             // filter polled records for null-keys and also possibly update buffer limit index
             if (record.key() == null) {
                 log.warn("Read changelog record with null key from changelog {} at offset {}, " +
-                        "skipping it for restoration", changelogMetadata.storeMetadata.changelogPartition(), record.offset());
+                    "skipping it for restoration", changelogMetadata.storeMetadata.changelogPartition(), record.offset());
             } else {
                 changelogMetadata.bufferedRecords.add(record);
                 final long offset = record.offset();
@@ -667,7 +667,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
             final Long currentOffset = storeMetadata.offset();
             log.trace("Restored {} records from changelog {} to store {}, end offset is {}, current offset is {}",
-                    numRecords, partition, storeName, recordEndOffset(changelogMetadata.restoreEndOffset), currentOffset);
+                numRecords, partition, storeName, recordEndOffset(changelogMetadata.restoreEndOffset), currentOffset);
 
             changelogMetadata.bufferedLimitIndex = 0;
             changelogMetadata.totalRestored += numRecords;
@@ -691,7 +691,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // we should check even if there's nothing restored, but do not check completed if we are processing standby tasks
         if (changelogMetadata.stateManager.taskType() == Task.TaskType.ACTIVE && hasRestoredToEnd(changelogMetadata)) {
             log.info("Finished restoring changelog {} to store {} with a total number of {} records",
-                    partition, storeName, changelogMetadata.totalRestored);
+                partition, storeName, changelogMetadata.totalRestored);
 
             changelogMetadata.transitTo(ChangelogState.COMPLETED);
             pauseChangelogsFromRestoreConsumer(Collections.singleton(partition));
@@ -744,23 +744,23 @@ public class StoreChangelogReader implements ChangelogReader {
         try {
             // those which do not have a committed offset would default to 0
             final ListConsumerGroupOffsetsOptions options = new ListConsumerGroupOffsetsOptions()
-                    .requireStable(true);
+                .requireStable(true);
             final ListConsumerGroupOffsetsSpec spec = new ListConsumerGroupOffsetsSpec()
-                    .topicPartitions(new ArrayList<>(partitions));
+                .topicPartitions(new ArrayList<>(partitions));
             final Map<TopicPartition, Long> committedOffsets =
-                    adminClient.listConsumerGroupOffsets(
-                                    Collections.singletonMap(groupId, spec),
-                                    options
-                            )
-                            .partitionsToOffsetAndMetadata(groupId).get().entrySet()
-                            .stream()
-                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() == null ? 0L : e.getValue().offset()));
+                adminClient.listConsumerGroupOffsets(
+                        Collections.singletonMap(groupId, spec),
+                        options
+                    )
+                    .partitionsToOffsetAndMetadata(groupId).get().entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() == null ? 0L : e.getValue().offset()));
 
             clearTaskTimeout(getTasksFromPartitions(tasks, partitions));
             return committedOffsets;
         } catch (final TimeoutException | InterruptedException | ExecutionException retriableException) {
             log.debug("Could not retrieve the committed offsets for partitions {} due to {}, will retry in the next run loop",
-                    partitions, retriableException.toString());
+                partitions, retriableException.toString());
             maybeInitTaskTimeoutOrThrow(getTasksFromPartitions(tasks, partitions), retriableException);
             return Collections.emptyMap();
         } catch (final KafkaException e) {
@@ -770,7 +770,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
     private void filterNewPartitionsToRestore(final Map<TaskId, Task> tasks, final Set<ChangelogMetadata> newPartitionsToRestore) {
         newPartitionsToRestore.removeIf(changelogMetadata ->
-                !tasks.containsKey(changelogs.get(changelogMetadata.storeMetadata.changelogPartition()).stateManager.taskId()));
+            !tasks.containsKey(changelogs.get(changelogMetadata.storeMetadata.changelogPartition()).stateManager.taskId()));
     }
 
     private Map<TopicPartition, Long> endOffsetForChangelogs(final Map<TaskId, Task> tasks, final Set<TopicPartition> partitions) {
@@ -783,16 +783,16 @@ public class StoreChangelogReader implements ChangelogReader {
             // see KAFKA-10167 for more details
             final ListOffsetsOptions options = new ListOffsetsOptions(IsolationLevel.READ_UNCOMMITTED);
             final Map<TopicPartition, OffsetSpec> offsetSpecs =
-                    partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
+                partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()));
             final Map<TopicPartition, Long> logEndOffsets = adminClient.listOffsets(offsetSpecs, options)
-                    .all().get().entrySet()
-                    .stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().offset()));
+                .all().get().entrySet()
+                .stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().offset()));
 
             clearTaskTimeout(getTasksFromPartitions(tasks, partitions));
             return logEndOffsets;
         } catch (final TimeoutException | InterruptedException | ExecutionException retriableException) {
             log.debug("Could not fetch all end offsets for {} due to {}, will retry in the next run loop",
-                    partitions, retriableException.toString());
+                partitions, retriableException.toString());
             maybeInitTaskTimeoutOrThrow(getTasksFromPartitions(tasks, partitions), retriableException);
             return Collections.emptyMap();
         } catch (final KafkaException e) {
@@ -804,22 +804,22 @@ public class StoreChangelogReader implements ChangelogReader {
         for (final ChangelogMetadata metadata : changelogs.values()) {
             final TopicPartition partition = metadata.storeMetadata.changelogPartition();
             if (metadata.stateManager.taskType() == Task.TaskType.STANDBY &&
-                    metadata.stateManager.changelogAsSource(partition) &&
-                    committedOffsets.containsKey(partition)) {
+                metadata.stateManager.changelogAsSource(partition) &&
+                committedOffsets.containsKey(partition)) {
 
                 final Long newLimit = committedOffsets.get(partition);
                 final Long previousLimit = metadata.restoreEndOffset;
 
                 if (previousLimit != null && previousLimit > newLimit) {
                     throw new IllegalStateException("Offset limit should monotonically increase, but was reduced for partition " +
-                            partition + ". New limit: " + newLimit + ". Previous limit: " + previousLimit);
+                        partition + ". New limit: " + newLimit + ". Previous limit: " + previousLimit);
                 }
 
                 metadata.restoreEndOffset = newLimit;
 
                 // update the limit index for buffered records
                 while (metadata.bufferedLimitIndex < metadata.bufferedRecords.size() &&
-                        metadata.bufferedRecords.get(metadata.bufferedLimitIndex).offset() < metadata.restoreEndOffset)
+                    metadata.bufferedRecords.get(metadata.bufferedLimitIndex).offset() < metadata.restoreEndOffset)
                     metadata.bufferedLimitIndex++;
             }
         }
@@ -865,13 +865,13 @@ public class StoreChangelogReader implements ChangelogReader {
             final ChangelogMetadata changelogMetadata = changelogs.get(partition);
             final Long endOffset = endOffsets.get(partition);
             final Long committedOffset = newPartitionsToFindCommittedOffset.contains(partition) ?
-                    committedOffsets.get(partition) : Long.valueOf(Long.MAX_VALUE);
+                committedOffsets.get(partition) : Long.valueOf(Long.MAX_VALUE);
 
             if (endOffset != null && committedOffset != null) {
                 if (changelogMetadata.restoreEndOffset != null) {
                     throw new IllegalStateException("End offset for " + partition +
-                            " should only be initialized once. Existing value: " + changelogMetadata.restoreEndOffset +
-                            ", new value: (" + endOffset + ", " + committedOffset + ")");
+                        " should only be initialized once. Existing value: " + changelogMetadata.restoreEndOffset +
+                        ", new value: (" + endOffset + ", " + committedOffset + ")");
                 }
 
                 changelogMetadata.restoreEndOffset = Math.min(endOffset, committedOffset);
@@ -880,7 +880,7 @@ public class StoreChangelogReader implements ChangelogReader {
             } else {
                 if (!newPartitionsToRestore.remove(changelogMetadata)) {
                     throw new IllegalStateException("New changelogs to restore " + newPartitionsToRestore +
-                            " does not contain the one looking for end offset: " + partition + ", this should not happen.");
+                        " does not contain the one looking for end offset: " + partition + ", this should not happen.");
                 }
 
                 log.info("End offset for changelog {} cannot be found; will retry in the next time.", partition);
@@ -894,7 +894,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
         // add new partitions to the restore consumer and transit them to restoring state
         addChangelogsToRestoreConsumer(newPartitionsToRestore.stream().map(metadata -> metadata.storeMetadata.changelogPartition())
-                .collect(Collectors.toSet()));
+            .collect(Collectors.toSet()));
 
         newPartitionsToRestore.forEach(metadata -> metadata.transitTo(ChangelogState.RESTORING));
 
@@ -917,7 +917,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should not contain any of the new partitions
         if (assignment.removeAll(partitions)) {
             throw new IllegalStateException("The current assignment " + restoreConsumer.assignment() + " " +
-                    "already contains some of the new partitions " + partitions);
+                "already contains some of the new partitions " + partitions);
         }
         assignment.addAll(partitions);
         restoreConsumer.assign(assignment);
@@ -931,7 +931,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should contain all the partitions to pause
         if (!assignment.containsAll(partitions)) {
             throw new IllegalStateException("The current assignment " + assignment + " " +
-                    "does not contain some of the partitions " + partitions + " for pausing.");
+                "does not contain some of the partitions " + partitions + " for pausing.");
         }
         restoreConsumer.pause(partitions);
 
@@ -948,7 +948,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should contain all the partitions to remove
         if (!assignment.containsAll(partitions)) {
             throw new IllegalStateException("The current assignment " + assignment + " " +
-                    "does not contain some of the partitions " + partitions + " for removing.");
+                "does not contain some of the partitions " + partitions + " for removing.");
         }
         assignment.removeAll(partitions);
         restoreConsumer.assign(assignment);
@@ -960,7 +960,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // the current assignment should contain all the partitions to resume
         if (!assignment.containsAll(partitions)) {
             throw new IllegalStateException("The current assignment " + assignment + " " +
-                    "does not contain some of the partitions " + partitions + " for resuming.");
+                "does not contain some of the partitions " + partitions + " for resuming.");
         }
         restoreConsumer.resume(partitions);
 
@@ -986,18 +986,18 @@ public class StoreChangelogReader implements ChangelogReader {
                 restoreConsumer.seek(partition, currentOffset + 1);
 
                 log.debug("Start restoring changelog partition {} from current offset {} to end offset {}.",
-                        partition, currentOffset, recordEndOffset(endOffset));
+                    partition, currentOffset, recordEndOffset(endOffset));
             } else {
                 final long retentionPeriod = storeMetadata.retentionPeriod();
                 final long seekTimestamp = retentionPeriod > 0 && retentionPeriod != Long.MAX_VALUE
-                        ? time.milliseconds() - retentionPeriod : -1L;
+                    ? time.milliseconds() - retentionPeriod : -1L;
                 if (seekTimestamp > 0) {
                     newPartitionsWithTimestampSeek.put(partition, seekTimestamp);
                     log.debug("Start restoring windowed changelog partition {} from timestamp {} to end offset {}.",
-                            partition, seekTimestamp, recordEndOffset(endOffset));
+                        partition, seekTimestamp, recordEndOffset(endOffset));
                 } else {
                     log.debug("Start restoring changelog partition {} from the beginning offset to end offset {} " +
-                            "since we cannot find current offset.", partition, recordEndOffset(endOffset));
+                        "since we cannot find current offset.", partition, recordEndOffset(endOffset));
                     newPartitionsWithoutStartOffset.add(partition);
                 }
             }
@@ -1050,7 +1050,7 @@ public class StoreChangelogReader implements ChangelogReader {
         // optimization: seek windowed stores by timestamp to skip expired data
         if (!partitionsWithTimestampSeek.isEmpty()) {
             final Map<TopicPartition, OffsetAndTimestamp> offsetsByTimestamp =
-                    restoreConsumer.offsetsForTimes(partitionsWithTimestampSeek);
+                restoreConsumer.offsetsForTimes(partitionsWithTimestampSeek);
             offsetsByTimestamp.forEach((key, value) -> {
                 if (value != null) {
                     restoreConsumer.seek(key, value.offset());
@@ -1115,8 +1115,8 @@ public class StoreChangelogReader implements ChangelogReader {
                 changelogMetadata.clear();
             } else {
                 log.debug("Changelog partition {} could not be found," +
-                        " it could be already cleaned up during the handling" +
-                        " of task corruption and never restore again", partition);
+                    " it could be already cleaned up during the handling" +
+                    " of task corruption and never restore again", partition);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -75,6 +75,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
     }
 
     @Override
+    public long retentionPeriod() {
+        return retentionPeriod;
+    }
+
+    @Override
     public KeyValueIterator<Bytes, byte[]> all() {
 
         final long actualFrom = getActualFrom(0, baseKeySchema instanceof PrefixedWindowKeySchemas.TimeFirstWindowKeySchema);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 
-public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Segment> implements SegmentedBytesStore {
+public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Segment> implements SegmentedBytesStore, WithRetentionPeriod {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDualSchemaRocksDBSegmentedBytesStore.class);
 
     private final String name;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -74,6 +74,11 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
     }
 
     @Override
+    public long retentionPeriod() {
+        return retentionPeriod;
+    }
+
+    @Override
     public KeyValueIterator<Bytes, byte[]> fetch(final Bytes key,
                                                  final long from,
                                                  final long to) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 
-public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements SegmentedBytesStore {
+public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements SegmentedBytesStore, WithRetentionPeriod {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractRocksDBSegmentedBytesStore.class);
 
     private final String name;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -112,9 +112,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             this.context = (InternalProcessorContext<?, ?>) stateStoreContext;
             final StreamsMetricsImpl metrics = this.context.metrics();
             expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
-                    threadId,
-                    taskName,
-                    metrics
+                threadId,
+                taskName,
+                metrics
             );
         } else {
             this.context = null;
@@ -123,9 +123,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
         if (root != null) {
             final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
-                    stateStoreContext.appConfigs(),
-                    IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
-                    false
+                stateStoreContext.appConfigs(),
+                IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
+                false
             );
             stateStoreContext.register(
                 root,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -54,7 +54,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
-public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
+public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRetentionPeriod {
 
     private static final Logger LOG = LoggerFactory.getLogger(InMemorySessionStore.class);
 
@@ -67,10 +67,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     private final long retentionPeriod;
 
     private static final String INVALID_RANGE_WARN_MSG =
-        "Returning empty iterator for fetch with invalid key range: from > to. " +
-        "This may be due to range arguments set in the wrong order, " +
-        "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
-        "Note that the built-in numerical serdes do not follow this for negative numbers";
+            "Returning empty iterator for fetch with invalid key range: from > to. " +
+                    "This may be due to range arguments set in the wrong order, " +
+                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
+                    "Note that the built-in numerical serdes do not follow this for negative numbers";
 
     private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeMap = new ConcurrentSkipListMap<>();
     private final Set<InMemorySessionStoreIterator> openIterators  = ConcurrentHashMap.newKeySet();
@@ -87,6 +87,11 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         this.retentionPeriod = retentionPeriod;
         this.metricScope = metricScope;
         this.position = Position.emptyPosition();
+    }
+
+    @Override
+    public long retentionPeriod() {
+        return retentionPeriod;
     }
 
     @Override
@@ -107,9 +112,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
             this.context = (InternalProcessorContext<?, ?>) stateStoreContext;
             final StreamsMetricsImpl metrics = this.context.metrics();
             expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
-                threadId,
-                taskName,
-                metrics
+                    threadId,
+                    taskName,
+                    metrics
             );
         } else {
             this.context = null;
@@ -118,24 +123,24 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
         if (root != null) {
             final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
-                stateStoreContext.appConfigs(),
-                IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
-                false
+                    stateStoreContext.appConfigs(),
+                    IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
+                    false
             );
             stateStoreContext.register(
-                root,
-                (RecordBatchingStateRestoreCallback) records -> {
-                    synchronized (position) {
-                        for (final ConsumerRecord<byte[], byte[]> record : records) {
-                            put(SessionKeySchema.from(Bytes.wrap(record.key())), record.value());
-                            ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
-                                record,
-                                consistencyEnabled,
-                                position
-                            );
+                    root,
+                    (RecordBatchingStateRestoreCallback) records -> {
+                        synchronized (position) {
+                            for (final ConsumerRecord<byte[], byte[]> record : records) {
+                                put(SessionKeySchema.from(Bytes.wrap(record.key())), record.value());
+                                ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
+                                        record,
+                                        consistencyEnabled,
+                                        position
+                                );
+                            }
                         }
                     }
-                }
             );
         }
         open = true;
@@ -225,7 +230,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         removeExpiredSegments();
 
         final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimSubMap
-            = endTimeMap.subMap(earliestSessionEndTime, true, latestSessionEndTime, true);
+                = endTimeMap.subMap(earliestSessionEndTime, true, latestSessionEndTime, true);
 
         return registerNewIterator(null, null, Long.MAX_VALUE, endTimSubMap.entrySet().iterator(), true);
     }
@@ -239,10 +244,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         removeExpiredSegments();
 
         return registerNewIterator(key,
-                                   key,
-                                   latestSessionStartTime,
-                                   endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
-                                   true);
+                key,
+                latestSessionStartTime,
+                endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
+                true);
     }
 
     @Override
@@ -254,11 +259,11 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         removeExpiredSegments();
 
         return registerNewIterator(
-            key,
-            key,
-            latestSessionStartTime,
-            endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
-            false
+                key,
+                key,
+                latestSessionStartTime,
+                endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
+                false
         );
     }
 
@@ -275,10 +280,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         }
 
         return registerNewIterator(keyFrom,
-                                   keyTo,
-                                   latestSessionStartTime,
-                                   endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
-                                   true);
+                keyTo,
+                latestSessionStartTime,
+                endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
+                true);
     }
 
     @Override
@@ -294,11 +299,11 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         }
 
         return registerNewIterator(
-            keyFrom,
-            keyTo,
-            latestSessionStartTime,
-            endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
-            false
+                keyFrom,
+                keyTo,
+                latestSessionStartTime,
+                endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
+                false
         );
     }
 
@@ -334,7 +339,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         removeExpiredSegments();
 
         return registerNewIterator(
-            keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.descendingMap().entrySet().iterator(), false);
+                keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.descendingMap().entrySet().iterator(), false);
     }
 
     @Override
@@ -353,12 +358,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
                                     final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
-            query,
-            positionBound,
-            config,
-            this,
-            position,
-            context
+                query,
+                positionBound,
+                config,
+                this,
+                position,
+                context
         );
     }
 
@@ -383,9 +388,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
     long numEntries() {
         return endTimeMap.values().stream()
-            .flatMap(keyMap -> keyMap.values().stream())
-            .mapToLong(Map::size)
-            .sum();
+                .flatMap(keyMap -> keyMap.values().stream())
+                .mapToLong(Map::size)
+                .sum();
     }
 
     private void removeExpiredSegments() {
@@ -404,14 +409,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
                                                              final Iterator<Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>>> endTimeIterator,
                                                              final boolean forward) {
         final InMemorySessionStoreIterator iterator =
-            new InMemorySessionStoreIterator(
-                keyFrom,
-                keyTo,
-                latestSessionStartTime,
-                endTimeIterator,
-                openIterators::remove,
-                forward
-            );
+                new InMemorySessionStoreIterator(
+                        keyFrom,
+                        keyTo,
+                        latestSessionStartTime,
+                        endTimeIterator,
+                        openIterators::remove,
+                        forward
+                );
         openIterators.add(iterator);
         return iterator;
     }
@@ -562,13 +567,13 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
                 } else {
                     if (forward) {
                         recordIterator = nextKeyEntry.getValue()
-                                                     .headMap(latestSessionStartTime, true)
-                                                     .descendingMap()
-                                                     .entrySet().iterator();
+                                .headMap(latestSessionStartTime, true)
+                                .descendingMap()
+                                .entrySet().iterator();
                     } else {
                         recordIterator = nextKeyEntry.getValue()
-                                                     .headMap(latestSessionStartTime, true)
-                                                     .entrySet().iterator();
+                                .headMap(latestSessionStartTime, true)
+                                .entrySet().iterator();
                     }
                 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -67,10 +67,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
     private final long retentionPeriod;
 
     private static final String INVALID_RANGE_WARN_MSG =
-            "Returning empty iterator for fetch with invalid key range: from > to. " +
-                    "This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
-                    "Note that the built-in numerical serdes do not follow this for negative numbers";
+        "Returning empty iterator for fetch with invalid key range: from > to. " +
+        "This may be due to range arguments set in the wrong order, " +
+        "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
+        "Note that the built-in numerical serdes do not follow this for negative numbers";
 
     private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeMap = new ConcurrentSkipListMap<>();
     private final Set<InMemorySessionStoreIterator> openIterators  = ConcurrentHashMap.newKeySet();
@@ -128,19 +128,19 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                     false
             );
             stateStoreContext.register(
-                    root,
-                    (RecordBatchingStateRestoreCallback) records -> {
-                        synchronized (position) {
-                            for (final ConsumerRecord<byte[], byte[]> record : records) {
-                                put(SessionKeySchema.from(Bytes.wrap(record.key())), record.value());
-                                ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
-                                        record,
-                                        consistencyEnabled,
-                                        position
-                                );
-                            }
+                root,
+                (RecordBatchingStateRestoreCallback) records -> {
+                    synchronized (position) {
+                        for (final ConsumerRecord<byte[], byte[]> record : records) {
+                            put(SessionKeySchema.from(Bytes.wrap(record.key())), record.value());
+                            ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
+                                record,
+                                consistencyEnabled,
+                                position
+                            );
                         }
                     }
+                }
             );
         }
         open = true;
@@ -230,7 +230,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         removeExpiredSegments();
 
         final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimSubMap
-                = endTimeMap.subMap(earliestSessionEndTime, true, latestSessionEndTime, true);
+            = endTimeMap.subMap(earliestSessionEndTime, true, latestSessionEndTime, true);
 
         return registerNewIterator(null, null, Long.MAX_VALUE, endTimSubMap.entrySet().iterator(), true);
     }
@@ -244,10 +244,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         removeExpiredSegments();
 
         return registerNewIterator(key,
-                key,
-                latestSessionStartTime,
-                endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
-                true);
+                                   key,
+                                   latestSessionStartTime,
+                                   endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
+                                   true);
     }
 
     @Override
@@ -259,11 +259,11 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         removeExpiredSegments();
 
         return registerNewIterator(
-                key,
-                key,
-                latestSessionStartTime,
-                endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
-                false
+            key,
+            key,
+            latestSessionStartTime,
+            endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
+            false
         );
     }
 
@@ -280,10 +280,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         }
 
         return registerNewIterator(keyFrom,
-                keyTo,
-                latestSessionStartTime,
-                endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
-                true);
+                                   keyTo,
+                                   latestSessionStartTime,
+                                   endTimeMap.tailMap(earliestSessionEndTime, true).entrySet().iterator(),
+                                   true);
     }
 
     @Override
@@ -299,11 +299,11 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         }
 
         return registerNewIterator(
-                keyFrom,
-                keyTo,
-                latestSessionStartTime,
-                endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
-                false
+            keyFrom,
+            keyTo,
+            latestSessionStartTime,
+            endTimeMap.tailMap(earliestSessionEndTime, true).descendingMap().entrySet().iterator(),
+            false
         );
     }
 
@@ -339,7 +339,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         removeExpiredSegments();
 
         return registerNewIterator(
-                keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.descendingMap().entrySet().iterator(), false);
+            keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.descendingMap().entrySet().iterator(), false);
     }
 
     @Override
@@ -358,12 +358,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                                     final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
-                query,
-                positionBound,
-                config,
-                this,
-                position,
-                context
+            query,
+            positionBound,
+            config,
+            this,
+            position,
+            context
         );
     }
 
@@ -388,9 +388,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
     long numEntries() {
         return endTimeMap.values().stream()
-                .flatMap(keyMap -> keyMap.values().stream())
-                .mapToLong(Map::size)
-                .sum();
+            .flatMap(keyMap -> keyMap.values().stream())
+            .mapToLong(Map::size)
+            .sum();
     }
 
     private void removeExpiredSegments() {
@@ -409,14 +409,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                                                              final Iterator<Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>>> endTimeIterator,
                                                              final boolean forward) {
         final InMemorySessionStoreIterator iterator =
-                new InMemorySessionStoreIterator(
-                        keyFrom,
-                        keyTo,
-                        latestSessionStartTime,
-                        endTimeIterator,
-                        openIterators::remove,
-                        forward
-                );
+            new InMemorySessionStoreIterator(
+                keyFrom,
+                keyTo,
+                latestSessionStartTime,
+                endTimeIterator,
+                openIterators::remove,
+                forward
+            );
         openIterators.add(iterator);
         return iterator;
     }
@@ -567,13 +567,13 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                 } else {
                     if (forward) {
                         recordIterator = nextKeyEntry.getValue()
-                                .headMap(latestSessionStartTime, true)
-                                .descendingMap()
-                                .entrySet().iterator();
+                                                     .headMap(latestSessionStartTime, true)
+                                                     .descendingMap()
+                                                     .entrySet().iterator();
                     } else {
                         recordIterator = nextKeyEntry.getValue()
-                                .headMap(latestSessionStartTime, true)
-                                .entrySet().iterator();
+                                                     .headMap(latestSessionStartTime, true)
+                                                     .entrySet().iterator();
                     }
                 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -114,35 +114,35 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final String threadId = Thread.currentThread().getName();
         final String taskName = stateStoreContext.taskId().toString();
         expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
-                threadId,
-                taskName,
-                metrics
+            threadId,
+            taskName,
+            metrics
         );
 
         if (root != null) {
             final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
-                    stateStoreContext.appConfigs(),
-                    IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
-                    false
+                stateStoreContext.appConfigs(),
+                IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
+                false
             );
             stateStoreContext.register(
-                    root,
-                    (RecordBatchingStateRestoreCallback) records -> {
-                        synchronized (position) {
-                            for (final ConsumerRecord<byte[], byte[]> record : records) {
-                                put(
-                                        Bytes.wrap(extractStoreKeyBytes(record.key())),
-                                        record.value(),
-                                        extractStoreTimestamp(record.key())
-                                );
-                                ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
-                                        record,
-                                        consistencyEnabled,
-                                        position
-                                );
-                            }
+                root,
+                (RecordBatchingStateRestoreCallback) records -> {
+                    synchronized (position) {
+                        for (final ConsumerRecord<byte[], byte[]> record : records) {
+                            put(
+                                Bytes.wrap(extractStoreKeyBytes(record.key())),
+                                record.value(),
+                                extractStoreTimestamp(record.key())
+                            );
+                            ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
+                                record,
+                                consistencyEnabled,
+                                position
+                            );
                         }
                     }
+                }
             );
         }
         open = true;
@@ -226,17 +226,17 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         if (forward) {
             return registerNewWindowStoreIterator(
-                    key,
-                    segmentMap.subMap(minTime, true, timeTo, true)
-                            .entrySet().iterator(),
-                    true
+                key,
+                segmentMap.subMap(minTime, true, timeTo, true)
+                    .entrySet().iterator(),
+                true
             );
         } else {
             return registerNewWindowStoreIterator(
-                    key,
-                    segmentMap.subMap(minTime, true, timeTo, true)
-                            .descendingMap().entrySet().iterator(),
-                    false
+                key,
+                segmentMap.subMap(minTime, true, timeTo, true)
+                    .descendingMap().entrySet().iterator(),
+                false
             );
         }
     }
@@ -266,9 +266,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         if (from != null && to != null && from.compareTo(to) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. " +
-                    "This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
-                    "Note that the built-in numerical serdes do not follow this for negative numbers");
+                "This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
+                "Note that the built-in numerical serdes do not follow this for negative numbers");
             return KeyValueIterators.emptyIterator();
         }
 
@@ -281,19 +281,19 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         if (forward) {
             return registerNewWindowedKeyValueIterator(
-                    from,
-                    to,
-                    segmentMap.subMap(minTime, true, timeTo, true)
-                            .entrySet().iterator(),
-                    true
+                from,
+                to,
+                segmentMap.subMap(minTime, true, timeTo, true)
+                    .entrySet().iterator(),
+                true
             );
         } else {
             return registerNewWindowedKeyValueIterator(
-                    from,
-                    to,
-                    segmentMap.subMap(minTime, true, timeTo, true)
-                            .descendingMap().entrySet().iterator(),
-                    false
+                from,
+                to,
+                segmentMap.subMap(minTime, true, timeTo, true)
+                    .descendingMap().entrySet().iterator(),
+                false
             );
         }
     }
@@ -320,19 +320,19 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         if (forward) {
             return registerNewWindowedKeyValueIterator(
-                    null,
-                    null,
-                    segmentMap.subMap(minTime, true, timeTo, true)
-                            .entrySet().iterator(),
-                    true
+                null,
+                null,
+                segmentMap.subMap(minTime, true, timeTo, true)
+                    .entrySet().iterator(),
+                true
             );
         } else {
             return registerNewWindowedKeyValueIterator(
-                    null,
-                    null,
-                    segmentMap.subMap(minTime, true, timeTo, true)
-                            .descendingMap().entrySet().iterator(),
-                    false
+                null,
+                null,
+                segmentMap.subMap(minTime, true, timeTo, true)
+                    .descendingMap().entrySet().iterator(),
+                false
             );
         }
     }
@@ -344,10 +344,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final long minTime = observedStreamTime - retentionPeriod;
 
         return registerNewWindowedKeyValueIterator(
-                null,
-                null,
-                segmentMap.tailMap(minTime, false).entrySet().iterator(),
-                true
+            null,
+            null,
+            segmentMap.tailMap(minTime, false).entrySet().iterator(),
+            true
         );
     }
 
@@ -358,10 +358,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final long minTime = observedStreamTime - retentionPeriod;
 
         return registerNewWindowedKeyValueIterator(
-                null,
-                null,
-                segmentMap.tailMap(minTime, false).descendingMap().entrySet().iterator(),
-                false
+            null,
+            null,
+            segmentMap.tailMap(minTime, false).descendingMap().entrySet().iterator(),
+            false
         );
     }
 
@@ -381,12 +381,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                                     final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
-                query,
-                positionBound,
-                config,
-                this,
-                position,
-                internalProcessorContext
+            query,
+            positionBound,
+            config,
+            this,
+            position,
+            internalProcessorContext
         );
     }
 
@@ -410,8 +410,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
     long numEntries() {
         return segmentMap.values().stream()
-                .mapToLong(Map::size)
-                .sum();
+            .mapToLong(Map::size)
+            .sum();
     }
 
     private void removeExpiredSegments() {
@@ -449,7 +449,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final Bytes keyTo = retainDuplicates ? wrapForDups(key, Integer.MAX_VALUE) : key;
 
         final WrappedInMemoryWindowStoreIterator iterator =
-                new WrappedInMemoryWindowStoreIterator(keyFrom, keyTo, segmentIterator, openIterators::remove, retainDuplicates, forward);
+            new WrappedInMemoryWindowStoreIterator(keyFrom, keyTo, segmentIterator, openIterators::remove, retainDuplicates, forward);
 
         openIterators.add(iterator);
         return iterator;
@@ -463,14 +463,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final Bytes to = (retainDuplicates && keyTo != null) ? wrapForDups(keyTo, Integer.MAX_VALUE) : keyTo;
 
         final WrappedWindowedKeyValueIterator iterator =
-                new WrappedWindowedKeyValueIterator(
-                        from,
-                        to,
-                        segmentIterator,
-                        openIterators::remove,
-                        retainDuplicates,
-                        windowSize,
-                        forward);
+            new WrappedWindowedKeyValueIterator(
+                from,
+                to,
+                segmentIterator,
+                openIterators::remove,
+                retainDuplicates,
+                windowSize,
+                forward);
         openIterators.add(iterator);
         return iterator;
     }
@@ -643,8 +643,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
     }
 
     private static class WrappedWindowedKeyValueIterator
-            extends InMemoryWindowStoreIteratorWrapper
-            implements KeyValueIterator<Windowed<Bytes>, byte[]> {
+        extends InMemoryWindowStoreIteratorWrapper
+        implements KeyValueIterator<Windowed<Bytes>, byte[]> {
 
         private final long windowSize;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -59,7 +59,7 @@ import static org.apache.kafka.streams.state.internals.WindowKeySchema.extractSt
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.extractStoreTimestamp;
 
 
-public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
+public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRetentionPeriod {
 
     private static final Logger LOG = LoggerFactory.getLogger(InMemoryWindowStore.class);
     private static final int SEQNUM_SIZE = 4;
@@ -96,6 +96,11 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     }
 
     @Override
+    public long retentionPeriod() {
+        return retentionPeriod;
+    }
+
+    @Override
     public String name() {
         return name;
     }
@@ -109,35 +114,35 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         final String threadId = Thread.currentThread().getName();
         final String taskName = stateStoreContext.taskId().toString();
         expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
-            threadId,
-            taskName,
-            metrics
+                threadId,
+                taskName,
+                metrics
         );
 
         if (root != null) {
             final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
-                stateStoreContext.appConfigs(),
-                IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
-                false
+                    stateStoreContext.appConfigs(),
+                    IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
+                    false
             );
             stateStoreContext.register(
-                root,
-                (RecordBatchingStateRestoreCallback) records -> {
-                    synchronized (position) {
-                        for (final ConsumerRecord<byte[], byte[]> record : records) {
-                            put(
-                                Bytes.wrap(extractStoreKeyBytes(record.key())),
-                                record.value(),
-                                extractStoreTimestamp(record.key())
-                            );
-                            ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
-                                record,
-                                consistencyEnabled,
-                                position
-                            );
+                    root,
+                    (RecordBatchingStateRestoreCallback) records -> {
+                        synchronized (position) {
+                            for (final ConsumerRecord<byte[], byte[]> record : records) {
+                                put(
+                                        Bytes.wrap(extractStoreKeyBytes(record.key())),
+                                        record.value(),
+                                        extractStoreTimestamp(record.key())
+                                );
+                                ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
+                                        record,
+                                        consistencyEnabled,
+                                        position
+                                );
+                            }
                         }
                     }
-                }
             );
         }
         open = true;
@@ -221,17 +226,17 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         if (forward) {
             return registerNewWindowStoreIterator(
-                key,
-                segmentMap.subMap(minTime, true, timeTo, true)
-                    .entrySet().iterator(),
-                true
+                    key,
+                    segmentMap.subMap(minTime, true, timeTo, true)
+                            .entrySet().iterator(),
+                    true
             );
         } else {
             return registerNewWindowStoreIterator(
-                key,
-                segmentMap.subMap(minTime, true, timeTo, true)
-                    .descendingMap().entrySet().iterator(),
-                false
+                    key,
+                    segmentMap.subMap(minTime, true, timeTo, true)
+                            .descendingMap().entrySet().iterator(),
+                    false
             );
         }
     }
@@ -261,9 +266,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         if (from != null && to != null && from.compareTo(to) > 0) {
             LOG.warn("Returning empty iterator for fetch with invalid key range: from > to. " +
-                "This may be due to range arguments set in the wrong order, " +
-                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
-                "Note that the built-in numerical serdes do not follow this for negative numbers");
+                    "This may be due to range arguments set in the wrong order, " +
+                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
+                    "Note that the built-in numerical serdes do not follow this for negative numbers");
             return KeyValueIterators.emptyIterator();
         }
 
@@ -276,19 +281,19 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         if (forward) {
             return registerNewWindowedKeyValueIterator(
-                from,
-                to,
-                segmentMap.subMap(minTime, true, timeTo, true)
-                    .entrySet().iterator(),
-                true
+                    from,
+                    to,
+                    segmentMap.subMap(minTime, true, timeTo, true)
+                            .entrySet().iterator(),
+                    true
             );
         } else {
             return registerNewWindowedKeyValueIterator(
-                from,
-                to,
-                segmentMap.subMap(minTime, true, timeTo, true)
-                    .descendingMap().entrySet().iterator(),
-                false
+                    from,
+                    to,
+                    segmentMap.subMap(minTime, true, timeTo, true)
+                            .descendingMap().entrySet().iterator(),
+                    false
             );
         }
     }
@@ -315,19 +320,19 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
         if (forward) {
             return registerNewWindowedKeyValueIterator(
-                null,
-                null,
-                segmentMap.subMap(minTime, true, timeTo, true)
-                    .entrySet().iterator(),
-                true
+                    null,
+                    null,
+                    segmentMap.subMap(minTime, true, timeTo, true)
+                            .entrySet().iterator(),
+                    true
             );
         } else {
             return registerNewWindowedKeyValueIterator(
-                null,
-                null,
-                segmentMap.subMap(minTime, true, timeTo, true)
-                    .descendingMap().entrySet().iterator(),
-                false
+                    null,
+                    null,
+                    segmentMap.subMap(minTime, true, timeTo, true)
+                            .descendingMap().entrySet().iterator(),
+                    false
             );
         }
     }
@@ -339,10 +344,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         final long minTime = observedStreamTime - retentionPeriod;
 
         return registerNewWindowedKeyValueIterator(
-            null,
-            null,
-            segmentMap.tailMap(minTime, false).entrySet().iterator(),
-            true
+                null,
+                null,
+                segmentMap.tailMap(minTime, false).entrySet().iterator(),
+                true
         );
     }
 
@@ -353,10 +358,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         final long minTime = observedStreamTime - retentionPeriod;
 
         return registerNewWindowedKeyValueIterator(
-            null,
-            null,
-            segmentMap.tailMap(minTime, false).descendingMap().entrySet().iterator(),
-            false
+                null,
+                null,
+                segmentMap.tailMap(minTime, false).descendingMap().entrySet().iterator(),
+                false
         );
     }
 
@@ -376,12 +381,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
                                     final QueryConfig config) {
 
         return StoreQueryUtils.handleBasicQueries(
-            query,
-            positionBound,
-            config,
-            this,
-            position,
-            internalProcessorContext
+                query,
+                positionBound,
+                config,
+                this,
+                position,
+                internalProcessorContext
         );
     }
 
@@ -405,8 +410,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
 
     long numEntries() {
         return segmentMap.values().stream()
-            .mapToLong(Map::size)
-            .sum();
+                .mapToLong(Map::size)
+                .sum();
     }
 
     private void removeExpiredSegments() {
@@ -444,7 +449,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         final Bytes keyTo = retainDuplicates ? wrapForDups(key, Integer.MAX_VALUE) : key;
 
         final WrappedInMemoryWindowStoreIterator iterator =
-            new WrappedInMemoryWindowStoreIterator(keyFrom, keyTo, segmentIterator, openIterators::remove, retainDuplicates, forward);
+                new WrappedInMemoryWindowStoreIterator(keyFrom, keyTo, segmentIterator, openIterators::remove, retainDuplicates, forward);
 
         openIterators.add(iterator);
         return iterator;
@@ -458,14 +463,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         final Bytes to = (retainDuplicates && keyTo != null) ? wrapForDups(keyTo, Integer.MAX_VALUE) : keyTo;
 
         final WrappedWindowedKeyValueIterator iterator =
-            new WrappedWindowedKeyValueIterator(
-                from,
-                to,
-                segmentIterator,
-                openIterators::remove,
-                retainDuplicates,
-                windowSize,
-                forward);
+                new WrappedWindowedKeyValueIterator(
+                        from,
+                        to,
+                        segmentIterator,
+                        openIterators::remove,
+                        retainDuplicates,
+                        windowSize,
+                        forward);
         openIterators.add(iterator);
         return iterator;
     }
@@ -638,8 +643,8 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
     }
 
     private static class WrappedWindowedKeyValueIterator
-        extends InMemoryWindowStoreIteratorWrapper
-        implements KeyValueIterator<Windowed<Bytes>, byte[]> {
+            extends InMemoryWindowStoreIteratorWrapper
+            implements KeyValueIterator<Windowed<Bytes>, byte[]> {
 
         private final long windowSize;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WithRetentionPeriod.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WithRetentionPeriod.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+public interface WithRetentionPeriod {
+    long retentionPeriod();
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -148,7 +148,7 @@ public class StoreChangelogReaderTest {
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(AutoOffsetResetStrategy.EARLIEST.name());
     private final MockAdminClient adminClient = new MockAdminClient();
     private final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+        new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
     private void setupStateManagerMock(final Task.TaskType type) {
         when(stateManager.storeMetadata(tp)).thenReturn(storeMetadata);
@@ -191,7 +191,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotRegisterStoreWithoutMetadata() {
         assertThrows(IllegalStateException.class,
-                () -> changelogReader.register(new TopicPartition("ChangelogWithoutStoreMetadata", 0), stateManager));
+            () -> changelogReader.register(new TopicPartition("ChangelogWithoutStoreMetadata", 0), stateManager));
     }
 
     @ParameterizedTest
@@ -202,7 +202,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -243,7 +243,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -298,7 +298,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -356,7 +356,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
         changelogReader.transitToUpdateStandby();
@@ -435,7 +435,7 @@ public class StoreChangelogReaderTest {
             consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
 
             final StoreChangelogReader changelogReader =
-                    new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
             changelogReader.register(tp, stateManager);
             changelogReader.restore(mockTasks);
@@ -490,7 +490,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -567,7 +567,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 11L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -643,7 +643,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 0L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore(mockTasks);
@@ -687,7 +687,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
@@ -729,13 +729,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
 
         final StreamsException thrown = assertThrows(
-                StreamsException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            StreamsException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -777,7 +777,7 @@ public class StoreChangelogReaderTest {
         };
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
@@ -816,13 +816,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 0L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
 
         final StreamsException thrown = assertThrows(
-                StreamsException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            StreamsException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -862,16 +862,16 @@ public class StoreChangelogReaderTest {
         adminClient.updateConsumerGroupOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
 
         assertEquals(
-                type == ACTIVE ?
-                        StoreChangelogReader.ChangelogState.REGISTERED :
-                        StoreChangelogReader.ChangelogState.RESTORING,
-                changelogReader.changelogMetadata(tp).state()
+            type == ACTIVE ?
+                StoreChangelogReader.ChangelogState.REGISTERED :
+                StoreChangelogReader.ChangelogState.RESTORING,
+            changelogReader.changelogMetadata(tp).state()
         );
         if (type == ACTIVE) {
             assertNull(changelogReader.changelogMetadata(tp).endOffset());
@@ -914,13 +914,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
         final StreamsException thrown = assertThrows(
-                StreamsException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            StreamsException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -934,7 +934,7 @@ public class StoreChangelogReaderTest {
             }
         };
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         final StreamsException thrown = assertThrows(StreamsException.class, changelogReader::clear);
         assertEquals(kaboom, thrown.getCause());
@@ -1180,9 +1180,9 @@ public class StoreChangelogReaderTest {
         when(activeStateManager.storeMetadata(tp1)).thenReturn(storeMetadataOne);
         when(activeStateManager.storeMetadata(tp2)).thenReturn(storeMetadataTwo);
         when(activeStateManager.changelogOffsets()).thenReturn(mkMap(
-                mkEntry(tp, 5L),
-                mkEntry(tp1, 5L),
-                mkEntry(tp2, 5L)
+            mkEntry(tp, 5L),
+            mkEntry(tp1, 5L),
+            mkEntry(tp2, 5L)
         ));
 
         setupConsumer(10, tp);
@@ -1278,8 +1278,8 @@ public class StoreChangelogReaderTest {
 
         // if a new active is registered, we should immediately transit to standby updating
         assertThrows(
-                IllegalStateException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            IllegalStateException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
 
         assertEquals(StoreChangelogReader.ChangelogState.RESTORING, changelogReader.changelogMetadata(tp).state());
@@ -1321,13 +1321,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, exceptionCallback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, exceptionCallback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
 
         StreamsException thrown = assertThrows(
-                StreamsException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            StreamsException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
 
@@ -1335,16 +1335,16 @@ public class StoreChangelogReaderTest {
         consumer.addRecord(new ConsumerRecord<>(topicName, 0, 7L, "key".getBytes(), "value".getBytes()));
 
         thrown = assertThrows(
-                StreamsException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            StreamsException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
 
         consumer.seek(tp, 10L);
 
         thrown = assertThrows(
-                StreamsException.class,
-                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+            StreamsException.class,
+            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -1356,9 +1356,9 @@ public class StoreChangelogReaderTest {
             changelogReader.unregister(Collections.singletonList(new TopicPartition("unknown", 0)));
 
             assertThat(
-                    appender.getMessages(),
-                    hasItem("test-reader Changelog partition unknown-0 could not be found," +
-                            " it could be already cleaned up during the handling of task corruption and never restore again")
+                appender.getMessages(),
+                hasItem("test-reader Changelog partition unknown-0 could not be found," +
+                    " it could be already cleaned up during the handling of task corruption and never restore again")
             );
         }
     }
@@ -1424,11 +1424,11 @@ public class StoreChangelogReaderTest {
     private void addRecords(final long messages, final TopicPartition topicPartition) {
         for (int i = 0; i < messages; i++) {
             consumer.addRecord(new ConsumerRecord<>(
-                    topicPartition.topic(),
-                    topicPartition.partition(),
-                    i,
-                    new byte[0],
-                    new byte[0]));
+                topicPartition.topic(),
+                topicPartition.partition(),
+                i,
+                new byte[0],
+                new byte[0]));
         }
     }
 
@@ -1466,12 +1466,12 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader reader =
-                new StoreChangelogReader(time, config, logContext, adminClient, timestampConsumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, timestampConsumer, callback, standbyListener);
 
         reader.register(tp, windowStateManager);
         reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
 
-        assertEquals(offsetForTimestamp, timestampConsumer.position(tp),"The consumer should be seeked to the offset returned by offsetsForTimes, not to the beginning");
+        assertEquals(offsetForTimestamp, timestampConsumer.position(tp), "The consumer should be seeked to the offset returned by offsetsForTimes, not to the beginning");
     }
 
     @Test
@@ -1506,12 +1506,12 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader reader =
-                new StoreChangelogReader(time, config, logContext, adminClient, timestampConsumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, timestampConsumer, callback, standbyListener);
 
         reader.register(tp, windowStateManager);
         reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
 
-        assertEquals(0L, timestampConsumer.position(tp),"When broker returns null, should fall back to seeking to the beginning");
+        assertEquals(0L, timestampConsumer.position(tp), "When broker returns null, should fall back to seeking to the beginning");
     }
 
     @Test
@@ -1534,24 +1534,24 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader reader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         reader.register(tp, kvStateManager);
         reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
 
-        assertEquals(0L, consumer.position(tp),"Non-windowed store should seek to beginning, not by timestamp");
+        assertEquals(0L, consumer.position(tp), "Non-windowed store should seek to beginning, not by timestamp");
     }
 
     private void assignPartition(final long messages,
                                  final TopicPartition topicPartition) {
         consumer.updatePartitions(
+            topicPartition.topic(),
+            Collections.singletonList(new PartitionInfo(
                 topicPartition.topic(),
-                Collections.singletonList(new PartitionInfo(
-                        topicPartition.topic(),
-                        topicPartition.partition(),
-                        null,
-                        null,
-                        null)));
+                topicPartition.partition(),
+                null,
+                null,
+                null)));
         consumer.updateBeginningOffsets(Collections.singletonMap(topicPartition, 0L));
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, Math.max(0, messages) + 1));
         adminClient.updateEndOffsets(Collections.singletonMap(topicPartition, Math.max(0, messages) + 1));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
@@ -59,6 +60,7 @@ import org.mockito.quality.Strictness;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -146,7 +148,7 @@ public class StoreChangelogReaderTest {
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(AutoOffsetResetStrategy.EARLIEST.name());
     private final MockAdminClient adminClient = new MockAdminClient();
     private final StoreChangelogReader changelogReader =
-        new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
     private void setupStateManagerMock(final Task.TaskType type) {
         when(stateManager.storeMetadata(tp)).thenReturn(storeMetadata);
@@ -189,7 +191,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotRegisterStoreWithoutMetadata() {
         assertThrows(IllegalStateException.class,
-            () -> changelogReader.register(new TopicPartition("ChangelogWithoutStoreMetadata", 0), stateManager));
+                () -> changelogReader.register(new TopicPartition("ChangelogWithoutStoreMetadata", 0), stateManager));
     }
 
     @ParameterizedTest
@@ -200,7 +202,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -241,7 +243,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -296,7 +298,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -354,7 +356,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
         changelogReader.transitToUpdateStandby();
@@ -433,7 +435,7 @@ public class StoreChangelogReaderTest {
             consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
 
             final StoreChangelogReader changelogReader =
-                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                    new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
             changelogReader.register(tp, stateManager);
             changelogReader.restore(mockTasks);
@@ -488,7 +490,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -565,7 +567,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 11L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
@@ -641,7 +643,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 0L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore(mockTasks);
@@ -685,7 +687,7 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
@@ -727,13 +729,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
 
         final StreamsException thrown = assertThrows(
-            StreamsException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                StreamsException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -775,7 +777,7 @@ public class StoreChangelogReaderTest {
         };
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
@@ -814,13 +816,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 0L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
 
         final StreamsException thrown = assertThrows(
-            StreamsException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                StreamsException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -860,16 +862,16 @@ public class StoreChangelogReaderTest {
         adminClient.updateConsumerGroupOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
 
         assertEquals(
-            type == ACTIVE ?
-                StoreChangelogReader.ChangelogState.REGISTERED :
-                StoreChangelogReader.ChangelogState.RESTORING,
-            changelogReader.changelogMetadata(tp).state()
+                type == ACTIVE ?
+                        StoreChangelogReader.ChangelogState.REGISTERED :
+                        StoreChangelogReader.ChangelogState.RESTORING,
+                changelogReader.changelogMetadata(tp).state()
         );
         if (type == ACTIVE) {
             assertNull(changelogReader.changelogMetadata(tp).endOffset());
@@ -912,13 +914,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
         final StreamsException thrown = assertThrows(
-            StreamsException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                StreamsException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -932,7 +934,7 @@ public class StoreChangelogReaderTest {
             }
         };
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         final StreamsException thrown = assertThrows(StreamsException.class, changelogReader::clear);
         assertEquals(kaboom, thrown.getCause());
@@ -1178,9 +1180,9 @@ public class StoreChangelogReaderTest {
         when(activeStateManager.storeMetadata(tp1)).thenReturn(storeMetadataOne);
         when(activeStateManager.storeMetadata(tp2)).thenReturn(storeMetadataTwo);
         when(activeStateManager.changelogOffsets()).thenReturn(mkMap(
-            mkEntry(tp, 5L),
-            mkEntry(tp1, 5L),
-            mkEntry(tp2, 5L)
+                mkEntry(tp, 5L),
+                mkEntry(tp1, 5L),
+                mkEntry(tp2, 5L)
         ));
 
         setupConsumer(10, tp);
@@ -1276,8 +1278,8 @@ public class StoreChangelogReaderTest {
 
         // if a new active is registered, we should immediately transit to standby updating
         assertThrows(
-            IllegalStateException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                IllegalStateException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
 
         assertEquals(StoreChangelogReader.ChangelogState.RESTORING, changelogReader.changelogMetadata(tp).state());
@@ -1319,13 +1321,13 @@ public class StoreChangelogReaderTest {
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
 
         final StoreChangelogReader changelogReader =
-            new StoreChangelogReader(time, config, logContext, adminClient, consumer, exceptionCallback, standbyListener);
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, exceptionCallback, standbyListener);
 
         changelogReader.register(tp, activeStateManager);
 
         StreamsException thrown = assertThrows(
-            StreamsException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                StreamsException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
 
@@ -1333,16 +1335,16 @@ public class StoreChangelogReaderTest {
         consumer.addRecord(new ConsumerRecord<>(topicName, 0, 7L, "key".getBytes(), "value".getBytes()));
 
         thrown = assertThrows(
-            StreamsException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                StreamsException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
 
         consumer.seek(tp, 10L);
 
         thrown = assertThrows(
-            StreamsException.class,
-            () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
+                StreamsException.class,
+                () -> changelogReader.restore(Collections.singletonMap(taskId, mock(Task.class)))
         );
         assertEquals(kaboom, thrown.getCause());
     }
@@ -1354,9 +1356,9 @@ public class StoreChangelogReaderTest {
             changelogReader.unregister(Collections.singletonList(new TopicPartition("unknown", 0)));
 
             assertThat(
-                appender.getMessages(),
-                hasItem("test-reader Changelog partition unknown-0 could not be found," +
-                    " it could be already cleaned up during the handling of task corruption and never restore again")
+                    appender.getMessages(),
+                    hasItem("test-reader Changelog partition unknown-0 could not be found," +
+                            " it could be already cleaned up during the handling of task corruption and never restore again")
             );
         }
     }
@@ -1422,24 +1424,134 @@ public class StoreChangelogReaderTest {
     private void addRecords(final long messages, final TopicPartition topicPartition) {
         for (int i = 0; i < messages; i++) {
             consumer.addRecord(new ConsumerRecord<>(
-                topicPartition.topic(),
-                topicPartition.partition(),
-                i,
-                new byte[0],
-                new byte[0]));
+                    topicPartition.topic(),
+                    topicPartition.partition(),
+                    i,
+                    new byte[0],
+                    new byte[0]));
         }
+    }
+
+    @Test
+    public void shouldSeekByTimestampForWindowedStoreWithoutCheckpoint() {
+        final long retentionMs = Duration.ofHours(2).toMillis();
+        final long offsetForTimestamp = 42L;
+
+        // Use a MockConsumer subclass that supports offsetsForTimes
+        final MockConsumer<byte[], byte[]> timestampConsumer = new MockConsumer<>(AutoOffsetResetStrategy.EARLIEST.name()) {
+            @Override
+            public synchronized Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch) {
+                final Map<TopicPartition, OffsetAndTimestamp> result = new HashMap<>();
+                timestampsToSearch.forEach((key, value) -> result.put(key, new OffsetAndTimestamp(offsetForTimestamp, value)));
+                return result;
+            }
+        };
+
+        // Set up mocks - storeMetadata returns null offset (no checkpoint) and positive retentionPeriod
+        final StateStoreMetadata windowStoreMetadata = mock(StateStoreMetadata.class);
+        final ProcessorStateManager windowStateManager = mock(ProcessorStateManager.class);
+        final StateStore windowStore = mock(StateStore.class);
+        when(windowStoreMetadata.changelogPartition()).thenReturn(tp);
+        when(windowStoreMetadata.store()).thenReturn(windowStore);
+        when(windowStoreMetadata.offset()).thenReturn(null);
+        when(windowStoreMetadata.retentionPeriod()).thenReturn(retentionMs);
+        when(windowStore.name()).thenReturn(storeName);
+        when(windowStateManager.storeMetadata(tp)).thenReturn(windowStoreMetadata);
+        when(windowStateManager.taskType()).thenReturn(ACTIVE);
+
+        final TaskId taskId = new TaskId(0, 0);
+        when(windowStateManager.taskId()).thenReturn(taskId);
+
+        timestampConsumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+        adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
+
+        final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, timestampConsumer, callback, standbyListener);
+
+        reader.register(tp, windowStateManager);
+        reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
+
+        assertEquals(offsetForTimestamp, timestampConsumer.position(tp),"The consumer should be seeked to the offset returned by offsetsForTimes, not to the beginning");
+    }
+
+    @Test
+    public void shouldSeekToBeginningWhenBrokerReturnsNullForOffsetsForTimes() {
+        final long retentionMs = Duration.ofHours(2).toMillis();
+
+        // Use a MockConsumer subclass that returns null for offsetsForTimes
+        final MockConsumer<byte[], byte[]> timestampConsumer = new MockConsumer<>(AutoOffsetResetStrategy.EARLIEST.name()) {
+            @Override
+            public synchronized Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(final Map<TopicPartition, Long> timestampsToSearch) {
+                final Map<TopicPartition, OffsetAndTimestamp> result = new HashMap<>();
+                timestampsToSearch.forEach((key, value) -> result.put(key, null));
+                return result;
+            }
+        };
+
+        final StateStoreMetadata windowStoreMetadata = mock(StateStoreMetadata.class);
+        final ProcessorStateManager windowStateManager = mock(ProcessorStateManager.class);
+        final StateStore windowStore = mock(StateStore.class);
+        when(windowStoreMetadata.changelogPartition()).thenReturn(tp);
+        when(windowStoreMetadata.store()).thenReturn(windowStore);
+        when(windowStoreMetadata.offset()).thenReturn(null);
+        when(windowStoreMetadata.retentionPeriod()).thenReturn(retentionMs);
+        when(windowStore.name()).thenReturn(storeName);
+        when(windowStateManager.storeMetadata(tp)).thenReturn(windowStoreMetadata);
+        when(windowStateManager.taskType()).thenReturn(ACTIVE);
+
+        final TaskId taskId = new TaskId(0, 0);
+        when(windowStateManager.taskId()).thenReturn(taskId);
+
+        timestampConsumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+        adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
+
+        final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, timestampConsumer, callback, standbyListener);
+
+        reader.register(tp, windowStateManager);
+        reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
+
+        assertEquals(0L, timestampConsumer.position(tp),"When broker returns null, should fall back to seeking to the beginning");
+    }
+
+    @Test
+    public void shouldSeekToBeginningForNonWindowedStoreWithoutCheckpoint() {
+        final StateStoreMetadata kvStoreMetadata = mock(StateStoreMetadata.class);
+        final ProcessorStateManager kvStateManager = mock(ProcessorStateManager.class);
+        final StateStore kvStore = mock(StateStore.class);
+        when(kvStoreMetadata.changelogPartition()).thenReturn(tp);
+        when(kvStoreMetadata.store()).thenReturn(kvStore);
+        when(kvStoreMetadata.offset()).thenReturn(null);
+        when(kvStoreMetadata.retentionPeriod()).thenReturn(-1L);
+        when(kvStore.name()).thenReturn(storeName);
+        when(kvStateManager.storeMetadata(tp)).thenReturn(kvStoreMetadata);
+        when(kvStateManager.taskType()).thenReturn(ACTIVE);
+
+        final TaskId taskId = new TaskId(0, 0);
+        when(kvStateManager.taskId()).thenReturn(taskId);
+
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+        adminClient.updateEndOffsets(Collections.singletonMap(tp, 100L));
+
+        final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+
+        reader.register(tp, kvStateManager);
+        reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
+
+        assertEquals(0L, consumer.position(tp),"Non-windowed store should seek to beginning, not by timestamp");
     }
 
     private void assignPartition(final long messages,
                                  final TopicPartition topicPartition) {
         consumer.updatePartitions(
-            topicPartition.topic(),
-            Collections.singletonList(new PartitionInfo(
                 topicPartition.topic(),
-                topicPartition.partition(),
-                null,
-                null,
-                null)));
+                Collections.singletonList(new PartitionInfo(
+                        topicPartition.topic(),
+                        topicPartition.partition(),
+                        null,
+                        null,
+                        null)));
         consumer.updateBeginningOffsets(Collections.singletonMap(topicPartition, 0L));
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, Math.max(0, messages) + 1));
         adminClient.updateEndOffsets(Collections.singletonMap(topicPartition, Math.max(0, messages) + 1));


### PR DESCRIPTION
1. Expose the retentionPeriod length to storeMetadata
2. In prepareChangelogs(), switch it from always seektobeginning if
checkpoint doesn't exist to seek to certain timestamp to avoid restoring
outdated records.

Reviewers: TengYao Chi <frankvicky@apache.org> , Bill Bejeck
 <bbejeck@apache.org>
