### PR TITLE
KAFKA-20094: Add sanity test coverage for default configuration (no environment variables)

### DIFF
--- a/docker/test/constants.py
+++ b/docker/test/constants.py
@@ -20,6 +20,7 @@ KAFKA_RUN_CLASS="fixtures/kafka/bin/kafka-run-class.sh"
 
 COMBINED_MODE_COMPOSE="fixtures/mode/combined/docker-compose.yml"
 ISOLATED_MODE_COMPOSE="fixtures/mode/isolated/docker-compose.yml"
+DEFAULT_MODE_COMPOSE="fixtures/mode/default/docker-compose.yml"
 
 CLIENT_TIMEOUT=40000
 
@@ -48,3 +49,7 @@ SASL_ERROR_PREFIX="SASL_ERR"
 BROKER_RESTART_ERROR_PREFIX="BROKER_RESTART_ERR"
 FILE_INPUT_ERROR_PREFIX="FILE_INPUT_ERR"
 BROKER_METRICS_ERROR_PREFIX="BROKER_METRICS_ERR"
+
+PLAINTEXT_FLOW_TESTS="PLAINTEXT Flow Tests"
+PLAINTEXT_TOPIC="test-topic-plaintext"
+PLAINTEXT_ERROR_PREFIX="PLAINTEXT_ERR"

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -221,6 +221,47 @@ class DockerSanityTestIsolatedMode(DockerSanityTest):
     def test_bed(self):
         self.execute()
 
+class DockerSanityTestDefaultMode(DockerSanityTest):
+    def setUp(self) -> None:
+        self.start_compose(f"{self.FIXTURES_DIR}/{constants.DEFAULT_MODE_COMPOSE}")
+    def tearDown(self) -> None:
+        self.destroy_compose(f"{self.FIXTURES_DIR}/{constants.DEFAULT_MODE_COMPOSE}")
+    def test_bed(self):
+        self.execute()
+
+    def plaintext_flow(self):
+        print(f"Running {constants.PLAINTEXT_FLOW_TESTS}")
+        errors = []
+        try:
+            self.assertTrue(self.create_topic(constants.PLAINTEXT_TOPIC, ["--bootstrap-server", "localhost:9092"]))
+        except AssertionError as e:
+            errors.append(constants.PLAINTEXT_ERROR_PREFIX + str(e))
+            return errors
+
+        producer_config = ["--bootstrap-server", "localhost:9092"]
+        self.produce_message(constants.PLAINTEXT_TOPIC, producer_config, "key", "message")
+        consumer_config = ["--bootstrap-server", "localhost:9092", "--command-property", "auto.offset.reset=earliest"]
+        message = self.consume_message(constants.PLAINTEXT_TOPIC, consumer_config)
+        try:
+            self.assertEqual(message, "key:message")
+        except AssertionError as e:
+            errors.append(constants.PLAINTEXT_ERROR_PREFIX + str(e))
+        return errors
+
+    def execute(self):
+        total_errors = []
+        try:
+            total_errors.extend(self.plaintext_flow())
+        except Exception as e:
+            print(constants.PLAINTEXT_ERROR_PREFIX, str(e))
+            total_errors.append(str(e))
+        try:
+            total_errors.extend(self.broker_restart_flow())
+        except Exception as e:
+            print(constants.BROKER_RESTART_ERROR_PREFIX, str(e))
+            total_errors.append(str(e))
+        self.assertEqual(total_errors, [])
+
 def run_tests(image, mode, fixtures_dir):
     DockerSanityTest.IMAGE = image
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
@@ -228,7 +269,7 @@ def run_tests(image, mode, fixtures_dir):
 
     test_classes_to_run = []
     if mode == "jvm" or mode == "native":
-        test_classes_to_run = [DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode]
+        test_classes_to_run = [DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode, DockerSanityTestDefaultMode]
     
     loader = unittest.TestLoader()
     suites_list = []

--- a/docker/test/fixtures/mode/default/docker-compose.yml
+++ b/docker/test/fixtures/mode/default/docker-compose.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+services:
+  broker1:
+    image: {$IMAGE}
+    hostname: broker1
+    container_name: broker1
+    ports:
+      - "9092:9092"
+      - "9999:9999"
+    environment:
+      CLUSTER_ID: '4L6g3nShT-eMCtK--X86sw'


### PR DESCRIPTION
Add DockerSanityTestDefaultMode for no environment variables case.
