### PR TITLE
KAFKA-20363 : server-common - Fix flaky testIdleTimeCallback in KafkaEventQueueTest

### DIFF
--- a/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
+++ b/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
@@ -440,6 +440,11 @@ public class KafkaEventQueueTest {
                     lastIdleTimeMs.set(idleDuration);
                     lastCurrentTimeMs.set(currentTime);
                 })) {
+            // Capture the queue's event handler thread so we can wait for it to be idle.
+            CompletableFuture<Thread> queueThreadFuture = new CompletableFuture<>();
+            queue.append(() -> queueThreadFuture.complete(Thread.currentThread()));
+            Thread queueThread = queueThreadFuture.get();
+
             time.sleep(2);
             assertEquals(0, lastIdleTimeMs.get(), "Last idle time should be 0ms");
 
@@ -450,6 +455,13 @@ public class KafkaEventQueueTest {
                 return "event1-processed";
             }));
             assertEquals("event1-processed", event1.get());
+
+            // Wait for the queue thread to enter cond.await() before advancing MockTime.
+            // This ensures startIdleMs is captured before the time advancement.
+            TestUtils.waitForCondition(
+                    () -> queueThread.getState() == Thread.State.WAITING,
+                    "Queue thread should be waiting"
+            );
 
             long timeBeforeWait = time.milliseconds();
             long waitTime5Ms = 5;
@@ -464,6 +476,12 @@ public class KafkaEventQueueTest {
             assertEquals(timeBeforeWait + waitTime5Ms, lastCurrentTimeMs.get(), "Current time should be " + (timeBeforeWait + waitTime5Ms) + "ms, was: " + lastCurrentTimeMs.get());
 
             // Test 2: Deferred event
+            // Wait for the queue thread to enter cond.await() before advancing MockTime.
+            TestUtils.waitForCondition(
+                    () -> queueThread.getState() == Thread.State.WAITING,
+                    "Queue thread should be waiting"
+            );
+
             long timeBeforeDeferred = time.milliseconds();
             long waitTime2Ms = 2;
             CompletableFuture<Void> deferredEvent2 = new CompletableFuture<>();

--- a/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
+++ b/server-common/src/test/java/org/apache/kafka/queue/KafkaEventQueueTest.java
@@ -425,6 +425,17 @@ public class KafkaEventQueueTest {
         }
     }
 
+    /**
+     * Wait for the queue's event handler thread to enter cond.await(), ensuring
+     * that startIdleMs has been captured before the test advances MockTime.
+     */
+    private static void waitForQueueThreadToBeIdle(Thread queueThread) throws InterruptedException {
+        TestUtils.waitForCondition(
+                () -> queueThread.getState() == Thread.State.WAITING,
+                "Queue thread should be waiting"
+        );
+    }
+
     @Test
     public void testIdleTimeCallback() throws Exception {
         MockTime time = new MockTime();
@@ -456,12 +467,7 @@ public class KafkaEventQueueTest {
             }));
             assertEquals("event1-processed", event1.get());
 
-            // Wait for the queue thread to enter cond.await() before advancing MockTime.
-            // This ensures startIdleMs is captured before the time advancement.
-            TestUtils.waitForCondition(
-                    () -> queueThread.getState() == Thread.State.WAITING,
-                    "Queue thread should be waiting"
-            );
+            waitForQueueThreadToBeIdle(queueThread);
 
             long timeBeforeWait = time.milliseconds();
             long waitTime5Ms = 5;
@@ -476,11 +482,7 @@ public class KafkaEventQueueTest {
             assertEquals(timeBeforeWait + waitTime5Ms, lastCurrentTimeMs.get(), "Current time should be " + (timeBeforeWait + waitTime5Ms) + "ms, was: " + lastCurrentTimeMs.get());
 
             // Test 2: Deferred event
-            // Wait for the queue thread to enter cond.await() before advancing MockTime.
-            TestUtils.waitForCondition(
-                    () -> queueThread.getState() == Thread.State.WAITING,
-                    "Queue thread should be waiting"
-            );
+            waitForQueueThreadToBeIdle(queueThread);
 
             long timeBeforeDeferred = time.milliseconds();
             long waitTime2Ms = 2;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-20363

The test had a race condition between Test thread and Queue thread.  We
actually wait until queue thread is sleeping/waiting so it guarantees
the order.

Reviewers: junvelop <151982401+junjunclub@users.noreply.github.com>,
 TaiJuWu <tjwu1217@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
