### PR TITLE
MINOR: Sort reviewer candidates by contribution count

### DIFF
--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -97,6 +97,8 @@ if __name__ == "__main__":
             if item[1] > 2:
                 parsed_reviewers.append((m.group("name"), m.group("email"), item[1]))
 
+    parsed_reviewers.sort(key=lambda x: x[2], reverse=True)
+
     selected_reviewers = []
     while True:
         if selected_reviewers:
@@ -113,7 +115,7 @@ if __name__ == "__main__":
         if not candidates:
             continue
 
-        print("\nPossible matches (in order of most recent):")
+        print("\nPossible matches (in order of most contributions):")
         for i, candidate in zip(range(10), candidates):
             print(f"[{i+1}] {candidate[0]} {candidate[1]} ({candidate[2]})")
 


### PR DESCRIPTION
There can only be one Chia.

Reviewer candidates were listed in git log insertion order, not by
contribution count. Chia-Ping Tsai (2305 contributions) was showing up
below Chia-Yi Chiu (3 contributions), and he was not happy about it.
Just kidding, this is definitely to make it easy for committers/PMCs to
just hit 1 and press enter.

**Before:**
```
Name or email (case insensitive): chia

Possible matches (in order of most recent):
[1] Chia-Yi Chiu cychiu8@gmail.com (3)
[2] Chia-Ping Tsai chia7712@gmail.com (2305)
[3] Chia-Ping Tsai chia7712@apache.org (13)
[4] Chia-Chuan Yu yujuan476@gmail.com (11)
[5] Chia Chuan Yu yujuan476@gmail.com (10)
```

Reviewers: Andrew Schofield <aschofield@confluent.io>
