### PR TITLE
KAFKA-20259: Verify IQv1 and IQv2 do not break with headers-aware state stores

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -950,13 +950,16 @@ public class IQv2StoreIntegrationTest {
                 )
             );
         assertThat(store, notNullValue());
-        final ValueAndTimestamp<Integer> result = store.fetch(
+        try (final WindowStoreIterator<ValueAndTimestamp<Integer>> it = store.fetch(
             2,
             Instant.ofEpochMilli(WINDOW_START),
             Instant.ofEpochMilli(WINDOW_START + WINDOW_SIZE.toMillis())
-        );
-        assertThat(result, notNullValue());
-        assertThat(result.value(), is(5));
+        )) {
+            assertThat(it.hasNext(), is(true));
+            final ValueAndTimestamp<Integer> result = it.next().value;
+            assertThat(result, notNullValue());
+            assertThat(result.value(), is(5));
+        }
     }
 
     private void shouldHandleIQv1SessionQuery() {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -69,6 +69,7 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -843,62 +844,65 @@ public class IQv2StoreIntegrationTest {
                 shouldRejectUnknownQuery();
                 shouldCollectExecutionInfo();
                 shouldCollectExecutionInfoUnderFailure();
-                if (storeToTest.keyValue()) {
-                    if (storeToTest.timestamped()) {
-                        shouldHandleKeyQuery(2,  5);
-                        shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.makeAllowNullable(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
-                        shouldHandleRangeQueries();
-                        shouldHandleTimestampedRangeQueries(true);
-                    } else {
-                        shouldHandleKeyQuery(2, 5);
-                        shouldHandleRangeQueries();
-
-                        if (kind.equals("DSL")) {
-                            shouldHandleTimestampedRangeQueries(false);
+                // IQv2 is not supported for headers-aware stores.
+                if (!storeToTest.isHeadersAware()) {
+                    if (storeToTest.keyValue()) {
+                        if (storeToTest.timestamped()) {
+                            shouldHandleKeyQuery(2,  5);
+                            shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.makeAllowNullable(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
                             shouldHandleRangeQueries();
-                            if (cache) {
-                                shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
+                            shouldHandleTimestampedRangeQueries(true);
+                        } else {
+                            shouldHandleKeyQuery(2, 5);
+                            shouldHandleRangeQueries();
+
+                            if (kind.equals("DSL")) {
+                                shouldHandleTimestampedRangeQueries(false);
+                                shouldHandleRangeQueries();
+                                if (cache) {
+                                    shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
+                                } else {
+                                    shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, -1L));
+                                }
                             } else {
-                                shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, -1L));
+                                assertThrows(AssertionError.class, () -> shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5)));
+                                assertThrows(AssertionError.class, () -> shouldHandleTimestampedRangeQueries(false));
+                            }
+
+                        }
+                    }
+
+                    if (storeToTest.isWindowed()) {
+                        if (storeToTest.timestamped()) {
+                            final Function<ValueAndTimestamp<Integer>, Integer> valueExtractor =
+                                ValueAndTimestamp::value;
+                            if (kind.equals("DSL")) {
+                                shouldHandleWindowKeyDSLQueries(valueExtractor);
+                                shouldHandleWindowRangeDSLQueries(valueExtractor);
+                            } else {
+                                shouldHandleWindowKeyPAPIQueries(valueExtractor);
+                                shouldHandleWindowRangePAPIQueries(valueExtractor);
                             }
                         } else {
-                            assertThrows(AssertionError.class, () -> shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5)));
-                            assertThrows(AssertionError.class, () -> shouldHandleTimestampedRangeQueries(false));
-                        }
-
-                    }
-                }
-
-                if (storeToTest.isWindowed()) {
-                    if (storeToTest.timestamped()) {
-                        final Function<ValueAndTimestamp<Integer>, Integer> valueExtractor =
-                            ValueAndTimestamp::value;
-                        if (kind.equals("DSL")) {
-                            shouldHandleWindowKeyDSLQueries(valueExtractor);
-                            shouldHandleWindowRangeDSLQueries(valueExtractor);
-                        } else {
-                            shouldHandleWindowKeyPAPIQueries(valueExtractor);
-                            shouldHandleWindowRangePAPIQueries(valueExtractor);
-                        }
-                    } else {
-                        final Function<Integer, Integer> valueExtractor = Function.identity();
-                        if (kind.equals("DSL")) {
-                            shouldHandleWindowKeyDSLQueries(valueExtractor);
-                            shouldHandleWindowRangeDSLQueries(valueExtractor);
-                        } else {
-                            shouldHandleWindowKeyPAPIQueries(valueExtractor);
-                            shouldHandleWindowRangePAPIQueries(valueExtractor);
+                            final Function<Integer, Integer> valueExtractor = Function.identity();
+                            if (kind.equals("DSL")) {
+                                shouldHandleWindowKeyDSLQueries(valueExtractor);
+                                shouldHandleWindowRangeDSLQueries(valueExtractor);
+                            } else {
+                                shouldHandleWindowKeyPAPIQueries(valueExtractor);
+                                shouldHandleWindowRangePAPIQueries(valueExtractor);
+                            }
                         }
                     }
-                }
 
-                if (storeToTest.isSession()) {
-                    // Note there's no "timestamped" differentiation here.
-                    // Idiosyncratically, SessionStores are _never_ timestamped.
-                    if (kind.equals("DSL")) {
-                        shouldHandleSessionKeyDSLQueries();
-                    } else {
-                        shouldHandleSessionKeyPAPIQueries();
+                    if (storeToTest.isSession()) {
+                        // Note there's no "timestamped" differentiation here.
+                        // Idiosyncratically, SessionStores are _never_ timestamped.
+                        if (kind.equals("DSL")) {
+                            shouldHandleSessionKeyDSLQueries();
+                        } else {
+                            shouldHandleSessionKeyPAPIQueries();
+                        }
                     }
                 }
 
@@ -939,6 +943,20 @@ public class IQv2StoreIntegrationTest {
         try (final KeyValueIterator<Integer, ValueAndTimestamp<Integer>> it = store.all()) {
             assertThat(it.hasNext(), is(true));
         }
+
+        // Verify headers are accessible via the raw KeyValueStore type
+        final ReadOnlyKeyValueStore<Integer, ValueTimestampHeaders<Integer>> storeWithHeaders =
+            kafkaStreams.store(
+                StoreQueryParameters.fromNameAndType(
+                    STORE_NAME,
+                    QueryableStoreTypes.keyValueStore()
+                )
+            );
+        assertThat(storeWithHeaders, notNullValue());
+        final ValueTimestampHeaders<Integer> resultWithHeaders = storeWithHeaders.get(2);
+        assertThat(resultWithHeaders, notNullValue());
+        assertThat(resultWithHeaders.value(), is(5));
+        assertThat(resultWithHeaders.headers(), notNullValue());
     }
 
     private void shouldHandleIQv1WindowQuery() {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
@@ -57,10 +56,6 @@ import org.apache.kafka.streams.query.WindowRangeQuery;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.QueryableStoreTypes;
-import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
-import org.apache.kafka.streams.state.ReadOnlySessionStore;
-import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -69,7 +64,6 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -121,7 +115,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -337,56 +330,6 @@ public class IQv2StoreIntegrationTest {
             public boolean isSession() {
                 return true;
             }
-        },
-        TIME_ROCKS_KV_HEADERS {
-            @Override
-            public StoreSupplier<?> supplier() {
-                return Stores.persistentTimestampedKeyValueStoreWithHeaders(STORE_NAME);
-            }
-
-            @Override
-            public boolean keyValue() {
-                return true;
-            }
-
-            @Override
-            public boolean isHeadersAware() {
-                return true;
-            }
-        },
-        TIME_ROCKS_WINDOW_HEADERS {
-            @Override
-            public StoreSupplier<?> supplier() {
-                return Stores.persistentTimestampedWindowStoreWithHeaders(
-                    STORE_NAME, Duration.ofDays(1), WINDOW_SIZE, false
-                );
-            }
-
-            @Override
-            public boolean isWindowed() {
-                return true;
-            }
-
-            @Override
-            public boolean isHeadersAware() {
-                return true;
-            }
-        },
-        ROCKS_SESSION_HEADERS {
-            @Override
-            public StoreSupplier<?> supplier() {
-                return Stores.persistentSessionStoreWithHeaders(STORE_NAME, Duration.ofDays(1));
-            }
-
-            @Override
-            public boolean isSession() {
-                return true;
-            }
-
-            @Override
-            public boolean isHeadersAware() {
-                return true;
-            }
         };
 
         public abstract StoreSupplier<?> supplier();
@@ -408,10 +351,6 @@ public class IQv2StoreIntegrationTest {
         }
 
         public boolean isSession() {
-            return false;
-        }
-
-        public boolean isHeadersAware() {
             return false;
         }
     }
@@ -844,79 +783,62 @@ public class IQv2StoreIntegrationTest {
                 shouldRejectUnknownQuery();
                 shouldCollectExecutionInfo();
                 shouldCollectExecutionInfoUnderFailure();
-                // IQv2 is not supported for headers-aware stores.
-                if (!storeToTest.isHeadersAware()) {
-                    if (storeToTest.keyValue()) {
-                        if (storeToTest.timestamped()) {
-                            shouldHandleKeyQuery(2,  5);
-                            shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.makeAllowNullable(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
-                            shouldHandleRangeQueries();
-                            shouldHandleTimestampedRangeQueries(true);
-                        } else {
-                            shouldHandleKeyQuery(2, 5);
-                            shouldHandleRangeQueries();
+                if (storeToTest.keyValue()) {
+                    if (storeToTest.timestamped()) {
+                        shouldHandleKeyQuery(2,  5);
+                        shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.makeAllowNullable(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
+                        shouldHandleRangeQueries();
+                        shouldHandleTimestampedRangeQueries(true);
+                    } else {
+                        shouldHandleKeyQuery(2, 5);
+                        shouldHandleRangeQueries();
 
-                            if (kind.equals("DSL")) {
-                                shouldHandleTimestampedRangeQueries(false);
-                                shouldHandleRangeQueries();
-                                if (cache) {
-                                    shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
-                                } else {
-                                    shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, -1L));
-                                }
-                            } else {
-                                assertThrows(AssertionError.class, () -> shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5)));
-                                assertThrows(AssertionError.class, () -> shouldHandleTimestampedRangeQueries(false));
-                            }
-
-                        }
-                    }
-
-                    if (storeToTest.isWindowed()) {
-                        if (storeToTest.timestamped()) {
-                            final Function<ValueAndTimestamp<Integer>, Integer> valueExtractor =
-                                ValueAndTimestamp::value;
-                            if (kind.equals("DSL")) {
-                                shouldHandleWindowKeyDSLQueries(valueExtractor);
-                                shouldHandleWindowRangeDSLQueries(valueExtractor);
-                            } else {
-                                shouldHandleWindowKeyPAPIQueries(valueExtractor);
-                                shouldHandleWindowRangePAPIQueries(valueExtractor);
-                            }
-                        } else {
-                            final Function<Integer, Integer> valueExtractor = Function.identity();
-                            if (kind.equals("DSL")) {
-                                shouldHandleWindowKeyDSLQueries(valueExtractor);
-                                shouldHandleWindowRangeDSLQueries(valueExtractor);
-                            } else {
-                                shouldHandleWindowKeyPAPIQueries(valueExtractor);
-                                shouldHandleWindowRangePAPIQueries(valueExtractor);
-                            }
-                        }
-                    }
-
-                    if (storeToTest.isSession()) {
-                        // Note there's no "timestamped" differentiation here.
-                        // Idiosyncratically, SessionStores are _never_ timestamped.
                         if (kind.equals("DSL")) {
-                            shouldHandleSessionKeyDSLQueries();
+                            shouldHandleTimestampedRangeQueries(false);
+                            shouldHandleRangeQueries();
+                            if (cache) {
+                                shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5));
+                            } else {
+                                shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, -1L));
+                            }
                         } else {
-                            shouldHandleSessionKeyPAPIQueries();
+                            assertThrows(AssertionError.class, () -> shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5)));
+                            assertThrows(AssertionError.class, () -> shouldHandleTimestampedRangeQueries(false));
+                        }
+
+                    }
+                }
+
+                if (storeToTest.isWindowed()) {
+                    if (storeToTest.timestamped()) {
+                        final Function<ValueAndTimestamp<Integer>, Integer> valueExtractor =
+                            ValueAndTimestamp::value;
+                        if (kind.equals("DSL")) {
+                            shouldHandleWindowKeyDSLQueries(valueExtractor);
+                            shouldHandleWindowRangeDSLQueries(valueExtractor);
+                        } else {
+                            shouldHandleWindowKeyPAPIQueries(valueExtractor);
+                            shouldHandleWindowRangePAPIQueries(valueExtractor);
+                        }
+                    } else {
+                        final Function<Integer, Integer> valueExtractor = Function.identity();
+                        if (kind.equals("DSL")) {
+                            shouldHandleWindowKeyDSLQueries(valueExtractor);
+                            shouldHandleWindowRangeDSLQueries(valueExtractor);
+                        } else {
+                            shouldHandleWindowKeyPAPIQueries(valueExtractor);
+                            shouldHandleWindowRangePAPIQueries(valueExtractor);
                         }
                     }
                 }
 
-                // Headers-aware stores are excluded from the IQv2 blocks above since IQv2 is not
-                // supported for them. Only IQv1 queries are verified below.
-                if (storeToTest.isHeadersAware()) {
-                    if (storeToTest.keyValue()) {
-                        shouldHandleIQv1KeyValueQuery();
-                    }
-                    if (storeToTest.isWindowed()) {
-                        shouldHandleIQv1WindowQuery();
-                    }
-                    if (storeToTest.isSession()) {
-                        shouldHandleIQv1SessionQuery();
+                if (storeToTest.isSession()) {
+                    // Note there's no "timestamped" differentiation here.
+                    // Idiosyncratically, SessionStores are _never_ timestamped.
+                    if (kind.equals("DSL")) {
+                        shouldHandleSessionKeyDSLQueries();
+                    } else {
+                        shouldHandleSessionKeyPAPIQueries();
                     }
                 }
             }
@@ -925,76 +847,6 @@ public class IQv2StoreIntegrationTest {
             throw e;
         }
     }
-
-    private void shouldHandleIQv1KeyValueQuery() {
-        final ReadOnlyKeyValueStore<Integer, ValueAndTimestamp<Integer>> store =
-            kafkaStreams.store(
-                StoreQueryParameters.fromNameAndType(
-                    STORE_NAME,
-                    QueryableStoreTypes.timestampedKeyValueStore()
-                )
-            );
-        assertThat(store, notNullValue());
-        final ValueAndTimestamp<Integer> result = store.get(2);
-        assertThat(result, notNullValue());
-        assertThat(result.value(), is(5));
-
-        // Verify all() iterator is accessible
-        try (final KeyValueIterator<Integer, ValueAndTimestamp<Integer>> it = store.all()) {
-            assertThat(it.hasNext(), is(true));
-        }
-
-        // Verify headers are accessible via the raw KeyValueStore type
-        final ReadOnlyKeyValueStore<Integer, ValueTimestampHeaders<Integer>> storeWithHeaders =
-            kafkaStreams.store(
-                StoreQueryParameters.fromNameAndType(
-                    STORE_NAME,
-                    QueryableStoreTypes.keyValueStore()
-                )
-            );
-        assertThat(storeWithHeaders, notNullValue());
-        final ValueTimestampHeaders<Integer> resultWithHeaders = storeWithHeaders.get(2);
-        assertThat(resultWithHeaders, notNullValue());
-        assertThat(resultWithHeaders.value(), is(5));
-        assertThat(resultWithHeaders.headers(), notNullValue());
-    }
-
-    private void shouldHandleIQv1WindowQuery() {
-        final ReadOnlyWindowStore<Integer, ValueAndTimestamp<Integer>> store =
-            kafkaStreams.store(
-                StoreQueryParameters.fromNameAndType(
-                    STORE_NAME,
-                    QueryableStoreTypes.timestampedWindowStore()
-                )
-            );
-        assertThat(store, notNullValue());
-        try (final WindowStoreIterator<ValueAndTimestamp<Integer>> it = store.fetch(
-            2,
-            Instant.ofEpochMilli(WINDOW_START),
-            Instant.ofEpochMilli(WINDOW_START + WINDOW_SIZE.toMillis())
-        )) {
-            assertThat(it.hasNext(), is(true));
-            final ValueAndTimestamp<Integer> result = it.next().value;
-            assertThat(result, notNullValue());
-            assertThat(result.value(), is(5));
-        }
-    }
-
-    private void shouldHandleIQv1SessionQuery() {
-        final ReadOnlySessionStore<Integer, Integer> store =
-            kafkaStreams.store(
-                StoreQueryParameters.fromNameAndType(
-                    STORE_NAME,
-                    QueryableStoreTypes.sessionStore()
-                )
-            );
-        assertThat(store, notNullValue());
-        try (final KeyValueIterator<Windowed<Integer>, Integer> it = store.fetch(2)) {
-            assertThat(it.hasNext(), is(true));
-            assertThat(it.next().value, is(5));
-        }
-    }
-
 
     private <T> void shouldHandleRangeQueries() {
         shouldHandleRangeQuery(

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
@@ -56,6 +57,10 @@ import org.apache.kafka.streams.query.WindowRangeQuery;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -115,6 +120,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -330,6 +336,56 @@ public class IQv2StoreIntegrationTest {
             public boolean isSession() {
                 return true;
             }
+        },
+        TIME_ROCKS_KV_HEADERS {
+            @Override
+            public StoreSupplier<?> supplier() {
+                return Stores.persistentTimestampedKeyValueStoreWithHeaders(STORE_NAME);
+            }
+
+            @Override
+            public boolean keyValue() {
+                return true;
+            }
+
+            @Override
+            public boolean isHeadersAware() {
+                return true;
+            }
+        },
+        TIME_ROCKS_WINDOW_HEADERS {
+            @Override
+            public StoreSupplier<?> supplier() {
+                return Stores.persistentTimestampedWindowStoreWithHeaders(
+                    STORE_NAME, Duration.ofDays(1), WINDOW_SIZE, false
+                );
+            }
+
+            @Override
+            public boolean isWindowed() {
+                return true;
+            }
+
+            @Override
+            public boolean isHeadersAware() {
+                return true;
+            }
+        },
+        ROCKS_SESSION_HEADERS {
+            @Override
+            public StoreSupplier<?> supplier() {
+                return Stores.persistentSessionStoreWithHeaders(STORE_NAME, Duration.ofDays(1));
+            }
+
+            @Override
+            public boolean isSession() {
+                return true;
+            }
+
+            @Override
+            public boolean isHeadersAware() {
+                return true;
+            }
         };
 
         public abstract StoreSupplier<?> supplier();
@@ -351,6 +407,10 @@ public class IQv2StoreIntegrationTest {
         }
 
         public boolean isSession() {
+            return false;
+        }
+
+        public boolean isHeadersAware() {
             return false;
         }
     }
@@ -841,10 +901,76 @@ public class IQv2StoreIntegrationTest {
                         shouldHandleSessionKeyPAPIQueries();
                     }
                 }
+
+                // IQv1 verification for headers-aware stores: ensure ReadOnly store interfaces
+                // are accessible and return correct results when dsl.store.format=HEADERS is used.
+                if (storeToTest.isHeadersAware()) {
+                    if (storeToTest.keyValue()) {
+                        shouldHandleIQv1KeyValueQuery();
+                    }
+                    if (storeToTest.isWindowed()) {
+                        shouldHandleIQv1WindowQuery();
+                    }
+                    if (storeToTest.isSession()) {
+                        shouldHandleIQv1SessionQuery();
+                    }
+                }
             }
         } catch (final AssertionError e) {
             LOG.error("Failed assertion", e);
             throw e;
+        }
+    }
+
+    private void shouldHandleIQv1KeyValueQuery() {
+        final ReadOnlyKeyValueStore<Integer, ValueAndTimestamp<Integer>> store =
+            kafkaStreams.store(
+                StoreQueryParameters.fromNameAndType(
+                    STORE_NAME,
+                    QueryableStoreTypes.timestampedKeyValueStore()
+                )
+            );
+        assertThat(store, notNullValue());
+        final ValueAndTimestamp<Integer> result = store.get(2);
+        assertThat(result, notNullValue());
+        assertThat(result.value(), is(5));
+
+        // Verify all() iterator is accessible
+        try (final KeyValueIterator<Integer, ValueAndTimestamp<Integer>> it = store.all()) {
+            assertThat(it.hasNext(), is(true));
+        }
+    }
+
+    private void shouldHandleIQv1WindowQuery() {
+        final ReadOnlyWindowStore<Integer, ValueAndTimestamp<Integer>> store =
+            kafkaStreams.store(
+                StoreQueryParameters.fromNameAndType(
+                    STORE_NAME,
+                    QueryableStoreTypes.timestampedWindowStore()
+                )
+            );
+        assertThat(store, notNullValue());
+        final ValueAndTimestamp<Integer> result = store.fetch(
+            2,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START + WINDOW_SIZE.toMillis())
+        );
+        assertThat(result, notNullValue());
+        assertThat(result.value(), is(5));
+    }
+
+    private void shouldHandleIQv1SessionQuery() {
+        final ReadOnlySessionStore<Integer, Integer> store =
+            kafkaStreams.store(
+                StoreQueryParameters.fromNameAndType(
+                    STORE_NAME,
+                    QueryableStoreTypes.sessionStore()
+                )
+            );
+        assertThat(store, notNullValue());
+        try (final KeyValueIterator<Windowed<Integer>, Integer> it = store.fetch(2)) {
+            assertThat(it.hasNext(), is(true));
+            assertThat(it.next().value, is(5));
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -906,8 +906,8 @@ public class IQv2StoreIntegrationTest {
                     }
                 }
 
-                // IQv1 verification for headers-aware stores: ensure ReadOnly store interfaces
-                // are accessible and return correct results when dsl.store.format=HEADERS is used.
+                // Headers-aware stores are excluded from the IQv2 blocks above since IQv2 is not
+                // supported for them. Only IQv1 queries are verified below.
                 if (storeToTest.isHeadersAware()) {
                     if (storeToTest.keyValue()) {
                         shouldHandleIQv1KeyValueQuery();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -47,8 +47,11 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -1297,11 +1300,8 @@ public class QueryableStateIntegrationTest {
         }
     }
 
-    // IQv1 verification for headers-aware stores (KIP-1271/KIP-1285): ensures that
-    // ReadOnlyKeyValueStore is accessible and returns correct results when a
-    // persistentTimestampedKeyValueStoreWithHeaders supplier is used directly.
     @Test
-    public void shouldBeAbleToQueryHeadersAwareStoreWithIQv1(final TestInfo testInfo) throws Exception {
+    public void shouldQueryHeadersAwareKeyValueStoreBasicOperations(final TestInfo testInfo) throws Exception {
         final String uniqueTestName = safeUniqueTestName(testInfo);
         final String inputTopic = uniqueTestName + "-input";
         final String storeName = uniqueTestName + "-store";
@@ -1326,7 +1326,13 @@ public class QueryableStateIntegrationTest {
         try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
             IntegrationTestUtils.produceKeyValuesSynchronously(
                 inputTopic,
-                Collections.singletonList(new KeyValue<>("hello", "world")),
+                Arrays.asList(
+                    new KeyValue<>("alpha", "a1"),
+                    new KeyValue<>("beta", "b1"),
+                    new KeyValue<>("gamma", "g1"),
+                    new KeyValue<>("delta", "d1"),
+                    new KeyValue<>("epsilon", "e1")
+                ),
                 TestUtils.producerConfig(
                     CLUSTER.bootstrapServers(),
                     StringSerializer.class,
@@ -1335,23 +1341,386 @@ public class QueryableStateIntegrationTest {
                 CLUSTER.time
             );
 
-            // Wait until the store reflects the produced record
             retryOnExceptionWithTimeout(30_000, () -> {
-                final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store =
-                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStore()));
-                assertThat(store, notNullValue());
-                final ValueAndTimestamp<String> result = store.get("hello");
-                assertThat(result, notNullValue());
-                assertThat(result.value(), is("world"));
-
-                // Verify headers are accessible via the raw KeyValueStore type
-                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> storeWithHeaders =
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
                     streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
-                assertThat(storeWithHeaders, notNullValue());
-                final ValueTimestampHeaders<String> resultWithHeaders = storeWithHeaders.get("hello");
-                assertThat(resultWithHeaders, notNullValue());
-                assertThat(resultWithHeaders.value(), is("world"));
-                assertThat(resultWithHeaders.headers(), notNullValue());
+                assertThat(store, notNullValue());
+
+                final ValueTimestampHeaders<String> result = store.get("alpha");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("a1"));
+                assertThat(result.timestamp() > 0, is(true));
+                assertThat(result.headers(), notNullValue());
+
+                assertThat(store.get("nonexistent"), org.hamcrest.CoreMatchers.nullValue());
+
+                assertThat(store.approximateNumEntries(), is(5L));
+
+                final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> tsStore =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStore()));
+                assertThat(tsStore, notNullValue());
+                final ValueAndTimestamp<String> tsResult = tsStore.get("beta");
+                assertThat(tsResult, notNullValue());
+                assertThat(tsResult.value(), is("b1"));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareKeyValueStoreIterationOperations(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("apple", "fruit"),
+                    new KeyValue<>("banana", "fruit"),
+                    new KeyValue<>("carrot", "vegetable"),
+                    new KeyValue<>("date", "fruit"),
+                    new KeyValue<>("eggplant", "vegetable")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                assertThat(store, notNullValue());
+                assertThat(store.get("apple"), notNullValue());
+
+                int rangeCount = 0;
+                try (final KeyValueIterator<String, ValueTimestampHeaders<String>> range = store.range("banana", "date")) {
+                    while (range.hasNext()) {
+                        final KeyValue<String, ValueTimestampHeaders<String>> entry = range.next();
+                        assertThat(entry.value, notNullValue());
+                        assertThat(entry.value.headers(), notNullValue());
+                        rangeCount++;
+                    }
+                }
+                assertThat(rangeCount, is(3));
+
+                int allCount = 0;
+                try (final KeyValueIterator<String, ValueTimestampHeaders<String>> all = store.all()) {
+                    while (all.hasNext()) {
+                        final KeyValue<String, ValueTimestampHeaders<String>> entry = all.next();
+                        assertThat(entry.value, notNullValue());
+                        assertThat(entry.value.headers(), notNullValue());
+                        allCount++;
+                    }
+                }
+                assertThat(allCount, is(5));
+
+                int prefixCount = 0;
+                try (final KeyValueIterator<String, ValueTimestampHeaders<String>> prefix =
+                         store.prefixScan("ba", new StringSerializer())) {
+                    while (prefix.hasNext()) {
+                        final KeyValue<String, ValueTimestampHeaders<String>> entry = prefix.next();
+                        assertThat(entry.key, is("banana"));
+                        assertThat(entry.value.value(), is("fruit"));
+                        assertThat(entry.value.headers(), notNullValue());
+                        prefixCount++;
+                    }
+                }
+                assertThat(prefixCount, is(1));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareKeyValueStoreViaDslConfig(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(storeName)
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            mkEntry(StreamsConfig.DSL_STORE_FORMAT_CONFIG, "headers")
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("key1", "val1")),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                assertThat(store, notNullValue());
+                final ValueTimestampHeaders<String> result = store.get("key1");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("val1"));
+                assertThat(result.headers(), notNullValue());
+
+                final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> tsStore =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStore()));
+                assertThat(tsStore, notNullValue());
+                final ValueAndTimestamp<String> tsResult = tsStore.get("key1");
+                assertThat(tsResult, notNullValue());
+                assertThat(tsResult.value(), is("val1"));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareWindowStoreOperations(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-window-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(WINDOW_SIZE)))
+            .count(Materialized.<String, Long>as(
+                Stores.persistentTimestampedWindowStoreWithHeaders(storeName, ofMillis(WINDOW_SIZE), ofMillis(WINDOW_SIZE), false))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long()));
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("w-key1", "v1"),
+                    new KeyValue<>("w-key1", "v2"),
+                    new KeyValue<>("w-key2", "v3")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyWindowStore<String, ValueTimestampHeaders<Long>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedWindowStoreWithHeaders()));
+                assertThat(store, notNullValue());
+
+                int fetchCount = 0;
+                try (final WindowStoreIterator<ValueTimestampHeaders<Long>> iter =
+                         store.fetch("w-key1", ofEpochMilli(0), ofEpochMilli(System.currentTimeMillis() + WINDOW_SIZE))) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Long, ValueTimestampHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value, notNullValue());
+                        assertThat(entry.value.value(), is(2L));
+                        assertThat(entry.value.headers(), notNullValue());
+                        fetchCount++;
+                    }
+                }
+                assertThat(fetchCount > 0, is(true));
+
+                int allCount = 0;
+                try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<Long>> all = store.all()) {
+                    while (all.hasNext()) {
+                        final KeyValue<Windowed<String>, ValueTimestampHeaders<Long>> entry = all.next();
+                        assertThat(entry.value, notNullValue());
+                        assertThat(entry.value.headers(), notNullValue());
+                        allCount++;
+                    }
+                }
+                assertThat(allCount, is(2));
+
+                final ReadOnlyWindowStore<String, ValueAndTimestamp<Long>> tsStore =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedWindowStore()));
+                assertThat(tsStore, notNullValue());
+                try (final WindowStoreIterator<ValueAndTimestamp<Long>> tsIter =
+                         tsStore.fetch("w-key2", ofEpochMilli(0), ofEpochMilli(System.currentTimeMillis() + WINDOW_SIZE))) {
+                    assertThat(tsIter.hasNext(), is(true));
+                    assertThat(tsIter.next().value.value(), is(1L));
+                }
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareSessionStoreOperations(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-session-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(ofMillis(WINDOW_SIZE)))
+            .count(Materialized.<String, Long>as(
+                Stores.persistentSessionStoreWithHeaders(storeName, ofMillis(WINDOW_SIZE)))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long()));
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("s-key1", "v1"),
+                    new KeyValue<>("s-key1", "v2"),
+                    new KeyValue<>("s-key2", "v3")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlySessionStore<String, AggregationWithHeaders<Long>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.sessionStoreWithHeaders()));
+                assertThat(store, notNullValue());
+
+                int sessionCount = 0;
+                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iter = store.fetch("s-key1")) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Windowed<String>, AggregationWithHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value, notNullValue());
+                        assertThat(entry.value.aggregation(), is(2L));
+                        assertThat(entry.value.headers(), notNullValue());
+                        sessionCount++;
+                    }
+                }
+                assertThat(sessionCount, is(1));
+
+                final ReadOnlySessionStore<String, Long> plainStore =
+                    streams.store(fromNameAndType(storeName, sessionStore()));
+                assertThat(plainStore, notNullValue());
+                try (final KeyValueIterator<Windowed<String>, Long> plainIter = plainStore.fetch("s-key2")) {
+                    assertThat(plainIter.hasNext(), is(true));
+                    assertThat(plainIter.next().value, is(1L));
+                }
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareKeyValueStoreAfterRestart(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+        final String stateDir = TestUtils.tempDirectory("headers-restart-test").getPath();
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir)
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("r-key1", "val1"),
+                    new KeyValue<>("r-key2", "val2")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                assertThat(store.get("r-key1"), notNullValue());
+                assertThat(store.get("r-key1").value(), is("val1"));
+            });
+        }
+
+        final StreamsBuilder builder2 = new StreamsBuilder();
+        builder2.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        try (final KafkaStreams streams2 = getRunningStreams(properties, builder2, true)) {
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams2.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                assertThat(store, notNullValue());
+                final ValueTimestampHeaders<String> result = store.get("r-key1");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("val1"));
+                assertThat(result.headers(), notNullValue());
+
+                final ValueTimestampHeaders<String> result2 = store.get("r-key2");
+                assertThat(result2, notNullValue());
+                assertThat(result2.value(), is("val2"));
             });
         }
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -1346,7 +1346,7 @@ public class QueryableStateIntegrationTest {
 
                 // Verify headers are accessible via the raw KeyValueStore type
                 final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> storeWithHeaders =
-                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
                 assertThat(storeWithHeaders, notNullValue());
                 final ValueTimestampHeaders<String> resultWithHeaders = storeWithHeaders.get("hello");
                 assertThat(resultWithHeaders, notNullValue());

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -86,6 +86,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1721,6 +1722,441 @@ public class QueryableStateIntegrationTest {
                 final ValueTimestampHeaders<String> result2 = store.get("r-key2");
                 assertThat(result2, notNullValue());
                 assertThat(result2.value(), is("val2"));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareKeyValueStoreReverseOperations(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("alpha", "a1"),
+                    new KeyValue<>("beta", "b1"),
+                    new KeyValue<>("gamma", "g1"),
+                    new KeyValue<>("delta", "d1"),
+                    new KeyValue<>("epsilon", "e1")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                assertThat(store.get("alpha"), notNullValue());
+
+                final List<String> reverseRangeKeys = new ArrayList<>();
+                try (final KeyValueIterator<String, ValueTimestampHeaders<String>> iter = store.reverseRange("beta", "epsilon")) {
+                    while (iter.hasNext()) {
+                        final KeyValue<String, ValueTimestampHeaders<String>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        reverseRangeKeys.add(entry.key);
+                    }
+                }
+                assertThat(reverseRangeKeys, is(Arrays.asList("epsilon", "delta", "beta")));
+
+                final List<String> reverseAllKeys = new ArrayList<>();
+                try (final KeyValueIterator<String, ValueTimestampHeaders<String>> iter = store.reverseAll()) {
+                    while (iter.hasNext()) {
+                        final KeyValue<String, ValueTimestampHeaders<String>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        reverseAllKeys.add(entry.key);
+                    }
+                }
+                assertThat(reverseAllKeys, is(Arrays.asList("gamma", "epsilon", "delta", "beta", "alpha")));
+            });
+        }
+    }
+
+    private <K, V> int countAndVerifyHeaders(final KeyValueIterator<K, V> iter,
+                                              final java.util.function.Function<V, Object> headersExtractor) {
+        int count = 0;
+        try (iter) {
+            while (iter.hasNext()) {
+                final KeyValue<K, V> entry = iter.next();
+                assertThat(headersExtractor.apply(entry.value), notNullValue());
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private <V> int countAndVerifyWindowHeaders(final WindowStoreIterator<V> iter,
+                                                 final java.util.function.Function<V, Object> headersExtractor) {
+        int count = 0;
+        try (iter) {
+            while (iter.hasNext()) {
+                final KeyValue<Long, V> entry = iter.next();
+                assertThat(headersExtractor.apply(entry.value), notNullValue());
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareWindowStoreBackwardAndFetchAllOperations(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-window-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(WINDOW_SIZE)))
+            .count(Materialized.<String, Long>as(
+                Stores.persistentTimestampedWindowStoreWithHeaders(storeName, ofMillis(WINDOW_SIZE), ofMillis(WINDOW_SIZE), false))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long()));
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("wa", "v1"),
+                    new KeyValue<>("wb", "v2"),
+                    new KeyValue<>("wc", "v3")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyWindowStore<String, ValueTimestampHeaders<Long>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedWindowStoreWithHeaders()));
+                assertThat(store, notNullValue());
+
+                final Instant timeFrom = ofEpochMilli(0);
+                final Instant timeTo = ofEpochMilli(System.currentTimeMillis() + WINDOW_SIZE);
+                final java.util.function.Function<ValueTimestampHeaders<Long>, Object> h = ValueTimestampHeaders::headers;
+
+                assertThat(countAndVerifyWindowHeaders(store.backwardFetch("wa", timeFrom, timeTo), h) > 0, is(true));
+                assertThat(countAndVerifyHeaders(store.fetchAll(timeFrom, timeTo), h), is(3));
+                assertThat(countAndVerifyHeaders(store.backwardFetchAll(timeFrom, timeTo), h), is(3));
+                assertThat(countAndVerifyHeaders(store.backwardAll(), h), is(3));
+                assertThat(countAndVerifyHeaders(store.fetch("wa", "wc", timeFrom, timeTo), h), is(3));
+                assertThat(countAndVerifyHeaders(store.backwardFetch("wa", "wc", timeFrom, timeTo), h), is(3));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareWindowStoreSinglePointLookup(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-window-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(WINDOW_SIZE)))
+            .count(Materialized.<String, Long>as(
+                Stores.persistentTimestampedWindowStoreWithHeaders(storeName, ofMillis(WINDOW_SIZE), ofMillis(WINDOW_SIZE), false))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long()));
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("wpt-key", "v1")),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyWindowStore<String, ValueTimestampHeaders<Long>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedWindowStoreWithHeaders()));
+                assertThat(store, notNullValue());
+
+                Long windowStart = null;
+                try (final WindowStoreIterator<ValueTimestampHeaders<Long>> iter =
+                         store.fetch("wpt-key", ofEpochMilli(0), ofEpochMilli(System.currentTimeMillis() + WINDOW_SIZE))) {
+                    assertThat(iter.hasNext(), is(true));
+                    windowStart = iter.next().key;
+                }
+                assertThat(windowStart, notNullValue());
+
+                final ValueTimestampHeaders<Long> pointResult = store.fetch("wpt-key", windowStart);
+                assertThat(pointResult, notNullValue());
+                assertThat(pointResult.value(), is(1L));
+                assertThat(pointResult.headers(), notNullValue());
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareSessionStoreBackwardAndFindSessionsOperations(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-session-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey()
+            .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(ofMillis(WINDOW_SIZE)))
+            .count(Materialized.<String, Long>as(
+                Stores.persistentSessionStoreWithHeaders(storeName, ofMillis(WINDOW_SIZE)))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long()));
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Arrays.asList(
+                    new KeyValue<>("sa", "v1"),
+                    new KeyValue<>("sa", "v2"),
+                    new KeyValue<>("sb", "v3"),
+                    new KeyValue<>("sc", "v4")
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlySessionStore<String, AggregationWithHeaders<Long>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.sessionStoreWithHeaders()));
+                assertThat(store, notNullValue());
+
+                int backwardFetchCount = 0;
+                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iter = store.backwardFetch("sa")) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Windowed<String>, AggregationWithHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        assertThat(entry.value.aggregation(), is(2L));
+                        backwardFetchCount++;
+                    }
+                }
+                assertThat(backwardFetchCount, is(1));
+
+                int findSessionsCount = 0;
+                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iter =
+                         store.findSessions("sa", 0L, System.currentTimeMillis() + WINDOW_SIZE)) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Windowed<String>, AggregationWithHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        findSessionsCount++;
+                    }
+                }
+                assertThat(findSessionsCount, is(1));
+
+                int backwardFindSessionsCount = 0;
+                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iter =
+                         store.backwardFindSessions("sa", 0L, System.currentTimeMillis() + WINDOW_SIZE)) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Windowed<String>, AggregationWithHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        backwardFindSessionsCount++;
+                    }
+                }
+                assertThat(backwardFindSessionsCount, is(1));
+
+                int multiKeyFetchCount = 0;
+                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iter = store.fetch("sa", "sc")) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Windowed<String>, AggregationWithHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        multiKeyFetchCount++;
+                    }
+                }
+                assertThat(multiKeyFetchCount, is(3));
+
+                int multiKeyBackwardCount = 0;
+                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<Long>> iter = store.backwardFetch("sa", "sc")) {
+                    while (iter.hasNext()) {
+                        final KeyValue<Windowed<String>, AggregationWithHeaders<Long>> entry = iter.next();
+                        assertThat(entry.value.headers(), notNullValue());
+                        multiKeyBackwardCount++;
+                    }
+                }
+                assertThat(multiKeyBackwardCount, is(3));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareKeyValueStoreWithRecordUpdate(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("upd-key", "v1")),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                final ValueTimestampHeaders<String> result = store.get("upd-key");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("v1"));
+            });
+
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("upd-key", "v2")),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                final ValueTimestampHeaders<String> result = store.get("upd-key");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("v2"));
+                assertThat(result.headers(), notNullValue());
+                assertThat(store.approximateNumEntries(), is(1L));
+            });
+        }
+    }
+
+    @Test
+    public void shouldQueryHeadersAwareKeyValueStoreWithTombstone(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("tomb-key", "alive")),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                final ValueTimestampHeaders<String> result = store.get("tomb-key");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("alive"));
+            });
+
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("tomb-key", (String) null)),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
+                assertThat(store.get("tomb-key"), org.hamcrest.CoreMatchers.nullValue());
             });
         }
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -53,10 +53,10 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
-import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.NoRetryException;
@@ -1311,7 +1311,7 @@ public class QueryableStateIntegrationTest {
         builder.table(
             inputTopic,
             Consumed.with(Serdes.String(), Serdes.String()),
-            Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(
+            Materialized.<String, String>as(
                 Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
                 .withKeySerde(Serdes.String())
                 .withValueSerde(Serdes.String())

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -57,6 +57,7 @@ import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.NoRetryException;
@@ -1342,6 +1343,15 @@ public class QueryableStateIntegrationTest {
                 final ValueAndTimestamp<String> result = store.get("hello");
                 assertThat(result, notNullValue());
                 assertThat(result.value(), is("world"));
+
+                // Verify headers are accessible via the raw KeyValueStore type
+                final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> storeWithHeaders =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
+                assertThat(storeWithHeaders, notNullValue());
+                final ValueTimestampHeaders<String> resultWithHeaders = storeWithHeaders.get("hello");
+                assertThat(resultWithHeaders, notNullValue());
+                assertThat(resultWithHeaders.value(), is("world"));
+                assertThat(resultWithHeaders.headers(), notNullValue());
             });
         }
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -53,6 +53,8 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -113,6 +115,7 @@ import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
 import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1290,6 +1293,56 @@ public class QueryableStateIntegrationTest {
                     incrementIteration();
                 }
             }
+        }
+    }
+
+    // IQv1 verification for headers-aware stores (KIP-1271/KIP-1285): ensures that
+    // ReadOnlyKeyValueStore is accessible and returns correct results when a
+    // persistentTimestampedKeyValueStoreWithHeaders supplier is used directly.
+    @Test
+    public void shouldBeAbleToQueryHeadersAwareStoreWithIQv1(final TestInfo testInfo) throws Exception {
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        final String inputTopic = uniqueTestName + "-input";
+        final String storeName = uniqueTestName + "-store";
+
+        CLUSTER.createTopic(inputTopic);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            inputTopic,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName))
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+        );
+
+        final Properties properties = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, uniqueTestName + "-app"),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+        ));
+
+        try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
+            IntegrationTestUtils.produceKeyValuesSynchronously(
+                inputTopic,
+                Collections.singletonList(new KeyValue<>("hello", "world")),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    StringSerializer.class,
+                    StringSerializer.class,
+                    new Properties()),
+                CLUSTER.time
+            );
+
+            // Wait until the store reflects the produced record
+            retryOnExceptionWithTimeout(30_000, () -> {
+                final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store =
+                    streams.store(fromNameAndType(storeName, QueryableStoreTypes.timestampedKeyValueStore()));
+                assertThat(store, notNullValue());
+                final ValueAndTimestamp<String> result = store.get("hello");
+                assertThat(result, notNullValue());
+                assertThat(result.value(), is("world"));
+            });
         }
     }
 


### PR DESCRIPTION
KAFKA-20259: Verify IQv1 and IQv2 do not break with headers-aware state stores
    
    Add verification that IQv1 and IQv2 query interfaces work correctly
    against the headers-aware state stores introduced by KIP-1271/KIP-1285.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
