### PR TITLE
MINOR: Add todo to WindowSegmentWithHeaders

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBMigratingWindowStoreWithHeaders.java
@@ -44,6 +44,8 @@ import java.util.List;
  *   <li>New format (HEADERS CF): {@code [headersSize(varint)][headersBytes][value]}</li>
  * </ul>
  * <p>
+ * TODO: Current format is {@code [headersSize(varint)][headersBytes][timestamp(8)][value]}.
+ *       The new format will be introduced in KAFKA-20334.
  * This is similar to {@link RocksDBMigratingSessionStoreWithHeaders} but for window stores.
  * Unlike timestamped stores, window stores don't include timestamp in the value (it's in the key).
  */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowSegmentWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowSegmentWithHeaders.java
@@ -38,6 +38,8 @@ import java.util.Objects;
  *   <li>Old format (DEFAULT CF): {@code [value]}</li>
  *   <li>New format (HEADERS CF): {@code [headersSize(varint)][headersBytes][value]}</li>
  * </ul>
+ * TODO: Current format is {@code [headersSize(varint)][headersBytes][timestamp(8)][value]}.
+ *       The new format will be introduced in KAFKA-20334.
  */
 class WindowSegmentWithHeaders extends RocksDBMigratingWindowStoreWithHeaders implements Segment {
 


### PR DESCRIPTION
Current implementation format for WindowSegmentWithHeaders and
RocksDBMigratingWindowStoreWithHeaders is
`[headersSize(varint)][headersBytes][timestamp(8)][value]`. Add todo to
mention the expected format will be achieved in KAFKA-20334.

Reviewers: TengYao Chi <frankvicky@apache.org>
