### PR TITLE
MINOR: deprecate internal config for NamedTopologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1362,6 +1362,7 @@ public class StreamsConfig extends AbstractConfig {
             + ".vector.enabled__";
 
         // Private API used to control the prefix of the auto created topics
+        @Deprecated
         public static final String TOPIC_PREFIX_ALTERNATIVE = "__internal.override.topic.prefix__";
 
         // Private API to enable processing threads (i.e. polling is decoupled from processing)

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1122,6 +1122,7 @@ public class InternalTopologyBuilder {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void buildProcessorNode(final Map<String, ProcessorNode<?, ?, ?, ?>> processorMap,
                                     final Map<String, StateStore> stateStoreMap,
                                     final ProcessorNodeFactory<?, ?, ?, ?> factory,
@@ -1456,6 +1457,7 @@ public class InternalTopologyBuilder {
         return decorateTopic(topic);
     }
 
+    @SuppressWarnings("deprecation")
     private String decorateTopic(final String topic) {
         if (applicationId == null) {
             throw new TopologyException("there are internal topics and "

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
@@ -52,6 +52,7 @@ public final class ProcessorContextUtils {
         return ProcessorStateManager.storeChangelogTopic(prefix, storeName, context.taskId().topologyName());
     }
 
+    @Deprecated
     public static String topicNamePrefix(final Map<String, Object> configs, final String applicationId) {
         if (configs == null) {
             return applicationId;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
@@ -113,6 +113,7 @@ public class TimeOrderedCachingWindowStore
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void init(final StateStoreContext stateStoreContext, final StateStore root) {
         final String prefix = StreamsConfig.InternalConfig.getString(


### PR DESCRIPTION
NamedTopologies got deprecated via KAFKA-17805. This PR deprecates the
internal "topic prefix" config, which is used by NamedTopologies.

Reviewers: Christo Lolov <lolovc@amazon.com>, TengYao Chi
 <frankvicky@apache.org>
