### PR TITLE
[POC] KAFKA-20171: Kafka Streams use topic ids.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -227,7 +227,8 @@ public class RequestManagers implements Closeable {
                             backgroundEventHandler,
                             logContext,
                             time,
-                            metrics);
+                            metrics, 
+                            metadata);
                         streamsMembershipManager.registerStateListener(commitRequestManager);
                         streamsMembershipManager.registerStateListener(applicationThreadMemberStateListener);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -81,6 +82,7 @@ public class StreamsMembershipManager implements RequestManager {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             false
         );
 
@@ -88,17 +90,20 @@ public class StreamsMembershipManager implements RequestManager {
         public final Map<String, SortedSet<Integer>> activeTasks;
         public final Map<String, SortedSet<Integer>> standbyTasks;
         public final Map<String, SortedSet<Integer>> warmupTasks;
+        public final Map<String, SortedSet<Uuid>> resolvedTopicIds;
         public final boolean isGroupReady;
 
         public LocalAssignment(final long localEpoch,
                                final Map<String, SortedSet<Integer>> activeTasks,
                                final Map<String, SortedSet<Integer>> standbyTasks,
                                final Map<String, SortedSet<Integer>> warmupTasks,
+                               final Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                final boolean isGroupReady) {
             this.localEpoch = localEpoch;
             this.activeTasks = activeTasks;
             this.standbyTasks = standbyTasks;
             this.warmupTasks = warmupTasks;
+            this.resolvedTopicIds = resolvedTopicIds;
             this.isGroupReady = isGroupReady;
             if (localEpoch == NONE_EPOCH &&
                     (!activeTasks.isEmpty() || !standbyTasks.isEmpty() || !warmupTasks.isEmpty())) {
@@ -109,18 +114,20 @@ public class StreamsMembershipManager implements RequestManager {
         Optional<LocalAssignment> updateWith(final Map<String, SortedSet<Integer>> activeTasks,
                                              final Map<String, SortedSet<Integer>> standbyTasks,
                                              final Map<String, SortedSet<Integer>> warmupTasks,
+                                             Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                              final boolean isGroupReady) {
             if (localEpoch != NONE_EPOCH &&
                     activeTasks.equals(this.activeTasks) &&
                     standbyTasks.equals(this.standbyTasks) &&
                     warmupTasks.equals(this.warmupTasks) &&
+                    resolvedTopicIds.equals(this.resolvedTopicIds) &&
                     isGroupReady == this.isGroupReady
             ) {
                 return Optional.empty();
             }
 
             long nextLocalEpoch = localEpoch + 1;
-            return Optional.of(new LocalAssignment(nextLocalEpoch, activeTasks, standbyTasks, warmupTasks, isGroupReady));
+            return Optional.of(new LocalAssignment(nextLocalEpoch, activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady));
         }
 
         @Override
@@ -130,6 +137,7 @@ public class StreamsMembershipManager implements RequestManager {
                 ", activeTasks=" + activeTasks +
                 ", standbyTasks=" + standbyTasks +
                 ", warmupTasks=" + warmupTasks +
+                ", resolvedTopicIds=" + resolvedTopicIds +
                 ", isGroupReady=" + isGroupReady +
                 '}';
         }
@@ -143,12 +151,13 @@ public class StreamsMembershipManager implements RequestManager {
                 Objects.equals(activeTasks, that.activeTasks) &&
                 Objects.equals(standbyTasks, that.standbyTasks) &&
                 Objects.equals(warmupTasks, that.warmupTasks) &&
+                Objects.equals(resolvedTopicIds, that.resolvedTopicIds) &&
                 isGroupReady == that.isGroupReady;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(localEpoch, activeTasks, standbyTasks, warmupTasks, isGroupReady);
+            return Objects.hash(localEpoch, activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady);
         }
     }
 
@@ -281,6 +290,10 @@ public class StreamsMembershipManager implements RequestManager {
      */
     private boolean isPollTimerExpired;
 
+    private final ConsumerMetadata metadata;
+
+    private final Map<Uuid, String> assignedTopicNamesCache;
+
     /**
      * Constructs the Streams membership manager.
      *
@@ -298,13 +311,17 @@ public class StreamsMembershipManager implements RequestManager {
                                     final BackgroundEventHandler backgroundEventHandler,
                                     final LogContext logContext,
                                     final Time time,
-                                    final Metrics metrics) {
+                                    final Metrics metrics, 
+                                    final ConsumerMetadata metadata
+                                    ) {
         log = logContext.logger(StreamsMembershipManager.class);
         this.state = MemberState.UNSUBSCRIBED;
         this.groupId = groupId;
         this.backgroundEventHandler = backgroundEventHandler;
         this.streamsRebalanceData = streamsRebalanceData;
         this.subscriptionState = subscriptionState;
+        this.metadata = metadata;
+        this.assignedTopicNamesCache = new HashMap<>();
         metricsManager = new ConsumerRebalanceMetricsManager(metrics, subscriptionState);
         this.time = time;
     }
@@ -716,6 +733,7 @@ public class StreamsMembershipManager implements RequestManager {
         final List<StreamsGroupHeartbeatResponseData.TaskIds> activeTasks = responseData.activeTasks();
         final List<StreamsGroupHeartbeatResponseData.TaskIds> standbyTasks = responseData.standbyTasks();
         final List<StreamsGroupHeartbeatResponseData.TaskIds> warmupTasks = responseData.warmupTasks();
+        final List<StreamsGroupHeartbeatResponseData.ResolvedTopicIds> resolvedTopicIds = responseData.resolvedTopicIdsBySubtopology();
         final boolean isGroupReady = isGroupReady(responseData.status());
 
         if (activeTasks != null && standbyTasks != null && warmupTasks != null) {
@@ -730,9 +748,11 @@ public class StreamsMembershipManager implements RequestManager {
                 toTasksAssignment(activeTasks),
                 toTasksAssignment(standbyTasks),
                 toTasksAssignment(warmupTasks),
+                toSortedTopicIds(resolvedTopicIds),
                 isGroupReady
             );
-        } else if (responseData.activeTasks() != null || responseData.standbyTasks() != null || responseData.warmupTasks() != null) {
+        } else if (responseData.activeTasks() != null || responseData.standbyTasks() != null || responseData.warmupTasks() != null || 
+                responseData.resolvedTopicIdsBySubtopology() != null) {
             throw new IllegalStateException("Invalid response data, task collections must be all null or all non-null: "
                 + responseData);
         } else if (isGroupReady != targetAssignment.isGroupReady) {
@@ -742,6 +762,7 @@ public class StreamsMembershipManager implements RequestManager {
                 targetAssignment.activeTasks,
                 targetAssignment.standbyTasks,
                 targetAssignment.warmupTasks,
+                targetAssignment.resolvedTopicIds,
                 isGroupReady
             );
         }
@@ -898,6 +919,14 @@ public class StreamsMembershipManager implements RequestManager {
             .collect(Collectors.toMap(StreamsGroupHeartbeatResponseData.TaskIds::subtopologyId, taskId -> new TreeSet<>(taskId.partitions())));
     }
 
+    private static Map<String, SortedSet<Uuid>> toSortedTopicIds(final List<StreamsGroupHeartbeatResponseData.ResolvedTopicIds> resolvedTopicIds) {
+        final Map<String, SortedSet<Uuid>> result = new HashMap<>();
+        for (StreamsGroupHeartbeatResponseData.ResolvedTopicIds resolvedTopicId : resolvedTopicIds) {
+            result.put(resolvedTopicId.subtopologyId(), new TreeSet<>(resolvedTopicId.topicIds()));
+        }
+        return result;
+    }
+
     /**
      * Leaves the group when the member closes.
      *
@@ -973,7 +1002,7 @@ public class StreamsMembershipManager implements RequestManager {
 
     private CompletableFuture<Void> releaseActiveTasks() {
         if (memberEpoch > 0) {
-            return revokeActiveTasks(toTaskIdSet(currentAssignment.activeTasks));
+            return revokeActiveTasks(toTaskIdSet(currentAssignment.activeTasks), subscriptionState.assignedPartitions());
         } else {
             return releaseLostActiveTasks();
         }
@@ -1012,8 +1041,9 @@ public class StreamsMembershipManager implements RequestManager {
     private void processAssignmentReceived(Map<String, SortedSet<Integer>> activeTasks,
                                            Map<String, SortedSet<Integer>> standbyTasks,
                                            Map<String, SortedSet<Integer>> warmupTasks,
+                                           Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                            boolean isGroupReady) {
-        replaceTargetAssignmentWithNewAssignment(activeTasks, standbyTasks, warmupTasks, isGroupReady);
+        replaceTargetAssignmentWithNewAssignment(activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady);
         if (!targetAssignmentReconciled()) {
             transitionTo(MemberState.RECONCILING);
         } else {
@@ -1033,8 +1063,9 @@ public class StreamsMembershipManager implements RequestManager {
     private void replaceTargetAssignmentWithNewAssignment(Map<String, SortedSet<Integer>> activeTasks,
                                                           Map<String, SortedSet<Integer>> standbyTasks,
                                                           Map<String, SortedSet<Integer>> warmupTasks,
+                                                          Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                                           boolean isGroupReady) {
-        targetAssignment.updateWith(activeTasks, standbyTasks, warmupTasks, isGroupReady)
+        targetAssignment.updateWith(activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady)
             .ifPresent(updatedAssignment -> {
                 log.debug("Target assignment updated from {} to {}. Member will reconcile it on the next poll.",
                     targetAssignment, updatedAssignment);
@@ -1062,9 +1093,14 @@ public class StreamsMembershipManager implements RequestManager {
      *  - Another reconciliation is already in progress.
      */
     private void maybeReconcile() {
-        if (targetAssignmentReconciled()) {
+        MaterializationPlan targetMaterializationPlan = buildMaterializationPlan(targetAssignment);
+        final SortedSet<TopicPartition> targetFetchablePartitions = targetMaterializationPlan.fetchablePartitions();
+        final SortedSet<TopicPartition> currentFetchablePartitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        currentFetchablePartitions.addAll(subscriptionState.assignedPartitions());
+
+        if (targetAssignmentReconciled() && currentFetchablePartitions.equals(targetFetchablePartitions)) {
             log.trace("Ignoring reconciliation attempt. Target assignment is equal to the " +
-                "current assignment.");
+                "current assignment and the materialized partitions are already applied.");
             return;
         }
         if (reconciliationInProgress) {
@@ -1085,46 +1121,60 @@ public class StreamsMembershipManager implements RequestManager {
         SortedSet<StreamsRebalanceData.TaskId> ownedWarmupTasks = toTaskIdSet(currentAssignment.warmupTasks);
         boolean isGroupReady = targetAssignment.isGroupReady;
 
-        log.info("Assigned tasks with local epoch {} and group {}\n" +
-                "\tMember:                        {}\n" +
-                "\tAssigned active tasks:         {}\n" +
-                "\tOwned active tasks:            {}\n" +
-                "\tActive tasks to revoke:        {}\n" +
-                "\tAssigned standby tasks:        {}\n" +
-                "\tOwned standby tasks:           {}\n" +
-                "\tAssigned warm-up tasks:        {}\n" +
-                "\tOwned warm-up tasks:           {}\n",
-            targetAssignment.localEpoch,
-            isGroupReady ? "is ready" : "is not ready",
-            memberId,
-            assignedActiveTasks,
-            ownedActiveTasks,
-            activeTasksToRevoke,
-            assignedStandbyTasks,
-            ownedStandbyTasks,
-            assignedWarmupTasks,
-            ownedWarmupTasks
-        );
-
-        SortedSet<TopicPartition> ownedTopicPartitionsFromSubscriptionState = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
-        ownedTopicPartitionsFromSubscriptionState.addAll(subscriptionState.assignedPartitions());
-        SortedSet<TopicPartition> ownedTopicPartitionsFromAssignedTasks =
-            topicPartitionsForActiveTasks(currentAssignment.activeTasks);
-        if (!ownedTopicPartitionsFromAssignedTasks.equals(ownedTopicPartitionsFromSubscriptionState)) {
-            throw new IllegalStateException("Owned partitions from subscription state and owned partitions from " +
-                "assigned active tasks are not equal. " +
-                "Owned partitions from subscription state: " + ownedTopicPartitionsFromSubscriptionState + ", " +
-                "Owned partitions from assigned active tasks: " + ownedTopicPartitionsFromAssignedTasks);
+        if (!targetAssignmentReconciled()) {
+            log.info("Assigned tasks with local epoch {} and group {}\n" +
+                            "\tMember:                        {}\n" +
+                            "\tAssigned active tasks:         {}\n" +
+                            "\tOwned active tasks:            {}\n" +
+                            "\tActive tasks to revoke:        {}\n" +
+                            "\tAssigned standby tasks:        {}\n" +
+                            "\tOwned standby tasks:           {}\n" +
+                            "\tAssigned warm-up tasks:        {}\n" +
+                            "\tOwned warm-up tasks:           {}\n",
+                    targetAssignment.localEpoch,
+                    isGroupReady ? "is ready" : "is not ready",
+                    memberId,
+                    assignedActiveTasks,
+                    ownedActiveTasks,
+                    activeTasksToRevoke,
+                    assignedStandbyTasks,
+                    ownedStandbyTasks,
+                    assignedWarmupTasks,
+                    ownedWarmupTasks
+            );    
         }
-        SortedSet<TopicPartition> assignedTopicPartitions = topicPartitionsForActiveTasks(targetAssignment.activeTasks);
-        SortedSet<TopicPartition> partitionsToRevoke = new TreeSet<>(ownedTopicPartitionsFromSubscriptionState);
-        partitionsToRevoke.removeAll(assignedTopicPartitions);
 
-        final CompletableFuture<Void> tasksRevoked = revokeActiveTasks(activeTasksToRevoke);
+        // SortedSet<TopicPartition> ownedTopicPartitionsFromSubscriptionState = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        // ownedTopicPartitionsFromSubscriptionState.addAll(subscriptionState.assignedPartitions());
+        // SortedSet<TopicPartition> ownedTopicPartitionsFromAssignedTasks =
+        //    topicPartitionsForActiveTasks(currentAssignment.activeTasks);
+        // TODO: Maybe, this require KIP as well.
+        // if (!ownedTopicPartitionsFromAssignedTasks.equals(ownedTopicPartitionsFromSubscriptionState)) {
+        //     throw new IllegalStateException("Owned partitions from subscription state and owned partitions from " +
+        //         "assigned active tasks are not equal. " +
+        //         "Owned partitions from subscription state: " + ownedTopicPartitionsFromSubscriptionState + ", " +
+        //         "Owned partitions from assigned active tasks: " + ownedTopicPartitionsFromAssignedTasks);
+        // }
+        // SortedSet<TopicPartition> assignedTopicPartitions = topicPartitionsForActiveTasks(targetAssignment.activeTasks);
+        // SortedSet<TopicPartition> partitionsToRevoke = new TreeSet<>(ownedTopicPartitionsFromSubscriptionState);
+        // partitionsToRevoke.removeAll(assignedTopicPartitions);
 
+        final SortedSet<TopicPartition> partitionsToRevoke = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        partitionsToRevoke.addAll(currentFetchablePartitions);
+        partitionsToRevoke.removeAll(targetFetchablePartitions);
+        final CompletableFuture<Void> tasksRevoked = revokeActiveTasks(activeTasksToRevoke, partitionsToRevoke);
+        
         final CompletableFuture<Void> tasksRevokedAndAssigned = tasksRevoked.thenCompose(__ -> {
             if (!maybeAbortReconciliation()) {
-                return assignTasks(assignedActiveTasks, ownedActiveTasks, assignedStandbyTasks, assignedWarmupTasks, isGroupReady);
+                return assignTasks(
+                        assignedActiveTasks, 
+                        ownedActiveTasks, 
+                        assignedStandbyTasks, 
+                        assignedWarmupTasks,
+                        targetMaterializationPlan.activeTaskInputPartitions,
+                        targetFetchablePartitions, 
+                        currentFetchablePartitions, 
+                        isGroupReady);
             }
             return CompletableFuture.completedFuture(null);
         });
@@ -1147,8 +1197,13 @@ public class StreamsMembershipManager implements RequestManager {
         });
     }
 
-    private CompletableFuture<Void> revokeActiveTasks(final SortedSet<StreamsRebalanceData.TaskId> activeTasksToRevoke) {
+    private CompletableFuture<Void> revokeActiveTasks(final SortedSet<StreamsRebalanceData.TaskId> activeTasksToRevoke,
+                                                      final Set<TopicPartition> partitionsToRevoke) {
         if (activeTasksToRevoke.isEmpty()) {
+            if (!partitionsToRevoke.isEmpty()) {
+                log.debug("Marking effective partitions pending for revocation: {}", partitionsToRevoke);
+                subscriptionState.markPendingRevocation(partitionsToRevoke);    
+            }
             return CompletableFuture.completedFuture(null);
         }
 
@@ -1156,8 +1211,7 @@ public class StreamsMembershipManager implements RequestManager {
             .map(StreamsRebalanceData.TaskId::toString)
             .collect(Collectors.joining(", ")));
 
-        final SortedSet<TopicPartition> partitionsToRevoke = topicPartitionsForActiveTasks(activeTasksToRevoke);
-        log.debug("Marking partitions pending for revocation: {}", partitionsToRevoke);
+        log.debug("Marking effective partitions pending for revocation: {}", partitionsToRevoke);
         subscriptionState.markPendingRevocation(partitionsToRevoke);
 
         CompletableFuture<Void> tasksRevoked = new CompletableFuture<>();
@@ -1178,6 +1232,9 @@ public class StreamsMembershipManager implements RequestManager {
                                                 final SortedSet<StreamsRebalanceData.TaskId> ownedActiveTasks,
                                                 final SortedSet<StreamsRebalanceData.TaskId> standbyTasksToAssign,
                                                 final SortedSet<StreamsRebalanceData.TaskId> warmupTasksToAssign,
+                                                final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions,
+                                                final SortedSet<TopicPartition> targetFetchablePartitions,
+                                                final SortedSet<TopicPartition> currentFetchablePartitions,
                                                 final boolean isGroupReady) {
         log.info("Assigning active tasks {{}}, standby tasks {{}}, and warm-up tasks {{}} to the member.",
             activeTasksToAssign.stream()
@@ -1191,9 +1248,15 @@ public class StreamsMembershipManager implements RequestManager {
                 .collect(Collectors.joining(", "))
         );
 
-        final SortedSet<TopicPartition> partitionsToAssign = topicPartitionsForActiveTasks(activeTasksToAssign);
-        final SortedSet<TopicPartition> partitionsToAssignNotPreviouslyOwned =
-            partitionsToAssignNotPreviouslyOwned(partitionsToAssign, topicPartitionsForActiveTasks(ownedActiveTasks));
+
+        final SortedSet<TopicPartition> partitionsToAssign = targetFetchablePartitions;
+        final SortedSet<TopicPartition> partitionsToAssignNotPreviouslyOwned = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        partitionsToAssignNotPreviouslyOwned.addAll(targetFetchablePartitions);
+        partitionsToAssignNotPreviouslyOwned.removeAll(currentFetchablePartitions);
+
+        // final SortedSet<TopicPartition> partitionsToAssign = topicPartitionsForActiveTasks(activeTasksToAssign);
+        // final SortedSet<TopicPartition> partitionsToAssignNotPreviouslyOwned =
+        //    partitionsToAssignNotPreviouslyOwned(partitionsToAssign, topicPartitionsForActiveTasks(ownedActiveTasks));
 
         // Enqueue event to app thread to apply assignment within poll() and invoke callback.
         // The app thread will trigger ApplyAssignmentEvent to update subscription state on background thread.
@@ -1205,6 +1268,7 @@ public class StreamsMembershipManager implements RequestManager {
                     activeTasksToAssign,
                     standbyTasksToAssign,
                     warmupTasksToAssign,
+                    activeTaskInputPartitions,
                     isGroupReady
                 )
             );
@@ -1229,7 +1293,8 @@ public class StreamsMembershipManager implements RequestManager {
             .map(StreamsRebalanceData.TaskId::toString)
             .collect(Collectors.joining(", ")));
 
-        final SortedSet<TopicPartition> partitionsToRelease = topicPartitionsForActiveTasks(activeTasksToRelease);
+        final SortedSet<TopicPartition> partitionsToRelease = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        partitionsToRelease.addAll(subscriptionState.assignedPartitions());
         log.debug("Marking lost partitions pending for revocation: {}", partitionsToRelease);
         subscriptionState.markPendingRevocation(partitionsToRelease);
 
@@ -1304,6 +1369,94 @@ public class StreamsMembershipManager implements RequestManager {
         final StreamsOnTasksRevokedCallbackNeededEvent onTasksRevokedCallbackNeededEvent = new StreamsOnTasksRevokedCallbackNeededEvent(activeTasksToRevoke);
         backgroundEventHandler.add(onTasksRevokedCallbackNeededEvent);
         return onTasksRevokedCallbackNeededEvent.future();
+    }
+
+    static final class MaterializationPlan {
+        // Assigned tasks and resolved topic.
+        final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions;
+        
+        // Assigned tasks but topic is unresolved.
+        final Set<StreamsRebalanceData.TaskId> unresolvedActiveTasks;
+
+        MaterializationPlan(final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions,
+                            final Set<StreamsRebalanceData.TaskId> unresolvedActiveTasks) {
+            this.activeTaskInputPartitions = Map.copyOf(activeTaskInputPartitions);
+            this.unresolvedActiveTasks = Set.copyOf(unresolvedActiveTasks);
+        }
+
+        SortedSet<TopicPartition> fetchablePartitions() {
+            final SortedSet<TopicPartition> partitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+            activeTaskInputPartitions.values().forEach(partitions::addAll);
+            return partitions;
+        }
+    }
+
+    private MaterializationPlan buildMaterializationPlan(final LocalAssignment assignment) {
+        final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions = new HashMap<>();
+        final Set<StreamsRebalanceData.TaskId> unresolvedActiveTasks = new TreeSet<>();
+        boolean needsMetadataUpdate = false;
+
+        for (final Map.Entry<String, SortedSet<Integer>> taskEntry : assignment.activeTasks.entrySet()) {
+            final String subtopologyId = taskEntry.getKey();
+            final SortedSet<Integer> taskPartitions = taskEntry.getValue();
+            final SortedSet<Uuid> topicIdsForSubtopology =
+                assignment.resolvedTopicIds.getOrDefault(subtopologyId, new TreeSet<>());
+
+            final List<String> resolvedSourceTopicNames = new ArrayList<>();
+            boolean subtopologyResolved = true;
+
+            for (final Uuid topicId : topicIdsForSubtopology) {
+                final Optional<String> maybeTopicName = findTopicNameInGlobalOrLocalCache(topicId);
+                if (maybeTopicName.isEmpty()) {
+                    subtopologyResolved = false;
+                    needsMetadataUpdate = true;
+                    break;
+                }
+                resolvedSourceTopicNames.add(maybeTopicName.get());
+            }
+
+            if (!subtopologyResolved) {
+                for (final int partitionId : taskPartitions) {
+                    unresolvedActiveTasks.add(new StreamsRebalanceData.TaskId(subtopologyId, partitionId));
+                }
+                continue;
+            }
+
+            final StreamsRebalanceData.Subtopology subtopology = streamsRebalanceData.subtopologies().get(subtopologyId);
+            final List<String> inputTopics = new ArrayList<>(resolvedSourceTopicNames);
+            inputTopics.addAll(subtopology.repartitionSourceTopics().keySet());
+
+            for (final int partitionId : taskPartitions) {
+                final StreamsRebalanceData.TaskId taskId = new StreamsRebalanceData.TaskId(subtopologyId, partitionId);
+                final Set<TopicPartition> taskInputPartitions = inputTopics.stream()
+                    .map(topic -> new TopicPartition(topic, partitionId))
+                    .collect(Collectors.toSet());
+                activeTaskInputPartitions.put(taskId, taskInputPartitions);
+            }
+        }
+
+        if (needsMetadataUpdate) {
+            metadata.requestUpdate(true);
+        }
+
+        return new MaterializationPlan(activeTaskInputPartitions, unresolvedActiveTasks);
+    }
+
+    private Optional<String> findTopicNameInGlobalOrLocalCache(Uuid topicId) {
+        String nameFromMetadataCache = metadata.topicNames().getOrDefault(topicId, null);
+        if (nameFromMetadataCache != null) {
+            // Add topic name to local cache, so it can be reused if included in a next target
+            // assignment if metadata cache not available.
+            assignedTopicNamesCache.put(topicId, nameFromMetadataCache);
+            return Optional.of(nameFromMetadataCache);
+        } else {
+            // Topic ID was not found in metadata. Check if the topic name is in the local
+            // cache of topics currently assigned. This will avoid a metadata request in the
+            // case where the metadata cache may have been flushed right before the
+            // revocation of a previously assigned topic.
+            String nameFromSubscriptionCache = assignedTopicNamesCache.getOrDefault(topicId, null);
+            return Optional.ofNullable(nameFromSubscriptionCache);
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceData.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * This class holds the data that is needed to participate in the Streams rebalance protocol.
@@ -157,27 +158,41 @@ public class StreamsRebalanceData {
 
         private final Set<TaskId> warmupTasks;
 
+        private final Map<TaskId, Set<TopicPartition>> activeTaskInputPartitions;
+
         private final boolean isGroupReady;
 
         private Assignment() {
             this.activeTasks = Set.of();
             this.standbyTasks = Set.of();
             this.warmupTasks = Set.of();
+            this.activeTaskInputPartitions = Map.of();
             this.isGroupReady = false;
         }
 
         public Assignment(final Set<TaskId> activeTasks,
                           final Set<TaskId> standbyTasks,
                           final Set<TaskId> warmupTasks,
+                          final Map<TaskId, Set<TopicPartition>> activeTaskInputPartitions,
                           final boolean isGroupReady) {
             this.activeTasks = Set.copyOf(Objects.requireNonNull(activeTasks, "Active tasks cannot be null"));
             this.standbyTasks = Set.copyOf(Objects.requireNonNull(standbyTasks, "Standby tasks cannot be null"));
             this.warmupTasks = Set.copyOf(Objects.requireNonNull(warmupTasks, "Warmup tasks cannot be null"));
+            this.activeTaskInputPartitions = activeTaskInputPartitions.entrySet().stream().collect(
+                    Collectors.toUnmodifiableMap(
+                            Map.Entry::getKey,
+                            entry -> Set.copyOf(entry.getValue())
+                    )
+            );
             this.isGroupReady = isGroupReady;
         }
 
         public Set<TaskId> activeTasks() {
             return activeTasks;
+        }
+
+        public Map<TaskId, Set<TopicPartition>> activeTaskInputPartitions() {
+            return activeTaskInputPartitions;
         }
 
         public Set<TaskId> standbyTasks() {
@@ -204,16 +219,17 @@ public class StreamsRebalanceData {
             return Objects.equals(activeTasks, that.activeTasks)
                 && Objects.equals(standbyTasks, that.standbyTasks)
                 && Objects.equals(warmupTasks, that.warmupTasks)
+                && Objects.equals(activeTaskInputPartitions, that.activeTaskInputPartitions)
                 && isGroupReady == that.isGroupReady;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(activeTasks, standbyTasks, warmupTasks, isGroupReady);
+            return Objects.hash(activeTasks, standbyTasks, warmupTasks, activeTaskInputPartitions, isGroupReady);
         }
 
         public Assignment copy() {
-            return new Assignment(activeTasks, standbyTasks, warmupTasks, isGroupReady);
+            return new Assignment(activeTasks, standbyTasks, warmupTasks, activeTaskInputPartitions, isGroupReady);
         }
 
         @Override
@@ -222,6 +238,7 @@ public class StreamsRebalanceData {
                 "activeTasks=" + activeTasks +
                 ", standbyTasks=" + standbyTasks +
                 ", warmupTasks=" + warmupTasks +
+                ", activeTaskInputPartitions=" + activeTaskInputPartitions +
                 ", isGroupReady=" + isGroupReady +
                 '}';
         }

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "StreamsGroupHeartbeatRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 88,
   "type": "response",
   "name": "StreamsGroupHeartbeatResponse",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
@@ -63,6 +63,9 @@
       "about": "Assigned standby tasks for this client. Null if unchanged since last heartbeat." },
     { "name": "WarmupTasks", "type": "[]TaskIds", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "Assigned warm-up tasks for this client. Null if unchanged since last heartbeat." },
+    
+    { "name": "ResolvedTopicIdsBySubtopology", "type": "[]ResolvedTopicIds", "versions": "1+", "nullableVersions": "1+", "default": "null",
+      "about": "TBD." },
 
     // IQ-related information
     { "name": "EndpointInformationEpoch", "type": "int32", "versions": "0+",
@@ -111,6 +114,12 @@
         "about": "The subtopology identifier." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "The partitions of the input topics processed by this member." }
+    ]},
+    { "name": "ResolvedTopicIds", "versions": "1+", "fields": [
+      { "name": "SubtopologyId", "type": "string", "versions": "1+",
+        "about": "The subtopology identifier." },
+      { "name": "TopicIds", "type": "[]uuid", "versions": "1+",
+        "about": "The topic ids." }
     ]},
     { "name": "Endpoint", "versions": "0+", "fields": [
       { "name": "Host", "type": "string", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
@@ -72,12 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class StreamsMembershipManagerTest {
@@ -128,7 +123,8 @@ public class StreamsMembershipManagerTest {
             streamsRebalanceData, subscriptionState, backgroundEventHandler,
             new LogContext("test"),
             time,
-            metrics
+            metrics,
+            mock(ConsumerMetadata.class)
         );
         membershipManager.registerStateListener(memberStateListener);
         verifyInStateUnsubscribed(membershipManager);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -116,6 +116,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
@@ -1292,6 +1294,13 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 groupMetadataManager.replay(
                     (StreamsGroupTargetAssignmentMetadataKey) key,
                     (StreamsGroupTargetAssignmentMetadataValue) Utils.messageOrNull(value)
+                );
+                break;
+                
+            case STREAMS_GROUP_TARGET_ASSIGNMENT_RESOLVED_TOPIC_IDS:
+                groupMetadataManager.replay(
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsKey) key,
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsValue) Utils.messageOrNull(value)
                 );
                 break;
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -134,6 +134,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.Assignment;
 import org.apache.kafka.coordinator.group.modern.MemberState;
@@ -156,6 +158,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
+import org.apache.kafka.coordinator.group.streams.TasksTupleAndResolvedTopicIds;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
@@ -301,19 +304,23 @@ public class GroupMetadataManager {
             );
         }
 
-        private static UpdateTargetAssignmentResult<TasksTuple> fromLastTargetAssignment(
+        private static UpdateTargetAssignmentResult<TasksTupleAndResolvedTopicIds> fromLastTargetAssignment(
             StreamsGroup group,
             Optional<StreamsGroupMember> member
         ) {
             if (member.isPresent()) {
                 return new UpdateTargetAssignmentResult<>(
                     group.assignmentEpoch(),
-                    group.targetAssignment(member.get().memberId())
+                    new TasksTupleAndResolvedTopicIds(
+                        group.targetAssignment(member.get().memberId()),
+                        group.targetAssignmentResolvedTopicIdPerSubTopology()    
+                    )
+                    
                 );
             } else {
                 return new UpdateTargetAssignmentResult<>(
                     group.assignmentEpoch(),
-                    TasksTuple.EMPTY
+                    TasksTupleAndResolvedTopicIds.EMPTY
                 );
             }
         }
@@ -2104,7 +2111,7 @@ public class GroupMetadataManager {
         // 4. Update the target assignment if the group epoch is larger than the target assignment epoch or a static member
         // replaces an existing static member.
         // The delta between the existing and the new target assignment is persisted to the partition.
-        UpdateTargetAssignmentResult<TasksTuple> updateTargetAssignmentResult = maybeUpdateStreamsTargetAssignment(
+        UpdateTargetAssignmentResult<TasksTupleAndResolvedTopicIds> updateTargetAssignmentResult = maybeUpdateStreamsTargetAssignment(
             group,
             groupEpoch,
             Optional.of(updatedMember),
@@ -2124,7 +2131,7 @@ public class GroupMetadataManager {
             group::currentStandbyTaskProcessIds,
             group::currentWarmupTaskProcessIds,
             updateTargetAssignmentResult.targetAssignmentEpoch(),
-            updateTargetAssignmentResult.targetAssignment(),
+            updateTargetAssignmentResult.targetAssignment().tasksTuple(),
             ownedActiveTasks,
             ownedStandbyTasks,
             ownedWarmupTasks,
@@ -2145,7 +2152,7 @@ public class GroupMetadataManager {
         // The assignment is only provided in the following cases:
         // 1. The member is joining.
         // 2. The member's assignment has been updated.
-        if (memberEpoch == 0 || hasAssignedTasksChanged(member, updatedMember)) {
+        if (memberEpoch == 0 || hasAssignedTasksChanged(member, updatedMember) || memberEpoch != updatedMember.memberEpoch()) {
             response.setActiveTasks(createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(updatedMember.assignedTasks().activeTasksWithEpochs()));
             response.setStandbyTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().standbyTasks()));
             response.setWarmupTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().warmupTasks()));
@@ -2155,6 +2162,17 @@ public class GroupMetadataManager {
                 // Otherwise, bump the endpoint information epoch
                 group.setEndpointInformationEpoch(group.endpointInformationEpoch() + 1);
             }
+            List<StreamsGroupHeartbeatResponseData.ResolvedTopicIds> responseResolvedTopicIds = updateTargetAssignmentResult
+                    .targetAssignment()
+                    .resolvedTopicIds()
+                    .entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .map(entry -> new StreamsGroupHeartbeatResponseData.ResolvedTopicIds()
+                            .setSubtopologyId(entry.getKey())
+                            .setTopicIds(entry.getValue())
+                    ).toList();
+
+            response.setResolvedTopicIdsBySubtopology(responseResolvedTopicIds);
         }
 
         if (group.endpointInformationEpoch() != memberEndpointEpoch) {
@@ -3999,7 +4017,7 @@ public class GroupMetadataManager {
      * @param returnedStatus       A mutable collection of status to be returned in the response.
      * @return The new target assignment for the updated member, or EMPTY if no member specified.
      */
-    private UpdateTargetAssignmentResult<TasksTuple> maybeUpdateStreamsTargetAssignment(
+    private UpdateTargetAssignmentResult<TasksTupleAndResolvedTopicIds> maybeUpdateStreamsTargetAssignment(
         StreamsGroup group,
         int groupEpoch,
         Optional<StreamsGroupMember> updatedMember,
@@ -4019,7 +4037,7 @@ public class GroupMetadataManager {
 
             return new UpdateTargetAssignmentResult<>(
                 group.assignmentEpoch(),
-                TasksTuple.EMPTY
+                TasksTupleAndResolvedTopicIds.EMPTY
             );
         }
 
@@ -4028,6 +4046,23 @@ public class GroupMetadataManager {
             return UpdateTargetAssignmentResult.fromLastTargetAssignment(group, updatedMember);
         }
 
+        Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology;
+        if (!configuredTopology.isReady()) {
+            resolvedTopicIdsPerSubTopology = Map.of();
+        } else {
+            Optional<Map<String, List<Uuid>>> maybeResolvedTopicIds = 
+                    resolveTopicIdsBySubtopology(configuredTopology, metadataImage);
+
+            if (maybeResolvedTopicIds.isEmpty()) {
+                returnedStatus.ifPresent(statusList -> statusList.add(
+                        new Status()
+                                .setStatusCode(StreamsGroupHeartbeatResponse.Status.ASSIGNMENT_DELAYED.code())
+                                .setStatusDetail("Assignment delayed because some of topic name missed their topic id.")
+                ));
+                return UpdateTargetAssignmentResult.fromLastTargetAssignment(group, updatedMember);
+            }
+            resolvedTopicIdsPerSubTopology = maybeResolvedTopicIds.get();
+        }
         boolean canComputeNextTargetAssignment = canComputeNextTargetAssignment(
             group.assignmentTimestamp(),
             streamsGroupAssignmentIntervalMs(group.groupId()),
@@ -4057,6 +4092,7 @@ public class GroupMetadataManager {
                 .withTopology(configuredTopology)
                 .withStaticMembers(group.staticMembers())
                 .withMetadataImage(metadataImage)
+                .withResolvedTopicIdsPerSubTopology(resolvedTopicIdsPerSubTopology)
                 .withTargetAssignment(group.targetAssignment());
 
             updatedMember.ifPresent(member ->
@@ -4077,11 +4113,13 @@ public class GroupMetadataManager {
             }
 
             records.addAll(assignmentResult.records());
-
-            return new UpdateTargetAssignmentResult<>(
-                groupEpoch,
-                updatedMember.map(member -> assignmentResult.targetAssignment().get(member.memberId()))
-                    .orElse(TasksTuple.EMPTY)
+            return new UpdateTargetAssignmentResult<>(groupEpoch,
+                    new TasksTupleAndResolvedTopicIds(
+                            updatedMember
+                                    .map(member -> assignmentResult.targetAssignment().get(member.memberId()))
+                                    .orElse(TasksTuple.EMPTY), 
+                            resolvedTopicIdsPerSubTopology
+                    )
             );
         } catch (TaskAssignorException ex) {
             String msg = String.format("Failed to compute a new target assignment for epoch %d: %s",
@@ -4091,6 +4129,33 @@ public class GroupMetadataManager {
         }
     }
 
+    private Optional<Map<String, List<Uuid>>> resolveTopicIdsBySubtopology(
+            ConfiguredTopology updatedConfiguredTopology,
+            CoordinatorMetadataImage metadataImage) {
+
+        Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology = new HashMap<>();
+        if (updatedConfiguredTopology.subtopologies().isPresent()) {
+            SortedMap<String, ConfiguredSubtopology> stringConfiguredSubtopologySortedMap = updatedConfiguredTopology
+                    .subtopologies()
+                    .get();
+            for (Map.Entry<String, ConfiguredSubtopology> entry : stringConfiguredSubtopologySortedMap.entrySet()) {
+                String subTopologyId = entry.getKey();
+                Set<Uuid> topicIds = new HashSet<>();
+                // TODO. Do we consider all kind of topics as well? (internal topic, sink topic and so on.)
+                for (String topicName : entry.getValue().sourceTopics()) {
+                    Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadata = metadataImage.topicMetadata(topicName);
+                    if (topicMetadata.isEmpty()) {
+                        log.warn("The topic id is missed for topic name '{}'", topicName);
+                        return Optional.empty();
+                    }
+                    topicIds.add(topicMetadata.get().id());
+                }
+                resolvedTopicIdsPerSubTopology.put(subTopologyId, topicIds.stream().sorted().toList());
+            }
+        }
+        return Optional.of(resolvedTopicIdsPerSubTopology);
+    }
+    
     /**
      * Fires the initial rebalance for a streams group when the delay timer expires.
      * Computes and persists target assignment for all members if conditions are met.
@@ -5779,6 +5844,37 @@ public class GroupMetadataManager {
                     + " but the assignment still has " + streamsGroup.targetAssignment().size() + " members.");
             }
             streamsGroup.setTargetAssignmentMetadata(-1, 0L);
+        }
+    }
+
+    /**
+     * TBD. should be updated.
+     *
+     * @param key   A StreamsGroupTargetAssignmentResolvedTopicIdsKey key.
+     * @param value A StreamsGroupTargetAssignmentResolvedTopicIdsValue record.
+     */
+    public void replay(
+            StreamsGroupTargetAssignmentResolvedTopicIdsKey key,
+            StreamsGroupTargetAssignmentResolvedTopicIdsValue value
+    ) {
+        String groupId = key.groupId();
+
+        if (value != null) {
+            StreamsGroup streamsGroup = getOrMaybeCreatePersistedStreamsGroup(groupId, true);
+            Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology = new HashMap<>();
+            for (StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds resolvedTopicIds : value.resolvedTopicIdsBySubtopology()) {
+                resolvedTopicIdsPerSubTopology.put(resolvedTopicIds.subtopologyId(), resolvedTopicIds.topicIds());
+            }
+            streamsGroup.setTargetAssignmentResolvedTopicIds(value.assignmentEpoch(), resolvedTopicIdsPerSubTopology);
+        } else {
+            StreamsGroup streamsGroup;
+            try {
+                streamsGroup = getOrMaybeCreatePersistedStreamsGroup(groupId, false);
+            } catch (GroupIdNotFoundException ex) {
+                // If the group does not exist, we can ignore the tombstone.
+                return;
+            }
+            streamsGroup.setTargetAssignmentResolvedTopicIds(-1, new HashMap<>());
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentKey;
@@ -30,6 +31,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 import java.util.ArrayList;
@@ -256,6 +259,54 @@ public class StreamsCoordinatorRecordHelpers {
         return CoordinatorRecord.tombstone(
             new StreamsGroupTargetAssignmentMetadataKey()
                 .setGroupId(groupId)
+        );
+    }
+
+    public static CoordinatorRecord newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+            String groupId,
+            int assignmentEpoch,
+            Map<String, List<Uuid>> subTopologyIdAndTopicIds
+    ) {
+        Objects.requireNonNull(groupId, "groupId should not be null here");
+        Objects.requireNonNull(subTopologyIdAndTopicIds, "subTopologyIdAndTopicIds should not be null here");
+
+        StreamsGroupTargetAssignmentResolvedTopicIdsKey key = new StreamsGroupTargetAssignmentResolvedTopicIdsKey()
+                .setGroupId(groupId);
+
+        List<StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds> resolvedTopicIds = subTopologyIdAndTopicIds.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds ids = 
+                            new StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds();
+                    ids.setSubtopologyId(entry.getKey());
+                    ids.setTopicIds(entry.getValue());
+                    return ids;
+                })
+                .toList();
+
+        StreamsGroupTargetAssignmentResolvedTopicIdsValue value = new StreamsGroupTargetAssignmentResolvedTopicIdsValue()
+                .setAssignmentEpoch(assignmentEpoch)
+                .setResolvedTopicIdsBySubtopology(resolvedTopicIds);
+        return CoordinatorRecord.record(key, new ApiMessageAndVersion(value, (short) 0)
+        );
+    }
+
+    /**
+     * Creates a StreamsGroupTargetAssignmentResolvedTopicIds tombstone.
+     *
+     * @param groupId The streams group id.
+     * @return The record.
+     */
+    public static CoordinatorRecord newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord(
+            String groupId
+            
+    ) {
+        Objects.requireNonNull(groupId, "groupId should not be null here");
+
+        return CoordinatorRecord.tombstone(
+                new StreamsGroupTargetAssignmentResolvedTopicIdsKey()
+                        .setGroupId(groupId)
         );
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
@@ -173,6 +174,11 @@ public class StreamsGroup implements Group {
     private final TimelineHashMap<String, TasksTuple> targetAssignment;
 
     /**
+     * The target resolved topic ids per subtopology.
+     */
+    private final TimelineObject<TargetResolvedTopicIds> targetResolvedTopics;
+
+    /**
      * These maps map each active/standby/warmup task to the process ID(s) of their current owner.
      * The mapping is of the form <code>subtopology -> partition -> memberId</code>.
      * When a member revokes a partition, it removes its process ID from this map.
@@ -245,6 +251,7 @@ public class StreamsGroup implements Group {
         this.metadataHash = new TimelineLong(snapshotRegistry);
         this.targetAssignmentMetadata = new TimelineObject<>(snapshotRegistry, TargetAssignmentMetadata.INITIAL);
         this.targetAssignment = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.targetResolvedTopics = new TimelineObject<>(snapshotRegistry, TargetResolvedTopicIds.INITIAL);
         this.currentActiveTaskToProcessId = new TimelineHashMap<>(snapshotRegistry, 0);
         this.currentStandbyTaskToProcessIds = new TimelineHashMap<>(snapshotRegistry, 0);
         this.currentWarmupTaskToProcessIds = new TimelineHashMap<>(snapshotRegistry, 0);
@@ -361,6 +368,34 @@ public class StreamsGroup implements Group {
     public void setTargetAssignmentMetadata(int targetAssignmentEpoch, long targetAssignmentTimestamp) {
         this.targetAssignmentMetadata.set(new TargetAssignmentMetadata(targetAssignmentEpoch, targetAssignmentTimestamp));
         maybeUpdateGroupState();
+    }
+
+    /**
+     * Sets the assignment resolved topic ids.
+     *
+     * @param assignmentEpoch The assignment Epoch.
+     * @param resolvedTopicIdPerSubTopology The resolved topic ids per sub topology.
+     */
+    public void setTargetAssignmentResolvedTopicIds(int assignmentEpoch,
+                                                    Map<String, List<Uuid>> resolvedTopicIdPerSubTopology) {
+        this.targetResolvedTopics.set(new TargetResolvedTopicIds(assignmentEpoch, resolvedTopicIdPerSubTopology));
+        maybeUpdateGroupState();
+    }
+
+    /**
+     * TBD
+     * @return
+     */
+    public int targetAssignmentResolvedTopicIdsAssignmentEpoch() {
+        return targetResolvedTopics.get().assignmentEpoch();
+    }
+
+    /**
+     * TBD
+     * @return
+     */
+    public Map<String, List<Uuid>> targetAssignmentResolvedTopicIdPerSubTopology() {
+        return targetResolvedTopics.get().topicIdsPerSubTopology();
     }
 
     /**
@@ -839,7 +874,8 @@ public class StreamsGroup implements Group {
             records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentTombstoneRecord(groupId(), memberId))
         );
         records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataTombstoneRecord(groupId()));
-
+        records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord(groupId()));
+        
         members().forEach((memberId, member) ->
             records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberTombstoneRecord(groupId(), memberId))
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -95,6 +96,11 @@ public class TargetAssignmentBuilder {
      * The topology.
      */
     private ConfiguredTopology topology;
+
+    /**
+     * The topic ids per sub-topology.
+     */
+    private Map<String, List<Uuid>> topicIdsPerSubTopology;
 
     /**
      * The static members in the group.
@@ -184,6 +190,13 @@ public class TargetAssignmentBuilder {
         CoordinatorMetadataImage metadataImage
     ) {
         this.metadataImage = metadataImage;
+        return this;
+    }
+
+    public TargetAssignmentBuilder withResolvedTopicIdsPerSubTopology(
+            Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology
+    ) {
+        this.topicIdsPerSubTopology = resolvedTopicIdsPerSubTopology;
         return this;
     }
 
@@ -334,6 +347,17 @@ public class TargetAssignmentBuilder {
             groupEpoch,
             time.milliseconds()
         ));
+        
+        // TODO: Should cover all test cases. 
+        // Temporarily insert this for POC.
+        if (topicIdsPerSubTopology != null) {
+            // Bump the target resolved topic ids.
+            records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+                    groupId,
+                    groupEpoch,
+                    topicIdsPerSubTopology
+            ));    
+        }
 
         return new TargetAssignmentResult(records, newTargetAssignment);
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetResolvedTopicIds.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetResolvedTopicIds.java
@@ -1,0 +1,34 @@
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * hello
+ * @param assignmentEpoch 
+ * @param topicIdsPerSubTopology
+ */
+public record TargetResolvedTopicIds(int assignmentEpoch, Map<String, List<Uuid>> topicIdsPerSubTopology) {
+
+    /**
+     * hello
+     */
+    public static final TargetResolvedTopicIds INITIAL = new TargetResolvedTopicIds(-1, new HashMap<>());
+    
+    public TargetResolvedTopicIds {
+        Objects.requireNonNull(topicIdsPerSubTopology, "topicIdsPerSubTopology should not be null");
+
+        Map<String, List<Uuid>> copy = new HashMap<>();
+        topicIdsPerSubTopology.forEach((subtopologyId, topicIds) -> {
+            Objects.requireNonNull(subtopologyId, "subtopologyId should not be null");
+            Objects.requireNonNull(topicIds, "topicIds should not be null");
+            copy.put(subtopologyId, List.copyOf(topicIds));
+        });
+
+        topicIdsPerSubTopology = Map.copyOf(copy);
+    }    
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleAndResolvedTopicIds.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleAndResolvedTopicIds.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TBD.
+ * @param tasksTuple
+ * @param resolvedTopicIds
+ */
+public record TasksTupleAndResolvedTopicIds(TasksTuple tasksTuple, Map<String, List<Uuid>> resolvedTopicIds) {
+
+    /**
+     * An empty task tuple.
+     */
+    public static final TasksTupleAndResolvedTopicIds EMPTY = new TasksTupleAndResolvedTopicIds(
+            TasksTuple.EMPTY,
+            Map.of()
+    );
+    
+    
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 24,
+  "type": "coordinator-key",
+  "name": "StreamsGroupTargetAssignmentResolvedTopicIdsKey",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "0",
+      "about": "The group ID." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsValue.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 24,
+  "type": "coordinator-value",
+  "name": "StreamsGroupTargetAssignmentResolvedTopicIdsValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "AssignmentEpoch", "versions": "0+", "type": "int32",
+      "about": "The assignment epoch this resolved topic snapshot belongs to." },
+    { "name": "ResolvedTopicIdsBySubtopology", "versions": "0+", "type": "[]ResolvedTopicIds",
+      "about": "The resolved topic ids keyed by subtopology." }
+  ],
+  "commonStructs": [
+    { "name": "ResolvedTopicIds", "versions": "0+", "fields": [
+      { "name": "SubtopologyId", "type": "string", "versions": "0+",
+        "about": "The subtopology identifier." },
+      { "name": "TopicIds", "type": "[]uuid", "versions": "0+",
+        "about": "The resolved topic ids for the subtopology." }
+    ]}
+  ]
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1182,6 +1182,7 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1, 2)
             )));
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord(groupId, 100, 12345L));
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(groupId, 100, Map.of(subtopology1, List.of(fooTopicId))));
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, member));
 
         // Member rejoins with epoch=0 - should succeed per KIP-848.
@@ -1206,6 +1207,11 @@ public class GroupMetadataManagerTest {
                     new StreamsGroupHeartbeatResponseData.TaskIds()
                         .setSubtopologyId(subtopology1)
                         .setPartitions(List.of(0, 1, 2))))
+                .setResolvedTopicIdsBySubtopology(List.of(
+                    new StreamsGroupHeartbeatResponseData.ResolvedTopicIds()
+                        .setSubtopologyId(subtopology1)
+                        .setTopicIds(List.of(fooTopicId))
+                ))
                 .setStandbyTasks(List.of())
                 .setWarmupTasks(List.of())
                 .setStatus(List.of())
@@ -11303,6 +11309,7 @@ public class GroupMetadataManagerTest {
             StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentTombstoneRecord(groupId, memberId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataTombstoneRecord(groupId),
+            StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord(groupId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupMemberTombstoneRecord(groupId, memberId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupEpochTombstoneRecord(groupId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecordTombstone(groupId)
@@ -18757,6 +18764,10 @@ public class GroupMetadataManagerTest {
                     new StreamsGroupHeartbeatResponseData.TaskIds()
                         .setSubtopologyId(subtopology1)
                         .setPartitions(List.of(0, 1))))
+                .setResolvedTopicIdsBySubtopology(List.of(
+                    new StreamsGroupHeartbeatResponseData.ResolvedTopicIds()
+                        .setSubtopologyId(subtopology1)
+                        .setTopicIds(List.of(fooTopicId))))
                 .setStandbyTasks(List.of())
                 .setWarmupTasks(List.of())
                 .setStatus(List.of())
@@ -18934,6 +18945,59 @@ public class GroupMetadataManagerTest {
                 .setTaskOffsetIntervalMs(60_000),
             result.response().data()
         );
+    }
+
+    @Test
+    public void testStreamsGroupHeartbeatAssignmentDelayedWhenTopicIdMissing() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        String subtopology1 = "subtopology1";
+        String fooTopicName = "foo";
+        Topology topology = new Topology().setSubtopologies(List.of(
+            new Subtopology().setSubtopologyId(subtopology1).setSourceTopics(List.of(fooTopicName))
+        ));
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                    .buildCoordinatorMetadataImage())
+            .withConfig(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, 0)
+            .build();
+
+        assignor.prepareGroupAssignment(
+            Map.of(memberId, TaskAssignmentTestUtil.mkTasksTuple(
+                TaskRole.ACTIVE,
+                TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1)
+            ))
+        );
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(1500)
+                .setTopology(topology)
+                .setActiveTasks(List.of())
+                .setStandbyTasks(List.of())
+                .setWarmupTasks(List.of())
+        );
+
+        StreamsGroupHeartbeatResponseData response = result.response().data();
+        assertEquals(memberId, response.memberId());
+        assertEquals(List.of(), response.activeTasks());
+        assertEquals(List.of(), response.standbyTasks());
+        assertEquals(List.of(), response.warmupTasks());
+        assertEquals(List.of(), response.resolvedTopicIdsBySubtopology());
+        assertEquals(2, response.status().size());
+        assertEquals(Status.MISSING_SOURCE_TOPICS.code(), response.status().get(0).statusCode());
+        assertEquals("One or more source topic's id are missing.", response.status().get(0).statusDetail());
+        assertEquals(Status.MISSING_SOURCE_TOPICS.code(), response.status().get(1).statusCode());
+        assertEquals("Source topics foo are missing.", response.status().get(1).statusDetail());
+        assertFalse(result.records().stream().anyMatch(
+            record -> record.key() instanceof org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey
+        ));
     }
 
     @Test
@@ -20806,6 +20870,7 @@ public class GroupMetadataManagerTest {
 
         List<CoordinatorRecord> expectedRecords = List.of(
             StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataTombstoneRecord(streamsGroupId),
+            StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord(streamsGroupId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupEpochTombstoneRecord(streamsGroupId),
             StreamsCoordinatorRecordHelpers.newStreamsGroupTopologyRecordTombstone(streamsGroupId)
         );
@@ -21996,6 +22061,55 @@ public class GroupMetadataManagerTest {
         context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord("foo", 10, 12345L));
         assertEquals(10, context.groupMetadataManager.streamsGroup("foo").assignmentEpoch());
         assertEquals(12345L, context.groupMetadataManager.streamsGroup("foo").assignmentTimestamp());
+    }
+
+    @Test
+    public void testReplayStreamsGroupTargetAssignmentResolvedTopicIds() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        Uuid topicId = Uuid.randomUuid();
+
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+            "foo",
+            10,
+            Map.of("subtopology-1", List.of(topicId))
+        ));
+
+        assertEquals(10, context.groupMetadataManager.streamsGroup("foo").targetAssignmentResolvedTopicIdsAssignmentEpoch());
+        assertEquals(
+            Map.of("subtopology-1", List.of(topicId)),
+            context.groupMetadataManager.streamsGroup("foo").targetAssignmentResolvedTopicIdPerSubTopology()
+        );
+    }
+
+    @Test
+    public void testReplayStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneExisting() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        Uuid topicId = Uuid.randomUuid();
+
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+            "foo",
+            10,
+            Map.of("subtopology-1", List.of(topicId))
+        ));
+
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord("foo"));
+
+        assertEquals(-1, context.groupMetadataManager.streamsGroup("foo").targetAssignmentResolvedTopicIdsAssignmentEpoch());
+        assertEquals(Map.of(), context.groupMetadataManager.streamsGroup("foo").targetAssignmentResolvedTopicIdPerSubTopology());
+    }
+
+    @Test
+    public void testReplayStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneNonExisting() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        context.replay(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord("foo"));
+
+        assertThrows(GroupIdNotFoundException.class, () -> context.groupMetadataManager.streamsGroup("foo"));
     }
 
     @Test
@@ -27415,6 +27529,11 @@ public class GroupMetadataManagerTest {
                         .setSubtopologyId(subtopology)
                         .setPartitions(List.of(0, 1, 2, 3, 4, 5))
                 ))
+                .setResolvedTopicIdsBySubtopology(List.of(
+                    new StreamsGroupHeartbeatResponseData.ResolvedTopicIds()
+                        .setSubtopologyId(subtopology)
+                        .setTopicIds(List.of(fooTopicId))
+                ))
                 .setStandbyTasks(List.of())
                 .setWarmupTasks(List.of())
                 .setStatus(List.of())
@@ -27442,6 +27561,11 @@ public class GroupMetadataManagerTest {
                         TaskAssignmentTestUtil.mkTasks(subtopology, 0, 1, 2, 3, 4, 5)
                     )),
                 StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord(groupId, 2, context.time.milliseconds()),
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+                    groupId,
+                    2,
+                    Map.of(subtopology, List.of(fooTopicId))
+                ),
                 StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, expectedMember1)
             ),
             result1.records()
@@ -27480,6 +27604,11 @@ public class GroupMetadataManagerTest {
                 .setStandbyTasks(List.of())
                 .setWarmupTasks(List.of())
                 .setEndpointInformationEpoch(0)
+                .setResolvedTopicIdsBySubtopology(List.of(
+                        new StreamsGroupHeartbeatResponseData.ResolvedTopicIds()
+                                .setSubtopologyId(subtopology)
+                                .setTopicIds(List.of(fooTopicId))
+                ))
                 .setStatus(List.of(new StreamsGroupHeartbeatResponseData.Status()
                     .setStatusCode(Status.ASSIGNMENT_DELAYED.code())
                     .setStatusDetail("Assignment delayed due to the configured assignment interval.")))
@@ -27520,6 +27649,10 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(3)
                 .setHeartbeatIntervalMs(5000)
                 .setEndpointInformationEpoch(0)
+                .setResolvedTopicIdsBySubtopology(List.of(
+                        new StreamsGroupHeartbeatResponseData.ResolvedTopicIds()
+                                .setSubtopologyId(subtopology)
+                                .setTopicIds(List.of(fooTopicId))))
                 .setStatus(List.of())
                 .setTaskOffsetIntervalMs(60_000),
             result3.response().data()
@@ -27544,6 +27677,7 @@ public class GroupMetadataManagerTest {
                         ))
                 ),
                 List.of(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord(groupId, 3, context.time.milliseconds())),
+                List.of(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(groupId, 3, Map.of(subtopology, List.of(fooTopicId)))),
                 List.of(StreamsCoordinatorRecordHelpers.newStreamsGroupCurrentAssignmentRecord(groupId, expectedMember3))
             ),
             result3.records()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -61,47 +61,7 @@ import org.apache.kafka.coordinator.common.runtime.MockCoordinatorTimer;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupRegularExpressionValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
-import org.apache.kafka.coordinator.group.generated.CoordinatorRecordType;
-import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
-import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ShareGroupCurrentMemberAssignmentKey;
-import org.apache.kafka.coordinator.group.generated.ShareGroupCurrentMemberAssignmentValue;
-import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ShareGroupMemberMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ShareGroupMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ShareGroupStatePartitionMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ShareGroupStatePartitionMetadataValue;
-import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMemberKey;
-import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMemberValue;
-import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataKey;
-import org.apache.kafka.coordinator.group.generated.ShareGroupTargetAssignmentMetadataValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentKey;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataKey;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupMetadataKey;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupMetadataValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberKey;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataKey;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
-import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.*;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.MemberState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
@@ -1759,6 +1719,13 @@ public class GroupMetadataManagerTestContext {
                 groupMetadataManager.replay(
                     (StreamsGroupTargetAssignmentMetadataKey) key,
                     (StreamsGroupTargetAssignmentMetadataValue) messageOrNull(value)
+                );
+                break;
+
+            case STREAMS_GROUP_TARGET_ASSIGNMENT_RESOLVED_TOPIC_IDS:
+                groupMetadataManager.replay(
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsKey) key,
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsValue) Utils.messageOrNull(value)
                 );
                 break;
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentKey;
@@ -30,6 +31,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue.TaskIds;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
@@ -398,6 +401,42 @@ class StreamsCoordinatorRecordHelpersTest {
         );
 
         assertEquals(expectedRecord, StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataTombstoneRecord(GROUP_ID));
+    }
+
+    @Test
+    public void testNewStreamsGroupTargetAssignmentResolvedTopicIdsRecord() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        CoordinatorRecord expectedRecord = CoordinatorRecord.record(
+            new StreamsGroupTargetAssignmentResolvedTopicIdsKey()
+                .setGroupId(GROUP_ID),
+            new ApiMessageAndVersion(
+                new StreamsGroupTargetAssignmentResolvedTopicIdsValue()
+                    .setAssignmentEpoch(42)
+                    .setResolvedTopicIdsBySubtopology(List.of(
+                        new StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds()
+                            .setSubtopologyId(SUBTOPOLOGY_1)
+                            .setTopicIds(List.of(topicId2)),
+                        new StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds()
+                            .setSubtopologyId(SUBTOPOLOGY_2)
+                            .setTopicIds(List.of(topicId1))
+                    )),
+                (short) 0
+            )
+        );
+
+        assertEquals(
+            expectedRecord,
+            StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+                GROUP_ID,
+                42,
+                Map.of(
+                    SUBTOPOLOGY_2, List.of(topicId1),
+                    SUBTOPOLOGY_1, List.of(topicId2)
+                )
+            )
+        );
     }
 
     @Test

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -65,11 +66,11 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
 
     @Override
     public void onTasksRevoked(final Set<StreamsRebalanceData.TaskId> tasks) {
-        final Map<TaskId, Set<TopicPartition>> activeTasksToRevokeWithPartitions =
-            pairWithTopicPartitions(tasks.stream());
-        final Set<TopicPartition> partitionsToRevoke = activeTasksToRevokeWithPartitions.values().stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet());
+        final Set<TopicPartition> partitionsToRevoke = tasks.stream()
+                .map(streamsRebalanceData.reconciledAssignment().activeTaskInputPartitions()::get)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
 
         final long start = time.milliseconds();
         try {
@@ -88,8 +89,7 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
     @Override
     public void onTasksAssigned(final StreamsRebalanceData.Assignment assignment) {
         final long start = time.milliseconds();
-        final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions =
-            pairWithTopicPartitions(assignment.activeTasks().stream());
+        final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions = toTaskPartitionMap(assignment.activeTaskInputPartitions());
         final Map<TaskId, Set<TopicPartition>> standbyTasksWithPartitions =
             pairWithTopicPartitions(Stream.concat(assignment.standbyTasks().stream(), assignment.warmupTasks().stream()));
 
@@ -115,6 +115,15 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
         } finally {
             tasksLostSensor.record(time.milliseconds() - start);
         }
+    }
+
+    private Map<TaskId, Set<TopicPartition>> toTaskPartitionMap(
+            final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> assignmentMap
+    ) {
+        return assignmentMap.entrySet().stream().collect(Collectors.toMap(
+                entry -> toTaskId(entry.getKey()),
+                entry -> Set.copyOf(entry.getValue())
+        ));
     }
 
     private Map<TaskId, Set<TopicPartition>> pairWithTopicPartitions(final Stream<StreamsRebalanceData.TaskId> taskIdStream) {


### PR DESCRIPTION
One possible way to support server-side regex in the `StreamsGroup` Protocol is for the server to send topic IDs, and for Kafka Streams to resolve those topic IDs back to topic names on the client side before using them. The `ConsumerGroup`
  Protocol already has a similar model, where the broker sends topic IDs and the client only consumes topics whose names it can resolve. This POC explores a similar approach for the `StreamsGroup` Protocol.

- In the current implementation, broken method signatures in JavaDoc and test code have not yet been fixed.
- The current implementation does not include regex source topic support itself. However, it appears that this could be completed by having the broker resolve regex source topics and send them to the client, while the client relaxes the regex-related constraints accordingly.

## Layering
This implementation can be divided into four layers.

### (1) Broker Assignment Layer
This layer produces the authoritative assignment and includes resolved topic IDs by subtopology in the response. The source of truth in this layer is the full task snapshot.

### (2) Membership / Client Control Plane Layer
StreamsMembershipManager manages the broker assignment in this layer. It operates on the full task snapshot and is responsible for owned-task reporting to the broker as well as callback sequencing.

### (3) Materialization / Fetch Layer
This layer resolves the topic IDs received from the broker into topic names using client metadata, and builds the actual fetchable TaskId -> TopicPartition plan. The source of truth in this layer is the materialized subset, and active tasks  in subtopologies with unresolved source topics are excluded here.

### (4) Streams Runtime Layer
Callbacks and task control-plane behavior continue to use the full task snapshot. In contrast, the TopicPartitions used for actual runtime assignment and revocation are based on the materialized subset.


In this POC, if even one source topic ID in a given subtopology cannot be resolved to a topic name, the active tasks for that subtopology:
1. are not registered in SubscriptionState as TopicPartitions, and
2. are not included in the Streams runtime active assignment.

Once topic id -> topic name resolution becomes possible, they are included again in the materialization plan during the next maybeReconcile(), and are then reflected in fetch and runtime.